### PR TITLE
feat(plugins): plugin UI extension points (host-rendered slots over capability-gated RPCs)

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -18,7 +18,7 @@ pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
     BuildStep, CommandContribution, KeybindContribution, ManifestError, PluginManifest,
-    RuntimeSpec, SettingContribution, SettingType, ThemeContribution, UiContribution,
+    RuntimeSpec, SettingContribution, SettingType, ThemeContribution, UiContribution, UiSlot,
 };
 
 /// Version of the manifest schema and host API this crate describes.

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -153,7 +153,7 @@ pub struct ThemeContribution {
 /// than carried forward. The worker pushes typed state into a declared slot
 /// over the `ui.state.*` host RPCs; the host renders it (the dashboard runs no
 /// plugin code).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UiSlot {
     /// A segment in the dashboard status/top bar (global).

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -187,6 +187,23 @@ impl UiSlot {
             UiSlot::RowBadge | UiSlot::RowColumn | UiSlot::DetailPanel | UiSlot::DetailBadge
         )
     }
+
+    /// The kebab-case wire name, matching the serde representation. Handy for
+    /// display (install prompt, plugin info) without round-tripping through
+    /// serde.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UiSlot::StatusBar => "status-bar",
+            UiSlot::RowBadge => "row-badge",
+            UiSlot::RowColumn => "row-column",
+            UiSlot::SortKey => "sort-key",
+            UiSlot::FilterFacet => "filter-facet",
+            UiSlot::Card => "card",
+            UiSlot::DetailPanel => "detail-panel",
+            UiSlot::DetailBadge => "detail-badge",
+            UiSlot::Notification => "notification",
+        }
+    }
 }
 
 /// A UI contribution: the plugin declares it may fill `slot` with entries

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -147,10 +147,54 @@ pub struct ThemeContribution {
     pub path: String,
 }
 
-/// A UI contribution targeting a named slot.
+/// A host-rendered UI slot a plugin may push state into (#2366). A closed set,
+/// unlike the open-string capabilities: the host must know how to render each
+/// slot, so an unknown slot is unrenderable and rejected at parse time rather
+/// than carried forward. The worker pushes typed state into a declared slot
+/// over the `ui.state.*` host RPCs; the host renders it (the dashboard runs no
+/// plugin code).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UiSlot {
+    /// A segment in the dashboard status/top bar (global).
+    StatusBar,
+    /// A badge on a session row (per session).
+    RowBadge,
+    /// A text column on a session row, carrying optional sort/filter scalars
+    /// (per session).
+    RowColumn,
+    /// A named sort option over a `RowColumn`'s scalar value (global).
+    SortKey,
+    /// A named filter over a `RowColumn`'s scalar value (global).
+    FilterFacet,
+    /// A card on the dashboard overview (global).
+    Card,
+    /// A panel in a session's detail view (per session).
+    DetailPanel,
+    /// A badge in a session's detail view (per session).
+    DetailBadge,
+    /// A transient notification, pushed via `ui.notify` (gated by the
+    /// `notifications` capability rather than a slot declaration).
+    Notification,
+}
+
+impl UiSlot {
+    /// Whether entries in this slot are scoped to a single session (and so must
+    /// carry a `session_id`), versus global to the dashboard.
+    pub fn is_per_session(self) -> bool {
+        matches!(
+            self,
+            UiSlot::RowBadge | UiSlot::RowColumn | UiSlot::DetailPanel | UiSlot::DetailBadge
+        )
+    }
+}
+
+/// A UI contribution: the plugin declares it may fill `slot` with entries
+/// addressed by `id`. The host gates `ui.state.set`/`ui.state.remove` on the
+/// `(slot, id)` pair being declared here.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiContribution {
-    pub slot: String,
+    pub slot: UiSlot,
     #[serde(default)]
     pub id: String,
 }
@@ -484,10 +528,11 @@ impl PluginManifest {
             );
         }
         for (i, u) in self.ui.iter().enumerate() {
-            check(
-                !u.slot.is_empty(),
-                format!("ui[{i}].slot must not be empty"),
-            );
+            // `slot` is a typed enum, so an unknown slot is already a parse
+            // error; only the addressing `id` needs checking. A UI entry is
+            // pushed and gated by its `(slot, id)` pair, so an empty id leaves
+            // it unaddressable.
+            check(!u.id.is_empty(), format!("ui[{i}].id must not be empty"));
         }
 
         if errors.is_empty() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -553,6 +553,20 @@ id = "panel"
 }
 
 #[test]
+fn ui_slot_as_str_round_trips_the_wire_name() {
+    // as_str (used for the install prompt / plugin info disclosure) must match
+    // the kebab-case serde name a manifest declares.
+    for (toml_slot, slot) in [
+        ("status-bar", UiSlot::StatusBar),
+        ("row-badge", UiSlot::RowBadge),
+        ("detail-panel", UiSlot::DetailPanel),
+        ("notification", UiSlot::Notification),
+    ] {
+        assert_eq!(slot.as_str(), toml_slot);
+    }
+}
+
+#[test]
 fn empty_command_argument_is_rejected() {
     let toml = r#"
 id = "acme.thing"

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -1,4 +1,4 @@
-use aoe_plugin_api::{ManifestError, PluginManifest, RuntimeSpec, SettingType};
+use aoe_plugin_api::{ManifestError, PluginManifest, RuntimeSpec, SettingType, UiSlot};
 
 #[test]
 fn minimal_manifest_parses_and_round_trips() {
@@ -67,7 +67,7 @@ key = "endpoint"
 label = "Endpoint"
 
 [[ui]]
-slot = "sidebar"
+slot = "status-bar"
 id = "panel"
 "#;
     let m = PluginManifest::from_toml_str(toml).expect("contribution sections parse");
@@ -77,7 +77,7 @@ id = "panel"
     assert_eq!(m.keybinds[0].key, "Ctrl+K");
     assert_eq!(m.settings[0].key, "endpoint");
     assert_eq!(m.settings[0].value_type, SettingType::String);
-    assert_eq!(m.ui[0].slot, "sidebar");
+    assert_eq!(m.ui[0].slot, UiSlot::StatusBar);
 }
 
 #[test]
@@ -510,7 +510,7 @@ command = ""
 key = ""
 
 [[ui]]
-slot = ""
+slot = "status-bar"
 "#;
     let err = PluginManifest::from_toml_str(toml).unwrap_err();
     let messages = match err {
@@ -526,8 +526,29 @@ slot = ""
         "{messages:?}"
     );
     assert!(
-        messages.iter().any(|m| m.contains("ui[0].slot")),
+        messages.iter().any(|m| m.contains("ui[0].id")),
         "{messages:?}"
+    );
+}
+
+#[test]
+fn unknown_ui_slot_is_a_parse_error() {
+    // `slot` is a typed enum (closed set), so a slot this host does not render
+    // is rejected at parse time, not carried forward like an unknown capability.
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[[ui]]
+slot = "sidebar"
+id = "panel"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(err, ManifestError::Parse(_)),
+        "expected Parse, got {err:?}"
     );
 }
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -472,6 +472,12 @@ wire: `status-bar`, `row-badge`, `row-column`, `sort-key`, `filter-facet`,
 `(slot, id)` pairs it may fill in its manifest `[[ui]]` section; an unknown
 slot is a hard parse error (the host must know how to render each).
 
+A UI contribution is not a capability and needs no grant, but the slots a
+plugin declares are disclosed so the user knows it modifies the dashboard
+before trusting it: the `aoe plugin install` prompt lists them alongside the
+requested capabilities, and they show in `aoe plugin info`, the TUI plugin
+manager, and the web Plugins panel (via `PluginView.ui_contributions`).
+
 ### RPCs (`src/plugin/host_api.rs`)
 
 - `ui.state.set { slot, id, session_id?, payload }` and

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -488,12 +488,38 @@ manager, and the web Plugins panel (via `PluginView.ui_contributions`).
   (`row-badge`, `row-column`, `detail-panel`, `detail-badge`) require a
   `session_id`; global slots must not carry one. The text-based slots
   (`status-bar`, `row-badge`, `detail-badge`) accept optional `icon` (a lucide
-  icon name in kebab-case, e.g. `git-pull-request-arrow`; an unknown name
-  renders nothing) and `href` (when set, the badge renders as a link that opens
-  in a new tab).
+  icon name in kebab-case, e.g. `git-pull-request-arrow`; the client maps it
+  through an allowlist, an unknown name renders nothing) and `href` (when set,
+  the badge renders as a link that opens in a new tab; only `http`/`https` URLs
+  are followed).
 - `ui.notify { tone, title, body?, session_id? }`. Gated by the existing
   `notifications` capability (not a slot declaration). Returns a monotonic
   `seq`.
+
+#### Richer payloads: `row-badge` items and the `detail-panel` block list
+
+Two slots carry more than a single value, so one entry (one declared
+`(slot, id)`) can render a list:
+
+- `row-badge` also accepts `items: BadgeItem[]` where
+  `BadgeItem = { text?, icon?, tone?, href?, tooltip? }`. Each item renders as a
+  compact, tone-tinted icon (falling back to `text`), linked when `href` is a
+  safe URL. The single `{ text, tone, tooltip, icon, href }` form still works.
+  An empty `items: []` clears the row.
+- `detail-panel` also accepts `blocks: Block[]`, an ordered list of typed
+  blocks. The host knows these kinds: `heading { text }`,
+  `row { label, value?, sublabel?, icon?, tone?, href? }`, `note { text, tone? }`,
+  `divider {}`, and `section { title?, children: Block[] }` (nested blocks). The
+  simple `{ title, body }` form still works when `blocks` is absent.
+
+**Block parsing is forward-compatible by design.** The host stores `blocks` as
+opaque JSON (`Vec<Value>`); it validates only that the payload envelope is
+well-formed, not the block kinds. The web renderer draws the kinds it knows and
+silently ignores any unknown `kind` or unknown field within a block. So a plugin
+can add a field to an existing kind, or push a brand new kind, without any host
+change: an older host simply renders what it understands and drops the rest.
+This is deliberate, the GitHub plugin's pane keeps growing (PR state today,
+review/CI/timelines later) and must not require lockstep host releases.
 
 ### Store and lifecycle (`src/plugin/ui_state.rs`)
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -459,13 +459,63 @@ capability grant prompt states this on every install. Restricted-environment,
 landlock, and `sandbox-exec` backends land later behind the same trait, with no
 change to the resolver or the supervisor.
 
+## UI extension points (#2366)
+
+A plugin worker pushes typed UI state to the host over capability-gated RPCs;
+the **host** renders every slot, on the web dashboard. No plugin code runs in
+the dashboard and the render path never awaits a worker: the host keeps an
+in-memory snapshot the dashboard reads synchronously.
+
+The nine slots are a closed `UiSlot` set (`aoe-plugin-api`), kebab-case on the
+wire: `status-bar`, `row-badge`, `row-column`, `sort-key`, `filter-facet`,
+`card`, `detail-panel`, `detail-badge`, `notification`. A plugin declares the
+`(slot, id)` pairs it may fill in its manifest `[[ui]]` section; an unknown
+slot is a hard parse error (the host must know how to render each).
+
+### RPCs (`src/plugin/host_api.rs`)
+
+- `ui.state.set { slot, id, session_id?, payload }` and
+  `ui.state.remove { slot, id, session_id? }`. Gated by `runtime.worker` **and**
+  the `(slot, id)` being declared in the manifest: no dedicated `ui` capability
+  is introduced. The `payload` is validated against the slot's typed shape and
+  stored normalized; an unknown field or bad tone is rejected. Per-session slots
+  (`row-badge`, `row-column`, `detail-panel`, `detail-badge`) require a
+  `session_id`; global slots must not carry one.
+- `ui.notify { tone, title, body?, session_id? }`. Gated by the existing
+  `notifications` capability (not a slot declaration). Returns a monotonic
+  `seq`.
+
+### Store and lifecycle (`src/plugin/ui_state.rs`)
+
+State is in-memory and dies with the daemon, like the rest of the Tier 1 host.
+Each worker spawn takes a *generation*; a plugin's entries are cleared when its
+worker exits, guarded by the generation so a late write or an instant respawn
+cannot resurrect or clobber the live worker's state. Notifications ride a
+separate bounded ring and survive a worker exit (a plugin that posts then
+crashes still reaches the browser). Per-plugin quotas bound memory.
+
+### Delivery
+
+`GET /api/plugins/ui-state` returns the full snapshot (entries grouped nowhere,
+plus the notification ring); it is small and bounded, so there is no
+incremental cursor. The dashboard polls it on the same cadence as
+`/api/sessions` and renders per-session entries only for sessions present in
+the live list. Notifications surface as toasts, deduped by `seq`.
+
+`sort-key` and `filter-facet` are accepted and stored by the host but their
+dashboard rendering (which needs changes to the sidebar's sort/filter core),
+and TUI rendering of any slot (the standalone TUI has no daemon link), are
+deferred to follow-ups.
+
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the Tier 0
-contribution registries and the command/keybind/UI surfaces (issues 2094 and
-2366), the builtin worker self-exec path and worker SDK (with the first builtin
-worker that needs them), and the discovery / featured supply-chain layer with
-integrity hashing (issues 2364 and 2365). Pinning a featured plugin's
+contribution registries (issue 2094), the UI extension points (issue 2366,
+above), the builtin worker self-exec path and worker SDK (with the first
+builtin worker that needs them), and the discovery / featured supply-chain
+layer with integrity hashing (issues 2364 and 2365). Within #2366, dashboard
+rendering of the `sort-key` and `filter-facet` slots and TUI rendering of any
+slot are themselves follow-ups. Pinning a featured plugin's
 release-binary asset hash in `featured.toml` (so a featured worker is attested,
 not just its source) is a follow-up; today a release-binary plugin cannot be
 featured.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -486,7 +486,11 @@ manager, and the web Plugins panel (via `PluginView.ui_contributions`).
   is introduced. The `payload` is validated against the slot's typed shape and
   stored normalized; an unknown field or bad tone is rejected. Per-session slots
   (`row-badge`, `row-column`, `detail-panel`, `detail-badge`) require a
-  `session_id`; global slots must not carry one.
+  `session_id`; global slots must not carry one. The text-based slots
+  (`status-bar`, `row-badge`, `detail-badge`) accept optional `icon` (a lucide
+  icon name in kebab-case, e.g. `git-pull-request-arrow`; an unknown name
+  renders nothing) and `href` (when set, the badge renders as a link that opens
+  in a new tab).
 - `ui.notify { tone, title, body?, session_id? }`. Gated by the existing
   `notifications` capability (not a slot declaration). Returns a monotonic
   `seq`.

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -129,6 +129,12 @@ fn run_info(id: &str) -> Result<()> {
             }
         );
     }
+    if !m.ui.is_empty() {
+        println!("  ui:");
+        for u in &m.ui {
+            println!("    - {} ({})", u.slot.as_str(), u.id);
+        }
+    }
     if !m.description.is_empty() {
         println!("  about:      {}", m.description);
     }

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -19,13 +19,14 @@
 //! per-worker respawn budget so a crash loop does not spin, and a concurrency
 //! cap. The worker's stderr drains to `<plugin-workers>/<id>.log`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use aoe_plugin_api::UiSlot;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
@@ -82,6 +83,12 @@ impl PluginHost {
             workers_dir,
             running: Mutex::new(HashMap::new()),
         }))
+    }
+
+    /// The aggregated UI-state snapshot for the web to render. Read
+    /// synchronously off the in-memory store; never awaits a worker.
+    pub fn ui_snapshot(&self) -> crate::plugin::ui_state::UiSnapshot {
+        self.api.ui_snapshot()
     }
 
     /// Launch a worker for every active plugin that declares a runtime, up to
