### PR TITLE
feat(session): add per-session signal settable via CLI for agent status signaling

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -33,6 +33,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe session unfavorite`↴](#aoe-session-unfavorite)
 * [`aoe session archive`↴](#aoe-session-archive)
 * [`aoe session unarchive`↴](#aoe-session-unarchive)
+* [`aoe session signal`↴](#aoe-session-signal)
 * [`aoe group`↴](#aoe-group)
 * [`aoe group list`↴](#aoe-group-list)
 * [`aoe group create`↴](#aoe-group-create)
@@ -337,6 +338,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `unfavorite` — Clear the favorite flag on a session
 * `archive` — Archive a session: sink it in the Attention sort and tear down its tmux sessions. Worktree, branch, container preserved. `--no-kill` skips tmux teardown. See #1868
 * `unarchive` — Unarchive a session (restores it to its tier in the Attention sort)
+* `signal` — Set or clear a session's status signal (a colored sidebar dot). An agent can signal its own state with no session id: it defaults to the session owning the current tmux pane. See #2383
 
 
 
@@ -586,6 +588,19 @@ Unarchive a session (restores it to its tier in the Attention sort)
 ###### **Arguments:**
 
 * `<IDENTIFIER>` — Session ID or title
+
+
+
+## `aoe session signal`
+
+Set or clear a session's status signal (a colored sidebar dot). An agent can signal its own state with no session id: it defaults to the session owning the current tmux pane. See #2383
+
+**Usage:** `aoe session signal <STATE> [SESSION]`
+
+###### **Arguments:**
+
+* `<STATE>` — Signal to set: `blocked`, `working`, or `done` (input aliases `red`, `amber`, `green`), or `clear` / `none` to remove it
+* `<SESSION>` — Session ID or title. Defaults to the session owning the current tmux pane, so a running agent can self-signal with `aoe session signal working`
 
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -135,6 +135,10 @@ Surface AoE session info inside your existing tmux status bar. Useful when you s
 
 [tmux Status Bar guide](guides/tmux-status-bar.md)
 
+### Session signals
+
+Attach a status signal (`blocked`, `working`, `done`) to a session; it shows as a colored dot in the web sidebar, turning the session list into a scannable fleet status board. Set it from the sidebar context menu, or via `aoe session signal <state> [session]`. The session argument defaults to the session owning the current tmux pane, so a running agent can self-signal with a bare `aoe session signal working` (and clear it with `aoe session signal clear`) to flag itself for attention without the operator opening it.
+
 ## Notifications
 
 ### Sound effects

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -5,7 +5,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::collections::HashSet;
 
-use crate::session::{GroupTree, StartOutcome, Storage};
+use crate::session::{GroupTree, Instance, SessionSignal, StartOutcome, Storage};
 
 #[derive(Subcommand)]
 pub enum SessionCommands {
@@ -70,6 +70,11 @@ pub enum SessionCommands {
 
     /// Unarchive a session (restores it to its tier in the Attention sort)
     Unarchive(SessionIdArgs),
+
+    /// Set or clear a session's status signal (a colored sidebar dot). An
+    /// agent can signal its own state with no session id: it defaults to the
+    /// session owning the current tmux pane. See #2383.
+    Signal(SignalArgs),
 }
 
 #[derive(Args)]
@@ -225,6 +230,17 @@ pub struct SetBaseArgs {
     pub clear: bool,
 }
 
+#[derive(Args)]
+pub struct SignalArgs {
+    /// Signal to set: `blocked`, `working`, or `done` (input aliases `red`,
+    /// `amber`, `green`), or `clear` / `none` to remove it.
+    pub state: String,
+    /// Session ID or title. Defaults to the session owning the current tmux
+    /// pane, so a running agent can self-signal with `aoe session signal
+    /// working`.
+    pub session: Option<String>,
+}
+
 #[derive(Serialize)]
 struct SessionDetails {
     id: String,
@@ -259,6 +275,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
         SessionCommands::Unfavorite(args) => unfavorite_session(profile, args).await,
         SessionCommands::Archive(args) => archive_session(profile, args).await,
         SessionCommands::Unarchive(args) => unarchive_session(profile, args).await,
+        SessionCommands::Signal(args) => signal_session(profile, args).await,
     }
 }
 
