### PR TITLE
fix(kiro): resolve --agent hooks target by name field, not filename

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -147,9 +147,14 @@ pub struct SidecarHooks {
 pub struct SelectedAgentHooks {
     /// CLI flag a user passes to choose a named agent (e.g. `"--agent"`).
     pub flag: &'static str,
-    /// Maps a selected agent name to the home-relative path of that agent's
-    /// config file (e.g. `custom-agent` → `.kiro/agents/custom-agent.json`).
-    pub config_subpath: fn(&str) -> std::path::PathBuf,
+    /// Absolute path, under the given agents directory, of the config file the
+    /// CLI actually loads for the selected agent name. The first argument is
+    /// the agents directory to resolve within (host: `$HOME/.kiro/agents`;
+    /// sandbox: the staged `.kiro/sandbox/agents`), the second is the validated
+    /// selected agent name. Resolves by the `name` field inside each config
+    /// rather than the filename, since generator-managed agents name files
+    /// `<prefix>-<name>.json`. See [`crate::hooks::resolve_kiro_agent_file`].
+    pub resolve_config_file: fn(&std::path::Path, &str) -> std::path::PathBuf,
 }
 
 /// On-disk format of a sidecar agent's config file. Drives
@@ -720,7 +725,7 @@ pub const AGENTS: &[AgentDef] = &[
             // agent, and skip the set-default promotion above.
             selected_agent_hooks: Some(SelectedAgentHooks {
                 flag: "--agent",
-                config_subpath: crate::hooks::kiro_agent_file_for,
+                resolve_config_file: crate::hooks::resolve_kiro_agent_file,
             }),
             format: SidecarFormat::KiroJson,
         }),
@@ -1233,9 +1238,12 @@ mod tests {
             .as_ref()
             .expect("kiro declares selected_agent_hooks");
         assert_eq!(sel.flag, "--agent");
+        // With no matching agent file in the dir, the resolver falls back to
+        // `<dir>/<name>.json` (the create-path for a brand-new user agent).
+        let tmp = tempfile::TempDir::new().unwrap();
         assert_eq!(
-            (sel.config_subpath)("custom-agent"),
-            std::path::Path::new(".kiro/agents/custom-agent.json")
+            (sel.resolve_config_file)(tmp.path(), "custom-agent"),
+            tmp.path().join("custom-agent.json")
         );
         // The other sidecar agents do not (their hooks apply globally).
         for name in ["settl", "hermes"] {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1788,9 +1788,13 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
 
         let before = config.clone();
 
+        let default_name = agent_config_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(KIRO_HOOKS_AGENT_NAME);
         config
             .entry("name".to_string())
-            .or_insert_with(|| Value::String(KIRO_HOOKS_AGENT_NAME.to_string()));
+            .or_insert_with(|| Value::String(default_name.to_string()));
         config
             .entry("tools".to_string())
             .or_insert_with(|| serde_json::json!(["*"]));
@@ -1836,20 +1840,56 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
     })
 }
 
-/// Home-relative path to a user's Kiro agent config file by name, e.g.
-/// `custom-agent` → `.kiro/agents/custom-agent.json`. Wired into `kiro`'s
-/// [`crate::agents::SelectedAgentHooks::config_subpath`] so the install site can
-/// target the selected agent's own file. The caller is responsible for
-/// validating `name` (see [`crate::agents::parse_selected_agent`], which rejects
-/// path separators) before joining to `$HOME`.
+/// Resolve which file under `agents_dir` holds the agent Kiro loads for
+/// `--agent <name>`, returning the path AoE installs its status hooks into.
 ///