@@ -184,6 +191,13 @@ impl PluginHost {
             .iter()
             .map(|c| c.as_str().to_string())
             .collect();
+        // The slots the plugin may push into; gates every ui.state.* call.
+        let ui_contributions: HashSet<(UiSlot, String)> = plugin
+            .manifest
+            .ui
+            .iter()
+            .map(|u| (u.slot, u.id.clone()))
+            .collect();
 
         let launch = resolve_launch(plugin, &OsLaunchResolver)?;
         let prepared = self.sandbox.prepare(&launch)?;
@@ -234,15 +248,25 @@ impl PluginHost {
 
         let stdin = child.stdin.take().context("worker stdin missing")?;
         let stdout = child.stdout.take().context("worker stdout missing")?;
+        // A fresh UI generation per spawn: every ui.state.* write the worker
+        // makes is stamped with it, so once this generation is retired below a
+        // late write cannot resurrect state, and an instant respawn owns a new
+        // generation that this worker's cleanup will not touch.
+        let ui_generation = self.api.begin_ui_generation(plugin_id);
         let ctx = PluginRpcContext {
             plugin_id: plugin_id.to_string(),
             granted_capabilities: granted,
+            ui_contributions,
+            ui_generation,
         };
         serve_connection(&self.api, &ctx, stdout, stdin).await;
 
         // The loop returned: the worker closed its stdout (exited or crashed).
-        // Reap the whole group so no forked helper is left behind, then let the
-        // caller decide whether to respawn.
+        // Drop this generation's UI state (a respawn repopulates it); guarded by
+        // the generation so it never wipes a newer worker's state. Then reap the
+        // whole group so no forked helper is left behind, and let the caller
+        // decide whether to respawn.
+        self.api.clear_ui(plugin_id, ui_generation);
         if pid != 0 {
             worker::reap_group_escalating(pid, REAP_GRACE).await;
         }
@@ -330,11 +354,15 @@ async fn serve_connection(
         let api = api.clone();
         let ctx_id = ctx.plugin_id.clone();
         let caps = ctx.granted_capabilities.clone();
+        let ui_contributions = ctx.ui_contributions.clone();
+        let ui_generation = ctx.ui_generation;
         let params = request.params.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             let ctx = PluginRpcContext {
                 plugin_id: ctx_id,
                 granted_capabilities: caps,
+                ui_contributions,
+                ui_generation,
             };
             dispatch(&api, &ctx, &method, &params)
         })
@@ -394,6 +422,8 @@ mod tests {
         let ctx = PluginRpcContext {
             plugin_id: "acme.worker".to_string(),
             granted_capabilities: vec!["runtime.worker".to_string()],
+            ui_contributions: std::collections::HashSet::new(),
+            ui_generation: 0,
         };
 
         // The worker: request a forbidden method, then publish the error code it

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -357,6 +357,7 @@ async fn serve_connection(
         let ui_contributions = ctx.ui_contributions.clone();
         let ui_generation = ctx.ui_generation;
         let params = request.params.clone();
+        let method_log = method.clone();
         let outcome = tokio::task::spawn_blocking(move || {
             let ctx = PluginRpcContext {
                 plugin_id: ctx_id,
@@ -367,6 +368,30 @@ async fn serve_connection(
             dispatch(&api, &ctx, &method, &params)
         })
         .await;
+
+        // Trace every dispatch outcome host-side, before the notification
+        // early-return below: a rejected call (a worker pushing an undeclared
+        // slot, a malformed payload, an ungranted capability) is otherwise
+        // invisible here, since the only signal is the error response the
+        // worker may or may not log. A notification (no id) is logged the same
+        // way even though it gets no response.
+        match &outcome {
+            Ok(Ok(_)) => tracing::debug!(
+                target: "plugin.host",
+                plugin = %ctx.plugin_id,
+                method = %method_log,
+                "worker rpc ok"
+            ),
+            Ok(Err(e)) => tracing::warn!(
+                target: "plugin.host",
+                plugin = %ctx.plugin_id,
+                method = %method_log,
+                code = e.code,
+                "worker rpc rejected: {}",
+                e.message
+            ),
+            Err(_) => {}
+        }
 
         // A notification (no id) gets no response, but still ran for its side
         // effects above.

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -226,6 +226,21 @@ fn str_param<'a>(params: &'a Value, key: &str) -> Result<&'a str, DispatchError>
         .ok_or_else(|| DispatchError::invalid_params(format!("missing string param {key:?}")))
 }
 
+/// An optional string param: absent or `null` is `None`, a string is `Some`, and
+/// any other JSON type is a hard error. Reading these (`session_id`, `body`)
+/// with a bare `as_str` would silently treat a non-string as absent, which can
+/// turn a malformed per-session call into a global one; rejecting keeps the wire
+/// contract honest.
+fn optional_str_param<'a>(params: &'a Value, key: &str) -> Result<Option<&'a str>, DispatchError> {
+    match params.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(DispatchError::invalid_params(format!(
+            "param {key:?} must be a string"
+        ))),
+    }
+}
+
 fn events_publish(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
     let topic = str_param(params, "topic")?;
     let payload = params
@@ -493,7 +508,7 @@ fn ui_state_set(
     let slot = parse_ui_slot(params)?;
     let id = str_param(params, "id")?;
     require_declared_slot(ctx, slot, id)?;
-    let session_id = params.get("session_id").and_then(Value::as_str);
+    let session_id = optional_str_param(params, "session_id")?;
     let payload = params
         .get("payload")
         .ok_or_else(|| DispatchError::invalid_params("missing param \"payload\""))?;
@@ -519,7 +534,7 @@ fn ui_state_remove(
     let slot = parse_ui_slot(params)?;
     let id = str_param(params, "id")?;
     require_declared_slot(ctx, slot, id)?;
-    let session_id = params.get("session_id").and_then(Value::as_str);
+    let session_id = optional_str_param(params, "session_id")?;
     state
         .ui
         .remove(&ctx.plugin_id, ctx.ui_generation, slot, id, session_id)
@@ -533,14 +548,8 @@ fn ui_notify(
     params: &Value,
 ) -> Result<Value, DispatchError> {
     let title = str_param(params, "title")?.to_string();
-    let body = params
-        .get("body")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let session_id = params
-        .get("session_id")
-        .and_then(Value::as_str)
-        .map(str::to_string);
+    let body = optional_str_param(params, "body")?.map(str::to_string);
+    let session_id = optional_str_param(params, "session_id")?.map(str::to_string);
     let tone = match params.get("tone") {
         None => Tone::Info,
         Some(v) => serde_json::from_value::<Tone>(v.clone())

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -30,13 +30,16 @@
 //! other-plugin config); `runtime.worker`, which every worker holds to run at
 //! all, is enough.
 
+use std::collections::HashSet;
 use std::sync::Mutex;
 
+use aoe_plugin_api::UiSlot;
 use rusqlite::Connection;
 use serde_json::{json, Value};
 
 use crate::events::{self, Order, Schema, SeqBound};
 use crate::plugin::protocol::codes;
+use crate::plugin::ui_state::{Tone, UiError, UiSnapshot, UiStore};
 use crate::session::Storage;
 
 /// Capability required by each host method. Reused from the manifest taxonomy
@@ -44,6 +47,10 @@ use crate::session::Storage;
 const CAP_WORKER: &str = "runtime.worker";
 const CAP_SESSION_READ: &str = "session.read";
 const CAP_SESSION_WRITE: &str = "session.write";
+/// `ui.notify` posts a notification; it reuses the existing `notifications`
+/// capability. `ui.state.*` need no extra capability beyond `runtime.worker`:
+/// the gate is the manifest `ui` slot declaration (see [`PluginRpcContext`]).
+const CAP_NOTIFICATIONS: &str = "notifications";
 
 /// Shared, host-owned state behind the API: the plugin event bus and the
 /// profile whose session storage the API reads and writes. One per running
@@ -55,6 +62,8 @@ pub struct HostApiState {
     retention: usize,
     /// Session-storage profile the API operates on (the daemon's profile).
     profile: String,
+    /// Host-rendered UI state pushed by workers over `ui.state.*`/`ui.notify`.
+    ui: UiStore,
 }
 
 impl HostApiState {
@@ -72,11 +81,28 @@ impl HostApiState {
             schema,
             retention,
             profile: profile.to_string(),
+            ui: UiStore::new(),
         })
     }
 
     fn storage(&self) -> anyhow::Result<Storage> {
         Storage::new_unwatched(&self.profile)
+    }
+
+    /// Register a freshly spawned worker's UI generation. The supervisor threads
+    /// the returned value into the worker's [`PluginRpcContext`].
+    pub fn begin_ui_generation(&self, plugin_id: &str) -> u64 {
+        self.ui.begin_generation(plugin_id)
+    }
+
+    /// Clear a worker's UI entries when it exits, guarded by its generation.
+    pub fn clear_ui(&self, plugin_id: &str, generation: u64) -> bool {
+        self.ui.clear_plugin(plugin_id, generation)
+    }
+
+    /// The full UI-state snapshot the web dashboard renders.
+    pub fn ui_snapshot(&self) -> UiSnapshot {
+        self.ui.snapshot()
     }
 }
 
@@ -85,6 +111,13 @@ impl HostApiState {
 pub struct PluginRpcContext {
     pub plugin_id: String,
     pub granted_capabilities: Vec<String>,
+    /// The `(slot, id)` pairs the plugin declared in its manifest `ui` section.
+    /// A `ui.state.set`/`ui.state.remove` for a pair not in this set is refused:
+    /// a plugin can only fill the slots it declared.
+    pub ui_contributions: HashSet<(UiSlot, String)>,
+    /// This worker spawn's UI generation, stamped on every `ui.state.*` write so
+    /// a stale worker cannot resurrect state after it exited.
+    pub ui_generation: u64,
 }
 
 impl PluginRpcContext {
@@ -169,6 +202,18 @@ pub fn dispatch(
         "config.get" => {
             ctx.require(CAP_WORKER)?;
             config_get(ctx, params)
+        }
+        "ui.state.set" => {
+            ctx.require(CAP_WORKER)?;
+            ui_state_set(state, ctx, params)
+        }
+        "ui.state.remove" => {
+            ctx.require(CAP_WORKER)?;
+            ui_state_remove(state, ctx, params)
+        }
+        "ui.notify" => {
+            ctx.require(CAP_NOTIFICATIONS)?;
+            ui_notify(state, ctx, params)
         }
         other => Err(DispatchError::method_not_found(other)),
     }
@@ -392,6 +437,122 @@ fn config_get(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchE
     Ok(json!({ "value": value }))
 }
 
+/// Parse the `slot` param into a typed [`UiSlot`]. An unknown slot is bad
+/// input, not a host failure.
+fn parse_ui_slot(params: &Value) -> Result<UiSlot, DispatchError> {
+    let raw = params
+        .get("slot")
+        .ok_or_else(|| DispatchError::invalid_params("missing string param \"slot\""))?;
+    serde_json::from_value::<UiSlot>(raw.clone())
+        .map_err(|_| DispatchError::invalid_params(format!("unknown ui slot {raw}")))
+}
+
+/// Map a store-level [`UiError`] to a JSON-RPC error. A bad payload/scope is the
+/// caller's input (INVALID_PARAMS); a quota or stale-generation refusal is the
+/// host declining the mutation (FORBIDDEN, our reserved code).
+fn ui_dispatch_error(e: UiError) -> DispatchError {
+    match e {
+        UiError::BadRequest(message) => DispatchError::invalid_params(message),
+        UiError::QuotaExceeded => DispatchError {
+            code: codes::FORBIDDEN,
+            message: "plugin UI-state quota exceeded".into(),
+        },
+        UiError::StaleWorker => DispatchError {
+            code: codes::FORBIDDEN,
+            message: "worker generation is no longer active".into(),
+        },
+    }
+}
+
+/// Refuse a `ui.state.*` call unless the plugin declared this `(slot, id)` in
+/// its manifest `ui` section. This, plus `runtime.worker`, is the full gate on
+/// pushing UI state; no dedicated `ui` capability is introduced.
+fn require_declared_slot(
+    ctx: &PluginRpcContext,
+    slot: UiSlot,
+    id: &str,
+) -> Result<(), DispatchError> {
+    if ctx.ui_contributions.contains(&(slot, id.to_string())) {
+        Ok(())
+    } else {
+        Err(DispatchError {
+            code: codes::FORBIDDEN,
+            message: format!(
+                "plugin {} did not declare ui slot {slot:?} with id {id:?}",
+                ctx.plugin_id
+            ),
+        })
+    }
+}
+
+fn ui_state_set(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let slot = parse_ui_slot(params)?;
+    let id = str_param(params, "id")?;
+    require_declared_slot(ctx, slot, id)?;
+    let session_id = params.get("session_id").and_then(Value::as_str);
+    let payload = params
+        .get("payload")
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"payload\""))?;
+    state
+        .ui
+        .set(
+            &ctx.plugin_id,
+            ctx.ui_generation,
+            slot,
+            id,
+            session_id,
+            payload,
+        )
+        .map_err(ui_dispatch_error)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn ui_state_remove(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let slot = parse_ui_slot(params)?;
+    let id = str_param(params, "id")?;
+    require_declared_slot(ctx, slot, id)?;
+    let session_id = params.get("session_id").and_then(Value::as_str);
+    state
+        .ui
+        .remove(&ctx.plugin_id, ctx.ui_generation, slot, id, session_id)
+        .map_err(ui_dispatch_error)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn ui_notify(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let title = str_param(params, "title")?.to_string();
+    let body = params
+        .get("body")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let session_id = params
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let tone = match params.get("tone") {
+        None => Tone::Info,
+        Some(v) => serde_json::from_value::<Tone>(v.clone())
+            .map_err(|_| DispatchError::invalid_params(format!("unknown tone {v}")))?,
+    };
+    let seq = state
+        .ui
+        .notify(&ctx.plugin_id, tone, title, body, session_id)
+        .map_err(ui_dispatch_error)?;
+    Ok(json!({ "seq": seq }))
+}
+
 /// Set `key = value` inside `inst.plugin_meta[plugin_id]`, creating the slot as
 /// a JSON object if absent. The slot is namespaced to the plugin id, never a
 /// request parameter, which is what keeps one plugin out of another's data.
@@ -416,6 +577,8 @@ mod tests {
         PluginRpcContext {
             plugin_id: "acme.worker".to_string(),
             granted_capabilities: caps.iter().map(|c| c.to_string()).collect(),
+            ui_contributions: HashSet::new(),
+            ui_generation: 0,
         }
     }
 
@@ -567,6 +730,8 @@ mod tests {
         let b = PluginRpcContext {
             plugin_id: "other.plugin".to_string(),
             granted_capabilities: vec![CAP_SESSION_READ.to_string()],
+            ui_contributions: HashSet::new(),
+            ui_generation: 0,
         };
         let other = dispatch(
             &state,
@@ -627,6 +792,8 @@ mod tests {
         let other = PluginRpcContext {
             plugin_id: "other.plugin".to_string(),
             granted_capabilities: vec![CAP_WORKER.to_string()],
+            ui_contributions: HashSet::new(),
+            ui_generation: 0,
         };
         let other_got = dispatch(
             &state,
@@ -651,5 +818,115 @@ mod tests {
             Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
             None => std::env::remove_var("XDG_CONFIG_HOME"),
         }
+    }
+
+    /// Build a context that declared a single `(slot, id)` UI contribution and
+    /// holds the given capabilities, registered against `state` so its
+    /// generation is the active one.
+    fn ui_ctx(state: &HostApiState, caps: &[&str], slot: UiSlot, id: &str) -> PluginRpcContext {
+        let mut contributions = HashSet::new();
+        contributions.insert((slot, id.to_string()));
+        PluginRpcContext {
+            plugin_id: "acme.worker".to_string(),
+            granted_capabilities: caps.iter().map(|c| c.to_string()).collect(),
+            ui_contributions: contributions,
+            ui_generation: state.begin_ui_generation("acme.worker"),
+        }
+    }
+
+    #[test]
+    fn ui_state_set_requires_declared_slot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        // Declared status-bar/"main", but pushing row-badge/"main" is refused.
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::StatusBar, "main");
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "row-badge", "id": "main", "session_id": "s1", "payload": {"text": "x"}}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        // The declared slot succeeds and surfaces in the snapshot.
+        dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "status-bar", "id": "main", "payload": {"text": "ok", "tone": "success"}}),
+        )
+        .unwrap();
+        let snap = state.ui_snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(snap.entries[0].payload["text"], json!("ok"));
+    }
+
+    #[test]
+    fn ui_state_set_needs_worker_capability() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ui_ctx(&state, &[], UiSlot::StatusBar, "main");
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "status-bar", "id": "main", "payload": {"text": "x"}}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+    }
+
+    #[test]
+    fn ui_notify_requires_notifications_capability() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        // runtime.worker alone is not enough for ui.notify.
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::Notification, "n");
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.notify",
+            &json!({"title": "Build failed", "tone": "danger"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        // With the capability it posts and returns a seq.
+        let c = ui_ctx(&state, &[CAP_NOTIFICATIONS], UiSlot::Notification, "n");
+        let ok = dispatch(
+            &state,
+            &c,
+            "ui.notify",
+            &json!({"title": "Build failed", "tone": "danger"}),
+        )
+        .unwrap();
+        assert_eq!(ok["seq"], json!(1));
+        assert_eq!(state.ui_snapshot().notifications.len(), 1);
+    }
+
+    #[test]
+    fn ui_state_set_rejects_unknown_slot_and_bad_payload() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::StatusBar, "main");
+        // Unknown slot string.
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "sidebar", "id": "main", "payload": {"text": "x"}}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::INVALID_PARAMS);
+        // Declared slot, malformed payload (missing required `text`).
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "status-bar", "id": "main", "payload": {"tone": "info"}}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::INVALID_PARAMS);
     }
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{anyhow, bail, Context, Result};
-use aoe_plugin_api::{BuildStep, PluginManifest, RuntimeSpec};
+use aoe_plugin_api::{BuildStep, PluginManifest, RuntimeSpec, UiContribution};
 
 use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
 
