### PR TITLE
feat(plugins): tier 0 contribution registries (settings, themes, keybinds, CLI grafting)

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -3,10 +3,12 @@
 //! This crate is the stable surface a plugin author (and the in-tree host)
 //! compiles against: the `aoe-plugin.toml` manifest schema, the capability
 //! taxonomy, and the validation rules that gate a manifest before it loads.
-//! The contribution sections (capabilities, commands, keybinds, settings, ui,
-//! runtime worker) are defined here but consumed by follow-up PRs (#2094 /
-//! #2095 / #2366). Themes, status, and panes are deferred until a consumer
-//! exists. See `docs/development/internals/plugin-system.md`.
+//! The contribution sections (capabilities, commands, keybinds, settings,
+//! themes, ui, runtime worker) are defined here. Settings and themes are
+//! consumed by the Tier 0 registries (#2094); keybinds/commands resolve and
+//! graft at Tier 0 but execute only with the runtime host (#2095); ui slots
+//! land with #2366. Status and panes are deferred until a consumer exists
+//! (#2386). See `docs/development/internals/plugin-system.md`.
 
 mod capability;
 mod id;
@@ -16,7 +18,7 @@ pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
     CommandContribution, KeybindContribution, ManifestError, PluginManifest, RuntimeSpec,
-    SettingContribution, UiContribution,
+    SettingContribution, SettingType, ThemeContribution, UiContribution,
 };
 
 /// Version of the manifest schema and host API this crate describes.

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -337,11 +337,22 @@ impl PluginManifest {
                     }
                 }
                 if s.value_type == SettingType::Integer {
-                    if let (Some(v), Some(lo), Some(hi)) = (def.as_integer(), s.min, s.max) {
-                        check(
-                            v >= lo && v <= hi,
-                            format!("settings[{i}].default {v} is outside range [{lo}, {hi}]"),
-                        );
+                    if let Some(v) = def.as_integer() {
+                        // Check each bound independently so a single-sided range
+                        // (only min, or only max) still rejects an out-of-range
+                        // default.
+                        if let Some(lo) = s.min {
+                            check(
+                                v >= lo,
+                                format!("settings[{i}].default {v} is below min {lo}"),
+                            );
+                        }
+                        if let Some(hi) = s.max {
+                            check(
+                                v <= hi,
+                                format!("settings[{i}].default {v} is above max {hi}"),
+                            );
+                        }
                     }
                 }
             }

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -38,10 +40,25 @@ pub struct PluginManifest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub keybinds: Vec<KeybindContribution>,
 
-    /// Settings the plugin declares. The typed schema that validates and
-    /// renders them lands with #2094.
+    /// Settings the plugin declares. Each is a typed field the host renders in
+    /// the settings surfaces (TUI / web) and persists under
+    /// `[plugins."<id>".settings]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub settings: Vec<SettingContribution>,
+
+    /// Default overrides the plugin applies to *core* settings, keyed by the
+    /// core canonical path (`"theme.idle_decay_minutes"`). Resolution layers a
+    /// user value over the highest-priority active plugin override over the core
+    /// schema default; see the host's settings resolution (#2094). A plugin
+    /// cannot override another plugin's settings at Tier 0.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub setting_defaults: BTreeMap<String, toml::Value>,
+
+    /// Color themes the plugin ships. Each `path` is a theme TOML relative to
+    /// the plugin's install directory; the host adds them to the theme picker
+    /// (#2094).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub themes: Vec<ThemeContribution>,
 
     /// UI slots the plugin renders into. Consumed by #2366.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -73,8 +90,10 @@ pub struct KeybindContribution {
     pub key: String,
 }
 
-/// A setting the plugin declares. The typed schema arrives with #2094; here it
-/// is just the key and human-facing labels.
+/// A setting the plugin declares. The host renders it on every settings surface
+/// and persists its value under `[plugins."<id>".settings.<key>]`. The fields
+/// map directly onto the host's settings schema (widget + validation) without
+/// this crate depending on host types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettingContribution {
     pub key: String,
@@ -82,6 +101,50 @@ pub struct SettingContribution {
     pub label: String,
     #[serde(default)]
     pub description: String,
+    /// Value type. Drives the rendered widget and server-side validation.
+    #[serde(rename = "type", default)]
+    pub value_type: SettingType,
+    /// Allowed values for a `select`; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
+    /// Inclusive bounds for an `integer`; ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<i64>,
+    /// The plugin's declared default (the "owning manifest default" layer in
+    /// settings resolution). Absent means the type's zero value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<toml::Value>,
+    /// Group under an "Advanced" fold on the settings surfaces.
+    #[serde(default)]
+    pub advanced: bool,
+}
+
+/// The type of a plugin setting value. One declaration drives both the widget
+/// the surfaces render and the validation the server enforces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SettingType {
+    /// Free text, rendered as a text input.
+    #[default]
+    String,
+    /// On/off, rendered as a toggle.
+    Bool,
+    /// Integer, rendered as a number input (bounded by `min`/`max`).
+    Integer,
+    /// Closed set of strings, rendered as a select over `options`.
+    Select,
+}
+
+/// A color theme the plugin ships. `path` is a theme TOML relative to the
+/// plugin's install directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemeContribution {
+    /// Name shown in the theme picker; must not collide with a builtin.
+    pub name: String,
+    /// Theme TOML path, relative to the plugin directory.
+    pub path: String,
 }
 
 /// A UI contribution targeting a named slot.
@@ -238,6 +301,33 @@ impl PluginManifest {
             check(
                 !s.key.is_empty(),
                 format!("settings[{i}].key must not be empty"),
+            );
+            check(
+                s.value_type != SettingType::Select || !s.options.is_empty(),
+                format!("settings[{i}] is a select but declares no options"),
+            );
+            check(
+                match (s.min, s.max) {
+                    (Some(lo), Some(hi)) => lo <= hi,
+                    _ => true,
+                },
+                format!("settings[{i}].min must not exceed max"),
+            );
+        }
+        for (i, t) in self.themes.iter().enumerate() {
+            check(
+                !t.name.is_empty(),
+                format!("themes[{i}].name must not be empty"),
+            );
+            check(
+                !t.path.is_empty(),
+                format!("themes[{i}].path must not be empty"),
+            );
+        }
+        for key in self.setting_defaults.keys() {
+            check(
+                key.contains('.') && !key.starts_with('.') && !key.ends_with('.'),
+                format!("setting_defaults key {key:?} must be a dotted core path like \"section.field\""),
             );
         }
         for (i, u) in self.ui.iter().enumerate() {

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -313,6 +313,38 @@ impl PluginManifest {
                 },
                 format!("settings[{i}].min must not exceed max"),
             );
