### PR TITLE
fix(web): paste with Ctrl+V and copy with Ctrl+Shift+C in the live terminal

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 import { ansiToLines, wrapLine } from "../lib/liveTermLines";
 import { wheelNotches } from "../lib/liveMouse";
+import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
 import { useWebSettings } from "../hooks/useWebSettings";
 import { useIsCoarsePointer } from "../hooks/useIsCoarsePointer";
@@ -934,8 +935,24 @@ export function MobileLiveTerminal({
         sendData(seq);
         return;
       }
-      // Hardware Ctrl+letter chords (bluetooth keyboards).
-      if (e.ctrlKey && !e.metaKey && !e.altKey && e.key.length === 1) {
+      // Ctrl+Shift+C copies the current terminal selection (the terminal-
+      // emulator convention), distinct from plain Ctrl+C below which stays
+      // SIGINT. The hidden input is focused, so the browser's own copy would
+      // target the empty textarea rather than the rendered selection; read the
+      // document selection and copy it explicitly. No selection is a no-op, not
+      // a control code.
+      if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        const text = window.getSelection()?.toString() ?? "";
+        if (text) void writeClipboard(text);
+        return;
+      }
+      // Hardware Ctrl+letter chords (bluetooth keyboards). Ctrl+V (and
+      // Ctrl+Shift+V) is the exception: on Linux/Windows it is the paste
+      // shortcut, so let the browser's native paste event fire (onPaste turns
+      // it into a bracketed paste) instead of swallowing it into a literal ^V
+      // to tmux. Mac's Cmd+C / Cmd+V already fall through via the metaKey guard.
+      if (e.ctrlKey && !e.metaKey && !e.altKey && e.key.length === 1 && e.key.toLowerCase() !== "v") {
         const code = e.key.toUpperCase().charCodeAt(0);
         if (code >= 65 && code <= 90) {
           e.preventDefault();

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+//
+// Clipboard chords in the live terminal on a physical keyboard (#2384). On
+// Linux/Windows the paste shortcut is Ctrl+V; the Ctrl+letter chord handler
+// used to swallow it into a literal ^V to tmux AND preventDefault the keydown,
+// which blocked the browser's paste event from ever firing. Ctrl+V must now
+// fall through so the native paste event reaches onPaste (bracketed paste).
+// Ctrl+Shift+C copies the rendered terminal selection (read explicitly because
+// the hidden input is focused), while plain Ctrl+C stays SIGINT and every
+// other Ctrl+letter chord keeps working.
+
+import { createRef } from "react";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
+}));
+
+const writeClipboard = vi.fn();
+vi.mock("../../lib/clipboard", () => ({
+  writeClipboard: (text: string) => writeClipboard(text),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const frame: LiveFrame = {
+  content: "$ \n",
+  rows: 3,
+  history: 1000,
+  cursor: null,
+  altScreen: false,
+  mouse: false,
+  mouseSgr: false,
+};
+
+function renderTerm() {
+  const inputRef = createRef<HTMLTextAreaElement>();
+  const sendData = vi.fn();
+  render(
+    <MobileLiveTerminal
+      frame={frame}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={sendData}
+      forwardWheel={vi.fn()}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={inputRef}
+      onInputFocusChange={vi.fn()}
+      bottomAlign
+    />,
+  );
+  return { input: inputRef.current!, sendData };
+}
+
+describe("MobileLiveTerminal paste", () => {
+  it("does not swallow Ctrl+V into a literal ^V, and the paste event sends a bracketed paste", () => {
+    const { input, sendData } = renderTerm();
+
+    // Ctrl+V keydown must NOT be intercepted: no literal ^V (\x16) to tmux,
+    // and the default action is left intact so the paste event can fire.
+    const keydown = fireEvent.keyDown(input, { key: "v", ctrlKey: true });
+    expect(keydown).toBe(true); // not preventDefault'd
+    expect(sendData).not.toHaveBeenCalledWith("\x16");
+
+    // The native paste event onPaste handles it as a bracketed paste.
+    fireEvent.paste(input, {
+      clipboardData: { getData: (t: string) => (t === "text/plain" ? "hello world" : "") },
+    });
+    expect(sendData).toHaveBeenCalledWith("\x1b[200~hello world\x1b[201~");
+  });
+
+  it("still sends Ctrl+C as SIGINT (other chords unchanged)", () => {
+    const { input, sendData } = renderTerm();
+    fireEvent.keyDown(input, { key: "c", ctrlKey: true });
+    expect(sendData).toHaveBeenCalledWith("\x03");
+  });
+
+  it("copies the terminal selection on Ctrl+Shift+C without sending a control code", () => {
+    writeClipboard.mockClear();
+    const selSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "selected output",
+    } as unknown as Selection);
+    try {
+      const { input, sendData } = renderTerm();
+      fireEvent.keyDown(input, { key: "C", ctrlKey: true, shiftKey: true });
+      expect(writeClipboard).toHaveBeenCalledWith("selected output");
+      // Must NOT also send ^C (SIGINT) to tmux.
+      expect(sendData).not.toHaveBeenCalledWith("\x03");
+    } finally {
+      selSpy.mockRestore();
+    }
+  });
+
+  it("Ctrl+Shift+C with no selection is a no-op (no copy, no control code)", () => {
+    writeClipboard.mockClear();
+    const selSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "",
+    } as unknown as Selection);
+    try {
+      const { input, sendData } = renderTerm();
+      fireEvent.keyDown(input, { key: "C", ctrlKey: true, shiftKey: true });
+      expect(writeClipboard).not.toHaveBeenCalled();
+      expect(sendData).not.toHaveBeenCalledWith("\x03");
+    } finally {
+      selSpy.mockRestore();
+    }
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -80,6 +80,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.clipboard-chords",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/MobileLiveTerminal.paste.test.tsx"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.mobile-live-scrollback",
       "kind": "mocked-playwright",
       "risk": "high",
@@ -2682,7 +2689,7 @@
       "kind": "mocked-playwright",
       "risk": "high",
       "specs": ["tests/desktop-live-input.spec.ts"],
-      "components": ["web/src/components/LiveTerminalView.tsx"]
+      "components": ["web/src/components/LiveTerminalView.tsx", "web/src/components/MobileLiveTerminal.tsx"]
     }
   ]
 }

