### PR TITLE
feat(plugin): worker-facing config.get host RPC

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -353,6 +353,7 @@ reuse the existing taxonomy:
 | `session.meta.get` | `session.read` |
 | `session.meta.set` / `session.meta.cas` | `session.write` |
 | `sessions.list` | `session.read` |
+| `config.get` | `runtime.worker` |
 
 `events.*` run over a shared plugin event bus (a `plugin_host` schema on the
 durable event-log substrate, `src/events/`); `subscribe { topics, after_seq }`
@@ -363,6 +364,15 @@ plugin's id, so one plugin cannot reach another's data. A `session.meta.cas`
 that loses returns the current value rather than clobbering it. Writes go
 through `Storage`'s cross-process lock, so the daemon picks them up on its next
 session reload (eventual consistency, not a live push).
+
+`config.get { key }` returns the value at `plugins.<plugin-id>.settings.<key>`
+for the calling plugin's own id, so a worker reads back the settings the user
+edited on the TUI/web surfaces, falling back to its own default when the key is
+unset (the call returns null). The id is the caller's own, never a request
+parameter, so a plugin can only read its own table. Reading one's own declared
+settings needs no `config.*` capability: `config.read` / `config.write` gate
+host/global or other-plugin configuration, which no host method exposes yet, so
+`config.get` rides on `runtime.worker` like `events.*`.
 
 ### Sandboxing
 

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -18,11 +18,17 @@
 //! - `session.meta.set { session_id, key, value }` and
 //!   `session.meta.cas { session_id, key, expected, value }` (`session.write`).
 //! - `sessions.list` (`session.read`).
+//! - `config.get { key }` (`runtime.worker`): the value at
+//!   `plugins.<plugin-id>.settings.<key>` for the calling plugin's own id.
 //!
 //! Per-plugin namespace: session metadata is always read and written under the
-//! calling plugin's own `Instance.plugin_meta[<plugin-id>]` slot. The worker
-//! sends only `key`; it can never name another plugin's id, so one plugin
-//! cannot touch another's metadata.
+//! calling plugin's own `Instance.plugin_meta[<plugin-id>]` slot, and
+//! `config.get` reads only the caller's own `plugins.<plugin-id>.settings`
+//! table. The worker sends only `key`; it can never name another plugin's id,
+//! so one plugin cannot touch another's metadata or settings. Reading one's own
+//! declared settings needs no `config.*` capability (those gate host/global or
+//! other-plugin config); `runtime.worker`, which every worker holds to run at
+//! all, is enough.
 
 use std::sync::Mutex;
 
@@ -159,6 +165,10 @@ pub fn dispatch(
         "sessions.list" => {
             ctx.require(CAP_SESSION_READ)?;
             sessions_list(state)
+        }
+        "config.get" => {
+            ctx.require(CAP_WORKER)?;
+            config_get(ctx, params)
         }
         other => Err(DispatchError::method_not_found(other)),
     }
@@ -359,6 +369,29 @@ fn sessions_list(state: &HostApiState) -> Result<Value, DispatchError> {
     Ok(json!({ "sessions": sessions }))
 }
 
