### PR TITLE
fix(kiro): launch via `chat` subcommand and support user-selected agents

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -124,9 +124,32 @@ pub struct SidecarHooks {
     /// Optional host-only follow-up run after a successful host install
     /// (e.g. kiro promotes its `aoe-hooks` agent to the active default).
     pub post_install_host: Option<fn()>,
+    /// Set for CLIs whose hooks are scoped to a user-selectable named agent
+    /// rather than applying globally (e.g. Kiro: `--agent NAME` loads only that
+    /// agent's config, and there is no global hooks mechanism). When set and
+    /// the user selected an agent, AoE installs its hooks into that agent's own
+    /// config file instead of the standalone `host_config_subpath` agent, and
+    /// skips `post_install_host`. `None` for agents whose hooks apply
+    /// regardless of which agent is selected. See
+    /// [`crate::session::Instance::install_agent_status_hooks`].
+    pub selected_agent_hooks: Option<SelectedAgentHooks>,
     /// On-disk format of the sidecar's config file. Drives marker-presence
     /// walker dispatch in [`crate::hooks::has_aoe_marker`].
     pub format: SidecarFormat,
+}
+
+/// How to install status hooks into a user-selected named agent, for CLIs
+/// whose hooks are scoped to the selected agent (see
+/// [`SidecarHooks::selected_agent_hooks`]). Keeps the flag and path convention
+/// as data on the agent definition rather than a per-agent string match at the
+/// install site.
+#[derive(Debug)]
+pub struct SelectedAgentHooks {
+    /// CLI flag a user passes to choose a named agent (e.g. `"--agent"`).
+    pub flag: &'static str,
+    /// Maps a selected agent name to the home-relative path of that agent's
+    /// config file (e.g. `custom-agent` → `.kiro/agents/custom-agent.json`).
+    pub config_subpath: fn(&str) -> std::path::PathBuf,
 }
 
 /// On-disk format of a sidecar agent's config file. Drives
@@ -149,6 +172,20 @@ pub struct AgentDef {
     pub name: &'static str,
     /// Binary to invoke (usually same as name).
     pub binary: &'static str,
+    /// Subcommand token inserted immediately after `binary` when AoE builds the
+    /// default launch command (e.g. `Some("chat")` for kiro → `kiro-cli chat`).
+    /// Required for CLIs whose interactive flags (yolo, `--agent`, resume) live
+    /// on a subcommand rather than the top-level binary: bare
+    /// `kiro-cli --trust-all-tools` is rejected with "unexpected argument",
+    /// while `kiro-cli chat --trust-all-tools` parses. `None` for agents whose
+    /// bare binary already accepts those flags. Only applied to the default
+    /// binary path, never to a user's custom command override.
+    ///
+    /// Must not be combined with [`ResumeStrategy::Subcommand`]: that strategy
+    /// inserts the resume token after the first whitespace token (the binary),
+    /// which would land it before this launch subcommand. The pairing is
+    /// rejected by `test_launch_subcommand_not_combined_with_subcommand_resume`.
+    pub launch_subcommand: Option<&'static str>,
     /// Alternative substrings recognised by `resolve_tool_name` (e.g. `"open-code"`).
     pub aliases: &'static [&'static str],
     /// How to detect availability on the host.
@@ -359,6 +396,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "claude",
         oneshot_flag: Some("-p"),
         binary: "claude",
+        launch_subcommand: None,
         aliases: &[],
         detection: DetectionMethod::Which("claude"),
         yolo: Some(YoloMode::CliFlag("--dangerously-skip-permissions")),
@@ -385,6 +423,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "opencode",
         oneshot_flag: Some("run"),
         binary: "opencode",
