### PR TITLE
chore(marketing): add X build-in-public posting tooling

### DIFF
--- a/marketing/x/README.md
+++ b/marketing/x/README.md
@@ -1,0 +1,108 @@
+# X posting tooling for @agentofempires
+
+The "pipe" for getting build-in-public posts onto X. It is intentionally dumb:
+it composes a post, optionally attaches media, optionally adds a link reply, and
+sends it. What to say is decided by the `aoe-build-in-public` Claude skill (see
+`.claude/skills/aoe-build-in-public/`) and by you.
+
+## Why this exists
+
+aoe's happiest user is a multi-agent power user who lives in X dev circles. That
+person adopts tools they see respected builders *using*, not tools that get
+advertised at them. So the play is build-in-public: show aoe shipping aoe. This
+script is the last 5% that turns an approved draft into a posted tweet.
+
+## Safety model
+
+- **Dry-run is the default.** Without `--send`, the script only previews. The
+  preview path has zero dependencies and never hits the network.
+- **Credentials never live in the repo.** The scripts read four `X_*` variables
+  straight from your shell environment. Keep them in `~/.zshrc` (or your shell's
+  rc), not in any tracked file.
+- **The human stays the trigger.** The script can post, but it only posts when a
+  person runs it with `--send`. The skill enforces a draft -> approve -> send
+  gate on top of that.
+
+## Credentials
+
+Four variables, exported in your shell:
+
+| Variable | What it is |
+| --- | --- |
+| `X_API_KEY` | App consumer key (developer portal -> app -> Keys and tokens) |
+| `X_API_SECRET` | App consumer secret |
+| `X_ACCESS_TOKEN` | @agentofempires user token (minted by `mint_token.py`) |
+| `X_ACCESS_SECRET` | @agentofempires user token secret |
+
+See `exports.example.sh` for a copy-paste block. Add the filled-in lines to
+`~/.zshrc`, then `source ~/.zshrc` or open a new terminal. Verify with:
+
+```bash
+env | grep -E '^X_(API|ACCESS)' | sed -E 's/=.*/=<set>/'
+```
+
+## One-time setup
+
+1. Create an X developer app (Production environment) under your developer
+   account. Enable OAuth 1.0a with **Read and Write** permission and set a
+   callback URL (any valid URL; the PIN flow does not use it).
+2. Copy the app's API Key + Secret into `~/.zshrc` as `export X_API_KEY=...` and
+   `export X_API_SECRET=...`, then `source ~/.zshrc`.
+3. Install the send-path dependency (the dry-run path needs nothing):
+   ```bash
+   python3 -m pip install -r marketing/x/requirements.txt
+   ```
+4. Mint the @agentofempires access token. Run this in your own terminal (you
+   need a browser for the authorize step):
+   ```bash
+   python3 marketing/x/mint_token.py
+   ```
+   Open the printed URL in a browser logged in as **@agentofempires**, approve,
+   paste back the PIN. It prints two `export` lines. Add them to `~/.zshrc` and
+   `source ~/.zshrc`.
+
+## Usage
+
+Preview a post (no creds, no network):
+```bash
+python3 marketing/x/post_to_x.py \
+  --text "9 PRs merged this week across 4 parallel agents in aoe."
+```
+
+Preview with media and a link reply (the link goes in the reply, not the post):
+```bash
+python3 marketing/x/post_to_x.py \
+  --text "Watch 5 agents work at once. Stuck, waiting, idle, all at a glance." \
+  --media docs/assets/demo.gif \
+  --reply "Run your own fleet: https://github.com/agent-of-empires/agent-of-empires"
+```
+
+Actually send it (needs the four `X_*` vars in your environment):
+```bash
+python3 marketing/x/post_to_x.py --text "..." --media demo.gif --reply "..." --send
+```
+
+## The link-in-reply rule
+
+X moved to pay-per-use on 2026-02-06: roughly **$0.015 per post**, but
+**$0.20 if the post contains a link**. A bare link in the main post also gets
+reach-suppressed by X's ranking. So keep the main post link-free and put the
+GitHub URL in `--reply`. Cheaper and better reach. The script warns you if a
+link shows up in the main post.
+
+## Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--text` | Main post body (required). Warns over 280 chars; refuses to send over. |
+| `--media PATH` | Attach an image/gif/video. Repeatable (max 4 images, or 1 video). |
+| `--reply TEXT` | Post TEXT as a reply under the main post. Put your link here. |
+| `--send` | Actually post. Omit to preview only. |
+
+## Voice rules (for whatever drafts these)
+
+- No em dashes, no `--` as a separator. Use commas, periods, or rephrase.
+- No hashtag spam. One tasteful tag at most, usually zero.
+- Show, do not tell: a 15-second clip of the dashboard beats three sentences of
+  adjectives.
+- Lead with the user's pain, not aoe's features.

