### PR TITLE
refactor(tui): typed WatcherInitError latch in ReloadFailureState

### DIFF
--- a/src/tui/home/file_watch_tests.rs
+++ b/src/tui/home/file_watch_tests.rs
@@ -571,7 +571,7 @@ async fn rewire_no_op_preserves_latched_disk_watcher_init_failure() {
     );
 
     view.reload_failure_state
-        .record_disk_watcher_init_failure("hv-noop: simulated prior failure");
+        .record_disk_watcher_init_failure("hv-noop", "simulated prior failure");
     assert!(
         view.reload_failure_state.has_any_failure(),
         "precondition: latch is set"
@@ -609,7 +609,7 @@ async fn rewire_disk_clears_stale_latch_when_failing_profile_is_removed() {
     .expect("HomeView::new");
 
     view.reload_failure_state
-        .record_disk_watcher_init_failure("ghost: simulated subscribe failure");
+        .record_disk_watcher_init_failure("ghost", "simulated subscribe failure");
     assert!(
         view.reload_failure_state.has_any_failure(),
         "precondition: latch is set, references the now-deleted profile"
@@ -645,7 +645,7 @@ async fn rewire_config_clears_stale_latch_when_failing_profile_is_removed() {
     .expect("HomeView::new");
 
     view.reload_failure_state
-        .record_config_watcher_init_failure("profile ghost config: simulated subscribe failure");
+        .record_config_watcher_init_failure(Some("ghost"), "simulated subscribe failure");
     assert!(
         view.reload_failure_state.has_any_failure(),
         "precondition: latch is set, references the now-deleted profile"
@@ -683,7 +683,7 @@ async fn config_init_failure_survives_concurrent_disk_rewire_clear() {
     .expect("HomeView::new");
 
     view.reload_failure_state
-        .record_config_watcher_init_failure("seed: config init failed");
+        .record_config_watcher_init_failure(None, "seed: config init failed");
     assert!(
         view.reload_failure_state.has_any_failure(),
         "precondition: config latch is set"
@@ -749,8 +749,8 @@ fn reload_failure_state_dialog_body_aggregates_all_four_sources() {
     let mut state = super::ReloadFailureState::default();
     state.record_storage(&Err::<(), _>(anyhow::anyhow!("storage err")));
     state.record_config(&Err::<(), _>(anyhow::anyhow!("config err")));
-    state.record_disk_watcher_init_failure("disk subscribe denied");
-    state.record_config_watcher_init_failure("config subscribe denied");
+    state.record_disk_watcher_init_failure("agg-disk", "disk subscribe denied");
+    state.record_config_watcher_init_failure(None, "config subscribe denied");
 
     let body = state.build_dialog_body();
     assert!(
@@ -762,11 +762,11 @@ fn reload_failure_state_dialog_body_aggregates_all_four_sources() {
         "missing config line: {body}"
     );
     assert!(
-        body.contains("- Disk watcher init: disk subscribe denied"),
+        body.contains("- Disk watcher init: agg-disk: disk subscribe denied"),
         "missing disk watcher-init line: {body}"
     );
     assert!(
-        body.contains("- Config watcher init: config subscribe denied"),
+        body.contains("- Config watcher init: global config: config subscribe denied"),
         "missing config watcher-init line: {body}"
     );
 }
@@ -775,13 +775,13 @@ fn reload_failure_state_dialog_body_aggregates_all_four_sources() {
 fn reload_failure_state_watcher_init_failure_lifecycle_is_per_source() {
     let mut state = super::ReloadFailureState::default();
 
-    state.record_disk_watcher_init_failure("first disk install failed");
+    state.record_disk_watcher_init_failure("life-disk", "first disk install failed");
     assert!(
         state.has_unacknowledged_failure(),
         "disk_watcher_init_error contributes to has_any_failure"
     );
 
-    state.record_config_watcher_init_failure("first config install failed");
+    state.record_config_watcher_init_failure(None, "first config install failed");
     state.acknowledge_dialog();
 
     state.clear_disk_watcher_init_failure();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1078,6 +1078,14 @@ fn drop_disk_watch_entry(entry: DiskWatchEntry) {
     forwarder.abort();
 }
 
+/// Latched record of a watcher init failure. The disk slot always carries
+/// `Some(profile)`; the config slot carries `None` for the global config
+/// watch and `Some(profile)` per-profile.
+pub(super) struct WatcherInitError {
+    profile: Option<String>,
+    message: String,
+}
+
 /// Per-tick reload failure tracking. Tick-driven reload paths in
 /// `App::run` (heartbeat `reload()`, watcher-driven `reload_storage_only()`,
 /// watcher-driven `refresh_from_config()`) route results through
@@ -1096,17 +1104,17 @@ pub(super) struct ReloadFailureState {
     storage_error: Option<String>,
     config_failed: bool,
     config_error: Option<String>,
-    /// Latched description of the most recent disk-watcher init failure
+    /// Latched record of the most recent disk-watcher init failure
     /// (typically `subscribe_channel` returning Err on disk rewire).
     /// Surfaced in the reload-failure dialog body. Cleared on the next
     /// successful disk rewire pass for the affected profile.
-    disk_watcher_init_error: Option<String>,
-    /// Latched description of the most recent config-watcher init failure
+    disk_watcher_init_error: Option<WatcherInitError>,
+    /// Latched record of the most recent config-watcher init failure
     /// (typically `subscribe_channel` returning Err on config rewire).
     /// Independent from `disk_watcher_init_error`: a config init failure
     /// is not overwritten by a disk rewire and persists until the next
     /// successful config rewire pass for the affected key.
-    config_watcher_init_error: Option<String>,
+    config_watcher_init_error: Option<WatcherInitError>,
     dialog_acknowledged: bool,
 }
 
@@ -1163,9 +1171,16 @@ impl ReloadFailureState {
         }
     }
 
-    pub(super) fn record_disk_watcher_init_failure(&mut self, detail: &str) {
+    pub(super) fn record_disk_watcher_init_failure(
+        &mut self,
+        profile: &str,
+        message: impl Into<String>,
+    ) {
         let was_clear = self.disk_watcher_init_error.is_none();
-        self.disk_watcher_init_error = Some(detail.to_string());
+        self.disk_watcher_init_error = Some(WatcherInitError {
+            profile: Some(profile.to_owned()),
+            message: message.into(),
+        });
         if was_clear {
             self.dialog_acknowledged = false;
         }
@@ -1180,9 +1195,16 @@ impl ReloadFailureState {
         }
     }
 
-    pub(super) fn record_config_watcher_init_failure(&mut self, detail: &str) {
+    pub(super) fn record_config_watcher_init_failure(
+        &mut self,
+        profile: Option<&str>,
+        message: impl Into<String>,
+    ) {
         let was_clear = self.config_watcher_init_error.is_none();
-        self.config_watcher_init_error = Some(detail.to_string());
+        self.config_watcher_init_error = Some(WatcherInitError {
+            profile: profile.map(str::to_owned),
+            message: message.into(),
+        });
         if was_clear {
             self.dialog_acknowledged = false;
         }
@@ -1197,42 +1219,24 @@ impl ReloadFailureState {
         }
     }
 
-    /// Whether the disk_watcher_init_error latch references a profile
-    /// name not in `current`. The latch detail string format is set by
-    /// `record_disk_watcher_init_failure` call sites in
-    /// `rewire_disk_subscriptions` as `"{profile_name}: {error}"`; the
-    /// extractor splits at the first `": "` to recover the name.
     pub(super) fn disk_watcher_init_error_references_missing_profile(
         &self,
         current: &[String],
     ) -> bool {
-        let Some(err) = self.disk_watcher_init_error.as_deref() else {
-            return false;
-        };
-        let Some((name, _)) = err.split_once(": ") else {
-            return false;
-        };
-        !current.iter().any(|p| p == name)
+        self.disk_watcher_init_error
+            .as_ref()
+            .and_then(|e| e.profile.as_deref())
+            .is_some_and(|name| !current.iter().any(|p| p == name))
     }
 
-    /// Whether the config_watcher_init_error latch references a
-    /// per-profile name not in `current`. The per-profile detail
-    /// string format is `"profile {name} config: {error}"`; the global
-    /// format `"global config: ..."` returns false.
     pub(super) fn config_watcher_init_error_references_missing_profile(
         &self,
         current: &[String],
     ) -> bool {
-        let Some(err) = self.config_watcher_init_error.as_deref() else {
-            return false;
-        };
-        let Some(rest) = err.strip_prefix("profile ") else {
-            return false;
-        };
-        let Some((name, _)) = rest.split_once(" config:") else {
-            return false;
-        };
-        !current.iter().any(|p| p == name)
+        self.config_watcher_init_error
+            .as_ref()
+            .and_then(|e| e.profile.as_deref())
+            .is_some_and(|name| !current.iter().any(|p| p == name))
     }
 
     pub(super) fn has_any_failure(&self) -> bool {
@@ -1255,10 +1259,18 @@ impl ReloadFailureState {
             lines.push(format!("- Config: {e}"));
         }
         if let Some(e) = &self.disk_watcher_init_error {
-            lines.push(format!("- Disk watcher init: {e}"));
+            let detail = match &e.profile {
+                Some(name) => format!("{name}: {}", e.message),
+                None => e.message.clone(),
+            };
+            lines.push(format!("- Disk watcher init: {detail}"));
         }
         if let Some(e) = &self.config_watcher_init_error {
-            lines.push(format!("- Config watcher init: {e}"));
+            let detail = match &e.profile {
+                Some(name) => format!("profile {name} config: {}", e.message),
+                None => format!("global config: {}", e.message),
+            };
+            lines.push(format!("- Config watcher init: {detail}"));
         }
         lines.push(String::new());
         lines.push("In-memory state preserved; sources retry automatically.".to_string());
@@ -2004,7 +2016,7 @@ impl HomeView {
                         "subscribe_channel failed; falling back to 5s heartbeat for this profile"
                     );
                     self.reload_failure_state
-                        .record_disk_watcher_init_failure(&format!("{}: {}", name, e));
+                        .record_disk_watcher_init_failure(name, e.to_string());
                 }
             }
         }
@@ -2213,7 +2225,7 @@ impl HomeView {
                                  falling back to settings-close + profile-switch reload"
                             );
                             self.reload_failure_state
-                                .record_config_watcher_init_failure(&format!("global config: {e}"));
+                                .record_config_watcher_init_failure(None, e.to_string());
                         }
                     }
                 }
@@ -2224,9 +2236,10 @@ impl HomeView {
                         "skipping global config subscribe; app dir resolution failed"
                     );
                     self.reload_failure_state
-                        .record_config_watcher_init_failure(&format!(
-                            "global config: app dir resolution failed: {e}"
-                        ));
+                        .record_config_watcher_init_failure(
+                            None,
+                            format!("app dir resolution failed: {e}"),
+                        );
                 }
             }
         }
@@ -2313,7 +2326,7 @@ impl HomeView {
                          falling back to settings-close + profile-switch reload for this profile"
                     );
                     self.reload_failure_state
-                        .record_config_watcher_init_failure(&format!("profile {name} config: {e}"));
+                        .record_config_watcher_init_failure(Some(name), e.to_string());
                 }
             }
         }


