### PR TITLE
fix(sandbox): pin container workdir so exec survives worktree git-linkage breaks (#2414)

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -1420,9 +1420,27 @@ impl SessionSandbox {
         source_profile: Option<String>,
     ) -> Result<(Self, SandboxPathMap), AcpError> {
         let project_path_str = project_path.to_string_lossy().to_string();
-        let (volumes, workdir) =
+        let (volumes, computed_workdir) =
             crate::session::container_config::compute_volume_paths(project_path, &project_path_str)
                 .map_err(|e| AcpError::Spawn(format!("compute container workdir: {e}")))?;
+        // The workdir must be what the container was actually created with, not
+        // a live recompute. `compute_volume_paths` resolves the worktree's git
+        // linkage and silently collapses to `/workspace/<basename>` once that
+        // linkage breaks on the host (and it ignores multi-repo `workspace_info`),
+        // which would `docker exec -w` into a path the container never mounted
+        // (#2414). Prefer the create-time-pinned value, then the live container's
+        // own `WorkingDir`, and only fall back to the recompute when neither is
+        // available (no container created yet). The mount map stays the computed
+        // project volumes; making it workspace-complete needs `workspace_info`,
+        // which the reattach path does not carry (tracked separately).
+        let workdir = sandbox
+            .container_workdir
+            .clone()
+            .or_else(|| {
+                crate::containers::get_container_runtime()
+                    .container_working_dir(&sandbox.container_name)
+            })
+            .unwrap_or(computed_workdir);
         let mounts: Vec<(PathBuf, PathBuf)> = volumes
             .into_iter()
             .map(|v| (PathBuf::from(v.container_path), PathBuf::from(v.host_path)))
@@ -7795,6 +7813,51 @@ mod tests {
         assert!(classify_rate_limit_from_message("connection refused").is_none());
     }
 
+    /// Regression for issue #2414 on the structured-view path: `from_info`
+    /// must use the create-time-pinned `SandboxInfo::container_workdir`, not a
+    /// live recompute. With the worktree's git linkage broken,
+    /// `compute_volume_paths` collapses to `/workspace/<basename>` (a path the
+    /// container never mounted), so the pin has to win.
+    #[test]
+    fn from_info_prefers_pinned_workdir_over_live_recompute() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Orphaned worktree: a `.git` file whose gitdir points nowhere.
+        let worktree = tmp.path().join("repo-worktrees").join("feature");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: ../../does-not-exist/.git/worktrees/feature\n",
+        )
+        .unwrap();
+
+        let sandbox = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "alpine:latest".into(),
+            container_name: "aoe-sandbox-pinned1".into(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: Some("/workspace/repo-worktrees/feature".into()),
+        };
+
+        // Pin present, so no live inspect is attempted; the pinned value is used.
+        let (resources, _map) = SessionSandbox::from_info(&sandbox, &worktree, None).unwrap();
+        assert_eq!(
+            resources.container_workdir,
+            PathBuf::from("/workspace/repo-worktrees/feature"),
+        );
+
+        // The pin is load-bearing: the live recompute on this orphaned worktree
+        // collapses to the basename, which is the path that never got mounted.
+        let (_volumes, computed) = crate::session::container_config::compute_volume_paths(
+            &worktree,
+            &worktree.to_string_lossy(),
+        )
+        .unwrap();
+        assert_eq!(computed, "/workspace/feature");
+    }
+
     /// Sandboxed structured view spawn must wrap the agent command in
     /// `docker exec` argv with `-i`, the container workdir, an `-e`
     /// flag per env entry, then the container name, then the agent
