### PR TITLE
feat(plugins): featured/curated index + integrity hashing

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -673,7 +673,7 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 
 ###### **Subcommands:**
 
-* `list` — List every known plugin with version, trust, and state
+* `list` — List every known plugin with version, validation, and state
 * `info` — Show one plugin's manifest details
 * `enable` — Enable a plugin's contributions
 * `disable` — Disable a plugin; its settings stay on disk for re-enabling
@@ -686,7 +686,7 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 
 ## `aoe plugin list`
 
-List every known plugin with version, trust, and state
+List every known plugin with version, validation, and state
 
 **Usage:** `aoe plugin list`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -46,6 +46,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe plugin install`↴](#aoe-plugin-install)
 * [`aoe plugin update`↴](#aoe-plugin-update)
 * [`aoe plugin uninstall`↴](#aoe-plugin-uninstall)
+* [`aoe plugin hash`↴](#aoe-plugin-hash)
 * [`aoe profile`↴](#aoe-profile)
 * [`aoe profile list`↴](#aoe-profile-list)
 * [`aoe profile create`↴](#aoe-profile-create)
@@ -679,6 +680,7 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `install` — Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. Community plugins run at your own risk
 * `update` — Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
 * `uninstall` — Uninstall an external plugin, removing its files and capability grant
+* `hash` — Print the deterministic source tree hash for a plugin directory, the value a maintainer pins in the featured index
 
 
 
@@ -763,6 +765,18 @@ Uninstall an external plugin, removing its files and capability grant
 ###### **Arguments:**
 
 * `<ID>` — Plugin id
+
+
+
+## `aoe plugin hash`
+
+Print the deterministic source tree hash for a plugin directory, the value a maintainer pins in the featured index
+
+**Usage:** `aoe plugin hash <PATH>`
+
+###### **Arguments:**
+
+* `<PATH>` — Path to the plugin directory
 
 
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -180,12 +180,51 @@ skipped at load.
 `plugins.lock` (`<app_dir>/plugins.lock`, TOML, keyed by id, deterministic and
 timestamp-free like `Cargo.lock`) records each external plugin's resolved
 identity: source slug, requested ref, resolved commit, version, manifest hash,
-trust, and (for a release-binary) the release tag, asset name, and asset
-sha256.
+tree hash (see below), trust, and (for a release-binary) the release tag, asset
+name, and asset sha256. `lock_version` is 2; a `tree_hash`-less v1 lock still
+reads (the field defaults) and is repopulated on the next install/update.
+
+## Integrity hashing and the featured index (#2364)
+
+`plugin::integrity::tree_hash` is a deterministic `sha256:<hex>` over a plugin's
+source tree. Files are sorted by their forward-slash relative path and hashed
+under a versioned header (`aoe-plugin-tree-hash-v1`) as `file\0<path>\0<len>
+<content>`. `.git` is skipped (it is stripped from an installed tree); a symlink
+or non-UTF-8 path is a hard error so nothing installed escapes the hash. File
+mode is excluded for cross-platform determinism, and `git clone` runs with
+`core.autocrlf=false` so line endings never differ by platform. The hash is
+computed over the staged source **before** any release-binary worker is
+injected, so an author's `aoe plugin hash <checkout>` reproduces the
+install-time value; the downloaded worker stays pinned separately by the lock's
+`asset_sha256`.
+
+`plugins/featured.toml` is the curated index, compiled into the binary. Each
+entry pins one vetted release per plugin id to its `{source, tree_hash}`: a
+maintainer's attestation that this exact tree was reviewed. When a plugin id
+appears in the index, install and update **refuse** unless the fetched source
+slug (case-insensitive) and tree hash both match the pin, and a release-binary
+manifest is refused outright (its worker bytes are not covered by the tree hash
+yet). A featured-verified install is the one case allowed to claim a reserved
+(`aoe.*` / `agent-of-empires.*`) namespace; a builtin-id collision is always
+rejected. In debug builds `AOE_FEATURED_INDEX_PATH` overrides the embedded index
+for tests; a release binary always uses the compiled-in index, since the curated
+set is a root of trust and must not be redefinable by the environment.
+
+Every surface (CLI `aoe plugin list` / `info`, the TUI plugin manager, the web
+Plugins panel) shows a `ValidationState`: `builtin`, `featured` (installed from a
+featured-verified source), `community` (an unvetted GitHub install), or `local`
+(a local-directory install). It is recorded at install time via the lockfile's
+`trust` and read back at load, not recomputed each load; the manifest-hash grant
+check is what catches a community plugin tampered after install.
+
+`aoe plugin hash <dir>` prints the tree hash for a plugin directory so an author
+can produce the value a maintainer pins. Run it on a clean checkout.
 
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the
 contribution registries and the JSON-RPC worker runtime and event bus built on
-the substrate above (issues 2094, 2095, and 2366), and the discovery / featured
-supply-chain layer with integrity hashing (issues 2364 and 2365).
+the substrate above (issues 2094, 2095, and 2366), and the discovery layer over
+the featured index (issue 2365). Pinning a featured plugin's release-binary
+asset hash in `featured.toml` (so a featured worker is attested, not just its
+source) is a follow-up; today a release-binary plugin cannot be featured.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -211,11 +211,17 @@ for tests; a release binary always uses the compiled-in index, since the curated
 set is a root of trust and must not be redefinable by the environment.
 
 Every surface (CLI `aoe plugin list` / `info`, the TUI plugin manager, the web
-Plugins panel) shows a `ValidationState`: `builtin`, `featured` (installed from a
-featured-verified source), `community` (an unvetted GitHub install), or `local`
-(a local-directory install). It is recorded at install time via the lockfile's
-`trust` and read back at load, not recomputed each load; the manifest-hash grant
-check is what catches a community plugin tampered after install.
+Plugins panel) shows a `ValidationState`: `builtin`, `featured`, `community` (an
+unvetted GitHub install), or `local` (a local-directory install). `featured` is
+re-derived live at load (the id is in the embedded index and the on-disk tree
+hashes to the pin), not trusted from the lockfile, since that same derivation
+gates the reserved-namespace lift and the lockfile is user-writable; `community`
+vs `local` is derived from the install source. The lockfile records the tree
+hash and the install-time `trust` as a resolved record, but the load path does
+not depend on them for validation. The recompute is cheap (only ids the index
+names, and a featured plugin ships no release-binary, so its installed tree
+equals its source tree). The manifest-hash grant check still catches a community
+plugin tampered after install.
 
 `aoe plugin hash <dir>` prints the tree hash for a plugin directory so an author
 can produce the value a maintainer pins. Run it on a clean checkout.

--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -17,4 +17,6 @@
 #   source = "gh:agent-of-empires/example"
 #   tree_hash = "sha256:<hex>"
 
-[plugins]
+[plugins."agent-of-empires.github"]
+source = "gh:agent-of-empires/plugin-github"
+tree_hash = "sha256:f5f204416197c99c47f46d1e0d5c7f16cbc95150bf6a8b7ad2420851886d974b"

--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -1,0 +1,20 @@
+# Curated / featured plugin index (issue #2364).
+#
+# This file is compiled into the aoe binary. Each entry is a maintainer's
+# attestation that an exact plugin source tree was reviewed: install and update
+# refuse unless the plugin's fetched source slug and tree hash match the pin,
+# and a featured entry is the only thing that lets a community install claim a
+# reserved (`aoe.*` / `agent-of-empires.*`) namespace.
+#
+# An entry's `tree_hash` is produced by `aoe plugin hash <plugin-dir>` on a
+# clean checkout. Generate it on a canonical platform with LF line endings; the
+# hash covers source files only (a release-binary worker is not pinned here, so
+# release-binary plugins cannot be featured yet).
+#
+# Schema (one vetted pin per plugin id):
+#
+#   [plugins."agent-of-empires.example"]
+#   source = "gh:agent-of-empires/example"
+#   tree_hash = "sha256:<hex>"
+
+[plugins]

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -43,6 +43,12 @@ pub enum PluginCommands {
         /// Plugin id
         id: String,
     },
+    /// Print the deterministic source tree hash for a plugin directory, the
+    /// value a maintainer pins in the featured index
+    Hash {
+        /// Path to the plugin directory
+        path: String,
+    },
 }
 
 pub async fn run(command: PluginCommands) -> Result<()> {
@@ -54,7 +60,14 @@ pub async fn run(command: PluginCommands) -> Result<()> {
         PluginCommands::Install { source, yes } => run_install(&source, yes).await,
         PluginCommands::Update { id } => run_update(&id).await,
         PluginCommands::Uninstall { id } => run_uninstall(&id),
+        PluginCommands::Hash { path } => run_hash(&path),
     }
+}
+
+fn run_hash(path: &str) -> Result<()> {
+    let hash = crate::plugin::integrity::tree_hash(std::path::Path::new(path))?;
+    println!("{hash}");
+    Ok(())
 }
 
 fn state_label(plugin: &crate::plugin::LoadedPlugin) -> &'static str {
@@ -72,13 +85,13 @@ fn run_list() -> Result<()> {
     if registry.all().is_empty() {
         println!("No plugins installed.");
     } else {
-        println!("{:<20} {:<9} {:<10} STATE", "ID", "VERSION", "TRUST");
+        println!("{:<20} {:<9} {:<12} STATE", "ID", "VERSION", "VALIDATION");
         for plugin in registry.all() {
             println!(
-                "{:<20} {:<9} {:<10} {}",
+                "{:<20} {:<9} {:<12} {}",
                 plugin.id(),
                 plugin.manifest.version,
-                plugin.trust,
+                plugin.validation.as_str(),
                 state_label(plugin),
             );
         }
@@ -96,18 +109,18 @@ fn run_info(id: &str) -> Result<()> {
     };
     let m = &plugin.manifest;
     println!("{} ({})", m.name, m.id);
-    println!("  version:  {}", m.version);
-    println!("  trust:    {}", plugin.trust);
-    println!("  state:    {}", state_label(plugin));
+    println!("  version:    {}", m.version);
+    println!("  validation: {}", plugin.validation.as_str());
+    println!("  state:      {}", state_label(plugin));
     if let Some(source) = &plugin.source {
-        println!("  source:   {source}");
+        println!("  source:     {source}");
     }
     if m.capabilities.is_empty() {
-        println!("  caps:     none");
+        println!("  caps:       none");
     } else {
         let caps: Vec<&str> = m.capabilities.iter().map(|c| c.as_str()).collect();
         println!(
-            "  caps:     {} ({})",
+            "  caps:       {} ({})",
             caps.join(", "),
             if plugin.granted {
                 "granted"
@@ -117,7 +130,7 @@ fn run_info(id: &str) -> Result<()> {
         );
     }
     if !m.description.is_empty() {
-        println!("  about:    {}", m.description);
+        println!("  about:      {}", m.description);
     }
     Ok(())
 }

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -6,7 +6,7 @@ use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum PluginCommands {
-    /// List every known plugin with version, trust, and state
+    /// List every known plugin with version, validation, and state
     List,
     /// Show one plugin's manifest details
     Info {

--- a/src/plugin/featured.rs
+++ b/src/plugin/featured.rs
@@ -1,0 +1,90 @@
+//! The curated / featured plugin index.
+//!
+//! `plugins/featured.toml` is compiled into the binary and pins a vetted plugin
+//! release to its source [`tree_hash`](super::integrity::tree_hash). A featured
+//! entry is the maintainer's attestation that this exact tree was reviewed: it
+//! is what makes "is this plugin safe" answerable, and it is the only thing
+//! that lets a community install claim a reserved (`aoe.*` /
+//! `agent-of-empires.*`) namespace. Install and update refuse on a mismatch
+//! against the pin.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+/// The compiled-in index. Ships effectively empty; entries land as maintainers
+/// vet plugin releases.
+const EMBEDDED: &str = include_str!("../../plugins/featured.toml");
+
+/// One vetted pin, keyed by plugin id in the index.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FeaturedEntry {
+    /// The canonical source slug the plugin must be installed from
+    /// (`gh:owner/repo`).
+    pub source: String,
+    /// `sha256:<hex>` of the vetted source tree.
+    pub tree_hash: String,
+}
+
+/// The parsed featured index.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct FeaturedIndex {
+    #[serde(default)]
+    plugins: BTreeMap<String, FeaturedEntry>,
+}
+
+impl FeaturedIndex {
+    /// Load the curated index.
+    ///
+    /// In debug builds `AOE_FEATURED_INDEX_PATH` overrides the embedded file so
+    /// tests can supply their own pins. Release builds ALWAYS use the
+    /// compiled-in index: the curated set is a root of trust, so it must not be
+    /// redefinable by the process environment in a shipped binary (an env
+    /// override would let any caller elevate a malicious plugin into a reserved
+    /// namespace).
+    pub fn load() -> Result<Self> {
+        #[cfg(debug_assertions)]
+        if let Ok(path) = std::env::var("AOE_FEATURED_INDEX_PATH") {
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading AOE_FEATURED_INDEX_PATH {path}"))?;
+            return Self::from_toml_str(&text);
+        }
+        Self::from_toml_str(EMBEDDED)
+    }
+
+    pub fn from_toml_str(text: &str) -> Result<Self> {
+        toml::from_str(text).context("parsing featured plugin index")
+    }
+
+    pub fn get(&self, id: &str) -> Option<&FeaturedEntry> {
+        self.plugins.get(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_index_parses() {
+        // A broken embedded featured.toml is a build defect; catch it in CI.
+        FeaturedIndex::from_toml_str(EMBEDDED).expect("embedded featured.toml must parse");
+    }
+
+    #[test]
+    fn looks_up_by_id() {
+        let index = FeaturedIndex::from_toml_str(
+            r#"
+[plugins."agent-of-empires.example"]
+source = "gh:agent-of-empires/example"
+tree_hash = "sha256:abc"
+"#,
+        )
+        .unwrap();
+        let entry = index.get("agent-of-empires.example").expect("present");
+        assert_eq!(entry.source, "gh:agent-of-empires/example");
+        assert_eq!(entry.tree_hash, "sha256:abc");
+        assert!(index.get("acme.absent").is_none());
+    }
+}

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -33,6 +33,9 @@ pub struct FetchedPlugin {
     pub manifest: PluginManifest,
     /// Raw `aoe-plugin.toml` bytes, for hashing the grant against.
     pub manifest_bytes: Vec<u8>,
+    /// `sha256:<hex>` over the source tree, computed before any release-binary
+    /// is injected so it matches an author's `aoe plugin hash` of the checkout.
+    pub tree_hash: String,
     pub source: PluginSource,
     pub requested_ref: Option<String>,
     pub resolved_commit: Option<String>,
@@ -78,6 +81,11 @@ pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
 
     let (manifest, manifest_bytes) = read_manifest(&tree)?;
 
+    // Hash the source tree before any release-binary is injected below, so the
+    // value matches `aoe plugin hash` run on the author's checkout (which has
+    // no downloaded worker) and can be checked against the featured pin.
+    let tree_hash = super::integrity::tree_hash(&tree)?;
+
     let mut release_tag = None;
     let mut asset_name = None;
     let mut asset_sha256 = None;
@@ -109,6 +117,7 @@ pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
         tree,
         manifest,
         manifest_bytes,
+        tree_hash,
         source: source.clone(),
         requested_ref,
         resolved_commit,
@@ -163,21 +172,49 @@ fn path_arg(path: &Path) -> Result<&str> {
 fn git_clone_checkout(url: &str, reference: Option<&str>, dest: &Path) -> Result<String> {
     let dest_str = path_arg(dest)?;
 
+    // `core.autocrlf=false` keeps the checkout byte-for-byte as committed, so
+    // the tree hash is the same on every platform; without it a Windows clone
+    // would rewrite line endings and never match a pin generated on Linux.
     let shallow = match reference {
         Some(reference) => run_git(
             &[
-                "clone", "--depth", "1", "--branch", reference, "--", url, dest_str,
+                "-c",
+                "core.autocrlf=false",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                reference,
+                "--",
+                url,
+                dest_str,
             ],
             None,
         )
         .is_ok(),
-        None => run_git(&["clone", "--depth", "1", "--", url, dest_str], None).is_ok(),
+        None => run_git(
+            &[
+                "-c",
+                "core.autocrlf=false",
+                "clone",
+                "--depth",
+                "1",
+                "--",
+                url,
+                dest_str,
+            ],
+            None,
+        )
+        .is_ok(),
     };
 
     if !shallow {
         // A partial clone may have created dest; clear it before retrying.
         let _ = std::fs::remove_dir_all(dest);
-        run_git(&["clone", "--", url, dest_str], None)?;
+        run_git(
+            &["-c", "core.autocrlf=false", "clone", "--", url, dest_str],
+            None,
+        )?;
         if let Some(reference) = reference {
             // `--` separates the revision from pathspecs so a ref that begins
             // with a dash is not parsed as a flag.

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -237,9 +237,12 @@ fn git_clone_checkout(url: &str, reference: Option<&str>, dest: &Path) -> Result
     Ok(sha)
 }
 
-/// Recursively copy `src` into `dst`, skipping `.git` and symlinks.
-// ponytail: symlinks are skipped rather than followed; a local plugin dir with
-// symlinked content is rare and following them risks escaping the tree.
+/// Recursively copy `src` into `dst`, skipping `.git` and rejecting symlinks.
+///
+/// A symlink is a hard error rather than a silent skip: `integrity::tree_hash`
+/// also rejects symlinks, so skipping one here would make the install-time hash
+/// disagree with the `aoe plugin hash` an author runs on the same directory
+/// (and following one risks escaping the tree).
 fn copy_tree(src: &Path, dst: &Path) -> Result<()> {
     std::fs::create_dir_all(dst).with_context(|| format!("creating {}", dst.display()))?;
     for entry in std::fs::read_dir(src).with_context(|| format!("reading {}", src.display()))? {
@@ -252,7 +255,10 @@ fn copy_tree(src: &Path, dst: &Path) -> Result<()> {
         let from = entry.path();
         let to = dst.join(&name);
         if file_type.is_symlink() {
-            continue;
+            bail!(
+                "plugin source contains a symlink ({}); symlinks are not allowed",
+                from.display()
+            );
         } else if file_type.is_dir() {
             copy_tree(&from, &to)?;
         } else {
@@ -467,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn copy_tree_skips_git_and_symlinks() {
+    fn copy_tree_skips_git() {
         let src = tempfile::tempdir().unwrap();
         std::fs::write(src.path().join("aoe-plugin.toml"), b"x").unwrap();
         std::fs::create_dir(src.path().join(".git")).unwrap();
@@ -477,5 +483,18 @@ mod tests {
         copy_tree(src.path(), &into).unwrap();
         assert!(into.join("aoe-plugin.toml").exists());
         assert!(!into.join(".git").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_tree_rejects_symlinks() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("real"), b"x").unwrap();
+        std::os::unix::fs::symlink("real", src.path().join("link")).unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let err = copy_tree(src.path(), &dst.path().join("tree"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("symlink"), "got: {err}");
     }
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -4,10 +4,11 @@ use std::collections::BTreeSet;
 use std::io::{self, IsTerminal, Write};
 
 use anyhow::{anyhow, bail, Context, Result};
-use aoe_plugin_api::{PluginManifest, TrustLevel};
+use aoe_plugin_api::{PluginManifest, RuntimeSpec};
 
 use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
 
+use super::featured::FeaturedIndex;
 use super::fetch::{self, FetchedPlugin};
 use super::lockfile::{LockedPlugin, Lockfile};
 use super::source::PluginSource;
@@ -52,7 +53,8 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     let fetched = fetch::fetch(&source).await?;
 
     let id = fetched.manifest.id.as_str().to_string();
-    reject_reserved_or_builtin(&fetched.manifest)?;
+    let featured_verified = verify_featured(&FeaturedIndex::load()?, &fetched)?;
+    reject_reserved_or_builtin(&fetched.manifest, featured_verified)?;
 
     let final_dir = super::plugins_dir()?.join(&id);
     if final_dir.exists() {
@@ -78,7 +80,7 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
         &capabilities,
         &manifest_hash,
     )?;
-    write_lock(&id, &fetched, &manifest_hash)?;
+    write_lock(&id, &fetched, &manifest_hash, featured_verified)?;
     super::reload_registry();
 
     Ok(InstallReport {
@@ -112,7 +114,8 @@ pub async fn update(id: &str) -> Result<InstallReport> {
             fetched.manifest.id.as_str()
         );
     }
-    reject_reserved_or_builtin(&fetched.manifest)?;
+    let featured_verified = verify_featured(&FeaturedIndex::load()?, &fetched)?;
+    reject_reserved_or_builtin(&fetched.manifest, featured_verified)?;
 
     let capabilities = capability_strings(&fetched)?;
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
@@ -156,7 +159,7 @@ pub async fn update(id: &str) -> Result<InstallReport> {
 
     let granted = grant.is_some();
     persist_update(id, &source_str, grant)?;
-    write_lock(id, &fetched, &manifest_hash)?;
+    write_lock(id, &fetched, &manifest_hash, featured_verified)?;
     super::reload_registry();
 
     if caps_changed && !granted {
@@ -201,18 +204,52 @@ pub fn uninstall(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Reject a manifest whose id is reserved for first-party plugins (`aoe.*` /
-/// `agent-of-empires.*`, lifted only by featured verification in #2364) or
-/// collides with a compiled-in builtin.
-fn reject_reserved_or_builtin(manifest: &PluginManifest) -> Result<()> {
+/// Reject a manifest that collides with a compiled-in builtin (always) or that
+/// claims a reserved first-party namespace (`aoe.*` / `agent-of-empires.*`)
+/// without being featured-verified. A featured-verified plugin is the one case
+/// allowed into a reserved namespace (#2364).
+fn reject_reserved_or_builtin(manifest: &PluginManifest, featured_verified: bool) -> Result<()> {
     let id = manifest.id.as_str();
-    if manifest.id.is_reserved_namespace() {
-        bail!("plugin id {id:?} uses a reserved namespace (aoe.* / agent-of-empires.*); external plugins cannot");
-    }
     if super::registry::is_builtin_id(id) {
         bail!("plugin id {id:?} collides with a builtin plugin");
     }
+    if manifest.id.is_reserved_namespace() && !featured_verified {
+        bail!("plugin id {id:?} uses a reserved namespace (aoe.* / agent-of-empires.*); only a featured-verified plugin may claim one");
+    }
     Ok(())
+}
+
+/// Check a fetched plugin against the curated index. Returns whether it is a
+/// verified featured plugin.
+///
+/// If the id is in the index, the install MUST match the pin: the source slug
+/// (case-insensitively, GitHub slugs are not case-sensitive) and the source
+/// tree hash both have to match, and a release-binary worker is refused (its
+/// bytes are not covered by the tree hash yet, so a featured pin cannot vouch
+/// for them). Any mismatch is a hard error, not a silent demotion: a featured
+/// id is only ever installed at its vetted tree.
+fn verify_featured(featured: &FeaturedIndex, fetched: &FetchedPlugin) -> Result<bool> {
+    let id = fetched.manifest.id.as_str();
+    let Some(entry) = featured.get(id) else {
+        return Ok(false);
+    };
+    if matches!(
+        fetched.manifest.runtime,
+        Some(RuntimeSpec::ReleaseBinary { .. })
+    ) {
+        bail!("{id} is featured but ships a release-binary worker, which the featured index cannot pin yet; refusing install");
+    }
+    let slug = fetched.source.slug();
+    if !slug.eq_ignore_ascii_case(&entry.source) {
+        bail!(
+            "{id} is featured from {:?} but you are installing from {slug:?}; refusing install",
+            entry.source
+        );
+    }
+    if fetched.tree_hash != entry.tree_hash {
+        bail!("{id} does not match its featured pin (source tree hash mismatch); refusing install");
+    }
+    Ok(true)
 }
 
 /// The manifest's capabilities as strings, rejecting any this host does not
@@ -322,7 +359,12 @@ fn persist_update(id: &str, source: &str, grant: Option<CapabilityGrant>) -> Res
     save_config(&config)
 }
 
-fn write_lock(id: &str, fetched: &FetchedPlugin, manifest_hash: &str) -> Result<()> {
+fn write_lock(
+    id: &str,
+    fetched: &FetchedPlugin,
+    manifest_hash: &str,
+    featured_verified: bool,
+) -> Result<()> {
     let mut lock = Lockfile::load()?;
     lock.upsert(
         id,
@@ -332,7 +374,13 @@ fn write_lock(id: &str, fetched: &FetchedPlugin, manifest_hash: &str) -> Result<
             resolved_commit: fetched.resolved_commit.clone(),
             version: fetched.manifest.version.clone(),
             manifest_hash: manifest_hash.to_string(),
-            trust: TrustLevel::Community.as_str().to_string(),
+            tree_hash: fetched.tree_hash.clone(),
+            trust: if featured_verified {
+                "featured"
+            } else {
+                "community"
+            }
+            .to_string(),
             release_tag: fetched.release_tag.clone(),
             asset_name: fetched.asset_name.clone(),
             asset_sha256: fetched.asset_sha256.clone(),

--- a/src/plugin/integrity.rs
+++ b/src/plugin/integrity.rs
@@ -1,0 +1,154 @@
+//! Deterministic content hash over a plugin's source tree.
+//!
+//! This is the hash a maintainer pins in `plugins/featured.toml` and an author
+//! reproduces with `aoe plugin hash`. It covers the source files only: a
+//! downloaded release-binary worker is excluded (it is injected after this is
+//! computed, and is pinned separately by the lockfile's `asset_sha256`), so an
+//! author's repo checkout and the installed tree hash to the same value.
+//!
+//! The format is versioned (`HASH_PREFIX`) so the hashed fields can change
+//! later (for example folding in the executable bit once #2095 launches
+//! workers) without a new value silently colliding with an old pin.
+
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use sha2::{Digest, Sha256};
+
+/// Domain-separation header. Bump the version when the hashed fields change.
+const HASH_PREFIX: &[u8] = b"aoe-plugin-tree-hash-v1\0";
+
+/// Deterministic `sha256:<hex>` over the files in `dir`.
+///
+/// Files are sorted by their forward-slash relative path; each contributes
+/// `file\0<path>\0<len><content>` to the digest, where `<len>` is the content
+/// length as 8 little-endian bytes so a path/content boundary is unambiguous.
+/// `.git` is skipped at every level (it is stripped from an installed tree). A
+/// symlink or a non-UTF-8 path is an error, not a silent skip, so nothing that
+/// would be installed escapes the hash. File mode is deliberately excluded for
+/// cross-platform determinism (Windows has no executable bit).
+pub fn tree_hash(dir: &Path) -> Result<String> {
+    let mut files = Vec::new();
+    collect(dir, dir, &mut files)?;
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    hasher.update(HASH_PREFIX);
+    for (rel, contents) in &files {
+        hasher.update(b"file\0");
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        hasher.update((contents.len() as u64).to_le_bytes());
+        hasher.update(contents);
+    }
+    Ok(format_digest(&hasher.finalize()))
+}
+
+fn collect(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> Result<()> {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry?;
+        if entry.file_name() == ".git" {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            bail!(
+                "plugin tree contains a symlink ({}); symlinks are not allowed in a hashed tree",
+                path.display()
+            );
+        }
+        if file_type.is_dir() {
+            collect(root, &path, out)?;
+        } else {
+            let rel = path
+                .strip_prefix(root)
+                .expect("entry path is under root")
+                .to_str()
+                .ok_or_else(|| anyhow!("non-UTF-8 path in plugin tree: {}", path.display()))?
+                .replace('\\', "/");
+            let contents =
+                std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+            out.push((rel, contents));
+        }
+    }
+    Ok(())
+}
+
+fn format_digest(digest: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, contents: &[u8]) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn stable_and_prefixed() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "aoe-plugin.toml", b"id = \"a.b\"\n");
+        write(dir.path(), "src/main.rs", b"fn main() {}\n");
+
+        let first = tree_hash(dir.path()).unwrap();
+        let second = tree_hash(dir.path()).unwrap();
+        assert_eq!(first, second, "hash is stable across runs");
+        assert!(first.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn content_change_flips_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "f.txt", b"one");
+        let before = tree_hash(dir.path()).unwrap();
+        write(dir.path(), "f.txt", b"two");
+        assert_ne!(before, tree_hash(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn order_independent_but_path_sensitive() {
+        // Two files swapping their contents must not hash the same: the path is
+        // bound to its content, not just concatenated alongside it.
+        let a = tempfile::tempdir().unwrap();
+        write(a.path(), "x", b"1");
+        write(a.path(), "y", b"2");
+        let b = tempfile::tempdir().unwrap();
+        write(b.path(), "x", b"2");
+        write(b.path(), "y", b"1");
+        assert_ne!(tree_hash(a.path()).unwrap(), tree_hash(b.path()).unwrap());
+    }
+
+    #[test]
+    fn git_dir_is_skipped() {
+        let with_git = tempfile::tempdir().unwrap();
+        write(with_git.path(), "aoe-plugin.toml", b"x");
+        write(with_git.path(), ".git/config", b"junk");
+        let without_git = tempfile::tempdir().unwrap();
+        write(without_git.path(), "aoe-plugin.toml", b"x");
+        assert_eq!(
+            tree_hash(with_git.path()).unwrap(),
+            tree_hash(without_git.path()).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "real", b"x");
+        std::os::unix::fs::symlink("real", dir.path().join("link")).unwrap();
+        let err = tree_hash(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("symlink"), "got: {err}");
+    }
+}

--- a/src/plugin/lockfile.rs
+++ b/src/plugin/lockfile.rs
@@ -13,8 +13,10 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-/// Current lockfile schema version.
-const LOCK_VERSION: u32 = 1;
+/// Current lockfile schema version. Bumped to 2 when `tree_hash` was added: an
+/// older aoe must refuse a v2 lock (the `lock_version > LOCK_VERSION` guard)
+/// rather than round-trip it and silently drop the integrity field.
+const LOCK_VERSION: u32 = 2;
 
 /// The parsed `plugins.lock`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,7 +52,11 @@ pub struct LockedPlugin {
     pub version: String,
     /// `sha256:<hex>` of the installed manifest bytes.
     pub manifest_hash: String,
-    /// `builtin` or `community`.
+    /// `sha256:<hex>` over the source tree (see [`crate::plugin::integrity`]).
+    /// Defaulted when reading a pre-v2 lock; always written going forward.
+    #[serde(default)]
+    pub tree_hash: String,
+    /// `featured`, `community`, or (historically) `builtin`.
     pub trust: String,
     /// The release tag the worker binary was pulled from (release-binary only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -130,6 +136,7 @@ mod tests {
                 resolved_commit: Some("deadbeef".into()),
                 version: "1.0.0".into(),
                 manifest_hash: "sha256:abc".into(),
+                tree_hash: "sha256:tree".into(),
                 trust: "community".into(),
                 release_tag: Some("v1.0.0".into()),
                 asset_name: Some("widget-x86_64.tar.gz".into()),
@@ -156,6 +163,7 @@ mod tests {
                 resolved_commit: None,
                 version: "0.1.0".into(),
                 manifest_hash: "sha256:abc".into(),
+                tree_hash: "sha256:tree".into(),
                 trust: "community".into(),
                 release_tag: None,
                 asset_name: None,

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,8 +6,10 @@
 //! installs, capability grants, and the Tier 0 / Tier 1 contribution surface
 //! return in follow-up PRs.
 
+pub mod featured;
 pub mod fetch;
 pub mod install;
+pub mod integrity;
 pub mod lockfile;
 pub mod registry;
 pub mod source;

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -11,7 +11,42 @@ use std::path::PathBuf;
 
 use aoe_plugin_api::{PluginManifest, TrustLevel};
 
+use super::lockfile::{LockedPlugin, Lockfile};
 use crate::session::{CapabilityGrant, Config};
+
+/// How an installed plugin was validated, the finer provenance the surfaces
+/// show. `TrustLevel` (builtin vs community) stays the coarse capability-policy
+/// axis; this is the user-facing "is this safe" label.
+///
+/// Recorded at install time (via the lockfile's `trust`) rather than recomputed
+/// on every load: the source tree hash is captured before any release-binary is
+/// injected, so re-hashing the installed directory would not reproduce it, and
+/// walking every plugin tree on each registry load is needless work. The
+/// manifest-hash grant check still deactivates a community plugin whose
+/// manifest is tampered after install.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationState {
+    /// Compiled into the binary.
+    Builtin,
+    /// External, installed from a featured-verified source (matched the curated
+    /// pin at install).
+    Featured,
+    /// External GitHub install, not in the featured index.
+    Community,
+    /// External local-directory install.
+    Local,
+}
+
+impl ValidationState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ValidationState::Builtin => "builtin",
+            ValidationState::Featured => "featured",
+            ValidationState::Community => "community",
+            ValidationState::Local => "local",
+        }
+    }
+}
 
 /// A plugin compiled into the aoe binary.
 pub struct BuiltinPlugin {
@@ -47,6 +82,8 @@ pub struct LoadedPlugin {
     pub enabled: bool,
     /// Builtin (auto-granted) or community (capabilities gated).
     pub trust: TrustLevel,
+    /// Finer provenance for display (builtin / featured / community / local).
+    pub validation: ValidationState,
     /// Install source for an external plugin; `None` for builtins.
     pub source: Option<String>,
     /// On-disk directory for an external plugin; `None` for builtins.
@@ -117,6 +154,7 @@ impl PluginRegistry {
                         manifest,
                         enabled,
                         trust: TrustLevel::Builtin,
+                        validation: ValidationState::Builtin,
                         source: None,
                         dir: None,
                         manifest_hash,
@@ -130,7 +168,11 @@ impl PluginRegistry {
             }
         }
 
-        load_external(config, &mut plugins, &mut load_errors);
+        let lock = Lockfile::load().unwrap_or_else(|e| {
+            load_errors.push(format!("reading plugins.lock: {e:#}"));
+            Lockfile::default()
+        });
+        load_external(config, &lock, &mut plugins, &mut load_errors);
 
         Self {
             plugins,
@@ -159,7 +201,26 @@ impl PluginRegistry {
 
 /// Load external plugins from `<app_dir>/plugins/<id>/aoe-plugin.toml`. Each
 /// problem is collected as a non-fatal load error rather than aborting the set.
-fn load_external(config: &Config, plugins: &mut Vec<LoadedPlugin>, load_errors: &mut Vec<String>) {
+/// The display provenance for an external plugin: featured when the lockfile
+/// recorded a featured-verified install, otherwise local or community by source
+/// kind.
+fn validation_for(lock: Option<&LockedPlugin>, source: Option<&str>) -> ValidationState {
+    if lock.is_some_and(|l| l.trust == "featured") {
+        return ValidationState::Featured;
+    }
+    let source = source.or(lock.map(|l| l.source.as_str()));
+    match source {
+        Some(s) if s.starts_with("gh:") => ValidationState::Community,
+        _ => ValidationState::Local,
+    }
+}
+
+fn load_external(
+    config: &Config,
+    lock: &Lockfile,
+    plugins: &mut Vec<LoadedPlugin>,
+    load_errors: &mut Vec<String>,
+) {
     let root = match super::plugins_dir() {
         Ok(root) => root,
         Err(e) => {
@@ -238,11 +299,13 @@ fn load_external(config: &Config, plugins: &mut Vec<LoadedPlugin>, load_errors: 
             .and_then(|p| p.grant.as_ref())
             .map(|g| grant_covers(g, &manifest, &manifest_hash))
             .unwrap_or(false);
+        let validation = validation_for(lock.get(&id), source.as_deref());
 
         plugins.push(LoadedPlugin {
             manifest,
             enabled,
             trust: TrustLevel::Community,
+            validation,
             source,
             dir: Some(dir),
             manifest_hash,

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -7,21 +7,24 @@
 //! contributions go live only once the user has granted the capability set the
 //! installed manifest declares (the grant is pinned to the manifest hash).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use aoe_plugin_api::{PluginManifest, TrustLevel};
 
-use super::lockfile::{LockedPlugin, Lockfile};
+use super::featured::FeaturedIndex;
+use super::integrity;
 use crate::session::{CapabilityGrant, Config};
 
 /// How an installed plugin was validated, the finer provenance the surfaces
 /// show. `TrustLevel` (builtin vs community) stays the coarse capability-policy
 /// axis; this is the user-facing "is this safe" label.
 ///
-/// Recorded at install time (via the lockfile's `trust`) rather than recomputed
-/// on every load: the source tree hash is captured before any release-binary is
-/// injected, so re-hashing the installed directory would not reproduce it, and
-/// walking every plugin tree on each registry load is needless work. The
+/// `Featured` is re-derived live from the embedded index and the on-disk tree
+/// hash, never trusted from the (user-writable) lockfile: that derivation also
+/// gates the reserved-namespace lift, so it must not rest on data an attacker
+/// could edit. A featured plugin cannot ship a release-binary, so its installed
+/// tree equals its source tree and the recompute reproduces the pinned hash; it
+/// is also only run for the handful of ids the index actually names. The
 /// manifest-hash grant check still deactivates a community plugin whose
 /// manifest is tampered after install.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,11 +171,11 @@ impl PluginRegistry {
             }
         }
 
-        let lock = Lockfile::load().unwrap_or_else(|e| {
-            load_errors.push(format!("reading plugins.lock: {e:#}"));
-            Lockfile::default()
+        let featured = FeaturedIndex::load().unwrap_or_else(|e| {
+            load_errors.push(format!("reading featured plugin index: {e:#}"));
+            FeaturedIndex::default()
         });
-        load_external(config, &lock, &mut plugins, &mut load_errors);
+        load_external(config, &featured, &mut plugins, &mut load_errors);
 
         Self {
             plugins,
@@ -201,14 +204,22 @@ impl PluginRegistry {
 
 /// Load external plugins from `<app_dir>/plugins/<id>/aoe-plugin.toml`. Each
 /// problem is collected as a non-fatal load error rather than aborting the set.
-/// The display provenance for an external plugin: featured when the lockfile
-/// recorded a featured-verified install, otherwise local or community by source
-/// kind.
-fn validation_for(lock: Option<&LockedPlugin>, source: Option<&str>) -> ValidationState {
-    if lock.is_some_and(|l| l.trust == "featured") {
-        return ValidationState::Featured;
+/// The display provenance for an external plugin. `Featured` is verified live:
+/// the id must be in the embedded index and the on-disk tree must hash to the
+/// pin. The source-slug match is enforced at install (where the slug is
+/// canonical); here the content hash is the gate, since it is the strong check
+/// and avoids depending on how a persisted source string was canonicalized.
+fn validation_for(
+    featured: &FeaturedIndex,
+    id: &str,
+    dir: &Path,
+    source: Option<&str>,
+) -> ValidationState {
+    if let Some(entry) = featured.get(id) {
+        if integrity::tree_hash(dir).is_ok_and(|h| h == entry.tree_hash) {
+            return ValidationState::Featured;
+        }
     }
-    let source = source.or(lock.map(|l| l.source.as_str()));
     match source {
         Some(s) if s.starts_with("gh:") => ValidationState::Community,
         _ => ValidationState::Local,
@@ -217,7 +228,7 @@ fn validation_for(lock: Option<&LockedPlugin>, source: Option<&str>) -> Validati
 
 fn load_external(
     config: &Config,
-    lock: &Lockfile,
+    featured: &FeaturedIndex,
     plugins: &mut Vec<LoadedPlugin>,
     load_errors: &mut Vec<String>,
 ) {
@@ -276,7 +287,14 @@ fn load_external(
         };
         let id = manifest.id.as_str().to_string();
 
-        if manifest.id.is_reserved_namespace() {
+        let plugin_config = config.plugins.get(&id);
+        let source = plugin_config.and_then(|p| p.source.clone());
+        let validation = validation_for(featured, &id, &dir, source.as_deref());
+
+        // A reserved namespace is only allowed for a live featured-verified
+        // plugin; this is the load-time twin of the install gate, and it
+        // re-derives featured status rather than trusting the lockfile.
+        if manifest.id.is_reserved_namespace() && validation != ValidationState::Featured {
             load_errors.push(format!(
                 "plugin {id:?} at {} uses a reserved namespace and was skipped",
                 dir.display()
@@ -292,14 +310,11 @@ fn load_external(
         }
 
         let manifest_hash = PluginManifest::hash_bytes(&bytes);
-        let plugin_config = config.plugins.get(&id);
         let enabled = plugin_config.map(|p| p.enabled).unwrap_or(true);
-        let source = plugin_config.and_then(|p| p.source.clone());
         let granted = plugin_config
             .and_then(|p| p.grant.as_ref())
             .map(|g| grant_covers(g, &manifest, &manifest_hash))
             .unwrap_or(false);
-        let validation = validation_for(lock.get(&id), source.as_deref());
 
         plugins.push(LoadedPlugin {
             manifest,

--- a/src/plugin/view.rs
+++ b/src/plugin/view.rs
@@ -18,8 +18,8 @@ pub struct PluginView {
     pub enabled: bool,
     /// First-party builtin (compiled in) versus an externally installed plugin.
     pub builtin: bool,
-    /// `builtin` or `community`.
-    pub trust: String,
+    /// Validation provenance: `builtin`, `featured`, `community`, or `local`.
+    pub validation: String,
     /// Install source for an external plugin (`gh:owner/repo` or a path).
     pub source: Option<String>,
     /// Capabilities the plugin's manifest declares.
@@ -41,7 +41,7 @@ impl LoadedPlugin {
             description: self.manifest.description.clone(),
             enabled: self.enabled,
             builtin: self.builtin(),
-            trust: self.trust.as_str().to_string(),
+            validation: self.validation.as_str().to_string(),
             source: self.source.clone(),
             capabilities: self
                 .manifest

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -190,7 +190,7 @@ impl PluginManagerDialog {
                         Style::default().fg(theme.text),
                     ),
                     Span::styled(
-                        format!("{:<10}", row.trust),
+                        format!("{:<10}", row.validation),
                         Style::default().fg(theme.dimmed),
                     ),
                     Span::styled(format!("{:<14}", state.0), Style::default().fg(state.1)),

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -14,10 +14,17 @@ use serial_test::serial;
 use tempfile::TempDir;
 
 /// Isolate the app dir under a fresh temp HOME for the duration of a test.
+///
+/// Also clears `AOE_FEATURED_INDEX_PATH`: it is a process-global env var, and
+/// these tests are `#[serial]`, so a featured test that aborts before its own
+/// cleanup would otherwise leave a stale (deleted-tempdir) path that breaks
+/// every later test. Clearing it at the start of each test makes the isolation
+/// robust regardless of ordering or prior failures.
 fn isolate() -> TempDir {
     let home = tempfile::tempdir().expect("tempdir");
     std::env::set_var("HOME", home.path());
     std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
+    std::env::remove_var("AOE_FEATURED_INDEX_PATH");
     home
 }
 

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -97,7 +97,18 @@ api_version = 2
         "no-capability community plugin is active once installed"
     );
     assert_eq!(plugin.trust.as_str(), "community");