-/// Installing into this path reuses [`install_kiro_hooks`], which preserves any
-/// existing user hooks and is idempotent; [`uninstall_kiro_hooks`] strips only
-/// the AoE-tagged entries.
-pub fn kiro_agent_file_for(name: &str) -> PathBuf {
-    Path::new(".kiro")
-        .join("agents")
-        .join(format!("{name}.json"))
+/// Kiro resolves `--agent <name>` by the `name` field inside each
+/// `<agents_dir>/*.json`, not by the filename stem. Generators (plugin/managed
+/// agent tooling) render files as `<prefix>-<name>.json`, so filename and
+/// logical name diverge; assuming `filename == name` installs into a file Kiro
+/// never loads and status detection silently fails. Matching the `name` field
+/// is therefore mandatory, not a nicety.
+///
+/// Falls back to `<agents_dir>/<name>.json` when no file declares that name:
+/// the correct create-path for a brand-new agent, which Kiro then reads `name`
+/// from. The caller validates `name` (rejecting path separators and `..`, see
+/// [`crate::agents::parse_selected_agent`]) so the fallback stays inside
+/// `agents_dir`.
+pub fn resolve_kiro_agent_file(agents_dir: &Path, name: &str) -> PathBuf {
+    if let Some(path) = find_kiro_agent_file_by_name(agents_dir, name) {
+        return path;
+    }
+    agents_dir.join(format!("{name}.json"))
+}
+
+/// First `<agents_dir>/*.json` whose top-level `name` equals `name`, or `None`.
+/// Sorted so a duplicate-name tie resolves deterministically; unreadable or
+/// non-object files are skipped rather than failing the scan. Two files
+/// declaring the same `name` is a user misconfiguration (Kiro warns about it
+/// too): we pick the lexicographically-first and `warn!` so the divergence is
+/// debuggable, since installing into the wrong one silently breaks detection.
+fn find_kiro_agent_file_by_name(agents_dir: &Path, name: &str) -> Option<PathBuf> {
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(agents_dir)
+        .ok()?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    entries.sort();
+    let mut matches = entries.into_iter().filter(|path| {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<Value>(&content).ok())
+            .and_then(|v| v.get("name").and_then(|n| n.as_str()).map(|n| n == name))
+            .unwrap_or(false)
+    });
+    let first = matches.next()?;
+    if let Some(second) = matches.next() {
+        tracing::warn!(target: "hooks.install",
+            "multiple Kiro agent files in {} declare name '{}' (e.g. {} and {}); \
+             installing hooks into the first. Remove the duplicate to avoid ambiguity.",
+            agents_dir.display(), name, first.display(), second.display());
+    }
+    Some(first)
 }
 
 /// Make `aoe-hooks` the active default Kiro agent if the user is still on
@@ -3575,10 +3615,90 @@ hooks_auto_accept: false
     }
 
     #[test]
-    fn test_kiro_agent_file_for() {
+    fn test_resolve_kiro_agent_file_falls_back_to_name_json_when_dir_absent() {
+        // Brand-new agent, nothing on disk yet: resolve to `<dir>/<name>.json`,
+        // the path Kiro will read the name from once the file is written.
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("agents");
         assert_eq!(
-            kiro_agent_file_for("custom-agent"),
-            Path::new(".kiro/agents/custom-agent.json")
+            resolve_kiro_agent_file(&missing, "custom-agent"),
+            missing.join("custom-agent.json")
+        );
+    }
+
+    #[test]
+    fn test_resolve_kiro_agent_file_falls_back_when_no_name_matches() {
+        // The directory exists and has files, but none declares the selected
+        // name. Fall back to the create-path so a new agent can be added.
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("something-else.json"),
+            r#"{"name":"something-else"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_kiro_agent_file(dir.path(), "custom-agent"),
+            dir.path().join("custom-agent.json")
+        );
+    }
+
+    #[test]
+    fn test_resolve_kiro_agent_file_matches_name_field_not_filename() {
+        // Regression: a generator renders the `custom-agent` agent under a
+        // prefixed filename, so the file Kiro loads for `--agent custom-agent`
+        // is name-matched, not stem-matched. The resolver must return it and
+        // ignore a decoy whose stem matches but whose `name` does not.
+        let dir = TempDir::new().unwrap();
+        let managed_file = dir.path().join("TeamAgents-custom-agent.json");
+        std::fs::write(
+            &managed_file,
+            r#"{"name":"custom-agent","hooks":{"agentSpawn":[{"command":"team-tool emit"}]}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("custom-agent.json"),
+            r#"{"name":"aoe-hooks"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_kiro_agent_file(dir.path(), "custom-agent"),
+            managed_file,
+            "must resolve by the JSON name field, not the filename stem"
+        );
+    }
+
+    #[test]
+    fn test_resolve_kiro_agent_file_ignores_non_json_and_invalid_files() {
+        // Unreadable-as-JSON and non-.json files in the dir must not break the
+        // scan or produce a false match.
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("notes.txt"), "name: custom-agent").unwrap();
+        std::fs::write(dir.path().join("broken.json"), "{ not json").unwrap();
+        let good = dir.path().join("AcmePkg-custom-agent.json");
+        std::fs::write(&good, r#"{"name":"custom-agent"}"#).unwrap();
+        assert_eq!(resolve_kiro_agent_file(dir.path(), "custom-agent"), good);
+    }
+
+    #[test]
+    fn test_resolve_kiro_agent_file_duplicate_names_pick_lexicographic_first() {
+        // Two files declaring the same name is a misconfiguration; resolution
+        // must be deterministic (lexicographically-first filename) so the
+        // install target does not flip between launches.
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("ZZZ-custom.json"),
+            r#"{"name":"custom-agent"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("AAA-custom.json"),
+            r#"{"name":"custom-agent"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_kiro_agent_file(dir.path(), "custom-agent"),
+            dir.path().join("AAA-custom.json"),
         );
     }
 