+        launch_subcommand: None,
         aliases: &["open-code"],
         detection: DetectionMethod::Which("opencode"),
         yolo: Some(YoloMode::EnvVar("OPENCODE_PERMISSION", r#"{"*":"allow"}"#)),
@@ -403,6 +442,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "vibe",
         oneshot_flag: None,
         binary: "vibe",
+        launch_subcommand: None,
         aliases: &["mistral-vibe"],
         detection: DetectionMethod::RunWithArg("vibe", "--version"),
         yolo: Some(YoloMode::CliFlag("--agent auto-approve")),
@@ -421,6 +461,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "codex",
         oneshot_flag: Some("exec"),
         binary: "codex",
+        launch_subcommand: None,
         aliases: &[],
         detection: DetectionMethod::Which("codex"),
         yolo: Some(YoloMode::CliFlag(
@@ -451,6 +492,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "gemini",
         oneshot_flag: Some("-p"),
         binary: "gemini",
+        launch_subcommand: None,
         aliases: &[],
         detection: DetectionMethod::Which("gemini"),
         yolo: Some(YoloMode::CliFlag("--approval-mode yolo")),
@@ -499,6 +541,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "cursor",
         oneshot_flag: None,
         binary: "agent",
+        launch_subcommand: None,
         aliases: &["agent"],
         detection: DetectionMethod::Which("agent"),
         yolo: Some(YoloMode::CliFlag("--yolo")),
@@ -522,6 +565,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "copilot",
         oneshot_flag: None,
         binary: "copilot",
+        launch_subcommand: None,
         aliases: &["github-copilot"],
         detection: DetectionMethod::Which("copilot"),
         yolo: Some(YoloMode::CliFlag("--yolo")),
@@ -540,6 +584,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "pi",
         oneshot_flag: None,
         binary: "pi",
+        launch_subcommand: None,
         aliases: &[],
         detection: DetectionMethod::Which("pi"),
         // Pi runs in full YOLO mode by default (no approval gates), so no flag needed.
@@ -559,6 +604,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "droid",
         oneshot_flag: None,
         binary: "droid",
+        launch_subcommand: None,
         aliases: &["factory-droid"],
         detection: DetectionMethod::Which("droid"),
         yolo: Some(YoloMode::CliFlag("--skip-permissions-unsafe")),
@@ -577,6 +623,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "settl",
         oneshot_flag: None,
         binary: "settl",
+        launch_subcommand: None,
         aliases: &["settlers", "catan"],
         detection: DetectionMethod::Which("settl"),
         yolo: Some(YoloMode::AlwaysYolo),
@@ -594,6 +641,7 @@ pub const AGENTS: &[AgentDef] = &[
             install: crate::hooks::install_settl_hooks,
             uninstall: crate::hooks::uninstall_settl_hooks,
             post_install_host: None,
+            selected_agent_hooks: None,
             format: SidecarFormat::SettlToml,
         }),
         resume_strategy: ResumeStrategy::Unsupported,
@@ -605,6 +653,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "hermes",
         oneshot_flag: None,
         binary: "hermes",
+        launch_subcommand: None,
         aliases: &[],
         detection: DetectionMethod::Which("hermes"),
         yolo: Some(YoloMode::CliFlag("--yolo")),
@@ -628,6 +677,7 @@ pub const AGENTS: &[AgentDef] = &[
             install: crate::hooks::install_hermes_hooks,
             uninstall: crate::hooks::uninstall_hermes_hooks,
             post_install_host: None,
+            selected_agent_hooks: None,
             format: SidecarFormat::HermesYaml,
         }),
         resume_strategy: ResumeStrategy::Flag("--resume"),
@@ -640,6 +690,10 @@ pub const AGENTS: &[AgentDef] = &[
         name: "kiro",
         oneshot_flag: None,
         binary: "kiro-cli",
+        // Kiro's interactive flags (--trust-all-tools, --agent, --resume-id)
+        // are defined on the `chat` subcommand. Bare `kiro-cli --trust-all-tools`
+        // fails with "unexpected argument"; `kiro-cli chat ...` parses.
+        launch_subcommand: Some("chat"),
         aliases: &["kiro-cli"],
         detection: DetectionMethod::Which("kiro-cli"),
         yolo: Some(YoloMode::CliFlag("--trust-all-tools")),
@@ -660,6 +714,14 @@ pub const AGENTS: &[AgentDef] = &[
             install: crate::hooks::install_kiro_hooks,
             uninstall: crate::hooks::uninstall_kiro_hooks,
             post_install_host: Some(crate::hooks::set_kiro_default_agent_if_builtin),
+            // Kiro scopes hooks to the agent selected by `--agent`; when the
+            // user picks their own agent, install hooks into that agent's file
+            // (Kiro has no global hooks) instead of the standalone aoe-hooks
+            // agent, and skip the set-default promotion above.
+            selected_agent_hooks: Some(SelectedAgentHooks {
+                flag: "--agent",
+                config_subpath: crate::hooks::kiro_agent_file_for,
+            }),
             format: SidecarFormat::KiroJson,
         }),
         resume_strategy: ResumeStrategy::Flag("--resume-id"),
@@ -671,6 +733,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "qwen",
         oneshot_flag: None,
         binary: "qwen",
+        launch_subcommand: None,
         aliases: &[],
         detection: DetectionMethod::Which("qwen"),
         yolo: Some(YoloMode::CliFlag("--yolo")),
@@ -697,6 +760,7 @@ pub const AGENTS: &[AgentDef] = &[
         name: "antigravity",
         oneshot_flag: None,
         binary: "agy",
+        launch_subcommand: None,
         aliases: &["agy"],
         detection: DetectionMethod::Which("agy"),
         yolo: Some(YoloMode::CliFlag("--dangerously-skip-permissions")),
@@ -730,10 +794,76 @@ impl AgentDef {
             _ => &[],
         }
     }
+
+    /// The base launch token(s) for the default (non-overridden) command:
+    /// the binary, plus any `launch_subcommand` (e.g. `"kiro-cli chat"`). All
+    /// subsequent flags (extra args, yolo, resume) are appended after this, so
+    /// subcommand-scoped flags land on the subcommand where the CLI expects
+    /// them. Agents without a `launch_subcommand` just return the binary.
+    pub fn launch_base_command(&self) -> String {
+        match self.launch_subcommand {
+            Some(sub) => format!("{} {}", self.binary, sub),
+            None => self.binary.to_string(),
+        }
+    }
 }
 
 pub fn get_agent(name: &str) -> Option<&'static AgentDef> {
     AGENTS.iter().find(|a| a.name == name)
+}
+
+/// Extract the agent name a user selected via `<flag> NAME` or `<flag>=NAME`
+/// in a command/extra-args string (e.g. Kiro's `--agent custom-agent`). The flag
+/// comes from [`SelectedAgentHooks::flag`] so the convention stays data on the
+/// agent definition. Returns `None` when the flag is absent or has no value.
+///
+/// The **last** occurrence wins, matching how clap-based CLIs (Kiro included)
+/// resolve a repeated single-value flag: `--agent a --agent b` loads `b`, so AoE
+/// must install hooks into `b`, not `a`. This also gives extra-args the final
+/// say over a command override when [`crate::session::Instance::selected_agent_args`]
+/// concatenates command then extra-args.
+///
+/// Names that are empty, contain path separators, or are `.`/`..` are rejected
+/// so a parsed value can be safely joined to an agents directory without path
+/// traversal. Whitespace-tokenized, which matches how AoE assembles the launch
+/// string; quoted values containing spaces are not handled (agent names do not
+/// contain spaces in practice).
+pub fn parse_selected_agent(args: &str, flag: &str) -> Option<String> {
+    let eq_prefix = format!("{flag}=");
+    let mut tokens = args.split_whitespace().peekable();
+    let mut selected = None;
+    while let Some(tok) = tokens.next() {
+        let candidate = if let Some(rest) = tok.strip_prefix(&eq_prefix) {
+            Some(rest)
+        } else if tok == flag {
+            tokens.next()
+        } else {
+            None
+        };
+        if let Some(name) = candidate {
+            // A later valid occurrence overrides an earlier one; an invalid
+            // value (empty / path-unsafe) is ignored rather than clearing a
+            // prior valid selection.
+            if is_safe_agent_name(name) {
+                selected = Some(name.to_string());
+            }
+        }
+    }
+    selected
+}
+
+/// Guard against path traversal and obvious misparses: a selected agent name is
+/// joined to an agents directory, so reject empty names, `.`/`..`, anything
+/// containing a path separator, and flag-shaped tokens. The leading-dash check
+/// means a value-less flag (`--agent --model`) yields `None` rather than
+/// treating the following flag as an agent name.
+fn is_safe_agent_name(name: &str) -> bool {
+    !name.is_empty()
+        && name != "."
+        && name != ".."
+        && !name.starts_with('-')
+        && !name.contains('/')
+        && !name.contains('\\')
 }
 
 /// Returns the delay (in ms) to insert before the submit-Enter for this agent.