+            // A declared default must match the value type, so an author learns
+            // of a type mismatch at parse time rather than at render/store time.
+            if let Some(def) = &s.default {
+                let type_ok = match s.value_type {
+                    SettingType::String | SettingType::Select => def.is_str(),
+                    SettingType::Bool => def.as_bool().is_some(),
+                    SettingType::Integer => def.as_integer().is_some(),
+                };
+                check(
+                    type_ok,
+                    format!(
+                        "settings[{i}].default does not match type {:?}",
+                        s.value_type
+                    ),
+                );
+                if s.value_type == SettingType::Select {
+                    if let (Some(d), false) = (def.as_str(), s.options.is_empty()) {
+                        check(
+                            s.options.iter().any(|o| o == d),
+                            format!("settings[{i}].default {d:?} is not one of the options"),
+                        );
+                    }
+                }
+                if s.value_type == SettingType::Integer {
+                    if let (Some(v), Some(lo), Some(hi)) = (def.as_integer(), s.min, s.max) {
+                        check(
+                            v >= lo && v <= hi,
+                            format!("settings[{i}].default {v} is outside range [{lo}, {hi}]"),
+                        );
+                    }
+                }
+            }
         }
         for (i, t) in self.themes.iter().enumerate() {
             check(

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -1,4 +1,4 @@
-use aoe_plugin_api::{ManifestError, PluginManifest, RuntimeSpec};
+use aoe_plugin_api::{ManifestError, PluginManifest, RuntimeSpec, SettingType};
 
 #[test]
 fn minimal_manifest_parses_and_round_trips() {
@@ -76,14 +76,118 @@ id = "panel"
     assert_eq!(m.commands.len(), 1);
     assert_eq!(m.keybinds[0].key, "Ctrl+K");
     assert_eq!(m.settings[0].key, "endpoint");
+    assert_eq!(m.settings[0].value_type, SettingType::String);
     assert_eq!(m.ui[0].slot, "sidebar");
 }
 
 #[test]
+fn typed_settings_and_defaults_and_themes_parse() {
+    let toml = r#"
+id = "acme.kit"
+name = "Kit"
+version = "0.1.0"
+api_version = 2
+
+[[settings]]
+key = "enabled"
+label = "Enabled"
+type = "bool"
+default = true
+
+[[settings]]
+key = "retries"
+type = "integer"
+min = 0
+max = 10
+default = 3
+advanced = true
+
+[[settings]]
+key = "mode"
+type = "select"
+options = ["fast", "slow"]
+default = "fast"
+
+[setting_defaults]
+"theme.idle_decay_minutes" = 10
+
+[[themes]]
+name = "kit-dark"
+path = "themes/dark.toml"
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("typed contributions parse");
+    assert_eq!(m.settings[0].value_type, SettingType::Bool);
+    assert_eq!(m.settings[1].value_type, SettingType::Integer);
+    assert_eq!(m.settings[1].min, Some(0));
+    assert!(m.settings[1].advanced);
+    assert_eq!(m.settings[2].options, ["fast", "slow"]);
+    assert_eq!(
+        m.setting_defaults.get("theme.idle_decay_minutes"),
+        Some(&toml::Value::Integer(10))
+    );
+    assert_eq!(m.themes[0].name, "kit-dark");
+    assert_eq!(m.themes[0].path, "themes/dark.toml");
+}
+
+#[test]
+fn invalid_typed_settings_and_themes_collect_problems() {
+    let toml = r#"
+id = "acme.kit"
+name = "Kit"
+version = "0.1.0"
+api_version = 2
+
+[[settings]]
+key = "mode"
+type = "select"
+
+[[settings]]
+key = "n"
+type = "integer"
+min = 9
+max = 1
+
+[setting_defaults]
+"nosection" = 1
+
+[[themes]]
+name = ""
+path = ""
+"#;
+    let messages = match PluginManifest::from_toml_str(toml).unwrap_err() {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages.iter().any(|m| m.contains("select")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("min must not exceed max")),
+        "{messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("setting_defaults key")),
+        "{messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("themes[0].name")),
+        "{messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("themes[0].path")),
+        "{messages:?}"
+    );
+}
+
+#[test]
 fn deferred_sections_are_rejected() {
-    // themes / status / panes are deferred until a consumer exists; with
-    // deny_unknown_fields a manifest declaring one must fail to parse.
-    for section in ["themes", "status", "panes"] {
+    // status / panes are still deferred until a consumer exists (#2386); with
+    // deny_unknown_fields a manifest declaring one must fail to parse. themes
+    // is now consumed (#2094) and parses, asserted above.
+    for section in ["status", "panes"] {
         let toml = format!(
             r#"
 id = "acme.thing"

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -183,6 +183,58 @@ path = ""
 }
 
 #[test]
+fn setting_default_must_match_type() {
+    let toml = r#"
+id = "acme.kit"
+name = "Kit"
+version = "0.1.0"
+api_version = 2
+
+[[settings]]
+key = "retries"
+type = "integer"
+min = 0
+max = 5
+default = "not-an-int"
+
+[[settings]]
+key = "n"
+type = "integer"
+min = 0
+max = 5
+default = 9
+
+[[settings]]
+key = "mode"
+type = "select"
+options = ["fast", "slow"]
+default = "turbo"
+"#;
+    let messages = match PluginManifest::from_toml_str(toml).unwrap_err() {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("settings[0].default does not match")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("settings[1].default 9 is outside range")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("settings[2].default") && m.contains("not one of the options")),
+        "{messages:?}"
+    );
+}
+
+#[test]
 fn deferred_sections_are_rejected() {
     // status / panes are still deferred until a consumer exists (#2386); with
     // deny_unknown_fields a manifest declaring one must fail to parse. themes

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -200,9 +200,14 @@ default = "not-an-int"
 [[settings]]
 key = "n"
 type = "integer"
-min = 0
 max = 5
 default = 9
+
+[[settings]]
+key = "lo"
+type = "integer"
+min = 10
+default = 1
 
 [[settings]]
 key = "mode"
@@ -220,16 +225,23 @@ default = "turbo"
             .any(|m| m.contains("settings[0].default does not match")),
         "{messages:?}"
     );
+    // Single-sided bounds are each enforced.
     assert!(
         messages
             .iter()
-            .any(|m| m.contains("settings[1].default 9 is outside range")),
+            .any(|m| m.contains("settings[1].default 9 is above max 5")),
         "{messages:?}"
     );
     assert!(
         messages
             .iter()
-            .any(|m| m.contains("settings[2].default") && m.contains("not one of the options")),
+            .any(|m| m.contains("settings[2].default 1 is below min 10")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("settings[3].default") && m.contains("not one of the options")),
         "{messages:?}"
     );
 }

--- a/aoe-settings-derive/src/lib.rs
+++ b/aoe-settings-derive/src/lib.rs
@@ -101,6 +101,10 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 profile_overridable: #overridable,
                 validation: #validation,
                 advanced: #advanced,
+                // Core fields always exist in the serialized Config via the
+                // struct Default, so they need no schema-carried default; only
+                // plugin fields set this.
+                default: ::core::option::Option::None,
             }
         });
     }

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -71,6 +71,8 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe theme list`↴](#aoe-theme-list)
 * [`aoe theme export`↴](#aoe-theme-export)
 * [`aoe theme dir`↴](#aoe-theme-dir)
+* [`aoe settings`↴](#aoe-settings)
+* [`aoe settings explain`↴](#aoe-settings-explain)
 * [`aoe telemetry`↴](#aoe-telemetry)
 * [`aoe telemetry status`↴](#aoe-telemetry-status)
 * [`aoe telemetry enable`↴](#aoe-telemetry-enable)
@@ -129,6 +131,7 @@ Run without arguments to launch the TUI dashboard.
 * `tmux` — tmux integration utilities
 * `sounds` — Manage sound effects for agent state transitions
 * `theme` — Manage color themes (list, export, customize)
+* `settings` — Inspect resolved settings and their provenance
 * `telemetry` — Manage anonymous opt-in usage telemetry
 * `mcp` — Inspect the effective MCP server set (provenance, conflicts, drift)
 * `serve` — Start a web dashboard for remote session access
@@ -1085,6 +1088,30 @@ Export a built-in theme as a TOML file for customization
 Show the custom themes directory path
 
 **Usage:** `aoe theme dir`
+
+
+
+## `aoe settings`
+
+Inspect resolved settings and their provenance
+
+**Usage:** `aoe settings <COMMAND>`
+
+###### **Subcommands:**
+
+* `explain` — Explain where a setting's effective value comes from. KEY is a core `section.field` (e.g. `acp.default_agent`) or a plugin `plugin:<id>.<field>` (e.g. `plugin:acme.kit.retries`)
+
+
+
+## `aoe settings explain`
+
+Explain where a setting's effective value comes from. KEY is a core `section.field` (e.g. `acp.default_agent`) or a plugin `plugin:<id>.<field>` (e.g. `plugin:acme.kit.retries`)
+
+**Usage:** `aoe settings explain <KEY>`
+
+###### **Arguments:**
+
+* `<KEY>` — The setting key to explain
 
 
 

--- a/docs/development/adding-settings.md
+++ b/docs/development/adding-settings.md
@@ -115,6 +115,14 @@ are not user-facing settings. A few things are deliberately not schematized:
   endpoint (it records "has responded" and honors `DO_NOT_TRACK`), not the
   generic PATCH.
 
+## Plugin settings
+
+The above is for core settings. A plugin declares its own settings in its
+`aoe-plugin.toml` manifest, not in a `Config` struct; the host turns each into a
+virtual `plugin:<id>` schema section that renders and validates through the same
+path. See the Tier 0 registries section in
+[the plugin system internals](internals/plugin-system.md).
+
 ## Breaking changes
 
 Renaming or relocating a stored field is a breaking change to `config.toml`;

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -226,6 +226,60 @@ plugin tampered after install.
 `aoe plugin hash <dir>` prints the tree hash for a plugin directory so an author
 can produce the value a maintainer pins. Run it on a clean checkout.
 
+## Tier 0 contribution registries (#2094)
+
+Tier 0 wires a plugin's declarative manifest contributions into the host's
+registries, with no plugin code execution (that is the Tier 1 host, #2095). Four
+registries consume the manifest:
+
+### Settings
+
+A plugin's `[[settings]]` are typed: `type` (`string` / `bool` / `integer` /
+`select`), with `options`, `min`/`max`, a `default`, and `advanced`. The host
+maps each to its single-source settings schema as a virtual `plugin:<id>`
+section. `settings_schema::runtime_schema()` returns the static core schema plus
+those sections; `GET /api/settings/schema` serves it, the server validates
+PATCHes against it (`validate_patch_with`), and the TUI/web render it through the
+same generic field path as core settings. The API/validation layer speaks the
+flat `plugin:<id>.<key>` shape; only the merge boundary translates to the on-disk
+storage path `plugins.<id>.settings.<key>` (`settings_schema::plugin`). Plugin
+settings are global-only at Tier 0 (not profile-overridable). In the TUI they
+render read-only under the Plugins tab; edit them from the web dashboard or
+`aoe settings`.
+
+A manifest may also override the *default* of a core setting via
+`[setting_defaults]` (keyed by the core `section.field`). Resolution layers, in
+order: the user's value (when it differs from the baseline default) > the
+highest-priority active plugin's `setting_defaults` override > the core schema
+default. A plugin's own setting layers stored value > manifest default.
+`settings_schema::resolve` returns the effective value, its source, and the full
+candidate chain; `aoe settings explain <key>` and `GET /api/settings/resolved`
+surface it. "Highest priority" is active-plugin order (builtins first).
+
+### Themes
+
+A plugin's `[[themes]]` (`name`, `path`) add theme TOMLs to the picker. Each
+`path` is resolved under the plugin's install directory (absolute or
+parent-escaping paths are rejected); precedence is builtin > user custom >
+plugin, so a plugin can never shadow a builtin or a user theme.
+
+### Keybinds
+
+A plugin's `[[keybinds]]` resolve through a merged resolver
+(`tui::home::bindings::resolve_action`): the static core table is tried first and
+always shadows a plugin binding on the same chord; active plugins' keybinds are
+consulted only after. A resolved plugin keybind is inspectable but not runnable
+at Tier 0 (it shows a "needs the plugin runtime" notice); `aoe plugin info` lists
+a plugin's keybinds and flags any chord core shadows. Execution lands with #2095.
+
+### CLI grafting
+
+Active plugins' `[[commands]]` are grafted onto the derived clap tree at runtime
+(`cli::graft`), so they appear in `aoe --help` and parse. Core commands always
+win a name conflict. Dispatch tries the core derive first; a grafted command
+falls through to the plugin dispatcher, which at Tier 0 reports that running it
+needs the runtime (#2095).
+
 ## Tier 1 worker host (#2095)
 
 The worker host runs inside the `aoe serve` daemon (it is `serve`-gated, like

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -247,14 +247,22 @@ settings are global-only at Tier 0 (not profile-overridable). In the TUI they
 render read-only under the Plugins tab; edit them from the web dashboard or
 `aoe settings`.
 
-A manifest may also override the *default* of a core setting via
-`[setting_defaults]` (keyed by the core `section.field`). Resolution layers, in
-order: the user's value (when it differs from the baseline default) > the
-highest-priority active plugin's `setting_defaults` override > the core schema
-default. A plugin's own setting layers stored value > manifest default.
+A manifest may also declare a *default* override for a core setting via
+`[setting_defaults]` (keyed by the core `section.field`).
 `settings_schema::resolve` returns the effective value, its source, and the full
 candidate chain; `aoe settings explain <key>` and `GET /api/settings/resolved`
-surface it. "Highest priority" is active-plugin order (builtins first).
+surface it.
+
+The effective value of a core key at Tier 0 is the user's value (when it differs
+from the baseline default), else the core schema default. A plugin's
+`setting_defaults` override is included in the candidate chain so it is
+observable, but it is NOT applied at runtime yet, so it never reports as the
+effective `source`: nothing layers it during real `Config` load/merge, so every
+core consumer still reads the struct default. The runtime host applies these
+overrides for real (#2095); until then a `plugin_default` candidate is
+"declared, not yet in effect". A plugin's own setting layers stored value >
+manifest default. "Highest priority" (for the candidate ordering) is
+active-plugin order, builtins first.
 
 ### Themes
 

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -26,6 +26,7 @@ use super::send::SendArgs;
 #[cfg(feature = "serve")]
 use super::serve::ServeArgs;
 use super::session::SessionCommands;
+use super::settings::SettingsCommands;
 use super::sounds::SoundsCommands;
 use super::status::StatusArgs;
 use super::telemetry::TelemetryCommands;
@@ -169,6 +170,12 @@ pub enum Commands {
         command: ThemeCommands,
     },
 
+    /// Inspect resolved settings and their provenance
+    Settings {
+        #[command(subcommand)]
+        command: SettingsCommands,
+    },
+
     /// Manage anonymous opt-in usage telemetry
     Telemetry {
         #[command(subcommand)]
@@ -252,6 +259,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "tmux",
     "sounds",
     "theme",
+    "settings",
     "telemetry",
     "mcp",
     "serve",
@@ -296,6 +304,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Tmux { .. } => "tmux",
         Commands::Sounds { .. } => "sounds",
         Commands::Theme { .. } => "theme",
+        Commands::Settings { .. } => "settings",
         Commands::Telemetry { .. } => "telemetry",
         Commands::Mcp { .. } => "mcp",
         #[cfg(feature = "serve")]

--- a/src/cli/graft.rs
+++ b/src/cli/graft.rs
@@ -1,0 +1,143 @@
+//! Runtime grafting of plugin-declared commands onto the clap tree.
+//!
+//! Core commands stay clap-derive. Active plugins' declared commands are
+//! appended to the derived [`Command`] at runtime so they appear in `aoe --help`
+//! and parse. Dispatch tries the core derive first (`Cli::from_arg_matches`); a
+//! grafted command falls through to [`dispatch_plugin_command`]. Core always
+//! wins a name conflict: a plugin command whose name collides with a core
+//! subcommand is not grafted.
+//!
+//! Tier 0 has no executor, so a grafted command parses and is discoverable but
+//! reports that it needs the plugin runtime (#2095) when invoked.
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use clap::{ArgMatches, Command, CommandFactory};
+
+use super::definition::Cli;
+
+/// A command a plugin contributes to the CLI.
+pub struct PluginCommand {
+    pub plugin_id: String,
+    pub name: String,
+    pub title: String,
+}
+
+/// Commands declared by the active plugin set.
+pub fn plugin_commands() -> Vec<PluginCommand> {
+    let mut out = Vec::new();
+    for p in crate::plugin::registry().active() {
+        for c in &p.manifest.commands {
+            out.push(PluginCommand {
+                plugin_id: p.id().to_string(),
+                name: c.id.clone(),
+                title: c.title.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// The clap command augmented with active plugins' commands. A plugin command
+/// whose name collides with a core subcommand (or an already-grafted plugin
+/// command) is skipped, so core always wins.
+pub fn augmented_command() -> Command {
+    graft_onto(Cli::command(), plugin_commands())
+}
+
+/// Graft `commands` onto `cmd`, skipping any whose name collides with an
+/// existing subcommand (core wins) or with an earlier grafted command.
+fn graft_onto(mut cmd: Command, commands: Vec<PluginCommand>) -> Command {
+    let core: HashSet<String> = cmd
+        .get_subcommands()
+        .map(|s| s.get_name().to_string())
+        .collect();
+    let mut grafted: HashSet<String> = HashSet::new();
+    for pc in commands {
+        if core.contains(&pc.name) || !grafted.insert(pc.name.clone()) {
+            continue;
+        }
+        let about = if pc.title.is_empty() {
+            format!("Plugin command (from {})", pc.plugin_id)
+        } else {
+            format!("{} (from {})", pc.title, pc.plugin_id)
+        };
+        cmd = cmd.subcommand(Command::new(pc.name).about(about));
+    }
+    cmd
+}
+
+/// Handle a grafted plugin command. At Tier 0 there is no executor, so this
+/// reports the command is plugin-provided and needs the runtime (#2095).
+pub fn dispatch_plugin_command(matches: &ArgMatches) -> Result<()> {
+    let Some(name) = matches.subcommand_name() else {
+        anyhow::bail!("no command given");
+    };
+    match plugin_commands().into_iter().find(|p| p.name == name) {
+        Some(pc) => {
+            println!(
+                "'{name}' is a command from plugin '{}'. Running plugin commands needs the \
+                 plugin runtime, which is not available yet.",
+                pc.plugin_id
+            );
+            Ok(())
+        }
+        None => anyhow::bail!("unknown command '{name}'"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn augmented_command_keeps_core_subcommands() {
+        // With no active plugins in the test process, augmentation is a no-op:
+        // the command still carries the core subcommands and no others.
+        let core: HashSet<String> = Cli::command()
+            .get_subcommands()
+            .map(|s| s.get_name().to_string())
+            .collect();
+        let augmented: HashSet<String> = augmented_command()
+            .get_subcommands()
+            .map(|s| s.get_name().to_string())
+            .collect();
+        assert_eq!(core, augmented);
+        // Sanity: a known core command is present.
+        assert!(augmented.contains("add"));
+    }
+
+    fn pc(plugin_id: &str, name: &str) -> PluginCommand {
+        PluginCommand {
+            plugin_id: plugin_id.to_string(),
+            name: name.to_string(),
+            title: String::new(),
+        }
+    }
+
+    #[test]
+    fn graft_onto_skips_core_and_duplicate_names() {
+        let commands = vec![
+            // Collides with the core `add` command: core wins, not grafted.
+            pc("acme.kit", "add"),
+            pc("acme.kit", "do-thing"),
+            // Duplicate of an already-grafted plugin command: skipped.
+            pc("acme.other", "do-thing"),
+        ];
+        let cmd = graft_onto(Cli::command(), commands);
+        let names: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
+        assert_eq!(names.iter().filter(|n| **n == "add").count(), 1);
+        assert_eq!(names.iter().filter(|n| **n == "do-thing").count(), 1);
+    }
+
+    #[test]
+    fn dispatch_rejects_unknown_command() {
+        let matches = Cli::command()
+            .try_get_matches_from(["aoe", "agents"])
+            .expect("core agents parses");
+        // `agents` is a core command, not a plugin one: dispatch refuses it
+        // rather than claiming it as a plugin command.
+        assert!(dispatch_plugin_command(&matches).is_err());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod add;
 pub mod agents;
 pub mod definition;
 pub mod extract_session_id;
+pub mod graft;
 pub mod group;
 pub mod init;
 pub mod killall;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,6 +23,7 @@ pub mod send;
 #[cfg(feature = "serve")]
 pub mod serve;
 pub mod session;
+pub mod settings;
 pub mod sounds;
 pub mod status;
 pub mod telemetry;

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -137,10 +137,13 @@ fn run_info(id: &str) -> Result<()> {
         for kb in &m.keybinds {
             // A core binding on the same chord always wins; flag the conflict so
             // the author knows the plugin keybind will never fire (#2094).
-            let shadowed = crate::tui::home::bindings::parse_chord(&kb.key)
-                .map(|c| crate::tui::home::bindings::core_shadows(&c))
-                .unwrap_or(false);
-            let note = if shadowed { "  (shadowed by core)" } else { "" };
+            // An unparseable key is skipped by the TUI resolver, so flag it
+            // here rather than print it as if it were usable.
+            let note = match crate::tui::home::bindings::parse_chord(&kb.key) {
+                Some(c) if crate::tui::home::bindings::core_shadows(&c) => "  (shadowed by core)",
+                Some(_) => "",
+                None => "  (invalid key, ignored)",
+            };
             println!("    {} -> {}{note}", kb.key, kb.command);
         }
     }

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -132,6 +132,18 @@ fn run_info(id: &str) -> Result<()> {
     if !m.description.is_empty() {
         println!("  about:      {}", m.description);
     }
+    if !m.keybinds.is_empty() {
+        println!("  keybinds:");
+        for kb in &m.keybinds {
+            // A core binding on the same chord always wins; flag the conflict so
+            // the author knows the plugin keybind will never fire (#2094).
+            let shadowed = crate::tui::home::bindings::parse_chord(&kb.key)
+                .map(|c| crate::tui::home::bindings::core_shadows(&c))
+                .unwrap_or(false);
+            let note = if shadowed { "  (shadowed by core)" } else { "" };
+            println!("    {} -> {}{note}", kb.key, kb.command);
+        }
+    }
     Ok(())
 }
 

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -25,7 +25,9 @@ pub fn run(command: SettingsCommands) -> Result<()> {
 fn source_label(source: &SettingSource) -> String {
     match source {
         SettingSource::User => "user value".to_string(),
-        SettingSource::PluginDefault { plugin } => format!("plugin default ({plugin})"),
+        SettingSource::PluginDefault { plugin } => {
+            format!("plugin default ({plugin}, declared, not yet applied at runtime)")
+        }
         SettingSource::ManifestDefault { plugin } => format!("manifest default ({plugin})"),
         SettingSource::SchemaDefault => "schema default".to_string(),
     }

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -1,0 +1,47 @@
+//! CLI commands for inspecting resolved settings.
+
+use anyhow::{bail, Result};
+use clap::Subcommand;
+
+use crate::session::settings_schema::{resolve, SettingSource};
+
+#[derive(Subcommand)]
+pub enum SettingsCommands {
+    /// Explain where a setting's effective value comes from. KEY is a core
+    /// `section.field` (e.g. `acp.default_agent`) or a plugin
+    /// `plugin:<id>.<field>` (e.g. `plugin:acme.kit.retries`).
+    Explain {
+        /// The setting key to explain.
+        key: String,
+    },
+}
+
+pub fn run(command: SettingsCommands) -> Result<()> {
+    match command {
+        SettingsCommands::Explain { key } => run_explain(&key),
+    }
+}
+
+fn source_label(source: &SettingSource) -> String {
+    match source {
+        SettingSource::User => "user value".to_string(),
+        SettingSource::PluginDefault { plugin } => format!("plugin default ({plugin})"),
+        SettingSource::ManifestDefault { plugin } => format!("manifest default ({plugin})"),
+        SettingSource::SchemaDefault => "schema default".to_string(),
+    }
+}
+
+fn run_explain(key: &str) -> Result<()> {
+    let Some(resolved) = resolve(key) else {
+        bail!("'{key}' is not a known setting. Use a core `section.field` or a `plugin:<id>.<field>` key.");
+    };
+    let value = serde_json::to_string(&resolved.value).unwrap_or_else(|_| "null".to_string());
+    println!("{key} = {value}");
+    println!("  source: {}", source_label(&resolved.source));
+    println!("  candidates (highest precedence first):");
+    for c in &resolved.candidates {
+        let v = serde_json::to_string(&c.value).unwrap_or_else(|_| "null".to_string());
+        println!("    - {}: {v}", source_label(&c.source));
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use agent_of_empires::logging::{self, LogConfig, ProcessContext, SubscriberTarge
 use agent_of_empires::migrations;
 use agent_of_empires::tui;
 use anyhow::Result;
-use clap::{CommandFactory, FromArgMatches};
+use clap::{CommandFactory, FromArgMatches, Parser};
 use clap_complete::generate;
 
 /// Did the user invoke `aoe serve`? Feature-gated because `Commands::Serve`
@@ -40,14 +40,21 @@ fn is_serve_daemon_child(_cli: &Cli) -> bool {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Parse against the clap tree augmented with active plugins' commands, so a
-    // grafted command shows in `aoe --help` and parses. The core derive is tried
-    // first; a grafted plugin command falls through to the plugin dispatcher.
-    // With no plugin commands this is equivalent to `Cli::parse()`.
-    let matches = cli::graft::augmented_command().get_matches();
-    let cli = match Cli::from_arg_matches(&matches) {
+    // Parse the core clap tree first. On success (every valid core command,
+    // including the app-data-free ones like completion/init/agents) this never
+    // touches the plugin registry. Only an error, --help/--version, or an
+    // unknown subcommand falls through to the augmented tree, which grafts
+    // active plugins' commands (loading the registry); there a grafted plugin
+    // command is dispatched to the plugin handler, and core wins name conflicts.
+    let cli = match Cli::try_parse() {
         Ok(cli) => cli,
-        Err(_) => return cli::graft::dispatch_plugin_command(&matches),
+        Err(_) => {
+            let matches = cli::graft::augmented_command().get_matches();
+            match Cli::from_arg_matches(&matches) {
+                Ok(cli) => cli,
+                Err(_) => return cli::graft::dispatch_plugin_command(&matches),
+            }
+        }
     };
 
     // If the user passed --daemon-url, mirror the value into the env

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use agent_of_empires::logging::{self, LogConfig, ProcessContext, SubscriberTarge
 use agent_of_empires::migrations;
 use agent_of_empires::tui;
 use anyhow::Result;
-use clap::{CommandFactory, Parser};
+use clap::{CommandFactory, FromArgMatches};
 use clap_complete::generate;
 
 /// Did the user invoke `aoe serve`? Feature-gated because `Commands::Serve`
@@ -40,7 +40,15 @@ fn is_serve_daemon_child(_cli: &Cli) -> bool {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    // Parse against the clap tree augmented with active plugins' commands, so a
+    // grafted command shows in `aoe --help` and parses. The core derive is tried
+    // first; a grafted plugin command falls through to the plugin dispatcher.
+    // With no plugin commands this is equivalent to `Cli::parse()`.
+    let matches = cli::graft::augmented_command().get_matches();
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(_) => return cli::graft::dispatch_plugin_command(&matches),
+    };
 
     // If the user passed --daemon-url, mirror the value into the env
     // var so the acp::client::discovery layer (used by both the

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,7 @@ async fn main() -> Result<()> {
                 ThemeCommands::Dir => cli::theme::run_dir(),
             };
         }
+        Some(Commands::Settings { command }) => return cli::settings::run(command),
         Some(Commands::Telemetry { command }) => return cli::telemetry::run(command),
         Some(Commands::Mcp { command }) => {
             let profile = cli.profile.clone().unwrap_or_default();

--- a/src/plugin/contributions.rs
+++ b/src/plugin/contributions.rs
@@ -1,0 +1,117 @@
+//! Normalized Tier 0 contributions from the active plugin set.
+//!
+//! Each surface (themes, settings schema, keybinds, CLI) reads its slice of the
+//! manifest through one place here rather than walking `registry().active()` and
+//! manifest fields itself, so contribution-filtering rules (active-only, path
+//! safety, id namespacing) live once.
+
+use std::path::{Component, Path, PathBuf};
+
+use super::registry::LoadedPlugin;
+
+/// Resolve a plugin-relative resource path under the plugin's install
+/// directory, rejecting anything that escapes it (absolute paths, `..`). A
+/// builtin (no on-disk dir) ships no file resources, so it returns `None`.
+fn resolve_under_dir(plugin: &LoadedPlugin, rel: &str) -> Option<PathBuf> {
+    let dir = plugin.dir.as_ref()?;
+    let rel = Path::new(rel);
+    if rel.is_absolute()
+        || rel
+            .components()
+            .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
+    {
+        return None;
+    }
+    Some(dir.join(rel))
+}
+
+/// Themes contributed by active plugins, as `(name, path)` pairs. The path is
+/// resolved under the contributing plugin's directory; unsafe or builtin-only
+/// paths are skipped.
+pub fn active_themes(plugins: &[&LoadedPlugin]) -> Vec<(String, PathBuf)> {
+    let mut out = Vec::new();
+    for plugin in plugins {
+        for theme in &plugin.manifest.themes {
+            if let Some(path) = resolve_under_dir(plugin, &theme.path) {
+                out.push((theme.name.clone(), path));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::registry::ValidationState;
+    use aoe_plugin_api::{PluginManifest, ThemeContribution, TrustLevel};
+
+    fn loaded(dir: Option<PathBuf>, themes: Vec<ThemeContribution>) -> LoadedPlugin {
+        let mut manifest = PluginManifest::from_toml_str(
+            r#"
+id = "acme.kit"
+name = "Kit"
+version = "0.1.0"
+api_version = 2
+"#,
+        )
+        .unwrap();
+        manifest.themes = themes;
+        LoadedPlugin {
+            manifest,
+            enabled: true,
+            trust: TrustLevel::Community,
+            validation: ValidationState::Community,
+            source: None,
+            dir,
+            manifest_hash: "sha256:x".into(),
+            granted: true,
+        }
+    }
+
+    #[test]
+    fn resolves_relative_theme_under_dir() {
+        let p = loaded(
+            Some(PathBuf::from("/plugins/acme.kit")),
+            vec![ThemeContribution {
+                name: "kit-dark".into(),
+                path: "themes/dark.toml".into(),
+            }],
+        );
+        let themes = active_themes(&[&p]);
+        assert_eq!(themes.len(), 1);
+        assert_eq!(themes[0].0, "kit-dark");
+        assert_eq!(
+            themes[0].1,
+            PathBuf::from("/plugins/acme.kit/themes/dark.toml")
+        );
+    }
+
+    #[test]
+    fn rejects_escaping_and_builtin_paths() {
+        let escaping = loaded(
+            Some(PathBuf::from("/plugins/acme.kit")),
+            vec![
+                ThemeContribution {
+                    name: "abs".into(),
+                    path: "/etc/evil.toml".into(),
+                },
+                ThemeContribution {
+                    name: "dotdot".into(),
+                    path: "../../etc/evil.toml".into(),
+                },
+            ],
+        );
+        assert!(active_themes(&[&escaping]).is_empty());
+
+        // A builtin (no dir) contributes no file themes.
+        let builtin = loaded(
+            None,
+            vec![ThemeContribution {
+                name: "x".into(),
+                path: "x.toml".into(),
+            }],
+        );
+        assert!(active_themes(&[&builtin]).is_empty());
+    }
+}

--- a/src/plugin/contributions.rs
+++ b/src/plugin/contributions.rs
@@ -15,14 +15,23 @@ use super::registry::LoadedPlugin;
 fn resolve_under_dir(plugin: &LoadedPlugin, rel: &str) -> Option<PathBuf> {
     let dir = plugin.dir.as_ref()?;
     let rel = Path::new(rel);
-    if rel.is_absolute()
+    // Reject syntactic escapes first: empty, rooted (absolute or Windows
+    // root-relative like `\Windows\...`), a drive prefix, or any `..`.
+    if rel.as_os_str().is_empty()
+        || rel.has_root()
         || rel
             .components()
             .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
     {
         return None;
     }
-    Some(dir.join(rel))
+    // Then canonicalize both and require the resolved candidate to stay under
+    // the plugin directory, so a symlink inside the plugin dir cannot point
+    // outside it. A non-existent file canonicalizes to None and is dropped (it
+    // could not load anyway).
+    let base = dir.canonicalize().ok()?;
+    let candidate = base.join(rel).canonicalize().ok()?;
+    candidate.starts_with(&base).then_some(candidate)
 }
 
 /// Themes contributed by active plugins, as `(name, path)` pairs. The path is
@@ -69,49 +78,63 @@ api_version = 2
         }
     }
 
+    fn theme(name: &str, path: &str) -> ThemeContribution {
+        ThemeContribution {
+            name: name.into(),
+            path: path.into(),
+        }
+    }
+
     #[test]
     fn resolves_relative_theme_under_dir() {
-        let p = loaded(
-            Some(PathBuf::from("/plugins/acme.kit")),
-            vec![ThemeContribution {
-                name: "kit-dark".into(),
-                path: "themes/dark.toml".into(),
-            }],
-        );
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("acme.kit");
+        std::fs::create_dir_all(dir.join("themes")).unwrap();
+        let file = dir.join("themes/dark.toml");
+        std::fs::write(&file, "background = \"#000000\"\n").unwrap();
+
+        let p = loaded(Some(dir), vec![theme("kit-dark", "themes/dark.toml")]);
         let themes = active_themes(&[&p]);
         assert_eq!(themes.len(), 1);
         assert_eq!(themes[0].0, "kit-dark");
-        assert_eq!(
-            themes[0].1,
-            PathBuf::from("/plugins/acme.kit/themes/dark.toml")
-        );
+        assert_eq!(themes[0].1, file.canonicalize().unwrap());
     }
 
     #[test]
     fn rejects_escaping_and_builtin_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("acme.kit");
+        std::fs::create_dir_all(&dir).unwrap();
         let escaping = loaded(
-            Some(PathBuf::from("/plugins/acme.kit")),
+            Some(dir),
             vec![
-                ThemeContribution {
-                    name: "abs".into(),
-                    path: "/etc/evil.toml".into(),
-                },
-                ThemeContribution {
-                    name: "dotdot".into(),
-                    path: "../../etc/evil.toml".into(),
-                },
+                theme("abs", "/etc/evil.toml"),
+                theme("dotdot", "../../etc/evil.toml"),
+                theme("empty", ""),
             ],
         );
         assert!(active_themes(&[&escaping]).is_empty());
 
         // A builtin (no dir) contributes no file themes.
-        let builtin = loaded(
-            None,
-            vec![ThemeContribution {
-                name: "x".into(),
-                path: "x.toml".into(),
-            }],
-        );
+        let builtin = loaded(None, vec![theme("x", "x.toml")]);
         assert!(active_themes(&[&builtin]).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("acme.kit");
+        std::fs::create_dir_all(&dir).unwrap();
+        let outside = tmp.path().join("outside.toml");
+        std::fs::write(&outside, "background = \"#000000\"\n").unwrap();
+        // A symlink inside the plugin dir pointing outside it must be rejected.
+        std::os::unix::fs::symlink(&outside, dir.join("link.toml")).unwrap();
+
+        let p = loaded(Some(dir), vec![theme("esc", "link.toml")]);
+        assert!(
+            active_themes(&[&p]).is_empty(),
+            "a symlink escaping the plugin dir must not resolve"
+        );
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,6 +6,7 @@
 //! installs, capability grants, and the Tier 0 / Tier 1 contribution surface
 //! return in follow-up PRs.
 
+pub mod contributions;
 pub mod featured;
 pub mod fetch;
 pub mod install;
@@ -76,6 +77,14 @@ pub fn registry() -> Arc<PluginRegistry> {
     let reg = Arc::new(PluginRegistry::load(&config));
     *slot = Some(reg.clone());
     reg
+}
+
+/// Themes contributed by the active plugin set, as `(name, resolved path)`
+/// pairs. The theme registry layers these below builtins and user themes.
+pub fn active_plugin_themes() -> Vec<(String, PathBuf)> {
+    let reg = registry();
+    let active: Vec<&LoadedPlugin> = reg.active().collect();
+    contributions::active_themes(&active)
 }
 
 /// Rebuild the registry from the current on-disk config (after an

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -52,11 +52,11 @@ pub(crate) use sessions::persist_session_update;
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
     docker_status, filesystem_home, get_about, get_current_theme, get_profile_settings,
-    get_resolved_theme, get_settings, get_settings_schema, get_tips, get_update_status,
-    get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds, list_themes,
-    mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen, patch_web_ui_state,
-    rename_profile, serve_sound_file, set_show_tips, update_profile_settings, update_settings,
-    update_theme,
+    get_resolved_theme, get_settings, get_settings_resolved, get_settings_schema, get_tips,
+    get_update_status, get_web_ui_state, list_agents, list_groups, list_profiles, list_sounds,
+    list_themes, mark_tip_seen, mark_volume_ignores_globs_acknowledged, mark_web_tour_seen,
+    patch_web_ui_state, rename_profile, serve_sound_file, set_show_tips, update_profile_settings,
+    update_settings, update_theme,
 };
 pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -11,7 +11,8 @@ use super::validate_profile_name;
 use super::AppState;
 use crate::server::auth::AuthenticatedSession;
 use crate::session::settings_schema::{
-    clear_path, strip_local_only, validate_patch, PatchRejection, Scope,
+    clear_path, rewrite_plugin_sections, runtime_schema, strip_local_only, validate_patch,
+    validate_patch_with, PatchRejection, Scope,
 };
 
 // --- Agents ---
@@ -232,13 +233,16 @@ pub async fn update_settings(
     // or echoed-back patch keeps its safe leaves and silently drops the
     // local-only ones (#1692). They can never reach disk from the web.
     strip_local_only(&mut body);
-    // Validate every remaining leaf against the schema (single source of
-    // truth): unknown section/field -> 400, bad value -> 400. `PATCH
-    // /api/settings` is already elevation-gated by the auth middleware, so any
-    // field reaching here is treated as elevated.
-    if let Err(rej) = validate_patch(&body, Scope::Global, true) {
+    // Validate every remaining leaf against the runtime schema (core plus
+    // active-plugin `plugin:<id>` sections): unknown section/field -> 400, bad
+    // value -> 400. `PATCH /api/settings` is already elevation-gated by the
+    // auth middleware, so any field reaching here is treated as elevated.
+    if let Err(rej) = validate_patch_with(&runtime_schema(), &body, Scope::Global, true) {
         return reject_response(rej);
     }
+    // Fold validated `plugin:<id>` sections into their on-disk storage path
+    // (`plugins.<id>.settings.*`) before the generic merge.
+    rewrite_plugin_sections(&mut body);
 
     let result = tokio::task::spawn_blocking(move || {
         let config = crate::session::Config::load_or_warn();
@@ -300,7 +304,7 @@ pub async fn update_settings(
 /// secrets: descriptors are pure metadata (labels, widgets, validation, write
 /// policy), so this needs no elevation, only normal authentication.
 pub async fn get_settings_schema() -> Json<Vec<crate::session::settings_schema::FieldDescriptor>> {
-    Json(crate::session::settings_schema::schema())
+    Json(runtime_schema())
 }
 
 /// Body of `PATCH /api/theme`. Either field may be omitted to leave it

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -1585,6 +1585,14 @@ pub async fn get_profile_settings(
                 "logging".to_string(),
                 serde_json::to_value(&global.logging)?,
             );
+            // Plugin settings live in the global config (global-only at Tier 0),
+            // not the profile override. Splice them in so the dashboard's plugin
+            // settings render their persisted values instead of reverting to the
+            // manifest default on every profile-view load (#2094).
+            obj.insert(
+                "plugins".to_string(),
+                serde_json::to_value(&global.plugins)?,
+            );
         }
         Ok::<_, anyhow::Error>(val)
     })

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -307,6 +307,20 @@ pub async fn get_settings_schema() -> Json<Vec<crate::session::settings_schema::
     Json(runtime_schema())
 }
 
