### PR TITLE
fix(tui): stabilize live capture worker empty capture test

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1093,6 +1093,36 @@ mod tests {
         }
     }
 
+    fn wait_for_latest(worker: &LiveCaptureWorker, timeout: std::time::Duration) -> Option<String> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(value) = worker.take_latest() {
+                return Some(value);
+            }
+            if std::time::Instant::now() >= deadline {
+                return None;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    fn assert_no_latest_for(
+        worker: &LiveCaptureWorker,
+        timeout: std::time::Duration,
+        message: &str,
+    ) {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(value) = worker.take_latest() {
+                panic!("{message}: got {value:?}");
+            }
+            if std::time::Instant::now() >= deadline {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     // Exit-chord detection moved out of translate() into
     // handle_live_send_key. Translate now never emits Exit; the
     // chord-list tests below cover the configurable exit path.
@@ -1619,9 +1649,9 @@ mod tests {
         // so nothing crosses the channel. (`capture_lines == 0` guard.)
         let worker = LiveCaptureWorker::spawn(std::sync::Arc::new(tokio::sync::Notify::new()));
         worker.set_target("aoe_test_capture_no_geometry".into());
-        std::thread::sleep(std::time::Duration::from_millis(60));
-        assert!(
-            worker.take_latest().is_none(),
+        assert_no_latest_for(
+            &worker,
+            std::time::Duration::from_millis(500),
             "worker should stay idle until set_capture_lines is called",
         );
     }
@@ -1634,16 +1664,13 @@ mod tests {
         // without a real tmux session: a missing pane always reads empty.
         let worker = LiveCaptureWorker::spawn(std::sync::Arc::new(tokio::sync::Notify::new()));
         worker.set_target("aoe_test_capture_missing_session".into());
-        // Fast cadence so the worker actually captures (and drops the empty
-        // frame) within the wait, instead of still being in its first idle
-        // sleep when we assert.
+        // Fast cadence so the worker actually captures and drops the empty
+        // frame during the polling window.
         worker.set_live(true);
         worker.set_capture_lines(40);
-        std::thread::sleep(std::time::Duration::from_millis(
-            LIVE_CAPTURE_INTERVAL_FAST_MS + 60,
-        ));
-        assert!(
-            worker.take_latest().is_none(),
+        assert_no_latest_for(
+            &worker,
+            std::time::Duration::from_millis(500),
             "empty captures must never be forwarded",
         );
     }
@@ -1673,15 +1700,11 @@ mod tests {
         let worker = LiveCaptureWorker::spawn(std::sync::Arc::new(tokio::sync::Notify::new()));
         worker.set_target("aoe_test_capture_forward_empty".into());
         worker.set_forward_empty(true);
-        // Fast cadence so the worker captures within the wait rather than
-        // still being in its first idle sleep when we assert.
+        // Fast cadence so the worker captures during the polling window.
         worker.set_live(true);
         worker.set_capture_lines(40);
-        std::thread::sleep(std::time::Duration::from_millis(
-            LIVE_CAPTURE_INTERVAL_FAST_MS + 60,
-        ));
         assert_eq!(
-            worker.take_latest(),
+            wait_for_latest(&worker, std::time::Duration::from_secs(2)),
             Some(String::new()),
             "forward-empty policy must surface empty captures",
         );


### PR DESCRIPTION
## Description

Stabilizes the live capture worker tests that were relying on a fixed 85ms sleep after changing worker state. On macOS CI the worker thread can miss early condvar nudges or observe the updated config on a later loop, so the positive empty-capture test could read `None` before the worker had a fair chance to publish.

What changed:

- Added test helpers that poll `take_latest()` until a deadline instead of sleeping once.
- Updated the forward-empty test to wait for the expected empty capture.
- Updated the negative worker tests to assert that no capture appears during a bounded 500ms window.
- Left production synchronization unchanged; this PR only fixes the flaky test synchronization.

Closes #2354

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI behavior changes; this is a test-only stability fix, so there is no screenshot or recording.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- `cargo test --lib tui::home::live_send::tests::live_capture_worker_ -- --test-threads=1 --nocapture`
- `for i in $(seq 1 200); do cargo test --lib tui::home::live_send::tests::live_capture_worker_forwards_empty_when_policy_set -- --test-threads=1 >/tmp/aoe-live-capture-hammer.log 2>&1 || exit 1; done`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib tui::home::live_send::tests -- --test-threads=1`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** GPT-5 Codex

**Any Additional AI Details you'd like to share:**
Investigation, implementation, validation, and PR preparation were handled by GPT-5 Codex. Two read-only subagents reviewed the upstream/PR preflight and two read-only subagents reviewed the final diff and cleanup scope; I made the final decisions and ran the validation listed above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784988094&installation_id=139138837&pr_number=2390&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2390&signature=ece593acdcd854fcd6182ef218e29acffbd2d9bd3d36ea089a62e4e271ae547b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved live-capture test reliability by replacing fixed waits with event-based polling.
  * Made several capture-related assertions more deterministic, reducing flaky test behavior around empty and delayed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->