+/// Read `plugins.<plugin_id>.settings.<key>` for the calling plugin's own id,
+/// or `Value::Null` when the plugin has no config entry or the key is unset, so
+/// the worker can fall back to its own default. The id is always the caller's
+/// own ([`PluginRpcContext::plugin_id`]), never a request parameter, so one
+/// plugin can never read another's settings.
+fn config_get(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchError> {
+    let key = str_param(params, "key")?;
+    let config =
+        crate::session::Config::load().map_err(|e| DispatchError::internal(e.to_string()))?;
+    let value = match config
+        .plugins
+        .get(&ctx.plugin_id)
+        .and_then(|plugin| plugin.settings.get(key))
+    {
+        // The stored value is TOML; hand it back to the worker as JSON.
+        Some(toml_value) => {
+            serde_json::to_value(toml_value).map_err(|e| DispatchError::internal(e.to_string()))?
+        }
+        None => Value::Null,
+    };
+    Ok(json!({ "value": value }))
+}
+
 /// Set `key = value` inside `inst.plugin_meta[plugin_id]`, creating the slot as
 /// a JSON object if absent. The slot is namespaced to the plugin id, never a
 /// request parameter, which is what keeps one plugin out of another's data.
@@ -548,5 +581,75 @@ mod tests {
         let list = dispatch(&state, &a, "sessions.list", &json!({})).unwrap();
         let sessions = list["sessions"].as_array().unwrap();
         assert!(sessions.iter().any(|s| s["id"] == json!(session_id)));
+    }
+
+    /// `config.get` reads the calling plugin's own persisted settings, gated by
+    /// `runtime.worker`: a granted worker reads its value, an unset key returns
+    /// null, a different plugin id cannot see it, and a worker without
+    /// `runtime.worker` is refused. Isolated under a temp `XDG_CONFIG_HOME` so it
+    /// never touches real user config; serial because it mutates the env.
+    #[test]
+    #[serial_test::serial]
+    fn config_get_scopes_to_caller_and_requires_worker() {
+        use crate::session::{save_config, Config, PluginConfig};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+
+        // Seed the global config with one setting under "acme.worker".
+        let mut config = Config::default();
+        let mut plugin = PluginConfig::default();
+        plugin
+            .settings
+            .insert("poll_interval_ms".to_string(), toml::Value::Integer(5000));
+        config.plugins.insert("acme.worker".to_string(), plugin);
+        save_config(&config).unwrap();
+
+        let state = state(tmp.path());
+        let worker = ctx(&[CAP_WORKER]);
+
+        // The owning plugin reads its own setting back as JSON.
+        let got = dispatch(
+            &state,
+            &worker,
+            "config.get",
+            &json!({"key": "poll_interval_ms"}),
+        )
+        .unwrap();
+        assert_eq!(got["value"], json!(5000));
+
+        // An unset key returns null so the worker falls back to its default.
+        let missing = dispatch(&state, &worker, "config.get", &json!({"key": "nope"})).unwrap();
+        assert_eq!(missing["value"], json!(null));
+
+        // A different plugin id cannot see "acme.worker"'s settings.
+        let other = PluginRpcContext {
+            plugin_id: "other.plugin".to_string(),
+            granted_capabilities: vec![CAP_WORKER.to_string()],
+        };
+        let other_got = dispatch(
+            &state,
+            &other,
+            "config.get",
+            &json!({"key": "poll_interval_ms"}),
+        )
+        .unwrap();
+        assert_eq!(other_got["value"], json!(null));
+
+        // Without runtime.worker the call is forbidden.
+        let err = dispatch(
+            &state,
+            &ctx(&[CAP_SESSION_READ]),
+            "config.get",
+            &json!({"key": "poll_interval_ms"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        match prev {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
     }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A plugin can declare a `[[settings]]` control (#2094): the host renders it, validates it, and persists it at `plugins.<id>.settings.<key>`. Until now the running worker had no way to read that value back, so a declared setting was a dead control from the worker's point of view.

This adds a worker-facing `config.get { key }` host RPC. It returns the value at `plugins.<plugin-id>.settings.<key>` for the **calling plugin's own id**, converting the stored TOML to JSON, and returns null when the plugin has no entry or the key is unset so the worker falls back to its own default. The id is always the caller's own, never a request parameter, so a plugin can only ever read its own table (scoped exactly like `session.meta.*`).

Capability gate: `config.get` rides on `runtime.worker`, the capability every worker already holds to run at all (same as `events.*`). It is deliberately **not** gated by `config.read`. Reading your own declared settings needs no `config.*` capability; per the taxonomy comment at `aoe-plugin-api/src/capability.rs:60`, `config.read` / `config.write` mean host/global or other-plugin configuration, which no host method exposes yet. So nothing new is shown in the install grant prompt for reading your own settings.

`config.read` / `config.write` (cross-plugin / global read, and config write) stay declared-but-reserved and are tracked as a follow-up, #2398.

Read path only; no `config.set` / `config.write` in this PR.

**Base:** Rebased onto `main` now that the Tier 1 worker host (#2095, PR #2387) has merged; this is a single commit on top of current `main`.

Closes #2397

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Install a plugin that declares a `[[settings]]` field and set a value on the TUI/web settings surface (persists to `plugins.<id>.settings.<key>`).
- [ ] From the plugin worker, call `config.get { "key": "<your_key>" }` and confirm it returns `{ "value": <the value you set> }`.
- [ ] Call `config.get` with a key you never set and confirm it returns `{ "value": null }`.
- [ ] Confirm a worker without the `runtime.worker` capability gets a FORBIDDEN error from `config.get`.
- [ ] Confirm one plugin cannot read another plugin's settings (a different `plugin_id` reading the same key gets `null`).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

(Covered by an in-module `#[cfg(test)]` test in `src/plugin/host_api.rs` mirroring the existing `session.meta` capability-gate test: granted read, unset key returns null, cross-plugin read refused, and missing `runtime.worker` is FORBIDDEN.)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (gate on `runtime.worker`, not `config.read`) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new worker-facing `config.get` host RPC so plugins can read back their own persisted settings after they are saved by the host. The read is limited to the calling plugin’s own settings, returns `null` when a value is missing, and is gated by `runtime.worker` instead of `config.read`.

The docs were updated to reflect the new capability mapping and the per-plugin read scope. Tests were also added to cover successful reads, missing values, cross-plugin isolation, and access denial without the worker capability.

Benefit: plugins can now reliably load their saved defaults without exposing broader config access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->