### PR TITLE
fix(session): preserve slashes in title-derived branch names

### DIFF
--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -935,6 +935,23 @@ pub(crate) fn branch_name_from_title(title: &str) -> String {
     let mut last_was_dash = false;
 
     let mut push_processed = |ch: char| {
+        // Preserve '/' as git's namespace separator (so a title like
+        // `jacob/feature-1` yields a branch `jacob/feature-1`). The worktree
+        // folder leaf is sanitized separately via `sanitize_branch_name`, so
+        // the slash never reaches a path. Never emit a leading, trailing, or
+        // doubled slash; trim any pending dash before it.
+        if ch == '/' {
+            while branch.ends_with('-') {
+                branch.pop();
+            }
+            if branch.is_empty() || branch.ends_with('/') {
+                return;
+            }
+            branch.push('/');
+            last_was_dash = true;
+            return;
+        }
+
         let next = if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
             Some(ch.to_ascii_lowercase())
         } else if ch.is_whitespace() || ch.is_ascii_punctuation() {
@@ -963,7 +980,7 @@ pub(crate) fn branch_name_from_title(title: &str) -> String {
         }
     }
 
-    while branch.ends_with('-') {
+    while branch.ends_with('-') || branch.ends_with('/') {
         branch.pop();
     }
 
@@ -1092,10 +1109,25 @@ mod tests {
             branch_name_from_title("Fix: login @ mobile #42"),
             "fix-login-mobile-42"
         );
+        // '/' is the legal git namespace separator and is preserved; '.' is
+        // still folded to '-'.
         assert_eq!(
             branch_name_from_title("feat/auth.refactor"),
-            "feat-auth-refactor"
+            "feat/auth-refactor"
         );
+    }
+
+    #[test]
+    fn test_branch_name_from_title_preserves_slashes() {
+        // The motivating case: a `user/topic` title keeps its slash in the
+        // branch, while the worktree folder leaf is sanitized elsewhere.
+        assert_eq!(branch_name_from_title("jacob/feature-1"), "jacob/feature-1");
+        // No leading, trailing, or doubled slash; dashes around a slash are
+        // trimmed.
+        assert_eq!(branch_name_from_title("/leading"), "leading");
+        assert_eq!(branch_name_from_title("trailing/"), "trailing");
+        assert_eq!(branch_name_from_title("a//b"), "a/b");
+        assert_eq!(branch_name_from_title("a / b"), "a/b");
     }
 
     #[test]

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -32,12 +32,15 @@ use crate::session::WorktreeInfo;
 ///
 /// Reuses the creation-time title slugger (`branch_name_from_title`) so a tied
 /// rename produces the same leaf the session would have been created with: an
-/// accent-folded, lowercased, dash-collapsed single path component. It never
-/// yields an empty string, a path separator, or `.`/`..` (it falls back to
-/// `"session"`), so the result is always a safe sibling-leaf name. Feeding it
-/// back through [`edit_worktree_workdir`]'s internal sanitizer is idempotent.
+/// accent-folded, lowercased, dash-collapsed single path component. The title
+/// slugger preserves '/' as a git namespace separator, so the result is run
+/// through `sanitize_branch_name` to fold slashes to dashes, exactly as
+/// `resolve_template` does when deriving a leaf from a branch at creation. It
+/// never yields an empty string, a path separator, or `.`/`..` (it falls back
+/// to `"session"`), so the result is always a safe sibling-leaf name. Feeding
+/// it back through [`edit_worktree_workdir`]'s internal sanitizer is idempotent.
 pub fn worktree_leaf_from_title(title: &str) -> String {
-    crate::session::builder::branch_name_from_title(title)
+    sanitize_branch_name(&crate::session::builder::branch_name_from_title(title))
 }
 
 /// Whether a sandbox session's container is still running and therefore
@@ -260,6 +263,11 @@ mod tests {
             worktree_leaf_from_title("Fix: the/thing (v2)"),
             "fix-the-thing-v2"
         );
+        // A slash-bearing title yields a slashed branch but the folder leaf
+        // must stay a single, flat path component.
+        let leaf = worktree_leaf_from_title("jacob/feature-1");
+        assert_eq!(leaf, "jacob-feature-1");
+        assert!(!leaf.contains('/'));
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Setting a session title like `jacob/feature-1` produced the branch `jacob-feature-1`: the title-to-branch slugger folded every ASCII punctuation char, including `/`, to `-`. Git branches natively support `/` as a namespace separator, and the explicit-branch path already preserved it, so only the title-derived path was wrong.

This preserves `/` in `branch_name_from_title` (`src/session/builder.rs`), never emitting a leading, trailing, or doubled slash and trimming any dash adjacent to a slash. The worktree folder leaf is sanitized independently, so a slashed branch still maps to a flat directory leaf:

- New worktree from title `jacob/feature-1` now creates branch `jacob/feature-1` with folder leaf `jacob-feature-1`.
- `worktree_leaf_from_title` (`src/session/worktree_edit.rs`) previously reused the slugger and relied on it returning a single path component. With slashes now preserved it folds the slug through `sanitize_branch_name`, mirroring how `resolve_template` derives a leaf at creation time, so tied renames keep producing a flat folder while the branch keeps its slash.

Closes #2376

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a session with worktree enabled and title `jacob/feature-1` (no explicit branch); confirm the created git branch is `jacob/feature-1`.
- [ ] Confirm the worktree folder for that session is a flat leaf `jacob-feature-1` (no nested `jacob/` directory).
- [ ] Rename a tied worktree session to a slashed title and confirm the folder stays a single flat component while the branch keeps the slash.
- [ ] Create a session with title `a / b`; confirm the branch is `a/b` (no doubled slash, no leading/trailing slash).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the change is a pure-function slug fix covered by unit tests (`branch_name_from_title` slash-preservation plus the red-then-green case, and `worktree_leaf_from_title` flat-leaf invariant); no new TUI/CLI rendering path is introduced.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and the fix ships with reproduce-then-fix unit tests.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784959819&installation_id=139138837&pr_number=2379&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2379&signature=abdcfeeeda2593618e666f4bec939cad6900777a264de3f418354cf86ddc0cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change fixes how session titles are turned into branch names so slash-separated names are preserved instead of flattened. As a result, a title like `jacob/feature-1` now stays `jacob/feature-1` for the branch, while still keeping branch names valid by filtering out bad slash placement.

Worktree folder naming is handled separately so it still creates a flat directory name and does not mirror the slash structure. Tests were updated to cover the new branch behavior and the worktree leaf behavior.

Benefits:
- Keeps branch names aligned with Git’s namespace style
- Avoids unwanted renaming of slash-based titles
- Preserves simple, flat worktree paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->