--- a/marketing/x/README.md
+++ b/marketing/x/README.md
@@ -38,8 +38,14 @@ See `exports.example.sh` for a copy-paste block. Add the filled-in lines to
 `~/.zshrc`, then `source ~/.zshrc` or open a new terminal. Verify with:
 
 ```bash
-env | grep -E '^X_(API|ACCESS)' | sed -E 's/=.*/=<set>/'
+for v in X_API_KEY X_API_SECRET X_ACCESS_TOKEN X_ACCESS_SECRET; do
+  eval "val=\$$v"
+  [ -n "$val" ] && echo "$v: set" || echo "$v: MISSING or empty"
+done
 ```
+
+It must report all four as `set`. If any shows `MISSING or empty`, you likely
+sourced the template (`exports.example.sh`) without filling in the values.
 
 ## One-time setup
 
@@ -101,7 +107,7 @@ link shows up in the main post.
 
 ## Voice rules (for whatever drafts these)
 
-- No em dashes, no `--` as a separator. Use commas, periods, or rephrase.
+- No em dashes, and no double-hyphen separators in prose. Use commas, periods, or rephrase.
 - No hashtag spam. One tasteful tag at most, usually zero.
 - Show, do not tell: a 15-second clip of the dashboard beats three sentences of
   adjectives.

--- a/marketing/x/exports.example.sh
+++ b/marketing/x/exports.example.sh
@@ -1,0 +1,15 @@
+# X credentials for @agentofempires posting tooling.
+#
+# These are SECRETS. Do not commit them. Add them to your shell rc (~/.zshrc),
+# then `source ~/.zshrc` or open a new terminal. The scripts read them straight
+# from the environment; nothing is stored in the repo.
+#
+#   X_API_KEY / X_API_SECRET:        the app's consumer keys (developer portal ->
+#                                    your app -> "Keys and tokens").
+#   X_ACCESS_TOKEN / X_ACCESS_SECRET: the @agentofempires user token, minted by
+#                                    marketing/x/mint_token.py.
+
+export X_API_KEY=""
+export X_API_SECRET=""
+export X_ACCESS_TOKEN=""
+export X_ACCESS_SECRET=""

--- a/marketing/x/mint_token.py
+++ b/marketing/x/mint_token.py
@@ -79,7 +79,8 @@ def main() -> None:
     except Exception as exc:  # noqa: BLE001
         sys.exit(f"failed to exchange PIN for an access token: {exc}")
 