### PR DESCRIPTION
## Description

Closes #2099.

Replaces the two `Option<String>` latches in `ReloadFailureState` (`disk_watcher_init_error`, `config_watcher_init_error`) with `Option<WatcherInitError>`, where `WatcherInitError { profile: Option<String>, message: String }` splits the per-profile name from the error text. `profile = None` marks the global config slot.

The four record-call sites in `rewire_disk_subscriptions` and `rewire_config_subscriptions` pass `(profile, message)` separately rather than a preformatted string. The two `*_references_missing_profile` checkers read `e.profile.as_deref()` directly; their previous string-parsing (`split_once(": ")` for disk, `strip_prefix("profile ")` + `split_once(" config:")` for config) is removed, along with the inline rustdocs that documented the implicit format coupling. `build_dialog_body` reconstructs the same three preexisting strings from the typed wrapper so dialog output stays byte-identical on every production path:

- per-profile disk: `- Disk watcher init: {profile}: {message}`
- per-profile config: `- Config watcher init: profile {profile} config: {message}`
- global config: `- Config watcher init: global config: {message}`

Three watcher-init tests cited by the issue move their `record_*_watcher_init_failure` calls to the typed signature with no assert changes: `rewire_no_op_preserves_latched_disk_watcher_init_failure`, `rewire_disk_clears_stale_latch_when_failing_profile_is_removed`, `rewire_config_clears_stale_latch_when_failing_profile_is_removed`. Three other `ReloadFailureState` unit tests share the same signature surface and get a mechanical call-site update so they keep compiling: `config_init_failure_survives_concurrent_disk_rewire_clear`, `reload_failure_state_dialog_body_aggregates_all_four_sources`, `reload_failure_state_watcher_init_failure_lifecycle_is_per_source`. The body-aggregation test additionally retargets two `body.contains` asserts because its synthetic inputs were never production-shaped and the rendered substring changes accordingly; the test continues to lock body aggregation across the four sources. No tests added or removed.

