### PR TITLE
feat(plugin): tier 1 worker host: runtime resolution, ndjson worker protocol, capability-gated API, NoSandbox

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -257,9 +257,9 @@ Filesystem and `PATH` probing go through a `LaunchResolver` trait so the
 resolution policy is unit-tested with no real filesystem.
 
 Builtins do not declare a `[runtime]` in this release, so `resolve_launch`
-returns "no worker" for them. The `aoe __plugin-worker` self-exec path for a
-builtin worker, and the worker-side SDK, arrive with the first builtin worker
-that needs them; shipping them now would be unused code.
+returns `Err(LaunchError::NoRuntime)` for them. The `aoe __plugin-worker`
+self-exec path for a builtin worker, and the worker-side SDK, arrive with the
+first builtin worker that needs them; shipping them now would be unused code.
 
 ### Transport and supervision
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -82,7 +82,7 @@ write them, so the later API PRs (#2094, #2095) stay focused on behavior:
   by plugin id, persisted per session in `sessions.json`. Each plugin owns only
   its own slot; data for an uninstalled plugin is retained (cheap, and
   reinstalling restores it). The read/write/cas host API over it
-  (`session.meta.{get,set,cas}`) lands with the Tier 1 host (#2095).
+  (`session.meta.{get,set,cas}`) ships with the Tier 1 host (see below).
 
 Both fields are additive (`#[serde(default, skip_serializing_if = ...)]`):
 absent in older on-disk rows, so they deserialize to empty and need no data
@@ -124,8 +124,8 @@ exists, so no schema lands in core ahead of one (#2386). With
 
 The `runtime` section is one of two kinds: `command` (an argv launched from the
 plugin directory) or `release-binary` (a compiled worker shipped as a GitHub
-release asset). Only installation acts on `release-binary` today (it downloads
-the asset); launching either worker is #2095.
+release asset). Installation resolves and downloads a `release-binary` asset;
+the Tier 1 host (below) launches and supervises both kinds.
 
 ## Capabilities and grants (#2093)
 
@@ -226,11 +226,100 @@ plugin tampered after install.
 `aoe plugin hash <dir>` prints the tree hash for a plugin directory so an author
 can produce the value a maintainer pins. Run it on a clean checkout.
 
+## Tier 1 worker host (#2095)
+
+The worker host runs inside the `aoe serve` daemon (it is `serve`-gated, like
+`aoe.web`), because the host API it exposes reads and writes the event store and
+session storage the daemon owns. A TUI-only build has no host. The daemon builds
+one `PluginHost` at startup, launches a worker for every active plugin that
+declares a `[runtime]`, and reaps them all on shutdown
+(`AppState.plugin_host`, `src/server/mod.rs`).
+
+### Launching a worker, language-agnostically
+
+The host, not the plugin, decides how to resolve and execute a worker.
+`src/plugin/launch.rs` turns a `LoadedPlugin` into a `ResolvedLaunch { program,
+args, cwd, env }`, dispatched off the `[runtime]` kind in a single `match`.
+Adding a new runtime kind later is a new arm there; the supervisor and the
+transport only ever see a `ResolvedLaunch`, so nothing downstream changes.
+
+- `command`: `argv[0]` resolves on `PATH` via `which` when it is a bare name (a
+  console-script entrypoint like `aoe-github-worker`, or an interpreter like
+  `python3`), or relative to the plugin directory when it contains a separator
+  (an in-tree script or binary), verified executable. Absolute and
+  parent-traversal paths are rejected.
+- `release-binary`: the per-platform binary that installation already placed in
+  the plugin directory.
+
+A missing runtime fails loudly with an actionable hint naming the program (and,
+for a binary, the host `os-arch`), matching the project's error-with-hint style.
+Filesystem and `PATH` probing go through a `LaunchResolver` trait so the
+resolution policy is unit-tested with no real filesystem.
+
+Builtins do not declare a `[runtime]` in this release, so `resolve_launch`
+returns "no worker" for them. The `aoe __plugin-worker` self-exec path for a
+builtin worker, and the worker-side SDK, arrive with the first builtin worker
+that needs them; shipping them now would be unused code.
+
+### Transport and supervision
+
+A worker is an executable speaking newline-delimited JSON-RPC 2.0
+(`src/plugin/protocol.rs`) over its stdio: it writes one request object per line
+to stdout and reads one response per line on stdin. The host is the server. Any
+language that speaks this wire is a valid worker.
+
+The worker is a child owned by the daemon, not a detached process (this is the
+ACP supervision model minus its persistence half). There is no socket, no
+on-disk runner record, and no reattach: a plugin worker is a stateless
+transformer over a host-owned event stream, so surviving a daemon restart would
+only strand it with a stale view. The daemon dies, its workers die, a fresh
+daemon respawns them. What is kept from ACP: process-group reaping (a worker
+that forks helpers is torn down whole), a per-worker respawn budget so a crash
+loop does not spin, and a concurrency cap. The worker's stderr drains to
+`<app_dir>/plugin-workers/<id>.log`.
+
+### Capability-gated host API
+
+Each host method maps to a capability the plugin declared and was granted; the
+middleware refuses an undeclared or ungranted call before the method runs
+(`src/plugin/host_api.rs`). No new capabilities are introduced; the v1 methods
+reuse the existing taxonomy:
+
+| Method | Capability |
+| --- | --- |
+| `events.publish` / `events.subscribe` | `runtime.worker` |
+| `session.meta.get` | `session.read` |
+| `session.meta.set` / `session.meta.cas` | `session.write` |
+| `sessions.list` | `session.read` |
+
+`events.*` run over a shared plugin event bus (a `plugin_host` schema on the
+durable event-log substrate, `src/events/`); `subscribe { topics, after_seq }`
+is a replay-after-cursor read, so a worker polls forward from the last seq it
+saw. Session metadata is always read and written under the calling plugin's own
+`plugin_meta[<plugin-id>]` slot: the worker sends only a `key`, never another
+plugin's id, so one plugin cannot reach another's data. A `session.meta.cas`
+that loses returns the current value rather than clobbering it. Writes go
+through `Storage`'s cross-process lock, so the daemon picks them up on its next
+session reload (eventual consistency, not a live push).
+
+### Sandboxing
+
+`SandboxBackend` (`src/plugin/sandbox.rs`) is the seam between a resolved launch
+and the spawn. The only v1 backend is `NoSandbox`, which runs the worker as an
+ordinary child. Per D8 this is honest, not complete: capability gating at the
+host API boundary stops a cooperative plugin from overreaching, but a granted
+worker has no OS-level isolation, so an adversarial plugin is not contained. The
+capability grant prompt states this on every install. Restricted-environment,
+landlock, and `sandbox-exec` backends land later behind the same trait, with no
+change to the resolver or the supervisor.
+
 ## What comes next
 
-Each deferred piece returns as its own PR once the core is proven: the
-contribution registries and the JSON-RPC worker runtime and event bus built on
-the substrate above (issues 2094, 2095, and 2366), and the discovery layer over
-the featured index (issue 2365). Pinning a featured plugin's release-binary
-asset hash in `featured.toml` (so a featured worker is attested, not just its
-source) is a follow-up; today a release-binary plugin cannot be featured.
+Each deferred piece returns as its own PR once the core is proven: the Tier 0
+contribution registries and the command/keybind/UI surfaces (issues 2094 and
+2366), the builtin worker self-exec path and worker SDK (with the first builtin
+worker that needs them), and the discovery / featured supply-chain layer with
+integrity hashing (issues 2364 and 2365). Pinning a featured plugin's
+release-binary asset hash in `featured.toml` (so a featured worker is attested,
+not just its source) is a follow-up; today a release-binary plugin cannot be
+featured.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -169,6 +169,7 @@ pub const KNOWN_SUB_TARGETS: &[&str] = &[
     "acp.supervisor",
     "acp.event_store",
     "acp.runner",
+    "plugin.host",
     "terminal.ws",
     "terminal.ws.bytes",
     "auth.token",

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -130,6 +130,7 @@ pub const DEFAULT_TARGET_ROOTS: &[&str] = &[
     "containers",
     "git",
     "migrations",
+    "plugin",
     "web",
     // `log` is the meta-target prefix for filter-swap audit events
     // (`log.runtime`). Without this, `log.runtime` would be dropped

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -249,11 +249,16 @@ impl PluginHost {
 
     /// Reap every running worker. Called on daemon shutdown.
     pub async fn shutdown(&self) {
-        let mut running = self.running.lock().await;
-        for (plugin_id, w) in running.drain() {
+        // Drain under the lock, then reap without holding it: the escalating
+        // reap awaits a grace period, and we must not hold the running lock
+        // across that await.
+        let workers: Vec<_> = self.running.lock().await.drain().collect();
+        for (plugin_id, w) in workers {
             w.task.abort();
             if w.pid != 0 {
-                worker::terminate_process_group(w.pid);
+                // SIGTERM the group, wait the grace, then SIGKILL: a worker or
+                // forked helper that ignores SIGTERM must not survive shutdown.
+                worker::reap_group_escalating(w.pid, REAP_GRACE).await;
             }
             tracing::debug!(target: "plugin.host", plugin = %plugin_id, "stopped plugin worker");
         }

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -334,3 +334,85 @@ async fn serve_connection(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::host_api::PluginRpcContext;
+    use serde_json::json;
+
+    /// End-to-end over a real child process: a Node worker speaks ndjson
+    /// JSON-RPC through `serve_connection`, hits the capability gate on a method
+    /// it was not granted (`session.meta.set` with only `runtime.worker`), then
+    /// publishes the refusal code over the granted events path. The test reads
+    /// the event back, proving the wire, the capability gate, and the host
+    /// dispatch all work through a genuine subprocess. Node-gated like the ACP
+    /// fake-agent e2e; the capability refusal happens before any storage access,
+    /// so this needs no profile isolation.
+    #[tokio::test]
+    async fn worker_subprocess_round_trip_and_capability_gate() {
+        if which::which("node").is_err() {
+            eprintln!("skipping: node not found on PATH");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let api = Arc::new(
+            HostApiState::open(&tmp.path().join("plugin_events.db"), "default", 100).unwrap(),
+        );
+        // Granted only runtime.worker: events.* succeed, session.meta.set is
+        // refused with FORBIDDEN.
+        let ctx = PluginRpcContext {
+            plugin_id: "acme.worker".to_string(),
+            granted_capabilities: vec!["runtime.worker".to_string()],
+        };
+
+        // The worker: request a forbidden method, then publish the error code it
+        // got back over the granted events bus, then exit.
+        const WORKER: &str = r#"
+const rl = require('readline').createInterface({ input: process.stdin });
+let step = 0;
+rl.on('line', (line) => {
+  const resp = JSON.parse(line);
+  if (step === 0) {
+    step = 1;
+    const code = resp.error ? resp.error.code : 0;
+    process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:2,method:"events.publish",params:{topic:"result",payload:{forbidden_code:code}}}) + "\n");
+  } else {
+    process.exit(0);
+  }
+});
+process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:1,method:"session.meta.set",params:{session_id:"x",key:"k",value:1}}) + "\n");
+"#;
+
+        let mut child = tokio::process::Command::new("node")
+            .arg("-e")
+            .arg(WORKER)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+
+        serve_connection(&api, &ctx, stdout, stdin).await;
+        let _ = child.wait().await;
+
+        // Read the event the worker published: it carries the FORBIDDEN code the
+        // host returned for the ungranted session.meta.set.
+        let got = dispatch(
+            &api,
+            &ctx,
+            "events.subscribe",
+            &json!({ "topics": ["result"], "after_seq": 0 }),
+        )
+        .unwrap();
+        let events = got["events"].as_array().unwrap();
+        assert_eq!(events.len(), 1, "worker should have published one result");
+        assert_eq!(
+            events[0]["payload"]["forbidden_code"],
+            json!(codes::FORBIDDEN)
+        );
+    }
+}

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -256,7 +256,12 @@ impl PluginHost {
         // reap awaits a grace period, and we must not hold the running lock
         // across that await.
         let workers: Vec<_> = self.running.lock().await.drain().collect();
-        for (plugin_id, w) in workers {
+        // Reap in parallel: each escalating reap awaits up to REAP_GRACE before
+        // SIGKILL, so a sequential loop would make total shutdown scale with the
+        // worker count. The daemon's shutdown grace-period force-exit is armed
+        // only after this returns, so a bounded reap keeps that safety net
+        // meaningful. join_all bounds the whole thing to one REAP_GRACE.
+        futures_util::future::join_all(workers.into_iter().map(|(plugin_id, w)| async move {
             w.task.abort();
             if w.pid != 0 {
                 // SIGTERM the group, wait the grace, then SIGKILL: a worker or
@@ -264,7 +269,8 @@ impl PluginHost {
                 worker::reap_group_escalating(w.pid, REAP_GRACE).await;
             }
             tracing::debug!(target: "plugin.host", plugin = %plugin_id, "stopped plugin worker");
-        }
+        }))
+        .await;
     }
 }
 

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -1,0 +1,336 @@
+//! The Tier 1 plugin worker host: launch and supervise plugin workers.
+//!
+//! The host runs inside the `aoe serve` daemon. For each active community
+//! plugin that declares a `[runtime]`, it resolves a launch
+//! ([`crate::plugin::launch::resolve_launch`]), applies the sandbox backend
+//! ([`crate::plugin::sandbox`]), and spawns the worker as a child process that
+//! speaks newline-delimited JSON-RPC ([`crate::plugin::protocol`]) over its
+//! stdio. Each worker call is checked against the plugin's granted
+//! capabilities and dispatched to the host API
+//! ([`crate::plugin::host_api`]).
+//!
+//! Supervision is the ACP supervision model minus the persistence half: the
+//! worker is a child owned by this daemon, not a detached process. There is no
+//! socket, no on-disk runner record, and no reattach: a plugin worker is a
+//! stateless transformer over a host-owned event stream, so surviving a daemon
+//! restart would only strand it with a stale view. The daemon dies, the
+//! workers die, and a fresh daemon respawns them. What is kept from ACP:
+//! process-group reaping (a worker that forks helpers is torn down whole), a
+//! per-worker respawn budget so a crash loop does not spin, and a concurrency
+//! cap. The worker's stderr drains to `<plugin-workers>/<id>.log`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+use crate::plugin::host_api::{dispatch, HostApiState, PluginRpcContext};
+use crate::plugin::launch::{resolve_launch, OsLaunchResolver};
+use crate::plugin::protocol::{self, codes, RpcResponse};
+use crate::plugin::registry::PluginRegistry;
+use crate::plugin::sandbox::{NoSandbox, SandboxBackend};
+use crate::process::worker;
+
+/// Events kept per topic on the plugin event bus before the oldest are pruned.
+const EVENT_RETENTION_PER_TOPIC: usize = 10_000;
+/// Most workers the host runs at once. A cooperative cap, not a security one.
+const MAX_WORKERS: usize = 32;
+/// Respawn budget: at most this many restarts within [`RESPAWN_WINDOW`] before
+/// the host gives up on a crash-looping worker.
+const MAX_RESPAWNS: usize = 3;
+const RESPAWN_WINDOW: Duration = Duration::from_secs(60);
+/// Grace period between SIGTERM and SIGKILL when reaping a worker tree.
+const REAP_GRACE: Duration = Duration::from_secs(2);
+
+/// One supervised worker: the plugin it runs, its pid, and the task driving it.
+struct RunningWorker {
+    pid: u32,
+    task: tokio::task::JoinHandle<()>,
+}
+
+/// The plugin worker host, owned by the daemon for its lifetime.
+pub struct PluginHost {
+    api: Arc<HostApiState>,
+    sandbox: Arc<dyn SandboxBackend>,
+    workers_dir: PathBuf,
+    /// Running workers keyed by plugin id (one worker per plugin in v1).
+    running: Mutex<HashMap<String, RunningWorker>>,
+}
+
+impl PluginHost {
+    /// Build a host bound to `app_dir` (where the worker logs and the plugin
+    /// event-bus database live) and `profile` (whose session storage the host
+    /// API reads and writes). The only v1 sandbox backend is [`NoSandbox`].
+    pub fn new(app_dir: &std::path::Path, profile: &str) -> Result<Arc<Self>> {
+        let workers_dir = app_dir.join("plugin-workers");
+        worker::ensure_dir(&workers_dir)
+            .with_context(|| format!("prepare {}", workers_dir.display()))?;
+        let api = HostApiState::open(
+            &app_dir.join("plugin_events.db"),
+            profile,
+            EVENT_RETENTION_PER_TOPIC,
+        )?;
+        Ok(Arc::new(Self {
+            api: Arc::new(api),
+            sandbox: Arc::new(NoSandbox),
+            workers_dir,
+            running: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    /// Launch a worker for every active plugin that declares a runtime, up to
+    /// the concurrency cap. A plugin whose runtime cannot be resolved (a
+    /// missing interpreter or binary) is logged and skipped; it does not block
+    /// the others.
+    pub async fn start(self: &Arc<Self>, registry: &PluginRegistry) {
+        for plugin in registry.active() {
+            if plugin.manifest.runtime.is_none() {
+                continue;
+            }
+            {
+                let running = self.running.lock().await;
+                if running.len() >= MAX_WORKERS {
+                    tracing::warn!(
+                        target: "plugin.host",
+                        cap = MAX_WORKERS,
+                        "plugin worker concurrency cap reached; not launching {}",
+                        plugin.id()
+                    );
+                    break;
+                }
+            }
+            self.clone().launch(plugin.id().to_string()).await;
+        }
+    }
+
+    /// Spawn the supervising task for one plugin id. The task spawns the worker
+    /// process, runs its protocol loop, and respawns within the budget if it
+    /// exits.
+    async fn launch(self: Arc<Self>, plugin_id: String) {
+        let host = self.clone();
+        let id_for_task = plugin_id.clone();
+        let task = tokio::spawn(async move {
+            host.supervise(id_for_task).await;
+        });
+        // The pid is filled in by `supervise` on each spawn; record the task so
+        // shutdown can reap. A placeholder pid of 0 until the first spawn writes
+        // the real one is never used for signalling (supervise reaps its own
+        // child by the live pid it holds).
+        self.running
+            .lock()
+            .await
+            .insert(plugin_id, RunningWorker { pid: 0, task });
+    }
+
+    /// Drive one plugin's worker: spawn, serve, respawn within budget.
+    async fn supervise(self: Arc<Self>, plugin_id: String) {
+        let mut restarts: Vec<Instant> = Vec::new();
+        loop {
+            match self.spawn_once(&plugin_id).await {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::error!(
+                        target: "plugin.host",
+                        plugin = %plugin_id,
+                        "failed to launch plugin worker: {e:#}"
+                    );
+                    return;
+                }
+            }
+            let now = Instant::now();
+            restarts.retain(|t| now.duration_since(*t) < RESPAWN_WINDOW);
+            restarts.push(now);
+            if restarts.len() > MAX_RESPAWNS {
+                tracing::error!(
+                    target: "plugin.host",
+                    plugin = %plugin_id,
+                    "plugin worker exceeded respawn budget ({MAX_RESPAWNS} in {}s); giving up",
+                    RESPAWN_WINDOW.as_secs()
+                );
+                self.running.lock().await.remove(&plugin_id);
+                return;
+            }
+            tracing::warn!(
+                target: "plugin.host",
+                plugin = %plugin_id,
+                "plugin worker exited; respawning"
+            );
+        }
+    }
+
+    /// Spawn the worker process once and run its protocol loop until it exits.
+    /// Resolution and the granted-capability list are recomputed from the live
+    /// registry each spawn so an enable/disable/regrant between restarts is
+    /// honored.
+    async fn spawn_once(&self, plugin_id: &str) -> Result<()> {
+        let registry = crate::plugin::registry();
+        let plugin = registry
+            .get(plugin_id)
+            .filter(|p| p.active())
+            .ok_or_else(|| anyhow::anyhow!("plugin {plugin_id} is no longer active"))?;
+        let granted: Vec<String> = plugin
+            .manifest
+            .capabilities
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect();
+
+        let launch = resolve_launch(plugin, &OsLaunchResolver)?;
+        let prepared = self.sandbox.prepare(&launch)?;
+
+        let worker_id = uuid::Uuid::new_v4().to_string();
+        let log_path = worker::log_path(&self.workers_dir, &worker_id)?;
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .with_context(|| format!("open worker log {}", log_path.display()))?;
+
+        let mut cmd = tokio::process::Command::new(&prepared.program);
+        cmd.args(&prepared.args)
+            .current_dir(&prepared.cwd)
+            .env("AOE_PLUGIN_WORKER_ID", &worker_id)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::from(log))
+            .kill_on_drop(true);
+        for (k, v) in &prepared.env {
+            cmd.env(k, v);
+        }
+        // New session so the worker and any helpers it forks share one process
+        // group, reapable in one signal.
+        #[cfg(unix)]
+        unsafe {
+            cmd.pre_exec(|| {
+                nix::unistd::setsid().map_err(std::io::Error::other)?;
+                Ok(())
+            });
+        }
+
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("spawn worker for {plugin_id}"))?;
+        let pid = child.id().unwrap_or(0);
+        tracing::info!(
+            target: "plugin.host",
+            plugin = %plugin_id,
+            pid,
+            program = %prepared.program.display(),
+            "launched plugin worker"
+        );
+        if let Some(w) = self.running.lock().await.get_mut(plugin_id) {
+            w.pid = pid;
+        }
+
+        let stdin = child.stdin.take().context("worker stdin missing")?;
+        let stdout = child.stdout.take().context("worker stdout missing")?;
+        let ctx = PluginRpcContext {
+            plugin_id: plugin_id.to_string(),
+            granted_capabilities: granted,
+        };
+        serve_connection(&self.api, &ctx, stdout, stdin).await;
+
+        // The loop returned: the worker closed its stdout (exited or crashed).
+        // Reap the whole group so no forked helper is left behind, then let the
+        // caller decide whether to respawn.
+        if pid != 0 {
+            worker::reap_group_escalating(pid, REAP_GRACE).await;
+        }
+        let _ = child.wait().await;
+        Ok(())
+    }
+
+    /// Reap every running worker. Called on daemon shutdown.
+    pub async fn shutdown(&self) {
+        let mut running = self.running.lock().await;
+        for (plugin_id, w) in running.drain() {
+            w.task.abort();
+            if w.pid != 0 {
+                worker::terminate_process_group(w.pid);
+            }
+            tracing::debug!(target: "plugin.host", plugin = %plugin_id, "stopped plugin worker");
+        }
+    }
+}
+
+/// Read JSON-RPC requests from a worker's stdout, dispatch each through the
+/// capability-gated host API, and write the response to its stdin. Returns when
+/// the worker closes stdout or sends an unparseable line (fatal).
+async fn serve_connection(
+    api: &Arc<HostApiState>,
+    ctx: &PluginRpcContext,
+    stdout: tokio::process::ChildStdout,
+    mut stdin: tokio::process::ChildStdin,
+) {
+    let mut lines = BufReader::new(stdout).lines();
+    // Unbounded line read: per the honest model (D8) the worker is cooperative,
+    // not adversarial, so a malicious oversized line is out of scope here; an
+    // OS-level sandbox backend is where that ceiling belongs.
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => return, // EOF: worker exited.
+            Err(e) => {
+                tracing::warn!(target: "plugin.host", plugin = %ctx.plugin_id, "worker read error: {e}");
+                return;
+            }
+        };
+        let request = match protocol::parse_request(&line) {
+            Ok(Some(req)) => req,
+            Ok(None) => continue, // blank line
+            Err(e) => {
+                // A malformed line is a protocol violation; answer with a parse
+                // error (best effort) and stop reading from this worker.
+                let resp =
+                    RpcResponse::error(Value::Null, codes::PARSE_ERROR, e.to_string()).to_line();
+                let _ = stdin.write_all(resp.as_bytes()).await;
+                return;
+            }
+        };
+
+        // Dispatch does blocking SQLite and session-storage IO; run it off the
+        // async runtime. The handler is fully synchronous and self-contained.
+        let api = api.clone();
+        let ctx_id = ctx.plugin_id.clone();
+        let caps = ctx.granted_capabilities.clone();
+        let method = request.method.clone();
+        let params = request.params.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            let ctx = PluginRpcContext {
+                plugin_id: ctx_id,
+                granted_capabilities: caps,
+            };
+            dispatch(&api, &ctx, &method, &params)
+        })
+        .await;
+
+        // A notification (no id) gets no response, but still ran for its side
+        // effects above.
+        let Some(id) = request.id else {
+            continue;
+        };
+
+        let response = match outcome {
+            Ok(Ok(result)) => RpcResponse::success(id, result),
+            Ok(Err(e)) => RpcResponse::error(id, e.code, e.message),
+            Err(join_err) => RpcResponse::error(
+                id,
+                codes::INTERNAL_ERROR,
+                format!("host dispatch task failed: {join_err}"),
+            ),
+        };
+        if stdin
+            .write_all(response.to_line().as_bytes())
+            .await
+            .is_err()
+        {
+            return; // worker closed stdin; nothing more to say.
+        }
+    }
+}

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -89,23 +89,26 @@ impl PluginHost {
     /// missing interpreter or binary) is logged and skipped; it does not block
     /// the others.
     pub async fn start(self: &Arc<Self>, registry: &PluginRegistry) {
-        for plugin in registry.active() {
-            if plugin.manifest.runtime.is_none() {
-                continue;
+        let candidates: Vec<String> = registry
+            .active()
+            .filter(|p| p.manifest.runtime.is_some())
+            .map(|p| p.id().to_string())
+            .collect();
+        tracing::info!(
+            target: "plugin.host",
+            count = candidates.len(),
+            "launching plugin workers"
+        );
+        for id in candidates {
+            if self.running.lock().await.len() >= MAX_WORKERS {
+                tracing::warn!(
+                    target: "plugin.host",
+                    cap = MAX_WORKERS,
+                    "plugin worker concurrency cap reached; not launching {id}"
+                );
+                break;
             }
-            {
-                let running = self.running.lock().await;
-                if running.len() >= MAX_WORKERS {
-                    tracing::warn!(
-                        target: "plugin.host",
-                        cap = MAX_WORKERS,
-                        "plugin worker concurrency cap reached; not launching {}",
-                        plugin.id()
-                    );
-                    break;
-                }
-            }
-            self.clone().launch(plugin.id().to_string()).await;
+            self.clone().launch(id).await;
         }
     }
 

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -115,17 +115,15 @@ impl PluginHost {
     async fn launch(self: Arc<Self>, plugin_id: String) {
         let host = self.clone();
         let id_for_task = plugin_id.clone();
+        // Hold the lock across spawn and insert so `supervise` (which updates
+        // the pid under the same lock) cannot run its first `spawn_once` before
+        // the placeholder entry exists. Otherwise the pid update would no-op and
+        // shutdown could never reap the worker.
+        let mut running = self.running.lock().await;
         let task = tokio::spawn(async move {
             host.supervise(id_for_task).await;
         });
-        // The pid is filled in by `supervise` on each spawn; record the task so
-        // shutdown can reap. A placeholder pid of 0 until the first spawn writes
-        // the real one is never used for signalling (supervise reaps its own
-        // child by the live pid it holds).
-        self.running
-            .lock()
-            .await
-            .insert(plugin_id, RunningWorker { pid: 0, task });
+        running.insert(plugin_id, RunningWorker { pid: 0, task });
     }
 
     /// Drive one plugin's worker: spawn, serve, respawn within budget.

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -300,12 +300,27 @@ async fn serve_connection(
             }
         };
 
+        // The JSON parsed; now check the JSON-RPC envelope. A well-formed JSON
+        // object with the wrong shape is an invalid request, distinct from
+        // malformed JSON (PARSE_ERROR above). This message is rejected; the
+        // connection continues.
+        let method = match request.validate_envelope() {
+            Ok(m) => m.to_string(),
+            Err(msg) => {
+                let id = request.id.clone().unwrap_or(Value::Null);
+                let resp = RpcResponse::error(id, codes::INVALID_REQUEST, msg).to_line();
+                if stdin.write_all(resp.as_bytes()).await.is_err() {
+                    return;
+                }
+                continue;
+            }
+        };
+
         // Dispatch does blocking SQLite and session-storage IO; run it off the
         // async runtime. The handler is fully synchronous and self-contained.
         let api = api.clone();
         let ctx_id = ctx.plugin_id.clone();
         let caps = ctx.granted_capabilities.clone();
-        let method = request.method.clone();
         let params = request.params.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             let ctx = PluginRpcContext {

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -138,6 +138,9 @@ impl PluginHost {
                         plugin = %plugin_id,
                         "failed to launch plugin worker: {e:#}"
                     );
+                    // Drop the entry so a dead worker does not count against the
+                    // concurrency cap or block a later retry.
+                    self.running.lock().await.remove(&plugin_id);
                     return;
                 }
             }

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -431,4 +431,95 @@ mod tests {
         assert_eq!(events[0]["payload"]["n"], json!(2));
         assert_eq!(got["high_seq"], json!(3));
     }
+
+    /// Session metadata round-trip against real session storage: set, get, a
+    /// compare-and-swap that loses and one that wins, per-plugin namespace
+    /// isolation, and sessions.list. Isolated under a temp `XDG_CONFIG_HOME` so
+    /// it never touches real user state; serial because it mutates the env.
+    #[test]
+    #[serial_test::serial]
+    fn session_meta_cas_namespace_and_list() {
+        use crate::session::{Instance, Storage};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+
+        // Seed one session in the default profile's storage.
+        let storage = Storage::new_unwatched("default").unwrap();
+        let session_id = storage
+            .update(|instances, _groups| {
+                let inst = Instance::new("sess", "/tmp/plugin-host-test");
+                let id = inst.id.clone();
+                instances.push(inst);
+                Ok(id)
+            })
+            .unwrap();
+
+        let state =
+            HostApiState::open(&tmp.path().join("plugin_events.db"), "default", 100).unwrap();
+        let a = ctx(&[CAP_SESSION_READ, CAP_SESSION_WRITE]);
+
+        // set then get.
+        dispatch(
+            &state,
+            &a,
+            "session.meta.set",
+            &json!({"session_id": session_id, "key": "k", "value": 42}),
+        )
+        .unwrap();
+        let got = dispatch(
+            &state,
+            &a,
+            "session.meta.get",
+            &json!({"session_id": session_id, "key": "k"}),
+        )
+        .unwrap();
+        assert_eq!(got["value"], json!(42));
+
+        // CAS that loses (wrong expected) reports the current value, no clobber.
+        let lose = dispatch(
+            &state,
+            &a,
+            "session.meta.cas",
+            &json!({"session_id": session_id, "key": "k", "expected": 0, "value": 99}),
+        )
+        .unwrap();
+        assert_eq!(lose["swapped"], json!(false));
+        assert_eq!(lose["current"], json!(42));
+
+        // CAS that wins.
+        let win = dispatch(
+            &state,
+            &a,
+            "session.meta.cas",
+            &json!({"session_id": session_id, "key": "k", "expected": 42, "value": 99}),
+        )
+        .unwrap();
+        assert_eq!(win["swapped"], json!(true));
+
+        // A different plugin cannot see plugin "acme.worker"'s slot.
+        let b = PluginRpcContext {
+            plugin_id: "other.plugin".to_string(),
+            granted_capabilities: vec![CAP_SESSION_READ.to_string()],
+        };
+        let other = dispatch(
+            &state,
+            &b,
+            "session.meta.get",
+            &json!({"session_id": session_id, "key": "k"}),
+        )
+        .unwrap();
+        assert_eq!(other["value"], json!(null));
+
+        // sessions.list surfaces the seeded session.
+        let list = dispatch(&state, &a, "sessions.list", &json!({})).unwrap();
+        let sessions = list["sessions"].as_array().unwrap();
+        assert!(sessions.iter().any(|s| s["id"] == json!(session_id)));
+
+        match prev {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+    }
 }

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -461,8 +461,20 @@ mod tests {
     fn session_meta_cas_namespace_and_list() {
         use crate::session::{Instance, Storage};
 
+        // Restore XDG_CONFIG_HOME on drop, so a failing assertion does not leak
+        // the override into the rest of the test process.
+        struct XdgGuard(Option<std::ffi::OsString>);
+        impl Drop for XdgGuard {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var_os("XDG_CONFIG_HOME");
+        let _xdg = XdgGuard(std::env::var_os("XDG_CONFIG_HOME"));
         std::env::set_var("XDG_CONFIG_HOME", tmp.path());
 
         // Seed one session in the default profile's storage.
@@ -536,10 +548,5 @@ mod tests {
         let list = dispatch(&state, &a, "sessions.list", &json!({})).unwrap();
         let sessions = list["sessions"].as_array().unwrap();
         assert!(sessions.iter().any(|s| s["id"] == json!(session_id)));
-
-        match prev {
-            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
-        }
     }
 }

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -194,6 +194,16 @@ fn events_subscribe(state: &HostApiState, params: &Value) -> Result<Value, Dispa
         .get("topics")
         .and_then(Value::as_array)
         .ok_or_else(|| DispatchError::invalid_params("missing array param \"topics\""))?;
+    // `after_seq` is a single cursor, but each topic carries its own seq
+    // sequence (events_publish allocates per topic). Returning one `high_seq`
+    // across several topics would let a client advance past a slower topic and
+    // skip its later events. Until the response carries per-topic cursors, v1
+    // accepts exactly one topic per call.
+    if topics.len() != 1 {
+        return Err(DispatchError::invalid_params(
+            "\"topics\" currently supports exactly one topic; per-topic cursors are not implemented yet",
+        ));
+    }
     let after_seq = params.get("after_seq").and_then(Value::as_u64).unwrap_or(0);
 
     let conn = state.events.lock().unwrap_or_else(|p| p.into_inner());

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -1,0 +1,434 @@
+//! The capability-gated host API a plugin worker calls over the worker
+//! protocol.
+//!
+//! Every method maps to a capability the plugin must have declared in its
+//! manifest and had granted at install. The middleware
+//! ([`PluginRpcContext::require`]) refuses an undeclared or ungranted call
+//! before the method runs, so a worker can never reach a resource it was not
+//! approved for. This is the cooperative-plugin boundary of the honest v1
+//! model (D8): it stops a well-behaved plugin from overreaching; it does not
+//! contain an adversarial one (that needs the OS-level sandbox backends that
+//! land later behind [`crate::plugin::sandbox::SandboxBackend`]).
+//!
+//! v1 method list:
+//! - `events.publish { topic, payload }` and
+//!   `events.subscribe { topics, after_seq }` over a shared plugin event bus
+//!   (capability `runtime.worker`, which every worker holds to run at all).
+//! - `session.meta.get { session_id, key }` (`session.read`).
+//! - `session.meta.set { session_id, key, value }` and
+//!   `session.meta.cas { session_id, key, expected, value }` (`session.write`).
+//! - `sessions.list` (`session.read`).
+//!
+//! Per-plugin namespace: session metadata is always read and written under the
+//! calling plugin's own `Instance.plugin_meta[<plugin-id>]` slot. The worker
+//! sends only `key`; it can never name another plugin's id, so one plugin
+//! cannot touch another's metadata.
+
+use std::sync::Mutex;
+
+use rusqlite::Connection;
+use serde_json::{json, Value};
+
+use crate::events::{self, Order, Schema, SeqBound};
+use crate::plugin::protocol::codes;
+use crate::session::Storage;
+
+/// Capability required by each host method. Reused from the manifest taxonomy
+/// (`aoe_plugin_api::KNOWN_CAPABILITIES`); no new capability is introduced.
+const CAP_WORKER: &str = "runtime.worker";
+const CAP_SESSION_READ: &str = "session.read";
+const CAP_SESSION_WRITE: &str = "session.write";
+
+/// Shared, host-owned state behind the API: the plugin event bus and the
+/// profile whose session storage the API reads and writes. One per running
+/// host; cloned cheaply via `Arc` by each worker's dispatch task.
+pub struct HostApiState {
+    events: Mutex<Connection>,
+    schema: Schema,
+    /// How many events to keep per topic before the oldest are pruned.
+    retention: usize,
+    /// Session-storage profile the API operates on (the daemon's profile).
+    profile: String,
+}
+
+impl HostApiState {
+    /// Open (or create) the plugin event-bus database at `db_path` and bind the
+    /// API to `profile`'s session storage.
+    pub fn open(
+        db_path: &std::path::Path,
+        profile: &str,
+        retention: usize,
+    ) -> anyhow::Result<Self> {
+        let schema = Schema::new("plugin_host")?;
+        let conn = events::open(db_path, &schema)?;
+        Ok(Self {
+            events: Mutex::new(conn),
+            schema,
+            retention,
+            profile: profile.to_string(),
+        })
+    }
+
+    fn storage(&self) -> anyhow::Result<Storage> {
+        Storage::new_unwatched(&self.profile)
+    }
+}
+
+/// Per-worker call context: who is calling and what they were granted. Built
+/// once when the worker connects, from its `LoadedPlugin`.
+pub struct PluginRpcContext {
+    pub plugin_id: String,
+    pub granted_capabilities: Vec<String>,
+}
+
+impl PluginRpcContext {
+    /// Refuse the call unless the plugin holds `capability`.
+    fn require(&self, capability: &str) -> Result<(), DispatchError> {
+        if self.granted_capabilities.iter().any(|c| c == capability) {
+            Ok(())
+        } else {
+            Err(DispatchError {
+                code: codes::FORBIDDEN,
+                message: format!(
+                    "plugin {} did not declare or was not granted capability {capability:?}",
+                    self.plugin_id
+                ),
+            })
+        }
+    }
+}
+
+/// A failed dispatch, carrying the JSON-RPC error code and message to return.
+#[derive(Debug)]
+pub struct DispatchError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl DispatchError {
+    fn invalid_params(msg: impl Into<String>) -> Self {
+        Self {
+            code: codes::INVALID_PARAMS,
+            message: msg.into(),
+        }
+    }
+    fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            code: codes::INTERNAL_ERROR,
+            message: msg.into(),
+        }
+    }
+    fn method_not_found(method: &str) -> Self {
+        Self {
+            code: codes::METHOD_NOT_FOUND,
+            message: format!("unknown method {method:?}"),
+        }
+    }
+}
+
+/// Dispatch one request to its handler after the capability check. Returns the
+/// JSON result on success, or a [`DispatchError`] the transport turns into a
+/// JSON-RPC error response.
+pub fn dispatch(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    method: &str,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    match method {
+        "events.publish" => {
+            ctx.require(CAP_WORKER)?;
+            events_publish(state, params)
+        }
+        "events.subscribe" => {
+            ctx.require(CAP_WORKER)?;
+            events_subscribe(state, params)
+        }
+        "session.meta.get" => {
+            ctx.require(CAP_SESSION_READ)?;
+            session_meta_get(state, ctx, params)
+        }
+        "session.meta.set" => {
+            ctx.require(CAP_SESSION_WRITE)?;
+            session_meta_set(state, ctx, params)
+        }
+        "session.meta.cas" => {
+            ctx.require(CAP_SESSION_WRITE)?;
+            session_meta_cas(state, ctx, params)
+        }
+        "sessions.list" => {
+            ctx.require(CAP_SESSION_READ)?;
+            sessions_list(state)
+        }
+        other => Err(DispatchError::method_not_found(other)),
+    }
+}
+
+fn str_param<'a>(params: &'a Value, key: &str) -> Result<&'a str, DispatchError> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| DispatchError::invalid_params(format!("missing string param {key:?}")))
+}
+
+fn events_publish(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let topic = str_param(params, "topic")?;
+    let payload = params
+        .get("payload")
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"payload\""))?;
+    let payload_json =
+        serde_json::to_string(payload).map_err(|e| DispatchError::internal(e.to_string()))?;
+    let conn = state.events.lock().unwrap_or_else(|p| p.into_inner());
+    // The host assigns the seq, so a worker cannot forge ordering. Serialized
+    // by the connection mutex, so highest_seq + 1 is race-free within the host.
+    let seq = events::highest_seq(&conn, &state.schema, topic) + 1;
+    let created_at = chrono::Utc::now().timestamp_millis();
+    events::insert_event(&conn, &state.schema, topic, seq, &payload_json, created_at)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    events::prune_retention(&conn, &state.schema, topic, state.retention, &[]);
+    Ok(json!({ "seq": seq }))
+}
+
+fn events_subscribe(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let topics = params
+        .get("topics")
+        .and_then(Value::as_array)
+        .ok_or_else(|| DispatchError::invalid_params("missing array param \"topics\""))?;
+    let after_seq = params.get("after_seq").and_then(Value::as_u64).unwrap_or(0);
+
+    let conn = state.events.lock().unwrap_or_else(|p| p.into_inner());
+    let mut out = Vec::new();
+    let mut high_seq = after_seq;
+    for topic in topics {
+        let Some(topic) = topic.as_str() else {
+            return Err(DispatchError::invalid_params("\"topics\" must be strings"));
+        };
+        for (seq, payload_json) in events::scan(
+            &conn,
+            &state.schema,
+            topic,
+            SeqBound::After(after_seq),
+            Order::Asc,
+            None,
+        ) {
+            high_seq = high_seq.max(seq);
+            let payload: Value = serde_json::from_str(&payload_json).unwrap_or(Value::Null);
+            out.push(json!({ "topic": topic, "seq": seq, "payload": payload }));
+        }
+    }
+    Ok(json!({ "events": out, "high_seq": high_seq }))
+}
+
+/// Read this plugin's metadata object for `session_id` (its own namespaced
+/// slot), or `Value::Null` when the session or slot is absent.
+fn session_meta_get(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let session_id = str_param(params, "session_id")?;
+    let key = str_param(params, "key")?;
+    let storage = state
+        .storage()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let instances = storage
+        .load()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let inst = instances
+        .iter()
+        .find(|i| i.id == session_id)
+        .ok_or_else(|| DispatchError::invalid_params(format!("unknown session {session_id:?}")))?;
+    let value = inst
+        .plugin_meta
+        .get(&ctx.plugin_id)
+        .and_then(|slot| slot.get(key))
+        .cloned()
+        .unwrap_or(Value::Null);
+    Ok(json!({ "value": value }))
+}
+
+fn session_meta_set(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let session_id = str_param(params, "session_id")?.to_string();
+    let key = str_param(params, "key")?.to_string();
+    let value = params
+        .get("value")
+        .cloned()
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"value\""))?;
+    let plugin_id = ctx.plugin_id.clone();
+    let storage = state
+        .storage()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    storage
+        .update(|instances, _groups| {
+            let inst = instances
+                .iter_mut()
+                .find(|i| i.id == session_id)
+                .ok_or_else(|| anyhow::anyhow!("unknown session {session_id:?}"))?;
+            set_in_slot(inst, &plugin_id, &key, value.clone());
+            Ok(())
+        })
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "ok": true }))
+}
+
+/// Compare-and-swap a key in this plugin's slot: write `value` only if the
+/// current value equals `expected`. Returns `{ swapped, current }` so a losing
+/// writer sees the value that beat it rather than clobbering it.
+fn session_meta_cas(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let session_id = str_param(params, "session_id")?.to_string();
+    let key = str_param(params, "key")?.to_string();
+    let expected = params.get("expected").cloned().unwrap_or(Value::Null);
+    let value = params
+        .get("value")
+        .cloned()
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"value\""))?;
+    let plugin_id = ctx.plugin_id.clone();
+    let storage = state
+        .storage()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let (swapped, current) = storage
+        .update(|instances, _groups| {
+            let inst = instances
+                .iter_mut()
+                .find(|i| i.id == session_id)
+                .ok_or_else(|| anyhow::anyhow!("unknown session {session_id:?}"))?;
+            let current = inst
+                .plugin_meta
+                .get(&plugin_id)
+                .and_then(|slot| slot.get(&key))
+                .cloned()
+                .unwrap_or(Value::Null);
+            if current == expected {
+                set_in_slot(inst, &plugin_id, &key, value.clone());
+                Ok((true, value.clone()))
+            } else {
+                Ok((false, current))
+            }
+        })
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "swapped": swapped, "current": current }))
+}
+
+fn sessions_list(state: &HostApiState) -> Result<Value, DispatchError> {
+    let storage = state
+        .storage()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let instances = storage
+        .load()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let sessions: Vec<Value> = instances
+        .iter()
+        .map(|i| {
+            json!({
+                "id": i.id,
+                "title": i.title,
+                "project_path": i.project_path,
+                "tool": i.tool,
+                "status": format!("{:?}", i.status),
+            })
+        })
+        .collect();
+    Ok(json!({ "sessions": sessions }))
+}
+
+/// Set `key = value` inside `inst.plugin_meta[plugin_id]`, creating the slot as
+/// a JSON object if absent. The slot is namespaced to the plugin id, never a
+/// request parameter, which is what keeps one plugin out of another's data.
+fn set_in_slot(inst: &mut crate::session::Instance, plugin_id: &str, key: &str, value: Value) {
+    let slot = inst
+        .plugin_meta
+        .entry(plugin_id.to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !slot.is_object() {
+        *slot = Value::Object(serde_json::Map::new());
+    }
+    if let Some(map) = slot.as_object_mut() {
+        map.insert(key.to_string(), value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(caps: &[&str]) -> PluginRpcContext {
+        PluginRpcContext {
+            plugin_id: "acme.worker".to_string(),
+            granted_capabilities: caps.iter().map(|c| c.to_string()).collect(),
+        }
+    }
+
+    fn state(dir: &std::path::Path) -> HostApiState {
+        HostApiState::open(&dir.join("plugin_events.db"), "default", 100).unwrap()
+    }
+
+    #[test]
+    fn ungranted_capability_is_forbidden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        // No capabilities granted: even events.publish is refused.
+        let err = dispatch(
+            &state,
+            &ctx(&[]),
+            "events.publish",
+            &json!({"topic": "t", "payload": {}}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        // session.meta.set requires session.write specifically.
+        let err = dispatch(
+            &state,
+            &ctx(&[CAP_SESSION_READ]),
+            "session.meta.set",
+            &json!({"session_id": "s", "key": "k", "value": 1}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+    }
+
+    #[test]
+    fn unknown_method_is_method_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let err = dispatch(&state, &ctx(&[CAP_WORKER]), "no.such", &json!({})).unwrap_err();
+        assert_eq!(err.code, codes::METHOD_NOT_FOUND);
+    }
+
+    #[test]
+    fn events_publish_then_subscribe_replays_after_cursor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_WORKER]);
+        for n in 1..=3 {
+            dispatch(
+                &state,
+                &c,
+                "events.publish",
+                &json!({"topic": "build", "payload": {"n": n}}),
+            )
+            .unwrap();
+        }
+        // Subscribe after seq 1: see seq 2 and 3 only.
+        let got = dispatch(
+            &state,
+            &c,
+            "events.subscribe",
+            &json!({"topics": ["build"], "after_seq": 1}),
+        )
+        .unwrap();
+        let events = got["events"].as_array().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0]["seq"], json!(2));
+        assert_eq!(events[0]["payload"]["n"], json!(2));
+        assert_eq!(got["high_seq"], json!(3));
+    }
+}

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -272,16 +272,23 @@ fn session_meta_set(
     let storage = state
         .storage()
         .map_err(|e| DispatchError::internal(e.to_string()))?;
-    storage
+    // An unknown session is bad caller input, not a host failure, so the
+    // closure reports it as Ok(false) and we map that to INVALID_PARAMS,
+    // matching session_meta_get. Only a genuine storage error is INTERNAL.
+    let found = storage
         .update(|instances, _groups| {
-            let inst = instances
-                .iter_mut()
-                .find(|i| i.id == session_id)
-                .ok_or_else(|| anyhow::anyhow!("unknown session {session_id:?}"))?;
+            let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) else {
+                return Ok(false);
+            };
             set_in_slot(inst, &plugin_id, &key, value.clone());
-            Ok(())
+            Ok(true)
         })
         .map_err(|e| DispatchError::internal(e.to_string()))?;