-    who = "unknown (could not verify)"
+    who = None
+    verify_error = None
     try:
         client = tweepy.Client(
             consumer_key=consumer_key,
@@ -90,16 +91,24 @@ def main() -> None:
         me = client.get_me()
         if me and me.data:
             who = me.data.username
-    except Exception:  # noqa: BLE001 - verification is best-effort
-        pass
+    except Exception as exc:  # noqa: BLE001 - report it, do not mask it
+        verify_error = exc
 
-    print(f"\nThis token posts as: @{who}")
-    if who.lower() != "agentofempires":
-        print(
-            "WARNING: that is not @agentofempires. You likely authorized while "
-            "logged in as the wrong account.\nRe-run and approve in a window "
-            "logged in as @agentofempires.\n"
-        )
+    if who:
+        print(f"\nThis token posts as: @{who}")
+        if who.lower() != "agentofempires":
+            print(
+                "WARNING: that is not @agentofempires. You likely authorized while "
+                "logged in as the wrong account.\nRe-run and approve in a window "
+                "logged in as @agentofempires.\n"
+            )
+    else:
+        # Verification failed (network/API), which is NOT the same as a
+        # wrong-account result. Say so plainly instead of crying wrong-account.
+        detail = f": {verify_error}" if verify_error else "."
+        print(f"\nCould not verify which account this token posts as{detail}")
+        print("Confirm you authorized as @agentofempires before relying on it.")
+
     print("\nAdd these two lines to ~/.zshrc, then `source ~/.zshrc`:\n")
     print(f'export X_ACCESS_TOKEN="{access_token}"')
     print(f'export X_ACCESS_SECRET="{access_secret}"')

--- a/marketing/x/mint_token.py
+++ b/marketing/x/mint_token.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""One-time: mint an OAuth 1.0a access token for @agentofempires.
+
+Path B setup. The X app (its API key/secret) is owned by njbrake's developer
+account, which keeps billing under njbrake. But the access token is what decides
+WHICH account a post comes from, so we run a one-time 3-legged OAuth flow: you
+authorize the app while logged in as @agentofempires, and this prints that
+account's access token + secret as `export` lines to add to your shell.
+
+Credentials live in your shell environment (e.g. ~/.zshrc), never in the repo.
+
+Prereqs:
+  * X_API_KEY and X_API_SECRET exported in your shell (the app's consumer
+    key/secret from the developer portal "Keys and tokens" tab).
+  * The app has OAuth 1.0a user authentication enabled, Read and Write
+    permission, and a callback URL configured.
+  * tweepy installed: python3 -m pip install -r marketing/x/requirements.txt
+
+Run it in your own terminal (you need a browser for the authorize step):
+  python3 marketing/x/mint_token.py
+Then add the two printed export lines to ~/.zshrc and reload your shell.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import parse_qs, urlparse
+
+
+def import_tweepy():
+    try:
+        import tweepy
+    except ModuleNotFoundError:
+        sys.exit(
+            "tweepy not installed.\n"
+            "Run: python3 -m pip install -r marketing/x/requirements.txt"
+        )
+    return tweepy
+
+
+def get_consumer() -> tuple[str, str]:
+    consumer_key = os.environ.get("X_API_KEY")
+    consumer_secret = os.environ.get("X_API_SECRET")
+    if not consumer_key or not consumer_secret:
+        sys.exit(
+            "X_API_KEY / X_API_SECRET are not in your environment.\n"
+            "Export them first (the app's consumer key/secret), e.g. add\n"
+            "  export X_API_KEY=...\n  export X_API_SECRET=...\n"
+            "to ~/.zshrc, then `source ~/.zshrc` and re-run."
+        )
+    return consumer_key, consumer_secret
+
+
+def main() -> None:
+    tweepy = import_tweepy()
+    consumer_key, consumer_secret = get_consumer()
+
+    handler = tweepy.OAuth1UserHandler(consumer_key, consumer_secret, callback="oob")
+    try:
+        url = handler.get_authorization_url()
+    except Exception as exc:  # noqa: BLE001 - surface the real cause
+        sys.exit(
+            f"could not start the OAuth flow: {exc}\n"
+            "Check the app has OAuth 1.0a enabled, Read+Write permission, and a "
+            "callback URL set in User authentication settings."
+        )
+
+    print("\n1. Open this URL in a browser LOGGED IN AS @agentofempires")
+    print("   (an incognito/private window is the easy way):\n")
+    print("   " + url + "\n")
+    print("2. Approve the app. X shows a 7-digit PIN (or redirects you).\n")
+    raw = input("3. Paste the PIN here (or the full redirected URL): ").strip()
+    if "oauth_verifier=" in raw:
+        raw = parse_qs(urlparse(raw).query)["oauth_verifier"][0]
+
+    try:
+        access_token, access_secret = handler.get_access_token(raw)
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"failed to exchange PIN for an access token: {exc}")
+
+    who = "unknown (could not verify)"
+    try:
+        client = tweepy.Client(
+            consumer_key=consumer_key,
+            consumer_secret=consumer_secret,
+            access_token=access_token,
+            access_token_secret=access_secret,
+        )
+        me = client.get_me()
+        if me and me.data:
+            who = me.data.username
+    except Exception:  # noqa: BLE001 - verification is best-effort
+        pass
+
+    print(f"\nThis token posts as: @{who}")
+    if who.lower() != "agentofempires":
+        print(
+            "WARNING: that is not @agentofempires. You likely authorized while "
+            "logged in as the wrong account.\nRe-run and approve in a window "
+            "logged in as @agentofempires.\n"
+        )
+    print("\nAdd these two lines to ~/.zshrc, then `source ~/.zshrc`:\n")
+    print(f'export X_ACCESS_TOKEN="{access_token}"')
+    print(f'export X_ACCESS_SECRET="{access_secret}"')
+
+
+if __name__ == "__main__":
+    main()