@@ -967,6 +1097,143 @@ mod tests {
                 agent.yolo.is_some(),
                 "Agent '{}' should have YOLO mode configured",
                 agent.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_kiro_launches_via_chat_subcommand() {
+        // Kiro's interactive flags (--trust-all-tools, --agent, --resume-id)
+        // are scoped to the `chat` subcommand, so the base command must include
+        // it; bare `kiro-cli --trust-all-tools` is rejected by the CLI.
+        let kiro = get_agent("kiro").unwrap();
+        assert_eq!(kiro.launch_subcommand, Some("chat"));
+        assert_eq!(kiro.launch_base_command(), "kiro-cli chat");
+    }
+
+    #[test]
+    fn test_launch_base_command_without_subcommand_is_binary() {
+        // Agents with no launch_subcommand keep their bare binary.
+        let claude = get_agent("claude").unwrap();
+        assert_eq!(claude.launch_subcommand, None);
+        assert_eq!(claude.launch_base_command(), "claude");
+    }
+
+    #[test]
+    fn test_only_kiro_uses_launch_subcommand() {
+        // Lock the surface: today only kiro needs a launch subcommand. A new
+        // agent that needs one must update this test deliberately.
+        for agent in AGENTS {
+            let expected = if agent.name == "kiro" {
+                Some("chat")
+            } else {
+                None
+            };
+            assert_eq!(
+                agent.launch_subcommand, expected,
+                "agent '{}' launch_subcommand drifted",
+                agent.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_launch_subcommand_not_combined_with_subcommand_resume() {
+        // `append_resume_flags` inserts a Subcommand resume token after the
+        // first whitespace token, which for a launch_subcommand agent is the
+        // binary — landing the resume token before the subcommand and producing
+        // a malformed command (e.g. `kiro-cli resume <id> chat ...`). Forbid the
+        // pairing until that insertion is made subcommand-aware.
+        for agent in AGENTS {
+            if agent.launch_subcommand.is_some() {
+                assert!(
+                    !matches!(agent.resume_strategy, ResumeStrategy::Subcommand(_)),
+                    "agent '{}' combines launch_subcommand with ResumeStrategy::Subcommand; \
+                     resume token would be inserted before the subcommand",
+                    agent.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_selected_agent() {
+        assert_eq!(
+            parse_selected_agent("--agent custom-agent", "--agent"),
+            Some("custom-agent".to_string())
+        );
+        assert_eq!(
+            parse_selected_agent(
+                "--trust-all-tools --agent custom-agent --model x",
+                "--agent"
+            ),
+            Some("custom-agent".to_string())
+        );
+        assert_eq!(
+            parse_selected_agent("--agent=custom-agent", "--agent"),
+            Some("custom-agent".to_string())
+        );
+        // Absent flag.
+        assert_eq!(parse_selected_agent("--trust-all-tools", "--agent"), None);
+        assert_eq!(parse_selected_agent("", "--agent"), None);
+        // Dangling flag with no value.
+        assert_eq!(parse_selected_agent("--foo --agent", "--agent"), None);
+        // A value-less flag followed by another flag must not capture the flag
+        // as the agent name.
+        assert_eq!(parse_selected_agent("--agent --model x", "--agent"), None);
+        // Repeated flag: last occurrence wins, matching clap precedence.
+        assert_eq!(
+            parse_selected_agent("--agent first --agent second", "--agent"),
+            Some("second".to_string())
+        );
+        // A trailing invalid value does not clear an earlier valid one.
+        assert_eq!(
+            parse_selected_agent("--agent good --agent ..", "--agent"),
+            Some("good".to_string())
+        );
+        // Path-traversal / unsafe names are rejected.
+        assert_eq!(
+            parse_selected_agent("--agent ../../etc/passwd", "--agent"),
+            None
+        );
+        assert_eq!(parse_selected_agent("--agent=a/b", "--agent"), None);
+        assert_eq!(parse_selected_agent("--agent .", "--agent"), None);
+        // Flag is parameterized, not hardcoded.
+        assert_eq!(
+            parse_selected_agent("--profile prod", "--profile"),
+            Some("prod".to_string())
+        );
+    }
+
+    #[test]
+    fn test_kiro_declares_selected_agent_hooks() {
+        // Kiro's hooks are scoped to the --agent-selected agent; the flag and
+        // path convention live as data on the AgentDef, not a string match at
+        // the install site.
+        let kiro = get_agent("kiro").unwrap();
+        let sel = kiro
+            .sidecar_hooks
+            .as_ref()
+            .unwrap()
+            .selected_agent_hooks
+            .as_ref()
+            .expect("kiro declares selected_agent_hooks");
+        assert_eq!(sel.flag, "--agent");
+        assert_eq!(
+            (sel.config_subpath)("custom-agent"),
+            std::path::Path::new(".kiro/agents/custom-agent.json")
+        );
+        // The other sidecar agents do not (their hooks apply globally).
+        for name in ["settl", "hermes"] {
+            assert!(
+                get_agent(name)
+                    .unwrap()
+                    .sidecar_hooks
+                    .as_ref()
+                    .unwrap()
+                    .selected_agent_hooks
+                    .is_none(),
+                "agent '{name}' should not declare selected_agent_hooks"
             );
         }
     }

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -815,39 +815,43 @@ pub fn get_agent(name: &str) -> Option<&'static AgentDef> {
 /// Extract the agent name a user selected via `<flag> NAME` or `<flag>=NAME`
 /// in a command/extra-args string (e.g. Kiro's `--agent custom-agent`). The flag
 /// comes from [`SelectedAgentHooks::flag`] so the convention stays data on the
-/// agent definition. Returns `None` when the flag is absent or has no value.
+/// agent definition. Returns `None` when the flag is absent, has no value, or
+/// its final occurrence carries a rejected value.
 ///
-/// The **last** occurrence wins, matching how clap-based CLIs (Kiro included)
-/// resolve a repeated single-value flag: `--agent a --agent b` loads `b`, so AoE
-/// must install hooks into `b`, not `a`. This also gives extra-args the final
+/// The **last** occurrence decides the result, matching how clap-based CLIs
+/// (Kiro included) resolve a repeated single-value flag: `--agent a --agent b`
+/// loads `b`. Crucially, a later occurrence overwrites an earlier one even when
+/// its value is rejected, so `--agent good --agent ..` returns `None` rather
+/// than `good`: the CLI itself would load `..` (and reject it / fall back to its
+/// default), so AoE must not install hooks into `good`, an agent the CLI is not
+/// running. Returning `None` makes AoE fall back to its standalone hooks agent,
+/// which is what the CLI effectively does. This also gives extra-args the final
 /// say over a command override when [`crate::session::Instance::selected_agent_args`]
 /// concatenates command then extra-args.
 ///
-/// Names that are empty, contain path separators, or are `.`/`..` are rejected
-/// so a parsed value can be safely joined to an agents directory without path
-/// traversal. Whitespace-tokenized, which matches how AoE assembles the launch
-/// string; quoted values containing spaces are not handled (agent names do not
-/// contain spaces in practice).
+/// A value is rejected by [`is_safe_agent_name`] (empty, `.`/`..`, leading dash,
+/// or a path separator) so a parsed value can be safely joined to an agents
+/// directory without path traversal. Whitespace-tokenized, which matches how AoE
+/// assembles the launch string; quoted values containing spaces are not handled
+/// (agent names do not contain spaces in practice).
 pub fn parse_selected_agent(args: &str, flag: &str) -> Option<String> {
     let eq_prefix = format!("{flag}=");
-    let mut tokens = args.split_whitespace().peekable();
+    let mut tokens = args.split_whitespace();
     let mut selected = None;
     while let Some(tok) = tokens.next() {
-        let candidate = if let Some(rest) = tok.strip_prefix(&eq_prefix) {
+        // The value of this flag occurrence: the text after `=`, the next token
+        // for the space-separated form, or `None` for a dangling flag.
+        let value = if let Some(rest) = tok.strip_prefix(&eq_prefix) {
             Some(rest)
         } else if tok == flag {
             tokens.next()
         } else {
-            None
+            continue;
         };
-        if let Some(name) = candidate {
-            // A later valid occurrence overrides an earlier one; an invalid
-            // value (empty / path-unsafe) is ignored rather than clearing a
-            // prior valid selection.
-            if is_safe_agent_name(name) {
-                selected = Some(name.to_string());
-            }
-        }
+        // Last occurrence wins: overwrite with this occurrence's validated
+        // value, so a trailing rejected/missing value clears an earlier valid
+        // one (mirroring the CLI's last-wins resolution).
+        selected = value.filter(|&v| is_safe_agent_name(v)).map(str::to_string);
     }
     selected
 }
@@ -1141,7 +1145,7 @@ mod tests {
     fn test_launch_subcommand_not_combined_with_subcommand_resume() {
         // `append_resume_flags` inserts a Subcommand resume token after the
         // first whitespace token, which for a launch_subcommand agent is the
-        // binary — landing the resume token before the subcommand and producing
+        // binary. That lands the resume token before the subcommand and produces
         // a malformed command (e.g. `kiro-cli resume <id> chat ...`). Forbid the
         // pairing until that insertion is made subcommand-aware.
         for agent in AGENTS {
@@ -1186,11 +1190,21 @@ mod tests {
             parse_selected_agent("--agent first --agent second", "--agent"),
             Some("second".to_string())
         );
-        // A trailing invalid value does not clear an earlier valid one.
+        // Last-wins is honored even when the trailing value is rejected: the CLI
+        // would load `..` (and reject / fall back), so AoE must NOT keep `good`
+        // and write hooks into an agent the CLI is not running. Returns None so
+        // AoE falls back to its standalone hooks agent.
         assert_eq!(
             parse_selected_agent("--agent good --agent ..", "--agent"),
-            Some("good".to_string())
+            None
         );
+        // A trailing dangling flag likewise clears an earlier valid value.
+        assert_eq!(
+            parse_selected_agent("--agent good --agent", "--agent"),
+            None
+        );
+        // `--agent=` (empty value) is rejected.
+        assert_eq!(parse_selected_agent("--agent=", "--agent"), None);
         // Path-traversal / unsafe names are rejected.
         assert_eq!(
             parse_selected_agent("--agent ../../etc/passwd", "--agent"),

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1836,6 +1836,22 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
     })
 }
 
+/// Home-relative path to a user's Kiro agent config file by name, e.g.
+/// `custom-agent` → `.kiro/agents/custom-agent.json`. Wired into `kiro`'s
+/// [`crate::agents::SelectedAgentHooks::config_subpath`] so the install site can
+/// target the selected agent's own file. The caller is responsible for
+/// validating `name` (see [`crate::agents::parse_selected_agent`], which rejects
+/// path separators) before joining to `$HOME`.
+///
+/// Installing into this path reuses [`install_kiro_hooks`], which preserves any
+/// existing user hooks and is idempotent; [`uninstall_kiro_hooks`] strips only
+/// the AoE-tagged entries.
+pub fn kiro_agent_file_for(name: &str) -> PathBuf {
+    Path::new(".kiro")
+        .join("agents")
+        .join(format!("{name}.json"))
+}
+
 /// Make `aoe-hooks` the active default Kiro agent if the user is still on
 /// Kiro's built-in default. Skipped when a user has chosen a custom default
 /// so we never silently override their preference. Best-effort: any failure
@@ -3556,6 +3572,71 @@ hooks_auto_accept: false
         let config_path = tmp.path().join("nonexistent.json");
         let modified = uninstall_kiro_hooks(&config_path).unwrap();
         assert!(!modified);
+    }
+
+    #[test]
+    fn test_kiro_agent_file_for() {
+        assert_eq!(
+            kiro_agent_file_for("custom-agent"),
+            Path::new(".kiro/agents/custom-agent.json")
+        );
+    }
+
+    #[test]
+    fn test_install_into_selected_kiro_agent_creates_file() {
+        // No pre-existing agent file: installing into the selected agent's path
+        // creates it with AoE hooks, just like the dedicated aoe-hooks agent.
+        // Mirrors how `install_sidecar_host_hooks` composes the path helper with
+        // the sidecar installer.
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(kiro_agent_file_for("custom-agent"));
+        install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
+
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        for (event, _) in KIRO_HOOKS {
+            let entries = config["hooks"][event].as_array().unwrap();
+            assert_eq!(
+                entries.len(),
+                1,
+                "event {} should have one AoE entry",
+                event
+            );
+            assert!(is_aoe_hook_command(entries[0]["command"].as_str().unwrap()));
+        }
+    }
+
+    #[test]
+    fn test_install_into_selected_kiro_agent_preserves_user_config() {
+        // A real user agent has its own name/prompt/tools/hooks. Installing must
+        // keep all of that and only add AoE hook entries.
+        let home = TempDir::new().unwrap();
+        let path = home.path().join(kiro_agent_file_for("custom-agent"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            r#"{"name":"custom-agent","prompt":"custom helper","tools":["read","shell"],"hooks":{"preToolUse":[{"command":"echo mine"}]}}"#,
+        )
+        .unwrap();
+
+        install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
+
+        let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // User fields untouched.
+        assert_eq!(config["name"].as_str().unwrap(), "custom-agent");
+        assert_eq!(config["prompt"].as_str().unwrap(), "custom helper");
+        assert_eq!(config["tools"].as_array().unwrap().len(), 2);
+        // User's own preToolUse hook is preserved, AoE's appended after it.
+        let pre = config["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(pre[0]["command"].as_str().unwrap(), "echo mine");
+        assert!(pre
+            .iter()
+            .any(|h| is_aoe_hook_command(h["command"].as_str().unwrap())));
+        // And it's reversible without harming the user's hook.
+        assert!(uninstall_kiro_hooks(&path).unwrap());
+        let after: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let pre_after = after["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(pre_after.len(), 1);
+        assert_eq!(pre_after[0]["command"].as_str().unwrap(), "echo mine");
     }
 
     fn run_session_id_hook(payload: &str, instance_id: &str, base: &Path) -> std::process::Output {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -856,6 +856,21 @@ pub struct SessionConfig {
     #[setting(label = "Agent Status Hooks", widget = "toggle", category = "Agents")]
     pub agent_status_hooks: bool,
 
+    /// For agents whose hooks are scoped to a user-selected named agent (e.g.
+    /// Kiro's `--agent NAME`), install AoE's status hooks into that agent's own
+    /// config file so status detection keeps working. Such CLIs have no global
+    /// hooks, so without this AoE's standalone hooks agent is never loaded for a
+    /// user-selected agent and status goes dark. When disabled, AoE installs its
+    /// standalone hooks agent instead and leaves the user's agent file
+    /// untouched.
+    #[serde(default = "default_true")]
+    #[setting(
+        label = "Merge Hooks Into Selected Agent",
+        widget = "toggle",
+        category = "Agents"
+    )]
+    pub merge_hooks_into_selected_agent: bool,
+
     /// Auto-rename a new structured-view (ACP) session from its first message,
     /// using the session's own agent in one-shot mode (e.g. `claude -p`). Only
     /// applies while the session still carries its auto-generated name; a
@@ -1244,6 +1259,7 @@ impl Default for SessionConfig {
             agent_extra_args: HashMap::new(),
             agent_command_override: HashMap::new(),
             agent_status_hooks: true,
+            merge_hooks_into_selected_agent: true,
             smart_rename: true,
             smart_rename_agent: String::new(),
             mouse_capture: true,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -858,11 +858,11 @@ pub struct SessionConfig {
 
     /// For agents whose hooks are scoped to a user-selected named agent (e.g.
     /// Kiro's `--agent NAME`), install AoE's status hooks into that agent's own
-    /// config file so status detection keeps working. Such CLIs have no global
-    /// hooks, so without this AoE's standalone hooks agent is never loaded for a
-    /// user-selected agent and status goes dark. When disabled, AoE installs its
-    /// standalone hooks agent instead and leaves the user's agent file
-    /// untouched.
+    /// config file so status detection keeps working, on both host and sandbox
+    /// sessions. Such CLIs have no global hooks, so without this AoE's standalone
+    /// hooks agent is never loaded for a user-selected agent and status goes
+    /// dark. When disabled, AoE installs its standalone hooks agent instead and
+    /// leaves the user's agent file untouched.
     #[serde(default = "default_true")]
     #[setting(
         label = "Merge Hooks Into Selected Agent",

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1102,11 +1102,28 @@ fn agent_config_container_path(
 pub(crate) struct ContainerAgentSelection<'a> {
     tool: &'a str,
     detect_as: Option<&'a str>,
+    /// The agent name a user selected via the agent's selected-agent flag (e.g.
+    /// Kiro's `--agent NAME`), if any. When set, sidecar status hooks are
+    /// installed into that agent's sandbox config file rather than the
+    /// standalone hooks agent, mirroring the host path so a sandboxed session
+    /// running a user's own agent still reports status (Kiro has no global
+    /// hooks). `None` for the default / no selection.
+    selected_agent: Option<&'a str>,
 }
 
 impl<'a> ContainerAgentSelection<'a> {
     pub(crate) fn new(tool: &'a str, detect_as: Option<&'a str>) -> Self {
-        Self { tool, detect_as }
+        Self {
+            tool,
+            detect_as,
+            selected_agent: None,
+        }
+    }
+
+    /// Set the user-selected agent name (see [`Self::selected_agent`]).
+    pub(crate) fn with_selected_agent(mut self, selected_agent: Option<&'a str>) -> Self {
+        self.selected_agent = selected_agent;
+        self
     }
 }
 
@@ -1469,7 +1486,25 @@ pub(crate) fn build_container_config(
             }
 
             if let Some(sidecar) = &agent.sidecar_hooks {
-                let config_file = home.join(sidecar.sandbox_config_subpath);
+                // Default target: the standalone hooks agent's sandbox config.
+                // When the user selected their own agent via the sidecar's
+                // selected-agent flag (e.g. Kiro `--agent NAME`), the container
+                // loads THAT agent's config (these CLIs have no global hooks), so
+                // install into its staged file instead. The selected agent's dir
+                // is copied into the sandbox via AGENT_CONFIG_MOUNTS, so the
+                // staged path is the sandbox config dir plus the selected name's
+                // file (mirrors the host path in
+                // `Instance::install_sidecar_host_hooks`).
+                let config_file = sidecar
+                    .selected_agent_hooks
+                    .as_ref()
+                    .zip(agent_selection.selected_agent)
+                    .and_then(|(sel, name)| {
+                        let sandbox_dir = Path::new(sidecar.sandbox_config_subpath).parent()?;
+                        let file_name = (sel.config_subpath)(name).file_name()?.to_owned();
+                        Some(home.join(sandbox_dir).join(file_name))
+                    })
+                    .unwrap_or_else(|| home.join(sidecar.sandbox_config_subpath));
                 if let Err(e) =
                     (sidecar.install)(&config_file, crate::hooks::HookInstallTarget::Sandbox)
                 {
@@ -3346,6 +3381,69 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             );
             crate::hooks::cleanup_hook_status_dir(&instance_id);
         }
+    }
+
+    // #2381 (sandbox side): a sandboxed Kiro session launched with `--agent
+    // NAME` loads NAME's config inside the container, which has no AoE hooks, so
+    // status detection goes dark. When a selected agent is threaded in, the
+    // sandbox install must target NAME's staged config file, not the standalone
+    // aoe-hooks agent.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_installs_hooks_into_selected_kiro_agent() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+
+        let kiro = crate::agents::get_agent("kiro").unwrap();
+        let sidecar = kiro.sidecar_hooks.as_ref().unwrap();
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+        };
+        let instance_id = "kiro-selected-agent-sandbox-test";
+        build_container_config(
+            project_dir.path().to_str().unwrap(),
+            &sandbox_info,
+            ContainerAgentSelection::new("kiro", None).with_selected_agent(Some("custom-agent")),
+            false,
+            instance_id,
+            None,
+            "",
+        )
+        .unwrap();
+
+        // Hooks land in the selected agent's staged sandbox config...
+        let selected_config = temp_home
+            .path()
+            .join(".kiro/sandbox/agents/custom-agent.json");
+        assert!(
+            selected_config.exists(),
+            "selected-agent sandbox hook config should be installed at {}",
+            selected_config.display()
+        );
+        assert!(fs::read_to_string(&selected_config)
+            .unwrap()
+            .contains("aoe-hooks"));
+
+        // ...NOT the standalone aoe-hooks sandbox agent.
+        let standalone = temp_home.path().join(sidecar.sandbox_config_subpath);
+        assert!(
+            !standalone.exists(),
+            "standalone aoe-hooks sandbox config must not be written when an agent is selected"
+        );
+
+        crate::hooks::cleanup_hook_status_dir(instance_id);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2706,7 +2706,11 @@ impl Instance {
                 .session
                 .merge_hooks_into_selected_agent;
         let selected_agent = if merge_selected {
+            // Mirror the host path's agent resolution (a custom wrapper detected
+            // as kiro carries kiro's sidecar via detect_as), and the sandbox's
+            // own `resolve_active_agent`, which also falls back to detect_as.
             crate::agents::get_agent(&self.tool)
+                .or_else(|| crate::agents::get_agent(&self.detect_as))
                 .and_then(|a| a.sidecar_hooks.as_ref())
                 .and_then(|s| s.selected_agent_hooks.as_ref())
                 .and_then(|sel| {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2697,10 +2697,29 @@ impl Instance {
             .sandbox_info
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("sandbox_info missing for sandboxed session"))?;
+        // Resolve the user-selected agent (e.g. Kiro `--agent NAME`) so the
+        // sandbox installs status hooks into that agent's config, matching the
+        // host path. Gated by the same setting; only applies to agents that
+        // declare selected_agent_hooks.
+        let merge_selected =
+            super::profile_config::resolve_config_or_warn(&self.effective_profile())
+                .session
+                .merge_hooks_into_selected_agent;
+        let selected_agent = if merge_selected {
+            crate::agents::get_agent(&self.tool)
+                .and_then(|a| a.sidecar_hooks.as_ref())
+                .and_then(|s| s.selected_agent_hooks.as_ref())
+                .and_then(|sel| {
+                    crate::agents::parse_selected_agent(&self.selected_agent_args(), sel.flag)
+                })
+        } else {
+            None
+        };
         container_config::build_container_config(
             &self.project_path,
             sandbox,
-            container_config::ContainerAgentSelection::new(&self.tool, Some(&self.detect_as)),
+            container_config::ContainerAgentSelection::new(&self.tool, Some(&self.detect_as))
+                .with_selected_agent(selected_agent.as_deref()),
             self.is_yolo_mode(),
             &self.id,
             self.workspace_info.as_ref(),
@@ -5883,7 +5902,7 @@ mod tests {
             .build_host_command(crate::agents::get_agent("kiro"), &None)
             .unwrap();
         let cmd_str = cmd.unwrap();
-        // Exactly one "chat" token — no doubled `chat chat`.
+        // Exactly one "chat" token (no doubled `chat chat`).
         assert_eq!(
             cmd_str.matches("chat").count(),
             1,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1695,6 +1695,34 @@ impl Instance {
         }
     }
 
+    /// The text searched for a user-selected `--agent NAME` flag: both the
+    /// command override (where a custom command like `kiro-cli chat --agent x`
+    /// may live) and the extra-args field (the usual place). Joined so a flag
+    /// in either is found.
+    fn selected_agent_args(&self) -> String {
+        if self.command.is_empty() {
+            self.extra_args.clone()
+        } else if self.extra_args.is_empty() {
+            self.command.clone()
+        } else {
+            format!("{} {}", self.command, self.extra_args)
+        }
+    }
+
+    /// Launch command including any agent `launch_subcommand` (e.g.
+    /// `kiro-cli chat`). A user command override takes precedence verbatim and
+    /// the subcommand is not applied to it. Used when assembling the launch
+    /// command so subcommand-scoped flags (yolo, resume) parse correctly.
+    fn get_launch_command(&self) -> String {
+        if self.command.is_empty() {
+            crate::agents::get_agent(&self.tool)
+                .map(|a| a.launch_base_command())
+                .unwrap_or_else(|| "bash".to_string())
+        } else {
+            self.command.clone()
+        }
+    }
+
     pub fn tmux_session(&self) -> Result<tmux::Session> {
         tmux::Session::new(&self.id, &self.title)
     }
@@ -2009,10 +2037,11 @@ impl Instance {
                 }
             }
 
+            let launch_cmd = self.get_launch_command();
             let base_cmd = if self.extra_args.is_empty() {
-                self.get_tool_command().to_string()
+                launch_cmd
             } else {
-                format!("{} {}", self.get_tool_command(), self.extra_args)
+                format!("{} {}", launch_cmd, self.extra_args)
             };
             let mut tool_cmd = if self.is_yolo_mode() {
                 if let Some(ref yolo) = agent.and_then(|a| a.yolo.as_ref()) {
@@ -2111,10 +2140,8 @@ impl Instance {
     /// Respects the `agent_status_hooks` config setting.
     fn install_agent_status_hooks(&self, agent: Option<&'static crate::agents::AgentDef>) {
         let profile = self.effective_profile();
-        let hooks_enabled = super::profile_config::resolve_config_or_warn(&profile)
-            .session
-            .agent_status_hooks;
-        if !hooks_enabled {
+        let session_cfg = super::profile_config::resolve_config_or_warn(&profile).session;
+        if !session_cfg.agent_status_hooks {
             return;
         }
         if let Some(sidecar) = agent.and_then(|a| a.sidecar_hooks.as_ref()) {
@@ -2124,16 +2151,7 @@ impl Instance {
             // sandboxed, so the gate is a no-op for them.
             if !self.is_sandboxed() {
                 if let Some(home) = dirs::home_dir() {
-                    let config_path = home.join(sidecar.host_config_subpath);
-                    match (sidecar.install)(&config_path, crate::hooks::HookInstallTarget::Host) {
-                        Ok(()) => {
-                            if let Some(post_install) = sidecar.post_install_host {
-                                post_install();
-                            }
-                        }
-                        Err(e) => tracing::warn!(target: "session.store",
-                            "Failed to install {} hooks: {}", self.tool, e),
-                    }
+                    self.install_sidecar_host_hooks(sidecar, &home, &session_cfg);
                 }
             }
         } else if let Some(hook_cfg) = agent.and_then(|a| a.hook_config.as_ref()) {
@@ -2146,6 +2164,51 @@ impl Instance {
                 }
             }
             // Sandboxed sessions install via build_container_config.
+        }
+    }
+
+    /// Install a sidecar agent's host hooks. For agents whose hooks are scoped
+    /// to a user-selected named agent (`selected_agent_hooks`, e.g. Kiro), and
+    /// when the user actually selected one and the merge setting is on, install
+    /// into that agent's own config file and stop. Otherwise install into the
+    /// agent's standalone config and run any `post_install_host` follow-up.
+    fn install_sidecar_host_hooks(
+        &self,
+        sidecar: &'static crate::agents::SidecarHooks,
+        home: &Path,
+        session_cfg: &super::config::SessionConfig,
+    ) {
+        if session_cfg.merge_hooks_into_selected_agent {
+            if let Some(sel) = sidecar.selected_agent_hooks.as_ref() {
+                if let Some(name) =
+                    crate::agents::parse_selected_agent(&self.selected_agent_args(), sel.flag)
+                {
+                    // The selected agent is what the CLI loads; install AoE's
+                    // hooks into its config (these CLIs have no global hooks) and
+                    // skip the standalone-agent install + post_install_host.
+                    let path = home.join((sel.config_subpath)(&name));
+                    match (sidecar.install)(&path, crate::hooks::HookInstallTarget::Host) {
+                        Ok(()) => tracing::info!(target: "session.store",
+                            "Installed AoE status hooks into {} agent '{}'", self.tool, name),
+                        Err(e) => tracing::warn!(target: "session.store",
+                            "Failed to install AoE hooks into {} agent '{}': {}", self.tool, name, e),
+                    }
+                    return;
+                }
+            }
+        }
+
+        let config_path = home.join(sidecar.host_config_subpath);
+        match (sidecar.install)(&config_path, crate::hooks::HookInstallTarget::Host) {
+            Ok(()) => {
+                tracing::info!(target: "session.store",
+                    "Installed AoE status hooks for {} via standalone hooks agent", self.tool);
+                if let Some(post_install) = sidecar.post_install_host {
+                    post_install();
+                }
+            }
+            Err(e) => tracing::warn!(target: "session.store",
+                "Failed to install {} hooks: {}", self.tool, e),
         }
     }
 
@@ -2241,7 +2304,7 @@ impl Instance {
         if self.command.is_empty() {
             match crate::agents::get_agent(&self.tool) {
                 Some(a) => {
-                    let mut cmd = a.binary.to_string();
+                    let mut cmd = a.launch_base_command();
                     if !self.extra_args.is_empty() {
                         cmd = format!("{} {}", cmd, self.extra_args);
                     }
@@ -5773,6 +5836,90 @@ mod tests {
         assert!(cmd_str.contains("TERM=xterm-256color"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("agy"));
+    }
+
+    #[test]
+    fn test_build_host_command_kiro_uses_chat_subcommand() {
+        // Regression: Kiro must launch via `kiro-cli chat` so the binary
+        // accepts chat-scoped flags. Bare `kiro-cli` rejects --trust-all-tools.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "kiro".to_string();
+        let (cmd, _) = inst
+            .build_host_command(crate::agents::get_agent("kiro"), &None)
+            .unwrap();
+        assert!(cmd.unwrap().contains("kiro-cli chat"));
+    }
+
+    #[test]
+    fn test_build_host_command_kiro_yolo_after_chat() {
+        // YOLO flag must follow the `chat` subcommand, not precede it.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "kiro".to_string();
+        inst.yolo_mode = true;
+        let (cmd, _) = inst
+            .build_host_command(crate::agents::get_agent("kiro"), &None)
+            .unwrap();
+        let cmd_str = cmd.unwrap();
+        let chat_pos = cmd_str
+            .find("kiro-cli chat")
+            .expect("chat subcommand present");
+        let yolo_pos = cmd_str
+            .find("--trust-all-tools")
+            .expect("yolo flag present");
+        assert!(
+            yolo_pos > chat_pos,
+            "--trust-all-tools must come after `kiro-cli chat`: {cmd_str}"
+        );
+    }
+
+    #[test]
+    fn test_build_host_command_custom_override_skips_subcommand() {
+        // A user command override is passed through verbatim; AoE must not
+        // inject a launch subcommand into it (the user is in full control).
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "kiro".to_string();
+        inst.command = "kiro-cli chat --trust-all-tools".to_string();
+        let (cmd, _) = inst
+            .build_host_command(crate::agents::get_agent("kiro"), &None)
+            .unwrap();
+        let cmd_str = cmd.unwrap();
+        // Exactly one "chat" token — no doubled `chat chat`.
+        assert_eq!(
+            cmd_str.matches("chat").count(),
+            1,
+            "no duplicate subcommand: {cmd_str}"
+        );
+    }
+
+    #[test]
+    fn test_selected_agent_args_combines_command_and_extra() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "kiro".to_string();
+        inst.extra_args = "--agent custom-agent".to_string();
+        assert_eq!(
+            crate::agents::parse_selected_agent(&inst.selected_agent_args(), "--agent"),
+            Some("custom-agent".to_string())
+        );
+
+        // Agent named inside a command override is also found.
+        let mut inst2 = Instance::new("test", "/tmp/test");
+        inst2.tool = "kiro".to_string();
+        inst2.command = "kiro-cli chat --agent custom-agent".to_string();
+        assert_eq!(
+            crate::agents::parse_selected_agent(&inst2.selected_agent_args(), "--agent"),
+            Some("custom-agent".to_string())
+        );
+
+        // extra_args is appended after the command override, so a per-session
+        // --agent there wins over one baked into the override (last wins).
+        let mut inst3 = Instance::new("test", "/tmp/test");
+        inst3.tool = "kiro".to_string();
+        inst3.command = "kiro-cli chat --agent from-command".to_string();
+        inst3.extra_args = "--agent from-extra".to_string();
+        assert_eq!(
+            crate::agents::parse_selected_agent(&inst3.selected_agent_args(), "--agent"),
+            Some("from-extra".to_string())
+        );
     }
 
     #[test]

--- a/tests/e2e/kiro_launch.rs
+++ b/tests/e2e/kiro_launch.rs
@@ -84,10 +84,18 @@ fn pane_start_command(session: &str) -> String {
 /// `launched_tmux_name` fails loudly if it wasn't. The returned guard kills the
 /// session when the caller's scope ends, including on assertion panic.
 fn launch_kiro_and_read_command(
-    h: &TuiTestHarness,
+    h: &mut TuiTestHarness,
     title: &str,
     extra: &[&str],
 ) -> (String, TmuxSessionGuard) {
+    // `aoe add --tool kiro` verifies `kiro-cli` is on PATH before persisting the
+    // session, so without a stub it bails (and never writes sessions.json) in
+    // CI / any machine without kiro-cli installed. Installing an exit-0 stub
+    // lets `add` proceed. We assert on the command tmux is *told* to run
+    // (`pane_start_command`), which aoe builds regardless of the binary, so the
+    // stub never needs to behave like real kiro-cli.
+    h.install_path_command("kiro-cli");
+
     let project = h.project_path();
     let mut args = vec![
         "add",
@@ -112,8 +120,8 @@ fn launch_kiro_and_read_command(
 fn test_kiro_launches_via_chat_subcommand() {
     require_tmux!();
 
-    let h = TuiTestHarness::new("kiro_launch_chat");
-    let (cmd, _guard) = launch_kiro_and_read_command(&h, "KiroChat", &[]);
+    let mut h = TuiTestHarness::new("kiro_launch_chat");
+    let (cmd, _guard) = launch_kiro_and_read_command(&mut h, "KiroChat", &[]);
 
     assert!(
         cmd.contains("kiro-cli chat"),
@@ -126,8 +134,8 @@ fn test_kiro_launches_via_chat_subcommand() {
 fn test_kiro_yolo_passes_trust_all_tools_after_chat() {
     require_tmux!();
 
-    let h = TuiTestHarness::new("kiro_launch_yolo");
-    let (cmd, _guard) = launch_kiro_and_read_command(&h, "KiroYolo", &["--yolo"]);
+    let mut h = TuiTestHarness::new("kiro_launch_yolo");
+    let (cmd, _guard) = launch_kiro_and_read_command(&mut h, "KiroYolo", &["--yolo"]);
 
     // The fix: YOLO mode must produce a parseable command. `kiro-cli chat` must
     // appear and `--trust-all-tools` must follow it; bare

--- a/tests/e2e/kiro_launch.rs
+++ b/tests/e2e/kiro_launch.rs
@@ -1,0 +1,145 @@
+//! End-to-end coverage for how a Kiro session is launched.
+//!
+//! Kiro's interactive flags (`--trust-all-tools`, `--agent`, `--resume-id`)
+//! live on the `kiro-cli chat` subcommand, not the top-level binary. AoE used
+//! to launch bare `kiro-cli` plus the yolo flag, so YOLO mode produced
+//! `kiro-cli --trust-all-tools`, which the real CLI rejects with
+//! `error: unexpected argument '--trust-all-tools' found`.
+//!
+//! These tests drive the full `aoe add --launch` path and assert on the command
+//! tmux was actually told to run (`pane_start_command`), so a regression in
+//! launch-command construction is caught at the session-launch layer, not just
+//! in the `build_host_command` unit tests. We read the command tmux recorded
+//! rather than executing a fake `kiro-cli`: aoe wraps the launch in a login
+//! shell (`sh -lc`) that re-resolves `kiro-cli` from the real PATH, so a stub
+//! would be shadowed; `pane_start_command` captures the exact intended command
+//! regardless of whether the binary is installed.
+
+use crate::harness::{require_tmux, TuiTestHarness};
+use serde_json::Value;
+use serial_test::serial;
+use std::process::Command;
+
+/// Kills its tmux session when dropped, so a panicking assertion in the test
+/// body still tears the real session down (the default tmux server is shared
+/// across runs, so a leak would accumulate stale sessions).
+struct TmuxSessionGuard(String);
+
+impl Drop for TmuxSessionGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &self.0])
+            .output();
+    }
+}
+
+/// The tmux session name aoe derives for the session titled `title`
+/// (`<SESSION_PREFIX><title>_<id[..8]>`). Looks the session up by title rather
+/// than assuming a position, and panics with a clear message if it is absent,
+/// so a launch that never persisted a session fails here rather than as a
+/// downstream tmux lookup miss.
+fn launched_tmux_name(h: &TuiTestHarness, title: &str) -> String {
+    let path = crate::harness::app_dir_in(h.home_path())
+        .join("profiles")
+        .join("default")
+        .join("sessions.json");
+    let sessions: Value = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| panic!("no sessions.json at {} after launch", path.display()));
+    let id = sessions
+        .as_array()
+        .and_then(|arr| arr.iter().find(|s| s["title"].as_str() == Some(title)))
+        .and_then(|s| s["id"].as_str())
+        .unwrap_or_else(|| panic!("no session titled '{title}' in {}", path.display()));
+    let truncated = &id[..8.min(id.len())];
+    format!(
+        "{}{}_{}",
+        agent_of_empires::tmux::SESSION_PREFIX,
+        title,
+        truncated
+    )
+}
+
+/// The command tmux was told to run for the session's pane. This is the launch
+/// command aoe built, captured before (and independent of) execution.
+fn pane_start_command(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["list-panes", "-t", session, "-F", "#{pane_start_command}"])
+        .output()
+        .expect("tmux list-panes");
+    assert!(
+        out.status.success(),
+        "tmux list-panes failed for {session}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Run `aoe add --launch ...` for a kiro session and return the command tmux
+/// was told to run. `--launch` creates the tmux session and then attempts a
+/// foreground attach, which fails under the test's non-TTY stdio; that attach
+/// failure is expected and irrelevant here, so the exit status is not asserted.
+/// The session (and its recorded pane command) is created regardless, and
+/// `launched_tmux_name` fails loudly if it wasn't. The returned guard kills the
+/// session when the caller's scope ends, including on assertion panic.
+fn launch_kiro_and_read_command(
+    h: &TuiTestHarness,
+    title: &str,
+    extra: &[&str],
+) -> (String, TmuxSessionGuard) {
+    let project = h.project_path();
+    let mut args = vec![
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        title,
+        "--tool",
+        "kiro",
+        "--launch",
+    ];
+    args.extend_from_slice(extra);
+    let _ = h.run_cli(&args);
+
+    let session = launched_tmux_name(h, title);
+    let guard = TmuxSessionGuard(session.clone());
+    let cmd = pane_start_command(&session);
+    (cmd, guard)
+}
+
+#[test]
+#[serial]
+fn test_kiro_launches_via_chat_subcommand() {
+    require_tmux!();
+
+    let h = TuiTestHarness::new("kiro_launch_chat");
+    let (cmd, _guard) = launch_kiro_and_read_command(&h, "KiroChat", &[]);
+
+    assert!(
+        cmd.contains("kiro-cli chat"),
+        "kiro must launch via `kiro-cli chat`, got: {cmd:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_kiro_yolo_passes_trust_all_tools_after_chat() {
+    require_tmux!();
+
+    let h = TuiTestHarness::new("kiro_launch_yolo");
+    let (cmd, _guard) = launch_kiro_and_read_command(&h, "KiroYolo", &["--yolo"]);
+
+    // The fix: YOLO mode must produce a parseable command. `kiro-cli chat` must
+    // appear and `--trust-all-tools` must follow it; bare
+    // `kiro-cli --trust-all-tools` is what the CLI rejected.
+    let chat = cmd
+        .find("kiro-cli chat")
+        .unwrap_or_else(|| panic!("`kiro-cli chat` not in launch command: {cmd:?}"));
+    let yolo = cmd
+        .find("--trust-all-tools")
+        .unwrap_or_else(|| panic!("`--trust-all-tools` not in launch command: {cmd:?}"));
+    assert!(
+        yolo > chat,
+        "--trust-all-tools must come after `kiro-cli chat`, got: {cmd:?}"
+    );
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -34,6 +34,7 @@ mod filewatch_tui_burst_reload;
 mod filewatch_tui_dynamic_profile;
 mod filewatch_tui_reload;
 mod intro;
+mod kiro_launch;
 mod logs;
 mod new_session;
 mod plugins;


### PR DESCRIPTION
## Description

Two related Kiro fixes. Closes #2380 and Closes #2381.

**1. YOLO mode was broken (#2380).** Kiro's interactive flags (`--trust-all-tools`, `--agent`, `--resume-id`) live on the `kiro-cli chat` subcommand, not the top-level binary. AoE built the launch command as bare `kiro-cli` plus the yolo flag, producing `kiro-cli --trust-all-tools`, which the CLI rejects with `error: unexpected argument '--trust-all-tools' found`. Added a `launch_subcommand: Option<&'static str>` field to `AgentDef` (`Some("chat")` for kiro, `None` elsewhere) and inject it right after the binary in the default host and sandbox command builders, before extra args, yolo, and resume flags. User command overrides are passed through verbatim.

**2. Custom agents could not be used (#2381).** AoE installs its status hooks into a dedicated `aoe-hooks` Kiro agent and sets it as the global default. Kiro has no global hooks, so launching with a user's own `--agent NAME` loads that agent's config (no AoE hooks) and status detection goes dark. Now, when a Kiro session selects a custom agent, AoE merges its status hooks into *that* agent's own config file (reusing the idempotent, user-hook-preserving installer) and skips the global-default promotion. Modeled as a data-driven `selected_agent_hooks` field on `SidecarHooks` (flag + config-path fn) rather than a per-agent string check, matching the collapse-special-cases direction from #2062/#2333. Gated by a new `merge_hooks_into_selected_agent` setting (default on). Selected agent names are validated against path traversal and flag-shaped values; `--agent` parsing is last-wins to match clap precedence.

**Open question for the maintainer (also noted in #2381):** the merge is automatic, gated by a default-on setting, rather than an interactive prompt. If you'd prefer a new-session dialog opt-in, or the setting defaulting off so existing users' agent files are never touched without opt-in, both are small changes — happy to adjust to your preference.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Added `tests/e2e/kiro_launch.rs`: drives the full `aoe add --launch` path for a kiro session and asserts on the command tmux was actually told to run (`pane_start_command`) — that it launches via `kiro-cli chat`, and that `--trust-all-tools` lands after `chat` in YOLO mode. (Reads the recorded pane command rather than executing a stub `kiro-cli`, since aoe wraps the launch in a login shell that re-resolves the binary from the real PATH.) Also added unit tests for command construction (chat subcommand, yolo ordering, override passthrough, drift guards), `--agent` parsing (last-wins, path-traversal + flag-shaped-value rejection, parameterized flag), and merging hooks into a user agent while preserving their config and removing cleanly.

Verification: `cargo fmt --check` clean, `cargo clippy --lib --tests -- -D warnings` clean, full lib suite passes (`cargo test --lib -- --test-threads=1`: 3355 passed), e2e kiro_launch passes.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus).

**Any Additional AI Details you'd like to share:** I'm a developer evaluating AoE for managing several Kiro sessions and hit both bugs in real use. I used Claude Code to investigate the root causes, implement the fix, and write the tests; I directed the work, reviewed every change, and verified the build/clippy/tests on my machine against `kiro-cli` 2.9.0. I'll respond to review comments myself.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784961594&installation_id=139138837&pr_number=2382&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2382&signature=7224183f790a14cd473ef1926e9f25e542e356f13e71d46e20cf5893b7fa0c58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes two Kiro-related issues and improves reliability for users using custom agents:

- It corrects how Kiro interactive options are wired by passing Kiro flags through `kiro-cli chat` (via a new `launch_subcommand` mechanism). This ensures `--trust-all-tools`, `--agent`, and resume behavior apply in the right place and that YOLO/extra args order is preserved. User command overrides still work as before.
- It restores custom Kiro agent compatibility with AoE status hooks by merging AoE’s hooks into the *selected* agent’s config when enabled. This includes fixing sandbox installation to target the selected agent’s staged config (so hooks don’t get stuck only on the default agent).

The PR adds safer `--agent` parsing with true last-wins semantics and validation, introduces configuration-controlled hook merging (`merge_hooks_into_selected_agent`, defaulting to enabled), and adds validation around selected agent names. It also includes an end-to-end launch test for Kiro command construction (with a `kiro-cli` stub for CI robustness) plus unit tests covering command building, parsing behavior, hook merging, and sandbox behavior.

Potential follow-up: consider whether the default-on merge behavior (`merge_hooks_into_selected_agent`) should be changed to default-off or made interactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->