+/// `GET /api/settings/resolved` returns every setting's effective value plus
+/// its provenance chain (user value > highest-priority plugin default > schema
+/// default for core; stored value > manifest default for plugin settings). The
+/// dashboard uses it to show where a value comes from. Pure metadata derived
+/// from the same schema the surfaces render, so only normal authentication.
+pub async fn get_settings_resolved() -> Json<Vec<crate::session::settings_schema::ResolvedSetting>>
+{
+    Json(
+        tokio::task::spawn_blocking(crate::session::settings_schema::resolve_all)
+            .await
+            .unwrap_or_default(),
+    )
+}
+
 /// Body of `PATCH /api/theme`. Either field may be omitted to leave it
 /// unchanged.
 #[derive(serde::Deserialize)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1491,6 +1491,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::get_settings).patch(api::update_settings),
         )
         .route("/api/settings/schema", get(api::get_settings_schema))
+        .route("/api/settings/resolved", get(api::get_settings_resolved))
         .route("/api/tips", get(api::get_tips))
         .route("/api/tips/show", post(api::set_show_tips))
         .route("/api/app-state/tip-seen", post(api::mark_tip_seen))

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -22,6 +22,7 @@ mod merge;
 mod plugin;
 mod policy;
 mod registry;
+mod resolved;
 mod validate;
 
 pub use merge::{clear_path, merge_json};