@@ -72,7 +72,7 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     let granted = if assume_yes || (capabilities.is_empty() && build.is_empty()) {
         true
     } else {
-        confirm_capabilities(&id, &capabilities, build)?
+        confirm_capabilities(&id, &capabilities, &fetched.manifest.ui, build)?
     };
     if !granted {
         bail!("install cancelled; no capabilities were granted");
@@ -158,7 +158,12 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     // non-interactive prompt bails while the old install, config, and lockfile
     // are still consistent.
     let grant = if needs_prompt {
-        if confirm_capabilities(id, &capabilities, build_steps(&fetched.manifest))? {
+        if confirm_capabilities(
+            id,
+            &capabilities,
+            &fetched.manifest.ui,
+            build_steps(&fetched.manifest),
+        )? {
             Some(CapabilityGrant {
                 manifest_hash: manifest_hash.clone(),
                 capabilities: capabilities.clone(),
@@ -318,7 +323,12 @@ fn capability_strings(fetched: &FetchedPlugin) -> Result<Vec<String>> {
 /// can pass `--yes` there. Build steps are disclosed verbatim because they run
 /// as the user, outside capability enforcement, before the plugin is
 /// registered.
-fn confirm_capabilities(id: &str, capabilities: &[String], build: &[BuildStep]) -> Result<bool> {
+fn confirm_capabilities(
+    id: &str,
+    capabilities: &[String],
+    ui: &[UiContribution],
+    build: &[BuildStep],
+) -> Result<bool> {
     if !io::stdin().is_terminal() {
         bail!(
             "{id} requests capabilities [{}]{} but stdin is not a terminal; re-run with --yes to grant them",
@@ -330,6 +340,14 @@ fn confirm_capabilities(id: &str, capabilities: &[String], build: &[BuildStep]) 
         println!("Plugin {id} requests these capabilities:");
         for capability in capabilities {
             println!("  - {capability}");
+        }
+    }
+    // UI contributions are not capabilities (they need no grant), but the user
+    // should know the plugin will render into the dashboard before trusting it.
+    if !ui.is_empty() {
+        println!("Plugin {id} will add UI elements to these dashboard slots:");
+        for u in ui {
+            println!("  - {} ({})", u.slot.as_str(), u.id);
         }
     }
     if !build.is_empty() {

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -65,15 +65,12 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
 
     let capabilities = capability_strings(&fetched)?;
     let build = build_steps(&fetched.manifest);
-    // A build step runs arbitrary, unsandboxed code as the user at install
-    // time, so it requires the same explicit consent as a capability even when
-    // the plugin requests no capabilities at all (where install would
-    // otherwise auto-grant silently).
-    let granted = if assume_yes || (capabilities.is_empty() && build.is_empty()) {
-        true
-    } else {
-        confirm_capabilities(&id, &capabilities, &fetched.manifest.ui, build)?
-    };
+    let granted =
+        if assume_yes || !install_needs_consent(&capabilities, build, &fetched.manifest.ui) {
+            true
+        } else {
+            confirm_capabilities(&id, &capabilities, &fetched.manifest.ui, build)?
+        };
     if !granted {
         bail!("install cancelled; no capabilities were granted");
     }
@@ -149,10 +146,17 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     let manifest_changed =
         prior_grant.as_ref().map(|g| g.manifest_hash.as_str()) != Some(manifest_hash.as_str());
     let build_changed = manifest_changed && !build_steps(&fetched.manifest).is_empty();
-    // Prompt when there is something to consent to: capabilities that changed,
-    // or build steps that could have changed. Dropping all capabilities with no
-    // build steps has nothing to grant, so it still (re)grants silently.
-    let needs_prompt = (!capabilities.is_empty() && caps_changed) || build_changed;
+    // UI contributions are disclosed at install, so an update that changes the
+    // manifest while declaring UI slots must re-disclose them: otherwise an
+    // update could add new dashboard slots the user never saw. The manifest
+    // hash covers the `[[ui]]` section, so a hash change with UI present means
+    // the slots could have changed.
+    let ui_changed = manifest_changed && !fetched.manifest.ui.is_empty();
+    // Prompt when there is something to consent to or disclose: capabilities
+    // that changed, build steps that could have changed, or UI slots on a
+    // changed manifest. Dropping all capabilities with no build/UI has nothing
+    // to grant, so it still (re)grants silently.
+    let needs_prompt = (!capabilities.is_empty() && caps_changed) || build_changed || ui_changed;
 
     // Decide the grant BEFORE touching the installed tree, so a declined or
     // non-interactive prompt bails while the old install, config, and lockfile
@@ -316,6 +320,18 @@ fn capability_strings(fetched: &FetchedPlugin) -> Result<Vec<String>> {
         .iter()
         .map(|c| c.as_str().to_string())
         .collect())
+}
+
+/// Whether an install must prompt for consent rather than auto-grant silently.
+/// Capabilities and build steps need a grant; UI contributions need no grant
+/// but are disclosed, so a UI-only plugin still prompts rather than installing
+/// silently (#2366).
+fn install_needs_consent(
+    capabilities: &[String],
+    build: &[BuildStep],
+    ui: &[UiContribution],
+) -> bool {
+    !capabilities.is_empty() || !build.is_empty() || !ui.is_empty()
 }
 
 /// Prompt the user to grant a plugin's capabilities and run any build steps.
@@ -601,4 +617,32 @@ fn write_lock(
         },
     );
     lock.save()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aoe_plugin_api::UiSlot;
+
+    fn ui(slot: UiSlot, id: &str) -> UiContribution {
+        UiContribution {
+            slot,
+            id: id.to_string(),
+        }
+    }
+
+    #[test]
+    fn install_consent_required_for_caps_build_or_ui() {
+        // Nothing declared: auto-grant is fine.
+        assert!(!install_needs_consent(&[], &[], &[]));
+        // A capability needs a grant.
+        assert!(install_needs_consent(&["net".to_string()], &[], &[]));
+        // A UI-only plugin must still prompt so the slots are disclosed (#2366):
+        // the regression this guards is auto-granting when only `ui` is set.
+        assert!(install_needs_consent(
+            &[],
+            &[],
+            &[ui(UiSlot::StatusBar, "s")]
+        ));
+    }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -27,6 +27,8 @@ pub mod host_api;
 pub mod protocol;
 #[cfg(feature = "serve")]
 pub mod sandbox;
+#[cfg(feature = "serve")]
+pub mod ui_state;
 
 // Launch resolution is pure (PATH / filesystem probing) and is shared by the
 // serve-only host and the always-present installer, which runs a plugin's

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -99,6 +99,44 @@ struct TextPayload {
     href: Option<String>,
 }
 
+/// One icon/text badge inside a `row-badge` `items` list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BadgeItem {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    href: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tooltip: Option<String>,
+}
+
+/// `row-badge` payload: the single-badge fields (back-compat with any plugin
+/// pushing `{ text, tone, tooltip, icon, href }`) plus an optional `items` list
+/// so one entry can carry several icon badges. `text` is optional here: an
+/// items-only badge has no top-level text. Empty `items: []` is valid (clears
+/// the row).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RowBadgePayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tooltip: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    href: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    items: Vec<BadgeItem>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RowColumnPayload {
@@ -146,11 +184,21 @@ struct CardPayload {
     tone: Option<Tone>,
 }
 
+/// `detail-panel` payload. Either the simple `{ title, body }` form or an
+/// ordered `blocks` list. The blocks are kept as opaque JSON on purpose: the
+/// host validates only the envelope (an array of objects) and the web renders
+/// the block kinds it knows, dropping the rest. This is the forward-compat
+/// contract: a plugin can add fields to a known kind, or a whole new kind, and
+/// never need a host change; only the web renderer grows.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct DetailPanelPayload {
-    title: String,
-    body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    blocks: Option<Vec<Value>>,
 }
 
 /// Why a `ui.state.set`/`ui.state.remove` was rejected. The host API maps each
@@ -450,7 +498,8 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
         serde_json::to_value(parsed).map_err(|e| e.to_string())
     }
     match slot {
-        UiSlot::StatusBar | UiSlot::RowBadge | UiSlot::DetailBadge => normalize::<TextPayload>(raw),
+        UiSlot::StatusBar | UiSlot::DetailBadge => normalize::<TextPayload>(raw),
+        UiSlot::RowBadge => normalize::<RowBadgePayload>(raw),
         UiSlot::RowColumn => normalize::<RowColumnPayload>(raw),
         UiSlot::SortKey => normalize::<SortKeyPayload>(raw),
         UiSlot::FilterFacet => normalize::<FilterFacetPayload>(raw),
@@ -544,14 +593,14 @@ mod tests {
     fn malformed_payload_rejected() {
         let s = store();
         let g = s.begin_generation("acme.kit");
-        // Missing required `text`.
+        // Missing required `text` on a text slot (status-bar still requires it).
         assert!(matches!(
             s.set(
                 "acme.kit",
                 g,
-                UiSlot::RowBadge,
+                UiSlot::StatusBar,
                 "b",
-                Some("s1"),
+                None,
                 &json!({"tone": "info"})
             ),
             Err(UiError::BadRequest(_))
@@ -670,6 +719,87 @@ mod tests {
             s.notify("acme.kit", Tone::Info, String::new(), None, None),
             Err(UiError::BadRequest(_))
         ));
+    }
+
+    #[test]
+    fn row_badge_accepts_items_list() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::RowBadge,
+            "repos",
+            Some("s1"),
+            &json!({"items": [
+                {"icon": "git-pull-request-arrow", "tone": "success", "href": "https://x/pr/1", "tooltip": "PR #1"},
+                {"icon": "git-pull-request-draft", "tone": "warn"}
+            ]}),
+        )
+        .unwrap();
+        let snap = s.snapshot();
+        assert_eq!(
+            snap.entries[0].payload["items"].as_array().unwrap().len(),
+            2
+        );
+        // Empty items is valid (clears the row).
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::RowBadge,
+            "repos",
+            Some("s1"),
+            &json!({"items": []}),
+        )
+        .unwrap();
+        // A bad tone inside an item is still rejected.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "repos",
+                Some("s1"),
+                &json!({"items": [{"tone": "rainbow"}]})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn detail_panel_blocks_are_forward_compatible() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // A mix of known kinds and an unknown kind: the unknown one is accepted
+        // and stored verbatim, not rejected, so an old host renders what it knows.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::DetailPanel,
+            "gh",
+            Some("s1"),
+            &json!({"title": "GitHub", "blocks": [
+                {"kind": "heading", "text": "GitHub"},
+                {"kind": "row", "label": "nexus", "value": "PR #12", "href": "https://x/pr/12"},
+                {"kind": "divider"},
+                {"kind": "some-future-kind", "whatever": {"nested": true}}
+            ]}),
+        )
+        .unwrap();
+        let snap = s.snapshot();
+        let blocks = snap.entries[0].payload["blocks"].as_array().unwrap();
+        assert_eq!(blocks.len(), 4);
+        assert_eq!(blocks[3]["kind"], json!("some-future-kind"));
+        // The simple title/body form still works.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::DetailPanel,
+            "gh",
+            Some("s1"),
+            &json!({"title": "T", "body": "B"}),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -245,6 +245,12 @@ impl UiStore {
     pub fn begin_generation(&self, plugin_id: &str) -> u64 {
         let gen = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let mut inner = self.write();
+        // A fresh worker starts from a clean slate: drop any entries the
+        // previous generation left behind. This makes eviction robust against a
+        // fast respawn (begin running before the exited worker's clear_plugin),
+        // where clearing by the old generation would otherwise no-op and leave
+        // its entries visible until the new worker happened to overwrite them.
+        inner.entries.retain(|k, _| k.plugin_id != plugin_id);
         inner.active.insert(plugin_id.to_string(), gen);
         gen
     }
@@ -289,7 +295,10 @@ impl UiStore {
         Ok(())
     }
 
-    /// Remove one entry. A remove of an absent entry is a no-op success.
+    /// Remove one entry. A remove of an absent entry is a no-op success, but a
+    /// scope mismatch (a per-session slot without a `session_id`, or vice versa)
+    /// is rejected, same as `set`, so a bad call is an error rather than a silent
+    /// no-op that leaves the real entry standing.
     pub fn remove(
         &self,
         plugin_id: &str,
@@ -298,6 +307,7 @@ impl UiStore {
         id: &str,
         session_id: Option<&str>,
     ) -> Result<(), UiError> {
+        check_scope(slot, session_id)?;
         let key = EntryKey {
             plugin_id: plugin_id.to_string(),
             slot,
@@ -379,8 +389,16 @@ impl UiStore {
             })
             .collect();
         // Deterministic order so the snapshot does not jitter between polls.
+        // `slot` is part of the key (a plugin may reuse one id across two slots),
+        // so it is part of the sort key too, or those entries would compare equal
+        // and fall back to HashMap iteration order.
         entries.sort_by(|a, b| {
-            (&a.plugin_id, &a.id, &a.session_id).cmp(&(&b.plugin_id, &b.id, &b.session_id))
+            (&a.plugin_id, a.slot, &a.id, &a.session_id).cmp(&(
+                &b.plugin_id,
+                b.slot,
+                &b.id,
+                &b.session_id,
+            ))
         });
         UiSnapshot {
             entries,
@@ -506,6 +524,12 @@ mod tests {
             ),
             Err(UiError::BadRequest(_))
         ));
+        // remove enforces the same scope rules, so a wrong-scope remove is a
+        // rejection rather than a silent no-op that leaves the entry standing.
+        assert!(matches!(
+            s.remove("acme.kit", g, UiSlot::RowBadge, "x", None),
+            Err(UiError::BadRequest(_))
+        ));
     }
 
     #[test]
@@ -563,8 +587,12 @@ mod tests {
             &json!({"title": "Hi"}),
         )
         .unwrap();
-        // Worker respawns: new generation supersedes g1.
+        assert_eq!(s.snapshot().entries.len(), 1);
+        // Worker respawns: starting the new generation evicts the old
+        // generation's entries up front, so no stale state survives even when
+        // begin runs before the exited worker's clear_plugin.
         let g2 = s.begin_generation("acme.kit");
+        assert_eq!(s.snapshot().entries.len(), 0);
         // A late write from the old generation is rejected, not applied.
         assert_eq!(
             s.set(
@@ -579,7 +607,6 @@ mod tests {
         );
         // The old worker's exit must NOT wipe the live g2 state.
         assert!(!s.clear_plugin("acme.kit", g1));
-        assert_eq!(s.snapshot().entries.len(), 1);
         // The current generation can write and be cleared.
         s.set(
             "acme.kit",

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -1,0 +1,677 @@
+//! Host-owned store of UI state that plugin workers push over the `ui.state.*`
+//! and `ui.notify` RPCs (#2366).
+//!
+//! The honest model: a worker pushes *typed display state* into a slot it
+//! declared; the host stores it here and the web dashboard renders it. No
+//! plugin code runs in the dashboard and the render path never awaits a worker,
+//! so this store is read synchronously via [`UiStore::snapshot`].
+//!
+//! State is ephemeral, like the rest of the Tier 1 host: it lives in memory and
+//! dies with the daemon. A plugin's entries are cleared when its worker exits
+//! (a fresh worker repopulates them), guarded by a per-spawn *generation* so a
+//! late write from an exited worker, or an instant respawn, cannot resurrect or
+//! clobber stale state. Notifications are point-in-time events on a separate
+//! bounded ring: they survive a worker exit (a plugin that posts a notification
+//! and immediately crashes should still reach the browser) and the client
+//! toasts each one once by tracking the monotonic `seq`.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+
+use aoe_plugin_api::UiSlot;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Most entries one plugin may hold at once across all slots. A cooperative
+/// bound (the model is honest, not adversarial), enough to keep a buggy plugin
+/// from growing host memory without limit.
+const MAX_ENTRIES_PER_PLUGIN: usize = 256;
+/// Largest normalized payload accepted for one entry, in bytes of JSON.
+const MAX_PAYLOAD_BYTES: usize = 8 * 1024;
+/// Notifications kept on the shared ring before the oldest are dropped.
+const NOTIFICATION_RING: usize = 200;
+/// Caps on notification text, so one notify cannot post an unbounded blob.
+const MAX_TITLE_LEN: usize = 256;
+const MAX_BODY_LEN: usize = 4096;
+
+/// A display tone, mapped to a color by each rendering surface. A closed set so
+/// a plugin cannot inject an arbitrary class or color.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Tone {
+    Neutral,
+    Info,
+    Success,
+    Warn,
+    Danger,
+}
+
+/// Sort direction for a [`UiSlot::SortKey`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+/// A scalar a `RowColumn` exposes for client-side sorting. Kept to comparable
+/// scalars (no objects/arrays) so the dashboard can order rows deterministically
+/// without running plugin code.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SortValue {
+    Number(f64),
+    String(String),
+}
+
+/// One option in a [`UiSlot::FilterFacet`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FacetOption {
+    pub value: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tone: Option<Tone>,
+}
+
+// Per-slot payloads. Each is the typed shape a worker must send for that slot;
+// `ui.state.set` validates the incoming JSON against the slot's payload before
+// storing, so a malformed push is rejected at the host boundary rather than
+// crashing the dashboard. They carry no `session_id`: that is an RPC-level
+// param and becomes part of the entry key, never duplicated in the body.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TextPayload {
+    text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tooltip: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RowColumnPayload {
+    text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tooltip: Option<String>,
+    /// Scalar driving client-side sorting (referenced by a `SortKey`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sort_value: Option<SortValue>,
+    /// Tokens this row matches for client-side filtering (referenced by a
+    /// `FilterFacet`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    filter_values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SortKeyPayload {
+    label: String,
+    /// The `RowColumn` id whose `sort_value` this orders by.
+    column: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    direction: Option<SortDirection>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FilterFacetPayload {
+    label: String,
+    /// The `RowColumn` id whose `filter_values` this filters over.
+    column: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    options: Vec<FacetOption>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CardPayload {
+    title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DetailPanelPayload {
+    title: String,
+    body: String,
+}
+
+/// Why a `ui.state.set`/`ui.state.remove` was rejected. The host API maps each
+/// to a JSON-RPC error code.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UiError {
+    /// The calling worker's generation is no longer active (it exited, or a
+    /// newer worker replaced it). The write is dropped rather than resurrecting
+    /// stale state.
+    StaleWorker,
+    /// The plugin already holds [`MAX_ENTRIES_PER_PLUGIN`] entries.
+    QuotaExceeded,
+    /// The payload did not match the slot's typed shape, or a scope rule
+    /// (per-session slot needs a `session_id`; a global slot must not have one).
+    BadRequest(String),
+}
+
+/// Identifies one stored entry. A per-session slot keys on `session_id`; a
+/// global slot leaves it `None`. `id` is the plugin-chosen address within the
+/// slot, gated against the manifest `ui` declarations.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct EntryKey {
+    plugin_id: String,
+    slot: UiSlot,
+    id: String,
+    session_id: Option<String>,
+}
+
+/// A notification as rendered: the seq lets the client toast each one once.
+#[derive(Debug, Clone, Serialize)]
+pub struct Notification {
+    pub seq: u64,
+    pub plugin_id: String,
+    pub tone: Tone,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+/// One entry in the snapshot the web renders.
+#[derive(Debug, Clone, Serialize)]
+pub struct UiEntry {
+    pub plugin_id: String,
+    pub slot: UiSlot,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Normalized, slot-validated payload. The `slot` tells the client its
+    /// shape.
+    pub payload: Value,
+}
+
+/// The full UI state the dashboard polls each tick. Bounded and small, so it is
+/// sent whole rather than incrementally (verdict: no since_seq/tombstones).
+#[derive(Debug, Clone, Serialize)]
+pub struct UiSnapshot {
+    pub entries: Vec<UiEntry>,
+    pub notifications: Vec<Notification>,
+}
+
+#[derive(Default)]
+struct Inner {
+    entries: HashMap<EntryKey, Value>,
+    /// Per-plugin currently-active worker generation. Absent once a worker has
+    /// exited and its state cleared; a respawn re-registers via
+    /// [`UiStore::begin_generation`].
+    active: HashMap<String, u64>,
+    notifications: VecDeque<Notification>,
+    notify_seq: u64,
+}
+
+/// The shared store. A `std::sync::RwLock` (not `tokio::Mutex`): writes happen
+/// in the host's `spawn_blocking` dispatch and the web read just clones a small
+/// snapshot, so neither side holds the lock across an `.await`.
+pub struct UiStore {
+    inner: RwLock<Inner>,
+    next_generation: AtomicU64,
+}
+
+impl Default for UiStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UiStore {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner::default()),
+            next_generation: AtomicU64::new(1),
+        }
+    }
+
+    /// Register a freshly spawned worker for `plugin_id` and return its
+    /// generation. The supervisor threads this into the worker's RPC context;
+    /// every `ui.state.*` write carries it so a stale worker's writes are
+    /// rejected.
+    pub fn begin_generation(&self, plugin_id: &str) -> u64 {
+        let gen = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let mut inner = self.write();
+        inner.active.insert(plugin_id.to_string(), gen);
+        gen
+    }
+
+    /// Validate and store one entry. Rejects a stale generation, a payload that
+    /// does not match the slot, a scope mismatch, or a plugin over quota.
+    pub fn set(
+        &self,
+        plugin_id: &str,
+        generation: u64,
+        slot: UiSlot,
+        id: &str,
+        session_id: Option<&str>,
+        payload: &Value,
+    ) -> Result<(), UiError> {
+        check_scope(slot, session_id)?;
+        let normalized = validate_payload(slot, payload).map_err(UiError::BadRequest)?;
+        if normalized.to_string().len() > MAX_PAYLOAD_BYTES {
+            return Err(UiError::BadRequest("payload too large".into()));
+        }
+        let key = EntryKey {
+            plugin_id: plugin_id.to_string(),
+            slot,
+            id: id.to_string(),
+            session_id: session_id.map(str::to_string),
+        };
+        let mut inner = self.write();
+        if inner.active.get(plugin_id) != Some(&generation) {
+            return Err(UiError::StaleWorker);
+        }
+        if !inner.entries.contains_key(&key)
+            && inner
+                .entries
+                .keys()
+                .filter(|k| k.plugin_id == plugin_id)
+                .count()
+                >= MAX_ENTRIES_PER_PLUGIN
+        {
+            return Err(UiError::QuotaExceeded);
+        }
+        inner.entries.insert(key, normalized);
+        Ok(())
+    }
+
+    /// Remove one entry. A remove of an absent entry is a no-op success.
+    pub fn remove(
+        &self,
+        plugin_id: &str,
+        generation: u64,
+        slot: UiSlot,
+        id: &str,
+        session_id: Option<&str>,
+    ) -> Result<(), UiError> {
+        let key = EntryKey {
+            plugin_id: plugin_id.to_string(),
+            slot,
+            id: id.to_string(),
+            session_id: session_id.map(str::to_string),
+        };
+        let mut inner = self.write();
+        if inner.active.get(plugin_id) != Some(&generation) {
+            return Err(UiError::StaleWorker);
+        }
+        inner.entries.remove(&key);
+        Ok(())
+    }
+
+    /// Push a notification onto the shared ring and return its seq. No
+    /// generation check: notifications outlive the worker that posted them.
+    pub fn notify(
+        &self,
+        plugin_id: &str,
+        tone: Tone,
+        title: String,
+        body: Option<String>,
+        session_id: Option<String>,
+    ) -> Result<u64, UiError> {
+        if title.is_empty() {
+            return Err(UiError::BadRequest("notification title is required".into()));
+        }
+        if title.len() > MAX_TITLE_LEN {
+            return Err(UiError::BadRequest("notification title too long".into()));
+        }
+        if body.as_ref().is_some_and(|b| b.len() > MAX_BODY_LEN) {
+            return Err(UiError::BadRequest("notification body too long".into()));
+        }
+        let mut inner = self.write();
+        inner.notify_seq += 1;
+        let seq = inner.notify_seq;
+        inner.notifications.push_back(Notification {
+            seq,
+            plugin_id: plugin_id.to_string(),
+            tone,
+            title,
+            body,
+            session_id,
+        });
+        while inner.notifications.len() > NOTIFICATION_RING {
+            inner.notifications.pop_front();
+        }
+        Ok(seq)
+    }
+
+    /// Clear a plugin's entries when its worker exits, but only if `generation`
+    /// is still the active one. An instant respawn (which already called
+    /// [`UiStore::begin_generation`]) leaves the new generation in place, so the
+    /// old worker's exit does not wipe the new worker's state. Notifications are
+    /// left untouched. Returns whether anything was cleared.
+    pub fn clear_plugin(&self, plugin_id: &str, generation: u64) -> bool {
+        let mut inner = self.write();
+        if inner.active.get(plugin_id) != Some(&generation) {
+            return false;
+        }
+        inner.active.remove(plugin_id);
+        let before = inner.entries.len();
+        inner.entries.retain(|k, _| k.plugin_id != plugin_id);
+        before != inner.entries.len()
+    }
+
+    /// Clone the full state for the web to render.
+    pub fn snapshot(&self) -> UiSnapshot {
+        let inner = self.read();
+        let mut entries: Vec<UiEntry> = inner
+            .entries
+            .iter()
+            .map(|(k, payload)| UiEntry {
+                plugin_id: k.plugin_id.clone(),
+                slot: k.slot,
+                id: k.id.clone(),
+                session_id: k.session_id.clone(),
+                payload: payload.clone(),
+            })
+            .collect();
+        // Deterministic order so the snapshot does not jitter between polls.
+        entries.sort_by(|a, b| {
+            (&a.plugin_id, &a.id, &a.session_id).cmp(&(&b.plugin_id, &b.id, &b.session_id))
+        });
+        UiSnapshot {
+            entries,
+            notifications: inner.notifications.iter().cloned().collect(),
+        }
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, Inner> {
+        self.inner.read().unwrap_or_else(|p| p.into_inner())
+    }
+    fn write(&self) -> std::sync::RwLockWriteGuard<'_, Inner> {
+        self.inner.write().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// A per-session slot needs a `session_id`; a global slot must not carry one.
+/// `Notification` is not a `ui.state.set` target (use `ui.notify`).
+fn check_scope(slot: UiSlot, session_id: Option<&str>) -> Result<(), UiError> {
+    if slot == UiSlot::Notification {
+        return Err(UiError::BadRequest(
+            "notification is pushed via ui.notify, not ui.state.set".into(),
+        ));
+    }
+    match (slot.is_per_session(), session_id.is_some()) {
+        (true, false) => Err(UiError::BadRequest(format!(
+            "slot {slot:?} requires a session_id"
+        ))),
+        (false, true) => Err(UiError::BadRequest(format!(
+            "slot {slot:?} is global and must not carry a session_id"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+/// Validate `raw` against the slot's typed payload and return the normalized
+/// JSON (re-serialized from the parsed struct, so unknown fields are rejected
+/// and the stored shape is canonical).
+fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
+    fn normalize<T: serde::de::DeserializeOwned + Serialize>(raw: &Value) -> Result<Value, String> {
+        let parsed: T = serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
+        serde_json::to_value(parsed).map_err(|e| e.to_string())
+    }
+    match slot {
+        UiSlot::StatusBar | UiSlot::RowBadge | UiSlot::DetailBadge => normalize::<TextPayload>(raw),
+        UiSlot::RowColumn => normalize::<RowColumnPayload>(raw),
+        UiSlot::SortKey => normalize::<SortKeyPayload>(raw),
+        UiSlot::FilterFacet => normalize::<FilterFacetPayload>(raw),
+        UiSlot::Card => normalize::<CardPayload>(raw),
+        UiSlot::DetailPanel => normalize::<DetailPanelPayload>(raw),
+        UiSlot::Notification => Err("notification is pushed via ui.notify".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn store() -> UiStore {
+        UiStore::new()
+    }
+
+    #[test]
+    fn set_get_and_remove_global_entry() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::StatusBar,
+            "build",
+            None,
+            &json!({"text": "ok", "tone": "success"}),
+        )
+        .unwrap();
+        let snap = s.snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(snap.entries[0].slot, UiSlot::StatusBar);
+        assert_eq!(snap.entries[0].payload["text"], json!("ok"));
+
+        s.remove("acme.kit", g, UiSlot::StatusBar, "build", None)
+            .unwrap();
+        assert_eq!(s.snapshot().entries.len(), 0);
+    }
+
+    #[test]
+    fn scope_rules_enforced() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // Global slot must not carry a session_id.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::StatusBar,
+                "x",
+                Some("s1"),
+                &json!({"text": "hi"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Per-session slot requires a session_id.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "x",
+                None,
+                &json!({"text": "hi"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Notification is not a ui.state.set target.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::Notification,
+                "x",
+                None,
+                &json!({"text": "hi"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_payload_rejected() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // Missing required `text`.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "b",
+                Some("s1"),
+                &json!({"tone": "info"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Unknown field rejected (deny_unknown_fields).
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "b",
+                Some("s1"),
+                &json!({"text": "x", "bogus": 1})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Bad tone value rejected.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "b",
+                Some("s1"),
+                &json!({"text": "x", "tone": "rainbow"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn stale_generation_rejected_and_clear_is_generation_guarded() {
+        let s = store();
+        let g1 = s.begin_generation("acme.kit");
+        s.set(
+            "acme.kit",
+            g1,
+            UiSlot::Card,
+            "c",
+            None,
+            &json!({"title": "Hi"}),
+        )
+        .unwrap();
+        // Worker respawns: new generation supersedes g1.
+        let g2 = s.begin_generation("acme.kit");
+        // A late write from the old generation is rejected, not applied.
+        assert_eq!(
+            s.set(
+                "acme.kit",
+                g1,
+                UiSlot::Card,
+                "c2",
+                None,
+                &json!({"title": "stale"})
+            ),
+            Err(UiError::StaleWorker)
+        );
+        // The old worker's exit must NOT wipe the live g2 state.
+        assert!(!s.clear_plugin("acme.kit", g1));
+        assert_eq!(s.snapshot().entries.len(), 1);
+        // The current generation can write and be cleared.
+        s.set(
+            "acme.kit",
+            g2,
+            UiSlot::Card,
+            "c3",
+            None,
+            &json!({"title": "new"}),
+        )
+        .unwrap();
+        assert!(s.clear_plugin("acme.kit", g2));
+        assert_eq!(s.snapshot().entries.len(), 0);
+    }
+
+    #[test]
+    fn notifications_survive_clear_and_carry_monotonic_seq() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::StatusBar,
+            "x",
+            None,
+            &json!({"text": "hi"}),
+        )
+        .unwrap();
+        let seq1 = s
+            .notify("acme.kit", Tone::Danger, "Build failed".into(), None, None)
+            .unwrap();
+        let seq2 = s
+            .notify(
+                "acme.kit",
+                Tone::Info,
+                "Done".into(),
+                Some("see log".into()),
+                Some("s1".into()),
+            )
+            .unwrap();
+        assert!(seq2 > seq1);
+        // Clearing entries on worker exit leaves notifications in place.
+        s.clear_plugin("acme.kit", g);
+        let snap = s.snapshot();
+        assert_eq!(snap.entries.len(), 0);
+        assert_eq!(snap.notifications.len(), 2);
+        assert_eq!(snap.notifications[1].session_id.as_deref(), Some("s1"));
+    }
+
+    #[test]
+    fn empty_notification_title_rejected() {
+        let s = store();
+        assert!(matches!(
+            s.notify("acme.kit", Tone::Info, String::new(), None, None),
+            Err(UiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn per_plugin_quota_enforced() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        for i in 0..MAX_ENTRIES_PER_PLUGIN {
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::Card,
+                &format!("c{i}"),
+                None,
+                &json!({"title": "x"}),
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::Card,
+                "overflow",
+                None,
+                &json!({"title": "x"})
+            ),
+            Err(UiError::QuotaExceeded)
+        );
+        // Updating an existing entry is not blocked by the quota.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Card,
+            "c0",
+            None,
+            &json!({"title": "y"}),
+        )
+        .unwrap();
+    }
+}

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -89,6 +89,14 @@ struct TextPayload {
     tone: Option<Tone>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     tooltip: Option<String>,
+    /// Lucide icon name, e.g. "git-pull-request-arrow". The client maps it
+    /// through a small allowlist; an unknown name renders no icon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    /// URL to open (e.g. the PR). When set, the client renders the badge as a
+    /// link instead of static text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    href: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/plugin/view.rs
+++ b/src/plugin/view.rs
@@ -24,11 +24,23 @@ pub struct PluginView {
     pub source: Option<String>,
     /// Capabilities the plugin's manifest declares.
     pub capabilities: Vec<String>,
+    /// UI slots the plugin declares it will render into (#2366). Disclosed
+    /// alongside capabilities so a surface can show the user that the plugin
+    /// modifies the dashboard, even though a UI contribution needs no grant.
+    pub ui_contributions: Vec<UiContributionView>,
     /// Whether the user's grant covers the installed manifest (always true for
     /// builtins).
     pub granted: bool,
     /// Installed but inactive: a community plugin awaiting capability approval.
     pub needs_reapproval: bool,
+}
+
+/// A declared UI contribution, flattened for display: the kebab-case slot name
+/// and the plugin-chosen entry id.
+#[derive(Debug, Clone, Serialize)]
+pub struct UiContributionView {
+    pub slot: String,
+    pub id: String,
 }
 
 impl LoadedPlugin {
@@ -48,6 +60,15 @@ impl LoadedPlugin {
                 .capabilities
                 .iter()
                 .map(|c| c.as_str().to_string())
+                .collect(),
+            ui_contributions: self
+                .manifest
+                .ui
+                .iter()
+                .map(|u| UiContributionView {
+                    slot: u.slot.as_str().to_string(),
+                    id: u.id.clone(),
+                })
                 .collect(),
             granted: self.granted,
             needs_reapproval: self.needs_reapproval(),

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -36,7 +36,7 @@ pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
-pub use plugins::{list_plugins, set_plugin_enabled};
+pub use plugins::{list_plugins, plugin_ui_state, set_plugin_enabled};
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -59,6 +59,19 @@ pub async fn list_plugins() -> Json<serde_json::Value> {
     }))
 }
 
+/// `GET /api/plugins/ui-state`: the plugin host's aggregated UI-state snapshot
+/// (the slots workers have pushed, plus the notification ring). Empty when no
+/// host is running (read-only mode, or a TUI-only build with no daemon). The
+/// dashboard polls this alongside `/api/sessions` and renders each slot itself.
+pub async fn plugin_ui_state(
+    State(state): State<std::sync::Arc<AppState>>,
+) -> Json<serde_json::Value> {
+    match state.plugin_host.as_ref().map(|h| h.ui_snapshot()) {
+        Some(snapshot) => Json(serde_json::to_value(snapshot).unwrap_or_else(|_| json!(null))),
+        None => Json(json!({ "entries": [], "notifications": [] })),
+    }
+}
+
 #[derive(Deserialize)]
 pub struct SetEnabledBody {
     pub enabled: bool,

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -67,7 +67,7 @@ pub async fn plugin_ui_state(
     State(state): State<std::sync::Arc<AppState>>,
 ) -> Json<serde_json::Value> {
     match state.plugin_host.as_ref().map(|h| h.ui_snapshot()) {
-        Some(snapshot) => Json(serde_json::to_value(snapshot).unwrap_or_else(|_| json!(null))),
+        Some(snapshot) => Json(serde_json::to_value(snapshot).unwrap_or(serde_json::Value::Null)),
         None => Json(json!({ "entries": [], "notifications": [] })),
     }
 }

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -66,9 +66,15 @@ pub async fn list_plugins() -> Json<serde_json::Value> {
 pub async fn plugin_ui_state(
     State(state): State<std::sync::Arc<AppState>>,
 ) -> Json<serde_json::Value> {
+    let empty = || json!({ "entries": [], "notifications": [] });
     match state.plugin_host.as_ref().map(|h| h.ui_snapshot()) {
-        Some(snapshot) => Json(serde_json::to_value(snapshot).unwrap_or(serde_json::Value::Null)),
-        None => Json(json!({ "entries": [], "notifications": [] })),
+        Some(snapshot) => Json(serde_json::to_value(snapshot).unwrap_or_else(|e| {
+            // Serializing the snapshot should never fail; if it somehow does,
+            // keep the response shape stable rather than returning JSON null.
+            tracing::warn!(target: "serve.api", "failed to serialize plugin UI snapshot: {e}");
+            empty()
+        })),
+        None => Json(empty()),
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1498,6 +1498,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Plugin management. The enable/disable toggle gates on read-only +
         // elevation inside the handler.
         .route("/api/plugins", get(api::list_plugins))
+        .route("/api/plugins/ui-state", get(api::plugin_ui_state))
         .route("/api/plugins/{id}/enabled", post(api::set_plugin_enabled))
         .route(
             "/api/app-state/web-tour-seen",

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -184,7 +184,7 @@ impl PluginManagerDialog {
                 } else {
                     ("enabled", theme.running)
                 };
-                let spans = vec![
+                let mut spans = vec![
                     Span::styled(
                         format!("{:<28}", format!("{} v{}", row.name, row.version)),
                         Style::default().fg(theme.text),
@@ -195,6 +195,21 @@ impl PluginManagerDialog {
                     ),
                     Span::styled(format!("{:<14}", state.0), Style::default().fg(state.1)),
                 ];
+                // Disclose the dashboard UI slots the plugin renders into, so the
+                // manager shows that a plugin modifies the UI (#2366). Distinct
+                // slot names only; ids are in `aoe plugin info`.
+                if !row.ui_contributions.is_empty() {
+                    let mut slots: Vec<&str> = Vec::new();
+                    for u in &row.ui_contributions {
+                        if !slots.contains(&u.slot.as_str()) {
+                            slots.push(u.slot.as_str());
+                        }
+                    }
+                    spans.push(Span::styled(
+                        format!("ui: {}", slots.join(", ")),
+                        Style::default().fg(theme.dimmed),
+                    ));
+                }
                 ListItem::new(Line::from(spans))
             })
             .collect();

--- a/tests/e2e/plugins.rs
+++ b/tests/e2e/plugins.rs
@@ -158,6 +158,19 @@ fn test_serve_refuses_when_web_plugin_disabled() {
         "serve must start once aoe.web is enabled:\n{}",
         String::from_utf8_lossy(&started.stderr)
     );
+    // `serve --daemon` returns once the child is spawned, before it has finished
+    // binding the port and writing serve.pid. Stopping in that window races the
+    // startup, so wait for the port to accept a connection first (mirrors the
+    // serve.rs lifecycle test).
+    let port: u16 = free_port.parse().unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::net::TcpStream::connect(("127.0.0.1", port)).is_err() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "daemon never bound port {port} after enabling aoe.web"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
     let stopped = h.run_cli(&["serve", "--stop"]);
     assert!(stopped.status.success(), "serve --stop must succeed");
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { useLastSessionRestore } from "./hooks/useLastSessionRestore";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useSessionGroups } from "./hooks/useSessionGroups";
 import { useNestedSidebarGroups } from "./hooks/useNestedSidebarGroups";
+import { PluginUiProvider } from "./lib/pluginUiContext";
 import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
 import { useSidebarAxis } from "./hooks/useSidebarAxis";
 import { repoGroupToSidebarGroup, type SidebarGroup } from "./lib/sidebarGroups";
@@ -1386,162 +1387,164 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   return (
     <AcpPrefsProvider value={acpPrefs}>
-      <div className="h-dvh flex flex-col bg-surface-900 text-text-primary overflow-hidden safe-area-inset">
-        <TopBar
-          activeWorkspace={activeWorkspace}
-          activeSession={activeSession ?? null}
-          onToggleSidebar={handleToggleSidebar}
-          onOpenPalette={() => setShowPalette(true)}
-          onToggleDiff={toggleDiff}
-          diffCollapsed={diffCollapsed}
-          onOpenHelp={handleOpenHelp}
-          onOpenAbout={handleOpenAbout}
-          onStartTutorial={tour.startTour}
-          onLogout={onLogout}
-          loginRequired={loginRequired}
-          isOffline={!!error}
-          isDevBuild={isDebugBuild(serverAbout)}
-          onOpenTips={tips.open}
-          onGoDashboard={handleGoDashboard}
-          sidebarColumnVisible={!showSettings && sidebarOpen}
-          rightColumnVisible={isMdUp && !showSettings && !!activeWorkspace && !!activeSession && !diffCollapsed}
-        />
+      <PluginUiProvider>
+        <div className="h-dvh flex flex-col bg-surface-900 text-text-primary overflow-hidden safe-area-inset">
+          <TopBar
+            activeWorkspace={activeWorkspace}
+            activeSession={activeSession ?? null}
+            onToggleSidebar={handleToggleSidebar}
+            onOpenPalette={() => setShowPalette(true)}
+            onToggleDiff={toggleDiff}
+            diffCollapsed={diffCollapsed}
+            onOpenHelp={handleOpenHelp}
+            onOpenAbout={handleOpenAbout}
+            onStartTutorial={tour.startTour}
+            onLogout={onLogout}
+            loginRequired={loginRequired}
+            isOffline={!!error}
+            isDevBuild={isDebugBuild(serverAbout)}
+            onOpenTips={tips.open}
+            onGoDashboard={handleGoDashboard}
+            sidebarColumnVisible={!showSettings && sidebarOpen}
+            rightColumnVisible={isMdUp && !showSettings && !!activeWorkspace && !!activeSession && !diffCollapsed}
+          />
 
-        <DisconnectBanner />
-        <UpdateBanner />
-        <DashboardUpdateBanner />
+          <DisconnectBanner />
+          <UpdateBanner />
+          <DashboardUpdateBanner />
 
-        <div className="flex flex-1 min-h-0">
-          {!showSettings && (
-            <WorkspaceSidebar
-              groups={sidebarGroups}
-              nestedGroups={nestedGroups}
-              onToggleSubgroup={toggleSubgroupCollapsed}
-              onReorderWorkspaces={handleReorderWorkspaces}
-              onReorderGroups={reorderRepoGroups}
-              activeId={activeWorkspace?.id ?? null}
-              open={sidebarOpen}
-              onToggle={() => setSidebarOpen(false)}
-              onSelect={handleSelectWorkspace}
-              onToggleGroup={toggleSidebarGroup}
-              onUpdateRepoAppearance={updateRepoAppearance}
-              onNew={() => {
+          <div className="flex flex-1 min-h-0">
+            {!showSettings && (
+              <WorkspaceSidebar
+                groups={sidebarGroups}
+                nestedGroups={nestedGroups}
+                onToggleSubgroup={toggleSubgroupCollapsed}
+                onReorderWorkspaces={handleReorderWorkspaces}
+                onReorderGroups={reorderRepoGroups}
+                activeId={activeWorkspace?.id ?? null}
+                open={sidebarOpen}
+                onToggle={() => setSidebarOpen(false)}
+                onSelect={handleSelectWorkspace}
+                onToggleGroup={toggleSidebarGroup}
+                onUpdateRepoAppearance={updateRepoAppearance}
+                onNew={() => {
+                  setWizardPrefill(undefined);
+                  setShowSessionWizard(true);
+                }}
+                onCreateSession={handleCreateSession}
+                onPinProject={handlePinProject}
+                onUnpinProject={handleUnpinProject}
+                savedProjects={savedProjects}
+                onAddProject={handleAddProject}
+                onEditProject={handleEditProject}
+                onRemoveProject={handleRemoveProject}
+                onSettings={handleOpenSettings}
+                onDeleteSession={handleDeleteSession}
+                onStopSession={handleStopSession}
+                onStartSession={handleStartSession}
+                readOnly={serverAbout?.read_only}
+                sortMode={sidebarSortMode}
+                onSortModeChange={setSidebarSortMode}
+                axis={sidebarAxis}
+                onAxisChange={setSidebarAxis}
+              />
+            )}
+
+            <div className="flex-1 flex flex-col min-h-0 min-w-0">{renderContent()}</div>
+          </div>
+
+          {showSessionWizard && (
+            <SessionWizard
+              onClose={() => {
+                setShowSessionWizard(false);
                 setWizardPrefill(undefined);
-                setShowSessionWizard(true);
               }}
-              onCreateSession={handleCreateSession}
-              onPinProject={handlePinProject}
-              onUnpinProject={handleUnpinProject}
-              savedProjects={savedProjects}
-              onAddProject={handleAddProject}
-              onEditProject={handleEditProject}
-              onRemoveProject={handleRemoveProject}
-              onSettings={handleOpenSettings}
-              onDeleteSession={handleDeleteSession}
-              onStopSession={handleStopSession}
-              onStartSession={handleStartSession}
-              readOnly={serverAbout?.read_only}
-              sortMode={sidebarSortMode}
-              onSortModeChange={setSidebarSortMode}
-              axis={sidebarAxis}
-              onAxisChange={setSidebarAxis}
+              onCreated={(session?: SessionResponse) => {
+                if (session) {
+                  injectSession(session);
+                  navigate(`/session/${encodeURIComponent(session.id)}`);
+                  if (window.innerWidth < 768) setSidebarOpen(false);
+                }
+                setShowSessionWizard(false);
+                setWizardPrefill(undefined);
+              }}
+              prefill={wizardPrefill}
             />
           )}
 
-          <div className="flex-1 flex flex-col min-h-0 min-w-0">{renderContent()}</div>
+          {projectForm && (
+            <ProjectFormModal
+              initial={projectForm.editProject}
+              onClose={() => setProjectForm(null)}
+              onSaved={() => refreshProjects()}
+            />
+          )}
+
+          {welcome.showWelcome && <ThemeIntro onDone={welcome.dismissWelcome} />}
+
+          {tour.tourElement}
+
+          {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
+
+          {tips.isOpen && (
+            <TipsModal
+              tips={tips.tips}
+              startIndex={tips.startIndex}
+              enabled={tips.enabled}
+              onMarkSeen={tips.markSeen}
+              onSetEnabled={tips.setEnabled}
+              onClose={tips.close}
+            />
+          )}
+
+          {showAbout && <AboutModal onClose={() => setShowAbout(false)} sessionId={activeSessionId} />}
+          {telemetryConsentNeeded && <TelemetryConsentModal onChoose={handleTelemetryConsent} />}
+
+          {deletingSession && (
+            <DeleteSessionDialog
+              sessionTitle={deletingSession.title}
+              branchName={deletingSession.branch}
+              hasManagedWorktree={deletingSession.has_cleanable_worktree ?? false}
+              isSandboxed={deletingSession.is_sandboxed}
+              isScratch={deletingSession.scratch}
+              cleanupDefaults={deletingSession.cleanup_defaults}
+              onConfirm={handleConfirmDelete}
+              onCancel={() => setDeletingWorkspaceId(null)}
+            />
+          )}
+
+          {stoppingSession && (
+            <StopSessionDialog
+              sessionTitle={stoppingSession.title}
+              onConfirm={handleConfirmStop}
+              onCancel={() => setStoppingWorkspaceId(null)}
+            />
+          )}
+
+          <CommandPalette
+            open={showPalette}
+            onClose={() => setShowPalette(false)}
+            actions={[...commandActions, ...settingsCommands]}
+          />
+
+          {activeWorkspace && activeSession && (
+            <MobileRightPanelPicker
+              open={pickerOpen && singlePane}
+              active={rightPanelView}
+              onSelect={handlePickView}
+              onClose={() => setPickerOpen(false)}
+            />
+          )}
+
+          <textarea
+            ref={keyboardProxyRef}
+            aria-hidden="true"
+            tabIndex={-1}
+            className="fixed opacity-0 w-0 h-0 pointer-events-none"
+            style={{ top: -9999, left: -9999 }}
+          />
         </div>
-
-        {showSessionWizard && (
-          <SessionWizard
-            onClose={() => {
-              setShowSessionWizard(false);
-              setWizardPrefill(undefined);
-            }}
-            onCreated={(session?: SessionResponse) => {
-              if (session) {
-                injectSession(session);
-                navigate(`/session/${encodeURIComponent(session.id)}`);
-                if (window.innerWidth < 768) setSidebarOpen(false);
-              }
-              setShowSessionWizard(false);
-              setWizardPrefill(undefined);
-            }}
-            prefill={wizardPrefill}
-          />
-        )}
-
-        {projectForm && (
-          <ProjectFormModal
-            initial={projectForm.editProject}
-            onClose={() => setProjectForm(null)}
-            onSaved={() => refreshProjects()}
-          />
-        )}
-
-        {welcome.showWelcome && <ThemeIntro onDone={welcome.dismissWelcome} />}
-
-        {tour.tourElement}
-
-        {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
-
-        {tips.isOpen && (
-          <TipsModal
-            tips={tips.tips}
-            startIndex={tips.startIndex}
-            enabled={tips.enabled}
-            onMarkSeen={tips.markSeen}
-            onSetEnabled={tips.setEnabled}
-            onClose={tips.close}
-          />
-        )}
-
-        {showAbout && <AboutModal onClose={() => setShowAbout(false)} sessionId={activeSessionId} />}
-        {telemetryConsentNeeded && <TelemetryConsentModal onChoose={handleTelemetryConsent} />}
-
-        {deletingSession && (
-          <DeleteSessionDialog
-            sessionTitle={deletingSession.title}
-            branchName={deletingSession.branch}
-            hasManagedWorktree={deletingSession.has_cleanable_worktree ?? false}
-            isSandboxed={deletingSession.is_sandboxed}
-            isScratch={deletingSession.scratch}
-            cleanupDefaults={deletingSession.cleanup_defaults}
-            onConfirm={handleConfirmDelete}
-            onCancel={() => setDeletingWorkspaceId(null)}
-          />
-        )}
-
-        {stoppingSession && (
-          <StopSessionDialog
-            sessionTitle={stoppingSession.title}
-            onConfirm={handleConfirmStop}
-            onCancel={() => setStoppingWorkspaceId(null)}
-          />
-        )}
-
-        <CommandPalette
-          open={showPalette}
-          onClose={() => setShowPalette(false)}
-          actions={[...commandActions, ...settingsCommands]}
-        />
-
-        {activeWorkspace && activeSession && (
-          <MobileRightPanelPicker
-            open={pickerOpen && singlePane}
-            active={rightPanelView}
-            onSelect={handlePickView}
-            onClose={() => setPickerOpen(false)}
-          />
-        )}
-
-        <textarea
-          ref={keyboardProxyRef}
-          aria-hidden="true"
-          tabIndex={-1}
-          className="fixed opacity-0 w-0 h-0 pointer-events-none"
-          style={{ top: -9999, left: -9999 }}
-        />
-      </div>
+      </PluginUiProvider>
     </AcpPrefsProvider>
   );
 }

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { AOE_BRAND_MARK_COLORS, AOE_BRAND_MARK_TEXT_SHADOW } from "../lib/brandMark";
 import { TOUR_ANCHORS, type TourAnchorId } from "../lib/tourSteps";
+import { PluginCards } from "./plugin/PluginSlots";
 
 interface Props {
   sessions: SessionResponse[];
@@ -157,6 +158,11 @@ export function Dashboard({ sessions, onNewSession, onCloneFromUrl, onToggleSide
           />
         </div>
       )}
+
+      {/* Plugin-contributed dashboard cards (#2366). */}
+      <div className="mt-4 max-w-2xl w-full">
+        <PluginCards />
+      </div>
 
       {/* Keyboard hint (desktop only) */}
       {!readOnly && (

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -159,10 +159,9 @@ export function Dashboard({ sessions, onNewSession, onCloneFromUrl, onToggleSide
         </div>
       )}
 
-      {/* Plugin-contributed dashboard cards (#2366). */}
-      <div className="mt-4 max-w-2xl w-full">
-        <PluginCards />
-      </div>
+      {/* Plugin-contributed dashboard cards (#2366). Renders nothing (and adds
+          no spacing) until a plugin pushes a card. */}
+      <PluginCards />
 
       {/* Keyboard hint (desktop only) */}
       {!readOnly && (

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -5,6 +5,7 @@ import { PairedShellPane } from "./PairedTerminal";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
+import { PluginDetailBadges, PluginDetailPanels } from "./plugin/PluginSlots";
 
 const VSPLIT_STORAGE_KEY = "aoe-right-vsplit";
 const DEFAULT_TOP_RATIO = 0.5;
@@ -152,6 +153,12 @@ export function RightPanel({
             onSend={onOpenSendDialog}
             onDiscardAll={onDiscardAllComments}
           />
+        )}
+        {sessionId && (
+          <div className="shrink-0 flex flex-col gap-2 p-2 empty:hidden">
+            <PluginDetailBadges sessionId={sessionId} />
+            <PluginDetailPanels sessionId={sessionId} />
+          </div>
         )}
         <DiffFileList
           files={files}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -3,6 +3,7 @@ import type { SessionResponse, Workspace } from "../lib/types";
 import { PaletteTriggerPill } from "./PaletteTriggerPill";
 import { OverflowMenu, type OverflowItem } from "./OverflowMenu";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
+import { PluginStatusBarSegments } from "./plugin/PluginSlots";
 
 interface Props {
   activeWorkspace: Workspace | undefined;
@@ -126,6 +127,7 @@ export function TopBar({
           rightColumnVisible ? "md:w-[var(--aoe-right-panel-width)] md:border-b-0 md:border-l" : ""
         }`}
       >
+        <PluginStatusBarSegments />
         {isDevBuild && (
           <span
             className="font-mono text-[11px] px-1.5 py-0.5 rounded-full bg-status-waiting/15 text-status-waiting ring-1 ring-status-waiting/30"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -99,6 +99,7 @@ import { OwnerAvatar } from "./OwnerAvatar";
 import { SessionGroupModal } from "./SessionGroupModal";
 import { SidebarSortPicker } from "./SidebarSortPicker";
 import { Tooltip } from "./Tooltip";
+import { PluginRowBadges, PluginRowColumn } from "./plugin/PluginSlots";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const SUNK_EXPANDED_KEY = "aoe-sidebar-sunk-expanded";
@@ -1195,6 +1196,8 @@ export const SessionRow = memo(function SessionRow({
                 <WakeupCountdown wakeAt={firstSession.next_wakeup_at} reason={firstSession.next_wakeup_reason} />
               )}
               {firstSession?.monitor_active && <MonitorBadge description={firstSession.monitor_description} />}
+              {firstSession && <PluginRowBadges sessionId={firstSession.id} />}
+              {firstSession && <PluginRowColumn sessionId={firstSession.id} />}
             </span>
             {subtitle && (
               <span className="block text-[11px] font-mono text-text-dim truncate" title={subtitleTitle ?? subtitle}>

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -5,24 +5,53 @@
 // detail-panel, detail-badge. Notifications surface as toasts via the hook;
 // sort-key and filter-facet are deferred (see #2366 follow-ups).
 
+import { createElement } from "react";
+import { icons } from "lucide-react";
+
 import { usePluginUiEntries } from "../../lib/pluginUiContext";
 import { entryText, entryTone, globalEntries, payloadStr, sessionEntries, toneClasses } from "../../lib/pluginUi";
 import type { PluginUiEntry } from "../../lib/api";
+
+// A plugin names an icon by its lucide kebab name (e.g. "git-pull-request-arrow");
+// lucide keys its `icons` record by PascalCase, so convert. Any lucide icon is
+// allowed; an unknown name renders no icon. Icons use currentColor, so
+// toneClasses tints them.
+function lucideIcon(name: string) {
+  if (!name) return undefined;
+  const pascal = name
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+  return icons[pascal as keyof typeof icons];
+}
 
 function Badge({ entry }: { entry: PluginUiEntry }) {
   const text = entryText(entry);
   if (!text) return null;
   const tooltip = payloadStr(entry, "tooltip");
-  return (
-    <span
-      className={`inline-flex max-w-48 min-w-0 items-center truncate font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(entryTone(entry))}`}
-      title={tooltip || text}
-      data-plugin-slot={entry.slot}
-      data-plugin-id={entry.plugin_id}
-    >
-      {text}
-    </span>
+  const icon = lucideIcon(payloadStr(entry, "icon"));
+  const href = payloadStr(entry, "href");
+  const className = `inline-flex max-w-48 min-w-0 items-center gap-1 truncate font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(entryTone(entry))}`;
+  const inner = (
+    <>
+      {icon && createElement(icon, { className: "size-3 shrink-0", "aria-hidden": true })}
+      <span className="truncate">{text}</span>
+    </>
   );
+  const common = {
+    className,
+    title: tooltip || text,
+    "data-plugin-slot": entry.slot,
+    "data-plugin-id": entry.plugin_id,
+  };
+  if (href) {
+    return (
+      <a {...common} href={href} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </a>
+    );
+  }
+  return <span {...common}>{inner}</span>;
 }
 
 /** status-bar: global segments in the top bar's right zone. */

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -1,0 +1,144 @@
+// Renderers for the host-rendered plugin UI slots (#2366). The host ships
+// typed display state; these components draw it. No plugin code runs here.
+// Each reads the shared snapshot via context and the pure selectors in
+// `pluginUi.ts`. Slots shipped here: status-bar, row-badge, row-column, card,
+// detail-panel, detail-badge. Notifications surface as toasts via the hook;
+// sort-key and filter-facet are deferred (see #2366 follow-ups).
+
+import { usePluginUiEntries } from "../../lib/pluginUiContext";
+import { entryText, entryTone, globalEntries, payloadStr, sessionEntries, toneClasses } from "../../lib/pluginUi";
+import type { PluginUiEntry } from "../../lib/api";
+
+function Badge({ entry }: { entry: PluginUiEntry }) {
+  const text = entryText(entry);
+  if (!text) return null;
+  const tooltip = payloadStr(entry, "tooltip");
+  return (
+    <span
+      className={`font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(entryTone(entry))}`}
+      title={tooltip || `${entry.plugin_id}`}
+      data-plugin-slot={entry.slot}
+      data-plugin-id={entry.plugin_id}
+    >
+      {text}
+    </span>
+  );
+}
+
+/** status-bar: global segments in the top bar's right zone. */
+export function PluginStatusBarSegments() {
+  const entries = globalEntries(usePluginUiEntries(), "status-bar");
+  if (entries.length === 0) return null;
+  return (
+    <>
+      {entries.map((e) => (
+        <Badge key={`${e.plugin_id}:${e.id}`} entry={e} />
+      ))}
+    </>
+  );
+}
+
+/** row-badge: per-session badges shown inline on a session row. */
+export function PluginRowBadges({ sessionId }: { sessionId: string }) {
+  const entries = sessionEntries(usePluginUiEntries(), "row-badge", sessionId);
+  if (entries.length === 0) return null;
+  return (
+    <>
+      {entries.map((e) => (
+        <Badge key={`${e.plugin_id}:${e.id}`} entry={e} />
+      ))}
+    </>
+  );
+}
+
+/** row-column: per-session text column, right-aligned on a session row. The
+ *  payload may also carry sort/filter scalars; rendering those as interactive
+ *  controls is the deferred sort-key/filter-facet work. */
+export function PluginRowColumn({ sessionId }: { sessionId: string }) {
+  const entries = sessionEntries(usePluginUiEntries(), "row-column", sessionId);
+  if (entries.length === 0) return null;
+  return (
+    <span className="flex items-center gap-1.5">
+      {entries.map((e) => {
+        const text = entryText(e);
+        if (!text) return null;
+        return (
+          <span
+            key={`${e.plugin_id}:${e.id}`}
+            className={`font-mono text-[11px] ${
+              toneClasses(entryTone(e))
+                .split(" ")
+                .find((c) => c.startsWith("text-")) ?? "text-text-dim"
+            }`}
+            title={payloadStr(e, "tooltip") || e.plugin_id}
+            data-plugin-slot="row-column"
+            data-plugin-id={e.plugin_id}
+          >
+            {text}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+/** card: global cards on the dashboard overview. */
+export function PluginCards() {
+  const entries = globalEntries(usePluginUiEntries(), "card");
+  if (entries.length === 0) return null;
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="plugin-cards">
+      {entries.map((e) => {
+        const title = payloadStr(e, "title");
+        const body = payloadStr(e, "body");
+        return (
+          <div
+            key={`${e.plugin_id}:${e.id}`}
+            className={`rounded-lg p-3 ring-1 ring-surface-700/60 ${toneClasses(entryTone(e))}`}
+            data-plugin-id={e.plugin_id}
+          >
+            <div className="font-semibold text-sm">{title}</div>
+            {body && <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** detail-badge: per-session badges in the session detail panel. */
+export function PluginDetailBadges({ sessionId }: { sessionId: string }) {
+  const entries = sessionEntries(usePluginUiEntries(), "detail-badge", sessionId);
+  if (entries.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" data-testid="plugin-detail-badges">
+      {entries.map((e) => (
+        <Badge key={`${e.plugin_id}:${e.id}`} entry={e} />
+      ))}
+    </div>
+  );
+}
+
+/** detail-panel: per-session panels in the session detail view. */
+export function PluginDetailPanels({ sessionId }: { sessionId: string }) {
+  const entries = sessionEntries(usePluginUiEntries(), "detail-panel", sessionId);
+  if (entries.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2" data-testid="plugin-detail-panels">
+      {entries.map((e) => {
+        const title = payloadStr(e, "title");
+        const body = payloadStr(e, "body");
+        return (
+          <section
+            key={`${e.plugin_id}:${e.id}`}
+            className="rounded-lg p-3 ring-1 ring-surface-700/60 bg-surface-800/40"
+            data-plugin-id={e.plugin_id}
+          >
+            {title && <div className="font-semibold text-sm text-text-primary">{title}</div>}
+            <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -15,8 +15,8 @@ function Badge({ entry }: { entry: PluginUiEntry }) {
   const tooltip = payloadStr(entry, "tooltip");
   return (
     <span
-      className={`font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(entryTone(entry))}`}
-      title={tooltip || `${entry.plugin_id}`}
+      className={`inline-flex max-w-48 min-w-0 items-center truncate font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(entryTone(entry))}`}
+      title={tooltip || text}
       data-plugin-slot={entry.slot}
       data-plugin-id={entry.plugin_id}
     >
@@ -58,19 +58,19 @@ export function PluginRowColumn({ sessionId }: { sessionId: string }) {
   const entries = sessionEntries(usePluginUiEntries(), "row-column", sessionId);
   if (entries.length === 0) return null;
   return (
-    <span className="flex items-center gap-1.5">
+    <span className="flex min-w-0 items-center gap-1.5">
       {entries.map((e) => {
         const text = entryText(e);
         if (!text) return null;
         return (
           <span
             key={`${e.plugin_id}:${e.id}`}
-            className={`font-mono text-[11px] ${
+            className={`max-w-32 truncate font-mono text-[11px] ${
               toneClasses(entryTone(e))
                 .split(" ")
                 .find((c) => c.startsWith("text-")) ?? "text-text-dim"
             }`}
-            title={payloadStr(e, "tooltip") || e.plugin_id}
+            title={payloadStr(e, "tooltip") || text}
             data-plugin-slot="row-column"
             data-plugin-id={e.plugin_id}
           >
@@ -87,7 +87,10 @@ export function PluginCards() {
   const entries = globalEntries(usePluginUiEntries(), "card");
   if (entries.length === 0) return null;
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="plugin-cards">
+    <div
+      className="mt-4 w-full max-w-2xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+      data-testid="plugin-cards"
+    >
       {entries.map((e) => {
         const title = payloadStr(e, "title");
         const body = payloadStr(e, "body");

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -6,52 +6,129 @@
 // sort-key and filter-facet are deferred (see #2366 follow-ups).
 
 import { createElement } from "react";
-import { icons } from "lucide-react";
+import {
+  CircleAlert,
+  CircleCheck,
+  CircleDot,
+  Clock,
+  GitMerge,
+  GitPullRequestArrow,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  type LucideIcon,
+} from "lucide-react";
 
 import { usePluginUiEntries } from "../../lib/pluginUiContext";
-import { entryText, entryTone, globalEntries, payloadStr, sessionEntries, toneClasses } from "../../lib/pluginUi";
-import type { PluginUiEntry } from "../../lib/api";
+import {
+  entryText,
+  entryTone,
+  globalEntries,
+  payloadStr,
+  sessionEntries,
+  toneClasses,
+  toneTextClass,
+  validTone,
+} from "../../lib/pluginUi";
+import type { PluginUiEntry, PluginUiTone } from "../../lib/api";
 
-// A plugin names an icon by its lucide kebab name (e.g. "git-pull-request-arrow");
-// lucide keys its `icons` record by PascalCase, so convert. Any lucide icon is
-// allowed; an unknown name renders no icon. Icons use currentColor, so
-// toneClasses tints them.
-function lucideIcon(name: string) {
-  if (!name) return undefined;
-  const pascal = name
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join("");
-  return icons[pascal as keyof typeof icons];
+// Plugins name an icon by its lucide kebab name. The set is an explicit
+// allowlist, not the whole lucide barrel: that keeps the bundle small and means
+// a plugin can never name an arbitrary import. An unknown name renders nothing.
+const ICONS: Record<string, LucideIcon> = {
+  "git-pull-request-arrow": GitPullRequestArrow,
+  "git-pull-request-draft": GitPullRequestDraft,
+  "git-pull-request-closed": GitPullRequestClosed,
+  "git-merge": GitMerge,
+  "circle-alert": CircleAlert,
+  "circle-check": CircleCheck,
+  "circle-dot": CircleDot,
+  clock: Clock,
+};
+
+function lucideIcon(name: string | undefined): LucideIcon | undefined {
+  return name ? ICONS[name] : undefined;
 }
 
-function Badge({ entry }: { entry: PluginUiEntry }) {
-  const text = entryText(entry);
-  if (!text) return null;
-  const tooltip = payloadStr(entry, "tooltip");
-  const icon = lucideIcon(payloadStr(entry, "icon"));
-  const href = payloadStr(entry, "href");
-  const className = `inline-flex max-w-48 min-w-0 items-center gap-1 truncate font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(entryTone(entry))}`;
+// Plugin strings are untrusted: only follow http/https hrefs, never
+// javascript:/data: and friends. Returns undefined for anything else, so the
+// badge/row renders as plain text instead of a link.
+function safeHref(href: string | undefined): string | undefined {
+  return href && /^https?:\/\//i.test(href) ? href : undefined;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function str(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+/** Objects in a payload's `items`/`blocks` array, or undefined when absent. */
+function objectList(payload: Record<string, unknown>, key: string): Record<string, unknown>[] | undefined {
+  const v = payload[key];
+  return Array.isArray(v) ? v.filter(isObject) : undefined;
+}
+
+/** One pill: an optional tone-tinted icon plus optional text, wrapped in a
+ *  link when the href is a safe http(s) URL. Shared by the single-badge slots
+ *  and each entry in a `row-badge` `items` list. */
+function BadgeChip({
+  text,
+  icon,
+  tone,
+  href,
+  tooltip,
+  slot,
+  pluginId,
+}: {
+  text?: string;
+  icon?: string;
+  tone?: PluginUiTone;
+  href?: string;
+  tooltip?: string;
+  slot: string;
+  pluginId: string;
+}) {
+  const iconComp = lucideIcon(icon);
+  if (!iconComp && !text) return null;
+  const safe = safeHref(href);
+  const className = `inline-flex max-w-48 min-w-0 items-center gap-1 truncate font-mono text-[11px] px-1.5 py-0.5 rounded-full ${toneClasses(tone)}`;
   const inner = (
     <>
-      {icon && createElement(icon, { className: "size-3 shrink-0", "aria-hidden": true })}
-      <span className="truncate">{text}</span>
+      {iconComp && createElement(iconComp, { className: "size-3 shrink-0", "aria-hidden": true })}
+      {text && <span className="truncate">{text}</span>}
     </>
   );
   const common = {
     className,
-    title: tooltip || text,
-    "data-plugin-slot": entry.slot,
-    "data-plugin-id": entry.plugin_id,
+    title: tooltip || text || undefined,
+    "data-plugin-slot": slot,
+    "data-plugin-id": pluginId,
   };
-  if (href) {
+  if (safe) {
     return (
-      <a {...common} href={href} target="_blank" rel="noopener noreferrer">
+      <a {...common} href={safe} target="_blank" rel="noopener noreferrer">
         {inner}
       </a>
     );
   }
   return <span {...common}>{inner}</span>;
+}
+
+function Badge({ entry }: { entry: PluginUiEntry }) {
+  return (
+    <BadgeChip
+      text={entryText(entry) || undefined}
+      icon={payloadStr(entry, "icon") || undefined}
+      tone={entryTone(entry)}
+      href={payloadStr(entry, "href") || undefined}
+      tooltip={payloadStr(entry, "tooltip") || undefined}
+      slot={entry.slot}
+      pluginId={entry.plugin_id}
+    />
+  );
 }
 
 /** status-bar: global segments in the top bar's right zone. */
@@ -67,15 +144,33 @@ export function PluginStatusBarSegments() {
   );
 }
 
-/** row-badge: per-session badges shown inline on a session row. */
+/** row-badge: per-session badges on a session row. An entry is either a single
+ *  badge (`{ text, tone, icon, href, tooltip }`) or a list (`items: BadgeItem[]`)
+ *  so one entry can show several icon badges. An empty `items: []` clears the
+ *  row (renders nothing). */
 export function PluginRowBadges({ sessionId }: { sessionId: string }) {
   const entries = sessionEntries(usePluginUiEntries(), "row-badge", sessionId);
   if (entries.length === 0) return null;
   return (
     <>
-      {entries.map((e) => (
-        <Badge key={`${e.plugin_id}:${e.id}`} entry={e} />
-      ))}
+      {entries.map((e) => {
+        const items = objectList(e.payload, "items");
+        if (items) {
+          return items.map((it, i) => (
+            <BadgeChip
+              key={`${e.plugin_id}:${e.id}:${i}`}
+              text={str(it, "text")}
+              icon={str(it, "icon")}
+              tone={validTone(it.tone)}
+              href={str(it, "href")}
+              tooltip={str(it, "tooltip")}
+              slot="row-badge"
+              pluginId={e.plugin_id}
+            />
+          ));
+        }
+        return <Badge key={`${e.plugin_id}:${e.id}`} entry={e} />;
+      })}
     </>
   );
 }
@@ -151,13 +246,87 @@ export function PluginDetailBadges({ sessionId }: { sessionId: string }) {
   );
 }
 
-/** detail-panel: per-session panels in the session detail view. */
+/** A clickable-when-href detail row: tone-tinted icon, primary label, secondary
+ *  value, muted sublabel. */
+function BlockRow({ block }: { block: Record<string, unknown> }) {
+  const label = str(block, "label");
+  const value = str(block, "value");
+  const sublabel = str(block, "sublabel");
+  const iconComp = lucideIcon(str(block, "icon"));
+  const tone = validTone(block.tone);
+  const safe = safeHref(str(block, "href"));
+  if (!label && !value && !iconComp) return null;
+  const inner = (
+    <span className="flex min-w-0 items-center gap-2">
+      {iconComp &&
+        createElement(iconComp, { className: `size-4 shrink-0 ${toneTextClass(tone)}`, "aria-hidden": true })}
+      <span className="min-w-0 truncate">
+        {label && <span className="font-medium text-text-primary">{label}</span>}
+        {value && <span className="ml-1.5 text-text-secondary">{value}</span>}
+        {sublabel && <span className="ml-1.5 text-[11px] text-text-dim">{sublabel}</span>}
+      </span>
+    </span>
+  );
+  return safe ? (
+    <a
+      className="block rounded px-1 py-0.5 text-xs hover:bg-surface-700/40"
+      href={safe}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {inner}
+    </a>
+  ) : (
+    <div className="px-1 py-0.5 text-xs">{inner}</div>
+  );
+}
+
+/** Render one detail-panel block. The block vocabulary is forward-compatible:
+ *  an unknown `kind` (or a known kind missing its required field) renders
+ *  nothing rather than throwing, so a newer plugin can push kinds an older host
+ *  has never heard of. */
+function DetailBlock({ block, pluginId }: { block: Record<string, unknown>; pluginId: string }) {
+  switch (str(block, "kind")) {
+    case "heading": {
+      const text = str(block, "text");
+      return text ? <div className="font-semibold text-sm text-text-primary">{text}</div> : null;
+    }
+    case "row":
+      return <BlockRow block={block} />;
+    case "note": {
+      const text = str(block, "text");
+      return text ? <p className={`text-xs ${toneTextClass(validTone(block.tone))}`}>{text}</p> : null;
+    }
+    case "divider":
+      return <hr className="border-surface-700/60" />;
+    case "section": {
+      const title = str(block, "title");
+      const children = Array.isArray(block.children) ? block.children.filter(isObject) : [];
+      return (
+        <section className="flex flex-col gap-1">
+          {title && <div className="text-[11px] font-semibold uppercase tracking-wide text-text-dim">{title}</div>}
+          {children.map((c, i) => (
+            <DetailBlock key={i} block={c} pluginId={pluginId} />
+          ))}
+        </section>
+      );
+    }
+    default:
+      // Unknown kind: ignored, not rendered, never throws.
+      return null;
+  }
+}
+
+/** detail-panel: per-session panels in the session detail view. An entry is
+ *  either a `blocks` list (the flexible, forward-compatible pane) or the simple
+ *  `{ title, body }` form. */
 export function PluginDetailPanels({ sessionId }: { sessionId: string }) {
   const entries = sessionEntries(usePluginUiEntries(), "detail-panel", sessionId);
   if (entries.length === 0) return null;
   return (
     <div className="flex flex-col gap-2" data-testid="plugin-detail-panels">
       {entries.map((e) => {
+        const blocks = objectList(e.payload, "blocks");
         const title = payloadStr(e, "title");
         const body = payloadStr(e, "body");
         return (
@@ -166,8 +335,18 @@ export function PluginDetailPanels({ sessionId }: { sessionId: string }) {
             className="rounded-lg p-3 ring-1 ring-surface-700/60 bg-surface-800/40"
             data-plugin-id={e.plugin_id}
           >
-            {title && <div className="font-semibold text-sm text-text-primary">{title}</div>}
-            <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>
+            {blocks ? (
+              <div className="flex flex-col gap-1.5">
+                {blocks.map((b, i) => (
+                  <DetailBlock key={i} block={b} pluginId={e.plugin_id} />
+                ))}
+              </div>
+            ) : (
+              <>
+                {title && <div className="font-semibold text-sm text-text-primary">{title}</div>}
+                {body && <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>}
+              </>
+            )}
           </section>
         );
       })}

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -104,6 +104,9 @@ function BadgeChip({
   const common = {
     className,
     title: tooltip || text || undefined,
+    // An icon-only badge has no visible text, so `title` alone leaves the link
+    // unlabeled for assistive tech: give it an explicit name from the tooltip.
+    "aria-label": text ? undefined : tooltip || undefined,
     "data-plugin-slot": slot,
     "data-plugin-id": pluginId,
   };
@@ -256,6 +259,8 @@ function BlockRow({ block }: { block: Record<string, unknown> }) {
   const tone = validTone(block.tone);
   const safe = safeHref(str(block, "href"));
   if (!label && !value && !iconComp) return null;
+  // Name the link from its text so an icon-only row is not announced unlabeled.
+  const ariaLabel = [label, value, sublabel].filter(Boolean).join(" · ") || undefined;
   const inner = (
     <span className="flex min-w-0 items-center gap-2">
       {iconComp &&
@@ -273,6 +278,7 @@ function BlockRow({ block }: { block: Record<string, unknown> }) {
       href={safe}
       target="_blank"
       rel="noopener noreferrer"
+      aria-label={ariaLabel}
     >
       {inner}
     </a>

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -37,6 +37,44 @@ describe("plugin slot renderers", () => {
     expect(screen.queryByText("other")).toBeNull();
   });
 
+  it("row-badge with href renders a clickable link with a lucide icon", () => {
+    set([
+      {
+        plugin_id: "acme.kit",
+        slot: "row-badge",
+        id: "b",
+        session_id: "s1",
+        payload: {
+          text: "PR #12",
+          icon: "git-pull-request-arrow",
+          href: "https://github.com/o/r/pull/12",
+        },
+      },
+    ]);
+    const { container } = render(<PluginRowBadges sessionId="s1" />);
+    const link = screen.getByRole("link", { name: /PR #12/ });
+    expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/12");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+    // The lucide icon renders as an inline svg.
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("row-badge with an unknown icon name renders text and no svg", () => {
+    set([
+      {
+        plugin_id: "acme.kit",
+        slot: "row-badge",
+        id: "b",
+        session_id: "s1",
+        payload: { text: "plain", icon: "not-a-real-icon" },
+      },
+    ]);
+    const { container } = render(<PluginRowBadges sessionId="s1" />);
+    expect(screen.getByText("plain")).toBeTruthy();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
   it("card renders title and body", () => {
     set([{ plugin_id: "acme.kit", slot: "card", id: "c", payload: { title: "Coverage", body: "92%" } }]);
     render(<PluginCards />);

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PluginUiEntry } from "../../../lib/api";
+import { PluginCards, PluginDetailPanels, PluginRowBadges, PluginStatusBarSegments } from "../PluginSlots";
+
+// The slot components read entries from context; mock that hook so each test
+// drives a fixed snapshot.
+const { entriesRef } = vi.hoisted(() => ({ entriesRef: { current: [] as PluginUiEntry[] } }));
+vi.mock("../../../lib/pluginUiContext", () => ({
+  usePluginUiEntries: () => entriesRef.current,
+}));
+
+function set(entries: PluginUiEntry[]) {
+  entriesRef.current = entries;
+}
+
+describe("plugin slot renderers", () => {
+  it("status-bar renders global segments and is empty otherwise", () => {
+    set([]);
+    const { container, rerender } = render(<PluginStatusBarSegments />);
+    expect(container.textContent).toBe("");
+
+    set([{ plugin_id: "acme.kit", slot: "status-bar", id: "s", payload: { text: "Build OK", tone: "success" } }]);
+    rerender(<PluginStatusBarSegments />);
+    expect(screen.getByText("Build OK")).toBeTruthy();
+  });
+
+  it("row-badge renders only the addressed session's entries", () => {
+    set([
+      { plugin_id: "acme.kit", slot: "row-badge", id: "b", session_id: "s1", payload: { text: "PR #12" } },
+      { plugin_id: "acme.kit", slot: "row-badge", id: "b", session_id: "s2", payload: { text: "other" } },
+    ]);
+    render(<PluginRowBadges sessionId="s1" />);
+    expect(screen.getByText("PR #12")).toBeTruthy();
+    expect(screen.queryByText("other")).toBeNull();
+  });
+
+  it("card renders title and body", () => {
+    set([{ plugin_id: "acme.kit", slot: "card", id: "c", payload: { title: "Coverage", body: "92%" } }]);
+    render(<PluginCards />);
+    expect(screen.getByText("Coverage")).toBeTruthy();
+    expect(screen.getByText("92%")).toBeTruthy();
+  });
+
+  it("detail-panel renders for its session", () => {
+    set([
+      {
+        plugin_id: "acme.kit",
+        slot: "detail-panel",
+        id: "p",
+        session_id: "s1",
+        payload: { title: "Logs", body: "tail..." },
+      },
+    ]);
+    render(<PluginDetailPanels sessionId="s1" />);
+    expect(screen.getByText("Logs")).toBeTruthy();
+    expect(screen.getByText("tail...")).toBeTruthy();
+  });
+});

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -118,6 +118,8 @@ describe("plugin slot renderers", () => {
     expect(links[0]!.getAttribute("href")).toBe("https://x/pr/1");
     expect(links[1]!.getAttribute("rel")).toContain("noopener");
     expect(container.querySelectorAll("svg")).toHaveLength(2);
+    // Icon-only links must carry an accessible name from the tooltip.
+    expect(screen.getByRole("link", { name: "PR #1" })).toBeTruthy();
   });
 
   it("row-badge empty items clears the row (renders nothing)", () => {

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -96,4 +96,84 @@ describe("plugin slot renderers", () => {
     expect(screen.getByText("Logs")).toBeTruthy();
     expect(screen.getByText("tail...")).toBeTruthy();
   });
+
+  it("row-badge items render one clickable icon per item", () => {
+    set([
+      {
+        plugin_id: "acme.kit",
+        slot: "row-badge",
+        id: "repos",
+        session_id: "s1",
+        payload: {
+          items: [
+            { icon: "git-pull-request-arrow", tone: "success", href: "https://x/pr/1", tooltip: "PR #1" },
+            { icon: "git-pull-request-draft", tone: "warn", href: "https://x/pr/2", tooltip: "PR #2" },
+          ],
+        },
+      },
+    ]);
+    const { container } = render(<PluginRowBadges sessionId="s1" />);
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]!.getAttribute("href")).toBe("https://x/pr/1");
+    expect(links[1]!.getAttribute("rel")).toContain("noopener");
+    expect(container.querySelectorAll("svg")).toHaveLength(2);
+  });
+
+  it("row-badge empty items clears the row (renders nothing)", () => {
+    set([{ plugin_id: "acme.kit", slot: "row-badge", id: "repos", session_id: "s1", payload: { items: [] } }]);
+    const { container } = render(<PluginRowBadges sessionId="s1" />);
+    expect(container.querySelector("a, span")).toBeNull();
+  });
+
+  it("row-badge item with a non-http href is not a link", () => {
+    set([
+      {
+        plugin_id: "acme.kit",
+        slot: "row-badge",
+        id: "repos",
+        session_id: "s1",
+        payload: { items: [{ text: "evil", href: "javascript:alert(1)" }] },
+      },
+    ]);
+    render(<PluginRowBadges sessionId="s1" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("evil")).toBeTruthy();
+  });
+
+  it("detail-panel blocks render heading, row, note, divider and skip unknown kinds", () => {
+    set([
+      {
+        plugin_id: "acme.kit",
+        slot: "detail-panel",
+        id: "gh",
+        session_id: "s1",
+        payload: {
+          blocks: [
+            { kind: "heading", text: "GitHub" },
+            {
+              kind: "row",
+              icon: "git-pull-request-arrow",
+              tone: "success",
+              label: "nexus",
+              value: "PR #12",
+              sublabel: "o/nexus",
+              href: "https://github.com/o/nexus/pull/12",
+            },
+            { kind: "note", text: "3 repos have no open PR", tone: "neutral" },
+            { kind: "divider" },
+            { kind: "some-future-kind", payload: { nested: true } },
+          ],
+        },
+      },
+    ]);
+    const { container } = render(<PluginDetailPanels sessionId="s1" />);
+    expect(screen.getByText("GitHub")).toBeTruthy();
+    expect(screen.getByText("nexus")).toBeTruthy();
+    expect(screen.getByText("3 repos have no open PR")).toBeTruthy();
+    // The row with an href is an anchor; the unknown kind contributed nothing.
+    const link = screen.getByRole("link", { name: /nexus/ });
+    expect(link.getAttribute("href")).toBe("https://github.com/o/nexus/pull/12");
+    expect(container.querySelector("hr")).toBeTruthy();
+  });
 });

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -117,6 +117,11 @@ export function PluginsSettings() {
                     {plugin.granted ? "" : " (not granted)"}
                   </p>
                 )}
+                {(plugin.ui_contributions ?? []).length > 0 && (
+                  <p className="mt-1 text-[11px] text-text-dim">
+                    UI: {[...new Set((plugin.ui_contributions ?? []).map((u) => u.slot))].join(", ")}
+                  </p>
+                )}
                 {plugin.needs_reapproval && (
                   <p className="mt-1 text-[11px] text-status-warning">
                     Installed but inactive. Re-approve with <code>aoe plugin update {plugin.id}</code>.

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -40,6 +40,7 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
         validation: "builtin",
         source: null,
         capabilities: [],
+        ui_contributions: [],
         granted: true,
         needs_reapproval: false,
       },
@@ -53,6 +54,10 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
         validation: "community",
         source: "gh:example/plugin",
         capabilities: ["net"],
+        ui_contributions: [
+          { slot: "status-bar", id: "s" },
+          { slot: "row-badge", id: "b" },
+        ],
         granted: true,
         needs_reapproval: false,
       },
@@ -75,6 +80,12 @@ describe("PluginsSettings", () => {
     await findByText("Agent Status Detection");
     await findByText("v1.1.0");
     await findByText("A community plugin.");
+  });
+
+  it("discloses the UI slots a plugin renders into, deduped", async () => {
+    const { findByText } = render(<PluginsSettings />);
+    // example.plugin declares status-bar + row-badge (#2366).
+    await findByText("UI: status-bar, row-badge");
   });
 
   it("shows validation badges and a needs-approval state for an ungranted community plugin", async () => {

--- a/web/src/hooks/usePluginUiState.test.tsx
+++ b/web/src/hooks/usePluginUiState.test.tsx
@@ -72,4 +72,39 @@ describe("usePluginUiState notifications", () => {
     });
     expect(reportError).toHaveBeenCalledTimes(1);
   });
+
+  it("re-seeds when the ring resets (daemon restart) so new toasts fire", async () => {
+    fetchMock
+      // Seed high.
+      .mockResolvedValueOnce(snapshot([{ seq: 5, plugin_id: "acme.kit", tone: "info", title: "old" }]))
+      // Daemon restarted: ring starts low again, below the watermark.
+      .mockResolvedValueOnce(snapshot([{ seq: 1, plugin_id: "acme.kit", tone: "info", title: "after restart" }]))
+      // A genuinely new one after the reset must toast.
+      .mockResolvedValue(
+        snapshot([
+          { seq: 1, plugin_id: "acme.kit", tone: "info", title: "after restart" },
+          { seq: 2, plugin_id: "acme.kit", tone: "info", title: "fresh" },
+        ]),
+      );
+
+    renderHook(() => usePluginUiState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(reportInfo).not.toHaveBeenCalled();
+
+    // The lower maxSeq is treated as a fresh ring: re-seed, still no toast.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(reportInfo).not.toHaveBeenCalled();
+
+    // seq 2 now exceeds the re-seeded watermark of 1: toast once.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(reportInfo).toHaveBeenCalledTimes(1);
+    expect(reportInfo).toHaveBeenCalledWith("fresh");
+  });
 });

--- a/web/src/hooks/usePluginUiState.test.tsx
+++ b/web/src/hooks/usePluginUiState.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+//
+// The hook polls the host snapshot and must toast each notification exactly
+// once: the first snapshot's backlog is adopted as already-seen (no replay on
+// load), and only strictly-newer seqs toast thereafter.
+
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginUiState } from "../lib/api";
+import { fetchPluginUiState } from "../lib/api";
+import { reportError, reportInfo } from "../lib/toastBus";
+import { usePluginUiState } from "./usePluginUiState";
+
+vi.mock("../lib/api", () => ({ fetchPluginUiState: vi.fn() }));
+vi.mock("../lib/toastBus", () => ({ reportError: vi.fn(), reportInfo: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchPluginUiState);
+
+function snapshot(notifications: PluginUiState["notifications"]): PluginUiState {
+  return { entries: [], notifications };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock.mockReset();
+  vi.mocked(reportError).mockReset();
+  vi.mocked(reportInfo).mockReset();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("usePluginUiState notifications", () => {
+  it("adopts the first backlog silently, then toasts only newer seqs once", async () => {
+    fetchMock
+      // First poll: a backlog notification already present at load.
+      .mockResolvedValueOnce(snapshot([{ seq: 1, plugin_id: "acme.kit", tone: "info", title: "old" }]))
+      // Second poll: a new one arrives.
+      .mockResolvedValueOnce(
+        snapshot([
+          { seq: 1, plugin_id: "acme.kit", tone: "info", title: "old" },
+          { seq: 2, plugin_id: "acme.kit", tone: "danger", title: "Build failed", body: "tests" },
+        ]),
+      )
+      // Third poll: nothing newer; no repeat toast.
+      .mockResolvedValue(
+        snapshot([
+          { seq: 1, plugin_id: "acme.kit", tone: "info", title: "old" },
+          { seq: 2, plugin_id: "acme.kit", tone: "danger", title: "Build failed", body: "tests" },
+        ]),
+      );
+
+    renderHook(() => usePluginUiState());
+
+    // Flush the mount poll: backlog adopted, nothing toasted.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(reportError).not.toHaveBeenCalled();
+    expect(reportInfo).not.toHaveBeenCalled();
+
+    // Next tick: seq 2 toasts once, as an error (danger tone), with body joined.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith("Build failed: tests");
+
+    // A further tick with no newer seq does not re-toast.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/usePluginUiState.ts
+++ b/web/src/hooks/usePluginUiState.ts
@@ -25,32 +25,46 @@ export function usePluginUiState() {
   // Highest notification seq already toasted. Seeded from the first snapshot so
   // a page load does not replay the whole backlog as fresh toasts.
   const lastNotifySeqRef = useRef<number | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    const poll = async () => {
-      const state = await fetchPluginUiState();
-      if (cancelled || state === null) return;
-      setEntries(state.entries);
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
-      const maxSeq = state.notifications.reduce((m, n) => Math.max(m, n.seq), 0);
-      if (lastNotifySeqRef.current === null) {
-        // First snapshot: adopt the backlog as already-seen, toast nothing.
+    const apply = (notifications: PluginUiNotification[]) => {
+      const maxSeq = notifications.reduce((m, n) => Math.max(m, n.seq), 0);
+      const seen = lastNotifySeqRef.current;
+      // Seed on the first snapshot, and re-seed when maxSeq drops below the
+      // watermark: the ring is in-memory and dies with the daemon, so after a
+      // restart seqs start low again. Treat that as a fresh ring and adopt the
+      // current backlog as seen rather than filtering every new toast out.
+      if (seen === null || maxSeq < seen) {
         lastNotifySeqRef.current = maxSeq;
-      } else {
-        const seen = lastNotifySeqRef.current;
-        for (const n of state.notifications) {
-          if (n.seq > seen) toast(n);
-        }
-        lastNotifySeqRef.current = Math.max(seen, maxSeq);
+        return;
+      }
+      for (const n of notifications) {
+        if (n.seq > seen) toast(n);
+      }
+      lastNotifySeqRef.current = Math.max(seen, maxSeq);
+    };
+
+    // Recursive setTimeout, not setInterval: the next poll is scheduled only
+    // after the current one settles, so requests never overlap and a slow
+    // response cannot land after a newer one and roll the dashboard back to
+    // stale plugin UI. A failed fetch (null) just skips this round.
+    const tick = async () => {
+      try {
+        const state = await fetchPluginUiState();
+        if (cancelled || state === null) return;
+        setEntries(state.entries);
+        apply(state.notifications);
+      } finally {
+        if (!cancelled) timer = setTimeout(() => void tick(), POLL_INTERVAL);
       }
     };
-    void poll();
-    intervalRef.current = setInterval(() => void poll(), POLL_INTERVAL);
+    void tick();
     return () => {
       cancelled = true;
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (timer) clearTimeout(timer);
     };
   }, []);
 

--- a/web/src/hooks/usePluginUiState.ts
+++ b/web/src/hooks/usePluginUiState.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+import { fetchPluginUiState, type PluginUiEntry, type PluginUiNotification } from "../lib/api";
+import { reportError, reportInfo } from "../lib/toastBus";
+
+// Polls the host's plugin UI-state snapshot on the same 3s cadence as the
+// session list, so a session and its plugin slots refresh in the same window
+// (no separate, tearing-prone clock). Notifications are point-in-time: each
+// arrives once, tracked by its monotonic seq, and is pushed to the toast bus.
+const POLL_INTERVAL = 3000;
+
+/** Map a plugin notification onto the toast bus. The bus only distinguishes
+ *  error vs info, so danger/warn tones surface as errors and the rest as info;
+ *  the title and optional body are joined into the single-line toast. */
+function toast(n: PluginUiNotification): void {
+  const message = n.body ? `${n.title}: ${n.body}` : n.title;
+  if (n.tone === "danger" || n.tone === "warn") {
+    reportError(message);
+  } else {
+    reportInfo(message);
+  }
+}
+
+export function usePluginUiState() {
+  const [entries, setEntries] = useState<PluginUiEntry[]>([]);
+  // Highest notification seq already toasted. Seeded from the first snapshot so
+  // a page load does not replay the whole backlog as fresh toasts.
+  const lastNotifySeqRef = useRef<number | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      const state = await fetchPluginUiState();
+      if (cancelled || state === null) return;
+      setEntries(state.entries);
+
+      const maxSeq = state.notifications.reduce((m, n) => Math.max(m, n.seq), 0);
+      if (lastNotifySeqRef.current === null) {
+        // First snapshot: adopt the backlog as already-seen, toast nothing.
+        lastNotifySeqRef.current = maxSeq;
+      } else {
+        const seen = lastNotifySeqRef.current;
+        for (const n of state.notifications) {
+          if (n.seq > seen) toast(n);
+        }
+        lastNotifySeqRef.current = Math.max(seen, maxSeq);
+      }
+    };
+    void poll();
+    intervalRef.current = setInterval(() => void poll(), POLL_INTERVAL);
+    return () => {
+      cancelled = true;
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return entries;
+}

--- a/web/src/lib/__tests__/pluginUi.test.ts
+++ b/web/src/lib/__tests__/pluginUi.test.ts
@@ -49,9 +49,9 @@ describe("pluginUi selectors", () => {
     expect(entryTone(entry("status-bar"))).toBeUndefined();
   });
 
-  it("toneClasses maps every tone and falls back to neutral", () => {
-    expect(toneClasses("success")).toContain("emerald");
-    expect(toneClasses("danger")).toContain("rose");
-    expect(toneClasses(undefined)).toContain("slate");
+  it("toneClasses maps every tone to theme tokens and falls back to neutral", () => {
+    expect(toneClasses("success")).toContain("status-running");
+    expect(toneClasses("danger")).toContain("status-error");
+    expect(toneClasses(undefined)).toContain("status-idle");
   });
 });

--- a/web/src/lib/__tests__/pluginUi.test.ts
+++ b/web/src/lib/__tests__/pluginUi.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { PluginUiEntry, PluginUiSlot } from "../api";
+import { entryText, entryTone, globalEntries, payloadStr, sessionEntries, toneClasses } from "../pluginUi";
+
+function entry(slot: PluginUiSlot, over: Partial<PluginUiEntry> = {}): PluginUiEntry {
+  return {
+    plugin_id: "acme.kit",
+    slot,
+    id: "x",
+    payload: {},
+    ...over,
+  };
+}
+
+describe("pluginUi selectors", () => {
+  it("globalEntries keeps only matching-slot entries without a session_id", () => {
+    const entries = [
+      entry("status-bar", { id: "a" }),
+      entry("status-bar", { id: "b", session_id: "s1" }), // has session => not global
+      entry("card", { id: "c" }),
+    ];
+    const got = globalEntries(entries, "status-bar");
+    expect(got.map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("sessionEntries scopes to one session and is empty for a missing id", () => {
+    const entries = [
+      entry("row-badge", { id: "a", session_id: "s1" }),
+      entry("row-badge", { id: "b", session_id: "s2" }),
+      entry("row-badge", { id: "c" }), // global, excluded
+    ];
+    expect(sessionEntries(entries, "row-badge", "s1").map((e) => e.id)).toEqual(["a"]);
+    expect(sessionEntries(entries, "row-badge", undefined)).toEqual([]);
+    // Tearing guard: an id for a session that no longer exists matches nothing.
+    expect(sessionEntries(entries, "row-badge", "gone")).toEqual([]);
+  });
+
+  it("payloadStr and entryText read string fields, falling back to empty", () => {
+    const e = entry("card", { payload: { title: "Hi", text: "ok", n: 3 } });
+    expect(payloadStr(e, "title")).toBe("Hi");
+    expect(payloadStr(e, "n")).toBe(""); // non-string
+    expect(payloadStr(e, "missing")).toBe("");
+    expect(entryText(e)).toBe("ok");
+  });
+
+  it("entryTone validates against the closed set", () => {
+    expect(entryTone(entry("status-bar", { payload: { tone: "success" } }))).toBe("success");
+    expect(entryTone(entry("status-bar", { payload: { tone: "rainbow" } }))).toBeUndefined();
+    expect(entryTone(entry("status-bar"))).toBeUndefined();
+  });
+
+  it("toneClasses maps every tone and falls back to neutral", () => {
+    expect(toneClasses("success")).toContain("emerald");
+    expect(toneClasses("danger")).toContain("rose");
+    expect(toneClasses(undefined)).toContain("slate");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -221,6 +221,56 @@ function isValidPluginListResponse(payload: unknown): payload is PluginListRespo
   );
 }
 
+// --- Plugin UI extension points (#2366) ---
+
+/** Display tone a plugin attaches to a slot entry or notification. The host
+ *  validates it to this closed set; each surface maps it to a color. */
+export type PluginUiTone = "neutral" | "info" | "success" | "warn" | "danger";
+
+/** The nine host-rendered slots, kebab-case as the host serializes them. */
+export type PluginUiSlot =
+  | "status-bar"
+  | "row-badge"
+  | "row-column"
+  | "sort-key"
+  | "filter-facet"
+  | "card"
+  | "detail-panel"
+  | "detail-badge"
+  | "notification";
+
+/** One piece of UI state a worker pushed. `payload` shape is determined by
+ *  `slot`; the dashboard renders it (no plugin code runs here). */
+export interface PluginUiEntry {
+  plugin_id: string;
+  slot: PluginUiSlot;
+  id: string;
+  session_id?: string;
+  payload: Record<string, unknown>;
+}
+
+/** A notification pushed via `ui.notify`. `seq` is monotonic so the client
+ *  toasts each one exactly once. */
+export interface PluginUiNotification {
+  seq: number;
+  plugin_id: string;
+  tone: PluginUiTone;
+  title: string;
+  body?: string;
+  session_id?: string;
+}
+
+export interface PluginUiState {
+  entries: PluginUiEntry[];
+  notifications: PluginUiNotification[];
+}
+
+/** The host's aggregated UI-state snapshot. Returns an empty state (not null)
+ *  shape on the server when no plugin host is running. */
+export function fetchPluginUiState(): Promise<PluginUiState | null> {
+  return fetchJson<PluginUiState>("/api/plugins/ui-state");
+}
+
 export async function setPluginEnabled(id: string, enabled: boolean): Promise<PluginToggleResult> {
   try {
     const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/enabled`, {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -221,7 +221,7 @@ function isValidPluginListResponse(payload: unknown): payload is PluginListRespo
   );
 }
 
-// --- Plugin UI extension points (#2366) ---
+// Plugin UI extension points (#2366).
 
 /** Display tone a plugin attaches to a slot entry or notification. The host
  *  validates it to this closed set; each surface maps it to a color. */

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -192,6 +192,10 @@ export interface PluginView {
   validation: string;
   source: string | null;
   capabilities: string[];
+  /** UI slots the plugin declares it will render into (#2366), disclosed so the
+   *  user sees the plugin modifies the dashboard. Not a capability (needs no
+   *  grant). `slot` is the kebab-case slot name. */
+  ui_contributions: { slot: string; id: string }[];
   granted: boolean;
   needs_reapproval: boolean;
 }

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -51,12 +51,27 @@ export function entryText(entry: PluginUiEntry): string {
   return payloadStr(entry, "text");
 }
 
-/** An entry's optional `tone`, validated to the closed set (anything else
- *  reads as neutral). */
-export function entryTone(entry: PluginUiEntry): PluginUiTone | undefined {
-  const t = entry.payload.tone;
+/** Validate an arbitrary value against the closed tone set (used for badge
+ *  items and detail blocks where the tone is nested, not on the entry). */
+export function validTone(t: unknown): PluginUiTone | undefined {
   if (t === "info" || t === "success" || t === "warn" || t === "danger" || t === "neutral") {
     return t;
   }
   return undefined;
+}
+
+/** An entry's optional `tone`, validated to the closed set (anything else
+ *  reads as neutral). */
+export function entryTone(entry: PluginUiEntry): PluginUiTone | undefined {
+  return validTone(entry.payload.tone);
+}
+
+/** Just the `text-*` color class for a tone, for surfaces that tint text/icons
+ *  without a filled background (row columns, detail rows). */
+export function toneTextClass(tone: PluginUiTone | undefined): string {
+  return (
+    toneClasses(tone)
+      .split(" ")
+      .find((c) => c.startsWith("text-")) ?? "text-text-dim"
+  );
 }

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -39,26 +39,23 @@ export function sessionEntries(
   return entries.filter((e) => e.slot === slot && e.session_id === sessionId);
 }
 
-/** A row-column entry's string text, if present. */
+/** A string field of an entry's payload, or "" when absent/non-string. */
+export function payloadStr(entry: PluginUiEntry, key: string): string {
+  const v = entry.payload[key];
+  return typeof v === "string" ? v : "";
+}
+
+/** An entry's primary `text` field. */
 export function entryText(entry: PluginUiEntry): string {
-  const text = entry.payload.text;
-  return typeof text === "string" ? text : "";
+  return payloadStr(entry, "text");
 }
 
-/** A row-column entry's sort scalar (number or string), for client-side
- *  ordering. `undefined` sorts last. */
-export function entrySortValue(entry: PluginUiEntry): number | string | undefined {
-  const v = entry.payload.sort_value;
-  if (typeof v === "number" || typeof v === "string") return v;
+/** An entry's optional `tone`, validated to the closed set (anything else
+ *  reads as neutral). */
+export function entryTone(entry: PluginUiEntry): PluginUiTone | undefined {
+  const t = entry.payload.tone;
+  if (t === "info" || t === "success" || t === "warn" || t === "danger" || t === "neutral") {
+    return t;
+  }
   return undefined;
-}
-
-/** Compare two optional sort scalars; undefined sorts after defined values.
- *  Numbers compare numerically, strings lexically, mixed by type name. */
-export function compareSortValues(a: number | string | undefined, b: number | string | undefined): number {
-  if (a === undefined && b === undefined) return 0;
-  if (a === undefined) return 1;
-  if (b === undefined) return -1;
-  if (typeof a === "number" && typeof b === "number") return a - b;
-  return String(a).localeCompare(String(b));
 }

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -4,21 +4,22 @@
 
 import type { PluginUiEntry, PluginUiSlot, PluginUiTone } from "./api";
 
-/** Tailwind classes per tone, shared by every slot renderer so a plugin's
- *  tone maps to one consistent palette. `undefined`/unknown falls back to
- *  neutral. */
+/** Theme-backed classes per tone, shared by every slot renderer so a plugin's
+ *  tone maps to one consistent palette that repaints with the user's theme
+ *  (the `status-*` colors are CSS-variable backed). `undefined`/unknown falls
+ *  back to neutral. */
 export function toneClasses(tone: PluginUiTone | undefined): string {
   switch (tone) {
     case "info":
-      return "bg-sky-500/15 text-sky-300";
+      return "bg-status-unread/15 text-status-unread";
     case "success":
-      return "bg-emerald-500/15 text-emerald-300";
+      return "bg-status-running/15 text-status-running";
     case "warn":
-      return "bg-amber-500/15 text-amber-300";
+      return "bg-status-waiting/15 text-status-waiting";
     case "danger":
-      return "bg-rose-500/15 text-rose-300";
+      return "bg-status-error/15 text-status-error";
     default:
-      return "bg-slate-500/15 text-slate-300";
+      return "bg-status-idle/15 text-status-idle";
   }
 }
 

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -1,0 +1,64 @@
+// Pure selectors over the plugin UI-state snapshot (#2366). Components read
+// slots through these so the filtering rules (and the per-session tearing
+// guard) live in one tested place rather than scattered across the UI.
+
+import type { PluginUiEntry, PluginUiSlot, PluginUiTone } from "./api";
+
+/** Tailwind classes per tone, shared by every slot renderer so a plugin's
+ *  tone maps to one consistent palette. `undefined`/unknown falls back to
+ *  neutral. */
+export function toneClasses(tone: PluginUiTone | undefined): string {
+  switch (tone) {
+    case "info":
+      return "bg-sky-500/15 text-sky-300";
+    case "success":
+      return "bg-emerald-500/15 text-emerald-300";
+    case "warn":
+      return "bg-amber-500/15 text-amber-300";
+    case "danger":
+      return "bg-rose-500/15 text-rose-300";
+    default:
+      return "bg-slate-500/15 text-slate-300";
+  }
+}
+
+/** Global (non per-session) entries for a slot, in snapshot order. */
+export function globalEntries(entries: PluginUiEntry[], slot: PluginUiSlot): PluginUiEntry[] {
+  return entries.filter((e) => e.slot === slot && e.session_id == null);
+}
+
+/** Per-session entries for a slot scoped to one session. A null/absent
+ *  `sessionId` yields nothing; this is also the tearing guard, since callers
+ *  pass a live session id and entries for vanished sessions never match. */
+export function sessionEntries(
+  entries: PluginUiEntry[],
+  slot: PluginUiSlot,
+  sessionId: string | undefined,
+): PluginUiEntry[] {
+  if (!sessionId) return [];
+  return entries.filter((e) => e.slot === slot && e.session_id === sessionId);
+}
+
+/** A row-column entry's string text, if present. */
+export function entryText(entry: PluginUiEntry): string {
+  const text = entry.payload.text;
+  return typeof text === "string" ? text : "";
+}
+
+/** A row-column entry's sort scalar (number or string), for client-side
+ *  ordering. `undefined` sorts last. */
+export function entrySortValue(entry: PluginUiEntry): number | string | undefined {
+  const v = entry.payload.sort_value;
+  if (typeof v === "number" || typeof v === "string") return v;
+  return undefined;
+}
+
+/** Compare two optional sort scalars; undefined sorts after defined values.
+ *  Numbers compare numerically, strings lexically, mixed by type name. */
+export function compareSortValues(a: number | string | undefined, b: number | string | undefined): number {
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return String(a).localeCompare(String(b));
+}

--- a/web/src/lib/pluginUiContext.tsx
+++ b/web/src/lib/pluginUiContext.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable react-refresh/only-export-components */
+// Shares the plugin UI-state snapshot (#2366) across the dashboard. The host
+// renders nothing; it ships the slot entries and the daemon's worker-pushed
+// state, and these components draw them. One poll lives in the provider so
+// TopBar, the sidebar rows, the dashboard cards, and the right panel all read
+// the same snapshot without each opening its own clock.
+
+import { createContext, useContext, type ReactNode } from "react";
+import { usePluginUiState } from "../hooks/usePluginUiState";
+import type { PluginUiEntry } from "./api";
+
+const PluginUiContext = createContext<PluginUiEntry[]>([]);
+
+export function PluginUiProvider({ children }: { children: ReactNode }) {
+  const entries = usePluginUiState();
+  return <PluginUiContext.Provider value={entries}>{children}</PluginUiContext.Provider>;
+}
+
+/** All current plugin UI entries. Filter with the selectors in `pluginUi.ts`. */
+export function usePluginUiEntries(): PluginUiEntry[] {
+  return useContext(PluginUiContext);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2690,6 +2690,17 @@
       "risk": "high",
       "specs": ["tests/desktop-live-input.spec.ts"],
       "components": ["web/src/components/LiveTerminalView.tsx", "web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
+      "id": "plugins.ui-slots",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/plugin/__tests__/PluginSlots.test.tsx",
+        "src/lib/__tests__/pluginUi.test.ts",
+        "src/hooks/usePluginUiState.test.tsx"
+      ],
+      "components": ["web/src/components/plugin/PluginSlots.tsx"]
     }
   ]
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

UI extension points for the plugin system (#2366), part of the #268 epic. Plugin workers push **typed UI state** to the host over capability-gated RPCs; the **host** renders every slot on the web dashboard. No plugin code runs in the dashboard and the render path never awaits a worker: the host keeps an in-memory snapshot the dashboard reads synchronously.

What lands here:

- **Slot taxonomy** (`aoe-plugin-api`): `UiContribution.slot` becomes a typed, closed `UiSlot` enum (nine slots), so an unknown slot is a hard parse error rather than carried forward.
- **Host RPCs** (`src/plugin/host_api.rs`): `ui.state.set`, `ui.state.remove`, `ui.notify`. `ui.state.*` are gated by `runtime.worker` **and** the `(slot, id)` being declared in the manifest `[[ui]]` section, so no dedicated `ui` capability is introduced; `ui.notify` reuses the existing `notifications` capability. Payloads validate against the slot's typed shape at the boundary.
- **Store** (`src/plugin/ui_state.rs`): in-memory, dies with the daemon. A per-spawn generation guards eviction so a late write or an instant respawn cannot resurrect or clobber a live worker's state; notifications ride a separate ring and survive a worker crash; per-plugin quotas bound memory.
- **Delivery**: `GET /api/plugins/ui-state` returns the full snapshot (small and bounded, no incremental cursor); the dashboard polls it on the same cadence as `/api/sessions` and renders per-session entries only for live sessions.
- **Rendering**: seven of nine slots draw today (status-bar, row-badge, row-column, card, detail-panel, detail-badge, plus notifications as toasts).
- **Observability**: the host traces every worker RPC outcome (`plugin.host` target), so a rejected push (undeclared slot, malformed payload, ungranted capability) is a `warn` line naming the reason rather than a silent drop.

The two interactive slots, `sort-key` and `filter-facet`, are accepted and stored by the host but their dashboard rendering needs changes to the sidebar's sort/filter core, deferred to #2401. TUI rendering of any slot is deferred to #2402 (the standalone TUI has no daemon link). Worker command-resolution ergonomics (interpreted/venv workers on PATH), surfaced while testing this, is tracked in #2404.

Closes #2366

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

Behavioral steps for a reviewer (each runs against `aoe serve` with a plugin whose worker speaks the host RPCs):

- [ ] A plugin declaring a `status-bar` `[[ui]]` slot + `runtime.worker`: its worker calls `ui.state.set`; the segment appears in the dashboard top bar within one poll, and `ui.state.remove` clears it.
- [ ] `ui.state.set` for a slot the plugin did NOT declare, or an unknown slot string, is refused; nothing renders.
- [ ] `ui.notify` without the `notifications` capability is refused; with it, a toast appears exactly once (reloading the dashboard does not replay it).
- [ ] A `row-badge` pushed with a `session_id` appears on that session's sidebar row only; a `detail-panel` appears in the right panel for the active session.
- [ ] Kill the worker: its slot entries clear; a daemon restart starts empty.
- [ ] With no plugin pushing UI state, the dashboard is visually unchanged.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated tests and updated `web/tests/coverage-matrix.json`

Vitest covers the `pluginUi` selectors, the slot renderers (RTL), and the notification-dedup contract of `usePluginUiState`; the new `plugins.ui-slots` matrix entry maps the new component. The rendering surfaces are passive (a slot draws nothing until a worker pushes state), so this is unit/RTL rather than a full live-Playwright story; a live story fits better with #2401 when the interactive sort/filter controls land.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Host-side behavior is covered by Rust unit tests for the store (`ui_state.rs`) and the dispatch gating (`host_api.rs`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a design debate across two external models, implementation, and prose were drafted by Claude under my direction. I made the design and scope calls (web-only this PR, defer sort/filter + TUI), reviewed each commit, and own the result.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785001978&installation_id=139138837&pr_number=2405&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2405&signature=c29dab8bb2c9dc64d8830d90e03fcccbdcad3176c82c09505d750979a572c753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a host-managed plugin UI extension system.

- Plugins declare which dashboard UI “slots” (from a closed, fixed set) they’re allowed to fill, along with specific contribution ids.
- Plugins push typed UI state to the host via new capability-gated RPCs: `ui.state.set`, `ui.state.remove`, and `ui.notify`. The host validates permissions and payload shape before storing updates.
- The host maintains an in-memory, generation-scoped UI snapshot (with bounded per-plugin quotas) and exposes it to the dashboard via `GET /api/plugins/ui-state` so the web UI can render synchronously by polling.
- The dashboard adds host-rendered UI components for multiple slot areas (including status bar segments, session-row badges/columns, dashboard cards, and detail panels/badges). Notifications are surfaced as toasts with sequence-based deduplication.
- Plugin install/update flows now disclose UI contributions for consent prompts, and the TUI plugin manager UI shows which dashboard slots a plugin will modify.

Notably deferred:
- `sort-key` and `filter-facet` slots are accepted and stored, but dashboard rendering is intentionally deferred (and all TUI rendering for these/double-checked slots is deferred).

Benefits:
- Keeps plugin code out of the dashboard runtime and avoids worker-dependent rendering loops by using host-owned snapshots.
- Improves safety and robustness via strict slot typing, explicit permission checks, payload validation, and generation-guarded cleanup.
- Makes UI behavior predictable for the frontend via deterministic snapshotting and controlled notification replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->