--- a/marketing/x/post_to_x.py
+++ b/marketing/x/post_to_x.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Post to X (Twitter) for the @agentofempires account.
+
+This is the "pipe": it composes a post (optionally with media and a link reply)
+and sends it through the X API v2. It is deliberately dumb. The judgment about
+what to say lives in the `aoe-build-in-public` Claude skill and in your own head.
+
+Safety by design:
+  * Dry-run is the DEFAULT. Nothing is sent unless you pass --send.
+  * The dry-run path has zero dependencies and never touches the network, so you
+    can preview a post anywhere.
+  * Credentials are read from the environment only (export them in your shell,
+    e.g. ~/.zshrc), never stored in the repo, hardcoded, or printed.
+
+Cost note (X moved to pay-per-use on 2026-02-06):
+  * ~$0.015 per post
+  * ~$0.20 per post that contains a link
+So put the GitHub link in a REPLY, not the main post. It is ~13x cheaper and X's
+ranking also suppresses reach on posts with bare external links. Same move, two
+wins. The --reply flag exists for exactly this.
+
+Usage:
+  # Preview (no network, no creds needed):
+  python post_to_x.py --text "9 PRs merged this week across 4 parallel agents."
+
+  # Preview with media + a link reply:
+  python post_to_x.py \
+      --text "Watch 5 agents work at once. Stuck vs waiting vs idle, at a glance." \
+      --media ../../docs/assets/demo.gif \
+      --reply "Run your own fleet: https://github.com/agent-of-empires/agent-of-empires"
+
+  # Actually send (requires the four X_* vars exported in your shell):
+  python post_to_x.py --text "..." --media demo.gif --reply "..." --send
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+MAX_LEN = 280
+ENV_KEYS = ("X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_SECRET")
+LINK_RE = re.compile(r"https?://", re.IGNORECASE)
+
+# Media upload must use the v2 endpoint: the v1.1 upload endpoint (what
+# tweepy's API.media_upload calls) 401s on the current non-elevated access
+# level, while v2 create_tweet works. So we do the v2 chunked flow by hand.
+MEDIA_UPLOAD_URL = "https://api.x.com/2/media/upload"
+CHUNK_SIZE = 4 * 1024 * 1024  # 4 MB per APPEND segment
+
+MEDIA_TYPES = {
+    ".gif": "image/gif",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".mp4": "video/mp4",
+    ".m4v": "video/mp4",
+    ".mov": "video/quicktime",
+}
+
+
+def has_link(text: str) -> bool:
+    return bool(LINK_RE.search(text))
+
+
+def estimate_cost(text: str, reply: str | None) -> float:
+    """Rough pay-per-use estimate: $0.015/post, $0.20 if it contains a link."""
+    cost = 0.20 if has_link(text) else 0.015
+    if reply is not None:
+        cost += 0.20 if has_link(reply) else 0.015
+    return cost
+
+
+def preview(text: str, media: list[str], reply: str | None) -> None:
+    bar = "=" * 60
+    print(bar)
+    print("DRY RUN - nothing sent. Pass --send to actually post.")
+    print(bar)
+    print("MAIN POST:")
+    print(text)
+    n = len(text)
+    flag = "  <-- OVER LIMIT" if n > MAX_LEN else ""
+    print(f"\n  chars: {n}/{MAX_LEN}{flag}")
+    if has_link(text):
+        print("  note: main post contains a link. Move it to --reply to cut cost")
+        print("        ~13x and avoid X's link-reach penalty.")
+    if media:
+        print("\nMEDIA:")
+        for m in media:
+            exists = "ok" if Path(m).is_file() else "MISSING"
+            print(f"  [{exists}] {m}")
+    if reply is not None:
+        print("\nREPLY (posted as a thread under the main post):")
+        print(reply)
+        rn = len(reply)
+        rflag = "  <-- OVER LIMIT" if rn > MAX_LEN else ""
+        print(f"\n  chars: {rn}/{MAX_LEN}{rflag}")
+    print(f"\nestimated cost: ${estimate_cost(text, reply):.3f}")
+    print(bar)
+
+
+def require_credentials() -> dict[str, str]:
+    missing = [k for k in ENV_KEYS if not os.environ.get(k)]
+    if missing:
+        sys.exit(
+            "Cannot --send: missing credentials "
+            + ", ".join(missing)
+            + ".\nExport them in your shell (see marketing/x/README.md), e.g. add"
+            "\n  export X_API_KEY=...   (and the other three) to ~/.zshrc,"
+            "\nthen `source ~/.zshrc` or open a new terminal."
+        )
+    return {k: os.environ[k] for k in ENV_KEYS}
+
+
+def import_tweepy():
+    """Import tweepy with a friendly message instead of a raw traceback."""
+    try:
+        import tweepy
+    except ModuleNotFoundError:
+        sys.exit(
+            "Cannot --send: tweepy is not installed.\n"
+            "Install it with: python3 -m pip install -r marketing/x/requirements.txt"
+        )
+    return tweepy
+
+
+def media_category(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext == ".gif":
+        return "tweet_gif"
+    if ext in (".mp4", ".m4v", ".mov"):
+        return "tweet_video"
+    return "tweet_image"
+
+
+def _check(resp, step: str) -> None:
+    if resp.status_code >= 300:
+        sys.exit(f"media upload {step} failed: {resp.status_code} {resp.text}")
+
+
+def upload_media(creds: dict[str, str], paths: list[str]) -> list[str]:
+    import requests
+    from requests_oauthlib import OAuth1
+
+    auth = OAuth1(
+        creds["X_API_KEY"],
+        creds["X_API_SECRET"],
+        creds["X_ACCESS_TOKEN"],
+        creds["X_ACCESS_SECRET"],
+    )
+    return [_upload_one(requests, auth, Path(p)) for p in paths]
+
+
+def _upload_one(requests, auth, path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"media file not found: {path}")
+    total = path.stat().st_size
+    media_type = MEDIA_TYPES.get(path.suffix.lower(), "application/octet-stream")
+
+    # v2 chunked upload uses dedicated sub-endpoints (initialize / append /
+    # finalize), not v1.1-style command= params. STATUS is the one exception:
+    # GET on the base with command=STATUS.
+    init = requests.post(
+        f"{MEDIA_UPLOAD_URL}/initialize",
+        auth=auth,
+        json={
+            "media_type": media_type,
+            "total_bytes": total,
+            "media_category": media_category(path),
+        },
+    )
+    _check(init, "INIT")
+    media_id = init.json()["data"]["id"]
+
+    with path.open("rb") as fh:
+        segment = 0
+        while True:
+            chunk = fh.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            append = requests.post(
+                f"{MEDIA_UPLOAD_URL}/{media_id}/append",
+                auth=auth,
+                data={"segment_index": str(segment)},
+                files={"media": ("chunk", chunk, "application/octet-stream")},
+            )
+            _check(append, f"APPEND segment {segment}")
+            segment += 1
+
+    final = requests.post(f"{MEDIA_UPLOAD_URL}/{media_id}/finalize", auth=auth)
+    _check(final, "FINALIZE")
+
+    info = (final.json().get("data") or {}).get("processing_info")
+    while info and info.get("state") in ("pending", "in_progress"):
+        time.sleep(info.get("check_after_secs", 1))
+        status = requests.get(
+            MEDIA_UPLOAD_URL,
+            auth=auth,
+            params={"command": "STATUS", "media_id": media_id},
+        )
+        _check(status, "STATUS")
+        info = (status.json().get("data") or {}).get("processing_info")
+    if info and info.get("state") == "failed":
+        sys.exit(f"media processing failed: {info}")
+
+    return media_id
+
+
+def send(text: str, media: list[str], reply: str | None) -> None:
+    creds = require_credentials()
+    tweepy = import_tweepy()
+    client = tweepy.Client(
+        consumer_key=creds["X_API_KEY"],
+        consumer_secret=creds["X_API_SECRET"],
+        access_token=creds["X_ACCESS_TOKEN"],
+        access_token_secret=creds["X_ACCESS_SECRET"],
+    )
+
+    media_ids = upload_media(creds, media) if media else None
+    resp = client.create_tweet(text=text, media_ids=media_ids)
+    tweet_id = resp.data["id"]
+    print(f"posted: https://x.com/agentofempires/status/{tweet_id}")
+
+    if reply is not None:
+        reply_resp = client.create_tweet(text=reply, in_reply_to_tweet_id=tweet_id)
+        reply_id = reply_resp.data["id"]
+        print(f"reply:  https://x.com/agentofempires/status/{reply_id}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compose and (optionally) post to X for @agentofempires.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--text", required=True, help="Main post body.")
+    parser.add_argument(
+        "--media",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Image/gif/video to attach. Repeatable (max 4 images, or 1 video).",
+    )
+    parser.add_argument(
+        "--reply",
+        default=None,
+        help="Text posted as a reply under the main post. Put your link here.",
+    )
+    parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Actually post. Without this flag the script only previews.",
+    )
+    args = parser.parse_args()
+
+    if not args.send:
+        preview(args.text, args.media, args.reply)
+        return
+
+    if len(args.text) > MAX_LEN or (args.reply and len(args.reply) > MAX_LEN):
+        sys.exit("refusing to send: a post exceeds 280 chars. Trim it and retry.")
+
+    send(args.text, args.media, args.reply)
+
+
+if __name__ == "__main__":
+    main()

