### PR TITLE
docs(live-mode): add SSH cursor-flicker troubleshooting note

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -97,3 +97,41 @@ herdr users already know as a leader. If you run AoE inside your own
 tmux session that also uses `Ctrl+B`, the outer tmux will claim it
 first; rebind `live_send_leader` to something free (for example `C-a` or
 `F1`), and remember that `Ctrl+Q` always exits regardless.
+
+## Troubleshooting
+
+### The cursor flickers or the preview stutters over SSH
+
+If you run AoE on a remote host and reach it over SSH, you may see the
+agent's input cursor blink out and back, or the preview stutter as you
+type. On an otherwise idle screen the agent's blinking cursor is usually
+the only thing moving, so it is the one place the stutter shows up.
+
+This is your SSH connection, not AoE. AoE captures the agent's pane
+locally on the box where AoE runs and renders the result there. When you
+view that over SSH, the rendered screen (cursor included) travels back to
+your terminal as one ordered TCP stream. On a lossy or high-latency link
+TCP holds the stream until dropped packets are resent, so redraws arrive
+late and in bursts.
+
+Quick check: run `vim` or `htop` over the same SSH session. If their
+cursors stutter the same way, it is the link.
+
+What helps, by leverage:
+
+* **Use [`mosh`](https://mosh.org) instead of `ssh` for flaky links.**
+  Mosh runs over UDP with local echo prediction and adapts its frame
+  rate to the connection, dropping stale frames instead of replaying a
+  backlog. On a shaky link you get a slightly-behind but stable cursor
+  instead of a stuttering one, and AoE manages its own screen so mosh's
+  lack of scrollback passthrough does not affect it. The trade: on a fast
+  clean link mosh's keystroke latency can be marginally worse than ssh,
+  and a very large redraw can blank the screen a touch longer while mosh
+  rebuilds it.
+* **[Eternal Terminal](https://eternalterminal.dev) (`et`)** is a
+  TCP-based alternative with fast reconnect if you would rather not run
+  mosh.
+
+This only applies when AoE itself runs on the remote host. Running AoE
+locally, even with the agent sandboxed in a container, renders everything
+on your machine and is not affected.


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Running the AoE TUI on a remote host and viewing it over SSH can make the agent's input cursor flicker, or the live preview stutter, on a shaky link. This came up from a real report ("the white cursor in the input box flickers, seems worse when my connection is shaky").

It is a transport artifact, not an AoE bug. Capture and render both happen locally on the box where AoE runs; the rendered screen then crosses the link as one ordered TCP stream, so a lossy or high-latency connection delivers redraws late and in bursts. On an otherwise idle screen the agent's blinking cursor is the only thing moving, so it is the one place the stutter is visible. The same thing happens with `vim` or `htop` over the same connection.

This adds a Troubleshooting section to the Live Mode guide that explains the cause, gives a quick self-check, and recommends `mosh` (with `et` as a TCP alternative), including the honest tradeoffs of mosh on fast clean links.

Docs only. No code or behavior change.

## PR Type

- [x] Documentation

## Checklist

- [x] New and existing tests pass (docs only; no tests affected)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any Additional AI Details you'd like to share:** Claude investigated the report, traced the live-capture and cursor-render paths, ruled out the in-tree capture logic, and concluded the cause was SSH transport. njbrake directed the investigation and the decision to document it.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785013052&installation_id=139138837&pr_number=2413&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2413&signature=4e11bc43c3c21835b87d0f6b199290fcd66bad280bf1e029a31870d0b66b08f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new troubleshooting note to the Live Mode guide for SSH sessions where the UI cursor flickers or the preview stutters on unstable connections. The update explains that this is usually caused by the connection itself, adds a simple way to confirm it, and recommends `mosh` (with `et` as an alternative) for better behavior on flaky links.

This improves the documentation by helping users quickly identify connection-related issues and choose a more reliable setup without changing any code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->