### PR TITLE
feat(plugin): run command-worker build steps for interpreted/venv workers

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -17,8 +17,8 @@ mod manifest;
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
-    CommandContribution, KeybindContribution, ManifestError, PluginManifest, RuntimeSpec,
-    SettingContribution, SettingType, ThemeContribution, UiContribution,
+    BuildStep, CommandContribution, KeybindContribution, ManifestError, PluginManifest,
+    RuntimeSpec, SettingContribution, SettingType, ThemeContribution, UiContribution,
 };
 
 /// Version of the manifest schema and host API this crate describes.

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -163,7 +163,23 @@ pub enum RuntimeSpec {
     /// script, an interpreter invocation, or an in-tree binary).
     Command {
         /// argv; the first element is the program, the rest its arguments.
+        ///
+        /// The program (`argv[0]`) must be plugin-relative (a path containing a
+        /// separator, like `.venv/bin/worker`, resolved inside the install
+        /// directory), unless `system` is set. A plugin-relative entrypoint is
+        /// PATH-independent: the daemon's PATH never decides whether the worker
+        /// launches. Validation rejects a bare program name here so the
+        /// PATH-independent shape is the default and a PATH dependency is a
+        /// conscious opt-in (`system = true`).
         command: Vec<String>,
+        /// Opt in to resolving `command`'s program (`argv[0]`) on the host PATH
+        /// at launch, instead of in the plugin directory. Set this only when the
+        /// worker genuinely depends on a system tool (`uv run worker`,
+        /// `python3 -m pkg`): it makes the daemon's PATH a launch dependency,
+        /// which is the fragility a plugin-relative entrypoint avoids. With
+        /// `system` set, `argv[0]` must be a bare program name, not a path.
+        #[serde(default, skip_serializing_if = "is_false")]
+        system: bool,
         /// Ordered build steps the host runs once at install and update,
         /// inside the installed plugin directory, before the plugin is
         /// registered (e.g. create a venv, `pip install`, `npm ci`). They run
@@ -210,6 +226,19 @@ pub struct BuildStep {
 /// `std::env::consts::OS`; a typo is rejected at parse rather than silently
 /// skipping the step on every platform.
 const KNOWN_PLATFORMS: [&str; 3] = ["linux", "macos", "windows"];
+
+/// `skip_serializing_if` predicate for a defaulted `bool` flag.
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// Whether `arg` reads as a path (carries a separator, or is absolute) rather
+/// than a bare program name. The same classification the launch-time resolver
+/// applies to `argv[0]`, lifted here so validation rejects a misshapen worker
+/// entrypoint before install rather than at the first launch.
+fn looks_like_path(arg: &str) -> bool {
+    arg.contains('/') || arg.contains('\\') || std::path::Path::new(arg).is_absolute()
+}
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -289,7 +318,12 @@ impl PluginManifest {
         check(!self.version.is_empty(), "version must not be empty".into());
         check(!self.name.is_empty(), "name must not be empty".into());
 
-        if let Some(RuntimeSpec::Command { command, build }) = &self.runtime {
+        if let Some(RuntimeSpec::Command {
+            command,
+            system,
+            build,
+        }) = &self.runtime
+        {
             check(
                 !command.is_empty(),
                 "runtime command must not be empty".into(),
@@ -298,6 +332,32 @@ impl PluginManifest {
                 command.iter().all(|arg| !arg.is_empty()),
                 "runtime command must not contain empty arguments".into(),
             );
+            // The worker entrypoint must be plugin-relative so the daemon's PATH
+            // never decides whether the worker launches; depending on a system
+            // tool is a conscious opt-in (`system = true`), not a fallback from
+            // a name that happens not to be on PATH. Enforce the two shapes are
+            // mutually exclusive: relative path by default, bare name with
+            // `system`.
+            if let Some(program) = command.first().filter(|a| !a.is_empty()) {
+                if *system {
+                    check(
+                        !looks_like_path(program),
+                        format!(
+                            "runtime command program {program:?} has `system = true` but is a path; \
+                             a system dependency must be a bare program name resolved on PATH (like \"uv\" or \"python3\")"
+                        ),
+                    );
+                } else {
+                    check(
+                        looks_like_path(program) && !std::path::Path::new(program).is_absolute(),
+                        format!(
+                            "runtime command program {program:?} must be a plugin-relative path \
+                             (containing a separator, like \".venv/bin/worker\"); set `system = true` \
+                             to depend on a program from the host PATH instead"
+                        ),
+                    );
+                }
+            }
             for (i, step) in build.iter().enumerate() {
                 check(
                     !step.command.is_empty(),

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -164,6 +164,17 @@ pub enum RuntimeSpec {
     Command {
         /// argv; the first element is the program, the rest its arguments.
         command: Vec<String>,
+        /// Ordered build steps the host runs once at install and update,
+        /// inside the installed plugin directory, before the plugin is
+        /// registered (e.g. create a venv, `pip install`, `npm ci`). They run
+        /// in the user's interactive shell at install time, where PATH is
+        /// reliable, so an interpreted worker can produce a self-contained
+        /// in-tree environment and then launch via a plugin-relative
+        /// `command`, never depending on the daemon's PATH. Builds run in the
+        /// final directory, not a staging tree, because tools like Python
+        /// venvs embed absolute paths and are not relocatable.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        build: Vec<BuildStep>,
     },
     /// A worker binary downloaded from the source repo's GitHub release assets.
     /// Installation resolves the asset for the host platform, downloads it, and
@@ -178,6 +189,27 @@ pub enum RuntimeSpec {
         bin: Option<String>,
     },
 }
+
+/// One install/update build command for a `command` runtime.
+///
+/// `command` is argv (program then arguments), resolved with the same policy
+/// as the launch `command`: a bare name on the install-time PATH, a
+/// separator-bearing path relative to the plugin directory, an absolute path
+/// rejected. `platforms`, when non-empty, restricts the step to host OSes
+/// matching `std::env::consts::OS` (`linux`, `macos`, `windows`); an empty
+/// `platforms` runs on every platform.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildStep {
+    pub command: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub platforms: Vec<String>,
+}
+
+/// Host OS names a build step's `platforms` may name. These match
+/// `std::env::consts::OS`; a typo is rejected at parse rather than silently
+/// skipping the step on every platform.
+const KNOWN_PLATFORMS: [&str; 3] = ["linux", "macos", "windows"];
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -257,7 +289,7 @@ impl PluginManifest {
         check(!self.version.is_empty(), "version must not be empty".into());
         check(!self.name.is_empty(), "name must not be empty".into());
 
-        if let Some(RuntimeSpec::Command { command }) = &self.runtime {
+        if let Some(RuntimeSpec::Command { command, build }) = &self.runtime {
             check(
                 !command.is_empty(),
                 "runtime command must not be empty".into(),
@@ -266,6 +298,24 @@ impl PluginManifest {
                 command.iter().all(|arg| !arg.is_empty()),
                 "runtime command must not contain empty arguments".into(),
             );
+            for (i, step) in build.iter().enumerate() {
+                check(
+                    !step.command.is_empty(),
+                    format!("runtime.build[{i}].command must not be empty"),
+                );
+                check(
+                    step.command.iter().all(|arg| !arg.is_empty()),
+                    format!("runtime.build[{i}].command must not contain empty arguments"),
+                );
+                for p in &step.platforms {
+                    check(
+                        KNOWN_PLATFORMS.contains(&p.as_str()),
+                        format!(
+                            "runtime.build[{i}].platforms contains unknown platform {p:?}; expected one of linux, macos, windows"
+                        ),
+                    );
+                }
+            }
         }
         if let Some(RuntimeSpec::ReleaseBinary { asset, bin }) = &self.runtime {
             check(

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -302,9 +302,80 @@ command = ["python3", "worker.py"]
 "#;
     let m = PluginManifest::from_toml_str(toml).expect("runtime command parses");
     match m.runtime.expect("has runtime") {
-        RuntimeSpec::Command { command } => assert_eq!(command, ["python3", "worker.py"]),
+        RuntimeSpec::Command { command, build } => {
+            assert_eq!(command, ["python3", "worker.py"]);
+            assert!(build.is_empty());
+        }
         other => panic!("expected command runtime, got {other:?}"),
     }
+}
+
+#[test]
+fn runtime_command_build_steps_parse() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = [".venv/bin/worker"]
+
+[[runtime.build]]
+command = ["python3", "-m", "venv", ".venv"]
+
+[[runtime.build]]
+command = [".venv/bin/pip", "install", "."]
+platforms = ["linux", "macos"]
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("build steps parse");
+    match m.runtime.expect("has runtime") {
+        RuntimeSpec::Command { command, build } => {
+            assert_eq!(command, [".venv/bin/worker"]);
+            assert_eq!(build.len(), 2);
+            assert_eq!(build[0].command, ["python3", "-m", "venv", ".venv"]);
+            assert!(build[0].platforms.is_empty());
+            assert_eq!(build[1].command, [".venv/bin/pip", "install", "."]);
+            assert_eq!(build[1].platforms, ["linux", "macos"]);
+        }
+        other => panic!("expected command runtime, got {other:?}"),
+    }
+}
+
+#[test]
+fn build_step_empty_command_and_unknown_platform_rejected() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = [".venv/bin/worker"]
+
+[[runtime.build]]
+command = [""]
+platforms = ["linux", "plan9"]
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    let messages = match err {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("runtime.build[0].command")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("runtime.build[0].platforms") && m.contains("plan9")),
+        "{messages:?}"
+    );
 }
 
 #[test]

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -299,11 +299,17 @@ api_version = 2
 [runtime]
 kind = "command"
 command = ["python3", "worker.py"]
+system = true
 "#;
     let m = PluginManifest::from_toml_str(toml).expect("runtime command parses");
     match m.runtime.expect("has runtime") {
-        RuntimeSpec::Command { command, build } => {
+        RuntimeSpec::Command {
+            command,
+            system,
+            build,
+        } => {
             assert_eq!(command, ["python3", "worker.py"]);
+            assert!(system);
             assert!(build.is_empty());
         }
         other => panic!("expected command runtime, got {other:?}"),
@@ -331,8 +337,13 @@ platforms = ["linux", "macos"]
 "#;
     let m = PluginManifest::from_toml_str(toml).expect("build steps parse");
     match m.runtime.expect("has runtime") {
-        RuntimeSpec::Command { command, build } => {
+        RuntimeSpec::Command {
+            command,
+            system,
+            build,
+        } => {
             assert_eq!(command, [".venv/bin/worker"]);
+            assert!(!system);
             assert_eq!(build.len(), 2);
             assert_eq!(build[0].command, ["python3", "-m", "venv", ".venv"]);
             assert!(build[0].platforms.is_empty());
@@ -376,6 +387,72 @@ platforms = ["linux", "plan9"]
             .any(|m| m.contains("runtime.build[0].platforms") && m.contains("plan9")),
         "{messages:?}"
     );
+}
+
+/// The worker entrypoint must be plugin-relative by default; a bare program
+/// name is rejected unless the manifest opts into a PATH dependency with
+/// `system = true`.
+#[test]
+fn bare_worker_program_requires_system_opt_in() {
+    let manifest = |line: &str| {
+        format!(
+            r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+{line}
+"#
+        )
+    };
+
+    // Bare name, no opt-in: rejected, and the message points at the fix.
+    let err = PluginManifest::from_toml_str(&manifest("command = [\"worker\"]")).unwrap_err();
+    match err {
+        ManifestError::Invalid(messages) => assert!(
+            messages
+                .iter()
+                .any(|m| m.contains("plugin-relative") && m.contains("system = true")),
+            "{messages:?}"
+        ),
+        other => panic!("expected Invalid, got {other:?}"),
+    }
+
+    // Same bare name with the opt-in parses.
+    PluginManifest::from_toml_str(&manifest(
+        "command = [\"uv\", \"run\", \"worker\"]\nsystem = true",
+    ))
+    .expect("system opt-in accepts a bare program name");
+
+    // A plugin-relative path is the default-accepted shape.
+    PluginManifest::from_toml_str(&manifest("command = [\".venv/bin/worker\"]"))
+        .expect("plugin-relative entrypoint accepted without opt-in");
+
+    // An absolute path pins a host path and is rejected in both modes.
+    let abs = if cfg!(windows) {
+        "C:/tools/worker.exe"
+    } else {
+        "/usr/bin/worker"
+    };
+    assert!(matches!(
+        PluginManifest::from_toml_str(&manifest(&format!("command = [\"{abs}\"]"))).unwrap_err(),
+        ManifestError::Invalid(_)
+    ));
+
+    // `system = true` with a path is contradictory and rejected.
+    let err =
+        PluginManifest::from_toml_str(&manifest("command = [\".venv/bin/worker\"]\nsystem = true"))
+            .unwrap_err();
+    match err {
+        ManifestError::Invalid(messages) => assert!(
+            messages.iter().any(|m| m.contains("system = true")),
+            "{messages:?}"
+        ),
+        other => panic!("expected Invalid, got {other:?}"),
+    }
 }
 
 #[test]

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -146,10 +146,12 @@ command = [".venv/bin/pip", "install", "."]
 platforms = ["linux", "macos"]              # optional; omitted runs everywhere
 ```
 
-Each step's argv resolves with the same policy as the launch `command` (bare
-name on PATH, separator path relative to the plugin dir, absolute rejected),
-evaluated just before the step runs so `.venv/bin/pip` resolves once the prior
-step created it. A step's optional `platforms` (`linux` / `macos` / `windows`)
+Each step's argv resolves through the host's argv resolver (bare name on PATH,
+separator path relative to the plugin dir, absolute rejected), evaluated just
+before the step runs so `.venv/bin/pip` resolves once the prior step created it.
+Build steps are free to name bare PATH programs (`python3`, `node`, `uv`): they
+run in the user's interactive shell where PATH is reliable, which is exactly why
+the worker entrypoint, launched later by the daemon, is not. A step's optional `platforms` (`linux` / `macos` / `windows`)
 restricts it to matching hosts. Builds run with cwd set to the plugin dir, with
 stdin closed and stdout/stderr inherited so the user sees progress.
 
@@ -162,11 +164,31 @@ a staging tree that is then renamed. A failed build aborts the install with no
 trace; a failed update restores the prior version from a backup, and a leftover
 backup from an interrupted update is recovered on the next install/update.
 
-A worker whose env it manages itself, for example `command = ["uv", "run",
-"worker"]`, needs no build step, but then depends on that one system tool
-(`uv`) being on the daemon's PATH. That is the author's call: depending on a
-system toolchain is fine, but a plugin's own entrypoint should be
-plugin-relative so it is never subject to the daemon's PATH.
+The worker entrypoint (`command`'s `argv[0]`) must be plugin-relative: a path
+containing a separator (`.venv/bin/worker`), resolved inside the install
+directory. The host enforces this at manifest validation, so the
+PATH-independent shape is the default and a bare program name is rejected rather
+than silently resolved against whatever PATH the daemon happens to have. An
+absolute path is rejected in every mode (it pins a host path).
+
+A worker that genuinely depends on a system tool, for example `command = ["uv",
+"run", "worker"]`, opts into that PATH dependency explicitly with `system =
+true`:
+
+```toml
+[runtime]
+kind = "command"
+command = ["uv", "run", "worker"]
+system = true   # argv[0] is a bare PATH program, resolved at launch
+```
+
+`system = true` requires a bare program name (a path is contradictory and
+rejected) and moves resolution to launch time against the daemon's PATH. It is
+the conscious "I accept the daemon must have this tool" choice, not a fallback a
+manifest falls into by naming a program that happens not to be on PATH. Because
+its program is resolved at launch, a `system` worker is also not PATH-checked at
+install (the install shell's PATH is not the daemon's), so it installs even when
+the tool is absent from the install environment.
 
 Two trust notes for build steps. They run as the user, unsandboxed, before any
 capability gate (the same honest D8 model as the worker, just earlier), so a

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -127,6 +127,56 @@ plugin directory) or `release-binary` (a compiled worker shipped as a GitHub
 release asset). Installation resolves and downloads a `release-binary` asset;
 the Tier 1 host (below) launches and supervises both kinds.
 
+A `command` runtime may declare ordered `[[runtime.build]]` steps, run once at
+install and update inside the installed plugin directory before the plugin is
+registered. This is how an interpreted worker sets itself up (create a venv,
+`pip install`, `npm ci`), so it can then launch via a plugin-relative
+`command` that never depends on the daemon's PATH:
+
+```toml
+[runtime]
+kind = "command"
+command = [".venv/bin/aoe-github-worker"]   # plugin-relative: PATH-independent
+
+[[runtime.build]]
+command = ["python3", "-m", "venv", ".venv"]
+
+[[runtime.build]]
+command = [".venv/bin/pip", "install", "."]
+platforms = ["linux", "macos"]              # optional; omitted runs everywhere
+```
+
+Each step's argv resolves with the same policy as the launch `command` (bare
+name on PATH, separator path relative to the plugin dir, absolute rejected),
+evaluated just before the step runs so `.venv/bin/pip` resolves once the prior
+step created it. A step's optional `platforms` (`linux` / `macos` / `windows`)
+restricts it to matching hosts. Builds run with cwd set to the plugin dir, with
+stdin closed and stdout/stderr inherited so the user sees progress.
+
+Why install time and the final dir, not launch or staging: `aoe plugin
+install` runs in the user's interactive shell, where `python3` / `node` / `uv`
+are reliably on PATH; the daemon that later launches the worker is not. And a
+Python venv is not relocatable (console-script shebangs and `pyvenv.cfg` embed
+absolute paths), so the build runs in the final `<plugins_dir>/<id>`, never in
+a staging tree that is then renamed. A failed build aborts the install with no
+trace; a failed update restores the prior version from a backup, and a leftover
+backup from an interrupted update is recovered on the next install/update.
+
+A worker whose env it manages itself, for example `command = ["uv", "run",
+"worker"]`, needs no build step, but then depends on that one system tool
+(`uv`) being on the daemon's PATH. That is the author's call: depending on a
+system toolchain is fine, but a plugin's own entrypoint should be
+plugin-relative so it is never subject to the daemon's PATH.
+
+Two trust notes for build steps. They run as the user, unsandboxed, before any
+capability gate (the same honest D8 model as the worker, just earlier), so a
+plugin with build steps always prompts at install, even when it requests no
+capabilities, and discloses the commands verbatim; `--yes` consents to both.
+And a build that runs `pip install` pulls dependency bytes the source tree hash
+does not attest; a featured plugin should pin them (for example a hash-locked
+`requirements.txt`). First-class dependency and release-binary attestation are
+deferred.
+
 ## Capabilities and grants (#2093)
 
 Static contributions are not capabilities; a theme or a command needs no
@@ -305,11 +355,13 @@ args, cwd, env }`, dispatched off the `[runtime]` kind in a single `match`.
 Adding a new runtime kind later is a new arm there; the supervisor and the
 transport only ever see a `ResolvedLaunch`, so nothing downstream changes.
 
-- `command`: `argv[0]` resolves on `PATH` via `which` when it is a bare name (a
-  console-script entrypoint like `aoe-github-worker`, or an interpreter like
-  `python3`), or relative to the plugin directory when it contains a separator
-  (an in-tree script or binary), verified executable. Absolute and
-  parent-traversal paths are rejected.
+- `command`: `argv[0]` resolves on `PATH` via `which` when it is a bare name (an
+  interpreter or system tool like `python3` / `uv`), or relative to the plugin
+  directory when it contains a separator (an in-tree script or binary, for
+  example a build-produced `.venv/bin/worker`), verified executable. Absolute
+  and parent-traversal paths are rejected. The same policy resolves each
+  `[[runtime.build]]` step at install time; a plugin's own entrypoint should be
+  plugin-relative so the daemon's PATH never decides whether it launches.
 - `release-binary`: the per-platform binary that installation already placed in
   the plugin directory.
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -438,7 +438,10 @@ fn run_build(plugin_id: &str, dir: &Path, steps: &[BuildStep]) -> Result<()> {
 /// success drop the backup, on failure restore it so the user is never left
 /// worse off than before the update.
 fn replace_and_build(plugin_id: &str, fetched: &FetchedPlugin, final_dir: &Path) -> Result<()> {
-    let backup_dir = final_dir.with_extension("bak");
+    // `with_file_name`, not `with_extension`: a plugin id like `acme.worker`
+    // has a dot, and `with_extension("bak")` would replace `.worker`, yielding
+    // `acme.bak` and colliding with every other `acme.*` plugin's backup.
+    let backup_dir = final_dir.with_file_name(format!("{plugin_id}.bak"));
 
     if backup_dir.exists() {
         if final_dir.exists() {

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -141,40 +141,56 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     let new_caps: BTreeSet<&str> = capabilities.iter().map(String::as_str).collect();
     let caps_changed = prior_caps != new_caps;
 
+    // Build steps run unsandboxed at update time, so a changed build recipe
+    // must re-prompt even when the capability set is unchanged; a static
+    // capability list must not let modified build commands run unattended. The
+    // manifest hash covers the build steps, so a hash change with build steps
+    // present means the recipe could have changed.
+    let manifest_changed =
+        prior_grant.as_ref().map(|g| g.manifest_hash.as_str()) != Some(manifest_hash.as_str());
+    let build_changed = manifest_changed && !build_steps(&fetched.manifest).is_empty();
+    // Prompt when there is something to consent to: capabilities that changed,
+    // or build steps that could have changed. Dropping all capabilities with no
+    // build steps has nothing to grant, so it still (re)grants silently.
+    let needs_prompt = (!capabilities.is_empty() && caps_changed) || build_changed;
+
     // Decide the grant BEFORE touching the installed tree, so a declined or
     // non-interactive prompt bails while the old install, config, and lockfile
-    // are still consistent. An empty capability set always (re)grants, so an
-    // update that drops all capabilities reactivates the plugin even if it was
-    // previously left ungranted.
-    let grant = if capabilities.is_empty() {
+    // are still consistent.
+    let grant = if needs_prompt {
+        if confirm_capabilities(id, &capabilities, build_steps(&fetched.manifest))? {
+            Some(CapabilityGrant {
+                manifest_hash: manifest_hash.clone(),
+                capabilities: capabilities.clone(),
+                granted_at: chrono::Utc::now(),
+            })
+        } else {
+            None
+        }
+    } else if capabilities.is_empty() {
+        // Nothing to grant; an empty capability set keeps the plugin active.
         Some(CapabilityGrant {
             manifest_hash: manifest_hash.clone(),
             capabilities: vec![],
             granted_at: chrono::Utc::now(),
         })
-    } else if !caps_changed {
+    } else {
+        // Capabilities unchanged and the build recipe (if any) unchanged: carry
+        // the prior grant forward, refreshed to the new manifest hash.
         prior_grant.map(|g| CapabilityGrant {
             manifest_hash: manifest_hash.clone(),
             capabilities: g.capabilities,
             granted_at: g.granted_at,
         })
-    } else if confirm_capabilities(id, &capabilities, build_steps(&fetched.manifest))? {
-        Some(CapabilityGrant {
-            manifest_hash: manifest_hash.clone(),
-            capabilities: capabilities.clone(),
-            granted_at: chrono::Utc::now(),
-        })
-    } else {
-        None
     };
 
     let final_dir = super::plugins_dir()?.join(id);
-    // A declined re-approval must not run the plugin's build steps (arbitrary
-    // code the user just refused). With no build steps the tree is still
-    // updated and left inactive (the prior behavior); with build steps a
-    // decline aborts the update, leaving the prior version untouched.
-    if grant.is_none() && caps_changed && !build_steps(&fetched.manifest).is_empty() {
-        bail!("update cancelled for {id}; its build steps were not approved, prior version kept");
+    // A declined prompt must not run the plugin's build steps (arbitrary code
+    // the user just refused): abort and keep the prior version. A capabilities
+    // decline with no build steps keeps the prior behavior (tree updated, left
+    // inactive until re-approved).
+    if needs_prompt && grant.is_none() && !build_steps(&fetched.manifest).is_empty() {
+        bail!("update cancelled for {id}; build steps were not approved, prior version kept");
     }
     replace_and_build(id, &fetched, &final_dir)?;
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -2,9 +2,11 @@
 
 use std::collections::BTreeSet;
 use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+use std::process::Stdio;
 
 use anyhow::{anyhow, bail, Context, Result};
-use aoe_plugin_api::{PluginManifest, RuntimeSpec};
+use aoe_plugin_api::{BuildStep, PluginManifest, RuntimeSpec};
 
 use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
 
@@ -62,16 +64,28 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     }
 
     let capabilities = capability_strings(&fetched)?;
-    let granted = if capabilities.is_empty() || assume_yes {
+    let build = build_steps(&fetched.manifest);
+    // A build step runs arbitrary, unsandboxed code as the user at install
+    // time, so it requires the same explicit consent as a capability even when
+    // the plugin requests no capabilities at all (where install would
+    // otherwise auto-grant silently).
+    let granted = if assume_yes || (capabilities.is_empty() && build.is_empty()) {
         true
     } else {
-        confirm_capabilities(&id, &capabilities)?
+        confirm_capabilities(&id, &capabilities, build)?
     };
     if !granted {
         bail!("install cancelled; no capabilities were granted");
     }
 
     move_into_place(&fetched, &final_dir)?;
+    if let Err(e) = build_in_place(&id, &final_dir, &fetched.manifest) {
+        // A failed build must not leave a half-installed tree behind; nothing
+        // is persisted to config or the lockfile, so removing the directory
+        // returns the host to its pre-install state.
+        let _ = std::fs::remove_dir_all(&final_dir);
+        return Err(e);
+    }
 
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
     persist_install(
@@ -144,7 +158,7 @@ pub async fn update(id: &str) -> Result<InstallReport> {
             capabilities: g.capabilities,
             granted_at: g.granted_at,
         })
-    } else if confirm_capabilities(id, &capabilities)? {
+    } else if confirm_capabilities(id, &capabilities, build_steps(&fetched.manifest))? {
         Some(CapabilityGrant {
             manifest_hash: manifest_hash.clone(),
             capabilities: capabilities.clone(),
@@ -155,7 +169,14 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     };
 
     let final_dir = super::plugins_dir()?.join(id);
-    move_into_place(&fetched, &final_dir)?;
+    // A declined re-approval must not run the plugin's build steps (arbitrary
+    // code the user just refused). With no build steps the tree is still
+    // updated and left inactive (the prior behavior); with build steps a
+    // decline aborts the update, leaving the prior version untouched.
+    if grant.is_none() && caps_changed && !build_steps(&fetched.manifest).is_empty() {
+        bail!("update cancelled for {id}; its build steps were not approved, prior version kept");
+    }
+    replace_and_build(id, &fetched, &final_dir)?;
 
     let granted = grant.is_some();
     persist_update(id, &source_str, grant)?;
@@ -276,27 +297,44 @@ fn capability_strings(fetched: &FetchedPlugin) -> Result<Vec<String>> {
         .collect())
 }
 
-/// Prompt the user to grant a plugin's capabilities. Fails on a non-interactive
-/// stdin rather than silently granting; the caller can pass `--yes` there.
-fn confirm_capabilities(id: &str, capabilities: &[String]) -> Result<bool> {
+/// Prompt the user to grant a plugin's capabilities and run any build steps.
+/// Fails on a non-interactive stdin rather than silently granting; the caller
+/// can pass `--yes` there. Build steps are disclosed verbatim because they run
+/// as the user, outside capability enforcement, before the plugin is
+/// registered.
+fn confirm_capabilities(id: &str, capabilities: &[String], build: &[BuildStep]) -> Result<bool> {
     if !io::stdin().is_terminal() {
         bail!(
-            "{id} requests capabilities [{}] but stdin is not a terminal; re-run with --yes to grant them",
-            capabilities.join(", ")
+            "{id} requests capabilities [{}]{} but stdin is not a terminal; re-run with --yes to grant them",
+            capabilities.join(", "),
+            if build.is_empty() { "" } else { " and declares build steps" },
         );
     }
-    println!("Plugin {id} requests these capabilities:");
-    for capability in capabilities {
-        println!("  - {capability}");
+    if !capabilities.is_empty() {
+        println!("Plugin {id} requests these capabilities:");
+        for capability in capabilities {
+            println!("  - {capability}");
+        }
+    }
+    if !build.is_empty() {
+        println!(
+            "Plugin {id} will run these build commands now, in its install directory,\n\
+             as your user and outside capability enforcement:"
+        );
+        for step in build {
+            println!("  $ {}", step.command.join(" "));
+        }
     }
     // The honest model (D8): the host enforces these capabilities at its API
     // boundary, which stops a cooperative plugin from overreaching. It does NOT
     // contain an adversarial plugin: a granted worker runs as an ordinary
-    // process with no OS-level isolation. State this on every grant prompt.
+    // process with no OS-level isolation. Build steps run with the same trust,
+    // earlier. State this on every grant prompt.
     println!(
-        "Note: granting a capability trusts this plugin. The host checks capabilities at its API\n\
-         boundary, but a plugin worker runs without OS-level sandboxing, so a malicious plugin is\n\
-         not contained. Only install plugins you trust."
+        "Note: installing trusts this plugin. The host checks capabilities at its API boundary,\n\
+         but a plugin worker (and any build step) runs without OS-level sandboxing, so a malicious\n\
+         plugin is not contained. Build steps run as your user before any capability gate. Only\n\
+         install plugins you trust."
     );
     print!("Grant them and install? [y/N] ");
     io::stdout().flush()?;
@@ -322,6 +360,125 @@ fn move_into_place(fetched: &FetchedPlugin, final_dir: &std::path::Path) -> Resu
             final_dir.display()
         )
     })
+}
+
+/// The build steps a `command` runtime declares, or an empty slice for any
+/// other (or absent) runtime.
+fn build_steps(manifest: &PluginManifest) -> &[BuildStep] {
+    match &manifest.runtime {
+        Some(RuntimeSpec::Command { build, .. }) => build,
+        _ => &[],
+    }
+}
+
+/// Run a plugin's declared build steps in its final directory, then confirm the
+/// worker entrypoint is runnable. Builds run in the final directory (not the
+/// staging tree) because tools like Python venvs embed absolute paths and are
+/// not relocatable, so a build followed by a rename would break the worker.
+fn build_in_place(plugin_id: &str, dir: &Path, manifest: &PluginManifest) -> Result<()> {
+    run_build(plugin_id, dir, build_steps(manifest))?;
+    // A build can succeed by exit code yet not produce the entrypoint (every
+    // step skipped on this platform, or a no-op build against a broken
+    // project). Resolve the launch command now, while the user is watching, so
+    // the failure is a clear install error instead of an opaque launch error
+    // the next time the daemon starts.
+    if let Some(RuntimeSpec::Command { command, .. }) = &manifest.runtime {
+        super::launch::resolve_command(plugin_id, dir, command, &super::launch::OsLaunchResolver)
+            .with_context(|| {
+            format!(
+                "plugin {plugin_id}: worker command is not runnable after install \
+                     (a build step may have been skipped on this platform, or did not produce it)"
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Execute build steps sequentially in `dir`. Each step's argv is resolved with
+/// the same policy as the launch command, immediately before it runs, so a step
+/// like `.venv/bin/pip` resolves once the prior step created it. Build stdin is
+/// `/dev/null` so an interactive prompt cannot hang a `--yes` install; stdout
+/// and stderr inherit the terminal so the user sees build progress.
+fn run_build(plugin_id: &str, dir: &Path, steps: &[BuildStep]) -> Result<()> {
+    let os = std::env::consts::OS;
+    for (i, step) in steps.iter().enumerate() {
+        if !step.platforms.is_empty() && !step.platforms.iter().any(|p| p == os) {
+            continue;
+        }
+        let pretty = step.command.join(" ");
+        let (program, args) = super::launch::resolve_command(
+            plugin_id,
+            dir,
+            &step.command,
+            &super::launch::OsLaunchResolver,
+        )
+        .with_context(|| format!("resolving build step {} ({pretty})", i + 1))?;
+        eprintln!("  building {plugin_id}: {pretty}");
+        let status = std::process::Command::new(&program)
+            .args(&args)
+            .current_dir(dir)
+            .env("AOE_PLUGIN_ID", plugin_id)
+            .stdin(Stdio::null())
+            .status()
+            .with_context(|| format!("spawning build step {} ({pretty})", i + 1))?;
+        if !status.success() {
+            bail!("build step {} ({pretty}) failed with {status}", i + 1);
+        }
+    }
+    Ok(())
+}
+
+/// Replace an installed plugin's directory with a freshly fetched tree and run
+/// its build, keeping the prior version intact if the build fails.
+///
+/// A leftover `<id>.bak` means a previous update was interrupted between
+/// exposing the new tree and finishing the build, leaving a possibly half-built
+/// `<id>`; the backup is the last known-good version, so recover it first.
+/// Then move the current install aside, place the new tree, and build: on
+/// success drop the backup, on failure restore it so the user is never left
+/// worse off than before the update.
+fn replace_and_build(plugin_id: &str, fetched: &FetchedPlugin, final_dir: &Path) -> Result<()> {
+    let backup_dir = final_dir.with_extension("bak");
+
+    if backup_dir.exists() {
+        if final_dir.exists() {
+            let _ = std::fs::remove_dir_all(final_dir);
+        }
+        std::fs::rename(&backup_dir, final_dir)
+            .with_context(|| format!("recovering interrupted update backup for {plugin_id}"))?;
+    }
+
+    let had_prior = final_dir.exists();
+    if had_prior {
+        std::fs::rename(final_dir, &backup_dir)
+            .with_context(|| format!("backing up current {plugin_id} before update"))?;
+    }
+
+    let place_and_build = (|| -> Result<()> {
+        std::fs::rename(&fetched.tree, final_dir).with_context(|| {
+            format!(
+                "moving plugin into {} (cross-device staging?)",
+                final_dir.display()
+            )
+        })?;
+        build_in_place(plugin_id, final_dir, &fetched.manifest)
+    })();
+
+    match place_and_build {
+        Ok(()) => {
+            if had_prior {
+                let _ = std::fs::remove_dir_all(&backup_dir);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(final_dir);
+            if had_prior {
+                let _ = std::fs::rename(&backup_dir, final_dir);
+            }
+            Err(e)
+        }
+    }
 }
 
 /// The source string to persist for a later `update`. A GitHub source keeps the

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -398,7 +398,18 @@ fn build_in_place(plugin_id: &str, dir: &Path, manifest: &PluginManifest) -> Res
     // project). Resolve the launch command now, while the user is watching, so
     // the failure is a clear install error instead of an opaque launch error
     // the next time the daemon starts.
-    if let Some(RuntimeSpec::Command { command, .. }) = &manifest.runtime {
+    //
+    // Only for an in-tree entrypoint. A `system = true` worker resolves its
+    // program on PATH, and the install shell's PATH is not the daemon's PATH:
+    // checking it here neither guarantees the daemon can launch the worker nor
+    // should it reject a valid system-tool plugin whose tool is simply absent
+    // from the install shell. Leave that entrypoint to resolve at launch.
+    if let Some(RuntimeSpec::Command {
+        command,
+        system: false,
+        ..
+    }) = &manifest.runtime
+    {
         super::launch::resolve_command(plugin_id, dir, command, &super::launch::OsLaunchResolver)
             .with_context(|| {
             format!(

--- a/src/plugin/launch.rs
+++ b/src/plugin/launch.rs
@@ -354,7 +354,7 @@ capabilities = ["runtime.worker"]
     #[test]
     fn command_bare_name_resolves_on_path() {
         let p = plugin(
-            Some("[runtime]\nkind = \"command\"\ncommand = [\"python3\", \"-m\", \"acme.main\"]"),
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"python3\", \"-m\", \"acme.main\"]\nsystem = true"),
             Some("/plugins/acme.worker"),
         );
         let resolver = FakeResolver::new().on_path("python3", "/usr/bin/python3");
@@ -371,7 +371,7 @@ capabilities = ["runtime.worker"]
     #[test]
     fn command_console_script_missing_on_path_fails_loudly() {
         let p = plugin(
-            Some("[runtime]\nkind = \"command\"\ncommand = [\"aoe-github-worker\"]"),
+            Some("[runtime]\nkind = \"command\"\ncommand = [\"aoe-github-worker\"]\nsystem = true"),
             Some("/plugins/acme.worker"),
         );
         let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
@@ -417,13 +417,16 @@ capabilities = ["runtime.worker"]
         } else {
             "/usr/bin/python3"
         };
-        let p = plugin(
-            Some(&format!(
-                "[runtime]\nkind = \"command\"\ncommand = [\"{argv0}\"]"
-            )),
-            Some("/plugins/acme.worker"),
-        );
-        let err = resolve_launch(&p, &FakeResolver::new()).unwrap_err();
+        // An absolute argv[0] never survives manifest validation, so exercise
+        // the resolver directly: it still guards build-step argv, which is not
+        // shape-validated up front.
+        let err = resolve_command(
+            "acme.worker",
+            Path::new("/plugins/acme.worker"),
+            &[argv0.to_string()],
+            &FakeResolver::new(),
+        )
+        .unwrap_err();
         assert!(matches!(err, LaunchError::AbsoluteArgv0 { .. }));
     }
 

--- a/src/plugin/launch.rs
+++ b/src/plugin/launch.rs
@@ -157,7 +157,9 @@ pub fn resolve_launch(
         })?;
 
     let (program, args) = match runtime {
-        RuntimeSpec::Command { command } => resolve_command(&plugin_id, dir, command, resolver)?,
+        RuntimeSpec::Command { command, .. } => {
+            resolve_command(&plugin_id, dir, command, resolver)?
+        }
         RuntimeSpec::ReleaseBinary { asset, bin } => {
             let target = bin.as_deref().unwrap_or(asset.as_str());
             let path = resolve_in_tree(&plugin_id, dir, target, resolver, |path| {
@@ -189,7 +191,12 @@ pub fn resolve_launch(
 /// breaks portability); a path containing a separator is resolved relative to
 /// the plugin directory and verified executable; a bare name is resolved on
 /// `PATH` via `which` (the console-script / interpreter case).
-fn resolve_command(
+///
+/// Shared with the install-time build runner (`crate::plugin::install`): a
+/// build step's argv is resolved with the exact same policy, against the same
+/// plugin directory, so a step like `.venv/bin/pip` resolves once the prior
+/// step created it.
+pub(crate) fn resolve_command(
     plugin_id: &str,
     dir: &Path,
     command: &[String],

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -24,11 +24,15 @@ pub mod host;
 #[cfg(feature = "serve")]
 pub mod host_api;
 #[cfg(feature = "serve")]
-pub mod launch;
-#[cfg(feature = "serve")]
 pub mod protocol;
 #[cfg(feature = "serve")]
 pub mod sandbox;
+
+// Launch resolution is pure (PATH / filesystem probing) and is shared by the
+// serve-only host and the always-present installer, which runs a plugin's
+// build steps with the same argv-resolution policy. It carries no host state,
+// so it is not gated.
+pub mod launch;
 
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -412,3 +412,191 @@ asset = "bin-${os}-${arch}"
     std::env::remove_var("AOE_UPDATE_API_BASE");
     server.abort();
 }
+
+/// Build steps run in the FINAL installed directory (not the staging tree that
+/// is renamed away), so a build artifact lands at `<plugins_dir>/<id>`. Uses a
+/// bare `sh` launch command (resolves on PATH) so install's post-build
+/// entrypoint check passes without the build having to produce an executable.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn build_step_runs_in_final_dir() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.built"
+name = "Built"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["cp", "aoe-plugin.toml", "build-marker"]
+"#,
+    );
+
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.built");
+    assert!(
+        installed.join("build-marker").exists(),
+        "build step ran with cwd = the final plugin dir"
+    );
+}
+
+/// A build step whose `platforms` excludes the host OS is skipped, so its
+/// artifact is never produced and install still succeeds.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn build_step_skipped_on_non_matching_platform() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.skip"
+name = "Skip"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["cp", "aoe-plugin.toml", "should-not-exist"]
+platforms = ["windows"]
+"#,
+    );
+
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.skip");
+    assert!(
+        installed.exists(),
+        "install succeeds with all steps skipped"
+    );
+    assert!(
+        !installed.join("should-not-exist").exists(),
+        "a platform-mismatched build step does not run"
+    );
+}
+
+/// A failing build aborts the install and leaves no trace: no installed
+/// directory, no registry entry, no lockfile entry.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn failed_build_aborts_install_and_cleans_up() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.failbuild"
+name = "FailBuild"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["false"]
+"#,
+    );
+
+    let err = install::install(dir.to_str().unwrap(), true)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("build step"), "got: {err}");
+
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.failbuild");
+    assert!(!installed.exists(), "no half-installed dir left behind");
+    assert!(load_registry().get("acme.failbuild").is_none());
+    assert!(Lockfile::load().unwrap().get("acme.failbuild").is_none());
+}
+
+/// A failing build during update restores the previously installed version
+/// instead of leaving the user with a broken plugin.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn failed_update_build_restores_prior_version() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+
+    // v1 installs cleanly and produces a build artifact.
+    write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.upd"
+name = "Upd"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["cp", "aoe-plugin.toml", "v1-marker"]
+"#,
+    );
+    let dir = src.path().join("src-plugin");
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.upd");
+    assert!(installed.join("v1-marker").exists());
+
+    // v2 at the same source now has a failing build.
+    std::fs::write(
+        dir.join("aoe-plugin.toml"),
+        r#"
+id = "acme.upd"
+name = "Upd"
+version = "0.2.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["false"]
+"#,
+    )
+    .unwrap();
+
+    let err = install::update("acme.upd").await.unwrap_err().to_string();
+    assert!(err.contains("build step"), "got: {err}");
+
+    // The prior install is intact: directory, artifact, and recorded version.
+    assert!(
+        installed.join("v1-marker").exists(),
+        "v1 build artifact restored after failed update"
+    );
+    assert!(load_registry().get("acme.upd").is_some());
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "0.1.0",
+        "lockfile still records the working version"
+    );
+    // No leftover backup directory from the failed update.
+    assert!(!installed.with_extension("bak").exists());
+}

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -598,5 +598,5 @@ command = ["false"]
         "lockfile still records the working version"
     );
     // No leftover backup directory from the failed update.
-    assert!(!installed.with_extension("bak").exists());
+    assert!(!installed.with_file_name("acme.upd.bak").exists());
 }

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -434,6 +434,7 @@ api_version = 2
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["cp", "aoe-plugin.toml", "build-marker"]
@@ -470,6 +471,7 @@ api_version = 2
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["cp", "aoe-plugin.toml", "should-not-exist"]
@@ -492,6 +494,42 @@ platforms = ["windows"]
     );
 }
 
+/// A `system = true` worker resolves its program on PATH at launch, not at
+/// install. Install must not gate on the install shell's PATH (which is not the
+/// daemon's PATH), so a system-tool entrypoint absent from the install
+/// environment still installs and is left to resolve at launch.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn system_worker_absent_from_install_path_still_installs() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.systool"
+name = "SysTool"
+version = "0.1.0"
+api_version = 2
+
+[runtime]
+kind = "command"
+command = ["aoe-definitely-not-on-path-xyz", "run", "worker"]
+system = true
+"#,
+    );
+
+    install::install(dir.to_str().unwrap(), true)
+        .await
+        .expect("system-tool worker installs without an install-time PATH check");
+
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.systool");
+    assert!(installed.exists(), "plugin dir is in place");
+    assert!(load_registry().get("acme.systool").is_some());
+}
+
 /// A failing build aborts the install and leaves no trace: no installed
 /// directory, no registry entry, no lockfile entry.
 #[cfg(unix)]
@@ -511,6 +549,7 @@ api_version = 2
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["false"]
@@ -552,6 +591,7 @@ api_version = 2
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["cp", "aoe-plugin.toml", "v1-marker"]
@@ -576,6 +616,7 @@ api_version = 2
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["false"]
@@ -623,6 +664,7 @@ capabilities = ["net"]
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["cp", "aoe-plugin.toml", "marker-v1"]
@@ -644,6 +686,7 @@ capabilities = ["net"]
 [runtime]
 kind = "command"
 command = ["sh"]
+system = true
 
 [[runtime.build]]
 command = ["cp", "aoe-plugin.toml", "marker-v2"]

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -600,3 +600,77 @@ command = ["false"]
     // No leftover backup directory from the failed update.
     assert!(!installed.with_file_name("acme.upd.bak").exists());
 }
+
+/// A changed build recipe on update must re-prompt even when capabilities are
+/// unchanged, so a modified (possibly malicious) build cannot run unattended.
+/// Non-interactively that prompt bails, leaving the prior version untouched.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn update_reprompts_when_build_recipe_changes() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+
+    write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.recipe"
+name = "Recipe"
+version = "0.1.0"
+api_version = 2
+capabilities = ["net"]
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["cp", "aoe-plugin.toml", "marker-v1"]
+"#,
+    );
+    let dir = src.path().join("src-plugin");
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    // Same capability, but the build recipe changed.
+    std::fs::write(
+        dir.join("aoe-plugin.toml"),
+        r#"
+id = "acme.recipe"
+name = "Recipe"
+version = "0.2.0"
+api_version = 2
+capabilities = ["net"]
+
+[runtime]
+kind = "command"
+command = ["sh"]
+
+[[runtime.build]]
+command = ["cp", "aoe-plugin.toml", "marker-v2"]
+"#,
+    )
+    .unwrap();
+
+    // The changed recipe forces a prompt, which bails on non-terminal stdin
+    // instead of silently running the new build.
+    let err = install::update("acme.recipe")
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not a terminal"), "got: {err}");
+
+    // Prior version is fully intact: v1 artifact present, v2 never ran.
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.recipe");
+    assert!(installed.join("marker-v1").exists());
+    assert!(!installed.join("marker-v2").exists());
+    assert_eq!(
+        Lockfile::load()
+            .unwrap()
+            .get("acme.recipe")
+            .unwrap()
+            .version,
+        "0.1.0"
+    );
+}


### PR DESCRIPTION
**Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A `[runtime] kind = "command"` worker referenced by a bare program name (a Python venv console script like `aoe-github-worker`) was resolved with `which` against the daemon's ambient PATH. Since the daemon starts from many contexts (a fresh shell, the TUI, a restart) where the plugin's venv is not on PATH, the same plugin launched in one session and failed with `worker program "..." was not found on PATH` in the next. The real gap: an interpreted plugin has an install step (create a venv, install deps) that the host never ran, so its entrypoint only existed wherever the author happened to set it up.

This adds an optional, ordered `[[runtime.build]]` to the `command` runtime, modeled on herdr.dev's plugin manifest. The host runs the steps once at install and update, inside the installed plugin directory, in the user's interactive shell where PATH is reliable. An interpreted worker now produces a self-contained in-tree environment and launches via a plugin-relative `command`, so the daemon's PATH never decides whether it starts:

```toml
[runtime]
kind = "command"
command = [".venv/bin/aoe-github-worker"]

[[runtime.build]]
command = ["python3", "-m", "venv", ".venv"]

[[runtime.build]]
command = [".venv/bin/pip", "install", "."]
platforms = ["linux", "macos"]   # optional; omitted runs everywhere
```

Key decisions (settled with a multi-model design debate):

- **Builds run in the final dir, not a staging tree.** Python venvs are not relocatable (console-script shebangs and `pyvenv.cfg` embed absolute paths), so building then renaming would break the worker. A failed install removes the half-built dir; a failed update restores the prior version from a backup, and a leftover backup from an interrupted update is recovered on the next run.
- **Each build step's argv reuses the launch resolver policy**, resolved just before it runs, so `.venv/bin/pip` resolves once the prior step created it. An optional `platforms` filter (`linux`/`macos`/`windows`) skips a step on a non-matching host.
- **Trust:** a build step is unsandboxed code run as the user before any capability gate, so install now prompts and discloses the build commands verbatim even when the plugin requests no capabilities. Build stdin is closed so an interactive prompt cannot hang a `--yes` install.
- The no-build `command = ["uv", "run", "worker"]` pattern still works; it just depends on `uv` being on the daemon PATH (a system tool, the author's call), which is structurally different from the plugin's own entrypoint depending on PATH.

This keeps the source-tree attestation model intact (featured pins the vetted source; the venv is derived locally from it) and does not touch launch behavior. Rejected the alternative of forcing all plugins to be release-binaries: it would break the one featured Python plugin and conflicts with the attestation model, which cannot pin release-binary bytes yet.

Closes #2404

## How to test

- [ ] Add `[[runtime.build]]` with `command = ["python3", "-m", "venv", ".venv"]` and `[".venv/bin/pip", "install", "."]` plus `command = [".venv/bin/<entry>"]` to a local plugin, `aoe plugin install ./that-dir`, confirm the venv is created under `<app_dir>/plugins/<id>/.venv` and the worker launches even from a shell where that venv is not on PATH.
- [ ] Install a plugin that declares build steps but no capabilities: confirm install still prompts and lists the build commands verbatim, and that `--yes` skips the prompt.
- [ ] Give a build step a failing command (e.g. `["false"]`): confirm `aoe plugin install` aborts with an error naming the step and leaves no `<app_dir>/plugins/<id>` directory.
- [ ] Install a working version, then update to one whose build fails: confirm the prior version is still installed and active, and no `.bak` directory is left behind.
- [ ] Give a build step `platforms = ["windows"]` on macOS/Linux: confirm the step is skipped and install still succeeds.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the install/update build flow is covered by in-process integration tests in `tests/plugin_install.rs` (build runs in the final dir, platform-skip, failed-install cleanup, failed-update restore) plus manifest parse/validate tests in `aoe-plugin-api/tests/manifest.rs`. There is no TUI rendering or session-lifecycle change, so a full-binary e2e adds nothing over these.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a multi-model design debate, plan, and implementation were drafted by Claude under my direction. I made the design calls (herdr-style schema, build-in-final-dir, the scope decision to keep interpreted plugins), reviewed each commit, and will run the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785004700&installation_id=139138837&pr_number=2406&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2406&signature=9cb752b7904d95ee23d6cd4dca849c614fb545fba04ec311f8a82f4a9f522c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds optional install/update-time build steps for `command`-based plugins (via `[[runtime.build]]`) so interpreted/venv-style entrypoints don’t depend on the daemon’s PATH at launch. Build steps run once during install/update inside the final installed plugin directory, and they’re included in the same “consent” flow as capabilities.

What changed:
- Added a new `[[runtime.build]]` manifest section for ordered build commands, with optional platform filtering.
- Extended manifest parsing/validation to ensure build steps are valid and platform names are recognized.
- Updated install/update so build steps execute after the plugin is placed in its final directory, using the same command-resolution rules as runtime launch.
- Build steps are now shown in the prompt/consent flow alongside capabilities (including when no capabilities are otherwise requested).
- Improved safety for updates:
  - If build steps exist and the user declines, the update is aborted before changing anything.
  - If only the build recipe changes, the user is prompted again (even when capabilities didn’t change).
  - Install failures clean up partially installed artifacts; update failures roll back to the previously installed version.
- Updated documentation and added integration tests covering build execution location, platform skipping, cleanup/rollback on failures, and re-prompting behavior.
- Added support for an explicit `system = true` escape hatch so some `command` entrypoints can intentionally rely on system PATH at launch time.

Benefits:
- More reliable plugin startup across daemon restarts and different environment contexts.
- Safer installs/updates because build actions are explicit, visible to the user, and protected by cleanup/rollback behavior.
- Better support for interpreted/venv-installed entrypoints by letting plugins prepare a stable in-tree environment during install/update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->