--- a/marketing/x/post_to_x.py
+++ b/marketing/x/post_to_x.py
@@ -51,6 +51,9 @@ LINK_RE = re.compile(r"https?://", re.IGNORECASE)
 # level, while v2 create_tweet works. So we do the v2 chunked flow by hand.
 MEDIA_UPLOAD_URL = "https://api.x.com/2/media/upload"
 CHUNK_SIZE = 4 * 1024 * 1024  # 4 MB per APPEND segment
+REQUEST_TIMEOUT = (10, 60)  # (connect, read) seconds, so a hang fails instead of stalling
+PROCESSING_TIMEOUT_SECS = 300  # hard cap on waiting for async media processing
+EXPECTED_USERNAME = "agentofempires"  # refuse to post from any other account
 
 MEDIA_TYPES = {
     ".gif": "image/gif",
@@ -173,6 +176,7 @@ def _upload_one(requests, auth, path: Path) -> str:
             "total_bytes": total,
             "media_category": media_category(path),
         },
+        timeout=REQUEST_TIMEOUT,
     )
     _check(init, "INIT")
     media_id = init.json()["data"]["id"]
@@ -188,20 +192,29 @@ def _upload_one(requests, auth, path: Path) -> str:
                 auth=auth,
                 data={"segment_index": str(segment)},
                 files={"media": ("chunk", chunk, "application/octet-stream")},
