### PR TITLE
fix(web): default the new-session worktree toggle to worktree.enabled

### DIFF
--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -181,6 +181,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
         setCommandMaps(commandMapsFromSettings(s));
         const sandbox = s.sandbox as Record<string, unknown> | undefined;
         const session = s.session as Record<string, unknown> | undefined;
+        const worktree = s.worktree as Record<string, unknown> | undefined;
         const img = (sandbox?.default_image as string) || "";
         if (img) dispatch({ type: "SET_FIELD", field: "sandboxImage", value: img });
         const env = Array.isArray(sandbox?.environment)
@@ -196,6 +197,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
           type: "APPLY_PROFILE_DEFAULTS",
           yoloMode: prefill?.yoloMode ?? (session?.yolo_mode_default as boolean) ?? false,
           sandboxEnabled: prefill?.sandboxEnabled ?? (sandbox?.enabled_by_default as boolean) ?? false,
+          worktreeEnabled: (worktree?.enabled as boolean) ?? false,
           tool: defaultTool,
           extraEnv: env,
           agentModel: acpDefaults.model,
@@ -218,6 +220,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
     (defaults: {
       yoloMode: boolean;
       sandboxEnabled: boolean;
+      worktreeEnabled: boolean;
       tool: string;
       extraEnv: string[];
       agentModel?: string;

--- a/web/src/components/session-wizard/steps/AgentOptions.tsx
+++ b/web/src/components/session-wizard/steps/AgentOptions.tsx
@@ -32,6 +32,7 @@ interface Props {
   onApplyProfileDefaults: (defaults: {
     yoloMode: boolean;
     sandboxEnabled: boolean;
+    worktreeEnabled: boolean;
     tool: string;
     extraEnv: string[];
     agentModel?: string;
@@ -167,6 +168,7 @@ export function AgentOptions({
         if (settings) {
           const session = settings.session as Record<string, unknown> | undefined;
           const sandbox = settings.sandbox as Record<string, unknown> | undefined;
+          const worktree = settings.worktree as Record<string, unknown> | undefined;
           // Pre-populate sandbox env from the profile so the user can see and edit
           // it before submission; without this, an empty extra_env is sent and the
           // backend falls back to the wrong (globally-default) profile's env vars.
@@ -179,6 +181,7 @@ export function AgentOptions({
           onApplyProfileDefaults({
             yoloMode: (session?.yolo_mode_default as boolean) ?? false,
             sandboxEnabled: (sandbox?.enabled_by_default as boolean) ?? false,
+            worktreeEnabled: (worktree?.enabled as boolean) ?? false,
             tool: defaultTool,
             extraEnv: env,
             agentModel: typeof acpDefault?.model === "string" ? acpDefault.model : "",

--- a/web/src/components/session-wizard/wizardReducer.test.ts
+++ b/web/src/components/session-wizard/wizardReducer.test.ts
@@ -34,6 +34,7 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: true,
       sandboxEnabled: false,
+      worktreeEnabled: false,
       tool: "claude",
       extraEnv: [],
       skipIfDirty: true,
@@ -49,6 +50,7 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: false,
       sandboxEnabled: true,
+      worktreeEnabled: false,
       tool: "claude",
       extraEnv: ["FOO=1", "BAR=baz"],
       skipIfDirty: true,
@@ -65,6 +67,7 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: false,
       sandboxEnabled: false,
+      worktreeEnabled: false,
       tool: "",
       extraEnv: [],
       skipIfDirty: true,
@@ -89,6 +92,7 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: true,
       sandboxEnabled: true,
+      worktreeEnabled: true,
       tool: "claude",
       extraEnv: ["FOO=1"],
       skipIfDirty: true,
@@ -112,6 +116,7 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: true,
       sandboxEnabled: true,
+      worktreeEnabled: true,
       tool: "claude",
       extraEnv: [],
     });
@@ -203,6 +208,7 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: false,
       sandboxEnabled: false,
+      worktreeEnabled: false,
       tool: "claude",
       extraEnv: [],
       skipIfDirty: true,
@@ -243,6 +249,7 @@ describe("SessionWizard reducer / useStructuredView (#1580)", () => {
       type: "APPLY_PROFILE_DEFAULTS",
       yoloMode: true,
       sandboxEnabled: false,
+      worktreeEnabled: false,
       tool: "claude",
       extraEnv: [],
       skipIfDirty: true,
@@ -322,5 +329,76 @@ describe("SessionWizard reducer / import id clearing (#2276)", () => {
     });
     expect(withId.data.importAcpSessionId).toBe("imp-789");
     expect(withId.data.path).toBe("/Users/me/imported-cwd");
+  });
+});
+
+describe("SessionWizard reducer / worktree default from config (#2423)", () => {
+  it("defaults useWorktree to false so it matches the backend worktree.enabled default", () => {
+    // Before #2423 this was hardcoded true, so the wizard ignored both
+    // worktree.enabled and the web Settings toggle.
+    expect(initialData.useWorktree).toBe(false);
+  });
+
+  it("seeds useWorktree from worktreeEnabled on the mount fetch", () => {
+    const off = reducer(makeState(), {
+      type: "APPLY_PROFILE_DEFAULTS",
+      yoloMode: false,
+      sandboxEnabled: false,
+      worktreeEnabled: false,
+      tool: "claude",
+      extraEnv: [],
+      skipIfDirty: true,
+    });
+    expect(off.data.useWorktree).toBe(false);
+
+    const on = reducer(makeState(), {
+      type: "APPLY_PROFILE_DEFAULTS",
+      yoloMode: false,
+      sandboxEnabled: false,
+      worktreeEnabled: true,
+      tool: "claude",
+      extraEnv: [],
+      skipIfDirty: true,
+    });
+    expect(on.data.useWorktree).toBe(true);
+  });
+
+  it("never enables worktree for a scratch session even when worktreeEnabled is true", () => {
+    const scratch = makeState({ data: { ...initialData, scratch: true } });
+    const next = reducer(scratch, {
+      type: "APPLY_PROFILE_DEFAULTS",
+      yoloMode: false,
+      sandboxEnabled: false,
+      worktreeEnabled: true,
+      tool: "claude",
+      extraEnv: [],
+      skipIfDirty: true,
+    });
+    expect(next.data.useWorktree).toBe(false);
+  });
+
+  it("does not stomp a user worktree toggle made before the mount fetch resolves", () => {
+    // The user opens the wizard and turns the toggle off (or on) before
+    // /api/settings resolves. SET_FIELD on useWorktree marks profileDirty,
+    // so the late skipIfDirty apply must be a no-op.
+    const toggled = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "useWorktree",
+      value: true,
+    });
+    expect(toggled.data.useWorktree).toBe(true);
+    expect(toggled.data.profileDirty).toBe(true);
+
+    const late = reducer(toggled, {
+      type: "APPLY_PROFILE_DEFAULTS",
+      yoloMode: false,
+      sandboxEnabled: false,
+      worktreeEnabled: false,
+      tool: "claude",
+      extraEnv: [],
+      skipIfDirty: true,
+    });
+    expect(late).toBe(toggled);
+    expect(late.data.useWorktree).toBe(true);
   });
 });

--- a/web/src/components/session-wizard/wizardReducer.ts
+++ b/web/src/components/session-wizard/wizardReducer.ts
@@ -91,6 +91,7 @@ export type Action =
       type: "APPLY_PROFILE_DEFAULTS";
       yoloMode: boolean;
       sandboxEnabled: boolean;
+      worktreeEnabled: boolean;
       tool: string;
       extraEnv: string[];
       agentModel?: string;
@@ -108,7 +109,11 @@ export const initialData: WizardData = {
   title: "",
   worktreeBranch: "",
   worktreeBranchDirty: false,
-  useWorktree: true,
+  // Default off to match the backend `worktree.enabled` default
+  // (WorktreeConfig::default). SessionWizard seeds the real value from
+  // /api/settings on mount via APPLY_PROFILE_DEFAULTS; this fallback also
+  // covers the case where that fetch fails. See #2423.
+  useWorktree: false,
   attachExisting: false,
   baseBranch: "",
   group: "",
@@ -175,7 +180,11 @@ export function reducer(state: WizardState, action: Action): WizardState {
       // no-profile guard would leave profileDirty false. The picker
       // path's window.confirm() also benefits: picking a profile after
       // unprofiled edits now prompts before overwriting.
-      if (["yoloMode", "sandboxEnabled", "tool", "extraEnv", "agentModel", "agentEffort"].includes(action.field)) {
+      if (
+        ["yoloMode", "sandboxEnabled", "useWorktree", "tool", "extraEnv", "agentModel", "agentEffort"].includes(
+          action.field,
+        )
+      ) {
         newData.profileDirty = true;
       }
       return { ...state, data: newData, error: null };
@@ -210,6 +219,9 @@ export function reducer(state: WizardState, action: Action): WizardState {
           ...state.data,
           yoloMode: action.yoloMode,
           sandboxEnabled: action.sandboxEnabled,
+          // Scratch sessions never use a worktree; don't let the seeded
+          // default flip it back on. Mirrors the SET_FIELD scratch arm.
+          useWorktree: state.data.scratch ? false : action.worktreeEnabled,
           tool: action.tool || state.data.tool,
           extraEnv: action.extraEnv,
           agentModel: action.agentModel ?? "",

--- a/web/tests/wizard-attach-existing.spec.ts
+++ b/web/tests/wizard-attach-existing.spec.ts
@@ -13,7 +13,14 @@ async function mockApis(page: Page) {
   for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
     await page.route(`**/api/${path}`, (r) =>
       r.fulfill({
-        json: path === "settings" || path === "about" || path === "system/update-status" ? {} : [],
+        // worktree.enabled drives the wizard's "Create a worktree" default (#2423);
+        // the attach-existing toggle only renders while worktree is on.
+        json:
+          path === "settings"
+            ? { worktree: { enabled: true } }
+            : path === "about" || path === "system/update-status"
+              ? {}
+              : [],
       }),
     );
   }

--- a/web/tests/wizard-base-branch.spec.ts
+++ b/web/tests/wizard-base-branch.spec.ts
@@ -17,7 +17,14 @@ async function mockApis(page: Page) {
   for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
     await page.route(`**/api/${path}`, (r) =>
       r.fulfill({
-        json: path === "settings" || path === "about" || path === "system/update-status" ? {} : [],
+        // worktree.enabled drives the wizard's "Create a worktree" default (#2423);
+        // these worktree-flow specs assume it is on.
+        json:
+          path === "settings"
+            ? { worktree: { enabled: true } }
+            : path === "about" || path === "system/update-status"
+              ? {}
+              : [],
       }),
     );
   }

--- a/web/tests/wizard-form-ui.spec.ts
+++ b/web/tests/wizard-form-ui.spec.ts
@@ -63,7 +63,14 @@ async function mockApis(
   for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
     await page.route(`**/api/${path}`, (r) =>
       r.fulfill({
-        json: path === "settings" || path === "about" || path === "system/update-status" ? {} : [],
+        // worktree.enabled drives the wizard's "Create a worktree" default (#2423);
+        // the branch input only renders while worktree is on.
+        json:
+          path === "settings"
+            ? { worktree: { enabled: true } }
+            : path === "about" || path === "system/update-status"
+              ? {}
+              : [],
       }),
     );
   }

--- a/web/tests/wizard-session-step.spec.ts
+++ b/web/tests/wizard-session-step.spec.ts
@@ -14,7 +14,14 @@ async function mockApis(page: Page) {
   for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
     await page.route(`**/api/${path}`, (r) =>
       r.fulfill({
-        json: path === "settings" || path === "about" || path === "system/update-status" ? {} : [],
+        // worktree.enabled drives the wizard's "Create a worktree" default (#2423);
+        // these worktree-flow specs assume it is on.
+        json:
+          path === "settings"
+            ? { worktree: { enabled: true } }
+            : path === "about" || path === "system/update-status"
+              ? {}
+              : [],
       }),
     );
   }
@@ -84,7 +91,9 @@ test.describe("Wizard session step (#1219)", () => {
     await expect(titleInput).toHaveValue("my-feature");
   });
 
-  test("worktree toggle is on by default and gates the branch input + Base branch section", async ({ page }) => {
+  test("worktree toggle follows worktree.enabled (on) and gates the branch input + Base branch section", async ({
+    page,
+  }) => {
     await mockApis(page);
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/");
@@ -109,6 +118,23 @@ test.describe("Wizard session step (#1219)", () => {
     await worktreeToggle.click();
     await expect(worktreeToggle).toHaveAttribute("aria-checked", "true");
     await expect(w.getByPlaceholder("Uses session title if empty")).toBeVisible();
+  });
+
+  test("worktree toggle defaults off when worktree.enabled is false (#2423)", async ({ page }) => {
+    await mockApis(page);
+    // Override the settings stub: worktree.enabled false must default the
+    // "Create a worktree" toggle off. The later route wins (LIFO).
+    await page.route("**/api/settings", (r) => r.fulfill({ json: { worktree: { enabled: false } } }));
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openWithProject(page);
+    await expandMoreOptions(page);
+    const w = wizard(page);
+    const worktreeToggle = w.getByRole("switch", { name: /Create a worktree/ });
+    await expect(worktreeToggle).toHaveAttribute("aria-checked", "false");
+    // Branch input + Base branch picker stay hidden while worktree is off.
+    await expect(w.getByPlaceholder("Uses session title if empty")).toHaveCount(0);
+    await expect(w.getByRole("button", { name: "Base branch" })).toHaveCount(0);
   });
 
   test("branch input mirrors the slugified title while not manually edited", async ({ page }) => {

--- a/web/tests/wizard-single-screen.spec.ts
+++ b/web/tests/wizard-single-screen.spec.ts
@@ -31,7 +31,14 @@ async function mockApis(page: Page, captured?: { body: Record<string, unknown> |
   for (const path of ["settings", "themes", "profiles", "groups", "devices", "about", "system/update-status"]) {
     await page.route(`**/api/${path}`, (r) =>
       r.fulfill({
-        json: path === "settings" || path === "about" || path === "system/update-status" ? {} : [],
+        // worktree.enabled drives the wizard's "Create a worktree" default (#2423);
+        // these worktree-flow specs assume it is on.
+        json:
+          path === "settings"
+            ? { worktree: { enabled: true } }
+            : path === "about" || path === "system/update-status"
+              ? {}
+              : [],
       }),
     );
   }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web new-session wizard always defaulted the "Create a worktree" toggle to on. It hardcoded `useWorktree: true` in the wizard's `initialData` and never read `worktree.enabled` from `/api/settings`, so it ignored both the config value and the Settings "Enabled by Default" toggle. The TUI reads the setting correctly; only the web side was wrong.

The fix seeds `useWorktree` from `worktree.enabled` through the same `APPLY_PROFILE_DEFAULTS` path that already seeds `yolo_mode_default` and the sandbox `enabled_by_default`, both on the mount-time settings fetch and on a profile switch. `initialData.useWorktree` now defaults to `false` to match the backend `WorktreeConfig` default and to cover the case where the settings fetch fails. A manual toggle before the fetch resolves marks the wizard dirty, so the late seed is a no-op and never stomps the user's choice (same guard `yoloMode` and `sandboxEnabled` already use). Scratch sessions still never enable a worktree.

Reading `worktree.enabled` alone; the TUI's extra host-only-tool gate is out of scope here.

Closes #2423

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Set `enabled = false` under `[worktree]` in your config (or toggle Settings, Worktree, "Enabled by Default" off). Open the web dashboard, press `N`, expand "More options": "Create a worktree" is OFF.
- [ ] Set `worktree.enabled = true`. Open the wizard again: "Create a worktree" is ON, and the branch input plus Base branch picker are visible.
- [ ] With `worktree.enabled = false`, open the wizard and toggle "Create a worktree" ON before doing anything else: it stays ON (the late settings seed does not flip it back off).
- [ ] Open the wizard with "Skip project folder" (scratch) on: the worktree controls are hidden and no worktree is created regardless of the setting.

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Docs: none. The toggle is discoverable UI and now matches the documented `worktree.enabled` setting; no non-discoverable behavior was added.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`wizard-session-step.spec.ts` gains a `worktree.enabled = false` defaults-off regression case, and the worktree-flow specs (`wizard-session-step`, `wizard-single-screen`, `wizard-base-branch`) now stub `worktree.enabled: true` so their default-on assertions test the config-driven behavior. Vitest `wizardReducer.test.ts` covers the seed, the scratch guard, and the dirty guard. The changed components are already mapped by the existing `wizard` coverage-matrix entry, so no new entry was needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (read `worktree.enabled` alone, default `initialData` to false), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785062224&installation_id=139138837&pr_number=2424&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2424&signature=e0305711417d4e98ac7a493bda71c990ad6328c25692ba74cde7ff652e65d86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### High-level
- The web new-session wizard now defaults the **“Create a worktree”** toggle based on the configured **`worktree.enabled`** setting (instead of always starting on).
- The wizard reads this preference when loading profile defaults, and safely falls back to **off** if settings can’t be loaded yet.
- If a user manually toggles the option before settings finish loading, the wizard no longer overwrites their choice afterward.
- **Scratch sessions still never create worktrees**, even if worktrees are enabled in settings.
- Tests were updated/added to cover: default-off behavior, scratch-session behavior, and “don’t override user toggle” behavior.

### Technical notes
- The profile-defaults flow now propagates a `worktreeEnabled` value derived from `settings.worktree.enabled` through the existing apply-profile-defaults dispatch path.
- `initialData.useWorktree` defaults to `false`.
- The reducer enforces scratch mode by forcing `useWorktree` off, and expands dirty-state tracking so user changes aren’t overridden by late settings seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->