### PR TITLE
fix(tui): scroll alt-screen agents in passive preview, send PgUp/PgDn

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -286,14 +286,18 @@ async fn handle_live_ws(
             .await;
 
             match captured {
-                Ok(Ok((content, cursor))) if !content.is_empty() || cursor.is_some() => {
+                // A position-unreliable cursor (the pane scrolled between the
+                // capture's two probes) is treated as "no cursor" here: the web
+                // frame has no `position_reliable` channel and its renderer maps
+                // the cursor row onto the content, so painting it would land on
+                // the wrong row. Folding `position_reliable` into the guard (not
+                // just `is_some`) keeps the empty-content case routing to the
+                // dead-probe arm exactly as it did before this flag existed.
+                Ok(Ok((content, cursor)))
+                    if !content.is_empty()
+                        || cursor.as_ref().is_some_and(|c| c.position_reliable) =>
+                {
                     dead_probes = 0;
-                    // The web frame has no `position_reliable` channel and its
-                    // renderer maps the cursor row onto the content, so a
-                    // position-unreliable cursor (the pane scrolled between the
-                    // capture's two cursor probes) would paint on the wrong
-                    // row. Drop it, preserving the pre-`position_reliable` web
-                    // behavior; this path does not consume the mode flags.
                     let cursor = cursor.filter(|c| c.position_reliable);
                     // Keep the size-owner lock alive while we hold it, and
                     // notice promptly if another client took over (then we

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -288,6 +288,13 @@ async fn handle_live_ws(
             match captured {
                 Ok(Ok((content, cursor))) if !content.is_empty() || cursor.is_some() => {
                     dead_probes = 0;
+                    // The web frame has no `position_reliable` channel and its
+                    // renderer maps the cursor row onto the content, so a
+                    // position-unreliable cursor (the pane scrolled between the
+                    // capture's two cursor probes) would paint on the wrong
+                    // row. Drop it, preserving the pre-`position_reliable` web
+                    // behavior; this path does not consume the mode flags.
+                    let cursor = cursor.filter(|c| c.position_reliable);
                     // Keep the size-owner lock alive while we hold it, and
                     // notice promptly if another client took over (then we
                     // demote ourselves to a read-only viewer).
@@ -634,6 +641,7 @@ mod tests {
             alternate_on: false,
             mouse_tracking: false,
             mouse_sgr: false,
+            position_reliable: true,
         };
         let json = frame_json("hello\nworld", Some(&cursor));
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -660,6 +668,7 @@ mod tests {
             alternate_on: true,
             mouse_tracking: true,
             mouse_sgr: false,
+            position_reliable: true,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
         assert_eq!(v["altScreen"], true);
@@ -679,6 +688,7 @@ mod tests {
             alternate_on: false,
             mouse_tracking: false,
             mouse_sgr: false,
+            position_reliable: true,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
         assert!(v["cursor"].is_null());

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -87,6 +87,16 @@ pub struct PaneCursor {
     /// can mean the legacy X10 encoding, which our SGR bytes would corrupt.
     /// Optional; parses as `false`.
     pub mouse_sgr: bool,
+    /// Whether `x`/`y` can be trusted to index the captured content. The
+    /// terminal-mode flags above (`alternate_on`, `mouse_tracking`,
+    /// `mouse_sgr`) are always valid, but `capture_pane_with_cursor` probes
+    /// the cursor twice and, if the pane scrolled mid-capture, the row no
+    /// longer maps onto the captured rows. It then publishes the cursor with
+    /// this `false` so the render skips painting it (avoiding the row-drift
+    /// bug), while the wheel forward, which reads only the mode flags, still
+    /// works while an agent streams. `parse` sets it `true`; only the
+    /// cross-probe check downgrades it.
+    pub position_reliable: bool,
 }
 
 impl PaneCursor {
@@ -117,7 +127,42 @@ impl PaneCursor {
             alternate_on,
             mouse_tracking,
             mouse_sgr,
+            // A single probe's own position is self-consistent; the
+            // cross-probe check in `capture_pane_with_cursor` is the only
+            // thing that downgrades this.
+            position_reliable: true,
         })
+    }
+}
+
+/// Reconcile the two cursor probes `capture_pane_with_cursor` takes around the
+/// capture. Only the VERTICAL-mapping inputs must be stable across the
+/// capture: if `history_size` or `pane_height` changed, the screen scrolled or
+/// resized mid-capture and the cursor's row no longer indexes the captured
+/// content (the row-drift bug). A blinking cursor or horizontal jitter from an
+/// animated TUI (claude's spinner) changes `visible`/`x` every frame but never
+/// moves the row, so comparing the whole struct would suppress the cursor on
+/// every frame of an actively repainting agent. Keep the post-capture cursor
+/// (closest to the freshest content); when the mapping moved, flag the
+/// POSITION as unreliable rather than dropping the whole cursor, so the wheel
+/// forward (which reads only the always-valid mode flags) still works while an
+/// agent streams, while the render skips painting on the drifted row. A probe
+/// that didn't parse (pane gone / malformed) carries no trustworthy mode flags
+/// either, so the result is `None`.
+fn merge_cursor_probes(
+    before: Option<PaneCursor>,
+    after: Option<PaneCursor>,
+) -> Option<PaneCursor> {
+    match (before, after) {
+        (Some(b), Some(a)) => {
+            let position_reliable =
+                b.history_size == a.history_size && b.pane_height == a.pane_height;
+            Some(PaneCursor {
+                position_reliable,
+                ..a
+            })
+        }
+        _ => None,
     }
 }
 
@@ -481,24 +526,7 @@ impl Session {
         };
         let before = PaneCursor::parse(cursor_line);
         let after = PaneCursor::parse(after_line);
-        // Only the VERTICAL-mapping inputs must be stable across the capture:
-        // if `history_size` or `pane_height` changed, the screen scrolled or
-        // resized mid-capture and the cursor's row no longer indexes the
-        // captured content (the row-drift bug). A blinking cursor or a
-        // horizontal jitter from an animated TUI (claude's spinner) changes
-        // `visible`/`x` every frame but never moves the row, so comparing the
-        // whole struct would suppress the cursor on every frame of an
-        // actively repainting agent. Keep the post-capture cursor (closest to
-        // the freshest content) when the mapping is stable.
-        let cursor = match (before, after) {
-            (Some(b), Some(a))
-                if b.history_size == a.history_size && b.pane_height == a.pane_height =>
-            {
-                Some(a)
-            }
-            _ => None,
-        };
-        Ok((content.to_string(), cursor))
+        Ok((content.to_string(), merge_cursor_probes(before, after)))
     }
 
     /// Deliver raw bytes to the session's active pane via `tmux send-keys
@@ -1010,6 +1038,7 @@ mod tests {
                 alternate_on: true,
                 mouse_tracking: true,
                 mouse_sgr: true,
+                position_reliable: true,
             }
         );
         // Legacy mouse (tracking on, SGR off) parses with mouse_sgr false.
@@ -1036,6 +1065,50 @@ mod tests {
         assert!(PaneCursor::parse("").is_none());
         assert!(PaneCursor::parse("1 2 3").is_none());
         assert!(PaneCursor::parse("a b c d").is_none());
+        // A freshly parsed probe trusts its own position.
+        assert!(
+            PaneCursor::parse("3 2 1 24 120 74 1 1 1")
+                .unwrap()
+                .position_reliable
+        );
+    }
+
+    #[test]
+    fn merge_cursor_probes_stable_mapping_keeps_after_and_trusts_position() {
+        // Cursor moved (x/y) but the vertical mapping (history_size,
+        // pane_height) held: the post-capture probe wins and is trusted.
+        let before = PaneCursor::parse("3 2 1 24 120 80 1 1 1").unwrap();
+        let after = PaneCursor::parse("5 4 1 24 120 80 1 1 1").unwrap();
+        let merged = merge_cursor_probes(Some(before), Some(after)).expect("both probes => Some");
+        assert_eq!((merged.x, merged.y), (5, 4));
+        assert!(merged.position_reliable);
+    }
+
+    #[test]
+    fn merge_cursor_probes_drift_keeps_modes_but_drops_position_trust() {
+        // history_size changed mid-capture (the pane scrolled): keep the mode
+        // flags so the wheel forward still works while the agent streams, but
+        // mark the row untrustworthy so the render won't paint on it.
+        let before = PaneCursor::parse("3 2 1 24 120 80 1 1 1").unwrap();
+        let after = PaneCursor::parse("3 2 1 24 137 80 1 1 1").unwrap();
+        let merged = merge_cursor_probes(Some(before), Some(after)).expect("both probes => Some");
+        assert!(!merged.position_reliable);
+        assert!(merged.alternate_on && merged.mouse_tracking && merged.mouse_sgr);
+
+        // pane_height change (resize mid-capture) is the other vertical-drift
+        // trigger and likewise drops position trust.
+        let before = PaneCursor::parse("3 2 1 24 120 80 1 0 0").unwrap();
+        let after = PaneCursor::parse("3 2 1 30 120 80 1 0 0").unwrap();
+        let merged = merge_cursor_probes(Some(before), Some(after)).expect("both probes => Some");
+        assert!(!merged.position_reliable);
+    }
+
+    #[test]
+    fn merge_cursor_probes_none_when_either_probe_missing() {
+        let c = PaneCursor::parse("3 2 1 24 120 80 1 1 1").unwrap();
+        assert!(merge_cursor_probes(None, Some(c)).is_none());
+        assert!(merge_cursor_probes(Some(c), None).is_none());
+        assert!(merge_cursor_probes(None, None).is_none());
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3366,16 +3366,22 @@ impl HomeView {
         else {
             return false;
         };
-        // Live-send: keep scroll ordered against typed keystrokes via the
-        // long-lived worker. Passive preview: no worker exists, so fork a
-        // one-shot send to whatever pane the capture worker is showing.
-        if let Some(worker) = &self.live_send_worker {
-            worker.send(key);
-            return true;
-        }
+        // The cursor and the mapped coordinates describe the pane the preview
+        // is showing (`preview_capture_target`), so the keys must go THERE.
+        // Route through the ordered live-send worker only when that pane is
+        // also the live-send target, so scroll stays in sequence with typed
+        // keystrokes; otherwise (passive preview, or live-send aimed at a
+        // different pane than the one on screen) fork a one-shot send to the
+        // displayed pane.
         let Some(target) = self.preview_capture_target.as_deref() else {
             return false;
         };
+        if let (Some(worker), Some(live)) = (&self.live_send_worker, &self.live_send) {
+            if live.tmux_name.as_str() == target {
+                worker.send(key);
+                return true;
+            }
+        }
         live_send::send_key_oneshot(target, key);
         true
     }
@@ -5270,6 +5276,7 @@ mod tests {
             alternate_on,
             mouse_tracking,
             mouse_sgr,
+            position_reliable: true,
         }
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -223,16 +223,17 @@ fn wheel_mouse_bytes(
     }
 }
 
-/// Arrow presses delivered per wheel notch when emulating alternate-scroll
-/// for a no-mouse full-screen app. Matches tmux's own alternate-scroll step
-/// and the capture-window `STEP` in `handle_scroll_up`.
-const WHEEL_ARROW_STEP: usize = 3;
+/// Page presses delivered per wheel notch for a no-mouse full-screen app.
+/// One page per notch: full-screen apps that scroll on `PageUp`/`PageDown`
+/// (Claude Code's fullscreen renderer is the motivating case) have no finer
+/// keyboard step, and a page per notch reads as a normal "flick to scroll".
+const WHEEL_PAGE_STEP: usize = 1;
 
-/// Decide what to forward to a full-screen live-send pane for one wheel
+/// Decide what to forward to the previewed full-screen pane for one wheel
 /// notch, or `None` to fall back to the capture-window scroll. Pure so the
-/// branch the fix turns on (named arrow keys vs. raw mouse bytes vs. no
-/// forward) is asserted directly, without standing up a worker. See
-/// `forward_wheel_to_live_pane` for the full rationale.
+/// branch the fix turns on (page keys vs. raw mouse bytes vs. no forward) is
+/// asserted directly, without standing up a worker. See
+/// `forward_wheel_to_preview` for the full rationale.
 fn wheel_forward_key(
     cursor: &crate::tmux::PaneCursor,
     up: bool,
@@ -252,9 +253,14 @@ fn wheel_forward_key(
             row,
         )))
     } else {
+        // No mouse tracking: send `PageUp`/`PageDown`, NOT arrow keys. A
+        // full-screen app reads arrow keys as cursor / input-history
+        // navigation, not scroll (Claude Code 2.1.x even surfaces "Scroll
+        // wheel is sending arrow keys, use PgUp/PgDn to scroll"). The page
+        // keys scroll its transcript regardless of cursor-key mode.
         Some(live_send::TmuxKey::NamedRepeat {
-            name: if up { "Up" } else { "Down" }.to_string(),
-            count: WHEEL_ARROW_STEP,
+            name: if up { "PageUp" } else { "PageDown" }.to_string(),
+            count: WHEEL_PAGE_STEP,
         })
     }
 }
@@ -3324,45 +3330,33 @@ impl HomeView {
         }
     }
 
-    /// Route a mouse-wheel-up at (col, row) to the pane under the cursor:
-    /// diff view (if open) → diff scroll; list pane → list cursor up;
-    /// preview pane → preview scroll. Returns `true` if the UI should
-    /// redraw. Scrolls do not cross pane boundaries: a wheel over the
-    /// preview never moves the list cursor, even when the preview is at
-    /// its scroll boundary or has no session selected.
-    /// When a live-send target is a full-screen (alternate-screen) app, the
-    /// preview's capture-window scroll is useless: the alternate screen has
-    /// no scrollback, so growing the window only exposes the unrelated
-    /// normal-buffer history underneath and the view bottoms out at the
-    /// session's start. Instead, forward the wheel to the app so it scrolls
-    /// its OWN content, exactly as a terminal does on direct attach. Two
-    /// cases, branched on what the app asked for:
+    /// Forward one wheel notch to the previewed full-screen (alternate-screen)
+    /// pane so it scrolls its OWN content, exactly as a terminal does on
+    /// direct attach. Active in BOTH live-send and passive preview: the
+    /// alternate screen has no scrollback, so the preview's capture-window
+    /// scroll is inert there (growing the window only exposes the unrelated
+    /// normal-buffer history and bottoms out at the session start), and
+    /// forwarding is the only way to reach the agent's history. Branched on
+    /// what the app asked for (see `wheel_forward_key`):
     ///
-    /// * **Mouse tracking on** (`mouse_tracking`): forward the wheel as a
-    ///   mouse event, the encoding following the app (SGR 1006 when
-    ///   `mouse_sgr` is set, otherwise the legacy X10 encoding).
-    /// * **Mouse tracking off**: an alternate-screen app with no mouse mode
-    ///   gets its wheel via the terminal's alternate-scroll behavior, which
-    ///   turns the wheel into cursor-key presses. tmux does this for any
-    ///   such pane on attach (`alternate-scroll`, on by default), so we
-    ///   replicate it: send `Up`/`Down` instead of raw mouse bytes (which
-    ///   the app would read as garbage keystrokes). Claude Code's fullscreen
-    ///   renderer is the motivating case: it sets `1049h` + `1007h` but
-    ///   never requests mouse tracking, and binds the arrow keys to scroll
-    ///   in that mode (#2407). `send-keys -N` renders all 3 presses in the
-    ///   pane's current application-cursor-key mode in a single fork; the
-    ///   step matches tmux's own alternate-scroll and the capture `STEP`.
+    /// * **Mouse tracking on**: forward the wheel as a mouse event, encoding
+    ///   following the app (SGR 1006 when `mouse_sgr` is set, else legacy
+    ///   X10). The previewed pane is sized to the preview rect in both modes
+    ///   (`preview_pane_synced` / the live-send sync resize), so the mapped
+    ///   coordinates land inside it.
+    /// * **Mouse tracking off**: send `PageUp`/`PageDown`, not arrow keys. A
+    ///   full-screen app reads arrows as cursor / input-history navigation,
+    ///   not scroll; the page keys scroll its transcript regardless of mode.
+    ///   Claude Code's fullscreen renderer is the motivating case (#2407).
     ///
-    /// Only alternate-screen panes are forwarded; on the normal buffer the
-    /// capture-window scroll reaches real scrollback, so the caller keeps
-    /// it. Returns true when the event was forwarded.
-    fn forward_wheel_to_live_pane(&self, up: bool, col: u16, row: u16) -> bool {
-        if self.live_send.is_none() {
-            return false;
-        }
-        let Some(worker) = &self.live_send_worker else {
-            return false;
-        };
+    /// Normal-buffer panes get `None` from `wheel_forward_key`, so the caller
+    /// keeps the capture-window scroll (which reaches real scrollback there).
+    ///
+    /// In live-send the key rides the ordered `LiveSendWorker` so it stays in
+    /// sequence with typed keystrokes. In passive preview there is no worker,
+    /// so it goes out as a one-shot fork to the previewed pane's tmux target.
+    /// Returns true when the event was forwarded.
+    fn forward_wheel_to_preview(&self, up: bool, col: u16, row: u16) -> bool {
         let cursor = self
             .preview_capture_worker
             .as_ref()
@@ -3372,7 +3366,17 @@ impl HomeView {
         else {
             return false;
         };
-        worker.send(key);
+        // Live-send: keep scroll ordered against typed keystrokes via the
+        // long-lived worker. Passive preview: no worker exists, so fork a
+        // one-shot send to whatever pane the capture worker is showing.
+        if let Some(worker) = &self.live_send_worker {
+            worker.send(key);
+            return true;
+        }
+        let Some(target) = self.preview_capture_target.as_deref() else {
+            return false;
+        };
+        live_send::send_key_oneshot(target, key);
         true
     }
 
@@ -3411,9 +3415,10 @@ impl HomeView {
         if self.selected_session.is_none() {
             return false;
         }
-        // Full-screen mouse app under live-send: send the wheel to the app
-        // instead of scrolling the (irrelevant) normal-buffer capture.
-        if self.forward_wheel_to_live_pane(true, col, row) {
+        // Full-screen (alternate-screen) app: send the wheel to the app
+        // instead of scrolling the (irrelevant) normal-buffer capture. Fires
+        // in both live-send and passive preview.
+        if self.forward_wheel_to_preview(true, col, row) {
             self.preview_scroll_offset = 0;
             return true;
         }
@@ -4392,9 +4397,9 @@ impl HomeView {
         if self.selected_session.is_none() {
             return false;
         }
-        // Mirror handle_scroll_up: a full-screen mouse app gets the wheel
+        // Mirror handle_scroll_up: a full-screen app gets the wheel
         // forwarded rather than moving the preview's capture window.
-        if self.forward_wheel_to_live_pane(false, col, row) {
+        if self.forward_wheel_to_preview(false, col, row) {
             self.preview_scroll_offset = 0;
             return true;
         }
@@ -5269,26 +5274,27 @@ mod tests {
     }
 
     /// The fix for #2407: a full-screen pane with no mouse tracking must
-    /// forward named arrow keys (repeated per notch), NOT raw mouse bytes.
-    /// Asserting the key variant guards against a regression to mouse-byte
-    /// forwarding that the preview-offset behavioral test can't catch.
+    /// forward `PageUp`/`PageDown`, NOT arrow keys (which an app reads as
+    /// cursor / input-history navigation, not scroll) and NOT raw mouse
+    /// bytes. Asserting the key variant guards against a regression to
+    /// either that the preview-offset behavioral test can't catch.
     #[test]
-    fn wheel_forward_key_no_mouse_alt_screen_is_arrow_repeat() {
+    fn wheel_forward_key_no_mouse_alt_screen_is_page_key() {
         use ratatui::layout::Rect;
         let pane = Rect::new(0, 0, 80, 24);
         let cursor = cursor_for(true, false, false);
         assert_eq!(
             wheel_forward_key(&cursor, true, pane, 10, 10),
             Some(live_send::TmuxKey::NamedRepeat {
-                name: "Up".into(),
-                count: WHEEL_ARROW_STEP,
+                name: "PageUp".into(),
+                count: WHEEL_PAGE_STEP,
             })
         );
         assert_eq!(
             wheel_forward_key(&cursor, false, pane, 10, 10),
             Some(live_send::TmuxKey::NamedRepeat {
-                name: "Down".into(),
-                count: WHEEL_ARROW_STEP,
+                name: "PageDown".into(),
+                count: WHEEL_PAGE_STEP,
             })
         );
     }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -940,6 +940,17 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
 const MAX_INFLIGHT_ONESHOT: usize = 8;
 static INFLIGHT_ONESHOT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
+/// Releases one `INFLIGHT_ONESHOT` slot on drop, so the count is balanced even
+/// if the fork thread panics (otherwise a leaked slot would permanently shrink
+/// the cap). Constructed inside the spawned closure, so a spawn that never
+/// starts must release its reserved slot itself.
+struct OneshotSlot;
+impl Drop for OneshotSlot {
+    fn drop(&mut self) {
+        INFLIGHT_ONESHOT.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+    }
+}
+
 /// Forward a single translated key to a tmux pane with a one-shot
 /// `tmux send-keys` fork on a detached thread. Used by the passive-preview
 /// wheel forward, where there is no long-lived `LiveSendWorker` to enqueue
@@ -963,17 +974,31 @@ pub(super) fn send_key_oneshot(tmux_name: &str, key: TmuxKey) {
         TmuxKey::NamedRepeat { name, count } => TmuxAction::NamedRepeat { name, count },
         TmuxKey::HexBytes(bytes) => TmuxAction::HexBytes(bytes),
     };
-    std::thread::spawn(move || {
-        if let Err(err) = dispatch_via_fork(&tmux_name, &action) {
-            tracing::warn!(
-                target: "tui.live_send",
-                error = %err,
-                action = ?action,
-                "passive-preview wheel forward fork failed; notch dropped",
-            );
-        }
+    // `Builder::spawn` returns the OS error instead of panicking (`spawn`
+    // panics if the OS refuses a new thread), so a thread-creation failure
+    // under load can't take down the UI thread we're called from. The slot is
+    // released by the `OneshotSlot` guard inside the closure on completion or
+    // panic; if the spawn never starts, release the reserved slot here.
+    let spawned = std::thread::Builder::new()
+        .name("aoe-wheel-forward".to_string())
+        .spawn(move || {
+            let _slot = OneshotSlot;
+            if let Err(err) = dispatch_via_fork(&tmux_name, &action) {
+                tracing::warn!(
+                    target: "tui.live_send",
+                    error = %err,
+                    action = ?action,
+                    "passive-preview wheel forward fork failed; notch dropped",
+                );
+            }
+        });
+    if spawned.is_err() {
         INFLIGHT_ONESHOT.fetch_sub(1, Ordering::AcqRel);
-    });
+        tracing::warn!(
+            target: "tui.live_send",
+            "could not spawn wheel-forward thread; notch dropped",
+        );
+    }
 }
 
 /// Upper bound on the number of bytes encoded into a single

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -932,14 +932,30 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
     Ok(())
 }
 
+/// Cap on concurrently in-flight passive-preview send forks. A fast wheel
+/// flick fires many notches in quick succession; without a ceiling each would
+/// spawn its own detached thread. Eight in flight keeps scroll responsive,
+/// and dropping a notch past that under rapid fire is harmless (the user is
+/// still scrolling, and the next notch after a slot frees goes through).
+const MAX_INFLIGHT_ONESHOT: usize = 8;
+static INFLIGHT_ONESHOT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Forward a single translated key to a tmux pane with a one-shot
 /// `tmux send-keys` fork on a detached thread. Used by the passive-preview
 /// wheel forward, where there is no long-lived `LiveSendWorker` to enqueue
 /// onto: `dispatch_via_fork` blocks on the subprocess, so it must not run on
 /// the UI thread. Fire-and-forget; a dropped scroll notch is harmless and a
 /// failed fork is logged, not surfaced. Scroll notches carry no ordering
-/// relationship to each other, so racing forks are fine.
+/// relationship to each other, so racing forks are fine, and the fan-out is
+/// bounded by `MAX_INFLIGHT_ONESHOT`.
 pub(super) fn send_key_oneshot(tmux_name: &str, key: TmuxKey) {
+    use std::sync::atomic::Ordering;
+    // Reserve a slot first; if we are already at the cap, drop this notch
+    // rather than pile another thread on.
+    if INFLIGHT_ONESHOT.fetch_add(1, Ordering::AcqRel) >= MAX_INFLIGHT_ONESHOT {
+        INFLIGHT_ONESHOT.fetch_sub(1, Ordering::AcqRel);
+        return;
+    }
     let tmux_name = tmux_name.to_string();
     let action = match key {
         TmuxKey::Literal(s) => TmuxAction::Literal(s),
@@ -956,6 +972,7 @@ pub(super) fn send_key_oneshot(tmux_name: &str, key: TmuxKey) {
                 "passive-preview wheel forward fork failed; notch dropped",
             );
         }
+        INFLIGHT_ONESHOT.fetch_sub(1, Ordering::AcqRel);
     });
 }
 

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -594,15 +594,15 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// would lag the first fast capture by ~250ms.
     nudge: std::sync::Arc<(std::sync::Mutex<()>, std::sync::Condvar)>,
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    /// Whether the displayed pane is the live-send target. Only then does the
-    /// worker pay for the cursor query (a one-line `display-message` folded
-    /// into the same fork) and publish a cursor; otherwise `cursor` stays
-    /// `None` so a backgrounded or merely-browsed preview paints no cursor.
-    live: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    /// Newest pane cursor, refreshed every live cycle (even when the captured
-    /// text is unchanged, so a bare cursor move still updates). Cleared on
-    /// `set_live(false)` and `set_target`. The render loop reads it via
-    /// `current_cursor` to place a real terminal cursor over the live preview.
+    /// Newest pane cursor, refreshed every capture cycle (even when the
+    /// captured text is unchanged, so a bare cursor move still updates).
+    /// Cleared on `set_target` (the previewed pane changed). Two consumers: the
+    /// render loop paints a real terminal cursor over the preview ONLY while
+    /// live-send is active (`live_preview_cursor_pos` gates on `live_send`),
+    /// and the wheel forward reads it in BOTH live-send and passive preview
+    /// to decide whether/how to scroll an alternate-screen agent. So the
+    /// cursor query (a one-line `display-message` folded into the capture
+    /// fork) runs every cycle, not just live ones.
     cursor: std::sync::Arc<std::sync::Mutex<Option<crate::tmux::PaneCursor>>>,
 }
 
@@ -626,7 +626,6 @@ impl LiveCaptureWorker {
         let forward_empty = Arc::new(AtomicBool::new(false));
         let nudge: Arc<(Mutex<()>, Condvar)> = Arc::new((Mutex::new(()), Condvar::new()));
         let stop = Arc::new(AtomicBool::new(false));
-        let live = Arc::new(AtomicBool::new(false));
         let cursor: Arc<Mutex<Option<crate::tmux::PaneCursor>>> = Arc::new(Mutex::new(None));
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
@@ -635,7 +634,6 @@ impl LiveCaptureWorker {
         let forward_empty_cell = forward_empty.clone();
         let nudge_thread = nudge.clone();
         let stop_flag = stop.clone();
-        let live_cell = live.clone();
         let cursor_cell = cursor.clone();
         std::thread::spawn(move || {
             let mut last_target = String::new();
@@ -659,27 +657,18 @@ impl LiveCaptureWorker {
                 if lines > 0 && !name.is_empty() {
                     let session = crate::tmux::Session::from_name(&name);
                     let forward_empty = forward_empty_cell.load(Ordering::Relaxed);
-                    // Only the live-send target pays for the cursor query; it
-                    // folds into the same fork as the capture, so a live cycle
-                    // is still one `tmux` invocation. Backgrounded / browsed
-                    // previews capture text only and carry no cursor.
-                    let is_live = live_cell.load(Ordering::Relaxed);
+                    // Always pay for the cursor query: it folds into the same
+                    // `tmux` fork as the capture (one invocation), and the
+                    // passive-preview wheel forward needs the cursor (is this
+                    // an alternate-screen app? mouse tracking on?) to decide
+                    // whether and how to scroll the agent, not just live-send.
                     // A failed fork reads as "gone". For preserve panes that
                     // means hold the last-good frame (drop it); for forward
                     // panes (terminals) surface it as empty so stale text clears.
-                    let (capture, cursor_now) = if is_live {
-                        match session.capture_pane_with_cursor(lines) {
-                            Ok((content, cur)) => (Some(content), cur),
-                            Err(_) if forward_empty => (Some(String::new()), None),
-                            Err(_) => (None, None),
-                        }
-                    } else {
-                        let cap = match session.capture_pane(lines) {
-                            Ok(content) => Some(content),
-                            Err(_) if forward_empty => Some(String::new()),
-                            Err(_) => None,
-                        };
-                        (cap, None)
+                    let (capture, cursor_now) = match session.capture_pane_with_cursor(lines) {
+                        Ok((content, cur)) => (Some(content), cur),
+                        Err(_) if forward_empty => (Some(String::new()), None),
+                        Err(_) => (None, None),
                     };
                     if let Some(content) = capture {
                         // Skip unchanged frames (no point waking a re-parse).
@@ -695,11 +684,11 @@ impl LiveCaptureWorker {
                         let still_current =
                             target_cell.lock().ok().map(|g| *g == name).unwrap_or(false);
                         if still_current {
-                            // Cursor refreshes every live cycle, independent of
-                            // the content dedup: a bare cursor move leaves the
+                            // Cursor refreshes every cycle, independent of the
+                            // content dedup: a bare cursor move leaves the
                             // captured cells unchanged but must still update the
-                            // painted cursor. When not live, `cursor_now` is None
-                            // so the slot clears and no cursor is painted.
+                            // cursor (the render paints it only under live-send;
+                            // the wheel forward reads it in passive preview too).
                             if let Ok(mut guard) = cursor_cell.lock() {
                                 *guard = cursor_now;
                             }
@@ -733,7 +722,6 @@ impl LiveCaptureWorker {
             forward_empty,
             nudge,
             stop,
-            live,
             cursor,
         }
     }
@@ -799,17 +787,10 @@ impl LiveCaptureWorker {
     /// Switch the capture cadence between live-send (fast) and background
     /// preview (idle). Cheap (one atomic store); called from the render
     /// reconcile so entering/leaving live mode retunes the worker in place
-    /// without a respawn.
+    /// without a respawn. Does NOT touch the cursor: it is published every
+    /// cycle now (the passive wheel forward reads it), and the render only
+    /// paints it under live-send, so a backgrounded preview never shows one.
     pub(in crate::tui) fn set_live(&self, live: bool) {
-        self.live.store(live, std::sync::atomic::Ordering::Relaxed);
-        if !live {
-            // Drop any painted cursor the moment the displayed pane stops
-            // being the live-send target, so a backgrounded preview doesn't
-            // keep a stale cursor from the last live cycle.
-            if let Ok(mut guard) = self.cursor.lock() {
-                *guard = None;
-            }
-        }
         let ms = if live {
             LIVE_CAPTURE_INTERVAL_FAST_MS
         } else {
@@ -949,6 +930,33 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
         anyhow::bail!("live-send tmux subprocess exited non-zero for {:?}", action);
     }
     Ok(())
+}
+
+/// Forward a single translated key to a tmux pane with a one-shot
+/// `tmux send-keys` fork on a detached thread. Used by the passive-preview
+/// wheel forward, where there is no long-lived `LiveSendWorker` to enqueue
+/// onto: `dispatch_via_fork` blocks on the subprocess, so it must not run on
+/// the UI thread. Fire-and-forget; a dropped scroll notch is harmless and a
+/// failed fork is logged, not surfaced. Scroll notches carry no ordering
+/// relationship to each other, so racing forks are fine.
+pub(super) fn send_key_oneshot(tmux_name: &str, key: TmuxKey) {
+    let tmux_name = tmux_name.to_string();
+    let action = match key {
+        TmuxKey::Literal(s) => TmuxAction::Literal(s),
+        TmuxKey::Named(name) => TmuxAction::Named(name),
+        TmuxKey::NamedRepeat { name, count } => TmuxAction::NamedRepeat { name, count },
+        TmuxKey::HexBytes(bytes) => TmuxAction::HexBytes(bytes),
+    };
+    std::thread::spawn(move || {
+        if let Err(err) = dispatch_via_fork(&tmux_name, &action) {
+            tracing::warn!(
+                target: "tui.live_send",
+                error = %err,
+                action = ?action,
+                "passive-preview wheel forward fork failed; notch dropped",
+            );
+        }
+    });
 }
 
 /// Upper bound on the number of bytes encoded into a single

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2400,14 +2400,20 @@ impl HomeView {
     ///
     /// Only fires while live-send is active and the preview is at the live
     /// tail (`preview_scroll_offset == 0`): over scrolled-back history the
-    /// live cursor would land on the wrong row. The capture worker only
-    /// publishes a cursor when the displayed pane IS the live-send target, so
-    /// a `Some` here already means "this pane is the one being driven."
+    /// live cursor would land on the wrong row. The capture worker now
+    /// publishes a cursor for every previewed pane (the wheel forward reads its
+    /// mode flags), so this gates on `live_send` to keep painting confined to
+    /// the driven pane, and on `position_reliable` (false while the pane
+    /// scrolled mid-capture) to avoid painting on a row the cursor no longer
+    /// indexes.
     fn live_preview_cursor_pos(&self) -> Option<Position> {
         if self.live_send.is_none() || self.preview_scroll_offset != 0 {
             return None;
         }
         let cursor = self.preview_capture_worker.as_ref()?.current_cursor()?;
+        if !cursor.position_reliable {
+            return None;
+        }
         map_live_preview_cursor(self.preview_pane_area, self.preview_visible_rows, cursor)
     }
 
@@ -3157,6 +3163,7 @@ mod tests {
             alternate_on: false,
             mouse_tracking: false,
             mouse_sgr: false,
+            position_reliable: true,
         }
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8893,6 +8893,30 @@ mod scroll_pane_isolation {
         env
     }
 
+    /// Like `live_env_with_cursor` but WITHOUT entering live-send: the
+    /// session is merely previewed (the common "hover the preview" case).
+    /// No `live_send` / `live_send_worker`; the capture worker and its
+    /// target are set so `forward_wheel_to_preview` can take the passive
+    /// one-shot path.
+    fn passive_env_with_cursor(cursor: crate::tmux::PaneCursor) -> TestEnv {
+        let mut env = create_test_env_with_sessions(3);
+        setup_panes(&mut env);
+        env.view.cursor = 1;
+        env.view.update_selected();
+        env.view.preview_cache.dimensions = (80, 24);
+        env.view.preview_cache.captured_lines = 200;
+        env.view.preview_scroll_offset = 10;
+        env.view
+            .sync_preview_capture_worker(Some("fake".to_string()));
+        env.view.preview_capture_target = Some("fake".to_string());
+        env.view
+            .preview_capture_worker
+            .as_ref()
+            .expect("capture worker spawned")
+            .set_cursor_for_test(Some(cursor));
+        env
+    }
+
     fn alt_screen_cursor(
         alternate_on: bool,
         mouse_tracking: bool,
@@ -8935,14 +8959,13 @@ mod scroll_pane_isolation {
     }
 
     /// A full-screen app WITHOUT mouse tracking (e.g. Claude Code's
-    /// fullscreen renderer: `1049h` + `1007h`, no mouse) relies on the
-    /// terminal's alternate-scroll to turn the wheel into cursor keys. The
-    /// raw SGR/X10 bytes would land as garbage keystrokes, so we forward
-    /// `Up`/`Down` named keys instead and pin the preview to the live edge,
-    /// just like the mouse-tracking case. Regression test for #2407.
+    /// fullscreen renderer: `1049h` + `1007h`, no mouse) does not scroll on
+    /// arrow keys (it reads them as cursor / input-history navigation), so we
+    /// forward `PageUp`/`PageDown` named keys instead and pin the preview to
+    /// the live edge, just like the mouse-tracking case. Regression for #2407.
     #[test]
     #[serial]
-    fn wheel_over_alt_screen_without_mouse_forwards_arrow_keys() {
+    fn wheel_over_alt_screen_without_mouse_forwards_page_keys() {
         let mut env = live_env_with_cursor(alt_screen_cursor(true, false, false));
 
         let up = env.view.handle_scroll_up(50, 10);
@@ -8950,6 +8973,37 @@ mod scroll_pane_isolation {
         assert_eq!(
             env.view.preview_scroll_offset, 0,
             "arrow-key forwarding pins the preview to the live edge, never the normal-buffer history"
+        );
+
+        env.view.preview_scroll_offset = 10;
+        let down = env.view.handle_scroll_down(50, 10);
+        assert!(down);
+        assert_eq!(env.view.preview_scroll_offset, 0);
+    }
+
+    /// Passive preview (NOT live-send) over a full-screen agent must ALSO
+    /// forward the wheel. The alternate screen has no scrollback, so the
+    /// capture-window scroll is inert; without forwarding, "hover the
+    /// preview and scroll" does literally nothing (the reported regression
+    /// after Claude Code's fullscreen renderer landed). Forwarding pins the
+    /// preview to the live edge, exactly like the live-send path.
+    #[test]
+    #[serial]
+    fn wheel_over_alt_screen_passive_preview_forwards() {
+        let mut env = passive_env_with_cursor(alt_screen_cursor(true, true, true));
+        assert!(
+            env.view.live_send.is_none(),
+            "this exercises passive preview, not live-send"
+        );
+
+        let up = env.view.handle_scroll_up(50, 10);
+        assert!(
+            up,
+            "wheel over a full-screen pane in passive preview is forwarded"
+        );
+        assert_eq!(
+            env.view.preview_scroll_offset, 0,
+            "passive forwarding pins the preview to the live edge"
         );
 
         env.view.preview_scroll_offset = 10;

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8932,6 +8932,7 @@ mod scroll_pane_isolation {
             alternate_on,
             mouse_tracking,
             mouse_sgr,
+            position_reliable: true,
         }
     }
 


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Hovering the preview pane and scrolling up did nothing for an alternate-screen agent (Claude Code's fullscreen renderer, the default in 2.1.x). Follow-up to #2411 (#2407): that PR wired wheel forwarding into live-send mode only, but the everyday case is passive preview, and it forwarded arrow keys, which the shipping Claude does not scroll on.

Three fixes:

1. **Forward in passive preview, not just live-send.** `forward_wheel_to_live_pane` (now `forward_wheel_to_preview`) only fired when `live_send.is_some()`. Passive preview fell back to the capture-window scroll, which is inert on the alternate screen (no scrollback), so nothing moved. It now fires in passive preview too, sending the notch via a one-shot `tmux send-keys` fork when there is no live-send worker.

2. **Publish the pane cursor in passive preview.** The capture worker only queried the `PaneCursor` when the displayed pane was the live-send target, so the passive forward had no cursor to branch on and silently bailed. It now queries the cursor every cycle (it folds into the same capture fork, so no extra fork). The render still paints a cursor only under live-send, so backgrounded previews look unchanged. The now-dead `live` flag is removed.

3. **Send `PageUp`/`PageDown` for no-mouse panes, not `Up`/`Down`.** Claude 2.1.x reads arrow keys as input-history navigation, not scroll, and surfaces "Scroll wheel is sending arrow keys, use PgUp/PgDn to scroll". The page keys scroll its transcript regardless of mouse mode. Mouse-tracking panes keep getting forwarded mouse events (SGR / X10).

**Behavior note:** scrolling the preview of an alternate-screen agent now forwards keys (mouse-wheel events, or `PageUp`/`PageDown`) to that agent, where passive preview previously sent it nothing. This is deliberate and scoped to alternate-screen panes only; normal-buffer panes keep the local capture-window scroll and still receive nothing.

### Note on the shipping Claude

Claude Code 2.1.193 fullscreen reports tmux `alternate_on=1, mouse_any_flag=1` (mouse tracking ON), so in practice it takes the forwarded-mouse-event branch; the `PageUp`/`PageDown` branch covers no-mouse alternate-screen apps. #2411 assumed fullscreen Claude was `mouse_any=0`, which no longer holds.

### Review follow-up (second commit)

A self-review pass added:

- **Streaming robustness:** the wheel forward needs only the terminal mode flags, which are stable, but the capture's twin cursor probes previously dropped the whole cursor whenever the pane scrolled mid-capture, so scroll bailed while an agent streamed output. A new `position_reliable` flag (and a pure, unit-tested `merge_cursor_probes` helper) keeps the mode flags while marking only the position untrustworthy; the TUI render and the web live view still gate cursor painting on it, so the row-drift fix is preserved.
- **Correct target:** forwarded keys now always go to the pane on screen (`preview_capture_target`); the ordered live-send worker is used only when that pane is also the live-send target, so live-send aimed at a different pane can no longer scroll the wrong one.
- **Bounded fan-out:** the passive one-shot send-fork is capped (`MAX_INFLIGHT_ONESHOT`) so a fast wheel flick can't spawn unbounded threads.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a)
- [x] For UI changes: included screenshot or recording (terminal scroll behavior; covered by unit tests plus the manual verification below)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: the `live_ws.rs` change is a behavior-preserving backend guard (a position-unreliable cursor is dropped to `None`, exactly as before `position_reliable` existed), so the web live view behaves identically; no user-facing dashboard flow changes.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: added unit regression tests instead (`wheel_over_alt_screen_passive_preview_forwards`, `wheel_over_alt_screen_without_mouse_forwards_page_keys`, `wheel_forward_key_no_mouse_alt_screen_is_page_key`, and the pure `merge_cursor_probes_*` tests). A full mouse-wheel e2e is impractical in the harness: it injects via `tmux send-keys`, which the TUI's crossterm input layer does not decode as mouse events (confirmed while debugging), so the wheel never reaches the scroll handler. The behavior was verified end to end by driving a real `aoe` through a PTY against real Claude 2.1.193.

### How tested

- `cargo fmt`, `cargo clippy -- -D warnings` (and `--features serve`), and `cargo test --lib --features serve` all pass (the only failures are two pre-existing sandbox-only tests unrelated to this change).
- Manual, real `aoe` + real Claude 2.1.193 fullscreen: passive preview scrolled the transcript (bottom 60 to 52), and live-send still scrolled (60 to 53). `PageUp`/`PageDown` confirmed to scroll Claude; arrow keys confirmed to NOT scroll (they move input history).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation, root-cause analysis, implementation, and a self-review pass done with Claude Code; @njbrake reviewed the root cause and chose the approach (forward in passive preview, plus `PageUp`/`PageDown` for no-mouse panes) and directed the review follow-up.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes mouse-wheel scrolling for alternate-screen (full-screen) apps in the TUI preview pane—especially when the preview is running passively (not in live-send mode).

Key changes:
- Passive preview wheel events are now forwarded to the previewed alternate-screen pane (instead of falling back to capture-window scrolling, which doesn’t work correctly for alternate-screen panes).
- When live-send isn’t available, wheel scrolling is handled via a one-shot key sent directly to the preview pane, so scrolling works in the alternate-screen context.
- The preview capture worker now refreshes/publishes cursor information continuously, so passive preview has the cursor context needed for scroll handling.
- Cursor probing was improved with a new “position reliability” signal; unreliable cursor positions are no longer used for rendering/geometry.
- For panes without mouse tracking, wheel scrolling is emulated with `PageUp`/`PageDown` (not `Up`/`Down`) to match how some apps handle history navigation (e.g., Claude 2.1.x).
- Tests were updated/added to cover passive alternate-screen wheel forwarding and the new cursor reliability behavior.

Benefits:
- Alternate-screen fullscreen previews scroll reliably with the mouse wheel in both live-send and passive-preview modes.
- Better cursor/scroll coordination reduces incorrect cursor/scroll “glitches” caused by unreliable cursor probes.
- Clearer, more robust wheel routing logic makes the behavior consistent across live-send and passive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->