+                timeout=REQUEST_TIMEOUT,
             )
             _check(append, f"APPEND segment {segment}")
             segment += 1
 
-    final = requests.post(f"{MEDIA_UPLOAD_URL}/{media_id}/finalize", auth=auth)
+    final = requests.post(
+        f"{MEDIA_UPLOAD_URL}/{media_id}/finalize",
+        auth=auth,
+        timeout=REQUEST_TIMEOUT,
+    )
     _check(final, "FINALIZE")
 
     info = (final.json().get("data") or {}).get("processing_info")
+    deadline = time.monotonic() + PROCESSING_TIMEOUT_SECS
     while info and info.get("state") in ("pending", "in_progress"):
+        if time.monotonic() > deadline:
+            sys.exit(f"media processing timed out after {PROCESSING_TIMEOUT_SECS}s: {info}")
         time.sleep(info.get("check_after_secs", 1))
         status = requests.get(
             MEDIA_UPLOAD_URL,
             auth=auth,
             params={"command": "STATUS", "media_id": media_id},
+            timeout=REQUEST_TIMEOUT,
         )
         _check(status, "STATUS")
         info = (status.json().get("data") or {}).get("processing_info")
@@ -209,6 +222,26 @@ def _upload_one(requests, auth, path: Path) -> str:
         sys.exit(f"media processing failed: {info}")
 
     return media_id