+    if !found {
+        return Err(DispatchError::invalid_params(format!(
+            "unknown session {session_id:?}"
+        )));
+    }
     Ok(json!({ "ok": true }))
 }
 
@@ -304,12 +311,13 @@ fn session_meta_cas(
     let storage = state
         .storage()
         .map_err(|e| DispatchError::internal(e.to_string()))?;
-    let (swapped, current) = storage
+    // Ok(None) means the session does not exist (bad caller input ->
+    // INVALID_PARAMS, like session_meta_get); Ok(Some(..)) carries the result.
+    let outcome = storage
         .update(|instances, _groups| {
-            let inst = instances
-                .iter_mut()
-                .find(|i| i.id == session_id)
-                .ok_or_else(|| anyhow::anyhow!("unknown session {session_id:?}"))?;
+            let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) else {
+                return Ok(None);
+            };
             let current = inst
                 .plugin_meta
                 .get(&plugin_id)
@@ -318,12 +326,14 @@ fn session_meta_cas(
                 .unwrap_or(Value::Null);
             if current == expected {
                 set_in_slot(inst, &plugin_id, &key, value.clone());
-                Ok((true, value.clone()))
+                Ok(Some((true, value.clone())))
             } else {
-                Ok((false, current))
+                Ok(Some((false, current)))
             }
         })
         .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let (swapped, current) = outcome
+        .ok_or_else(|| DispatchError::invalid_params(format!("unknown session {session_id:?}")))?;
     Ok(json!({ "swapped": swapped, "current": current }))
 }
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -289,6 +289,15 @@ fn confirm_capabilities(id: &str, capabilities: &[String]) -> Result<bool> {
     for capability in capabilities {
         println!("  - {capability}");
     }
+    // The honest model (D8): the host enforces these capabilities at its API
+    // boundary, which stops a cooperative plugin from overreaching. It does NOT
+    // contain an adversarial plugin: a granted worker runs as an ordinary
+    // process with no OS-level isolation. State this on every grant prompt.
+    println!(
+        "Note: granting a capability trusts this plugin. The host checks capabilities at its API\n\
+         boundary, but a plugin worker runs without OS-level sandboxing, so a malicious plugin is\n\
+         not contained. Only install plugins you trust."
+    );
     print!("Grant them and install? [y/N] ");
     io::stdout().flush()?;
     let mut line = String::new();

--- a/src/plugin/launch.rs
+++ b/src/plugin/launch.rs
@@ -329,6 +329,7 @@ capabilities = ["runtime.worker"]
             manifest,
             enabled: true,
             trust: TrustLevel::Community,
+            validation: crate::plugin::registry::ValidationState::Community,
             source: Some("gh:acme/worker".into()),
             dir: dir.map(PathBuf::from),
             manifest_hash: "sha256:test".into(),

--- a/src/plugin/launch.rs
+++ b/src/plugin/launch.rs
@@ -401,8 +401,18 @@ capabilities = ["runtime.worker"]
 
     #[test]
     fn command_absolute_argv0_rejected() {
+        // `Path::is_absolute` is platform-specific: a Unix-style path is not
+        // absolute on Windows (it lacks a drive/UNC prefix), so pick an
+        // argv[0] that is absolute under the host's own semantics.
+        let argv0 = if cfg!(windows) {
+            "C:/Windows/py.exe"
+        } else {
+            "/usr/bin/python3"
+        };
         let p = plugin(
-            Some("[runtime]\nkind = \"command\"\ncommand = [\"/usr/bin/python3\"]"),
+            Some(&format!(
+                "[runtime]\nkind = \"command\"\ncommand = [\"{argv0}\"]"
+            )),
             Some("/plugins/acme.worker"),
         );
         let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();

--- a/src/plugin/launch.rs
+++ b/src/plugin/launch.rs
@@ -1,0 +1,450 @@
+//! Resolve a plugin's declared `[runtime]` into a concrete, launchable
+//! command, dispatched off the runtime kind.
+//!
+//! The host, not the plugin, decides how to turn a `RuntimeSpec` into a real
+//! program path. This module is the single place that branching lives: a
+//! `Command` runtime resolves its `argv[0]` on `PATH` or inside the plugin
+//! directory; a `ReleaseBinary` runtime points at the per-platform binary
+//! installation already placed in the plugin directory. Adding a new runtime
+//! kind later is a new match arm in [`resolve_launch`], not a rewrite of the
+//! supervisor or the transport: they only ever see a [`ResolvedLaunch`].
+//!
+//! Resolution is language-agnostic. The Python reference plugin declares a
+//! console-script entrypoint (`aoe-github-worker`) or an interpreter
+//! invocation (`python -m aoe_github_plugin.main`); a Rust/native plugin
+//! ships a `release-binary`. Both reach the worker through the same path.
+//!
+//! Filesystem and `PATH` probing go through the [`LaunchResolver`] trait so
+//! the resolution policy is unit-testable without touching the real
+//! filesystem.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use aoe_plugin_api::RuntimeSpec;
+
+use crate::plugin::registry::LoadedPlugin;
+
+/// Everything `std::process::Command` needs to launch a worker, computed once
+/// and free of any `RuntimeSpec` branching. The supervisor takes this, applies
+/// the sandbox backend, wires stdio, and spawns; it never re-inspects the
+/// manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLaunch {
+    /// Absolute program path to execute.
+    pub program: PathBuf,
+    /// Arguments after the program (the manifest argv tail, or empty).
+    pub args: Vec<String>,
+    /// Working directory: the plugin's installed directory.
+    pub cwd: PathBuf,
+    /// Environment overlay applied on top of the inherited host environment.
+    pub env: BTreeMap<String, String>,
+}
+
+/// Why a plugin's runtime could not be resolved into a launchable command.
+/// Every variant carries the plugin id and an actionable hint, matching the
+/// project's error-with-hint style.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum LaunchError {
+    #[error("plugin {plugin_id} declares no [runtime]; it has no worker to launch")]
+    NoRuntime { plugin_id: String },
+
+    #[error("plugin {plugin_id} declares a runtime but has no installed directory")]
+    NoPluginDir { plugin_id: String },
+
+    #[error(
+        "plugin {plugin_id}: worker program {program:?} was not found on PATH. \
+         Install it (for example `python3`), or declare a plugin-relative path such as `bin/{program}`."
+    )]
+    ProgramNotOnPath { plugin_id: String, program: String },
+
+    #[error(
+        "plugin {plugin_id}: argv[0] {arg:?} is an absolute path. \
+         Use a PATH program (such as `python3`) or a plugin-relative path (such as `bin/worker`)."
+    )]
+    AbsoluteArgv0 { plugin_id: String, arg: String },
+
+    #[error("plugin {plugin_id}: worker path {arg:?} escapes the plugin directory")]
+    PathEscape { plugin_id: String, arg: String },
+
+    #[error(
+        "plugin {plugin_id}: worker program {path} is missing. \
+         Reinstall with `aoe plugin update {plugin_id}`."
+    )]
+    InTreeMissing { plugin_id: String, path: PathBuf },
+
+    #[error("plugin {plugin_id}: worker program {path} is not executable. Run `chmod +x {path}`.")]
+    NotExecutable { plugin_id: String, path: PathBuf },
+
+    #[error(
+        "plugin {plugin_id}: no prebuilt worker binary {path} for this platform ({os}-{arch}). \
+         Reinstall with `aoe plugin update {plugin_id}`, or publish a release asset for this platform."
+    )]
+    ReleaseBinaryMissing {
+        plugin_id: String,
+        path: PathBuf,
+        os: String,
+        arch: String,
+    },
+}
+
+/// Indirection over `PATH` lookup and filesystem probing, so the resolution
+/// policy in [`resolve_launch`] can be exercised by unit tests with a fake
+/// that never touches the real filesystem. The real implementation is
+/// [`OsLaunchResolver`].
+pub trait LaunchResolver {
+    /// Resolve a bare program name on `PATH`, returning its absolute path.
+    fn which(&self, program: &str) -> Option<PathBuf>;
+    /// Whether `path` exists.
+    fn exists(&self, path: &Path) -> bool;
+    /// Whether `path` is a regular file with an executable bit (Unix) or
+    /// simply a file (non-Unix).
+    fn is_executable(&self, path: &Path) -> bool;
+}
+
+/// The production [`LaunchResolver`]: real `PATH` and filesystem.
+pub struct OsLaunchResolver;
+
+impl LaunchResolver for OsLaunchResolver {
+    fn which(&self, program: &str) -> Option<PathBuf> {
+        which::which(program).ok()
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn is_executable(&self, path: &Path) -> bool {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::metadata(path)
+                .map(|m| m.is_file() && (m.permissions().mode() & 0o111) != 0)
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            path.is_file()
+        }
+    }
+}
+
+/// Resolve a plugin's runtime into a launchable command.
+///
+/// The single dispatch site. A new `RuntimeSpec` variant becomes a new match
+/// arm here; nothing downstream changes. Builtins do not declare a runtime in
+/// this release, so a builtin (or any plugin with `runtime = None`) returns
+/// [`LaunchError::NoRuntime`]: it has no worker. The `aoe __plugin-worker`
+/// self-exec path for builtin workers arrives with the first builtin worker.
+pub fn resolve_launch(
+    plugin: &LoadedPlugin,
+    resolver: &dyn LaunchResolver,
+) -> Result<ResolvedLaunch, LaunchError> {
+    let plugin_id = plugin.id().to_string();
+    let runtime = plugin
+        .manifest
+        .runtime
+        .as_ref()
+        .ok_or_else(|| LaunchError::NoRuntime {
+            plugin_id: plugin_id.clone(),
+        })?;
+    let dir = plugin
+        .dir
+        .as_ref()
+        .ok_or_else(|| LaunchError::NoPluginDir {
+            plugin_id: plugin_id.clone(),
+        })?;
+
+    let (program, args) = match runtime {
+        RuntimeSpec::Command { command } => resolve_command(&plugin_id, dir, command, resolver)?,
+        RuntimeSpec::ReleaseBinary { asset, bin } => {
+            let target = bin.as_deref().unwrap_or(asset.as_str());
+            let path = resolve_in_tree(&plugin_id, dir, target, resolver, |path| {
+                LaunchError::ReleaseBinaryMissing {
+                    plugin_id: plugin_id.clone(),
+                    path,
+                    os: std::env::consts::OS.to_string(),
+                    arch: std::env::consts::ARCH.to_string(),
+                }
+            })?;
+            (path, Vec::new())
+        }
+    };
+
+    let mut env = BTreeMap::new();
+    env.insert("AOE_PLUGIN_ID".to_string(), plugin_id);
+
+    Ok(ResolvedLaunch {
+        program,
+        args,
+        cwd: dir.clone(),
+        env,
+    })
+}
+
+/// Resolve a `Command` runtime's argv into `(program, args)`.
+///
+/// `argv[0]` policy: an absolute path is rejected (it pins a host path and
+/// breaks portability); a path containing a separator is resolved relative to
+/// the plugin directory and verified executable; a bare name is resolved on
+/// `PATH` via `which` (the console-script / interpreter case).
+fn resolve_command(
+    plugin_id: &str,
+    dir: &Path,
+    command: &[String],
+    resolver: &dyn LaunchResolver,
+) -> Result<(PathBuf, Vec<String>), LaunchError> {
+    // The manifest validator guarantees a non-empty command with non-empty
+    // arguments, so `split_first` cannot fail in practice; treat an empty one
+    // as a missing runtime rather than panicking.
+    let (head, tail) = command
+        .split_first()
+        .ok_or_else(|| LaunchError::NoRuntime {
+            plugin_id: plugin_id.to_string(),
+        })?;
+
+    let program = if Path::new(head).is_absolute() {
+        return Err(LaunchError::AbsoluteArgv0 {
+            plugin_id: plugin_id.to_string(),
+            arg: head.clone(),
+        });
+    } else if head.contains('/') || head.contains('\\') {
+        resolve_in_tree(plugin_id, dir, head, resolver, |path| {
+            LaunchError::InTreeMissing {
+                plugin_id: plugin_id.to_string(),
+                path,
+            }
+        })?
+    } else {
+        resolver
+            .which(head)
+            .ok_or_else(|| LaunchError::ProgramNotOnPath {
+                plugin_id: plugin_id.to_string(),
+                program: head.clone(),
+            })?
+    };
+
+    Ok((program, tail.to_vec()))
+}
+
+/// Resolve a plugin-relative executable path under `dir`, rejecting traversal
+/// and verifying the file exists and is executable. `missing` builds the
+/// not-found error so callers can distinguish a command in-tree miss from a
+/// release-binary platform miss.
+fn resolve_in_tree(
+    plugin_id: &str,
+    dir: &Path,
+    rel: &str,
+    resolver: &dyn LaunchResolver,
+    missing: impl FnOnce(PathBuf) -> LaunchError,
+) -> Result<PathBuf, LaunchError> {
+    // Reject explicit parent traversal before joining. This is defense in
+    // depth: per the honest model (D8) the security boundary is not here, but
+    // a relative worker path should never reach outside its own directory.
+    if Path::new(rel)
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+        || Path::new(rel).is_absolute()
+    {
+        return Err(LaunchError::PathEscape {
+            plugin_id: plugin_id.to_string(),
+            arg: rel.to_string(),
+        });
+    }
+    let candidate = dir.join(rel);
+    if !resolver.exists(&candidate) {
+        return Err(missing(candidate));
+    }
+    if !resolver.is_executable(&candidate) {
+        return Err(LaunchError::NotExecutable {
+            plugin_id: plugin_id.to_string(),
+            path: candidate,
+        });
+    }
+    Ok(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aoe_plugin_api::{PluginManifest, TrustLevel};
+    use std::collections::HashSet;
+
+    /// A fake resolver: a fixed `PATH` map plus a set of existing and
+    /// executable in-tree paths. No real filesystem access.
+    struct FakeResolver {
+        path: BTreeMap<String, PathBuf>,
+        exists: HashSet<PathBuf>,
+        executable: HashSet<PathBuf>,
+    }
+
+    impl FakeResolver {
+        fn new() -> Self {
+            Self {
+                path: BTreeMap::new(),
+                exists: HashSet::new(),
+                executable: HashSet::new(),
+            }
+        }
+        fn on_path(mut self, name: &str, at: &str) -> Self {
+            self.path.insert(name.to_string(), PathBuf::from(at));
+            self
+        }
+        fn file(mut self, path: PathBuf, executable: bool) -> Self {
+            self.exists.insert(path.clone());
+            if executable {
+                self.executable.insert(path);
+            }
+            self
+        }
+    }
+
+    impl LaunchResolver for FakeResolver {
+        fn which(&self, program: &str) -> Option<PathBuf> {
+            self.path.get(program).cloned()
+        }
+        fn exists(&self, path: &Path) -> bool {
+            self.exists.contains(path)
+        }
+        fn is_executable(&self, path: &Path) -> bool {
+            self.executable.contains(path)
+        }
+    }
+
+    fn plugin(runtime: Option<&str>, dir: Option<&str>) -> LoadedPlugin {
+        let runtime_toml = runtime.map(|r| format!("\n{r}\n")).unwrap_or_default();
+        let manifest = PluginManifest::from_toml_str(&format!(
+            r#"
+id = "acme.worker"
+name = "Worker"
+version = "1.0.0"
+api_version = 2
+capabilities = ["runtime.worker"]
+{runtime_toml}
+"#
+        ))
+        .unwrap();
+        LoadedPlugin {
+            manifest,
+            enabled: true,
+            trust: TrustLevel::Community,
+            source: Some("gh:acme/worker".into()),
+            dir: dir.map(PathBuf::from),
+            manifest_hash: "sha256:test".into(),
+            granted: true,
+        }
+    }
+
+    #[test]
+    fn no_runtime_has_no_worker() {
+        let p = plugin(None, Some("/plugins/acme.worker"));
+        let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
+        assert!(matches!(err, LaunchError::NoRuntime { .. }));
+    }
+
+    #[test]
+    fn command_bare_name_resolves_on_path() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"python3\", \"-m\", \"acme.main\"]"),
+            Some("/plugins/acme.worker"),
+        );
+        let resolver = FakeResolver::new().on_path("python3", "/usr/bin/python3");
+        let launch = resolve_launch(&p, &resolver).unwrap();
+        assert_eq!(launch.program, PathBuf::from("/usr/bin/python3"));
+        assert_eq!(launch.args, vec!["-m".to_string(), "acme.main".to_string()]);
+        assert_eq!(launch.cwd, PathBuf::from("/plugins/acme.worker"));
+        assert_eq!(
+            launch.env.get("AOE_PLUGIN_ID").map(String::as_str),
+            Some("acme.worker")
+        );
+    }
+
+    #[test]
+    fn command_console_script_missing_on_path_fails_loudly() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"aoe-github-worker\"]"),
+            Some("/plugins/acme.worker"),
+        );
+        let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
+        match err {
+            LaunchError::ProgramNotOnPath { program, .. } => {
+                assert_eq!(program, "aoe-github-worker");
+            }
+            other => panic!("expected ProgramNotOnPath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_relative_path_resolves_in_plugin_dir() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"bin/worker\"]"),
+            Some("/plugins/acme.worker"),
+        );
+        let bin = PathBuf::from("/plugins/acme.worker/bin/worker");
+        let resolver = FakeResolver::new().file(bin.clone(), true);
+        let launch = resolve_launch(&p, &resolver).unwrap();
+        assert_eq!(launch.program, bin);
+    }
+
+    #[test]
+    fn command_relative_path_not_executable_fails() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"bin/worker\"]"),
+            Some("/plugins/acme.worker"),
+        );
+        let bin = PathBuf::from("/plugins/acme.worker/bin/worker");
+        let resolver = FakeResolver::new().file(bin, false);
+        let err = resolve_launch(&p, &resolver).unwrap_err();
+        assert!(matches!(err, LaunchError::NotExecutable { .. }));
+    }
+
+    #[test]
+    fn command_absolute_argv0_rejected() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"/usr/bin/python3\"]"),
+            Some("/plugins/acme.worker"),
+        );
+        let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
+        assert!(matches!(err, LaunchError::AbsoluteArgv0 { .. }));
+    }
+
+    #[test]
+    fn command_parent_traversal_rejected() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"../escape\"]"),
+            Some("/plugins/acme.worker"),
+        );
+        let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
+        assert!(matches!(err, LaunchError::PathEscape { .. }));
+    }
+
+    #[test]
+    fn release_binary_resolves_in_tree() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"release-binary\"\nasset = \"worker-${os}-${arch}\"\nbin = \"bin/worker\""),
+            Some("/plugins/acme.worker"),
+        );
+        let bin = PathBuf::from("/plugins/acme.worker/bin/worker");
+        let resolver = FakeResolver::new().file(bin.clone(), true);
+        let launch = resolve_launch(&p, &resolver).unwrap();
+        assert_eq!(launch.program, bin);
+        assert!(launch.args.is_empty());
+    }
+
+    #[test]
+    fn release_binary_missing_names_platform() {
+        let p = plugin(
+            Some("[runtime]\nkind = \"release-binary\"\nasset = \"worker\""),
+            Some("/plugins/acme.worker"),
+        );
+        let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
+        match err {
+            LaunchError::ReleaseBinaryMissing { os, arch, .. } => {
+                assert_eq!(os, std::env::consts::OS);
+                assert_eq!(arch, std::env::consts::ARCH);
+            }
+            other => panic!("expected ReleaseBinaryMissing, got {other:?}"),
+        }
+    }
+}

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -15,6 +15,20 @@ pub mod registry;
 pub mod source;
 pub mod view;
 