-    assert!(Lockfile::load().unwrap().get("acme.local").is_some());
+    assert_eq!(
+        plugin.validation.as_str(),
+        "local",
+        "a local-directory install validates as local"
+    );
+    let locked = Lockfile::load().unwrap();
+    let locked = locked.get("acme.local").expect("lock entry");
+    assert!(
+        locked.tree_hash.starts_with("sha256:"),
+        "tree hash recorded: {:?}",
+        locked.tree_hash
+    );
 
     install::uninstall("acme.local").unwrap();
     assert!(load_registry().get("acme.local").is_none());
@@ -215,8 +226,104 @@ api_version = 2
         "resolved commit recorded: {:?}",
         locked.resolved_commit
     );
+    assert!(
+        locked.tree_hash.starts_with("sha256:"),
+        "tree hash recorded: {:?}",
+        locked.tree_hash
+    );
+    assert_eq!(
+        load_registry()
+            .get("acme.widget")
+            .unwrap()
+            .validation
+            .as_str(),
+        "community",
+        "an unfeatured GitHub install validates as community"
+    );
 
     std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+/// Write a featured index file and point `AOE_FEATURED_INDEX_PATH` at it (debug
+/// builds only; tests run in debug).
+fn write_featured(dir: &Path, id: &str, source: &str, tree_hash: &str) -> PathBuf {
+    let path = dir.join("featured.toml");
+    std::fs::write(
+        &path,
+        format!("[plugins.\"{id}\"]\nsource = \"{source}\"\ntree_hash = \"{tree_hash}\"\n"),
+    )
+    .unwrap();
+    std::env::set_var("AOE_FEATURED_INDEX_PATH", &path);
+    path
+}
+
+#[tokio::test]
+#[serial]
+async fn featured_verified_reserved_namespace_installs() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    // A reserved-namespace id is normally rejected; a matching featured pin
+    // lifts it.
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "agent-of-empires.official"
+name = "Official"
+version = "1.0.0"
+api_version = 2
+"#,
+    );
+    let tree_hash = agent_of_empires::plugin::integrity::tree_hash(&dir).unwrap();
+    write_featured(
+        src.path(),
+        "agent-of-empires.official",
+        dir.to_str().unwrap(),
+        &tree_hash,
+    );
+
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    let reg = load_registry();
+    let plugin = reg.get("agent-of-empires.official").expect("installed");
+    assert_eq!(plugin.validation.as_str(), "featured");
+    let lock = Lockfile::load().unwrap();
+    let locked = lock.get("agent-of-empires.official").unwrap();
+    assert_eq!(locked.trust, "featured");
+    assert_eq!(locked.tree_hash, tree_hash);
+
+    std::env::remove_var("AOE_FEATURED_INDEX_PATH");
+}
+
+#[tokio::test]
+#[serial]
+async fn featured_hash_mismatch_is_refused() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.featured"
+name = "Featured"
+version = "1.0.0"
+api_version = 2
+"#,
+    );
+    // Pin a hash that does not match the actual tree.
+    write_featured(
+        src.path(),
+        "acme.featured",
+        dir.to_str().unwrap(),
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    );
+
+    let err = install::install(dir.to_str().unwrap(), true)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("featured pin"), "got: {err}");
+    assert!(load_registry().get("acme.featured").is_none());
+
+    std::env::remove_var("AOE_FEATURED_INDEX_PATH");
 }
 
 #[tokio::test]

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -4,8 +4,8 @@ import { fetchPlugins, setPluginEnabled, type PluginListResponse, type PluginVie
 import { reportInfo } from "../../lib/toastBus";
 
 /// Plugin management: list every known plugin (name, version, description,
-/// trust level, capabilities, and enabled / approval state) and toggle it on or
-/// off. Installing and capability approval are CLI-driven (`aoe plugin
+/// validation provenance, capabilities, and enabled / approval state) and
+/// toggle it on or off. Installing and capability approval are CLI-driven (`aoe plugin
 /// install`); this panel shows the resulting state. The toggle POSTs to
 /// `/api/plugins/{id}/enabled`; it is a host mutation, so it needs read-write
 /// mode and (when login is enabled) an elevated session. A `403
@@ -97,9 +97,9 @@ export function PluginsSettings() {
                   <span className="text-xs text-text-dim">v{plugin.version}</span>
                   <span
                     className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
-                    data-testid={`plugin-trust-${plugin.id}`}
+                    data-testid={`plugin-validation-${plugin.id}`}
                   >
-                    {plugin.trust}
+                    {plugin.validation}
                   </span>
                   {plugin.needs_reapproval && (
                     <span

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -37,7 +37,7 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
         description: "Detects agent session status.",
         enabled: true,
         builtin: true,
-        trust: "builtin",
+        validation: "builtin",
         source: null,
         capabilities: [],
         granted: true,
@@ -50,7 +50,7 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
         description: "A community plugin.",
         enabled: false,
         builtin: false,
-        trust: "community",
+        validation: "community",
         source: "gh:example/plugin",
         capabilities: ["net"],
         granted: true,
@@ -77,7 +77,7 @@ describe("PluginsSettings", () => {
     await findByText("A community plugin.");
   });
 
-  it("shows trust badges and a needs-approval state for an ungranted community plugin", async () => {
+  it("shows validation badges and a needs-approval state for an ungranted community plugin", async () => {
     fetchPlugins.mockResolvedValue(
       listResponse({
         plugins: [
@@ -88,7 +88,7 @@ describe("PluginsSettings", () => {
             description: "A community plugin.",
             enabled: true,
             builtin: false,
-            trust: "community",
+            validation: "community",
             source: "gh:example/plugin",
             capabilities: ["net", "fs.read"],
             granted: false,
@@ -98,11 +98,36 @@ describe("PluginsSettings", () => {
       }),
     );
     const { findByTestId, getByText } = render(<PluginsSettings />);
-    const trust = await findByTestId("plugin-trust-example.plugin");
-    expect(trust.textContent).toBe("community");
+    const validation = await findByTestId("plugin-validation-example.plugin");
+    expect(validation.textContent).toBe("community");
     await findByTestId("plugin-needs-approval-example.plugin");
     expect(getByText(/net, fs\.read/)).toBeTruthy();
     expect(getByText(/not granted/)).toBeTruthy();
+  });
+
+  it("shows the featured validation badge for a featured plugin", async () => {
+    fetchPlugins.mockResolvedValue(
+      listResponse({
+        plugins: [
+          {
+            id: "agent-of-empires.example",
+            name: "Official Example",
+            version: "1.0.0",
+            description: "A featured plugin.",
+            enabled: true,
+            builtin: false,
+            validation: "featured",
+            source: "gh:agent-of-empires/example",
+            capabilities: [],
+            granted: true,
+            needs_reapproval: false,
+          },
+        ],
+      }),
+    );
+    const { findByTestId } = render(<PluginsSettings />);
+    const validation = await findByTestId("plugin-validation-agent-of-empires.example");
+    expect(validation.textContent).toBe("featured");
   });
 
   it("disable toggle POSTs setPluginEnabled(id, false) and adopts the refreshed list", async () => {
@@ -132,7 +157,7 @@ describe("PluginsSettings", () => {
       description: "The web dashboard.",
       enabled: true,
       builtin: true,
-      trust: "builtin",
+      validation: "builtin",
       source: null,
       capabilities: [],
       granted: true,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -188,7 +188,8 @@ export interface PluginView {
   description: string;
   enabled: boolean;
   builtin: boolean;
-  trust: string;
+  /** Validation provenance: "builtin" | "featured" | "community" | "local". */
+  validation: string;
   source: string | null;
   capabilities: string[];
   granted: boolean;


### PR DESCRIPTION
**Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The supply-chain / trust layer for the plugin system (the #2364 slice of #268), built on the install + lockfile core from #2375.

- **`integrity::tree_hash`** is a deterministic, cross-platform `sha256:<hex>` over a plugin's source tree: files sorted by forward-slash relative path, hashed under a versioned header, `.git` skipped, symlinks and non-UTF-8 paths rejected, file mode excluded, and `git clone` forced to `core.autocrlf=false` so line endings never differ by platform. It is computed over the staged source before any release-binary worker is injected, so an author's `aoe plugin hash <checkout>` reproduces the install-time value. The hash is recorded in `plugins.lock` (bumped to `lock_version` 2).
- **`plugins/featured.toml`** is a compiled-in curated index that pins one vetted release per plugin id to its `{source, tree_hash}`. A featured entry is the maintainer's attestation that this exact tree was reviewed, and the answer to "is this plugin safe".
- **Install and update refuse on mismatch:** when a plugin id is in the featured index, the fetched source slug and tree hash must both match the pin or the operation bails. A featured-verified install is the one case allowed to claim a reserved (`aoe.*` / `agent-of-empires.*`) namespace; a builtin-id collision is always rejected. A featured release-binary manifest is refused outright, since its worker bytes are not pinned yet (noted follow-up).
- **Every surface shows the validation state:** the CLI (`aoe plugin list` / `info`), the TUI plugin manager, and the web Plugins panel render one of `builtin` / `featured` / `community` / `local`, replacing the coarse trust label.
- **New command** `aoe plugin hash <dir>` prints the tree hash an author pins in the featured index.

The featured index ships empty (no vetted plugins exist yet); entries land as maintainers review releases. A debug-only `AOE_FEATURED_INDEX_PATH` lets tests inject pins; a release binary always uses the embedded index, since the curated set is a root of trust that must not be redefinable by the environment.

Closes #2364

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cargo run -- plugin hash <any-dir>` prints a `sha256:` value; re-running on the unchanged dir prints the same value, and editing a file in it changes the value.
- [ ] Install a local plugin (`cargo run -- plugin install <dir> --yes`), then `cargo run -- plugin list`: the plugin shows validation `local`; a `gh:` install shows `community`.
- [ ] With a debug build and `AOE_FEATURED_INDEX_PATH` pointing at a TOML that pins `{source, tree_hash}` for a reserved-namespace id (`agent-of-empires.*`), installing that source succeeds and lists as `featured`; pinning a wrong `tree_hash` makes install refuse with a "featured pin" error.
- [ ] Open the web dashboard Settings → Plugins panel: each plugin shows a validation badge (builtin / featured / community / local).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
  <!-- Specifically: updated the Vitest spec web/src/components/settings/__tests__/PluginsSettings.test.tsx (validation badge incl. a featured case). The panel is already mapped by the existing `settings.plugins` coverage-matrix entry, so no matrix change was needed. -->

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the new `aoe plugin hash` command is a thin wrapper over `integrity::tree_hash`, which is covered by unit tests, and the install/update featured + validation behavior is covered by `tests/plugin_install.rs` integration tests. A full-binary e2e for a hash-printing command would not add signal.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with the design critiqued by a multi-model `/debate` pass. I made the design calls (provenance recorded in the lockfile rather than recomputed each load, featured rejects release-binary in v1, the validation-state model) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784987424&installation_id=139138837&pr_number=2388&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2388&signature=36679d5fb9367de9b76740a35d2cb17054f592ec655de9ecc6c1d1d9880ac8da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a plugin verification (“trust” → “validation”) layer and makes plugin provenance explicit across the app.

At a high level it:
- Introduces a deterministic integrity hash (`tree_hash`) for a plugin’s source directory
- Adds a new maintainer command: `aoe plugin hash <PATH>` to compute/print the hash for a local plugin directory
- Ships a compiled-in curated featured index (`plugins/featured.toml`) that pins vetted plugins by `{source, tree_hash}`
- Enforces install/update refusal when a fetched plugin’s `{source, tree_hash}` doesn’t match its featured pin
- Expands plugin status to `builtin`, `featured`, `community`, and `local`, and surfaces it in the CLI, TUI, and the web Plugins panel
- Updates `plugins.lock` to `lock_version` 2 and records `tree_hash` (plus featured-vs-community validation behavior)

Benefits:
- Stronger supply-chain protection by rejecting tampered or unpinned plugin sources
- Clearer “where this plugin comes from” and how it was validated for users and maintainers
- More reproducible verification: the same tree hash is computed during install and can be reproduced with `aoe plugin hash`

Technical notes (brief):
- Hashing is deterministic and excludes `.git`, rejects symlinks, and is based on normalized/stable path+content framing.
- The featured index is embedded by default, with a debug-only override for tests.
- UI/API and client contracts were updated to replace “trust” with “validation”.

Potential area for further enhancement:
- Follow-up mentioned in docs to extend pinning/verification beyond source-tree hashes to include featured `release-binary` asset hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->