+
+
+def require_brand_account(client) -> None:
+    """Refuse to post unless the credentials authenticate as EXPECTED_USERNAME.
+
+    A terminal can hold tokens for the wrong handle; verify before anything goes
+    out so we never post from the wrong account.
+    """
+    try:
+        me = client.get_me()
+    except Exception as exc:  # noqa: BLE001 - surface the real cause
+        sys.exit(f"refusing to send: could not verify the X account: {exc}")
+    username = getattr(me.data, "username", None) if me else None
+    if not username:
+        sys.exit("refusing to send: could not read the authenticated username.")
+    if username.lower() != EXPECTED_USERNAME:
+        sys.exit(
+            f"refusing to send: credentials authenticate as @{username}, "
+            f"expected @{EXPECTED_USERNAME}."
+        )
 
 
 def send(text: str, media: list[str], reply: str | None) -> None:
@@ -220,6 +253,7 @@ def send(text: str, media: list[str], reply: str | None) -> None:
         access_token=creds["X_ACCESS_TOKEN"],
         access_token_secret=creds["X_ACCESS_SECRET"],
     )
+    require_brand_account(client)
 
     media_ids = upload_media(creds, media) if media else None
     resp = client.create_tweet(text=text, media_ids=media_ids)
@@ -230,6 +264,25 @@ def send(text: str, media: list[str], reply: str | None) -> None:
         reply_resp = client.create_tweet(text=reply, in_reply_to_tweet_id=tweet_id)
         reply_id = reply_resp.data["id"]
         print(f"reply:  https://x.com/agentofempires/status/{reply_id}")
+
+
+def validate_media(paths: list[str]) -> None:
+    """Enforce X's attachment limits locally before uploading anything."""
+    if not paths:
+        return
+    categories = []
+    for raw in paths:
+        path = Path(raw)
+        if not path.is_file():
+            sys.exit(f"media file not found: {path}")
+        if path.suffix.lower() not in MEDIA_TYPES:
+            sys.exit(f"unsupported media type: {path.suffix or path}")
+        categories.append(media_category(path))
+    animated = any(c in ("tweet_video", "tweet_gif") for c in categories)
+    if animated and len(paths) > 1:
+        sys.exit("refusing to send: a gif or video post can attach only one file.")
+    if not animated and len(paths) > 4:
+        sys.exit("refusing to send: an image post can attach at most 4 files.")
 
 
 def main() -> None:
@@ -264,6 +317,7 @@ def main() -> None:
     if len(args.text) > MAX_LEN or (args.reply and len(args.reply) > MAX_LEN):
         sys.exit("refusing to send: a post exceeds 280 chars. Trim it and retry.")
 
+    validate_media(args.media)
     send(args.text, args.media, args.reply)
 
 