@@ -1221,51 +1238,124 @@ async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<(
     Ok(())
 }
 
-async fn current_session(args: CurrentArgs) -> Result<()> {
-    // Auto-detect profile and session from tmux
-    let current_session = std::env::var("TMUX_PANE")
+/// Resolve the profile and instance of the aoe session owning the current
+/// tmux pane, scanning every profile. Returns `Ok(None)` when not inside a
+/// tmux pane at all, and an error only when in tmux but no aoe session
+/// matches, so callers can distinguish "not in tmux" from "wrong pane".
+fn current_tmux_session() -> Result<Option<(String, Instance)>> {
+    let session_name = match std::env::var("TMUX_PANE")
         .ok()
-        .and_then(|_| crate::tmux::get_current_session_name());
+        .and_then(|_| crate::tmux::get_current_session_name())
+    {
+        Some(name) => name,
+        None => return Ok(None),
+    };
 
-    let session_name = current_session.ok_or_else(|| anyhow::anyhow!("Not in a tmux session"))?;
-
-    // Search all profiles for this session
     let profiles = crate::session::list_profiles()?;
-
     for profile_name in &profiles {
         if let Ok(storage) = Storage::new_unwatched(profile_name) {
             if let Ok((instances, _)) = storage.load_with_groups() {
-                if let Some(inst) = instances.iter().find(|i| {
-                    let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
-                    tmux_name == session_name
-                }) {
-                    if args.json {
-                        #[derive(Serialize)]
-                        struct CurrentInfo {
-                            session: String,
-                            profile: String,
-                            id: String,
-                        }
-                        let info = CurrentInfo {
-                            session: inst.title.clone(),
-                            profile: profile_name.clone(),
-                            id: inst.id.clone(),
-                        };
-                        super::output::print_json(&info)?;
-                    } else if args.quiet {
-                        println!("{}", inst.title);
-                    } else {
-                        println!("Session: {}", inst.title);
-                        println!("Profile: {}", profile_name);
-                        println!("ID:      {}", inst.id);
-                    }
-                    return Ok(());
+                if let Some(inst) = instances
+                    .iter()
+                    .find(|i| crate::tmux::Session::generate_name(&i.id, &i.title) == session_name)
+                {
+                    return Ok(Some((profile_name.clone(), inst.clone())));
                 }
             }
         }
     }
 
     bail!("Current tmux session is not an Agent of Empires session")
+}
+
+async fn current_session(args: CurrentArgs) -> Result<()> {
+    let (profile_name, inst) =
+        current_tmux_session()?.ok_or_else(|| anyhow::anyhow!("Not in a tmux session"))?;
+
+    if args.json {
+        #[derive(Serialize)]
+        struct CurrentInfo {
+            session: String,
+            profile: String,
+            id: String,
+        }
+        let info = CurrentInfo {
+            session: inst.title.clone(),
+            profile: profile_name.clone(),
+            id: inst.id.clone(),
+        };
+        super::output::print_json(&info)?;
+    } else if args.quiet {
+        println!("{}", inst.title);
+    } else {
+        println!("Session: {}", inst.title);
+        println!("Profile: {}", profile_name);
+        println!("ID:      {}", inst.id);
+    }
+    Ok(())
+}
+
+/// Parse a CLI signal token into an `Option<SessionSignal>`. Accepts the
+/// canonical meanings, the `clear`/`none` sentinels, and the three
+/// traffic-light color aliases as INPUT only; the stored/returned value is
+/// always canonical. See #2383.
+fn parse_signal(input: &str) -> Result<Option<SessionSignal>> {
+    match input.trim().to_ascii_lowercase().as_str() {
+        "blocked" | "red" => Ok(Some(SessionSignal::Blocked)),
+        "working" | "amber" => Ok(Some(SessionSignal::Working)),
+        "done" | "green" => Ok(Some(SessionSignal::Done)),
+        "clear" | "none" => Ok(None),
+        other => bail!(
+            "Unknown signal {:?}. Valid: blocked, working, done, clear (input aliases: red, amber, green, none)",
+            other
+        ),
+    }
+}
+
+fn signal_label(signal: SessionSignal) -> &'static str {
+    match signal {
+        SessionSignal::Blocked => "blocked",
+        SessionSignal::Working => "working",
+        SessionSignal::Done => "done",
+    }
+}
+
+async fn signal_session(profile: &str, args: SignalArgs) -> Result<()> {
+    let parsed = parse_signal(&args.state)?;
+
+    // Explicit selector resolves within the active profile (like set-base);
+    // the self path scans all profiles via the current tmux pane.
+    let (target_profile, id, title) = match args.session.as_deref() {
+        Some(ident) => {
+            let storage = Storage::new_unwatched(profile)?;
+            let instances = storage.load()?;
+            let inst = super::resolve_session(ident, &instances)?;
+            (profile.to_string(), inst.id.clone(), inst.title.clone())
+        }
+        None => match current_tmux_session()? {
+            Some((p, inst)) => (p, inst.id.clone(), inst.title.clone()),
+            None => bail!(
+                "No session given and not inside a tmux pane. Pass one explicitly: aoe session signal {} <session>",
+                args.state
+            ),
+        },
+    };
+
+    let storage = Storage::new_unwatched(&target_profile)?;
+    storage.update(|instances, _groups| {
+        let stored = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+        stored.signal = parsed;
+        Ok(())
+    })?;
+
+    match parsed {
+        Some(s) => println!("✓ Set signal for '{}': {}", title, signal_label(s)),
+        None => println!("✓ Cleared signal for '{}'", title),
+    }
+    Ok(())
 }
 
 async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
@@ -1468,6 +1558,79 @@ mod restart_args_tests {
             result.is_err(),
             "passing both branch and --clear should error"
         );
+    }
+
+    #[test]
+    fn signal_state_only_parses_with_no_session() {
+        let cli = Cli::try_parse_from(["aoe", "signal", "working"])
+            .expect("state-only must parse for the self path");
+        match cli.cmd {
+            SessionCommands::Signal(args) => {
+                assert_eq!(args.state, "working");
+                assert!(args.session.is_none());
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn signal_state_and_session_parse() {
+        let cli = Cli::try_parse_from(["aoe", "signal", "done", "claude-3"])
+            .expect("state + session must parse");
+        match cli.cmd {
+            SessionCommands::Signal(args) => {
+                assert_eq!(args.state, "done");
+                assert_eq!(args.session.as_deref(), Some("claude-3"));
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod parse_signal_tests {
+    use super::{parse_signal, SessionSignal};
+
+    #[test]
+    fn canonical_states_parse() {
+        assert_eq!(
+            parse_signal("blocked").unwrap(),
+            Some(SessionSignal::Blocked)
+        );
+        assert_eq!(
+            parse_signal("working").unwrap(),
+            Some(SessionSignal::Working)
+        );
+        assert_eq!(parse_signal("done").unwrap(), Some(SessionSignal::Done));
+    }
+
+    #[test]
+    fn color_aliases_map_to_canonical() {
+        assert_eq!(parse_signal("red").unwrap(), Some(SessionSignal::Blocked));
+        assert_eq!(parse_signal("amber").unwrap(), Some(SessionSignal::Working));
+        assert_eq!(parse_signal("green").unwrap(), Some(SessionSignal::Done));
+    }
+
+    #[test]
+    fn clear_sentinels_parse_to_none() {
+        assert_eq!(parse_signal("clear").unwrap(), None);
+        assert_eq!(parse_signal("none").unwrap(), None);
+    }
+
+    #[test]
+    fn case_and_whitespace_insensitive() {
+        assert_eq!(
+            parse_signal("  Working ").unwrap(),
+            Some(SessionSignal::Working)
+        );
+    }
+
+    #[test]
+    fn rejects_non_traffic_light_palette_and_garbage() {
+        // The decorative palette must NOT be accepted as a signal.
+        assert!(parse_signal("violet").is_err());
+        assert!(parse_signal("teal").is_err());
+        assert!(parse_signal("nonsense").is_err());
     }
 }
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -44,8 +44,8 @@ pub use sessions::{
     read_output, rename_session, send_message, session_diff_file, session_diff_files,
     set_worktree_name, start_session, stop_session, update_session_archive,
     update_session_diff_base, update_session_group, update_session_notifications,
-    update_session_pin, update_session_snooze, update_session_unread, update_workspace_ordering,
-    CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
+    update_session_pin, update_session_signal, update_session_snooze, update_session_unread,
+    update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
@@ -164,6 +164,7 @@ mod tests {
                     "update_session_notifications",
                     "update_session_diff_base",
                     "update_session_pin",
+                    "update_session_signal",
                     "update_session_archive",
                     "update_session_snooze",
                     "update_session_unread",
@@ -321,6 +322,7 @@ mod tests {
                     "update_session_notifications",
                     "update_session_diff_base",
                     "update_session_pin",
+                    "update_session_signal",
                     "update_session_archive",
                     "update_session_snooze",
                     "update_session_unread",

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -11,7 +11,9 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::git::error::GitError;
-use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Status, Storage};
+use crate::session::{
+    EnsureReadyError, EnsureReadyOutcome, Instance, SessionSignal, Status, Storage,
+};
 
 use super::validate_no_shell_injection;
 use super::AppState;
@@ -46,6 +48,11 @@ pub struct SessionResponse {
     /// default, and auto-detection. See #970.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_branch_override: Option<String>,
+    /// Per-session status signal set via `aoe session signal` or the sidebar
+    /// context menu. `blocked`/`working`/`done`, or absent for idle. Drives
+    /// the colored sidebar dot. See #2383.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<SessionSignal>,
     pub is_sandboxed: bool,
     /// True when the session was created with `--scratch`; the
     /// `project_path` points at an auto-provisioned directory under
@@ -285,6 +292,7 @@ impl SessionResponse {
                 .as_ref()
                 .and_then(|w| w.base_branch.clone()),
             base_branch_override: inst.base_branch_override.clone(),
+            signal: inst.signal,
             is_sandboxed: inst.is_sandboxed(),
             scratch: inst.scratch,
             favorited: inst.is_favorited(),
@@ -1860,6 +1868,13 @@ pub struct UpdatePinBody {
 }
 
 #[derive(Deserialize)]
+pub struct UpdateSignalBody {
+    /// `Some(_)` sets the signal; `null` (or a missing field) clears it.
+    #[serde(default)]
+    pub signal: Option<SessionSignal>,
+}
+
+#[derive(Deserialize)]
 pub struct UpdateArchiveBody {
     pub archived: bool,
     /// On archive, tear down every tmux session this instance owns. `false`
@@ -1967,6 +1982,77 @@ pub async fn update_session_pin(
     } else {
         inst.unpin();
     }
+
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
+    (StatusCode::OK, Json(serde_json::json!(response))).into_response()
+}
+
+pub async fn update_session_signal(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Result<Json<UpdateSignalBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "read_only",
+                "message": "Server is in read-only mode"
+            })),
+        )
+            .into_response();
+    }
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    let profile = {
+        let instances = state.instances.read().await;
+        let Some(inst) = instances.iter().find(|i| i.id == id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        };
+        inst.source_profile.clone()
+    };
+
+    let signal = body.signal;
+
+    // Persist first; only mutate memory once disk is durable. See #1589.
+    let persist_id = id.clone();
+    if persist_session_update(
+        profile,
+        "signal update",
+        state.file_watch.clone(),
+        move |instances| {
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                inst.signal = signal;
+            }
+        },
+    )
+    .await
+    .is_err()
+    {
+        return persist_failed_response();
+    }
+
+    let mut instances = state.instances.write().await;
+    let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+        tracing::error!(
+            target: "http.api.sessions",
+            session = %id,
+            "signal update: instance vanished after persist"
+        );
+        return persist_failed_response();
+    };
+    inst.signal = signal;
 
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
@@ -7163,6 +7249,7 @@ mod workspace_ordering_tests {
             main_repo_path: None,
             base_branch: None,
             base_branch_override: None,
+            signal: None,
             is_sandboxed: false,
             scratch: false,
             has_managed_worktree: false,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1390,6 +1390,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/sessions/{id}/pin", patch(api::update_session_pin))
         .route(
+            "/api/sessions/{id}/signal",
+            patch(api::update_session_signal),
+        )
+        .route(
             "/api/sessions/{id}/archive",
             patch(api::update_session_archive),
         )

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -350,6 +350,22 @@ impl ResumeIntent {
     }
 }
 
+/// A semantic status an agent (or the operator) attaches to a session to
+/// signal what it needs, rendered as a colored dot in the web sidebar. This
+/// is deliberately a meaning, not a raw color: `blocked`/`working`/`done`
+/// can drive future sorting, filtering, or notifications, whereas a stored
+/// color string could not. `None` means idle / no explicit signal. See #2383.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SessionSignal {
+    /// Needs attention / blocked. Renders red/rose.
+    Blocked,
+    /// Actively working / in progress. Renders amber.
+    Working,
+    /// Ready for review / done. Renders green/teal.
+    Done,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Instance {
     pub id: String,
@@ -539,6 +555,11 @@ pub struct Instance {
     /// `get_commit_from_ref` resolves both forms.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_branch_override: Option<String>,
+
+    /// Per-session status signal set via `aoe session signal` or the web
+    /// context menu. `None` means idle / no signal. See #2383.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<SessionSignal>,
 
     /// How this session is rendered: `Structured` (ACP native rendering) or
     /// `Terminal` (raw tmux pane). When `Structured`, aoe spawns an ACP agent
@@ -854,6 +875,7 @@ impl Instance {
             notify_on_idle: None,
             notify_on_error: None,
             base_branch_override: None,
+            signal: None,
             #[cfg(feature = "serve")]
             view: View::Terminal,
             #[cfg(feature = "serve")]
@@ -8157,5 +8179,28 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
             Status::Waiting,
             "Claude blocked on an approval prompt must reconcile Running -> Waiting (#1913)"
         );
+    }
+
+    #[test]
+    fn signal_round_trips_and_is_omitted_when_none() {
+        // A None signal must be skipped entirely: this is exactly the shape of
+        // a sessions.json written before #2383, so deserializing it back proves
+        // backward compatibility (no `signal` key -> serde default None).
+        let inst = Instance::new("t", "/tmp/p");
+        let none_json = serde_json::to_string(&inst).unwrap();
+        assert!(
+            !none_json.contains("signal"),
+            "None signal must not serialize"
+        );
+        let back: Instance = serde_json::from_str(&none_json).unwrap();
+        assert_eq!(back.signal, None);
+
+        // Some(_) round-trips as the kebab-case meaning, not a color.
+        let mut inst = inst;
+        inst.signal = Some(SessionSignal::Blocked);
+        let json = serde_json::to_string(&inst).unwrap();
+        assert!(json.contains("\"signal\":\"blocked\""));
+        let back: Instance = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.signal, Some(SessionSignal::Blocked));
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -49,8 +49,8 @@ pub use groups::{
 };
 pub(crate) use instance::{persist_session_to_storage, ResumeIntent, SidWrite};
 pub use instance::{
-    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo, StartOutcome,
-    Status, TerminalInfo, View, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
+    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo, SessionSignal,
+    StartOutcome, Status, TerminalInfo, View, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
     TMUX_SESSION_GONE_ERROR,
 };
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -62,10 +62,13 @@ import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   renameSession,
   setSessionNotifications,
+  setSessionSignal,
   setWorktreeName,
   smartRenameSession,
   updateSessionGroup,
 } from "../lib/api";
+import type { SessionSignal } from "../lib/types";
+import { SESSION_SIGNALS, signalColor, signalLabel } from "../lib/sessionSignal";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { requestOpenSession } from "../lib/sessionRoute";
 import { requestSwitchAgent } from "../lib/switchAgentTrigger";
@@ -736,6 +739,7 @@ export const SessionRow = memo(function SessionRow({
   // and the auto-mark only ever lands on Idle anyway.
   const showUnreadGlyph = isUnread && (sessionStatus === "Idle" || sessionStatus === "Unknown");
   const sessionId = firstSession?.id;
+  const sessionSignal = firstSession?.signal ?? null;
   const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
   const sessionPath = navigationSessionId ? `/session/${encodeURIComponent(navigationSessionId)}` : "/";
   const isDeleting = sessionStatus === "Deleting";
@@ -773,6 +777,12 @@ export const SessionRow = memo(function SessionRow({
     setContextMenu(null);
     if (!sessionId || preset === notifyPreset) return;
     await setSessionNotifications(sessionId, preset);
+  };
+
+  const setSignal = async (signal: SessionSignal | null) => {
+    setContextMenu(null);
+    if (!sessionId || signal === sessionSignal) return;
+    await setSessionSignal(sessionId, signal);
   };
 
   // Triage actions (pin / archive / snooze). The optimistic overlay and the
@@ -1099,6 +1109,15 @@ export const SessionRow = memo(function SessionRow({
               <StatusGlyph status={sessionStatus} createdAt={createdAt} idleEnteredAt={idleEnteredAt} />
             )}
           </span>
+          {sessionSignal && (
+            <span
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ backgroundColor: signalColor(sessionSignal) }}
+              title={`Signal: ${signalLabel(sessionSignal)}`}
+              aria-label={`Signal: ${signalLabel(sessionSignal)}`}
+              data-testid="sidebar-signal-dot"
+            />
+          )}
           <div className="min-w-0 flex-1">
             <span
               className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${showUnreadGlyph ? "text-status-unread font-semibold" : isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited || effectivePinned ? "font-semibold" : ""} ${effectiveArchived || effectiveSnoozed ? "italic opacity-70" : ""}`}
@@ -1351,6 +1370,42 @@ export const SessionRow = memo(function SessionRow({
                     </button>
                   );
                 })}
+                {!readOnly && (
+                  <>
+                    <div className="border-t border-surface-700/20 my-1" />
+                    <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+                      Signal
+                    </div>
+                    {SESSION_SIGNALS.map((sig) => {
+                      const selected = sessionSignal === sig;
+                      return (
+                        <button
+                          key={sig}
+                          onClick={() => void setSignal(sig)}
+                          data-testid={`sidebar-context-menu-signal-${sig}`}
+                          className={`w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2 ${
+                            selected ? "text-text-primary" : "text-text-secondary"
+                          }`}
+                        >
+                          <span className="w-3 text-brand-500">{selected ? "✓" : ""}</span>
+                          <span
+                            className="h-2 w-2 shrink-0 rounded-full"
+                            style={{ backgroundColor: signalColor(sig) }}
+                          />
+                          {signalLabel(sig)}
+                        </button>
+                      );
+                    })}
+                    <button
+                      onClick={() => void setSignal(null)}
+                      data-testid="sidebar-context-menu-signal-clear"
+                      className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                    >
+                      <span className="w-3 text-brand-500">{sessionSignal === null ? "✓" : ""}</span>
+                      Clear
+                    </button>
+                  </>
+                )}
                 {!readOnly && (
                   <>
                     <div className="border-t border-surface-700/20 my-1" />

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -654,4 +654,68 @@ describe("SessionRow unread", () => {
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
     expect(screen.queryByTestId("sidebar-context-menu-unread")).toBeNull();
   });
+
+  it("renders the signal dot when the first session has a signal", () => {
+    const ws = workspace("w-signal", [session({ signal: "blocked" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByTestId("sidebar-signal-dot")).not.toBeNull();
+    expect(screen.getByLabelText("Signal: Blocked")).not.toBeNull();
+  });
+
+  it("renders no signal dot when the session has no signal", () => {
+    const ws = workspace("w-no-signal", [session()]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByTestId("sidebar-signal-dot")).toBeNull();
+  });
+
+  it("Signal click fires PATCH /api/sessions/:id/signal with { signal: 'working' }", async () => {
+    const ws = workspace("w-live", [session({ id: "sess-sig-it" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-signal-working"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-sig-it/signal");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(init!.body as string)).toEqual({ signal: "working" });
+  });
+
+  it("Signal Clear fires PATCH /api/sessions/:id/signal with { signal: null }", async () => {
+    const ws = workspace("w-live", [session({ id: "sess-sig-clr", signal: "done" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-signal-clear"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-sig-clr/signal");
+    expect(JSON.parse(init!.body as string)).toEqual({ signal: null });
+  });
+
+  it("does not fire PATCH when the chosen signal is already set", async () => {
+    const ws = workspace("w-live", [session({ id: "sess-sig-noop", signal: "blocked" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-signal-blocked"));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { clientFormFactor } from "./formFactor";
 import type {
   SessionResponse,
+  SessionSignal,
   RichDiffFilesResponse,
   RichFileContentsResponse,
   AgentInfo,
@@ -1467,6 +1468,22 @@ export async function setSessionPin(id: string, pinned: boolean): Promise<Sessio
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ pinned }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as SessionResponse;
+  } catch {
+    return null;
+  }
+}
+
+/** Set or clear a session's status signal (the colored sidebar dot). Pass
+ *  null to clear. See #2383. */
+export async function setSessionSignal(id: string, signal: SessionSignal | null): Promise<SessionResponse | null> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/signal`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ signal }),
     });
     if (!res.ok) return null;
     return (await res.json()) as SessionResponse;

--- a/web/src/lib/sessionSignal.ts
+++ b/web/src/lib/sessionSignal.ts
@@ -1,0 +1,29 @@
+import type { SessionSignal } from "./types";
+
+/** Per-session status signals an agent or operator can set, rendered as a
+ *  colored sidebar dot. Kept separate from `repoAppearance` (repo/workspace
+ *  visual color), because a signal is a meaning, not a decorative color. The
+ *  three map onto the existing traffic-light theme tokens. See #2383. */
+
+const SIGNAL_TOKENS: Record<SessionSignal, string> = {
+  blocked: "--color-status-error",
+  working: "--color-status-waiting",
+  done: "--color-terminal-active",
+};
+
+const SIGNAL_LABELS: Record<SessionSignal, string> = {
+  blocked: "Blocked",
+  working: "Working",
+  done: "Done",
+};
+
+/** Ordered list for rendering the context-menu submenu. */
+export const SESSION_SIGNALS: SessionSignal[] = ["blocked", "working", "done"];
+
+export function signalColor(signal: SessionSignal): string {
+  return `var(${SIGNAL_TOKENS[signal]})`;
+}
+
+export function signalLabel(signal: SessionSignal): string {
+  return SIGNAL_LABELS[signal];
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,5 +1,10 @@
 import type { RepoColor } from "./repoAppearance";
 
+/** A semantic per-session status signal, set by an agent or the operator and
+ *  rendered as a colored sidebar dot. Matches the Rust `SessionSignal` enum
+ *  (kebab-case). See #2383. */
+export type SessionSignal = "blocked" | "working" | "done";
+
 /** Session data returned by the API */
 export interface SessionResponse {
   id: string;
@@ -28,6 +33,10 @@ export interface SessionResponse {
    *  auto-detected default. Edited via the `vs <ref>` chip in the
    *  diff header. See #970. */
   base_branch_override?: string | null;
+  /** Per-session status signal set via `aoe session signal` or the sidebar
+   *  context menu. Drives the colored signal dot. Absent for idle. See
+   *  #2383. */
+  signal?: SessionSignal | null;
   is_sandboxed: boolean;
   /** True when the session was created in scratch mode (`aoe add
    *  --scratch` or the wizard toggle). The `project_path` points


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a per-session status signal so an agent can tell the operator what it needs without anyone opening the session. A signal is `blocked`, `working`, or `done`, rendered as a colored dot in the web sidebar, which turns the session list into a scannable fleet status board.

The key design call (settled via `/debate`): this is a semantic signal, not a raw color. A stored color string would couple persistence to CSS and could never drive future sorting, filtering, or notifications; a meaning can. Decorative per-session color is left out as YAGNI.

Set it from the CLI with `aoe session signal <state> [session]`. The session argument is optional and defaults to the session owning the current tmux pane, so a running agent self-signals with a bare `aoe session signal working` and clears with `aoe session signal clear`. It also accepts the three traffic-light color words (`red`/`amber`/`green`) as input-only aliases that persist as the canonical state. From the web dashboard, a Signal submenu on the session row context menu sets or clears it.

Stored as `Option<SessionSignal>` on `Instance` with a serde default, so old `sessions.json` files deserialize unchanged and no migration is needed. The web round-trips through a new `PATCH /api/sessions/{id}/signal` endpoint that mirrors the existing pin handler.

Closes #2383

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Inside a session's own tmux pane, run `aoe session signal working`; the row's sidebar dot turns amber with no session id needed.
- [ ] From anywhere, run `aoe session signal done <id>`; that session's dot turns green.
- [ ] Run `aoe session signal red <id>`; the dot turns red (the `red` alias persists as `blocked`).
- [ ] Run `aoe session signal clear` (or `none`); the dot disappears.
- [ ] Run `aoe session signal violet`; it errors listing the valid values instead of accepting a decorative color.
- [ ] Run `aoe session signal working` outside tmux with no session id; it hard-errors and points at the explicit-id form.
- [ ] In the web dashboard, right-click (or long-press) a session row, open the Signal submenu, pick Blocked/Working/Done; a colored dot appears. Pick Clear; it goes away. Reload the page; the dot persists (server-side, not localStorage).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`: extended the existing `SessionRowTriage` Vitest (already mapped via `triage.session-row-chips`) to cover the signal dot rendering and the submenu PATCH payloads (set + clear + no-op when unchanged). Per AGENTS.md, request-payload permutations belong in Vitest + RTL, not Playwright.

**TUI / CLI (e2e test)**
- [x] Skipped a full e2e, because: the CLI parsing (canonical states, color aliases, clear sentinels, rejection of the decorative palette) is covered by unit tests in `src/cli/session.rs`, the serde back-compat and round-trip by a unit test in `src/session/instance.rs`, and the mutation reuses the same `patch_instance` / `storage.update` idiom as `aoe session set-base`. Happy paths are listed under How to test for manual verification.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate, and implementation were drafted by Claude under my direction. I made the design calls (semantic signal over raw color, the CLI name and self-targeting behavior), reviewed each commit, and ran the test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784979836&installation_id=139138837&pr_number=2385&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2385&signature=611742b2f8231d8bff5e05b61450fb41bff61b243d299ce8a20f12b8f78cc9ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change adds a per-session status signal that shows up as a colored dot in the web sidebar and can be set from both the CLI and the web UI.

Key updates:
- Added new session states: `blocked`, `working`, and `done`
- Let agents default the CLI command to their current tmux-backed session
- Added support for clearing the signal, plus `red`/`amber`/`green` aliases for easier input
- Stored the signal on the server so it persists across refreshes and devices
- Added a new sidebar context-menu option to view and change the signal
- Exposed a new API route for updating session signals
- Updated docs and tests to cover the new workflow

Benefits:
- Makes the session sidebar useful as a quick fleet status board
- Lets running agents self-report progress without extra steps
- Keeps status durable instead of relying on client-side state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->