--- a/web/tests/desktop-live-input.spec.ts
+++ b/web/tests/desktop-live-input.spec.ts
@@ -47,6 +47,65 @@ test.describe("Desktop live terminal input", () => {
     await expect(pane).not.toHaveAttribute("data-pane-focused", "true");
   });
 
+  test("Ctrl+V pastes as a bracketed paste instead of sending a literal ^V", async ({ page }) => {
+    // The Ctrl+letter chord handler used to swallow Ctrl+V into a ^V (0x16) to
+    // tmux and preventDefault the keydown, blocking the browser's paste event.
+    // It must now fall through so the native paste reaches onPaste. (#2384)
+    const handle = await mockTerminalApis(page);
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator("[data-live-terminal]").first().waitFor({ state: "visible", timeout: 10_000 });
+    await page.locator("[data-live-terminal]").first().click();
+    await expect(page.locator('textarea[aria-label="Live terminal input"]').first()).toBeFocused();
+
+    await page.evaluate(() => navigator.clipboard.writeText("pasted text"));
+    const before = handle.liveMessages.length;
+    await page.keyboard.press("Control+v");
+
+    await expect
+      .poll(() => handle.liveMessages.slice(before).map((m) => m.toString("utf8")))
+      .toContainEqual("\x1b[200~pasted text\x1b[201~");
+    const sentCtrlV = handle.liveMessages.slice(before).some((m) => m.toString("utf8") === "\x16");
+    expect(sentCtrlV).toBe(false);
+  });
+
+  test("Ctrl+Shift+C copies the terminal selection without sending ^C", async ({ page }) => {
+    // The hidden input is focused, so the browser's own copy targets the empty
+    // textarea; the handler reads the rendered DOM selection and copies it
+    // explicitly. Plain Ctrl+C stays SIGINT. (#2384)
+    const handle = await mockTerminalApis(page);
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator("[data-live-content]").first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // Focus the input the way a user does (click the pane), then select a
+    // rendered terminal row. The selection lives in the DOM while the hidden
+    // input keeps focus, which is exactly the state Ctrl+Shift+C must read.
+    await page.locator("[data-live-terminal]").first().click();
+    const selected = await page.evaluate(() => {
+      const content = document.querySelector("[data-live-content]")!;
+      const row = Array.from(content.querySelectorAll("div")).find((d) => (d.textContent ?? "").trim().length > 0);
+      if (!row) throw new Error("no non-empty terminal row to select");
+      const range = document.createRange();
+      range.selectNodeContents(row);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      return sel.toString();
+    });
+    expect(selected.trim().length).toBeGreaterThan(0);
+    await expect(page.locator('textarea[aria-label="Live terminal input"]').first()).toBeFocused();
+
+    const before = handle.liveMessages.length;
+    await page.keyboard.press("Control+Shift+C");
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(selected);
+    const sentSigint = handle.liveMessages.slice(before).some((m) => m.toString("utf8") === "\x03");
+    expect(sentSigint).toBe(false);
+  });
+
   test("renders at the desktop font size, not the small mobile default", async ({ page }) => {
     // The live view used to always read `mobileFontSize` (default 8px), so on
     // desktop it came up tiny and ignored the dashboard's terminal font-size


### PR DESCRIPTION
## Description

Fixes #2384. In the web dashboard's live terminal you could type but not paste. The `onKeyDown` handler intercepted **every** physical Ctrl+letter chord and sent it as a control code. For Ctrl+V it called `preventDefault()` and sent a literal `^V` (0x16) to tmux, which also cancelled the browser's `paste` event, so the textarea's existing `onPaste` handler (a proper bracketed paste) never fired. Mac's Cmd+V was fine thanks to the `!metaKey` guard, so paste only broke on Linux/Windows, where Ctrl+V is the paste shortcut. This matches the reporter's proposed solution #1.

While here, the gnome-terminal copy/paste pair is completed:

- **Ctrl+V** (and Ctrl+Shift+V) now fall through to the native paste event, which `onPaste` turns into a bracketed paste.
- **Ctrl+Shift+C** copies the rendered terminal selection. The hidden input is focused, so the browser's own copy would target the empty textarea; the handler reads the document selection and copies it explicitly via `writeClipboard` (which also covers non-secure-context LAN / Tailscale serves). No selection is a no-op.
- **Plain Ctrl+C stays SIGINT**, and every other Ctrl+letter chord is unchanged.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

<!-- No visual change: this is keyboard-shortcut behavior with no UI surface. -->
_No visual change; this is keyboard-shortcut behavior with no new UI surface, so a screenshot would show nothing meaningful._

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added unit tests (`web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx`) and two mocked-Playwright specs in `web/tests/desktop-live-input.spec.ts` that paste via a real clipboard and copy a real DOM selection in Chromium. Both fail against the pre-fix component. Coverage matrix updated (`terminal.clipboard-chords` + the desktop-live-input entry).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation, fix, and tests drafted by Claude Code via back-and-forth with @njbrake; the diagnosis and the decision to add Ctrl+Shift+C copy are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785009050&installation_id=139138837&pr_number=2409&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2409&signature=00352fe3d1b3c45295804ff77fa06fb385dcc69151ec2cea52b7217da9256df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change fixes clipboard behavior in the web live terminal.

- Paste now works reliably with **Ctrl+V** by letting the browser handle the paste action instead of treating it like a terminal control key.
- Copy support was added for **Ctrl+Shift+C**, which copies the currently selected terminal text.
- **Ctrl+C** still sends an interrupt signal, so existing terminal behavior is preserved.
- New unit and Playwright tests cover paste and copy shortcuts to prevent regressions.
- Coverage metadata was updated to include the new terminal clipboard behavior tests.

Benefits:
- Better clipboard support on Linux and Windows
- More consistent terminal keyboard behavior
- Reduced risk of future regressions through added test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->