--- a/marketing/x/requirements.txt
+++ b/marketing/x/requirements.txt
@@ -1,6 +1,6 @@
 # Only needed for the --send path. The dry-run preview has no dependencies.
 # tweepy posts the tweet (v2); requests + requests-oauthlib do the v2 media
 # upload directly, since tweepy only offers the retired v1.1 media endpoint.
-tweepy>=4.14
-requests>=2.31
-requests-oauthlib>=1.3
+tweepy>=4.14,<5
+requests>=2.31,<3
+requests-oauthlib>=1.3,<3

--- a/marketing/x/requirements.txt
+++ b/marketing/x/requirements.txt
@@ -1,0 +1,6 @@
+# Only needed for the --send path. The dry-run preview has no dependencies.
+# tweepy posts the tweet (v2); requests + requests-oauthlib do the v2 media
+# upload directly, since tweepy only offers the retired v1.1 media endpoint.
+tweepy>=4.14
+requests>=2.31
+requests-oauthlib>=1.3


### PR DESCRIPTION
## Description

Adds `marketing/x/` tooling to post build-in-public updates to X
(@AgentofEmpires) as part of the adoption push. Self-contained Python; no Rust
or web code changes, no impact on the cargo build.

- `post_to_x.py`: composes and posts. Dry-run by default (zero deps, no network);
  `--send` posts. Uploads media via the X API v2 chunked endpoints, because the
  non-elevated access tier blocks API v1.1 (what tweepy's `media_upload` uses).
  Keeps links in a reply, not the main post, to cut pay-per-use cost and avoid
  X's link-reach penalty.
- `mint_token.py`: one-time OAuth 1.0a token mint for the brand account.
- `README.md`, `exports.example.sh`, `requirements.txt`.

Credentials are read from the shell environment only; nothing secret is stored
in the repo (`.env` stays gitignored). The first post is already live with a
verified animated gif attached.

The accompanying drafting/approval Claude skill is kept local (the repo
gitignores `.claude/` by convention), so it is not part of this PR.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (no compiled code paths change; the Python
  tooling is self-contained and was verified by dry-run plus a live post)
- [x] Documentation was updated where necessary (`marketing/x/README.md`)
- [x] For UI changes: included screenshot or recording (N/A, no UI changes)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus 4.8)

**Any Additional AI Details you'd like to share:**
Claude drafted the tooling and this PR description via back-and-forth with
@njbrake. The reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784989277&installation_id=139138837&pr_number=2391&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2391&signature=e6cac5e570502ef85fe72554e738d2734b1bf8c00f66d72cca4995a8265bb172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a self-contained `marketing/x/` workflow for creating and (optionally) publishing build-in-public updates to X for the `@agentofempires` brand account, without changing the Rust app or affecting the cargo build.

What changed / added:
- `marketing/x/post_to_x.py`: CLI tooling to draft and preview posts, optionally attach media, and optionally include a “link in reply” so the main post stays cleaner. Posting is **dry-run by default** and requires an explicit `--send`. It also validates message length, media constraints, and the target account, and uses the X API v2 chunked media upload flow with timeouts and processing deadline safeguards.
- `marketing/x/mint_token.py`: One-time OAuth 1.0a token minting helper to generate `X_ACCESS_TOKEN`/`X_ACCESS_SECRET` for the brand account, with clearer verification/error handling.
- `marketing/x/README.md`: Documentation for setup, safety model, environment-variable-only credentials, usage examples (preview vs send), and the link-in-reply rule.
- `marketing/x/exports.example.sh`: Example shell exports for required `X_*` environment variables (no secrets committed).
- `marketing/x/requirements.txt`: Dependencies needed for the send path (with upper bounds mentioned in the commit notes for reproducible installs).

Benefits:
- Makes recurring “build-in-public” posting easier and safer by default (preview-first, human `--send` gate).
- Keeps credentials out of the repo by relying only on environment variables.
- Reduces posting risk with account verification, stronger input/media validation, and more robust network/upload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->