### PR TITLE
feat(tui): opt-in block cursor for live-send preview (avoids hardware-cursor flicker over mosh)

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1100,6 +1100,21 @@ pub struct SessionConfig {
     )]
     pub live_send_leader: String,
 
+    /// Render the live-send preview cursor as a solid block painted into the
+    /// captured cells instead of the terminal's hardware cursor. The painted
+    /// block is identical every frame, so it stays steady over remote
+    /// transports that re-render and drop frames (notably mosh, where the
+    /// hardware cursor's per-frame hide/show shows up as a flickering caret).
+    /// Turn this off for the terminal's native hardware cursor, which keeps its
+    /// blink and shape but can flicker over such links.
+    #[serde(default = "default_true")]
+    #[setting(
+        label = "Live Preview Block Cursor",
+        widget = "toggle",
+        category = "Interaction"
+    )]
+    pub live_send_block_cursor: bool,
+
     /// What the TUI does immediately after a new session finishes
     /// creating. `Tmux` (default) drops into the tmux attach view, the
     /// historical behavior. `LiveSend` enters live-send mode against
@@ -1305,6 +1320,7 @@ impl Default for SessionConfig {
             session_id_poller_max_threads: default_session_id_poller_max_threads(),
             live_send_exit_chord: default_live_send_exit_chord(),
             live_send_leader: default_live_send_leader(),
+            live_send_block_cursor: true,
             new_session_attach_mode: NewSessionAttachMode::default(),
             default_attach_mode: NewSessionAttachMode::default(),
             click_action: ClickAction::default(),

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1101,13 +1101,14 @@ pub struct SessionConfig {
     pub live_send_leader: String,
 
     /// Render the live-send preview cursor as a solid block painted into the
-    /// captured cells instead of the terminal's hardware cursor. The painted
-    /// block is identical every frame, so it stays steady over remote
-    /// transports that re-render and drop frames (notably mosh, where the
-    /// hardware cursor's per-frame hide/show shows up as a flickering caret).
-    /// Turn this off for the terminal's native hardware cursor, which keeps its
-    /// blink and shape but can flicker over such links.
-    #[serde(default = "default_true")]
+    /// captured cells instead of the terminal's hardware cursor. Off by
+    /// default, so the preview shows the native hardware cursor (its blink and
+    /// shape, matching the caret a direct attach would show). Turn this on for
+    /// a painted block that is identical every frame: it stays steady over
+    /// remote transports that re-render and drop frames (notably mosh, where
+    /// the hardware cursor's per-frame hide/show shows up as a flickering
+    /// caret), at the cost of the native blink and shape.
+    #[serde(default)]
     #[setting(
         label = "Live Preview Block Cursor",
         widget = "toggle",
@@ -1320,7 +1321,7 @@ impl Default for SessionConfig {
             session_id_poller_max_threads: default_session_id_poller_max_threads(),
             live_send_exit_chord: default_live_send_exit_chord(),
             live_send_leader: default_live_send_leader(),
-            live_send_block_cursor: true,
+            live_send_block_cursor: false,
             new_session_attach_mode: NewSessionAttachMode::default(),
             default_attach_mode: NewSessionAttachMode::default(),
             click_action: ClickAction::default(),

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -444,6 +444,11 @@ pub struct HomeView {
     /// the render layer reads this rather than re-resolving the config on
     /// every paint.
     pub(super) row_tag_mode: crate::session::config::RowTagMode,
+    /// Whether the live-send preview paints a block cursor cell instead of
+    /// placing the terminal hardware cursor (config
+    /// `session.live_send_block_cursor`). Cached from resolved config like
+    /// `row_tag_mode`; the render layer reads it each paint.
+    pub(super) live_send_block_cursor: bool,
     /// Active profile's `default_attach_mode`, cached at construction and
     /// refreshed by `refresh_from_config` / `switch_profile`. The help
     /// overlay falls back to this when no session row is selected so the
@@ -1377,6 +1382,7 @@ impl HomeView {
             sort_order,
             group_by,
             row_tag_mode: resolved.session.row_tag,
+            live_send_block_cursor: resolved.session.live_send_block_cursor,
             profile_default_attach_mode: resolved.session.default_attach_mode,
             project_group_collapsed: user_config
                 .as_ref()
@@ -5664,6 +5670,7 @@ impl HomeView {
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.confirm_before_quit = config.session.confirm_before_quit;
         self.row_tag_mode = config.session.row_tag;
+        self.live_send_block_cursor = config.session.live_send_block_cursor;
         self.profile_default_attach_mode = config.session.default_attach_mode;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2378,13 +2378,13 @@ impl HomeView {
         // `capture-pane` carries only cell text (plus SGR color), not the
         // cursor, so without this the "feels-attached" preview shows no cursor
         // for programs that rely on the hardware cursor (shells, codex, anything
-        // using DECTCEM) even though a direct tmux attach would. The default is
-        // a painted block cell: ratatui re-emits a hardware hide/show on every
-        // ~30fps frame, and a state-syncing remote transport (mosh) samples that
-        // mid-toggle into a flickering caret, whereas a painted cell is
-        // identical every frame. `session.live_send_block_cursor = false`
-        // switches back to the native hardware cursor (its blink and shape, at
-        // the cost of that flicker over such links).
+        // using DECTCEM) even though a direct tmux attach would. By default we
+        // place the native hardware cursor (its blink and shape). ratatui
+        // re-emits a hardware hide/show on every ~30fps frame, and a
+        // state-syncing remote transport (mosh) can sample that mid-toggle into
+        // a flickering caret, so `session.live_send_block_cursor = true`
+        // switches to a painted block cell that is identical every frame and
+        // stays steady over such links.
         if self.live_send_block_cursor {
             self.paint_preview_cursor(frame, theme);
         } else if let Some(pos) = self.live_preview_cursor_pos() {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -102,9 +102,10 @@ fn truncate_to_width(text: &str, max_width: usize) -> String {
 /// `output`, so a screen row maps to `output.y + (visible_rows - pane_height)
 /// + cursor.y`. When the pane is sized to the output area (the live-send
 /// resize) the delta is zero and this is just `output.y + cursor.y`; the delta
-/// only bites for the frame or two after a resize. A hidden cursor, or one
-/// that maps outside `output` (e.g. a pane taller than the output area clips
-/// its top rows), yields `None` so nothing is painted.
+/// only bites for the frame or two after a resize. A hidden cursor
+/// (`cursor_flag` 0, e.g. a pager that hides its caret), or one that maps
+/// outside `output` (e.g. a pane taller than the output area clips its top
+/// rows), yields `None` so nothing is painted.
 fn map_live_preview_cursor(
     output: Rect,
     visible_rows: usize,
@@ -2373,18 +2374,17 @@ impl HomeView {
             }
         }
 
-        // In live-send mode, place a real terminal cursor over the preview at
+        // In live-send mode, paint a block cursor into the captured cells at
         // the target pane's cursor cell. `capture-pane` carries only cell text
         // (plus SGR color), not the cursor, so without this the
         // "feels-attached" preview shows no cursor for programs that rely on
         // the hardware cursor (shells, codex, anything using DECTCEM) even
-        // though a direct tmux attach would. Programs that paint their own
-        // caret into the cells (e.g. Claude Code's reverse-video block) hide
-        // the hardware cursor, so `cursor_flag` is 0 and this paints nothing
-        // over them, avoiding a double cursor.
-        if let Some(pos) = self.live_preview_cursor_pos() {
-            frame.set_cursor_position(pos);
-        }
+        // though a direct tmux attach would. We paint a cell rather than using
+        // the terminal's hardware cursor: ratatui re-emits a hardware
+        // hide/show on every ~30fps frame, and a state-syncing remote
+        // transport (mosh) samples that mid-toggle and renders a flickering
+        // caret. A painted cell is identical every frame, so it stays put.
+        self.paint_preview_cursor(frame, theme);
 
         // Selection highlight goes last so it sits on top of whatever
         // the active ViewMode painted into the inner area. The handlers
@@ -2409,6 +2409,24 @@ impl HomeView {
         }
         let cursor = self.preview_capture_worker.as_ref()?.current_cursor()?;
         map_live_preview_cursor(self.preview_pane_area, self.preview_visible_rows, cursor)
+    }
+
+    /// Paint an opaque block cursor into the captured preview cells at the
+    /// live-send cursor position. Style is set absolutely (the cell's existing
+    /// fg/bg and any inherited reverse/blink modifiers are reset) so the block
+    /// is a consistent cursor regardless of the styling the agent painted into
+    /// that cell, and is byte-identical frame to frame. A no-op when no cursor
+    /// is shown this frame, or the mapped cell fell outside the buffer after a
+    /// resize race (mirrors `paint_preview_selection`'s bounds guard).
+    fn paint_preview_cursor(&self, frame: &mut Frame, theme: &Theme) {
+        let Some(pos) = self.live_preview_cursor_pos() else {
+            return;
+        };
+        let buf = frame.buffer_mut();
+        if !buf.area.contains(pos) {
+            return;
+        }
+        buf[(pos.x, pos.y)].set_style(Style::reset().fg(theme.background).bg(theme.text));
     }
 
     /// Apply the drag-select highlight to cells inside the preview

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2374,17 +2374,22 @@ impl HomeView {
             }
         }
 
-        // In live-send mode, paint a block cursor into the captured cells at
-        // the target pane's cursor cell. `capture-pane` carries only cell text
-        // (plus SGR color), not the cursor, so without this the
-        // "feels-attached" preview shows no cursor for programs that rely on
-        // the hardware cursor (shells, codex, anything using DECTCEM) even
-        // though a direct tmux attach would. We paint a cell rather than using
-        // the terminal's hardware cursor: ratatui re-emits a hardware
-        // hide/show on every ~30fps frame, and a state-syncing remote
-        // transport (mosh) samples that mid-toggle and renders a flickering
-        // caret. A painted cell is identical every frame, so it stays put.
-        self.paint_preview_cursor(frame, theme);
+        // In live-send mode, show the target pane's cursor over the preview.
+        // `capture-pane` carries only cell text (plus SGR color), not the
+        // cursor, so without this the "feels-attached" preview shows no cursor
+        // for programs that rely on the hardware cursor (shells, codex, anything
+        // using DECTCEM) even though a direct tmux attach would. The default is
+        // a painted block cell: ratatui re-emits a hardware hide/show on every
+        // ~30fps frame, and a state-syncing remote transport (mosh) samples that
+        // mid-toggle into a flickering caret, whereas a painted cell is
+        // identical every frame. `session.live_send_block_cursor = false`
+        // switches back to the native hardware cursor (its blink and shape, at
+        // the cost of that flicker over such links).
+        if self.live_send_block_cursor {
+            self.paint_preview_cursor(frame, theme);
+        } else if let Some(pos) = self.live_preview_cursor_pos() {
+            frame.set_cursor_position(pos);
+        }
 
         // Selection highlight goes last so it sits on top of whatever
         // the active ViewMode painted into the inner area. The handlers


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

In live-send mode the agent-pane preview places a real terminal cursor over the captured cells via `frame.set_cursor_position`. ratatui re-emits the hardware cursor hide/show on every frame, and the live preview refreshes at ~30fps. Over a state-syncing remote transport like mosh (which re-renders from its own framebuffer and drops frames), a send can land in the sub-millisecond window where the cursor is hidden and hold "cursor hidden" until the next frame, stretching a microsecond toggle into a visible blink. The result is a cursor that flickers in the TUI live view, noticeably worse over mosh than over direct ssh.

Confirmed against a real session: a plain shell pane (`cursor_flag=1`, no alternate screen, no agent caret) flickers over mosh too, so the cause is generic hardware-cursor churn, not anything agent-specific.

### Changes

1. **A painted block cursor option for the live preview.** Instead of placing the hardware cursor, paint an opaque block cell at the cursor position. A painted cell is byte-identical every frame, so there is no hide/show for the transport to sample, which removes the flicker. Mirrors what the web dashboard already does for its captured-pane cursor.
2. **A `session.live_send_block_cursor` setting** to choose between the two. Declared as a single-source `#[setting]` toggle, so it surfaces in the TUI and web settings automatically. **Defaults to off**: the live preview keeps the native hardware cursor (its blink and shape, the same caret a direct attach shows), so default behavior is unchanged. Turn it on for the painted block when viewing over a frame-dropping link like mosh. Verified both paths over mosh: the native cursor flickers, the painted block stays steady.

The visibility rule is unchanged: `map_live_preview_cursor` still returns `None` for a hidden cursor, so apps that hide their caret get nothing either way.

## PR Type

- [x] New Feature
- [x] Bug Fix

## Checklist

- [x] New and existing tests pass (`cargo fmt --check`, `cargo clippy --lib`, and the `tui::home`, `session::config`, and `settings_schema` unit suites pass locally)
- [x] Documentation was updated where necessary (the setting's doc comment is its single-source description; code comments updated in place)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: no web files change. The new toggle is schema-driven and renders through the existing generic settings FormField path, which is already covered.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the cursor-cell mapping is unit-tested (`map_live_preview_cursor`), and the setting is config plumbing covered by the existing config roundtrip and schema tests. The behavior this PR adds (painted cell vs hardware cursor, and the flicker it avoids) only manifests over a frame-dropping remote transport like mosh, which is not reproducible in CI. Reproduced and verified manually over mosh on both a plain shell and an agent session.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any Additional AI Details you'd like to share:** Claude investigated the flicker report and initially proposed wrong root causes (ssh transport, then mosh defeating synchronized output, then an agent content caret). A `tmux display-message` check on the live panes plus a plain-shell-over-mosh repro corrected the diagnosis to hardware-cursor churn. njbrake directed the investigation, verified the fix over mosh, and chose the opt-in default.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change improves live-send cursor rendering in the TUI by drawing the cursor directly into the preview instead of relying on the terminal’s hardware cursor, which helps avoid flicker on unstable or frame-dropping transports.

A new session setting, `live_send_block_cursor`, was added so users can choose between the new painted block cursor behavior and the previous native cursor behavior.

The live preview state now keeps this setting in sync during config load and refresh, and the cursor-mapping logic was clarified to skip painting when the cursor is hidden or outside the preview area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->