@@ -7813,6 +7876,7 @@ mod tests {
             extra_env: Some(vec!["MY_LITERAL=hello".into()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let config = SpawnConfig {
             agent_key: "claude".into(),
@@ -7881,6 +7945,7 @@ mod tests {
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let config = SpawnConfig {
             agent_key: "claude".into(),
@@ -7953,6 +8018,7 @@ mod tests {
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let config = SpawnConfig {
             agent_key: "claude".into(),

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -1593,11 +1593,19 @@ impl AcpClient {
             seed_history_replay: config.seed_history_replay,
         };
         let sandbox_pair = if let Some(info) = &config.sandbox_info {
-            Some(SessionSandbox::from_info(
-                info,
-                config.cwd.as_path(),
-                config.source_profile.clone(),
-            )?)
+            // `from_info` resolves the container workdir, which touches git2 and
+            // (for a legacy session with no pinned workdir) shells out to
+            // `docker inspect`. Run it off the async executor.
+            let info = info.clone();
+            let cwd = config.cwd.clone();
+            let profile = config.source_profile.clone();
+            Some(
+                tokio::task::spawn_blocking(move || {
+                    SessionSandbox::from_info(&info, cwd.as_path(), profile)
+                })
+                .await
+                .map_err(|e| AcpError::Spawn(format!("sandbox resolve task panicked: {e}")))??,
+            )
         } else {
             None
         };

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2463,11 +2463,23 @@ impl<S: BroadcastSink> Supervisor<S> {
         // case `current_env_entries` warns and falls back to the global
         // default profile (matching pre-persistence behavior).
         let sandbox_resources = match sandbox {
-            Some(info) => Some(super::acp_client::SessionSandbox::from_info(
-                &info,
-                cwd.as_path(),
-                record.source_profile.clone(),
-            )?),
+            Some(info) => {
+                // `from_info` resolves the container workdir, which touches git2
+                // and (for a legacy session with no pinned workdir) shells out to
+                // `docker inspect`. Run it off the async executor, mirroring how
+                // `ensure_container_for_session` wraps its docker work.
+                let cwd = cwd.clone();
+                let profile = record.source_profile.clone();
+                Some(
+                    tokio::task::spawn_blocking(move || {
+                        super::acp_client::SessionSandbox::from_info(&info, cwd.as_path(), profile)
+                    })
+                    .await
+                    .map_err(|e| {
+                        AcpError::Spawn(format!("sandbox resolve task panicked: {e}"))
+                    })??,
+                )
+            }
             None => None,
         };
         // Prefer the persisted registry key; fall back to the legacy

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -729,6 +729,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 extra_env: None,
                 custom_instruction: config.sandbox.custom_instruction.clone(),
                 before_start_env: Vec::new(),
+                container_workdir: None,
             });
         }
     }

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -86,6 +86,13 @@ impl DockerContainer {
         self.runtime.is_container_running(&self.name)
     }
 
+    /// The container's configured working directory, read from the live
+    /// container. `None` if it can't be determined; see
+    /// [`ContainerRuntime::container_working_dir`].
+    pub fn working_dir(&self) -> Option<String> {
+        self.runtime.container_working_dir(&self.name)
+    }
+
     pub fn build_create_args(&self, config: &ContainerConfig) -> Vec<String> {
         self.runtime
             .build_create_args(&self.name, &self.image, config)

--- a/src/containers/runtime.rs
+++ b/src/containers/runtime.rs
@@ -166,6 +166,32 @@ impl ContainerRuntime {
         }
     }
 
+    /// The container's configured working directory (`Config.WorkingDir`), or
+    /// `None` if it can't be determined (container gone, inspect failed, or the
+    /// field is empty). Used to backfill the create-time-pinned workdir for
+    /// sandbox sessions that predate it (#2414). Works on stopped containers
+    /// too, since `inspect` reads static config.
+    ///
+    /// Apple's `container` CLI does not expose this via a stable `inspect`
+    /// field we rely on, so it returns `None` there and the caller keeps the
+    /// create-time value (or the live fallback for legacy sessions).
+    pub fn container_working_dir(&self, name: &str) -> Option<String> {
+        if !matches!(self.kind, RuntimeKind::Docker | RuntimeKind::Podman) {
+            return None;
+        }
+        let output = self
+            .base
+            .command()
+            .args(["container", "inspect", "-f", "{{.Config.WorkingDir}}", name])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let wd = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!wd.is_empty()).then_some(wd)
+    }
+
     pub fn build_create_args(
         &self,
         name: &str,

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -689,6 +689,7 @@ mod tests {
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         });
 
         let worktree = std::path::PathBuf::from("/tmp/aoe-cleanup-test-nonexistent");
@@ -762,6 +763,7 @@ mod tests {
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         });
 
         let git_wt = GitWorktree::new(main_repo.clone()).unwrap();

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -708,6 +708,7 @@ pub fn build_instance(
             },
             custom_instruction: config.sandbox.custom_instruction.clone(),
             before_start_env: Vec::new(),
+            container_workdir: None,
         });
     }
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2960,6 +2960,7 @@ extra_volumes = ["/host/data:/container/data:ro"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let project_path_str = project_dir.path().to_str().unwrap();
@@ -3067,6 +3068,7 @@ volume_ignores = ["**/bin", "**/obj", "target"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let project_path_str = project_dir.path().to_str().unwrap();
@@ -3209,6 +3211,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let config = build_container_config(
@@ -3254,6 +3257,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "codex-sandbox-hooks-test";
         let config = build_container_config(
@@ -3346,6 +3350,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             };
             let instance_id = format!("{}-sidecar-sandbox-test", agent.name);
             let config = build_container_config(
@@ -3414,6 +3419,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "kiro-selected-agent-sandbox-test";
         build_container_config(
@@ -3484,6 +3490,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             },
             ContainerAgentSelection::new("kiro", None).with_selected_agent(Some("custom-agent")),
             false,
@@ -3541,6 +3548,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = build_container_config(
@@ -3590,6 +3598,7 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "codex-sandbox-hooks-disabled-test";
         let config = build_container_config(
@@ -3652,6 +3661,7 @@ agent_detect_as = { "wrapped-codex" = "codex" }
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "wrapped-codex-sandbox-hooks-test";
         let config = build_container_config(
@@ -3711,6 +3721,7 @@ agent_detect_as = { "wrapped-codex" = "codex" }
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "codex-sandbox-refresh-hooks-test";
         build_container_config(
@@ -3779,6 +3790,7 @@ trusted_hash = "keep"
             extra_env: Some(vec!["CODEX_HOME=/root/custom-codex".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "codex-sandbox-extra-env-hooks-test";
         let config = build_container_config(
@@ -3834,6 +3846,7 @@ environment = ["CODEX_HOME=/root/profile-codex"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let instance_id = "codex-sandbox-config-env-hooks-test";
         let config = build_container_config(
@@ -3923,6 +3936,7 @@ extra_volumes = ["/host/personal-only:/container/personal-only:ro"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let has_volume = |config: &crate::containers::container_interface::ContainerConfig,
@@ -4074,6 +4088,7 @@ volume_ignores = ["target", "node_modules"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let project_path_str = worktree_path.to_str().unwrap();
@@ -4168,6 +4183,7 @@ volume_ignores = ["target"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let project_path_str = worktree_path.to_str().unwrap();
@@ -4323,6 +4339,7 @@ volume_ignores = ["target"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         }
     }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -696,6 +696,7 @@ mod tests {
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             });
 
             let request = DeletionRequest {
@@ -1001,6 +1002,7 @@ mod tests {
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             });
 
             (tmp, main_repo, worktree_path, instance)

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -744,6 +744,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let project_path = temp_home.path().join("nonexistent_project");
 
@@ -1004,6 +1005,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1095,6 +1097,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["TEST_VAR=foo".to_string(), "OTHER=bar".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let pairs = session_host_env_pairs("any-profile", tmp.path(), &info);
         assert_eq!(
@@ -1123,6 +1126,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: vec![("GH_TOKEN".to_string(), "ghs_fresh".to_string())],
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1149,6 +1153,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1168,6 +1173,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1205,6 +1211,7 @@ environment = ["GH_TOKEN=write_token"]
             ]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1236,6 +1243,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["AOE_TEST_EXTRA".to_string(), "FOO=bar".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1262,6 +1270,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["DUP_KEY=from_session".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1284,6 +1293,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1307,6 +1317,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1330,6 +1341,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1467,6 +1479,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["AOE_TEST_TOKEN=$AOE_TEST_TOKEN".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         // docker_args should have the key but NOT the secret value
@@ -1504,6 +1517,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["MY_MAPPED=$AOE_TEST_SOURCE".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
@@ -1541,6 +1555,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["AOE_TEST_BARE".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
@@ -1576,6 +1591,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: Some(vec!["MY_LITERAL=some_value".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
@@ -1611,6 +1627,7 @@ environment = ["GH_TOKEN=write_token"]
             ]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
         let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         // Secret: key only in docker_args, value in exports
@@ -1712,6 +1729,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1748,6 +1766,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1775,6 +1794,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1801,6 +1821,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);
@@ -1830,6 +1851,7 @@ environment = ["GH_TOKEN=write_token"]
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let result = collect_environment(&config, &info);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -303,6 +303,15 @@ pub struct SandboxInfo {
     /// Custom instruction text to inject into agent launch command
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_instruction: Option<String>,
+    /// The container's working directory, captured from
+    /// `ContainerConfig::working_dir` when the container is created (and
+    /// backfilled from a live container for sessions created before this field
+    /// existed). [`Instance::container_workdir`] returns this verbatim so every
+    /// `docker exec -w` targets the path the container was actually built with,
+    /// instead of a live recomputation that can drift once the host worktree's
+    /// git linkage breaks (#2414).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_workdir: Option<String>,
     /// `KEY=VALUE` pairs minted on the host by `host_hooks.before_start` when
     /// the container last came up. Injected into the container environment as
     /// inherited (leak-safe) entries by [`super::environment::collect_environment`].
@@ -2730,6 +2739,7 @@ impl Instance {
             // fresh process attached to a running container with no values yet.
             self.ensure_before_start_env(false)?;
             container_config::refresh_agent_configs();
+            self.backfill_container_workdir(&container);
             return Ok(container);
         }
 
@@ -2739,6 +2749,7 @@ impl Instance {
             self.ensure_before_start_env(true)?;
             container_config::refresh_agent_configs();
             container.start()?;
+            self.backfill_container_workdir(&container);
             return Ok(container);
         }
 
@@ -2754,13 +2765,62 @@ impl Instance {
 
         if let Some(ref mut sandbox) = self.sandbox_info {
             sandbox.container_id = Some(container_id);
+            // Pin the workdir to exactly what the container was built with, so
+            // later `docker exec -w` can never drift from it (#2414).
+            sandbox.container_workdir = Some(config.working_dir.clone());
         }
 
         Ok(container)
     }
 
+    /// Backfill [`SandboxInfo::container_workdir`] from a live container for a
+    /// session created before that field existed (or one whose value was
+    /// cleared). Authoritative: the value is the container's own
+    /// `Config.WorkingDir`, so a later host-side git-linkage break can't make
+    /// [`Self::container_workdir`] drift from the path the container was built
+    /// with (#2414). No-op once the value is set, when the session is not
+    /// sandboxed, or when the runtime can't report it (the live fallback
+    /// stands). Not persisted here; the next start re-backfills if needed.
+    fn backfill_container_workdir(&mut self, container: &containers::DockerContainer) {
+        let needs_backfill = self
+            .sandbox_info
+            .as_ref()
+            .is_some_and(|s| s.container_workdir.is_none());
+        if !needs_backfill {
+            return;
+        }
+        if let Some(workdir) = container.working_dir() {
+            if let Some(sandbox) = self.sandbox_info.as_mut() {
+                sandbox.container_workdir = Some(workdir);
+            }
+        }
+    }
+
     /// Get the container working directory for this instance.
+    /// The working directory a `docker exec` into this session's sandbox must
+    /// chdir to. Pinned to what the container was actually created with
+    /// ([`SandboxInfo::container_workdir`]): set at create time from
+    /// `ContainerConfig::working_dir` and backfilled from a live container for
+    /// sessions that predate the field.
+    ///
+    /// Recomputing it live from `compute_volume_paths` is unsafe, which is what
+    /// #2414 hit: that helper resolves the worktree's git linkage, and once the
+    /// container is up that linkage can break on the host (e.g. the worktree's
+    /// admin entry under `<main>/.git/worktrees/<name>` is pruned). When it
+    /// can't resolve, `compute_volume_paths` silently collapses to
+    /// `/workspace/<basename>` -- a path the container never mounted -- and the
+    /// exec dies with `chdir to cwd ("/workspace/<name>") ... no such file or
+    /// directory`. The live computation survives only as a fallback for a
+    /// session whose container has not been created yet, where there is nothing
+    /// to pin to.
     pub fn container_workdir(&self) -> String {
+        if let Some(pinned) = self
+            .sandbox_info
+            .as_ref()
+            .and_then(|s| s.container_workdir.clone())
+        {
+            return pinned;
+        }
         container_config::compute_volume_paths(Path::new(&self.project_path), &self.project_path)
             .map(|(_, wd)| wd)
             .unwrap_or_else(|_| "/workspace".to_string())
@@ -4086,6 +4146,55 @@ mod tests {
         }
     }
 
+    /// Regression for issue #2414: a sandboxed worktree session's
+    /// `container_workdir()` must stay pinned to what the container was created
+    /// with, even after the host worktree's git linkage breaks.
+    ///
+    /// When the worktree's admin entry under `<main>/.git/worktrees/<name>` is
+    /// pruned, the `.git` file's gitdir no longer resolves, `compute_volume_paths`
+    /// can't find the main repo, and it silently collapses to
+    /// `/workspace/<basename>` -- a path the container never mounted -- so a
+    /// `docker exec -w` dies with `chdir to cwd ... no such file or directory`.
+    /// The create-time-pinned `SandboxInfo::container_workdir` defends against
+    /// that drift.
+    #[test]
+    fn container_workdir_stays_pinned_when_worktree_linkage_breaks() {
+        use tempfile::TempDir;
+        let root = TempDir::new().unwrap();
+        // An orphaned worktree: a `.git` file whose gitdir points nowhere,
+        // exactly the state a pruned admin entry leaves behind.
+        let worktree = root.path().join("myrepo-worktrees").join("contexec");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: ../../does-not-exist/.git/worktrees/contexec\n",
+        )
+        .unwrap();
+
+        let mut inst = Instance::new("contexec", worktree.to_str().unwrap());
+        inst.sandbox_info = Some(SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "img".to_string(),
+            container_name: "aoe-sandbox-test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        });
+
+        // Bug reproduction: with nothing pinned, the live recompute can't resolve
+        // the orphaned worktree and falls back to the basename. This is the path
+        // that produced the `chdir to cwd ("/workspace/contexec")` failure.
+        assert_eq!(inst.container_workdir(), "/workspace/contexec");
+
+        // Fix: the value the container was actually built with is returned
+        // verbatim, so the exec targets a path that exists in the container.
+        let pinned = "/workspace/myrepo-worktrees/contexec".to_string();
+        inst.sandbox_info.as_mut().unwrap().container_workdir = Some(pinned.clone());
+        assert_eq!(inst.container_workdir(), pinned);
+    }
+
     #[test]
     fn test_new_instance() {
         let inst = Instance::new("test", "/tmp/test");
@@ -5245,6 +5354,7 @@ mod tests {
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         });
         assert!(!inst.is_sandboxed());
     }
@@ -5260,6 +5370,7 @@ mod tests {
             extra_env: None,
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         });
         assert!(inst.is_sandboxed());
     }
@@ -5366,6 +5477,7 @@ mod tests {
             extra_env: Some(vec!["MY_VAR".to_string(), "OTHER_VAR".to_string()]),
             custom_instruction: None,
             before_start_env: Vec::new(),
+            container_workdir: None,
         };
 
         let json = serde_json::to_string(&info).unwrap();
@@ -6693,6 +6805,7 @@ mod tests {
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             });
             let on_disk = inst.clone();
             storage
@@ -7457,6 +7570,7 @@ mod tests {
                     extra_env: None,
                     custom_instruction: None,
                     before_start_env: Vec::new(),
+                    container_workdir: None,
                 });
                 assert!(inst.is_sandboxed());
 

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -257,6 +257,16 @@ mod tests {
     }
 
     #[test]
+    fn holds_worktree_short_circuits_without_sandbox() {
+        // The gate that guards `set_worktree_name_for_selected` and
+        // `rename_selected` (#2117, #2414): a non-sandbox session must return
+        // false before touching the container runtime, so a plain worktree
+        // rename never pays a `docker inspect`. The live-container branch is the
+        // same helper the tied-rename path already relies on.
+        assert!(!sandbox_container_holds_worktree("any-session-id", false));
+    }
+
+    #[test]
     fn leaf_from_title_slugifies() {
         assert_eq!(worktree_leaf_from_title("Auth refactor"), "auth-refactor");
         assert_eq!(

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -771,6 +771,7 @@ mod tests {
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             }
         }
 
@@ -837,6 +838,7 @@ mod tests {
                 extra_env: None,
                 custom_instruction: None,
                 before_start_env: Vec::new(),
+                container_workdir: None,
             }
         }
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -872,10 +872,15 @@ impl HomeView {
         let Some(id) = self.selected_session.clone() else {
             return Ok(());
         };
-        let snapshot = self
-            .get_instance(&id)
-            .map(|i| (i.worktree_info.clone(), i.status, i.project_path.clone()));
-        let Some((worktree_info, status, project_path)) = snapshot else {
+        let snapshot = self.get_instance(&id).map(|i| {
+            (
+                i.worktree_info.clone(),
+                i.status,
+                i.project_path.clone(),
+                i.is_sandboxed(),
+            )
+        });
+        let Some((worktree_info, status, project_path, is_sandboxed)) = snapshot else {
             anyhow::bail!("Session not found");
         };
         let Some(worktree_info) = worktree_info else {
@@ -883,6 +888,19 @@ impl HomeView {
         };
         if status.blocks_worktree_edit() {
             anyhow::bail!("Stop the session before editing its workdir name");
+        }
+        // A sandbox session keeps its container alive (running `sleep infinity`)
+        // even while Idle, and that container bind-mounts the worktree dir, so
+        // the `git worktree move` below would hit EBUSY, and a reused container
+        // would keep mounting (and `cd`-ing into) the old path. Refuse until the
+        // session is stopped, mirroring the tied-rename path. `status` alone is
+        // insufficient: `blocks_worktree_edit` is false for an Idle session
+        // whose container is still up. See #2117, #2414.
+        if crate::session::worktree_edit::sandbox_container_holds_worktree(&id, is_sandboxed) {
+            anyhow::bail!(
+                "Stop the session before editing its workdir name: its sandbox container is \
+                 mounting the worktree directory"
+            );
         }
 
         let outcome = crate::session::worktree_edit::edit_worktree_workdir(
@@ -895,6 +913,17 @@ impl HomeView {
         )?;
         let new_path = outcome.new_path.to_string_lossy().to_string();
         let new_branch = outcome.new_branch.clone();
+
+        // A container created against the old path is now stale: its mounts and
+        // working dir are baked in at create time and do NOT follow a host-side
+        // `git worktree move`, so a reused container would `docker exec -w` into
+        // a path that no longer exists. Drop it to force a fresh create on next
+        // start. Only when the dir actually moved; a branch-only rename leaves
+        // the path valid. Mirrors `rename_selected` (#2117).
+        let dir_moved = outcome.new_path != std::path::Path::new(&project_path);
+        if dir_moved {
+            crate::session::worktree_edit::discard_sandbox_container_after_move(&id, is_sandboxed);
+        }
 
         self.apply_user_action(&id, |inst| {
             inst.project_path = new_path.clone();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2268,6 +2268,7 @@ fn create_test_env_with_group_sessions() -> TestEnv {
         extra_env: None,
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
     instances.push(inst3);
 
@@ -2367,6 +2368,7 @@ fn test_group_has_containers() {
         extra_env: None,
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
 
     let mut inst2 = Instance::new("other-session", "/tmp/other");
@@ -2764,6 +2766,7 @@ fn test_delete_group_with_sessions_respects_container_option() {
         extra_env: None,
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
 
     {

--- a/tests/integration/sandbox_integration.rs
+++ b/tests/integration/sandbox_integration.rs
@@ -24,6 +24,7 @@ fn test_sandbox_info_serialization() {
         extra_env: Some(vec!["MY_VAR".to_string()]),
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     };
 
     let json = serde_json::to_string(&sandbox_info).unwrap();
@@ -49,6 +50,7 @@ fn test_instance_is_sandboxed() {
         extra_env: None,
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
     assert!(inst.is_sandboxed());
 
@@ -60,6 +62,7 @@ fn test_instance_is_sandboxed() {
         extra_env: None,
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
     assert!(!inst.is_sandboxed());
 }
@@ -85,6 +88,7 @@ fn test_sandbox_info_persists_across_save_load() {
         extra_env: Some(vec!["API_KEY".to_string(), "SECRET=my_secret".to_string()]),
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
 
     let seeded = vec![inst.clone()];

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -267,6 +267,7 @@ fn with_sandbox(mut inst: Instance, enabled: bool) -> Instance {
         extra_env: None,
         custom_instruction: None,
         before_start_env: Vec::new(),
+        container_workdir: None,
     });
     inst
 }


### PR DESCRIPTION
## Description

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose and code are Claude's, reviewed by him._

Fixes #2414. Attaching the in-container paired terminal of a sandboxed worktree session failed with:

```
OCI runtime exec failed: ... chdir to cwd ("/workspace/<name>") set in config.json failed: no such file or directory
```

### Root cause

`Instance::container_workdir()` feeds `docker exec -w` for the paired terminal, on-launch hooks, and session-id capture, and the structured-view path computes the same value in `SessionSandbox::from_info`. Both derive it by calling `compute_volume_paths` live on every attach. That helper resolves the worktree's git linkage and, when it cannot (for example a pruned `<main>/.git/worktrees/<name>` admin entry, which happens when an aoe worktree set spans a host and sandbox path boundary), silently collapses to `/workspace/<basename>`. It also ignores multi-repo `workspace_info`. The container was created with the worktree-aware layout, so the recomputed path was never mounted and the exec chdir fails. The agent process itself is unaffected because it inherits the container's default working directory and passes no `-w`.

### Fix

Pin the working directory to what the container was actually built with, instead of recomputing it:

1. New `SandboxInfo.container_workdir`, set from `ContainerConfig.working_dir` at create time and backfilled from the live container's `Config.WorkingDir` (via `docker inspect`) for sessions created before the field existed. `Instance::container_workdir()` returns it; the live recompute remains only as a pre-create fallback. This also self-heals already-running containers on next attach without a recreate.
2. `SessionSandbox::from_info` (structured view) prefers the pinned value, then the live container's `WorkingDir`, then the recompute.
3. While here, two related latent bugs found during the investigation are fixed in the same area:
   - The TUI "edit workdir name" action (`set_worktree_name_for_selected`) now gates on `sandbox_container_holds_worktree` and discards the stale container after the directory moves, matching the tied-rename path from #2117. Previously this entry point moved the worktree without either step, leaving a container mounted at the old path.
   - The structured-view workdir no longer ignores multi-repo `workspace_info`, since it now uses the pinned or live value rather than the single-repo recompute.

Known follow-up, out of scope here: the structured-view mount path map in `from_info` still uses the single-repo `compute_volume_paths` for the mount list, so for a multi-repo workspace it omits the main-repo mounts. Making that workspace-complete needs `workspace_info`, which the reattach path does not carry. The workdir (the chdir-critical value) is fixed; the mount-map completeness is tracked separately.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording (no visual change)

Verified with `cargo fmt`, `cargo clippy --features serve`, and `cargo test --features serve` over the touched modules. New regression tests:

- `container_workdir_stays_pinned_when_worktree_linkage_breaks` builds an orphaned worktree and asserts the workdir stays pinned rather than collapsing to `/workspace/<basename>`. It fails without the pin.
- `from_info_prefers_pinned_workdir_over_live_recompute` covers the structured-view path.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow. The structured-view change is backend workdir resolution (the agent's container `cwd`), with no UI or request-payload change; it is covered by the Rust unit test above. No `web/` files change.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the fix is container-path-resolution logic, covered by in-module Rust unit tests per the repo's "unit tests for pure logic" guidance. A full e2e would require Docker, and the sandbox e2e tests are `#[ignore]` in CI.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation, root-cause analysis, fix, and tests were produced by Claude Code in a working session with @njbrake, who directed the investigation and approved the approach.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785027700&installation_id=139138837&pr_number=2418&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2418&signature=679ebd18245a6abb92326f6c38f9ae86a5ebbd978f09b3da12ad9782313e4167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### What changed
- Fixed sandbox container “workdir” handling by pinning the container’s working directory at creation time, so it no longer collapses to a recomputed fallback when git/worktree linkage is broken.
- Extended sandbox/session data to optionally store this pinned container workdir, and updated session rebuild logic to prefer the pinned value (with a fallback to the live container’s configured workdir when available).
- Adjusted async execution paths to avoid blocking in key sandbox-resolution steps.
- Updated the TUI “edit workdir name” flow to gate on whether the sandbox container truly “holds” the worktree, and to discard the container after a directory move so mounts/workdir are recreated—matching tied-rename behavior.
- Updated structured-view workdir handling to use the pinned/live workdir instead of re-deriving it from a single-repo computation.
- Added/updated regression tests to cover the pinned-workdir behavior (including orphaned worktree scenarios) and the updated TUI/structured-view preferences, along with test fixtures reflecting the new optional field.

### Benefits
- Prevents `docker exec -w` from targeting the wrong directory when worktree linkage can’t be resolved.
- Makes sandbox sessions more reliable across older/partially broken worktree states.
- Reduces issues from stale sandbox containers after renames/moves, improving consistency and safety in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->