+// The Tier 1 worker host runs only in the `aoe serve` daemon, where the event
+// store and session storage it serves over the capability-gated API live. A
+// TUI-only build has no host, so these modules are gated with it.
+#[cfg(feature = "serve")]
+pub mod host;
+#[cfg(feature = "serve")]
+pub mod host_api;
+#[cfg(feature = "serve")]
+pub mod launch;
+#[cfg(feature = "serve")]
+pub mod protocol;
+#[cfg(feature = "serve")]
+pub mod sandbox;
+
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 

--- a/src/plugin/protocol.rs
+++ b/src/plugin/protocol.rs
@@ -1,0 +1,158 @@
+//! The plugin worker protocol: newline-delimited JSON-RPC 2.0 over the
+//! worker's stdio.
+//!
+//! A worker is the JSON-RPC client: it writes one request object per line to
+//! its stdout and reads one response object per line on its stdin. The host
+//! is the server. This is the language-agnostic wire contract; any executable
+//! that speaks it is a valid worker, which is why the host resolves and
+//! launches workers of different runtime kinds (see [`crate::plugin::launch`])
+//! through the same path.
+//!
+//! Notifications (no `id`) are accepted but produce no response. Anything the
+//! worker writes to stderr is never protocol; it is drained to the worker log.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// JSON-RPC error codes. The negative range below `-32000` is reserved by the
+/// spec for implementation-defined server errors; [`FORBIDDEN`] is ours, for a
+/// method whose capability the plugin did not declare or was not granted.
+pub mod codes {
+    pub const PARSE_ERROR: i64 = -32700;
+    pub const INVALID_REQUEST: i64 = -32600;
+    pub const METHOD_NOT_FOUND: i64 = -32601;
+    pub const INVALID_PARAMS: i64 = -32602;
+    pub const INTERNAL_ERROR: i64 = -32603;
+    /// Capability not declared or not granted for the calling plugin.
+    pub const FORBIDDEN: i64 = -32001;
+}
+
+/// One inbound request from a worker. `id` is absent for a notification.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcRequest {
+    #[serde(default)]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+impl RpcRequest {
+    /// A request with no `id` is a notification: the host must not answer it.
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+/// One outbound response to a worker. Exactly one of `result` / `error` is set.
+#[derive(Debug, Clone, Serialize)]
+pub struct RpcResponse {
+    pub jsonrpc: &'static str,
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+/// A JSON-RPC error object.
+#[derive(Debug, Clone, Serialize)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl RpcResponse {
+    pub fn success(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: Value, code: i64, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+
+    /// Serialize to a single ndjson line including the trailing newline.
+    pub fn to_line(&self) -> String {
+        // Serializing a plain struct of JSON values cannot fail.
+        let mut line = serde_json::to_string(self).unwrap_or_else(|_| {
+            r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"serialize failed"}}"#
+                .to_string()
+        });
+        line.push('\n');
+        line
+    }
+}
+
+/// Parse one ndjson line into a request. An empty or whitespace-only line is
+/// `Ok(None)` (skipped); malformed JSON is an error the caller reports as a
+/// parse error and treats as fatal to the worker.
+pub fn parse_request(line: &str) -> Result<Option<RpcRequest>, serde_json::Error> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str(trimmed).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_request_round_trip() {
+        let req = parse_request(r#"{"jsonrpc":"2.0","id":7,"method":"sessions.list","params":{}}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(req.method, "sessions.list");
+        assert_eq!(req.id, Some(json!(7)));
+        assert!(!req.is_notification());
+    }
+
+    #[test]
+    fn notification_has_no_id() {
+        let req = parse_request(r#"{"jsonrpc":"2.0","method":"events.publish","params":{}}"#)
+            .unwrap()
+            .unwrap();
+        assert!(req.is_notification());
+    }
+
+    #[test]
+    fn blank_line_is_skipped() {
+        assert!(parse_request("   ").unwrap().is_none());
+        assert!(parse_request("").unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_line_is_error() {
+        assert!(parse_request("{not json").is_err());
+    }
+
+    #[test]
+    fn response_lines_are_single_ndjson() {
+        let ok = RpcResponse::success(json!(1), json!({"ok": true})).to_line();
+        assert!(ok.ends_with('\n'));
+        assert_eq!(ok.matches('\n').count(), 1);
+        let parsed: Value = serde_json::from_str(ok.trim()).unwrap();
+        assert_eq!(parsed["result"]["ok"], json!(true));
+        assert_eq!(parsed["jsonrpc"], json!("2.0"));
+
+        let err = RpcResponse::error(json!(2), codes::FORBIDDEN, "nope").to_line();
+        let parsed: Value = serde_json::from_str(err.trim()).unwrap();
+        assert_eq!(parsed["error"]["code"], json!(codes::FORBIDDEN));
+        assert!(parsed.get("result").is_none());
+    }
+}

--- a/src/plugin/protocol.rs
+++ b/src/plugin/protocol.rs
@@ -28,11 +28,20 @@ pub mod codes {
 }
 
 /// One inbound request from a worker. `id` is absent for a notification.
+///
+/// Every field is optional at the serde layer so that any well-formed JSON
+/// object deserializes; the JSON-RPC 2.0 envelope is then validated by
+/// [`RpcRequest::validate_envelope`]. This keeps a parse failure meaning
+/// "malformed JSON" (PARSE_ERROR) and a bad request shape meaning
+/// "invalid request" (INVALID_REQUEST), rather than conflating the two.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RpcRequest {
     #[serde(default)]
+    pub jsonrpc: Option<String>,
+    #[serde(default)]
     pub id: Option<Value>,
-    pub method: String,
+    #[serde(default)]
+    pub method: Option<String>,
     #[serde(default)]
     pub params: Value,
 }
@@ -41,6 +50,20 @@ impl RpcRequest {
     /// A request with no `id` is a notification: the host must not answer it.
     pub fn is_notification(&self) -> bool {
         self.id.is_none()
+    }
+
+    /// Validate the JSON-RPC 2.0 envelope, returning the method name on success.
+    /// `jsonrpc` must be exactly `"2.0"` and `method` must be present and
+    /// non-empty; otherwise the request is well-formed JSON but not a valid
+    /// request, which the host reports as `INVALID_REQUEST`.
+    pub fn validate_envelope(&self) -> Result<&str, &'static str> {
+        if self.jsonrpc.as_deref() != Some("2.0") {
+            return Err("jsonrpc field must be \"2.0\"");
+        }
+        match self.method.as_deref() {
+            Some(m) if !m.is_empty() => Ok(m),
+            _ => Err("missing or empty \"method\""),
+        }
     }
 }
 
@@ -117,7 +140,7 @@ mod tests {
         let req = parse_request(r#"{"jsonrpc":"2.0","id":7,"method":"sessions.list","params":{}}"#)
             .unwrap()
             .unwrap();
-        assert_eq!(req.method, "sessions.list");
+        assert_eq!(req.validate_envelope().unwrap(), "sessions.list");
         assert_eq!(req.id, Some(json!(7)));
         assert!(!req.is_notification());
     }
@@ -128,6 +151,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(req.is_notification());
+        assert_eq!(req.validate_envelope().unwrap(), "events.publish");
     }
 
     #[test]
@@ -139,6 +163,23 @@ mod tests {
     #[test]
     fn malformed_line_is_error() {
         assert!(parse_request("{not json").is_err());
+    }
+
+    #[test]
+    fn well_formed_json_with_bad_envelope_is_not_a_parse_error() {
+        // Missing jsonrpc: parses fine, but the envelope is invalid.
+        let req = parse_request(r#"{"method":"sessions.list"}"#)
+            .unwrap()
+            .unwrap();
+        assert!(req.validate_envelope().is_err());
+        // Wrong jsonrpc version.
+        let req = parse_request(r#"{"jsonrpc":"1.0","method":"sessions.list"}"#)
+            .unwrap()
+            .unwrap();
+        assert!(req.validate_envelope().is_err());
+        // Missing method.
+        let req = parse_request(r#"{"jsonrpc":"2.0"}"#).unwrap().unwrap();
+        assert!(req.validate_envelope().is_err());
     }
 
     #[test]

--- a/src/plugin/sandbox.rs
+++ b/src/plugin/sandbox.rs
@@ -1,0 +1,81 @@
+//! Sandbox backends for plugin workers.
+//!
+//! A [`SandboxBackend`] sits between a resolved launch and the actual spawn,
+//! transforming how the worker process is isolated. The honest v1 model (D8 in
+//! `docs/development/internals/plugin-system.md`): capability gating at the
+//! host API boundary stops a cooperative plugin from reaching resources it did
+//! not declare. It does NOT contain an adversarial plugin: a worker that wants
+//! to read the filesystem or open a socket can, because [`NoSandbox`] runs it
+//! as an ordinary child process. OS-level isolation (a restricted environment,
+//! landlock, `sandbox-exec`) arrives later as additional backends behind this
+//! same trait, with no change to the supervisor or the resolver.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::plugin::launch::ResolvedLaunch;
+
+/// A launch after the sandbox backend has had its say. Today this is the same
+/// shape as [`ResolvedLaunch`] because [`NoSandbox`] is a pass-through, but a
+/// future backend (a container wrapper, a `sandbox-exec` profile) rewrites the
+/// program / args / env here without the supervisor knowing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedLaunch {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    pub cwd: PathBuf,
+    pub env: BTreeMap<String, String>,
+}
+
+/// How a plugin worker process is isolated from the host. The only v1 backend
+/// is [`NoSandbox`]; the trait exists so OS-level isolation can be added later
+/// at the same call site.
+pub trait SandboxBackend: Send + Sync {
+    /// A short stable name for diagnostics and the install prompt.
+    fn name(&self) -> &'static str;
+
+    /// Transform a resolved launch into the command actually spawned.
+    fn prepare(&self, launch: &ResolvedLaunch) -> anyhow::Result<PreparedLaunch>;
+}
+
+/// The v1 backend: run the worker as an ordinary child process, unchanged.
+/// Honest about offering no OS-level isolation; see the module docs.
+pub struct NoSandbox;
+
+impl SandboxBackend for NoSandbox {
+    fn name(&self) -> &'static str {
+        "none"
+    }
+
+    fn prepare(&self, launch: &ResolvedLaunch) -> anyhow::Result<PreparedLaunch> {
+        Ok(PreparedLaunch {
+            program: launch.program.clone(),
+            args: launch.args.clone(),
+            cwd: launch.cwd.clone(),
+            env: launch.env.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_sandbox_is_pass_through() {
+        let mut env = BTreeMap::new();
+        env.insert("AOE_PLUGIN_ID".to_string(), "acme.worker".to_string());
+        let launch = ResolvedLaunch {
+            program: PathBuf::from("/usr/bin/python3"),
+            args: vec!["-m".into(), "acme.main".into()],
+            cwd: PathBuf::from("/plugins/acme.worker"),
+            env: env.clone(),
+        };
+        let prepared = NoSandbox.prepare(&launch).unwrap();
+        assert_eq!(prepared.program, launch.program);
+        assert_eq!(prepared.args, launch.args);
+        assert_eq!(prepared.cwd, launch.cwd);
+        assert_eq!(prepared.env, env);
+        assert_eq!(NoSandbox.name(), "none");
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -756,18 +756,25 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // the worker log dir) is cheap and side-effect-free until workers launch,
     // which happens after the daemon is up. A failure here is logged, not fatal:
     // the daemon serves fine without plugin workers.
+    // The host API includes mutating session.meta.set/cas, so a read-only
+    // daemon must not run plugin workers at all: gate the host on !read_only.
     #[cfg(feature = "serve")]
-    let plugin_host = match crate::session::get_app_dir() {
-        Ok(app_dir) => match crate::plugin::host::PluginHost::new(&app_dir, profile) {
-            Ok(host) => Some(host),
+    let plugin_host = if read_only {
+        tracing::info!(target: "plugin.host", "plugin host disabled in read-only serve mode");
+        None
+    } else {
+        match crate::session::get_app_dir() {
+            Ok(app_dir) => match crate::plugin::host::PluginHost::new(&app_dir, profile) {
+                Ok(host) => Some(host),
+                Err(e) => {
+                    tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
+                    None
+                }
+            },
             Err(e) => {
                 tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
                 None
             }
-        },
-        Err(e) => {
-            tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
-            None
         }
     };
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -368,6 +368,10 @@ pub struct AppState {
     #[cfg(feature = "serve")]
     pub acp_supervisor:
         Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
+    /// The Tier 1 plugin worker host. `None` in test harnesses that do not
+    /// stand up a host; `Some` in a live daemon.
+    #[cfg(feature = "serve")]
+    pub plugin_host: Option<Arc<crate::plugin::host::PluginHost>>,
     /// Epoch-millis timestamp of the most recent authenticated API request.
     /// Updated by auth middleware on every successful auth. The push consumer
     /// checks this to suppress notifications when someone is actively using
@@ -748,6 +752,24 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         supervisor.hydrate_seqs(acp_event_store.all_session_seqs());
         supervisor
     };
+    // The Tier 1 plugin worker host. Opening it (the plugin event-bus database,
+    // the worker log dir) is cheap and side-effect-free until workers launch,
+    // which happens after the daemon is up. A failure here is logged, not fatal:
+    // the daemon serves fine without plugin workers.
+    #[cfg(feature = "serve")]
+    let plugin_host = match crate::session::get_app_dir() {
+        Ok(app_dir) => match crate::plugin::host::PluginHost::new(&app_dir, profile) {
+            Ok(host) => Some(host),
+            Err(e) => {
+                tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
+            None
+        }
+    };
 
     // Telemetry (opt-in, no-op otherwise): announce the serve surface on boot.
     // The boot announcement fires here, before transport setup, so a launch
@@ -977,6 +999,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         acp_event_store: acp_event_store.clone(),
         #[cfg(feature = "serve")]
         acp_supervisor: acp_supervisor.clone(),
+        #[cfg(feature = "serve")]
+        plugin_host: plugin_host.clone(),
         push: push_state,
         push_enabled,
         web_config: config.web.clone(),
@@ -1147,6 +1171,14 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // (feature disabled via web.notifications_enabled=false).
     push::spawn_consumer(state.clone());
 
+    // Launch plugin workers for every active plugin that declares a runtime.
+    // Non-blocking: each worker runs in its own supervised task. A daemon with
+    // no community plugin workers (the common case) does nothing here.
+    #[cfg(feature = "serve")]
+    if let Some(host) = state.plugin_host.clone() {
+        host.start(&crate::plugin::registry()).await;
+    }
+
     rate_limiter.spawn_cleanup_task(state.shutdown.clone());
     login_manager.spawn_cleanup_task(state.shutdown.clone());
 
@@ -1297,6 +1329,12 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             tracing::info!(target: "serve.shutdown", "received ctrl-c, shutting down");
         }
         shutdown_state.shutdown.cancel();
+        // Reap plugin workers before the force-exit deadline so no worker tree
+        // is left behind when the daemon stops.
+        #[cfg(feature = "serve")]
+        if let Some(host) = shutdown_state.plugin_host.clone() {
+            host.shutdown().await;
+        }
         tokio::spawn(async {
             tokio::time::sleep(SHUTDOWN_GRACE).await;
             tracing::warn!(
@@ -3976,6 +4014,7 @@ pub mod test_support {
             acp_events_tx,
             acp_event_store: event_store,
             acp_supervisor: supervisor,
+            plugin_host: None,
             push: None,
             push_enabled: false,
             web_config: crate::session::config::WebConfig::default(),

--- a/web/src/components/settings/customWidgets.tsx
+++ b/web/src/components/settings/customWidgets.tsx
@@ -186,6 +186,7 @@ const KNOWN_TARGETS: { value: string; group: string }[] = [
   { value: "acp.supervisor", group: "Structured view" },
   { value: "acp.event_store", group: "Structured view" },
   { value: "acp.runner", group: "Structured view" },
+  { value: "plugin.host", group: "Plugins" },
   { value: "terminal.ws", group: "Terminal" },
   { value: "terminal.ws.bytes", group: "Terminal" },
   { value: "auth.token", group: "Auth" },


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Implements the Tier 1 plugin host (issue #2095): the daemon-side runtime that
launches and supervises plugin workers, exposes a capability-gated host API to
them, and does so behind a sandbox seam whose only v1 backend is `NoSandbox`.

The host, not the plugin, decides how to resolve and execute a worker.
`src/plugin/launch.rs` turns a plugin's manifest `[runtime]` into a concrete
`ResolvedLaunch { program, args, cwd, env }` through a single `match` on the
runtime kind, so the model is language-agnostic and adding a new kind later is
one additional arm, not a rewrite:

- `command`: `argv[0]` resolves on `PATH` for a bare name (a console-script
  entrypoint like `aoe-github-worker`, or an interpreter like `python3`), or
  relative to the plugin directory for a path (an in-tree script or binary),
  verified executable. Absolute and parent-traversal paths are rejected.
- `release-binary`: the per-platform binary installation already placed in the
  plugin directory.

A missing runtime fails loudly with an actionable hint naming the program (and,
for a binary, the host `os-arch`). `PATH` and filesystem probing go through a
`LaunchResolver` trait so the resolution policy is unit-tested with no real
filesystem.

A worker is any executable speaking newline-delimited JSON-RPC 2.0 over its
stdio (`src/plugin/protocol.rs`). The host owns it as a child process, not a
detached one: a plugin worker is a stateless transformer over a host-owned event
stream, so surviving a daemon restart would only strand it with a stale view.
Kept from the ACP supervision model are process-group reaping, a respawn budget,
and a concurrency cap; dropped are the socket, the on-disk runner record, and
reattach. Each call is checked against the plugin's granted capabilities before
it runs (`src/plugin/host_api.rs`): `events.publish` / `events.subscribe`
(`runtime.worker`), `session.meta.get` (`session.read`),
`session.meta.set` / `session.meta.cas` (`session.write`), and `sessions.list`
(`session.read`). No new capabilities are introduced. Session metadata is
namespaced to the calling plugin's own `plugin_meta` slot; the worker sends only
a key, never another plugin's id.

`NoSandbox` runs the worker as an ordinary child. Per the honest model (D8),
capability gating stops a cooperative plugin from overreaching but does not
contain an adversarial one, so the capability grant prompt now states that on
every install. OS-level isolation lands later behind the same `SandboxBackend`
trait.

The worker spawn/execution model was chosen via `/debate` across four LLMs
(Gemini, GPT, Claude, Grok), as the maintainers requested. They converged
unanimously on stdio-owned children over the ACP detach/reattach model, on
deferring the `aoe __plugin-worker` builtin self-exec path and worker SDK until
a real builtin worker exists (no consumer today = dead code), and on keeping the
host daemon-only.

Coverage is lib-level: unit tests for the resolution policy (fake resolver, no
filesystem), the capability middleware, the JSON-RPC framing, and a
storage-backed `session.meta` CAS / namespace / `sessions.list` test; plus an
end-to-end test that drives a real Node worker over the ndjson wire through the
host, hitting the capability gate and the events path. No tmux/TUI e2e is added
because this PR adds no CLI subcommand or session-lifecycle behavior.

Closes #2095

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cargo test --lib --features serve plugin::` passes (resolution policy, capability gate, protocol framing, session.meta CAS + namespace, real-subprocess worker round-trip).
- [ ] Install an external Python plugin that declares `[runtime] kind = "command"` with `command = ["aoe-github-worker"]` (or `["python3", "-m", "aoe_..."]`) and grant its capabilities; `aoe serve` launches its worker on startup, and the worker log appears at `~/.agent-of-empires*/plugin-workers/<id>.log`.
- [ ] Stop the daemon (`aoe serve --stop` or Ctrl-C): the worker process and any helpers it forked are reaped, leaving no orphans.
- [ ] Declare a `command` runtime whose program is not on `PATH` (e.g. `["python3"]` on a host without python3): the host logs a loud, actionable error naming the missing program rather than failing silently.
- [ ] A worker calling a host method whose capability it was not granted (e.g. `session.meta.set` without `session.write`) receives a JSON-RPC Forbidden error; a granted call succeeds.
- [ ] `aoe plugin install <source>` for a plugin with capabilities prints the honest-sandbox note (no OS-level isolation) before the grant prompt.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The worker host is daemon-internal: no dashboard flow, no CLI subcommand (the
`aoe __plugin-worker` self-exec path is deferred), no TUI rendering. Coverage is
lib unit tests plus an in-crate end-to-end test that spawns a real Node worker
over the ndjson protocol.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus 4.8 via Claude Code, the `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the `/debate`-driven design across four LLMs, implementation, and
this prose were produced by Claude under my direction. I made the design calls,
reviewed each commit, and ran the test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784987421&installation_id=139138837&pr_number=2387&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2387&signature=d817b3ffa63900cdd65a47d287e6b0fbfc92f3c66540ca6b6e6300035c947d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a Tier 1, daemon-side plugin worker host so `aoe serve` can run plugin workers as supervised child processes. When a plugin declares a `[runtime]`, the daemon resolves it into a concrete launch configuration (supports both `command` and `release-binary`), starts the worker, speaks a newline-delimited JSON-RPC 2.0 protocol over stdio, and manages restarts using a respawn budget plus a global concurrency cap (including full process-group reaping on exit).

It also introduces a capability-gated host API that workers can call, enabling:
- `events.publish` / `events.subscribe`
- `session.meta.get|set|cas` (with strict per-plugin namespace isolation)
- `sessions.list`

Key additions include centralized, testable runtime resolution via a `LaunchResolver` trait (with clearer error reporting when executables are missing/invalid paths), a `SandboxBackend` abstraction with only `NoSandbox` implemented, and updated install prompts/docs that reflect the “capability gating ≠ OS isolation” model. Protocol framing/validation (including explicit forbidden-method handling) and a focused set of unit tests plus an end-to-end Node-based ndjson JSON-RPC test are included. Docs and logging UI wiring are updated to reflect the new internals and add the `plugin.host` logging target.

Benefits:
- More reliable plugin lifecycle management under the daemon (restart control and cleanup)
- Safer defaults via least-privilege capabilities and per-plugin session metadata isolation
- A clear, enforceable wire contract between workers and the host
- A structured path to add real OS-level sandbox backends later without changing the worker-host interface

Potential follow-ups: implement additional sandbox backends for OS-level isolation, and finalize future worker/builtin (`aoe __plugin-worker`) wiring once the execution path is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->