### PR TITLE
feat(tui): reassure that updating won't tear down running sessions

### DIFF
--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -3117,8 +3117,11 @@ impl HomeView {
         let text = if let Some(s) = status {
             format!(" {s}  [Ctrl+x] dismiss")
         } else if let Some(info) = info {
+            // Reassure users (issue #2220) that updating is safe: it never
+            // tears down or interrupts running sessions. Kept after the keys so
+            // the action hints stay visible first on narrow terminals.
             format!(
-                " update available {} → {}  [{update_key}] update  [Ctrl+x] dismiss",
+                " update available {} → {}  [{update_key}] update  [Ctrl+x] dismiss  ·  running sessions stay safe",
                 info.current_version, info.latest_version
             )
         } else if image_update.is_some() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6343,6 +6343,55 @@ fn app_update_banner_takes_precedence_over_image_banner() {
     );
 }
 
+/// Issue #2220: the app-update banner reassures users that updating is safe
+/// for running sessions. The reassurance must render alongside the version and
+/// action keys so users know `u` won't tear down their work.
+#[test]
+#[serial]
+fn app_update_banner_reassures_running_sessions_are_safe() {
+    use crate::tui::styles::load_theme;
+    use crate::update::UpdateInfo;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_empty();
+    let backend = TestBackend::new(120, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let theme = load_theme("empire");
+
+    let update_info = UpdateInfo {
+        available: true,
+        current_version: "1.0.0".to_string(),
+        latest_version: "1.1.0".to_string(),
+    };
+
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            env.view
+                .render(f, area, &theme, Some(&update_info), None, None);
+        })
+        .unwrap();
+
+    let buf = terminal.backend().buffer();
+    let mut out = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+
+    assert!(
+        out.contains("running sessions stay safe"),
+        "expected the update banner to reassure that running sessions are safe.\nFull buffer:\n{out}"
+    );
+    assert!(
+        out.contains("[u] update"),
+        "the action key must still render alongside the reassurance.\nFull buffer:\n{out}"
+    );
+}
+
 /// Regression for the e2e CI failure (job 76034901940):
 /// `test_command_palette_fuzzy_search_settings` and
 /// `test_profile_picker_create_new_profile` failed because the harness types

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6390,6 +6390,37 @@ fn app_update_banner_reassures_running_sessions_are_safe() {
         out.contains("[u] update"),
         "the action key must still render alongside the reassurance.\nFull buffer:\n{out}"
     );
+
+    // Narrow-terminal contract: the reassurance is appended after the keys
+    // precisely so the action hints survive when the line is too narrow to
+    // hold everything. At 72 columns the keys fit but the reassurance clips.
+    let narrow = TestBackend::new(72, 30);
+    let mut narrow_terminal = Terminal::new(narrow).unwrap();
+    narrow_terminal
+        .draw(|f| {
+            let area = f.area();
+            env.view
+                .render(f, area, &theme, Some(&update_info), None, None);
+        })
+        .unwrap();
+
+    let nbuf = narrow_terminal.backend().buffer();
+    let mut nout = String::new();
+    for y in 0..nbuf.area.height {
+        for x in 0..nbuf.area.width {
+            nout.push_str(nbuf[(x, y)].symbol());
+        }
+        nout.push('\n');
+    }
+
+    assert!(
+        nout.contains("[u] update") && nout.contains("[Ctrl+x] dismiss"),
+        "the action keys must survive clipping on a narrow terminal.\nFull buffer:\n{nout}"
+    );
+    assert!(
+        !nout.contains("running sessions stay safe"),
+        "the trailing reassurance is expected to clip first on a narrow terminal.\nFull buffer:\n{nout}"
+    );
 }
 
 /// Regression for the e2e CI failure (job 76034901940):


### PR DESCRIPTION
## Description

Closes #2220. Pressing `u` in the TUI to update gave no indication of whether the upgrade would tear down or interrupt running sessions, so users had to ask before daring to do it. This appends a short reassurance to the bottom update bar, right where the user is making the decision:

```
 update available 1.0.0 → 1.1.0  [u] update  [Ctrl+x] dismiss  ·  running sessions stay safe
```

Design notes:
- The reassurance is placed **after** the action keys so `[u] update` / `[Ctrl+x] dismiss` stay visible first when the line truncates on narrow terminals.
- Only the **app-update** banner gets the note. The sandbox-image-pull banner is intentionally left alone, since pulling a new image does swap a container.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

UI change is a single line of banner text; the exact rendered string is shown above and asserted by the new render test.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Added `app_update_banner_reassures_running_sessions_are_safe` in `src/tui/home/tests.rs`, which renders a real frame through the `TestBackend` and asserts both the reassurance text and `[u] update` appear. (Render regression lives next to the sibling banner tests rather than under `tests/e2e/`, matching where the existing update-bar coverage is.)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Claude drafted the wording and test via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785008229&installation_id=139138837&pr_number=2408&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2408&signature=6e33b33e0824bc4e23f483dbd029a6fee1e62dd0380e68522f446ce5c39eba3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the TUI app-update banner to reassure users that pressing `u` to update won’t tear down or interrupt any running sessions. The banner now appends the message “running sessions stay safe” after the action hints, so `[u] update` and `[Ctrl+x] dismiss` remain visible first on narrow terminals. A render test was added to verify both the wording and the narrow-terminal clipping behavior.

Benefits:
- Removes uncertainty about whether updates affect active sessions
- Makes the update prompt friendlier and more confidence-inspiring
- Keeps the banner usable on small screens by preserving the key shortcuts

Technical note:
- The change applies only to the app-update banner; the sandbox-image-pull banner is unchanged.
- Added a render test covering banner text + key visibility/clipping on narrow widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->