@@ -3586,13 +3706,16 @@ hooks_auto_accept: false
     fn test_install_into_selected_kiro_agent_creates_file() {
         // No pre-existing agent file: installing into the selected agent's path
         // creates it with AoE hooks, just like the dedicated aoe-hooks agent.
-        // Mirrors how `install_sidecar_host_hooks` composes the path helper with
+        // Mirrors how `install_sidecar_host_hooks` resolves the path then calls
         // the sidecar installer.
-        let home = TempDir::new().unwrap();
-        let path = home.path().join(kiro_agent_file_for("custom-agent"));
+        let agents_dir = TempDir::new().unwrap();
+        let path = resolve_kiro_agent_file(agents_dir.path(), "custom-agent");
         install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
 
         let config: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // The created file's name must match the selected agent, not the
+        // standalone "aoe-hooks" default, so Kiro loads it for --agent custom-agent.
+        assert_eq!(config["name"].as_str(), Some("custom-agent"));
         for (event, _) in KIRO_HOOKS {
             let entries = config["hooks"][event].as_array().unwrap();
             assert_eq!(
@@ -3608,15 +3731,21 @@ hooks_auto_accept: false
     #[test]
     fn test_install_into_selected_kiro_agent_preserves_user_config() {
         // A real user agent has its own name/prompt/tools/hooks. Installing must
-        // keep all of that and only add AoE hook entries.
-        let home = TempDir::new().unwrap();
-        let path = home.path().join(kiro_agent_file_for("custom-agent"));
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // keep all of that and only add AoE hook entries. The file uses the
+        // `<prefix>-<name>.json` generator convention to prove the resolver
+        // targets it by `name` rather than the filename stem.
+        let agents_dir = TempDir::new().unwrap();
         std::fs::write(
-            &path,
+            agents_dir.path().join("CustomPkg-custom-agent.json"),
             r#"{"name":"custom-agent","prompt":"custom helper","tools":["read","shell"],"hooks":{"preToolUse":[{"command":"echo mine"}]}}"#,
         )
         .unwrap();
+        let path = resolve_kiro_agent_file(agents_dir.path(), "custom-agent");
+        assert_eq!(
+            path,
+            agents_dir.path().join("CustomPkg-custom-agent.json"),
+            "resolver must target the name-matched file, not custom-agent.json"
+        );
 
         install_kiro_hooks(&path, HookInstallTarget::Host).unwrap();
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1500,9 +1500,13 @@ pub(crate) fn build_container_config(
                     .as_ref()
                     .zip(agent_selection.selected_agent)
                     .and_then(|(sel, name)| {
-                        let sandbox_dir = Path::new(sidecar.sandbox_config_subpath).parent()?;
-                        let file_name = (sel.config_subpath)(name).file_name()?.to_owned();
-                        Some(home.join(sandbox_dir).join(file_name))
+                        // The selected agent's dir is staged into the sandbox
+                        // (parent of sandbox_config_subpath, e.g.
+                        // `.kiro/sandbox/agents`) before this install runs, so
+                        // the resolver can match by `name` there as on the host.
+                        let agents_dir =
+                            home.join(Path::new(sidecar.sandbox_config_subpath).parent()?);
+                        Some((sel.resolve_config_file)(&agents_dir, name))
                     })
                     .unwrap_or_else(|| home.join(sidecar.sandbox_config_subpath));
                 if let Err(e) =
@@ -3441,6 +3445,78 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
         assert!(
             !standalone.exists(),
             "standalone aoe-hooks sandbox config must not be written when an agent is selected"
+        );
+
+        crate::hooks::cleanup_hook_status_dir(instance_id);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_resolves_selected_kiro_agent_by_name_in_sandbox() {
+        // The host `.kiro/agents` dir is staged into `.kiro/sandbox/agents`
+        // before hook install, so a prefixed agent file (filename != name) must
+        // be resolved by its `name` field there, mirroring the host path.
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let host_agents = temp_home.path().join(".kiro/agents");
+        std::fs::create_dir_all(&host_agents).unwrap();
+        std::fs::write(
+            host_agents.join("TeamAgents-custom-agent.json"),
+            r#"{"name":"custom-agent","hooks":{"agentSpawn":[{"command":"team-tool emit"}]}}"#,
+        )
+        .unwrap();
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+
+        let instance_id = "kiro-managed-agent-sandbox-test";
+        build_container_config(
+            project_dir.path().to_str().unwrap(),
+            &super::super::instance::SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "test:latest".to_string(),
+                container_name: "test-container".to_string(),
+                extra_env: None,
+                custom_instruction: None,
+                before_start_env: Vec::new(),
+            },
+            ContainerAgentSelection::new("kiro", None).with_selected_agent(Some("custom-agent")),
+            false,
+            instance_id,
+            None,
+            "",
+        )
+        .unwrap();
+
+        let matched = temp_home
+            .path()
+            .join(".kiro/sandbox/agents/TeamAgents-custom-agent.json");
+        assert!(
+            matched.exists(),
+            "hooks should install into the name-matched staged file at {}",
+            matched.display()
+        );
+        let body = fs::read_to_string(&matched).unwrap();
+        assert!(
+            body.contains("aoe-hooks"),
+            "AoE hook command must be present"
+        );
+        assert!(
+            body.contains("agentSpawn"),
+            "the agent's own hook must be preserved"
+        );
+
+        let stem_clone = temp_home
+            .path()
+            .join(".kiro/sandbox/agents/custom-agent.json");
+        assert!(
+            !stem_clone.exists(),
+            "must not create a filename-stem clone the CLI never loads"
         );
 
         crate::hooks::cleanup_hook_status_dir(instance_id);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2203,13 +2203,21 @@ impl Instance {
                 {
                     // The selected agent is what the CLI loads; install AoE's
                     // hooks into its config (these CLIs have no global hooks) and
-                    // skip the standalone-agent install + post_install_host.
-                    let path = home.join((sel.config_subpath)(&name));
+                    // skip the standalone-agent install + post_install_host. The
+                    // agents directory is the parent of the standalone hooks
+                    // agent's config (e.g. `.kiro/agents`); the resolver picks the
+                    // right file within it by `name`.
+                    let agents_dir = home.join(
+                        Path::new(sidecar.host_config_subpath)
+                            .parent()
+                            .unwrap_or(Path::new(".")),
+                    );
+                    let path = (sel.resolve_config_file)(&agents_dir, &name);
                     match (sidecar.install)(&path, crate::hooks::HookInstallTarget::Host) {
                         Ok(()) => tracing::info!(target: "session.store",
-                            "Installed AoE status hooks into {} agent '{}'", self.tool, name),
+                            "Installed AoE status hooks into {} agent '{}' at {}", self.tool, name, path.display()),
                         Err(e) => tracing::warn!(target: "session.store",
-                            "Failed to install AoE hooks into {} agent '{}': {}", self.tool, name, e),
+                            "Failed to install AoE hooks into {} agent '{}' at {}: {}", self.tool, name, path.display(), e),
                     }
                     return;
                 }

--- a/tests/e2e/kiro_launch.rs
+++ b/tests/e2e/kiro_launch.rs
@@ -14,6 +14,13 @@
 //! shell (`sh -lc`) that re-resolves `kiro-cli` from the real PATH, so a stub
 //! would be shadowed; `pane_start_command` captures the exact intended command
 //! regardless of whether the binary is installed.
+//!
+//! A separate test covers the other half of `--agent` support: that AoE's
+//! status hooks are installed into the agent config Kiro actually loads. Kiro
+//! resolves `--agent NAME` by the `name` field inside `~/.kiro/agents/*.json`,
+//! not the filename, so a generator-managed agent stored as
+//! `<prefix>-NAME.json` must still receive the hooks. This drives the full
+//! launch path against a seeded agents dir and asserts the on-disk result.
 
 use crate::harness::{require_tmux, TuiTestHarness};
 use serde_json::Value;
@@ -149,5 +156,72 @@ fn test_kiro_yolo_passes_trust_all_tools_after_chat() {
     assert!(
         yolo > chat,
         "--trust-all-tools must come after `kiro-cli chat`, got: {cmd:?}"
+    );
+}
+
+/// `--agent NAME` must install AoE's status hooks into the config file Kiro
+/// actually loads. Kiro resolves the agent by the `name` field inside each
+/// `~/.kiro/agents/*.json`, not the filename, and generator-managed agents are
+/// stored as `<prefix>-NAME.json`. This seeds such a file under the harness's
+/// isolated `$HOME`, launches a kiro session selecting it, and asserts the hooks
+/// merged into that prefixed file (preserving its own hook) rather than a
+/// `NAME.json` clone the CLI never reads.
+#[test]
+#[serial]
+fn test_kiro_agent_hooks_install_into_name_matched_file() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("kiro_agent_hooks");
+
+    // Seed a generator-managed agent whose filename stem differs from its
+    // logical `name`. Its only hook is the generator's own agentSpawn: AoE's
+    // three events are absent, so finding them post-launch proves the install
+    // ran against this file (not stale state) and that agentSpawn is preserved.
+    let agents_dir = h.home_path().join(".kiro").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("create .kiro/agents");
+    let managed = agents_dir.join("TeamAgents-custom-agent.json");
+    std::fs::write(
+        &managed,
+        r#"{"name":"custom-agent","hooks":{"agentSpawn":[{"command":"team-tool emit"}]}}"#,
+    )
+    .expect("seed managed agent file");
+
+    // Guard kills the tmux session on scope exit; the launch command itself is
+    // covered by the sibling tests, so only the on-disk result matters here.
+    let _guard = launch_kiro_and_read_command(
+        &mut h,
+        "KiroAgentHooks",
+        &["--extra-args", "--agent custom-agent"],
+    )
+    .1;
+
+    let installed: Value = serde_json::from_str(
+        &std::fs::read_to_string(&managed).expect("managed agent file still present"),
+    )
+    .expect("managed agent file is valid JSON");
+    let hooks = installed["hooks"]
+        .as_object()
+        .expect("hooks object present after install");
+    for event in ["preToolUse", "userPromptSubmit", "stop"] {
+        assert!(
+            hooks.contains_key(event),
+            "AoE status hook '{event}' must be installed into the name-matched file, got: {:?}",
+            hooks.keys().collect::<Vec<_>>()
+        );
+    }
+    assert!(
+        hooks.contains_key("agentSpawn"),
+        "the agent's own agentSpawn hook must be preserved"
+    );
+    assert_eq!(
+        installed["name"].as_str(),
+        Some("custom-agent"),
+        "the agent's name field must be left intact"
+    );
+
+    // And NOT into a filename-stem clone the CLI would never load.
+    assert!(
+        !agents_dir.join("custom-agent.json").exists(),
+        "must not create a `custom-agent.json` clone derived from the filename stem"
     );
 }


### PR DESCRIPTION
## Description

Kiro CLI resolves `--agent <name>` by the `name` field **inside** each `~/.kiro/agents/*.json`, not by the filename. Generator-managed agents (e.g. tooling that renders agents into the global agents dir) name their files `<prefix>-<name>.json`, so the filename stem and the logical agent name diverge.

AoE's selected-agent hook install assumed `filename == name` and targeted `<name>.json`. For a prefixed agent that path doesn't exist, so AoE created a stray `<name>.json` that was a clone of the standalone `aoe-hooks` agent, while the real agent file (the one Kiro actually loads) never received AoE's status hooks. The result: working/idle/etc. status detection silently failed for any user-selected agent whose file is prefixed. It worked only for the standalone `aoe-hooks` agent, whose filename and name happen to match.

This is the second half of `--agent` support. #2382 made the launch command and the sandbox install honor the selected agent; this PR makes the install actually target the file Kiro loads.

### Fix

- Replace `SelectedAgentHooks::config_subpath: fn(&str) -> PathBuf` with `resolve_config_file: fn(&Path, &str) -> PathBuf`.
- New `resolve_kiro_agent_file(agents_dir, name)` scans the agents directory for a config whose top-level `name` field matches the selection, falling back to `<name>.json` only when no file declares that name (the correct create-path for a brand-new agent).
- Both install paths updated and kept symmetric: host (`Instance::install_sidecar_host_hooks`) and sandbox (`build_container_config`) derive the agents directory from the existing sidecar config subpaths.
- Duplicate `name` declarations resolve deterministically (lexicographically-first) and emit a `warn!` so the misconfiguration is debuggable.
- The host install log now records the resolved path, so a wrong-file target is observable instead of silent.

The agent registry stays data-driven: this is a function pointer on the `AgentDef`, not a per-agent string match, and the existing drift-guard test still asserts kiro is the only agent declaring `selected_agent_hooks`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- no user-facing docs affected; behavior is internal hook plumbing -->
- [x] For UI changes: included screenshot or recording <!-- N/A: no UI change -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

`tests/e2e/kiro_launch.rs::test_kiro_agent_hooks_install_into_name_matched_file` seeds a generator-style `<prefix>-<name>.json` agent under the harness's isolated `$HOME`, drives the full `aoe add --launch --tool kiro --extra-args "--agent <name>"` path, and asserts AoE's three status hooks merged into that prefixed file while its own `agentSpawn` hook and `name` are preserved, and that no filename-stem clone is created. Verified (TDD) to fail against the previous filename-stem behavior. Also covered by unit tests for the resolver (name-match wins over stem, fallback, invalid/non-json skipped, deterministic duplicate pick) and an in-crate integration test for the sandbox staging path.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:** AI assisted with the investigation (root-causing the filename-vs-name mismatch against a real host), implementation, and tests. The fix was verified end-to-end by running the actual resolver and installer against a snapshot of a real `~/.kiro/agents` directory. I reviewed and understand all of it and will respond to review feedback myself.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784992188&installation_id=139138837&pr_number=2395&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2395&signature=9ca9c7bff4cfdcf31d661e660675ac2b9eeb3215913b94b2b4c621ddd11f045a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change fixes Kiro agent hook installation so AoE updates the actual agent file Kiro uses, instead of assuming the file name matches the agent name.

What changed:
- Replaced filename-based agent lookup with name-based lookup by reading the agent JSON’s top-level `name` field.
- Updated both the host-side and sandbox-side hook installation flows to use the same resolver logic.
- Removed the old helper that directly constructed `~/.kiro/agents/<name>.json` and replaced it with a resolver that scans the agents directory.
- Added deterministic handling for duplicate agent `name` entries (with a warning), plus clearer logging of the chosen resolved path.
- Expanded test coverage, including sandbox staging behavior and an end-to-end case for generator/prefixed agent files where filename ≠ logical agent name.

Benefits:
- Hooks now land in the correct agent config file that Kiro actually loads.
- Prevents creation of stray/duplicate agent files when the filename is prefixed by a generator.
- Preserves existing user agent configuration fields while still supporting fallback behavior when no matching agent is found.

Potential area for further enhancement:
- Consider caching resolver results per run to avoid repeatedly scanning/parsing agent JSON files when installing multiple hook sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->