Out of scope (separate concerns):
- Multi-failure aggregation per source
- Dialog wording changes
- `storage_failed` / `config_failed` slots (their strings are not parsed back out)
- `DiskWatchState` / `ConfigWatchState` type-tightening (#2016)

Test plan:
- `cargo fmt`
- `cargo clippy --features serve --tests --all-targets -- -D warnings`
- `cargo test --features serve --lib file_watch_tests` passes (26/26)
- `cargo test --features serve --lib` passes (4441/4444; three pre-existing failures on `upstream/main@e82f787e` unrelated to this refactor: `tmux::session::tests::capture_pane_with_cursor_returns_content_and_cursor`, `tmux::session::tests::capture_with_cursor_stays_consistent_under_streaming_load`, `session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt`)

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (pure type-tightening on an internal latch; dialog body byte-identical, locked by existing unit tests)
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 4.7 (claude-opus-4-7)

**Any Additional AI Details you'd like to share:**

Implementation, test migration, and PR body drafted by Claude Opus 4.7 from a human-authored design spec that fixed the struct shape, the four record-call signatures, and the byte-identical dialog wording. The model also ran `cargo fmt`, `cargo clippy --features serve --tests --all-targets -- -D warnings`, and the test commands above locally before opening this PR.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR makes watcher-init reload failures more structured and easier to maintain.

### What changed
- Replaced string-based failure latches with a typed `WatcherInitError` that stores:
  - an optional profile name
  - the error message
- Updated watcher-init recording calls to pass profile and message separately.
- Simplified stale-failure checks by reading the stored profile directly instead of parsing text.
- Kept dialog rendering in one place so the user-facing reload failure text stays the same on normal paths.
- Updated tests to match the new input/output shape.

### Benefits
- Removes fragile string parsing.
- Makes failure tracking clearer and less error-prone.
- Preserves existing behavior, including last-writer-wins handling and current dialog output.
- Improves future maintainability by separating identity from message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->