@@ -31,6 +32,7 @@ pub use plugin::{
 };
 pub use policy::{strip_local_only, validate_patch, validate_patch_with, PatchRejection, Scope};
 pub use registry::{descriptor, runtime_schema, schema};
+pub use resolved::{resolve, resolve_all, Candidate, ResolvedSetting, SettingSource};
 pub use validate::{validate_value, ValidationError};
 
 /// Widget the surfaces render for a field. The variant carries everything a

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -19,13 +19,18 @@
 use serde::{Deserialize, Serialize};
 
 mod merge;
+mod plugin;
 mod policy;
 mod registry;
 mod validate;
 
 pub use merge::{clear_path, merge_json};
+pub use plugin::{
+    plugin_field_descriptors, plugin_section_id, rewrite_plugin_sections, section_plugin_id,
+    storage_leaf as plugin_storage_leaf, storage_value as plugin_storage_value, PLUGIN_CATEGORY,
+};
 pub use policy::{strip_local_only, validate_patch, validate_patch_with, PatchRejection, Scope};
-pub use registry::{descriptor, schema};
+pub use registry::{descriptor, runtime_schema, schema};
 pub use validate::{validate_value, ValidationError};
 
 /// Widget the surfaces render for a field. The variant carries everything a
@@ -150,6 +155,13 @@ pub struct FieldDescriptor {
     /// renders them after the primary fields under an "Advanced" divider.
     #[serde(default)]
     pub advanced: bool,
+    /// The field's default value, shown when no value is stored yet. Core
+    /// fields leave this `None` (their value always exists in the serialized
+    /// `Config` via the struct's `Default`); plugin fields carry the
+    /// manifest-declared default so the surfaces and the resolution chain show
+    /// it before the user has saved anything.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
 }
 
 impl FieldDescriptor {

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -130,6 +130,12 @@ pub enum ValidationKind {
     EnvList,
     /// Each list entry must be a `host:container` port mapping (digits only).
     PortMappingList,
+    /// Value must be one of a closed set of strings. Used by plugin `select`
+    /// settings so an off-menu value cannot be persisted (core selects encode
+    /// their options in the widget and need no separate rule).
+    OneOf {
+        options: Vec<String>,
+    },
 }
 
 /// One configurable field, emitted by the `SettingsSection` derive. Owned

--- a/src/session/settings_schema/plugin.rs
+++ b/src/session/settings_schema/plugin.rs
@@ -1,0 +1,304 @@
+//! Plugin settings as virtual schema sections.
+//!
+//! A plugin's declared settings render through the same generic schema path as
+//! core settings, under a virtual section id `plugin:<id>`. The API, validation,
+//! TUI, and web all speak that flat `plugin:<id>.<key>` shape; only the disk
+//! storage differs (a plugin value lives in `plugins.<id>.settings.<key>` in the
+//! serialized `Config`). That section-id to storage-path translation is the one
+//! thing that lives here, so no consumer scatters `starts_with("plugin:")`
+//! checks of its own.
+
+use aoe_plugin_api::{SettingContribution, SettingType};
+use serde_json::{json, Value};
+
+use super::{FieldDescriptor, SelectOption, ValidationKind, WebWritePolicy, WidgetKind};
+
+/// Prefix marking a virtual plugin settings section.
+pub const PLUGIN_SECTION_PREFIX: &str = "plugin:";
+
+/// TUI category / web tab plugin settings sit under.
+pub const PLUGIN_CATEGORY: &str = "Plugins";
+
+/// The virtual schema section id for a plugin's settings.
+pub fn plugin_section_id(plugin_id: &str) -> String {
+    format!("{PLUGIN_SECTION_PREFIX}{plugin_id}")
+}
+
+/// The plugin id if `section` is a virtual plugin settings section.
+pub fn section_plugin_id(section: &str) -> Option<&str> {
+    section.strip_prefix(PLUGIN_SECTION_PREFIX)
+}
+
+/// Read a plugin setting's stored value from a serialized `Config` JSON value
+/// (`plugins.<id>.settings.<field>`).
+pub fn storage_value<'a>(root: &'a Value, plugin_id: &str, field: &str) -> Option<&'a Value> {
+    root.get("plugins")?
+        .get(plugin_id)?
+        .get("settings")?
+        .get(field)
+}
+
+/// The nested `Config`-shaped leaf that writes a plugin setting:
+/// `{"plugins": {"<id>": {"settings": {"<field>": leaf}}}}`.
+pub fn storage_leaf(plugin_id: &str, field: &str, leaf: Value) -> Value {
+    json!({ "plugins": { plugin_id: { "settings": { field: leaf } } } })
+}
+
+/// Rewrite a settings PATCH body in place: every top-level `plugin:<id>`
+/// section is folded into `plugins.<id>.settings.*`, matching on-disk storage.
+/// Core sections are left untouched. Call after validation, before merge.
+pub fn rewrite_plugin_sections(body: &mut Value) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    let plugin_keys: Vec<String> = obj
+        .keys()
+        .filter(|k| k.starts_with(PLUGIN_SECTION_PREFIX))
+        .cloned()
+        .collect();
+    if plugin_keys.is_empty() {
+        return;
+    }
+    // Pull each plugin section out, remembering its id, then fold them into the
+    // `plugins.<id>.settings` subtree. One mutable borrow of `obj` throughout.
+    let mut sections = Vec::new();
+    for key in plugin_keys {
+        if let Some(section) = obj.remove(&key) {
+            let id = key[PLUGIN_SECTION_PREFIX.len()..].to_string();
+            sections.push((id, section));
+        }
+    }
+    let plugins = obj
+        .entry("plugins".to_string())
+        .or_insert_with(|| json!({}));
+    let Some(plugins) = plugins.as_object_mut() else {
+        return;
+    };
+    for (id, section) in sections {
+        let entry = plugins.entry(id).or_insert_with(|| json!({}));
+        let Some(entry) = entry.as_object_mut() else {
+            continue;
+        };
+        let settings = entry
+            .entry("settings".to_string())
+            .or_insert_with(|| json!({}));
+        if let (Some(settings), Some(section)) = (settings.as_object_mut(), section.as_object()) {
+            for (k, v) in section {
+                settings.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+/// Build the schema descriptors for one plugin's declared settings.
+pub fn plugin_field_descriptors(
+    plugin_id: &str,
+    settings: &[SettingContribution],
+) -> Vec<FieldDescriptor> {
+    let section = plugin_section_id(plugin_id);
+    settings
+        .iter()
+        .map(|s| {
+            let (widget, validation) = widget_and_validation(s);
+            FieldDescriptor {
+                section: section.clone(),
+                field: s.key.clone(),
+                category: PLUGIN_CATEGORY.to_string(),
+                label: if s.label.is_empty() {
+                    s.key.clone()
+                } else {
+                    s.label.clone()
+                },
+                description: s.description.clone(),
+                widget,
+                // Plugin settings are not host-execution surfaces; the settings
+                // PATCH endpoint is already elevation-gated by the auth layer.
+                web_write: WebWritePolicy::Allow,
+                // Global-only at Tier 0: a plugin setting has one value, stored
+                // in the global config, no per-profile override.
+                profile_overridable: false,
+                validation,
+                advanced: s.advanced,
+                default: s
+                    .default
+                    .as_ref()
+                    .and_then(|t| serde_json::to_value(t).ok()),
+            }
+        })
+        .collect()
+}
+
+fn widget_and_validation(s: &SettingContribution) -> (WidgetKind, ValidationKind) {
+    match s.value_type {
+        SettingType::Bool => (WidgetKind::Toggle, ValidationKind::None),
+        SettingType::String => (
+            WidgetKind::Text {
+                multiline: false,
+                mono: false,
+            },
+            ValidationKind::None,
+        ),
+        SettingType::Integer => {
+            let widget = WidgetKind::Number {
+                min: s.min,
+                max: s.max,
+            };
+            // RangeU64 is the only integer gate the host has; use it when the
+            // declared bounds are non-negative (the common plugin counter
+            // case), otherwise leave it ungated rather than misreport a signed
+            // range.
+            let validation = if s.min.unwrap_or(0) >= 0 && s.max.unwrap_or(0) >= 0 {
+                ValidationKind::RangeU64 {
+                    min: s.min.unwrap_or(0) as u64,
+                    max: s.max.map(|m| m as u64),
+                }
+            } else {
+                ValidationKind::None
+            };
+            (widget, validation)
+        }
+        SettingType::Select => (
+            WidgetKind::Select {
+                options: s.options.iter().map(|o| SelectOption::new(o, o)).collect(),
+            },
+            ValidationKind::None,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contrib(key: &str, ty: SettingType) -> SettingContribution {
+        SettingContribution {
+            key: key.to_string(),
+            label: String::new(),
+            description: String::new(),
+            value_type: ty,
+            options: Vec::new(),
+            min: None,
+            max: None,
+            default: None,
+            advanced: false,
+        }
+    }
+
+    #[test]
+    fn section_id_round_trips() {
+        let id = plugin_section_id("acme.kit");
+        assert_eq!(id, "plugin:acme.kit");
+        assert_eq!(section_plugin_id(&id), Some("acme.kit"));
+        assert_eq!(section_plugin_id("acp"), None);
+    }
+
+    #[test]
+    fn descriptors_map_types_to_widgets() {
+        let mut s_int = contrib("retries", SettingType::Integer);
+        s_int.min = Some(0);
+        s_int.max = Some(9);
+        s_int.default = Some(toml::Value::Integer(3));
+        let descs = plugin_field_descriptors(
+            "acme.kit",
+            &[
+                contrib("on", SettingType::Bool),
+                contrib("name", SettingType::String),
+                s_int,
+                SettingContribution {
+                    options: vec!["a".into(), "b".into()],
+                    ..contrib("mode", SettingType::Select)
+                },
+            ],
+        );
+        assert_eq!(descs[0].section, "plugin:acme.kit");
+        assert!(matches!(descs[0].widget, WidgetKind::Toggle));
+        assert!(matches!(descs[1].widget, WidgetKind::Text { .. }));
+        assert!(matches!(
+            descs[2].widget,
+            WidgetKind::Number {
+                min: Some(0),
+                max: Some(9)
+            }
+        ));
+        assert!(matches!(
+            descs[2].validation,
+            ValidationKind::RangeU64 {
+                min: 0,
+                max: Some(9)
+            }
+        ));
+        assert_eq!(descs[2].default, Some(serde_json::json!(3)));
+        assert!(matches!(descs[3].widget, WidgetKind::Select { .. }));
+        // Label falls back to the key when unset.
+        assert_eq!(descs[0].label, "on");
+        // Global-only at Tier 0.
+        assert!(!descs[0].profile_overridable);
+    }
+
+    #[test]
+    fn rewrite_folds_plugin_sections_into_storage() {
+        let mut body = json!({
+            "theme": { "idle_decay_minutes": 5 },
+            "plugin:acme.kit": { "retries": 4, "mode": "fast" },
+        });
+        rewrite_plugin_sections(&mut body);
+        assert_eq!(body["theme"]["idle_decay_minutes"], json!(5));
+        assert!(body.get("plugin:acme.kit").is_none());
+        assert_eq!(body["plugins"]["acme.kit"]["settings"]["retries"], json!(4));
+        assert_eq!(
+            body["plugins"]["acme.kit"]["settings"]["mode"],
+            json!("fast")
+        );
+    }
+
+    #[test]
+    fn storage_helpers_round_trip() {
+        let mut cfg = json!({});
+        let leaf = storage_leaf("acme.kit", "retries", json!(7));
+        super::super::merge_json(&mut cfg, &leaf);
+        assert_eq!(storage_value(&cfg, "acme.kit", "retries"), Some(&json!(7)));
+    }
+
+    #[test]
+    fn plugin_patch_validates_then_rewrites_to_storage() {
+        // A plugin section validates against runtime descriptors through the
+        // same gate as core, then folds into its storage path before merge.
+        let mut s_int = contrib("retries", SettingType::Integer);
+        s_int.min = Some(0);
+        s_int.max = Some(5);
+        let descriptors = plugin_field_descriptors("acme.kit", &[s_int]);
+
+        let good = json!({ "plugin:acme.kit": { "retries": 4 } });
+        assert!(super::super::validate_patch_with(
+            &descriptors,
+            &good,
+            super::super::Scope::Global,
+            true
+        )
+        .is_ok());
+
+        // Out-of-range is rejected by the derived RangeU64 gate.
+        let bad = json!({ "plugin:acme.kit": { "retries": 9 } });
+        assert!(super::super::validate_patch_with(
+            &descriptors,
+            &bad,
+            super::super::Scope::Global,
+            true
+        )
+        .is_err());
+
+        // Unknown plugin field is rejected.
+        let unknown = json!({ "plugin:acme.kit": { "nope": 1 } });
+        assert!(super::super::validate_patch_with(
+            &descriptors,
+            &unknown,
+            super::super::Scope::Global,
+            true
+        )
+        .is_err());
+
+        let mut body = good;
+        rewrite_plugin_sections(&mut body);
+        assert_eq!(body["plugins"]["acme.kit"]["settings"]["retries"], json!(4));
+    }
+}

--- a/src/session/settings_schema/plugin.rs
+++ b/src/session/settings_schema/plugin.rs
@@ -161,7 +161,11 @@ fn widget_and_validation(s: &SettingContribution) -> (WidgetKind, ValidationKind
             WidgetKind::Select {
                 options: s.options.iter().map(|o| SelectOption::new(o, o)).collect(),
             },
-            ValidationKind::None,
+            // Gate the value against the declared options server-side so an
+            // off-menu value can never reach storage.
+            ValidationKind::OneOf {
+                options: s.options.clone(),
+            },
         ),
     }
 }
@@ -300,5 +304,31 @@ mod tests {
         let mut body = good;
         rewrite_plugin_sections(&mut body);
         assert_eq!(body["plugins"]["acme.kit"]["settings"]["retries"], json!(4));
+    }
+
+    #[test]
+    fn select_value_is_gated_against_options() {
+        let descriptors = plugin_field_descriptors(
+            "acme.kit",
+            &[SettingContribution {
+                options: vec!["fast".into(), "slow".into()],
+                ..contrib("mode", SettingType::Select)
+            }],
+        );
+        // An on-menu value passes; an off-menu value is rejected.
+        assert!(super::super::validate_patch_with(
+            &descriptors,
+            &json!({ "plugin:acme.kit": { "mode": "fast" } }),
+            super::super::Scope::Global,
+            true
+        )
+        .is_ok());
+        assert!(super::super::validate_patch_with(
+            &descriptors,
+            &json!({ "plugin:acme.kit": { "mode": "turbo" } }),
+            super::super::Scope::Global,
+            true
+        )
+        .is_err());
     }
 }

--- a/src/session/settings_schema/registry.rs
+++ b/src/session/settings_schema/registry.rs
@@ -30,6 +30,22 @@ pub fn schema() -> Vec<FieldDescriptor> {
     out
 }
 
+/// The schema as the running process sees it: the static core [`schema`] plus
+/// one virtual `plugin:<id>` section per active plugin's declared settings. The
+/// server serves this over `GET /api/settings/schema`, validates PATCHes against
+/// it, and the TUI builds its Plugins tab from it, so plugin settings render and
+/// validate through the exact same path as core settings.
+pub fn runtime_schema() -> Vec<FieldDescriptor> {
+    let mut out = schema();
+    for p in crate::plugin::registry().active() {
+        out.extend(super::plugin::plugin_field_descriptors(
+            p.id(),
+            &p.manifest.settings,
+        ));
+    }
+    out
+}
+
 /// Look up a single field's descriptor by `section` and `field`.
 pub fn descriptor(section: &str, field: &str) -> Option<FieldDescriptor> {
     schema()

--- a/src/session/settings_schema/resolved.rs
+++ b/src/session/settings_schema/resolved.rs
@@ -1,10 +1,17 @@
 //! Settings resolution with provenance (#2094).
 //!
-//! A setting's effective value can come from more than one layer. Core settings
-//! layer: the user's value (when it differs from the baseline default) over the
-//! highest-priority active plugin's `setting_defaults` override over the core
-//! schema default. A plugin's own settings layer: the stored value over the
-//! plugin's manifest default.
+//! A setting's effective value can come from more than one layer.
+//!
+//! For a **core** key at Tier 0 the effective value is the user's value (when it
+//! differs from the baseline default), else the core schema default. A plugin's
+//! `setting_defaults` override of a core key is surfaced as a *candidate* so it
+//! is observable, but it does NOT win: nothing applies it during real `Config`
+//! load or merge yet, so the running app uses the user value or the struct
+//! default. The runtime host applies these overrides for real (#2095); until
+//! then a `plugin_default` candidate is "declared, not yet in effect".
+//!
+//! For a **plugin's own** setting the effective value is the stored value, else
+//! the plugin's manifest default.
 //!
 //! [`resolve`] returns the winning value, its [`SettingSource`], and every
 //! candidate that was considered, so `aoe settings explain` and
@@ -22,7 +29,10 @@ pub enum SettingSource {
     /// The user's stored value (a core field changed from its default, or a
     /// stored plugin setting value).
     User,
-    /// A plugin's `setting_defaults` override of a core setting.
+    /// A plugin's `setting_defaults` override of a core setting. At Tier 0 this
+    /// only ever appears as a candidate, never as the winning source: it is
+    /// declared but not yet applied at runtime (the runtime host applies it,
+    /// #2095).
     PluginDefault { plugin: String },
     /// The owning plugin's manifest default for one of its own settings.
     ManifestDefault { plugin: String },
@@ -120,20 +130,24 @@ fn resolve_core(
         .unwrap_or(Value::Null);
     let stored = cfg.get(section).and_then(|s| s.get(field)).cloned();
 
-    let mut candidates = Vec::new();
-
     // A user value is one that differs from the baseline default.
-    if let Some(v) = &stored {
-        if *v != schema_default {
-            candidates.push(Candidate {
-                source: SettingSource::User,
-                value: v.clone(),
-            });
-        }
+    let user = stored.filter(|v| *v != schema_default);
+
+    let mut candidates = Vec::new();
+    if let Some(v) = &user {
+        candidates.push(Candidate {
+            source: SettingSource::User,
+            value: v.clone(),
+        });
     }
 
-    // Plugin overrides, in active-plugin order (builtins first); the first is
-    // the highest priority.
+    // Plugin overrides, in active-plugin order (builtins first). At Tier 0 these
+    // are recorded as candidates so they are observable, but they do NOT win:
+    // nothing applies a plugin's core-default override during real Config load
+    // or merge yet, so the running app uses the user value or the struct
+    // default. The runtime host applies these for real (#2095). Reporting one
+    // as the effective value here would misrepresent what every core consumer
+    // actually reads.
     for p in crate::plugin::registry().active() {
         if let Some(tv) = p.manifest.setting_defaults.get(key) {
             if let Ok(v) = serde_json::to_value(tv) {
@@ -149,10 +163,22 @@ fn resolve_core(
 
     candidates.push(Candidate {
         source: SettingSource::SchemaDefault,
-        value: schema_default,
+        value: schema_default.clone(),
     });
 
-    finish(key, candidates)
+    // The effective value is what the app actually uses today: the user value,
+    // else the struct default. Plugin core-default overrides stay in
+    // `candidates` only.
+    let (source, value) = match user {
+        Some(v) => (SettingSource::User, v),
+        None => (SettingSource::SchemaDefault, schema_default),
+    };
+    ResolvedSetting {
+        key: key.to_string(),
+        value,
+        source,
+        candidates,
+    }
 }
 
 fn resolve_plugin_own(key: &str, plugin_id: &str, field: &str, cfg: &Value) -> ResolvedSetting {

--- a/src/session/settings_schema/resolved.rs
+++ b/src/session/settings_schema/resolved.rs
@@ -13,7 +13,7 @@
 use serde::Serialize;
 use serde_json::Value;
 
-use super::{runtime_schema, section_plugin_id};
+use super::{runtime_schema, section_plugin_id, FieldDescriptor};
 
 /// Where a resolved value came from.
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -62,24 +62,38 @@ fn split_key(key: &str) -> Option<(&str, &str)> {
 pub fn resolve(key: &str) -> Option<ResolvedSetting> {
     let cfg = serde_json::to_value(crate::session::Config::load_or_warn()).ok()?;
     let default_cfg = serde_json::to_value(crate::session::Config::default()).ok()?;
-    resolve_with(key, &cfg, &default_cfg)
+    resolve_with(key, &cfg, &default_cfg, &runtime_schema())
 }
 
 /// Resolve every known setting (core plus active-plugin). Used by
-/// `GET /api/settings/resolved`. Loads the config once for the whole set.
+/// `GET /api/settings/resolved`. Loads the config and builds the schema once
+/// for the whole set rather than per field.
 pub fn resolve_all() -> Vec<ResolvedSetting> {
     let cfg = serde_json::to_value(crate::session::Config::load_or_warn()).unwrap_or(Value::Null);
     let default_cfg =
         serde_json::to_value(crate::session::Config::default()).unwrap_or(Value::Null);
-    runtime_schema()
+    let schema = runtime_schema();
+    schema
         .iter()
-        .filter_map(|d| resolve_with(&format!("{}.{}", d.section, d.field), &cfg, &default_cfg))
+        .filter_map(|d| {
+            resolve_with(
+                &format!("{}.{}", d.section, d.field),
+                &cfg,
+                &default_cfg,
+                &schema,
+            )
+        })
         .collect()
 }
 
-fn resolve_with(key: &str, cfg: &Value, default_cfg: &Value) -> Option<ResolvedSetting> {
+fn resolve_with(
+    key: &str,
+    cfg: &Value,
+    default_cfg: &Value,
+    schema: &[FieldDescriptor],
+) -> Option<ResolvedSetting> {
     let (section, field) = split_key(key)?;
-    if !runtime_schema()
+    if !schema
         .iter()
         .any(|d| d.section == section && d.field == field)
     {

--- a/src/session/settings_schema/resolved.rs
+++ b/src/session/settings_schema/resolved.rs
@@ -1,0 +1,229 @@
+//! Settings resolution with provenance (#2094).
+//!
+//! A setting's effective value can come from more than one layer. Core settings
+//! layer: the user's value (when it differs from the baseline default) over the
+//! highest-priority active plugin's `setting_defaults` override over the core
+//! schema default. A plugin's own settings layer: the stored value over the
+//! plugin's manifest default.
+//!
+//! [`resolve`] returns the winning value, its [`SettingSource`], and every
+//! candidate that was considered, so `aoe settings explain` and
+//! `GET /api/settings/resolved` can show exactly why a value is what it is.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use super::{runtime_schema, section_plugin_id};
+
+/// Where a resolved value came from.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SettingSource {
+    /// The user's stored value (a core field changed from its default, or a
+    /// stored plugin setting value).
+    User,
+    /// A plugin's `setting_defaults` override of a core setting.
+    PluginDefault { plugin: String },
+    /// The owning plugin's manifest default for one of its own settings.
+    ManifestDefault { plugin: String },
+    /// The core schema (struct) default.
+    SchemaDefault,
+}
+
+/// One layer that contributed a candidate value, in precedence order.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Candidate {
+    pub source: SettingSource,
+    pub value: Value,
+}
+
+/// A setting's resolved value plus the full provenance chain.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ResolvedSetting {
+    /// Canonical key: `section.field` for core, `plugin:<id>.<key>` for plugin.
+    pub key: String,
+    pub value: Value,
+    pub source: SettingSource,
+    /// Every candidate considered, highest precedence first. The first entry
+    /// equals `source`/`value`.
+    pub candidates: Vec<Candidate>,
+}
+
+/// Split a canonical key into `(section, field)`. The field is the last dotted
+/// segment; the section is everything before it (so `plugin:acme.kit.retries`
+/// splits into `plugin:acme.kit` + `retries`, and `acp.default_agent` into
+/// `acp` + `default_agent`).
+fn split_key(key: &str) -> Option<(&str, &str)> {
+    key.rsplit_once('.')
+}
+
+/// Resolve one setting by canonical key against the live config and the active
+/// plugin set. `None` if the key is not a known setting.
+pub fn resolve(key: &str) -> Option<ResolvedSetting> {
+    let cfg = serde_json::to_value(crate::session::Config::load_or_warn()).ok()?;
+    let default_cfg = serde_json::to_value(crate::session::Config::default()).ok()?;
+    resolve_with(key, &cfg, &default_cfg)
+}
+
+/// Resolve every known setting (core plus active-plugin). Used by
+/// `GET /api/settings/resolved`. Loads the config once for the whole set.
+pub fn resolve_all() -> Vec<ResolvedSetting> {
+    let cfg = serde_json::to_value(crate::session::Config::load_or_warn()).unwrap_or(Value::Null);
+    let default_cfg =
+        serde_json::to_value(crate::session::Config::default()).unwrap_or(Value::Null);
+    runtime_schema()
+        .iter()
+        .filter_map(|d| resolve_with(&format!("{}.{}", d.section, d.field), &cfg, &default_cfg))
+        .collect()
+}
+
+fn resolve_with(key: &str, cfg: &Value, default_cfg: &Value) -> Option<ResolvedSetting> {
+    let (section, field) = split_key(key)?;
+    if !runtime_schema()
+        .iter()
+        .any(|d| d.section == section && d.field == field)
+    {
+        return None;
+    }
+    if let Some(plugin_id) = section_plugin_id(section) {
+        Some(resolve_plugin_own(key, plugin_id, field, cfg))
+    } else {
+        Some(resolve_core(key, section, field, cfg, default_cfg))
+    }
+}
+
+fn resolve_core(
+    key: &str,
+    section: &str,
+    field: &str,
+    cfg: &Value,
+    default_cfg: &Value,
+) -> ResolvedSetting {
+    let schema_default = default_cfg
+        .get(section)
+        .and_then(|s| s.get(field))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let stored = cfg.get(section).and_then(|s| s.get(field)).cloned();
+
+    let mut candidates = Vec::new();
+
+    // A user value is one that differs from the baseline default.
+    if let Some(v) = &stored {
+        if *v != schema_default {
+            candidates.push(Candidate {
+                source: SettingSource::User,
+                value: v.clone(),
+            });
+        }
+    }
+
+    // Plugin overrides, in active-plugin order (builtins first); the first is
+    // the highest priority.
+    for p in crate::plugin::registry().active() {
+        if let Some(tv) = p.manifest.setting_defaults.get(key) {
+            if let Ok(v) = serde_json::to_value(tv) {
+                candidates.push(Candidate {
+                    source: SettingSource::PluginDefault {
+                        plugin: p.id().to_string(),
+                    },
+                    value: v,
+                });
+            }
+        }
+    }
+
+    candidates.push(Candidate {
+        source: SettingSource::SchemaDefault,
+        value: schema_default,
+    });
+
+    finish(key, candidates)
+}
+
+fn resolve_plugin_own(key: &str, plugin_id: &str, field: &str, cfg: &Value) -> ResolvedSetting {
+    let mut candidates = Vec::new();
+
+    if let Some(v) = super::plugin_storage_value(cfg, plugin_id, field) {
+        candidates.push(Candidate {
+            source: SettingSource::User,
+            value: v.clone(),
+        });
+    }
+
+    // The owning plugin's manifest default for this key.
+    if let Some(p) = crate::plugin::registry().get(plugin_id) {
+        if let Some(s) = p.manifest.settings.iter().find(|s| s.key == field) {
+            if let Some(tv) = &s.default {
+                if let Ok(v) = serde_json::to_value(tv) {
+                    candidates.push(Candidate {
+                        source: SettingSource::ManifestDefault {
+                            plugin: plugin_id.to_string(),
+                        },
+                        value: v,
+                    });
+                }
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        candidates.push(Candidate {
+            source: SettingSource::ManifestDefault {
+                plugin: plugin_id.to_string(),
+            },
+            value: Value::Null,
+        });
+    }
+
+    finish(key, candidates)
+}
+
+fn finish(key: &str, candidates: Vec<Candidate>) -> ResolvedSetting {
+    let winner = candidates.first().cloned().unwrap_or(Candidate {
+        source: SettingSource::SchemaDefault,
+        value: Value::Null,
+    });
+    ResolvedSetting {
+        key: key.to_string(),
+        value: winner.value,
+        source: winner.source,
+        candidates,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_key_takes_last_segment() {
+        assert_eq!(
+            split_key("acp.default_agent"),
+            Some(("acp", "default_agent"))
+        );
+        assert_eq!(
+            split_key("plugin:acme.kit.retries"),
+            Some(("plugin:acme.kit", "retries"))
+        );
+        assert_eq!(split_key("nodot"), None);
+    }
+
+    #[test]
+    fn unknown_key_resolves_to_none() {
+        assert!(resolve("acp.totally_made_up").is_none());
+        assert!(resolve("nodot").is_none());
+    }
+
+    #[test]
+    fn core_field_falls_back_to_schema_default() {
+        // With no user override and no plugin setting_defaults, a core field
+        // resolves to its schema default.
+        let r = resolve("acp.default_agent").expect("known core key");
+        assert_eq!(r.source, SettingSource::SchemaDefault);
+        assert_eq!(
+            r.candidates.last().unwrap().source,
+            SettingSource::SchemaDefault
+        );
+    }
+}

--- a/src/session/settings_schema/validate.rs
+++ b/src/session/settings_schema/validate.rs
@@ -71,6 +71,19 @@ pub fn validate_value(kind: &ValidationKind, value: &Value) -> Result<(), Valida
         ValidationKind::PortMappingList => {
             validate_string_list(value, crate::session::validate_port_mapping_format)
         }
+        ValidationKind::OneOf { options } => {
+            let s = value
+                .as_str()
+                .ok_or_else(|| ValidationError::new("expected a string"))?;
+            if options.iter().any(|o| o == s) {
+                Ok(())
+            } else {
+                Err(ValidationError::new(format!(
+                    "must be one of: {}",
+                    options.join(", ")
+                )))
+            }
+        }
     }
 }
 
@@ -142,6 +155,16 @@ mod tests {
         assert!(validate_value(&ValidationKind::EnvList, &json!(["1BAD=v"])).is_err());
         assert!(validate_value(&ValidationKind::EnvList, &json!(["has space"])).is_err());
         assert!(validate_value(&ValidationKind::EnvList, &json!("notalist")).is_err());
+    }
+
+    #[test]
+    fn one_of_membership() {
+        let kind = ValidationKind::OneOf {
+            options: vec!["fast".into(), "slow".into()],
+        };
+        assert!(validate_value(&kind, &json!("fast")).is_ok());
+        assert!(validate_value(&kind, &json!("turbo")).is_err());
+        assert!(validate_value(&kind, &json!(3)).is_err());
     }
 
     #[test]

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -81,7 +81,7 @@ pub enum ActionId {
 /// the uppercase letter `code` (terminals deliver `Shift+d` as `Char('D')`,
 /// and iOS Mosh delivers a bare uppercase keycode with no Shift modifier, so
 /// matching on the uppercase code rather than a Shift flag covers both).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Chord {
     pub code: KeyCode,
     pub ctrl: bool,
@@ -194,6 +194,118 @@ pub fn resolve(key: &KeyEvent, strict: bool, ctx: &Ctx) -> Option<ActionId> {
         }
     }
     None
+}
+
+/// A plugin-contributed action a key resolved to: a plugin id plus the command
+/// the keybind targets. At Tier 0 there is no executor, so resolving one is
+/// inspectable (and surfaces a "needs runtime" notice) but not yet runnable;
+/// the executor lands with the runtime host (#2095).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginAction {
+    pub plugin_id: String,
+    pub action: String,
+}
+
+impl PluginAction {
+    /// Canonical external name, `plugin.<id>.<action>`.
+    pub fn canonical(&self) -> String {
+        format!("plugin.{}.{}", self.plugin_id, self.action)
+    }
+}
+
+/// The merged resolver's result: a core action, or a plugin action. Core always
+/// shadows a plugin binding on the same chord (core is resolved first).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedAction {
+    Core(ActionId),
+    Plugin(PluginAction),
+}
+
+/// Resolve a key across the merged core + plugin binding tables. Core bindings
+/// (the static [`BINDINGS`] table, honoring strict mode and context) are tried
+/// first and always win; only then are active plugins' declared keybinds
+/// consulted. Returns `None` if nothing claims the chord.
+pub fn resolve_action(key: &KeyEvent, strict: bool, ctx: &Ctx) -> Option<ResolvedAction> {
+    if let Some(id) = resolve(key, strict, ctx) {
+        return Some(ResolvedAction::Core(id));
+    }
+    for (chord, action) in plugin_bindings() {
+        if chord_matches(&chord, key) {
+            return Some(ResolvedAction::Plugin(action));
+        }
+    }
+    None
+}
+
+/// The active plugins' declared keybinds, parsed into `(chord, action)`. A
+/// keybind whose key string does not parse is skipped (its conflict-free state
+/// is surfaced by `aoe plugin info`).
+// ponytail: rebuilt per unmatched keypress; the active set is tiny and this is
+// not a hot path. Cache behind the registry generation if that ever changes.
+fn plugin_bindings() -> Vec<(Chord, PluginAction)> {
+    let mut out = Vec::new();
+    for p in crate::plugin::registry().active() {
+        for kb in &p.manifest.keybinds {
+            if let Some(chord) = parse_chord(&kb.key) {
+                out.push((
+                    chord,
+                    PluginAction {
+                        plugin_id: p.id().to_string(),
+                        action: kb.command.clone(),
+                    },
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Parse a key-chord string like `Ctrl+K`, `Shift+D`, `F5`, or `q` into a
+/// [`Chord`]. Supports `Ctrl`/`Shift` modifiers, single characters, and
+/// function keys. Returns `None` for anything else.
+pub fn parse_chord(s: &str) -> Option<Chord> {
+    let mut ctrl = false;
+    let mut shift = false;
+    let mut key: Option<&str> = None;
+    for tok in s.split('+').map(str::trim).filter(|t| !t.is_empty()) {
+        match tok.to_ascii_lowercase().as_str() {
+            "ctrl" | "control" => ctrl = true,
+            "shift" => shift = true,
+            _ => key = Some(tok),
+        }
+    }
+    let key = key?;
+    let code = if key.len() == 1 {
+        // Match the table's convention: bare letters are lowercase chars, Shift
+        // is encoded as the uppercase char (terminals deliver Ctrl+k as a
+        // lowercase Char with the CONTROL modifier, Shift+d as Char('D')).
+        let c = key.chars().next().unwrap();
+        let c = if shift {
+            c.to_ascii_uppercase()
+        } else {
+            c.to_ascii_lowercase()
+        };
+        KeyCode::Char(c)
+    } else if let Some(n) = key
+        .strip_prefix(['F', 'f'])
+        .and_then(|n| n.parse::<u8>().ok())
+    {
+        KeyCode::F(n)
+    } else {
+        return None;
+    };
+    Some(Chord { code, ctrl })
+}
+
+/// Whether a core binding already claims `chord` in either mode. Used by
+/// `aoe plugin info` to flag a plugin keybind that core shadows.
+pub fn core_shadows(chord: &Chord) -> bool {
+    BINDINGS.iter().any(|b| {
+        b.non_strict
+            .iter()
+            .chain(b.strict)
+            .any(|c| c.code == chord.code && c.ctrl == chord.ctrl)
+    })
 }
 
 /// Human-readable label for a binding's primary chord in the given mode, e.g.
@@ -815,6 +927,71 @@ mod tests {
 
     fn ctrl_key(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn parse_chord_handles_modifiers_and_keys() {
+        assert_eq!(
+            parse_chord("Ctrl+K"),
+            Some(Chord {
+                code: KeyCode::Char('k'),
+                ctrl: true
+            })
+        );
+        assert_eq!(
+            parse_chord("Shift+D"),
+            Some(Chord {
+                code: KeyCode::Char('D'),
+                ctrl: false
+            })
+        );
+        assert_eq!(
+            parse_chord("q"),
+            Some(Chord {
+                code: KeyCode::Char('q'),
+                ctrl: false
+            })
+        );
+        assert_eq!(
+            parse_chord("F5"),
+            Some(Chord {
+                code: KeyCode::F(5),
+                ctrl: false
+            })
+        );
+        assert_eq!(parse_chord(""), None);
+        assert_eq!(parse_chord("Ctrl+"), None);
+    }
+
+    #[test]
+    fn core_shadows_known_core_chords() {
+        // `q` is the Quit binding; an unbound chord is not shadowed.
+        assert!(core_shadows(&parse_chord("q").unwrap()));
+        assert!(!core_shadows(&Chord {
+            code: KeyCode::Char('z'),
+            ctrl: true
+        }));
+    }
+
+    #[test]
+    fn resolve_action_wraps_core_bindings() {
+        // With no active plugins in the test process, the merged resolver just
+        // returns the core action, wrapped as Core.
+        let c = ctx();
+        assert_eq!(
+            resolve_action(&key('q'), false, &c),
+            Some(ResolvedAction::Core(ActionId::Quit))
+        );
+        assert_eq!(resolve_action(&ctrl_key('z'), false, &c), None);
+    }
+
+    #[test]
+    fn plugin_action_canonical_is_namespaced() {
+        let a = PluginAction {
+            plugin_id: "acme.kit".to_string(),
+            action: "do-thing".to_string(),
+        };
+        assert_eq!(a.canonical(), "plugin.acme.kit.do-thing");
     }
 
     #[test]

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -207,8 +207,14 @@ pub struct PluginAction {
 }
 
 impl PluginAction {
-    /// Canonical external name, `plugin.<id>.<action>`.
+    /// Canonical external name, `plugin.<id>.<action>`. Idempotent: a manifest
+    /// keybind may already target a fully-qualified `plugin.<id>.<cmd>` command,
+    /// so an action that is already canonical is returned unchanged rather than
+    /// double-prefixed.
     pub fn canonical(&self) -> String {
+        if self.action.starts_with("plugin.") {
+            return self.action.clone();
+        }
         format!("plugin.{}.{}", self.plugin_id, self.action)
     }
 }
@@ -271,7 +277,12 @@ pub fn parse_chord(s: &str) -> Option<Chord> {
         match tok.to_ascii_lowercase().as_str() {
             "ctrl" | "control" => ctrl = true,
             "shift" => shift = true,
-            _ => key = Some(tok),
+            // Unsupported modifiers and a second key token are rejected rather
+            // than silently remapped: `Alt+K` must not collapse to a bare `k`
+            // that hijacks core navigation.
+            "alt" | "option" | "meta" | "super" | "cmd" => return None,
+            _ if key.is_none() => key = Some(tok),
+            _ => return None,
         }
     }
     let key = key?;
@@ -964,6 +975,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_chord_rejects_unsupported_and_repeated_tokens() {
+        // Unknown modifiers must not collapse to a bare key that hijacks core
+        // navigation, and a chord may carry at most one key token.
+        assert_eq!(parse_chord("Alt+K"), None);
+        assert_eq!(parse_chord("Ctrl+Alt+K"), None);
+        assert_eq!(parse_chord("Ctrl+K+J"), None);
+        assert_eq!(parse_chord("Meta+K"), None);
+    }
+
+    #[test]
     fn core_shadows_known_core_chords() {
         // `q` is the Quit binding; an unbound chord is not shadowed.
         assert!(core_shadows(&parse_chord("q").unwrap()));
@@ -992,6 +1013,13 @@ mod tests {
             action: "do-thing".to_string(),
         };
         assert_eq!(a.canonical(), "plugin.acme.kit.do-thing");
+
+        // Idempotent when the manifest already targets a canonical command.
+        let already = PluginAction {
+            plugin_id: "acme.kit".to_string(),
+            action: "plugin.acme.kit.do-thing".to_string(),
+        };
+        assert_eq!(already.canonical(), "plugin.acme.kit.do-thing");
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2250,8 +2250,22 @@ impl HomeView {
             has_search: !self.search_matches.is_empty(),
             project_group_selected: self.project_group_at_cursor().is_some(),
         };
-        if let Some(id) = bindings::resolve(&key, self.strict_hotkeys, &ctx) {
-            return self.run_action(id, update_info);
+        match bindings::resolve_action(&key, self.strict_hotkeys, &ctx) {
+            Some(bindings::ResolvedAction::Core(id)) => return self.run_action(id, update_info),
+            Some(bindings::ResolvedAction::Plugin(action)) => {
+                // Tier 0 has no plugin executor; the binding resolves and is
+                // inspectable, but running it waits for the runtime host (#2095).
+                self.info_dialog = Some(InfoDialog::sized_to_fit(
+                    "Plugin action",
+                    &format!(
+                        "{} is a plugin action. Running plugin actions needs the plugin runtime, \
+                         which is not available yet.",
+                        action.canonical()
+                    ),
+                ));
+                return None;
+            }
+            None => {}
         }
 
         // Navigation / structural keys: identical in both modes, never relocate.

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -204,6 +204,19 @@ impl SettingField {
         matches!(self.value, FieldValue::SectionHeader)
     }
 
+    /// Human-readable rendering of the current value (for read-only displays).
+    pub fn display_value(&self) -> String {
+        value_display_string(&self.value)
+    }
+
+    /// The schema `section` this row edits, if it is a schema-backed row.
+    pub fn schema_section(&self) -> Option<&str> {
+        match &self.kind {
+            FieldKind::Schema { section, .. } => Some(section),
+            _ => None,
+        }
+    }
+
     /// Stable identifier used by the search overlay to relocate the cursor
     /// after a jump, and by input handlers that special-case a specific field.
     pub fn ident(&self) -> String {
@@ -695,7 +708,7 @@ pub fn build_fields_for_category(
         });
     }
 
-    for desc in crate::session::settings_schema::schema()
+    for desc in crate::session::settings_schema::runtime_schema()
         .into_iter()
         .filter(|d| d.category == category.schema_name())
         // Global-only fields (e.g. the theme) are not profile-overridable, so
@@ -766,7 +779,19 @@ fn build_schema_row(
     desc: &FieldDescriptor,
     ctx: &BuildCtx,
 ) -> SettingField {
-    let current = json_at(ctx.effective_json, &desc.section, &desc.field);
+    // Plugin settings (`plugin:<id>` sections) live at a different storage
+    // path (`plugins.<id>.settings.<field>`) and fall back to the manifest's
+    // declared default when unset; core fields read their `section.field` leaf,
+    // which always exists via the struct Default.
+    let current = match crate::session::settings_schema::section_plugin_id(&desc.section) {
+        Some(id) => crate::session::settings_schema::plugin_storage_value(
+            ctx.effective_json,
+            id,
+            &desc.field,
+        )
+        .or(desc.default.as_ref()),
+        None => json_at(ctx.effective_json, &desc.section, &desc.field),
+    };
     let value = value_from_json(&desc.widget, current);
     let has_override = desc.profile_overridable && ctx.has_override(&desc.section, &desc.field);
     let inherited_display = if has_override {
@@ -958,10 +983,32 @@ pub fn apply_field_to_config(
     };
 
     match scope {
-        SettingsScope::Global => set_config_path(global, &section, &sub, leaf),
+        SettingsScope::Global => {
+            // Plugin settings are global-only and persist under
+            // `plugins.<id>.settings`; core fields write their `section.field`.
+            match crate::session::settings_schema::section_plugin_id(&section) {
+                Some(id) => set_config_plugin_path(global, id, &sub, leaf),
+                None => set_config_path(global, &section, &sub, leaf),
+            }
+        }
+        // Plugin fields are filtered out of Profile/Repo scope (not
+        // profile_overridable), so only core fields reach here.
         SettingsScope::Profile | SettingsScope::Repo => {
             set_override_path(profile, &section, &sub, leaf)
         }
+    }
+}
+
+/// Write a plugin setting leaf into `plugins.<id>.settings.<field>` of the
+/// global config.
+fn set_config_plugin_path(config: &mut Config, plugin_id: &str, field: &str, leaf: Value) {
+    let mut j = serde_json::to_value(&*config).unwrap_or_else(|_| json!({}));
+    merge_json(
+        &mut j,
+        &crate::session::settings_schema::plugin_storage_leaf(plugin_id, field, leaf),
+    );
+    if let Ok(updated) = serde_json::from_value(j) {
+        *config = updated;
     }
 }
 

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -255,8 +255,22 @@ impl SettingsView {
         // pane; every other category renders the normal field list.
         if self.current_category() == SettingsCategory::Plugins {
             let focused = self.focus == SettingsFocus::Fields;
-            self.plugin_manager
-                .render_inline(frame, layout[1], theme, focused);
+            // When the active plugin set declares settings, split the right pane:
+            // the enable/disable manager on top, a read-only summary of plugin
+            // settings below. Editing plugin settings is done from the web
+            // dashboard or `aoe settings` at Tier 0; the manager keeps focus.
+            if self.fields.is_empty() {
+                self.plugin_manager
+                    .render_inline(frame, layout[1], theme, focused);
+            } else {
+                let split = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                    .split(layout[1]);
+                self.plugin_manager
+                    .render_inline(frame, split[0], theme, focused);
+                self.render_plugin_settings_summary(frame, split[1], theme);
+            }
         } else {
             self.render_fields(frame, layout[1], theme);
         }
@@ -348,6 +362,50 @@ impl SettingsView {
                 }
             }
         }
+    }
+
+    /// Read-only summary of the active plugins' settings, grouped by plugin,
+    /// shown beneath the plugin manager. Editing is via the web dashboard or
+    /// `aoe settings` at Tier 0.
+    fn render_plugin_settings_summary(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.border))
+            .title(" Plugin Settings (edit via web or `aoe settings`) ")
+            .padding(Padding::horizontal(1));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let mut lines: Vec<Line> = Vec::new();
+        let mut current_section: Option<String> = None;
+        for field in &self.fields {
+            let Some(section) = field.schema_section() else {
+                continue;
+            };
+            let Some(plugin_id) = crate::session::settings_schema::section_plugin_id(section)
+            else {
+                continue;
+            };
+            if current_section.as_deref() != Some(section) {
+                if current_section.is_some() {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::from(Span::styled(
+                    plugin_id.to_string(),
+                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                )));
+                current_section = Some(section.to_string());
+            }
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {}: ", field.label),
+                    Style::default().fg(theme.dimmed),
+                ),
+                Span::styled(field.display_value(), Style::default().fg(theme.text)),
+            ]));
+        }
+        frame.render_widget(Paragraph::new(lines), inner);
     }
 
     fn render_fields(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -111,11 +111,29 @@ pub fn discover_custom_themes() -> Vec<(String, PathBuf)> {
     themes
 }
 
-/// Return the full list of available theme names: built-in themes first,
-/// then custom.
+/// Themes contributed by active plugins, as (name, path) pairs. Layered below
+/// builtins and user custom themes: a plugin cannot shadow a builtin or a theme
+/// the user dropped in their own themes dir. Names already claimed by a builtin
+/// or a user theme are filtered out.
+pub fn discover_plugin_themes() -> Vec<(String, PathBuf)> {
+    let claimed: std::collections::HashSet<String> = builtin_theme_names()
+        .map(|s| s.to_string())
+        .chain(discover_custom_themes().into_iter().map(|(n, _)| n))
+        .collect();
+    crate::plugin::active_plugin_themes()
+        .into_iter()
+        .filter(|(name, _)| !claimed.contains(name) && !is_builtin_theme(name))
+        .collect()
+}
+
+/// Return the full list of available theme names: built-in themes first, then
+/// user custom themes, then active-plugin themes.
 pub fn available_themes() -> Vec<String> {
     let mut names: Vec<String> = builtin_theme_names().map(|s| s.to_string()).collect();
     for (name, _) in discover_custom_themes() {
+        names.push(name);
+    }
+    for (name, _) in discover_plugin_themes() {
         names.push(name);
     }
     names
@@ -180,6 +198,19 @@ pub fn load_theme(name: &str) -> Theme {
                 debug!(
                     theme = name,
                     source = "custom",
+                    path = %path.display(),
+                    "loaded theme"
+                );
+                return theme;
+            }
+        }
+    }
+    for (theme_name, path) in discover_plugin_themes() {
+        if theme_name == name {
+            if let Some(theme) = load_custom_theme(&path) {
+                debug!(
+                    theme = name,
+                    source = "plugin",
                     path = %path.display(),
                     "loaded theme"
                 );

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -116,14 +116,20 @@ pub fn discover_custom_themes() -> Vec<(String, PathBuf)> {
 /// the user dropped in their own themes dir. Names already claimed by a builtin
 /// or a user theme are filtered out.
 pub fn discover_plugin_themes() -> Vec<(String, PathBuf)> {
-    let claimed: std::collections::HashSet<String> = builtin_theme_names()
+    let mut claimed: std::collections::HashSet<String> = builtin_theme_names()
         .map(|s| s.to_string())
         .chain(discover_custom_themes().into_iter().map(|(n, _)| n))
         .collect();
-    crate::plugin::active_plugin_themes()
-        .into_iter()
-        .filter(|(name, _)| !claimed.contains(name) && !is_builtin_theme(name))
-        .collect()
+    // De-dup across plugins too: two plugins contributing the same name would
+    // otherwise show as indistinguishable picker entries, and load_theme can
+    // only resolve the first. First active plugin to claim a name wins.
+    let mut out = Vec::new();
+    for (name, path) in crate::plugin::active_plugin_themes() {
+        if claimed.insert(name.clone()) {
+            out.push((name, path));
+        }
+    }
+    out
 }
 
 /// Return the full list of available theme names: built-in themes first, then

--- a/src/tui/styles/resolved.rs
+++ b/src/tui/styles/resolved.rs
@@ -34,7 +34,9 @@ use super::{contrast::contrast_ratio as wcag_contrast_ratio, load_theme, Theme, 
 pub enum ResolvedThemeSource {
     Builtin,
     Custom,
-    /// The requested theme name didn't match any builtin or custom
+    /// Contributed by an active plugin's manifest.
+    Plugin,
+    /// The requested theme name didn't match any builtin, custom, or plugin
     /// theme; the resolver returned the `default` builtin as a safety net.
     Fallback,
 }
@@ -130,6 +132,12 @@ fn classify_source(name: &str) -> ResolvedThemeSource {
         .any(|(n, _)| n == name)
     {
         return ResolvedThemeSource::Custom;
+    }
+    if super::discover_plugin_themes()
+        .iter()
+        .any(|(n, _)| n == name)
+    {
+        return ResolvedThemeSource::Plugin;
     }
     ResolvedThemeSource::Fallback
 }

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -20,6 +20,7 @@ import { SelectField } from "./settings/FormFields";
 import { DiffSettings } from "./settings/DiffSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { PluginsSettings } from "./settings/PluginsSettings";
+import { PluginSettingsSections } from "./settings/PluginSettingsSections";
 import { SettingsHeader } from "./settings/SettingsHeader";
 import { ProfilesSection } from "./profiles/ProfilesSection";
 import type { SettingsSearchHit } from "./settings/settingsSearchIndex";
@@ -545,7 +546,12 @@ export function SettingsView({
         );
 
       case "plugins":
-        return <PluginsSettings />;
+        return (
+          <div className="space-y-6">
+            <PluginsSettings />
+            {schemaGuard() ?? <PluginSettingsSections schema={schema} settings={settings} onSaved={loadSettings} />}
+          </div>
+        );
 
       case "notifications":
         return (

--- a/web/src/components/settings/PluginSettingsSections.tsx
+++ b/web/src/components/settings/PluginSettingsSections.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import { updateSettings } from "../../lib/api";
+import type { SettingsFieldDescriptor } from "../../lib/types";
+import { SchemaSection } from "./SchemaSection";
+
+const PLUGIN_PREFIX = "plugin:";
+
+interface Props {
+  /** Full schema descriptor list (`GET /api/settings/schema`), including the
+   *  virtual `plugin:<id>` sections of active plugins. */
+  schema: SettingsFieldDescriptor[];
+  /** The loaded global settings object (`GET /api/settings`). */
+  settings: Record<string, unknown> | null;
+  /** Re-fetch settings after a successful save, so the new value round-trips. */
+  onSaved: () => void;
+}
+
+/** Stored value table for a plugin's settings: `plugins.<id>.settings`. */
+function storedSettings(settings: Record<string, unknown> | null, id: string): Record<string, unknown> {
+  const plugins = (settings?.plugins ?? {}) as Record<string, { settings?: Record<string, unknown> }>;
+  return plugins[id]?.settings ?? {};
+}
+
+/**
+ * Settings for active plugins, rendered through the same generic SchemaSection
+ * as core settings, one block per `plugin:<id>` section. Plugin settings are
+ * global-only at Tier 0, so saves go through the global `PATCH /api/settings`
+ * (the server folds `plugin:<id>` into `plugins.<id>.settings`); the manifest's
+ * declared default is shown until a value is stored.
+ */
+export function PluginSettingsSections({ schema, settings, onSaved }: Props) {
+  const sections = useMemo(() => {
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const d of schema) {
+      if (d.section.startsWith(PLUGIN_PREFIX) && !seen.has(d.section)) {
+        seen.add(d.section);
+        ordered.push(d.section);
+      }
+    }
+    return ordered;
+  }, [schema]);
+
+  if (sections.length === 0) return null;
+
+  const save = async (section: string, field: string, value: unknown): Promise<boolean> => {
+    const ok = await updateSettings({ [section]: { [field]: value } });
+    if (ok) onSaved();
+    return ok;
+  };
+
+  return (
+    <div className="space-y-6">
+      <h4 className="text-xs font-mono uppercase tracking-widest text-text-muted">Plugin Settings</h4>
+      {sections.map((section) => {
+        const id = section.slice(PLUGIN_PREFIX.length);
+        // Seed manifest defaults for fields with no stored value yet.
+        const values: Record<string, unknown> = {};
+        for (const d of schema) {
+          if (d.section === section && d.default !== undefined) values[d.field] = d.default;
+        }
+        Object.assign(values, storedSettings(settings, id));
+        return (
+          <div key={section} className="space-y-3">
+            <h5 className="text-xs font-mono text-text-secondary">{id}</h5>
+            <SchemaSection section={section} schema={schema} values={values} onSaveField={save} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/settings/__tests__/PluginSettingsSections.test.tsx
+++ b/web/src/components/settings/__tests__/PluginSettingsSections.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// Contract test for plugin settings rendering (#2094). PluginSettingsSections
+// turns the virtual `plugin:<id>` schema sections into the generic
+// SchemaSection rows, seeds the manifest default until a value is stored, and
+// saves through the global PATCH (`updateSettings`) with the `plugin:<id>`
+// section the server folds into `plugins.<id>.settings`.
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../../lib/api", () => ({
+  updateSettings: vi.fn().mockResolvedValue(true),
+}));
+
+import { updateSettings } from "../../../lib/api";
+import { PluginSettingsSections } from "../PluginSettingsSections";
+import type { SettingsFieldDescriptor } from "../../../lib/types";
+
+const ALLOW = { policy: "allow" } as const;
+const NONE = { rule: "none" } as const;
+
+const SCHEMA: SettingsFieldDescriptor[] = [
+  // A core section is ignored by this component.
+  {
+    section: "theme",
+    field: "idle_decay_minutes",
+    category: "Theme",
+    label: "Idle Decay",
+    description: "",
+    widget: { kind: "number" },
+    web_write: ALLOW,
+    profile_overridable: true,
+    validation: NONE,
+    advanced: false,
+  },
+  {
+    section: "plugin:acme.kit",
+    field: "enabled",
+    category: "Plugins",
+    label: "Enabled",
+    description: "",
+    widget: { kind: "toggle" },
+    web_write: ALLOW,
+    profile_overridable: false,
+    validation: NONE,
+    advanced: false,
+    default: true,
+  },
+  {
+    section: "plugin:acme.kit",
+    field: "retries",
+    category: "Plugins",
+    label: "Retries",
+    description: "",
+    widget: { kind: "number" },
+    web_write: ALLOW,
+    profile_overridable: false,
+    validation: { rule: "range_u64", min: 0, max: 5 },
+    advanced: false,
+    default: 3,
+  },
+];
+
+describe("PluginSettingsSections", () => {
+  it("renders nothing when no plugin sections exist", () => {
+    const { container } = render(
+      <PluginSettingsSections schema={SCHEMA.slice(0, 1)} settings={{}} onSaved={() => {}} />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders plugin fields, seeding the manifest default when unstored", () => {
+    render(<PluginSettingsSections schema={SCHEMA} settings={{ plugins: {} }} onSaved={() => {}} />);
+    expect(screen.getByText("acme.kit")).toBeTruthy();
+    expect(screen.getByText("Retries")).toBeTruthy();
+    // The number field shows the seeded default of 3.
+    const retries = screen.getByDisplayValue("3");
+    expect(retries).toBeTruthy();
+  });
+
+  it("prefers the stored value over the default", () => {
+    render(
+      <PluginSettingsSections
+        schema={SCHEMA}
+        settings={{ plugins: { "acme.kit": { settings: { retries: 4 } } } }}
+        onSaved={() => {}}
+      />,
+    );
+    expect(screen.getByDisplayValue("4")).toBeTruthy();
+  });
+
+  it("saves through the global PATCH with the plugin:<id> section", async () => {
+    const onSaved = vi.fn();
+    render(<PluginSettingsSections schema={SCHEMA} settings={{ plugins: {} }} onSaved={onSaved} />);
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith({ "plugin:acme.kit": { enabled: false } });
+    });
+    expect(onSaved).toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -563,4 +563,8 @@ export interface SettingsFieldDescriptor {
   validation: SettingsValidation;
   /** Operational tuning shown under an "Advanced" fold. */
   advanced: boolean;
+  /** Default value shown before anything is stored. Present on plugin
+   *  (`plugin:<id>`) fields, which have no value in the config until saved;
+   *  omitted for core fields (their value always exists in the config). */
+  default?: unknown;
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -193,6 +193,17 @@
       ]
     },
     {
+      "id": "settings.plugin-settings",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/settings/__tests__/PluginSettingsSections.test.tsx"],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/PluginSettingsSections.tsx",
+        "web/src/components/settings/SchemaSection.tsx"
+      ]
+    },
+    {
       "id": "settings.mobile-header",
       "kind": "mocked-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Implements the Tier 0 plugin contribution registries (#2094): the host now wires a plugin's declarative manifest contributions into four of its registries, with no plugin code execution (that is the Tier 1 host, #2095). Builds on the manifest contribution schema from #2093.

What landed, by registry:

- **Settings.** `aoe-plugin.toml` settings are now typed (`type` = string/bool/integer/select, plus `options`/`min`/`max`/`default`/`advanced`). The host exposes them as virtual `plugin:<id>` sections via `settings_schema::runtime_schema()`, served over `GET /api/settings/schema`, validated on PATCH through the same gate as core settings, and rendered generically on the web (a new `PluginSettingsSections`) and read-only in the TUI Plugins tab. Only the merge boundary translates `plugin:<id>.<key>` to the on-disk path `plugins.<id>.settings.<key>`. Plugin settings are global-only at Tier 0.
- **Resolution + provenance.** A new resolution layer returns a setting's effective value, its source, and the full candidate chain: user value > highest-priority active plugin `setting_defaults` override (a manifest can override a core default) > core schema default; and for a plugin's own settings, stored value > manifest default. Surfaced by `aoe settings explain <key>` and `GET /api/settings/resolved`.
- **Themes.** A plugin's `[[themes]]` add theme TOMLs to the picker (resolved under the plugin dir, path-escapes rejected; precedence builtin > user > plugin). Reinstates the `themes` manifest section deferred from #2093.
- **Keybinds.** A merged resolver consults the static core table first (core always shadows), then active plugins' keybinds. At Tier 0 a resolved plugin keybind shows a "needs the plugin runtime" notice instead of running; `aoe plugin info` flags chords core shadows.
- **CLI grafting.** Active plugins' commands are grafted onto the clap tree at runtime so they appear in `aoe --help` and parse; core wins name conflicts; an invoked plugin command reports it needs the runtime.

Design was reviewed with a two-model `/debate` (gpt-5.5 + gemini): typed manifest settings over host-side inference, `plugin:<id>` kept flat with storage translation isolated to one module, and keybinds/CLI wired (not left as inert registries) but routed to a "needs runtime" stub so #2095 only swaps the executor in.

Closes #2094

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

These need a community plugin that declares the relevant manifest sections (e.g. a local `aoe plugin install <dir>` of a test plugin):

- [ ] Plugin with `[[settings]]`: open the web dashboard, Settings → Plugins; the plugin's settings render with their manifest defaults, and editing one persists it (reload shows the saved value).
- [ ] `aoe settings explain acp.default_agent` prints the value, its source, and the candidate chain; `aoe settings explain plugin:<id>.<key>` does the same for a plugin setting.
- [ ] `GET /api/settings/resolved` returns each setting's value plus provenance.
- [ ] Plugin with `[setting_defaults]` overriding a core key: `aoe settings explain <that core key>` lists the plugin default as a candidate below any user value.
- [ ] Plugin with `[[themes]]`: the theme shows in `aoe theme list` and the TUI theme picker, and selecting it repaints.
- [ ] Plugin with `[[keybinds]]`: pressing the chord in the TUI shows a "needs the plugin runtime" notice; `aoe plugin info <id>` lists the keybind and marks any core-shadowed chord.
- [ ] Plugin with `[[commands]]`: `aoe --help` lists the command; invoking it reports it needs the runtime; a core command with the same name still wins.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

<!-- Vitest, not Playwright: the plugin settings flow is request-payload + render logic (does the Plugins tab render the schema sections, seed defaults, and emit the right PATCH), which belongs in Vitest + RTL per AGENTS.md. Added web/src/components/settings/__tests__/PluginSettingsSections.test.tsx and a settings.plugin-settings entry in coverage-matrix.json. -->

**TUI / CLI (e2e test)**
- [x] N/A: covered by unit tests
- [ ] Skipped a test, because: the new logic (settings resolution, keybind merge/shadow, clap grafting conflict rules) is covered by unit tests in `settings_schema`, `tui::home::bindings`, and `cli::graft`; exercising a grafted command end to end needs an installed community plugin fixture, which has no harness yet.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill), with a `/debate` design consult across gpt-5.5 and gemini.

**Any Additional AI Details you'd like to share:**
Investigation, the plan, and the implementation were drafted by Claude under my direction. I made the scope and design calls (all four registries in one PR, the keybind/CLI Tier-0 stub approach, settings storage shape), reviewed each commit, and ran the validation steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784987971&installation_id=139138837&pr_number=2389&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2389&signature=84736b374ab6ac247792b886e1b5fa8bb4025629174c3c8d1a91f894f68f12b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds first-class, **declarative plugin contributions** across the app (**settings, themes, keybinds, and CLI commands**) while ensuring the Tier 0 host **does not execute any plugin code**.

## What changed
- **Plugin manifests** now support:
  - **Typed plugin settings** (string/bool/integer/select), including **select options** and **integer min/max** validation
  - **Plugin `setting_defaults` for core settings** (used for provenance/candidate chains in Tier 0)
  - **Plugin themes**
  - **Plugin keybinds**
  - **Plugin CLI command contributions**
- The host builds a **Tier 0 runtime settings schema** that merges core settings with active plugin settings using virtual sections like **`plugin:<id>`**.
- **Settings updates**:
  - **PATCH validation** is performed against the merged runtime schema.
  - Incoming `plugin:<id>` payloads are **safely rewritten** into the persisted config layout.
- **Settings explanations & API support**:
  - **CLI:** `aoe settings explain <key>` shows the effective value and full candidate provenance chain.
  - **API:** `GET /api/settings/schema` now serves the runtime (merged) schema.
  - **API:** **`GET /api/settings/resolved`** returns resolved effective settings with provenance.
- **Settings UI**:
  - **TUI:** plugin-derived settings are rendered as **read-only summaries**; when a plugin keybind is pressed, the UI shows a “runtime required” info dialog.
  - **Web:** the plugins tab now renders **schema-derived plugin settings blocks** (including defaults), and saving goes through the unified settings update flow.
- **Themes**:
  - Plugin theme discovery includes **path safety checks** and canonicalization (including protection against escaping via traversal/symlinks).
  - Plugin themes are correctly attributed as **plugin-sourced**, de-duplicated, and integrated into theme loading/selection precedence.
- **Keybinds**:
  - Plugin keybinds are merged with core bindings, with **core taking precedence**.
  - Plugin chord parsing/validation is improved and **shadowing/invalid chords** are surfaced more clearly (e.g., in `plugin info` output).
- **CLI command grafting**:
  - Plugin commands are **grafted into the clap tree** so they appear in `--help` and parse as subcommands.
  - Execution still reports that the **plugin runtime is required**.
  - Startup flow was updated to keep **app-data-free commands** working (including `aoe settings explain`) without triggering plugin-registry loading; shell completions remain core-only.

## Benefits
- A consistent, user-friendly configuration experience across **CLI, API, TUI, and web**, with **strong validation** and **clear “where the value came from” provenance**.
- Safer plugin support: Tier 0 can understand and display contributions **without running plugin code**.

## Potential follow-ups
- Improve user-facing diagnostics for **cross-plugin keybind/command conflicts** (especially when core precedence causes silent shadowing).
- Refine the UX messaging around **Tier 0 vs runtime** so “runtime required” states are maximally clear for plugin-provided actions and settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->