### PR TITLE
fix(tui): forward wheel as arrow keys for alt-screen apps without mouse tracking (#2407)

### DIFF
--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -114,9 +114,10 @@ pub fn append_pane_base_index_args(args: &mut Vec<String>, target: &str) {
 /// Required for the web dashboard's two-finger scroll on mobile when the
 /// underlying agent uses tmux copy-mode for scrollback (the default
 /// renderer for Claude Code, and all other agents). Claude Code's
-/// fullscreen renderer (`/tui fullscreen`) bypasses tmux copy-mode and
-/// handles wheel events itself, so the option is harmless but unused in
-/// that mode.
+/// fullscreen renderer (`/tui fullscreen`) bypasses tmux copy-mode: it
+/// runs on the alternate screen and relies on alternate-scroll turning the
+/// wheel into arrow keys (it binds the arrows to scroll), so this option is
+/// harmless but unused in that mode.
 pub fn append_mouse_on_args(args: &mut Vec<String>, target: &str) {
     args.extend([
         ";".to_string(),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3294,20 +3294,30 @@ impl HomeView {
     /// redraw. Scrolls do not cross pane boundaries: a wheel over the
     /// preview never moves the list cursor, even when the preview is at
     /// its scroll boundary or has no session selected.
-    /// When a live-send target is a full-screen (alternate-screen) app
-    /// that has mouse tracking on, the preview's capture-window scroll is
-    /// useless: the alternate screen has no scrollback, so growing the
-    /// window only exposes the unrelated normal-buffer history underneath
-    /// and the view bottoms out at the session's start. Instead, forward
-    /// the wheel to the app as a mouse event, exactly as a terminal does
-    /// when you wheel over a mouse-tracking pane on attach, so the app
-    /// scrolls its OWN content.
+    /// When a live-send target is a full-screen (alternate-screen) app, the
+    /// preview's capture-window scroll is useless: the alternate screen has
+    /// no scrollback, so growing the window only exposes the unrelated
+    /// normal-buffer history underneath and the view bottoms out at the
+    /// session's start. Instead, forward the wheel to the app so it scrolls
+    /// its OWN content, exactly as a terminal does on direct attach. Two
+    /// cases, branched on what the app asked for:
     ///
-    /// Gated on mouse tracking (`mouse_tracking`): with no mouse mode the
-    /// app would read the bytes as garbage keystrokes, so the caller keeps
-    /// the capture-window scroll. The encoding follows the app: SGR (1006)
-    /// when `mouse_sgr` is set, otherwise the legacy X10 encoding. Returns
-    /// true when the event was forwarded.
+    /// * **Mouse tracking on** (`mouse_tracking`): forward the wheel as a
+    ///   mouse event, the encoding following the app (SGR 1006 when
+    ///   `mouse_sgr` is set, otherwise the legacy X10 encoding).
+    /// * **Mouse tracking off**: the app relies on the terminal's
+    ///   alternate-scroll behavior (DECSET 1007) to turn the wheel into
+    ///   cursor-key presses. Claude Code's fullscreen renderer is exactly
+    ///   this: it sets `1049h` + `1007h` but never requests mouse tracking,
+    ///   so a raw mouse byte would land as a garbage keystroke (#2407).
+    ///   Send `Up`/`Down` named keys instead; `send-keys` renders them in
+    ///   the pane's current application-cursor-key mode, matching what tmux
+    ///   itself sends on attach. The step (3 keys) matches tmux's own
+    ///   alternate-scroll and the capture-window `STEP`.
+    ///
+    /// Only alternate-screen panes are forwarded; on the normal buffer the
+    /// capture-window scroll reaches real scrollback, so the caller keeps
+    /// it. Returns true when the event was forwarded.
     fn forward_wheel_to_live_pane(&self, up: bool, col: u16, row: u16) -> bool {
         if self.live_send.is_none() {
             return false;
@@ -3320,11 +3330,22 @@ impl HomeView {
             .as_ref()
             .and_then(|w| w.current_cursor());
         let Some(cursor) = cursor else { return false };
-        if !(cursor.alternate_on && cursor.mouse_tracking) {
+        if !cursor.alternate_on {
             return false;
         }
-        let bytes = wheel_mouse_bytes(up, cursor.mouse_sgr, self.preview_text_view.pane, col, row);
-        worker.send(crate::tui::home::live_send::TmuxKey::HexBytes(bytes));
+        if cursor.mouse_tracking {
+            let bytes =
+                wheel_mouse_bytes(up, cursor.mouse_sgr, self.preview_text_view.pane, col, row);
+            worker.send(crate::tui::home::live_send::TmuxKey::HexBytes(bytes));
+        } else {
+            const WHEEL_ARROW_STEP: usize = 3;
+            let name = if up { "Up" } else { "Down" };
+            for _ in 0..WHEEL_ARROW_STEP {
+                worker.send(crate::tui::home::live_send::TmuxKey::Named(
+                    name.to_string(),
+                ));
+            }
+        }
         true
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -223,6 +223,42 @@ fn wheel_mouse_bytes(
     }
 }
 
+/// Arrow presses delivered per wheel notch when emulating alternate-scroll
+/// for a no-mouse full-screen app. Matches tmux's own alternate-scroll step
+/// and the capture-window `STEP` in `handle_scroll_up`.
+const WHEEL_ARROW_STEP: usize = 3;
+
+/// Decide what to forward to a full-screen live-send pane for one wheel
+/// notch, or `None` to fall back to the capture-window scroll. Pure so the
+/// branch the fix turns on (named arrow keys vs. raw mouse bytes vs. no
+/// forward) is asserted directly, without standing up a worker. See
+/// `forward_wheel_to_live_pane` for the full rationale.
+fn wheel_forward_key(
+    cursor: &crate::tmux::PaneCursor,
+    up: bool,
+    pane: ratatui::layout::Rect,
+    col: u16,
+    row: u16,
+) -> Option<live_send::TmuxKey> {
+    if !cursor.alternate_on {
+        return None;
+    }
+    if cursor.mouse_tracking {
+        Some(live_send::TmuxKey::HexBytes(wheel_mouse_bytes(
+            up,
+            cursor.mouse_sgr,
+            pane,
+            col,
+            row,
+        )))
+    } else {
+        Some(live_send::TmuxKey::NamedRepeat {
+            name: if up { "Up" } else { "Down" }.to_string(),
+            count: WHEEL_ARROW_STEP,
+        })
+    }
+}
+
 fn resolve_hook_install_agent(
     tool_name: &str,
     session_config: &crate::session::config::SessionConfig,
@@ -3332,21 +3368,11 @@ impl HomeView {
             .as_ref()
             .and_then(|w| w.current_cursor());
         let Some(cursor) = cursor else { return false };
-        if !cursor.alternate_on {
+        let Some(key) = wheel_forward_key(&cursor, up, self.preview_text_view.pane, col, row)
+        else {
             return false;
-        }
-        if cursor.mouse_tracking {
-            let bytes =
-                wheel_mouse_bytes(up, cursor.mouse_sgr, self.preview_text_view.pane, col, row);
-            worker.send(crate::tui::home::live_send::TmuxKey::HexBytes(bytes));
-        } else {
-            const WHEEL_ARROW_STEP: usize = 3;
-            let name = if up { "Up" } else { "Down" };
-            worker.send(crate::tui::home::live_send::TmuxKey::NamedRepeat {
-                name: name.to_string(),
-                count: WHEEL_ARROW_STEP,
-            });
-        }
+        };
+        worker.send(key);
         true
     }
 
@@ -5221,6 +5247,83 @@ mod tests {
         assert_eq!(
             wheel_mouse_bytes(true, false, wide, 300, 300),
             vec![0x1b, b'[', b'M', 64 + 32, 223 + 32, 223 + 32]
+        );
+    }
+
+    fn cursor_for(
+        alternate_on: bool,
+        mouse_tracking: bool,
+        mouse_sgr: bool,
+    ) -> crate::tmux::PaneCursor {
+        crate::tmux::PaneCursor {
+            x: 0,
+            y: 0,
+            visible: true,
+            pane_height: 24,
+            history_size: 0,
+            pane_width: 80,
+            alternate_on,
+            mouse_tracking,
+            mouse_sgr,
+        }
+    }
+
+    /// The fix for #2407: a full-screen pane with no mouse tracking must
+    /// forward named arrow keys (repeated per notch), NOT raw mouse bytes.
+    /// Asserting the key variant guards against a regression to mouse-byte
+    /// forwarding that the preview-offset behavioral test can't catch.
+    #[test]
+    fn wheel_forward_key_no_mouse_alt_screen_is_arrow_repeat() {
+        use ratatui::layout::Rect;
+        let pane = Rect::new(0, 0, 80, 24);
+        let cursor = cursor_for(true, false, false);
+        assert_eq!(
+            wheel_forward_key(&cursor, true, pane, 10, 10),
+            Some(live_send::TmuxKey::NamedRepeat {
+                name: "Up".into(),
+                count: WHEEL_ARROW_STEP,
+            })
+        );
+        assert_eq!(
+            wheel_forward_key(&cursor, false, pane, 10, 10),
+            Some(live_send::TmuxKey::NamedRepeat {
+                name: "Down".into(),
+                count: WHEEL_ARROW_STEP,
+            })
+        );
+    }
+
+    /// A mouse-tracking full-screen pane still gets a forwarded mouse event
+    /// (SGR or legacy X10 bytes), never arrow keys.
+    #[test]
+    fn wheel_forward_key_mouse_tracking_is_hex_bytes() {
+        use ratatui::layout::Rect;
+        let pane = Rect::new(0, 0, 80, 24);
+        match wheel_forward_key(&cursor_for(true, true, true), true, pane, 10, 10) {
+            Some(live_send::TmuxKey::HexBytes(b)) => assert_eq!(b[0], 0x1b),
+            other => panic!("expected SGR HexBytes, got {other:?}"),
+        }
+        match wheel_forward_key(&cursor_for(true, true, false), true, pane, 10, 10) {
+            Some(live_send::TmuxKey::HexBytes(b)) => {
+                assert_eq!(&b[..3], &[0x1b, b'[', b'M'])
+            }
+            other => panic!("expected legacy HexBytes, got {other:?}"),
+        }
+    }
+
+    /// A normal-screen pane is never forwarded; the caller keeps the
+    /// capture-window scroll, which can reach real scrollback there.
+    #[test]
+    fn wheel_forward_key_normal_screen_is_none() {
+        use ratatui::layout::Rect;
+        let pane = Rect::new(0, 0, 80, 24);
+        assert_eq!(
+            wheel_forward_key(&cursor_for(false, false, false), true, pane, 10, 10),
+            None
+        );
+        assert_eq!(
+            wheel_forward_key(&cursor_for(false, true, true), true, pane, 10, 10),
+            None
         );
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3305,15 +3305,17 @@ impl HomeView {
     /// * **Mouse tracking on** (`mouse_tracking`): forward the wheel as a
     ///   mouse event, the encoding following the app (SGR 1006 when
     ///   `mouse_sgr` is set, otherwise the legacy X10 encoding).
-    /// * **Mouse tracking off**: the app relies on the terminal's
-    ///   alternate-scroll behavior (DECSET 1007) to turn the wheel into
-    ///   cursor-key presses. Claude Code's fullscreen renderer is exactly
-    ///   this: it sets `1049h` + `1007h` but never requests mouse tracking,
-    ///   so a raw mouse byte would land as a garbage keystroke (#2407).
-    ///   Send `Up`/`Down` named keys instead; `send-keys` renders them in
-    ///   the pane's current application-cursor-key mode, matching what tmux
-    ///   itself sends on attach. The step (3 keys) matches tmux's own
-    ///   alternate-scroll and the capture-window `STEP`.
+    /// * **Mouse tracking off**: an alternate-screen app with no mouse mode
+    ///   gets its wheel via the terminal's alternate-scroll behavior, which
+    ///   turns the wheel into cursor-key presses. tmux does this for any
+    ///   such pane on attach (`alternate-scroll`, on by default), so we
+    ///   replicate it: send `Up`/`Down` instead of raw mouse bytes (which
+    ///   the app would read as garbage keystrokes). Claude Code's fullscreen
+    ///   renderer is the motivating case: it sets `1049h` + `1007h` but
+    ///   never requests mouse tracking, and binds the arrow keys to scroll
+    ///   in that mode (#2407). `send-keys -N` renders all 3 presses in the
+    ///   pane's current application-cursor-key mode in a single fork; the
+    ///   step matches tmux's own alternate-scroll and the capture `STEP`.
     ///
     /// Only alternate-screen panes are forwarded; on the normal buffer the
     /// capture-window scroll reaches real scrollback, so the caller keeps
@@ -3340,11 +3342,10 @@ impl HomeView {
         } else {
             const WHEEL_ARROW_STEP: usize = 3;
             let name = if up { "Up" } else { "Down" };
-            for _ in 0..WHEEL_ARROW_STEP {
-                worker.send(crate::tui::home::live_send::TmuxKey::Named(
-                    name.to_string(),
-                ));
-            }
+            worker.send(crate::tui::home::live_send::TmuxKey::NamedRepeat {
+                name: name.to_string(),
+                count: WHEEL_ARROW_STEP,
+            });
         }
         true
     }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -340,8 +340,18 @@ pub(in crate::tui) fn format_target_label(title: &str, target: LiveSendTarget) -
 pub(super) enum TmuxAction {
     Literal(String),
     Named(String),
+    /// `send-keys -N <count> <name>`: the named key repeated `count` times
+    /// in one fork. Consecutive runs of the same key (e.g. several wheel
+    /// notches drained in one batch) fold their counts together.
+    NamedRepeat {
+        name: String,
+        count: usize,
+    },
     HexBytes(Vec<u8>),
-    Resize { cols: u16, rows: u16 },
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
 }
 
 /// Fold a batch of `WorkerMsg`s into the smallest sequence of
@@ -365,6 +375,16 @@ pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
             WorkerMsg::Send(TmuxKey::Named(name)) => {
                 flush(&mut out, &mut run);
                 out.push(TmuxAction::Named(name));
+            }
+            WorkerMsg::Send(TmuxKey::NamedRepeat { name, count }) => {
+                flush(&mut out, &mut run);
+                match out.last_mut() {
+                    Some(TmuxAction::NamedRepeat {
+                        name: prev_name,
+                        count: prev_count,
+                    }) if *prev_name == name => *prev_count += count,
+                    _ => out.push(TmuxAction::NamedRepeat { name, count }),
+                }
             }
             WorkerMsg::Send(TmuxKey::HexBytes(bytes)) => {
                 flush(&mut out, &mut run);
@@ -893,6 +913,14 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
         TmuxAction::Named(name) => {
             cmd.args(["send-keys", "-t", &target, name.as_str()]);
         }
+        TmuxAction::NamedRepeat { name, count } => {
+            // `-N <count>` repeats the key `count` times in one fork. tmux
+            // renders each press in the pane's current cursor-key mode, so
+            // the wheel-forward arrows honor DECCKM just like a single
+            // `Named` does.
+            let count = count.to_string();
+            cmd.args(["send-keys", "-t", &target, "-N", &count, name.as_str()]);
+        }
         TmuxAction::HexBytes(bytes) => {
             // `-H` sends each subsequent arg as the hex byte value of an
             // ASCII character. We use this for control bytes (CR, TAB,
@@ -978,13 +1006,22 @@ pub(super) enum LiveDispatch {
 
 /// How the translator wants the keystroke delivered. `Literal` payloads
 /// go through `tmux send-keys -l --`, named keys through `tmux send-keys`,
-/// and `HexBytes` through `tmux send-keys -H <byte> <byte> ...` for raw
-/// bytes that can't ride a literal payload (control bytes like ESC, CR,
-/// TAB, and the bracketed-paste markers).
+/// `NamedRepeat` through `tmux send-keys -N <count>` (one fork for N
+/// presses of the same key), and `HexBytes` through
+/// `tmux send-keys -H <byte> <byte> ...` for raw bytes that can't ride a
+/// literal payload (control bytes like ESC, CR, TAB, and the
+/// bracketed-paste markers).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum TmuxKey {
     Literal(String),
     Named(String),
+    /// A named key sent `count` times in a single fork. The wheel-forward
+    /// path uses this to deliver a notch's worth of arrow presses without
+    /// one fork per press.
+    NamedRepeat {
+        name: String,
+        count: usize,
+    },
     HexBytes(Vec<u8>),
 }
 
@@ -1511,6 +1548,69 @@ mod tests {
             vec![
                 TmuxAction::Named("Up".into()),
                 TmuxAction::Named("Up".into()),
+            ]
+        );
+    }
+
+    fn snd_named_repeat(name: &str, count: usize) -> WorkerMsg {
+        WorkerMsg::Send(TmuxKey::NamedRepeat {
+            name: name.into(),
+            count,
+        })
+    }
+
+    #[test]
+    fn coalesce_same_named_repeats_fold_counts() {
+        // Several wheel notches drained in one batch collapse to a single
+        // `send-keys -N <total>` fork.
+        let out = coalesce(vec![snd_named_repeat("Up", 3), snd_named_repeat("Up", 3)]);
+        assert_eq!(
+            out,
+            vec![TmuxAction::NamedRepeat {
+                name: "Up".into(),
+                count: 6,
+            }]
+        );
+    }
+
+    #[test]
+    fn coalesce_different_named_repeats_do_not_fold() {
+        // A direction change (Up then Down) must not merge; the counts and
+        // order have to survive so the agent scrolls each way in turn.
+        let out = coalesce(vec![snd_named_repeat("Up", 3), snd_named_repeat("Down", 3)]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::NamedRepeat {
+                    name: "Up".into(),
+                    count: 3,
+                },
+                TmuxAction::NamedRepeat {
+                    name: "Down".into(),
+                    count: 3,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesce_named_repeat_flushes_literal_run() {
+        // Order must hold: literals typed before the wheel notch flush
+        // ahead of the arrow repeat, never after it.
+        let out = coalesce(vec![
+            snd_lit("ab"),
+            snd_named_repeat("Down", 3),
+            snd_lit("cd"),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Literal("ab".into()),
+                TmuxAction::NamedRepeat {
+                    name: "Down".into(),
+                    count: 3,
+                },
+                TmuxAction::Literal("cd".into()),
             ]
         );
     }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8854,20 +8854,28 @@ mod scroll_pane_isolation {
         assert_eq!(env.view.preview_scroll_offset, 0);
     }
 
-    /// Guard the gate: a full-screen app WITHOUT any mouse tracking must
-    /// not get raw SGR bytes (it would read them as garbage keystrokes).
-    /// The wheel falls back to the existing capture-window scroll.
+    /// A full-screen app WITHOUT mouse tracking (e.g. Claude Code's
+    /// fullscreen renderer: `1049h` + `1007h`, no mouse) relies on the
+    /// terminal's alternate-scroll to turn the wheel into cursor keys. The
+    /// raw SGR/X10 bytes would land as garbage keystrokes, so we forward
+    /// `Up`/`Down` named keys instead and pin the preview to the live edge,
+    /// just like the mouse-tracking case. Regression test for #2407.
     #[test]
     #[serial]
-    fn wheel_over_alt_screen_without_mouse_uses_capture_scroll() {
+    fn wheel_over_alt_screen_without_mouse_forwards_arrow_keys() {
         let mut env = live_env_with_cursor(alt_screen_cursor(true, false, false));
 
         let up = env.view.handle_scroll_up(50, 10);
-        assert!(up);
-        assert!(
-            env.view.preview_scroll_offset > 10,
-            "no mouse tracking: keep the capture-window scroll (offset advances)"
+        assert!(up, "wheel over a full-screen no-mouse pane is handled");
+        assert_eq!(
+            env.view.preview_scroll_offset, 0,
+            "arrow-key forwarding pins the preview to the live edge, never the normal-buffer history"
         );
+
+        env.view.preview_scroll_offset = 10;
+        let down = env.view.handle_scroll_down(50, 10);
+        assert!(down);
+        assert_eq!(env.view.preview_scroll_offset, 0);
     }
 
     /// A full-screen app with mouse tracking but in the LEGACY (non-SGR)


### PR DESCRIPTION
## Description

Fixes #2407. Claude Code's new "fullscreen" (no-flicker) renderer breaks scroll-up in aoe's live mode.

**Root cause.** The fullscreen renderer enters the alternate screen and enables `DECSET 1007` (alternate-scroll) but never requests mouse tracking. Its terminal init is literally `\e[?1049h\e[?1007h...`. tmux reports such a pane as `alternate_on=1, mouse_any_flag=0, mouse_sgr_flag=0` (confirmed with a live tmux probe). Live mode's wheel forwarding (`forward_wheel_to_live_pane`) only fired when both `alternate_on` AND `mouse_tracking` were set, so for fullscreen Claude it fell through to the capture-window scroll. The alternate screen has no scrollback, so that scroll is inert: wheel-up appears to do nothing.

**Fix.** Gate the forward on `alternate_on` alone, then branch on `mouse_tracking`:
- mouse tracking on: forward a mouse event (existing behavior, SGR or legacy X10).
- mouse tracking off: send `Up`/`Down` named keys via `send-keys`, which tmux renders in the pane's current application-cursor-key mode (verified: `send-keys Up` against a DECCKM-on app emits `ESC O A`). 3 keys per notch matches tmux's own alternate-scroll step.

This replicates exactly what a direct tmux attach does: `alternate-scroll` defaults to `on` and translates the wheel into cursor keys for any alt-screen no-mouse app. Live mode now matches the attached experience instead of dead-scrolling.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a)
- [x] For UI changes: included screenshot or recording (n/a; terminal scroll behavior, covered by unit test)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: rewrote the unit test in `src/tui/home/tests.rs` that previously asserted the buggy capture-scroll behavior (`wheel_over_alt_screen_without_mouse_forwards_arrow_keys`) to assert the new arrow-key forwarding. The wheel-routing logic is fully exercised by the `scroll_pane_isolation` unit tests against an injected pane cursor, so an e2e standing up a real fullscreen pane is not warranted.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation, fix, and tests done via Claude Code with back-and-forth review. Confirmed the tmux flag behavior and `send-keys` cursor-key rendering empirically before writing the fix.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785009139&installation_id=139138837&pr_number=2411&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2411&signature=77bbc3fdf8b69c2b3a699008bd9f3f0edd6d0d5f0dda356b0dfe52cbcb28113f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR restores correct wheel scrolling in Claude Code “fullscreen”/no-flicker live mode when the terminal is using an alternate screen, fixing the regression where scroll-up stopped working.

What changed:
- Wheel input is now forwarded whenever the session is in alternate-screen mode (previously it depended on mouse tracking).
- If mouse tracking is enabled, wheel input is forwarded as mouse events (so SGR/X10 mouse behavior remains consistent).
- If mouse tracking is disabled, wheel input is translated into repeated Up/Down key presses (instead of trying to scroll a window that won’t accept it in alternate screen).
- Unit tests were updated to assert the new Up/Down key forwarding behavior and ensure the live preview remains pinned to the live edge.
- The live-send path gained a batching/coalescing optimization for repeated “named” key sends to reduce extra tmux dispatch work.
- Documentation around fullscreen/alternate-screen behavior was clarified.

Benefits:
- Fixes fullscreen/no-flicker wheel scrolling in live mode.
- Aligns behavior with what you’d expect from a direct tmux attach for alternate-screen apps without mouse support.
- Avoids wheel events “falling through” to alternate-screen behavior that doesn’t produce visible scrolling.

Technical (optional):
- Wheel forwarding now gates on alternate-screen first (`cursor.alternate_on`), then branches by mouse tracking: mouse bytes when mouse tracking is on, otherwise `NamedRepeat` Up/Down key forwarding.
- Added a `NamedRepeat { name, count }` action/key with coalescing so consecutive identical repeats are combined into fewer `tmux send-keys -N ...` calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->