### PR TITLE
feat(tui): interactive preview pane (mouse forwarding, smooth scroll, edge autoscroll, double-click attach)

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -970,11 +970,44 @@ impl App {
                                     continue;
                                 }
                             }
-                            // Mouse-tracking agent in live-send: forward the
-                            // press / drag / release straight to it, exactly as
-                            // a direct attach would. Shift falls through to
-                            // aoe's own preview text-selection. Consumes the
-                            // event when it forwards.
+                            // A double-click on the preview pane opens/attaches
+                            // the previewed session, the same as a sidebar
+                            // double-click. Checked BEFORE forwarding so the
+                            // agent doesn't swallow the second press; a single
+                            // press records its timing here and falls through to
+                            // the forward path below.
+                            if let Some(action) = self.home.preview_double_click_action(
+                                mouse.kind,
+                                mouse.modifiers,
+                                mouse.column,
+                                mouse.row,
+                            ) {
+                                let _ = self.home.clear_preview_selection();
+                                self.execute_action(action, terminal)?;
+                                // Mirror the list double-click path: an acp
+                                // session only stashes its id, so drain and open
+                                // the structured view here too.
+                                #[cfg(feature = "serve")]
+                                if let Some(session_id) =
+                                    self.pending_structured_view_open.take()
+                                {
+                                    self.run_structured_view(&session_id, terminal).await?;
+                                }
+                                self.sync_mouse_capture(terminal)?;
+                                if self.should_quit {
+                                    break;
+                                }
+                                if !self.needs_redraw {
+                                    self.draw(terminal)?;
+                                }
+                                continue;
+                            }
+                            // Mouse-tracking agent under the preview (live-send
+                            // OR passive hover): forward the press / drag /
+                            // release straight to it, exactly as a direct attach
+                            // would, so its native selection / scroll works.
+                            // Shift falls through to aoe's own preview text-
+                            // selection. Consumes the event when it forwards.
                             if self.home.forward_mouse_to_preview(
                                 mouse.kind,
                                 mouse.modifiers,

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -699,40 +699,58 @@ impl HomeView {
         }
         // Pace the scroll to a steady cadence regardless of how often the
         // loop woke this iteration, so the speed is even instead of racing
-        // with capture-worker activity.
+        // with capture-worker activity. The aoe-side line scroll runs at a
+        // smooth per-line cadence; the agent page-forward fallback below runs
+        // slower, since each press scrolls a whole page and a held edge would
+        // otherwise rocket through the transcript.
         const AUTOSCROLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(40);
+        const PAGE_FORWARD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
         let now = std::time::Instant::now();
-        if let Some(prev) = self.preview_autoscroll_at {
-            if now.duration_since(prev) < AUTOSCROLL_INTERVAL {
-                return false;
+        let line_ready = self
+            .preview_autoscroll_at
+            .is_none_or(|prev| now.duration_since(prev) >= AUTOSCROLL_INTERVAL);
+        let page_ready = self
+            .preview_autoscroll_at
+            .is_none_or(|prev| now.duration_since(prev) >= PAGE_FORWARD_INTERVAL);
+        // First try the aoe-side capture-window scroll (normal-buffer panes
+        // with real scrollback).
+        if line_ready {
+            let scrolled = if at_top {
+                self.scroll_preview_offset(1)
+            } else {
+                self.scroll_preview_offset(-1)
+            };
+            if scrolled {
+                self.preview_autoscroll_at = Some(now);
+                let col_off = col.clamp(pane.x, pane.right().saturating_sub(1)) - pane.x;
+                // Pin the extent to the now-revealed edge line in `from_bottom`
+                // terms, which the new scroll offset gives directly: the bottom
+                // visible line sits `offset` lines up from the newest line, the
+                // top visible line `offset + height - 1`. Deriving it from the
+                // offset (not the stale pre-scroll `total_lines`) keeps it
+                // correct even before the next frame re-captures.
+                let offset = self.preview_scroll_offset as usize;
+                let from_bottom = if at_top {
+                    offset + (pane.height as usize).saturating_sub(1)
+                } else {
+                    offset
+                };
+                if let Some(sel) = self.preview_selection.as_mut() {
+                    sel.extent = (col_off, from_bottom);
+                }
+                return true;
             }
         }
-        let scrolled = if at_top {
-            self.scroll_preview_offset(1)
-        } else {
-            self.scroll_preview_offset(-1)
-        };
-        if !scrolled {
-            return false;
+        // The capture-window scroll is inert: a full-screen (alternate-screen)
+        // agent has no aoe-side scrollback, so forward a PageUp/PageDown to the
+        // agent instead, scrolling its OWN transcript the way the wheel forward
+        // does (#2421). The extent stays pinned to the screen edge; the agent's
+        // redraw is what reveals more text under the held selection.
+        if page_ready && self.forward_page_to_preview(at_top) {
+            self.preview_autoscroll_at = Some(now);
+            return true;
         }
-        self.preview_autoscroll_at = Some(now);
-        let col_off = col.clamp(pane.x, pane.right().saturating_sub(1)) - pane.x;
-        // Pin the extent to the now-revealed edge line in `from_bottom`
-        // terms, which the new scroll offset gives directly: the bottom
-        // visible line sits `offset` lines up from the newest line, the top
-        // visible line `offset + height - 1`. Deriving it from the offset
-        // (not the stale pre-scroll `total_lines`) keeps it correct even
-        // before the next frame re-captures.
-        let offset = self.preview_scroll_offset as usize;
-        let from_bottom = if at_top {
-            offset + (pane.height as usize).saturating_sub(1)
-        } else {
-            offset
-        };
-        if let Some(sel) = self.preview_selection.as_mut() {
-            sel.extent = (col_off, from_bottom);
-        }
-        true
+        false
     }
 
     /// Shift the preview scroll offset by `delta` lines (positive scrolls
@@ -3404,6 +3422,32 @@ impl HomeView {
             return false;
         };
         self.send_to_preview_pane(key)
+    }
+
+    /// During an edge-held preview selection over a full-screen
+    /// (alternate-screen) agent, the aoe capture-window scroll is inert (the
+    /// alternate screen has no scrollback, so `scroll_preview_offset` can't
+    /// move), so forward a `PageUp`/`PageDown` to the agent to scroll its OWN
+    /// transcript, mirroring `forward_wheel_to_preview`. Gated on the previewed
+    /// pane being an alternate-screen app so a normal-buffer pane that has
+    /// merely bottomed out its scrollback never gets page keys injected into
+    /// its shell. `up` selects PageUp (top edge) vs PageDown (bottom edge).
+    /// Returns true when a key was sent.
+    fn forward_page_to_preview(&self, up: bool) -> bool {
+        let Some(cursor) = self
+            .preview_capture_worker
+            .as_ref()
+            .and_then(|w| w.current_cursor())
+        else {
+            return false;
+        };
+        if !cursor.alternate_on {
+            return false;
+        }
+        self.send_to_preview_pane(live_send::TmuxKey::NamedRepeat {
+            name: if up { "PageUp" } else { "PageDown" }.to_string(),
+            count: WHEEL_PAGE_STEP,
+        })
     }
 
     /// Send a forwarded key/mouse-byte payload to the pane the preview is

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -700,11 +700,11 @@ impl HomeView {
         // Pace the scroll to a steady cadence regardless of how often the
         // loop woke this iteration, so the speed is even instead of racing
         // with capture-worker activity. The aoe-side line scroll runs at a
-        // smooth per-line cadence; the agent page-forward fallback below runs
-        // slower, since each press scrolls a whole page and a held edge would
+        // smooth per-line cadence; the agent scroll-forward fallback below runs
+        // slower, since each notch scrolls a whole page and a held edge would
         // otherwise rocket through the transcript.
         const AUTOSCROLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(40);
-        const PAGE_FORWARD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+        const PAGE_FORWARD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
         let now = std::time::Instant::now();
         let line_ready = self
             .preview_autoscroll_at
@@ -742,11 +742,12 @@ impl HomeView {
             }
         }
         // The capture-window scroll is inert: a full-screen (alternate-screen)
-        // agent has no aoe-side scrollback, so forward a PageUp/PageDown to the
-        // agent instead, scrolling its OWN transcript the way the wheel forward
-        // does (#2421). The extent stays pinned to the screen edge; the agent's
-        // redraw is what reveals more text under the held selection.
-        if page_ready && self.forward_page_to_preview(at_top) {
+        // agent has no aoe-side scrollback, so forward the same scroll input a
+        // wheel notch would to the agent instead, scrolling its OWN transcript
+        // the way the wheel forward does (#2421). The extent stays pinned to the
+        // screen edge; the agent's redraw is what reveals more text under the
+        // held selection.
+        if page_ready && self.forward_scroll_to_preview(at_top, col, row) {
             self.preview_autoscroll_at = Some(now);
             return true;
         }
@@ -759,9 +760,18 @@ impl HomeView {
     /// handlers so the edge auto-scroll can move the pane without dragging
     /// the whole `handle_scroll_*` routing along with it.
     fn scroll_preview_offset(&mut self, delta: i32) -> bool {
-        let cache = self.active_preview_cache();
-        let visible_height = cache.dimensions.1.saturating_sub(1) as usize;
-        let real_max = cache.captured_lines.saturating_sub(visible_height) as i32;
+        // Use the same rendered output-body height the per-frame clamp uses
+        // (`clamp_scroll_to_capture`), NOT `dimensions.1 - 1`. The raw-height
+        // `- 1` over-counts the max offset by a row, so on an alternate-screen
+        // agent with no scrollback this would grant a phantom 1-row offset that
+        // render erases every frame: the offset oscillates 0->1->0, the view
+        // never moves, and because it returns `true` the caller never falls
+        // through to the agent scroll-forward fallback.
+        let visible_height = self.preview_visible_rows;
+        let real_max = self
+            .active_preview_cache()
+            .captured_lines
+            .saturating_sub(visible_height) as i32;
         let new = (self.preview_scroll_offset as i32 + delta).clamp(0, real_max) as u16;
         if new == self.preview_scroll_offset {
             return false;
@@ -3427,13 +3437,17 @@ impl HomeView {
     /// During an edge-held preview selection over a full-screen
     /// (alternate-screen) agent, the aoe capture-window scroll is inert (the
     /// alternate screen has no scrollback, so `scroll_preview_offset` can't
-    /// move), so forward a `PageUp`/`PageDown` to the agent to scroll its OWN
-    /// transcript, mirroring `forward_wheel_to_preview`. Gated on the previewed
-    /// pane being an alternate-screen app so a normal-buffer pane that has
-    /// merely bottomed out its scrollback never gets page keys injected into
-    /// its shell. `up` selects PageUp (top edge) vs PageDown (bottom edge).
-    /// Returns true when a key was sent.
-    fn forward_page_to_preview(&self, up: bool) -> bool {
+    /// move), so forward the SAME scroll input one wheel notch would, scrolling
+    /// the agent's OWN transcript. Mirrors `forward_wheel_to_preview` by reusing
+    /// `wheel_forward_key`: a mouse-tracking app gets a wheel-up/down mouse
+    /// report at the held cell (PageUp does nothing while it owns the mouse), a
+    /// no-mouse app gets `PageUp`/`PageDown`. `wheel_forward_key` also enforces
+    /// the alternate-screen gate, so a normal-buffer pane that has merely
+    /// bottomed out its scrollback never gets scroll input injected into its
+    /// shell. `up` selects the top-edge (scroll back) vs bottom-edge (scroll
+    /// forward) direction; `col`/`row` is the held pointer cell, mapped into the
+    /// pane for the mouse-byte encoding. Returns true when something was sent.
+    fn forward_scroll_to_preview(&self, up: bool, col: u16, row: u16) -> bool {
         let Some(cursor) = self
             .preview_capture_worker
             .as_ref()
@@ -3441,13 +3455,11 @@ impl HomeView {
         else {
             return false;
         };
-        if !cursor.alternate_on {
+        let Some(key) = wheel_forward_key(&cursor, up, self.preview_text_view.pane, col, row)
+        else {
             return false;
-        }
-        self.send_to_preview_pane(live_send::TmuxKey::NamedRepeat {
-            name: if up { "PageUp" } else { "PageDown" }.to_string(),
-            count: WHEEL_PAGE_STEP,
-        })
+        };
+        self.send_to_preview_pane(key)
     }
 
     /// Send a forwarded key/mouse-byte payload to the pane the preview is
@@ -3473,13 +3485,16 @@ impl HomeView {
     }
 
     /// The previewed agent's cursor when a mouse button event over the preview
-    /// should be forwarded to it instead of driving aoe's own UI: live-send
-    /// only, and the pane must be a full-screen app with mouse tracking on (the
-    /// same gate as the wheel's mouse-byte branch). `None` means let the event
-    /// fall through to aoe's handlers (selection, etc.). Returns the cursor so
-    /// the caller can read `mouse_sgr` for the encoding.
+    /// should be forwarded to it instead of driving aoe's own UI: the pane must
+    /// be a full-screen app with mouse tracking on (the same gate as the wheel's
+    /// mouse-byte branch). Works in passive preview too, not just live-send,
+    /// mirroring `forward_wheel_to_preview`: hovering a mouse agent and dragging
+    /// drives its native selection/scroll, and `send_to_preview_pane` forks a
+    /// one-shot send when there's no live-send worker. `None` means let the
+    /// event fall through to aoe's handlers (selection, etc.); Shift is the
+    /// caller's escape hatch back to aoe-side selection / copy. Returns the
+    /// cursor so the caller can read `mouse_sgr` for the encoding.
     fn preview_forwards_mouse(&self) -> Option<crate::tmux::PaneCursor> {
-        self.live_send.as_ref()?;
         let cursor = self
             .preview_capture_worker
             .as_ref()
@@ -4427,6 +4442,62 @@ impl HomeView {
                     self.start_live_send()
                 }
             }
+        }
+    }
+
+    /// A double-click on the preview pane opens/attaches the previewed session,
+    /// producing the SAME `Action` a sidebar double-click (or `Enter`) would, so
+    /// the two gestures match. Mirrors `handle_click`'s double-click detection
+    /// but keyed to the preview rect via its own `last_preview_click`, and gated
+    /// to a plain (no-Shift) left press over the preview with no overlay on top.
+    /// The previewed pane is always `selected_session`, so it activates the
+    /// right row without touching `cursor`. Returns the activation `Action` on
+    /// the second qualifying press within `DOUBLE_CLICK_THRESHOLD`, else `None`
+    /// (a single press, whose timing it records; the caller still forwards that
+    /// press to a mouse-tracking agent). Shift falls through so aoe's own
+    /// preview selection runs, matching the mouse-forward gate.
+    pub fn preview_double_click_action(
+        &mut self,
+        kind: crossterm::event::MouseEventKind,
+        modifiers: crossterm::event::KeyModifiers,
+        col: u16,
+        row: u16,
+    ) -> Option<Action> {
+        self.preview_double_click_action_at(std::time::Instant::now(), kind, modifiers, col, row)
+    }
+
+    /// Same as `preview_double_click_action`, but the caller supplies `now` so
+    /// unit tests can drive double-click detection deterministically.
+    pub(super) fn preview_double_click_action_at(
+        &mut self,
+        now: std::time::Instant,
+        kind: crossterm::event::MouseEventKind,
+        modifiers: crossterm::event::KeyModifiers,
+        col: u16,
+        row: u16,
+    ) -> Option<Action> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+        if !matches!(kind, MouseEventKind::Down(MouseButton::Left)) {
+            return None;
+        }
+        if modifiers.contains(crossterm::event::KeyModifiers::SHIFT) {
+            return None;
+        }
+        if self.has_non_live_send_overlay() || !self.hit_preview(col, row) {
+            return None;
+        }
+        let is_double = matches!(
+            self.last_preview_click,
+            Some((prev_time, _, prev_row))
+                if prev_row == row && now.duration_since(prev_time) <= DOUBLE_CLICK_THRESHOLD
+        );
+        if is_double {
+            // Reset so a triple-click doesn't immediately re-fire activation.
+            self.last_preview_click = None;
+            self.activate_selected_session()
+        } else {
+            self.last_preview_click = Some((now, col, row));
+            None
         }
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -706,7 +706,7 @@ impl HomeView {
         // page-key fallback stays slow: each press scrolls a WHOLE page, so a
         // held edge at the fast cadence would rocket through the transcript.
         const AUTOSCROLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(40);
-        const PAGE_FORWARD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
+        const PAGE_FORWARD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
         let now = std::time::Instant::now();
         let forward_interval = if self.preview_forwards_mouse().is_some() {
             AUTOSCROLL_INTERVAL
@@ -4459,10 +4459,11 @@ impl HomeView {
     /// to a plain (no-Shift) left press over the preview with no overlay on top.
     /// The previewed pane is always `selected_session`, so it activates the
     /// right row without touching `cursor`. Returns the activation `Action` on
-    /// the second qualifying press within `DOUBLE_CLICK_THRESHOLD`, else `None`
-    /// (a single press, whose timing it records; the caller still forwards that
-    /// press to a mouse-tracking agent). Shift falls through so aoe's own
-    /// preview selection runs, matching the mouse-forward gate.
+    /// the second qualifying press on the SAME cell within
+    /// `DOUBLE_CLICK_THRESHOLD`, else `None` (a single press, whose timing it
+    /// records; the caller still forwards that press to a mouse-tracking
+    /// agent). Shift falls through so aoe's own preview selection runs, matching
+    /// the mouse-forward gate.
     pub fn preview_double_click_action(
         &mut self,
         kind: crossterm::event::MouseEventKind,
@@ -4493,10 +4494,16 @@ impl HomeView {
         if self.has_non_live_send_overlay() || !self.hit_preview(col, row) {
             return None;
         }
+        // Match the SAME cell, not just the row: the sidebar can key by row
+        // because a row identifies an item, but a preview row is just a line of
+        // text, so two unrelated presses on the same line (different columns)
+        // must not count as a double-click.
         let is_double = matches!(
             self.last_preview_click,
-            Some((prev_time, _, prev_row))
-                if prev_row == row && now.duration_since(prev_time) <= DOUBLE_CLICK_THRESHOLD
+            Some((prev_time, prev_col, prev_row))
+                if prev_col == col
+                    && prev_row == row
+                    && now.duration_since(prev_time) <= DOUBLE_CLICK_THRESHOLD
         );
         if is_double {
             // Reset so a triple-click doesn't immediately re-fire activation.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -697,21 +697,28 @@ impl HomeView {
             self.preview_autoscroll_at = None;
             return false;
         }
-        // Pace the scroll to a steady cadence regardless of how often the
-        // loop woke this iteration, so the speed is even instead of racing
-        // with capture-worker activity. The aoe-side line scroll runs at a
-        // smooth per-line cadence; the agent scroll-forward fallback below runs
-        // slower, since each notch scrolls a whole page and a held edge would
-        // otherwise rocket through the transcript.
+        // Pace the scroll to a steady cadence regardless of how often the loop
+        // woke this iteration, so the speed is even instead of racing with
+        // capture-worker activity. The aoe-side line scroll and the wheel
+        // forward to a mouse agent are both fine-grained (one line / one wheel
+        // notch), so they run at the fast cadence and read as smooth, like the
+        // native wheel forward when the live pane is active. The no-mouse
+        // page-key fallback stays slow: each press scrolls a WHOLE page, so a
+        // held edge at the fast cadence would rocket through the transcript.
         const AUTOSCROLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(40);
         const PAGE_FORWARD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
         let now = std::time::Instant::now();
+        let forward_interval = if self.preview_forwards_mouse().is_some() {
+            AUTOSCROLL_INTERVAL
+        } else {
+            PAGE_FORWARD_INTERVAL
+        };
         let line_ready = self
             .preview_autoscroll_at
             .is_none_or(|prev| now.duration_since(prev) >= AUTOSCROLL_INTERVAL);
-        let page_ready = self
+        let forward_ready = self
             .preview_autoscroll_at
-            .is_none_or(|prev| now.duration_since(prev) >= PAGE_FORWARD_INTERVAL);
+            .is_none_or(|prev| now.duration_since(prev) >= forward_interval);
         // First try the aoe-side capture-window scroll (normal-buffer panes
         // with real scrollback).
         if line_ready {
@@ -747,7 +754,7 @@ impl HomeView {
         // the way the wheel forward does (#2421). The extent stays pinned to the
         // screen edge; the agent's redraw is what reveals more text under the
         // held selection.
-        if page_ready && self.forward_scroll_to_preview(at_top, col, row) {
+        if forward_ready && self.forward_scroll_to_preview(at_top, col, row) {
             self.preview_autoscroll_at = Some(now);
             return true;
         }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -769,7 +769,23 @@ impl LiveCaptureWorker {
                 // condvar so a cadence or target change is picked up at once
                 // rather than after the current sleep. Spurious wakeups just
                 // run an extra capture cycle, which the dedup makes harmless.
-                let ms = interval_cell.load(Ordering::Relaxed);
+                //
+                // A live in-process vt channel samples the grid cheaply (no
+                // `capture-pane` fork) and dedups unchanged frames, so the idle
+                // throttle buys nothing there: pace it fast so the PREVIEWED
+                // pane scrolls / streams as smoothly as the active live pane,
+                // even when it isn't the live-send target. The idle cadence
+                // still governs the capture-pane fallback, whose every sample is
+                // an expensive fork.
+                #[cfg(unix)]
+                let vt_active = vt_source.as_ref().is_some_and(|v| v.is_alive());
+                #[cfg(not(unix))]
+                let vt_active = false;
+                let ms = if vt_active {
+                    LIVE_CAPTURE_INTERVAL_FAST_MS
+                } else {
+                    interval_cell.load(Ordering::Relaxed)
+                };
                 if let Ok(guard) = nudge_thread.0.lock() {
                     let _ = nudge_thread
                         .1

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -756,6 +756,12 @@ pub struct HomeView {
     /// session (same as pressing Enter on the selected row).
     pub(super) last_click: Option<(std::time::Instant, u16, u16)>,
 
+    /// Same as `last_click`, but for left-presses on the preview pane. Kept
+    /// separate so preview and sidebar double-click detection don't cross-talk.
+    /// A second qualifying press within `DOUBLE_CLICK_THRESHOLD` activates the
+    /// previewed session, matching a sidebar double-click.
+    pub(super) last_preview_click: Option<(std::time::Instant, u16, u16)>,
+
     /// Dwell tracker for unread clear-on-read: the currently-selected session
     /// id and the instant the selection landed on it (while the list is the
     /// foreground, no dialog/live-send). When the same row stays selected for
@@ -1505,6 +1511,7 @@ impl HomeView {
             list_inner_area: Rect::default(),
             mouse_pos: None,
             last_click: None,
+            last_preview_click: None,
             unread_dwell: None,
             manual_unread_hold: None,
             terminal_modes: HashMap::new(),

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -9126,6 +9126,73 @@ mod scroll_pane_isolation {
         assert_eq!(env.view.mouse_forward_btn, None);
     }
 
+    /// Stage an in-flight Shift-selection drag held at the preview's top
+    /// (`row == pane.y`) or bottom edge, plus a capture window with NO aoe-side
+    /// scrollback, so `tick_preview_autoscroll` exercises the agent
+    /// page-forward fallback rather than the capture-window line scroll.
+    fn stage_edge_drag_no_scrollback(env: &mut TestEnv, at_top: bool) {
+        use crate::tui::home::PreviewTextView;
+        // Visible == captured: `scroll_preview_offset` has nowhere to go, the
+        // alternate-screen reality the fallback exists for.
+        env.view.preview_cache.captured_lines = 23;
+        env.view.preview_cache.dimensions = (80, 24);
+        env.view.preview_scroll_offset = 0;
+        let pane = Rect::new(30, 0, 100, 5);
+        env.view.preview_text_view = PreviewTextView {
+            pane,
+            first_line: 0,
+            total_lines: 23,
+        };
+        // Anchor away from the held edge, then drag onto it.
+        let (start_row, edge_row) = if at_top { (4, 0) } else { (0, 4) };
+        assert!(env.view.handle_drag_start(40, start_row));
+        assert!(env.view.handle_drag_move(40, edge_row));
+    }
+
+    /// Over a full-screen mouse-tracking agent the capture window has no
+    /// scrollback, so an edge-held selection forwards PageUp to the agent
+    /// (scrolling its own transcript) instead of moving the inert offset.
+    #[test]
+    #[serial]
+    fn autoscroll_forwards_pageup_to_alt_screen_agent_at_top_edge() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, true, true));
+        stage_edge_drag_no_scrollback(&mut env, true);
+        assert!(
+            env.view.tick_preview_autoscroll(),
+            "top-edge tick forwards a page to the agent"
+        );
+        // The inert capture-window offset never moved; the agent was paged.
+        assert_eq!(env.view.preview_scroll_offset, 0);
+    }
+
+    /// Same as above at the bottom edge: PageDown is forwarded.
+    #[test]
+    #[serial]
+    fn autoscroll_forwards_pagedown_to_alt_screen_agent_at_bottom_edge() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, true, true));
+        stage_edge_drag_no_scrollback(&mut env, false);
+        assert!(
+            env.view.tick_preview_autoscroll(),
+            "bottom-edge tick forwards a page to the agent"
+        );
+        assert_eq!(env.view.preview_scroll_offset, 0);
+    }
+
+    /// A normal-buffer pane (NOT alternate-screen) that has merely bottomed out
+    /// its scrollback must NOT get page keys injected into its shell: the tick
+    /// is a no-op there.
+    #[test]
+    #[serial]
+    fn autoscroll_does_not_forward_page_to_normal_pane() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(false, false, false));
+        stage_edge_drag_no_scrollback(&mut env, true);
+        assert!(
+            !env.view.tick_preview_autoscroll(),
+            "a non-alternate-screen pane never gets a forwarded page key"
+        );
+        assert_eq!(env.view.preview_scroll_offset, 0);
+    }
+
     /// A full-screen app with mouse tracking but in the LEGACY (non-SGR)
     /// encoding is still forwarded; the byte builder emits X10-encoded
     /// bytes for it instead of SGR (see `wheel_mouse_bytes_legacy_encodes_x10`).

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10485,6 +10485,38 @@ mod click_to_select {
         );
     }
 
+    /// Two presses on the same preview row but different columns are unrelated
+    /// clicks (e.g. tapping two different words), not a double-click: only a
+    /// same-cell second press within the window activates.
+    #[test]
+    #[serial]
+    fn preview_two_presses_on_same_row_different_col_do_not_activate() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        env.view.preview_area = Rect::new(30, 0, 100, 40);
+        env.view.cursor = 1;
+        env.view.update_selected();
+
+        let down = MouseEventKind::Down(MouseButton::Left);
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_millis(150);
+        // Same row 10, columns 40 then 70: within the time window but a
+        // different cell, so the second press is a fresh single click.
+        assert_eq!(
+            env.view
+                .preview_double_click_action_at(t0, down, KeyModifiers::NONE, 40, 10),
+            None
+        );
+        assert_eq!(
+            env.view
+                .preview_double_click_action_at(t1, down, KeyModifiers::NONE, 70, 10),
+            None,
+            "a different-column second press on the same row must not activate"
+        );
+    }
+
     #[test]
     #[serial]
     fn two_clicks_on_different_rows_do_not_activate() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -9043,6 +9043,44 @@ mod scroll_pane_isolation {
         assert!(env.view.preview_selection.is_none());
     }
 
+    /// Passive preview (NOT live-send) over a mouse-tracking agent ALSO forwards
+    /// a plain press/drag/release, so hovering an agent and dragging drives its
+    /// native selection / scroll, exactly like the live-send case (and like the
+    /// passive wheel path). The one-shot send carries it with no live worker.
+    #[test]
+    #[serial]
+    fn forward_mouse_to_preview_passive_preview_forwards() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        let mut env = passive_env_with_cursor(alt_screen_cursor(true, true, true));
+        assert!(
+            env.view.live_send.is_none(),
+            "this exercises passive preview, not live-send"
+        );
+        assert!(env.view.forward_mouse_to_preview(
+            MouseEventKind::Down(MouseButton::Left),
+            KeyModifiers::NONE,
+            50,
+            10
+        ));
+        assert_eq!(env.view.mouse_forward_btn, Some(0));
+        assert!(env.view.forward_mouse_to_preview(
+            MouseEventKind::Drag(MouseButton::Left),
+            KeyModifiers::NONE,
+            55,
+            12
+        ));
+        assert!(env.view.forward_mouse_to_preview(
+            MouseEventKind::Up(MouseButton::Left),
+            KeyModifiers::NONE,
+            55,
+            12
+        ));
+        assert_eq!(env.view.mouse_forward_btn, None);
+        // Forwarding never starts an aoe text selection, even passively.
+        assert!(env.view.drag_state.is_none());
+        assert!(env.view.preview_selection.is_none());
+    }
+
     /// Shift+press is NOT forwarded: it falls through so aoe's own preview
     /// text-selection (drag-to-copy) can run.
     #[test]
@@ -9129,12 +9167,15 @@ mod scroll_pane_isolation {
     /// Stage an in-flight Shift-selection drag held at the preview's top
     /// (`row == pane.y`) or bottom edge, plus a capture window with NO aoe-side
     /// scrollback, so `tick_preview_autoscroll` exercises the agent
-    /// page-forward fallback rather than the capture-window line scroll.
+    /// scroll-forward fallback rather than the capture-window line scroll.
     fn stage_edge_drag_no_scrollback(env: &mut TestEnv, at_top: bool) {
         use crate::tui::home::PreviewTextView;
         // Visible == captured: `scroll_preview_offset` has nowhere to go, the
-        // alternate-screen reality the fallback exists for.
+        // alternate-screen reality the fallback exists for. The clamp reads
+        // `preview_visible_rows`, so pin it to the captured-line count to make
+        // the max offset zero (no scrollback to move into).
         env.view.preview_cache.captured_lines = 23;
+        env.view.preview_visible_rows = 23;
         env.view.preview_cache.dimensions = (80, 24);
         env.view.preview_scroll_offset = 0;
         let pane = Rect::new(30, 0, 100, 5);
@@ -9150,45 +9191,65 @@ mod scroll_pane_isolation {
     }
 
     /// Over a full-screen mouse-tracking agent the capture window has no
-    /// scrollback, so an edge-held selection forwards PageUp to the agent
-    /// (scrolling its own transcript) instead of moving the inert offset.
+    /// scrollback, so an edge-held selection forwards the same scroll input the
+    /// wheel does (a wheel-up/down mouse report, NOT PageUp, since the agent
+    /// owns the mouse) to scroll its own transcript instead of moving the inert
+    /// offset. The fallback delegates to `wheel_forward_key`, whose byte output
+    /// per branch is asserted in `wheel_forward_key_*`; here we verify the tick
+    /// forwards and pins the offset. Regression for the "autoscroll does nothing
+    /// over a mouse-tracking agent" report (PageUp was a no-op there).
     #[test]
     #[serial]
-    fn autoscroll_forwards_pageup_to_alt_screen_agent_at_top_edge() {
+    fn autoscroll_forwards_scroll_to_mouse_tracking_agent_at_top_edge() {
         let mut env = live_env_with_cursor(alt_screen_cursor(true, true, true));
         stage_edge_drag_no_scrollback(&mut env, true);
         assert!(
             env.view.tick_preview_autoscroll(),
-            "top-edge tick forwards a page to the agent"
+            "top-edge tick forwards a wheel notch to the agent"
         );
-        // The inert capture-window offset never moved; the agent was paged.
+        // The inert capture-window offset never moved; the agent was scrolled.
         assert_eq!(env.view.preview_scroll_offset, 0);
     }
 
-    /// Same as above at the bottom edge: PageDown is forwarded.
+    /// Same as above at the bottom edge: a wheel-down notch is forwarded.
     #[test]
     #[serial]
-    fn autoscroll_forwards_pagedown_to_alt_screen_agent_at_bottom_edge() {
+    fn autoscroll_forwards_scroll_to_mouse_tracking_agent_at_bottom_edge() {
         let mut env = live_env_with_cursor(alt_screen_cursor(true, true, true));
         stage_edge_drag_no_scrollback(&mut env, false);
         assert!(
             env.view.tick_preview_autoscroll(),
-            "bottom-edge tick forwards a page to the agent"
+            "bottom-edge tick forwards a wheel notch to the agent"
+        );
+        assert_eq!(env.view.preview_scroll_offset, 0);
+    }
+
+    /// A full-screen agent WITHOUT mouse tracking (Claude Code's fullscreen
+    /// renderer: `1049h`, no mouse) gets `PageUp`/`PageDown` from the fallback
+    /// instead, matching the wheel path's no-mouse branch.
+    #[test]
+    #[serial]
+    fn autoscroll_forwards_page_keys_to_no_mouse_agent_at_top_edge() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, false, false));
+        stage_edge_drag_no_scrollback(&mut env, true);
+        assert!(
+            env.view.tick_preview_autoscroll(),
+            "top-edge tick forwards a page key to the no-mouse agent"
         );
         assert_eq!(env.view.preview_scroll_offset, 0);
     }
 
     /// A normal-buffer pane (NOT alternate-screen) that has merely bottomed out
-    /// its scrollback must NOT get page keys injected into its shell: the tick
-    /// is a no-op there.
+    /// its scrollback must NOT get scroll input injected into its shell: the
+    /// tick is a no-op there.
     #[test]
     #[serial]
-    fn autoscroll_does_not_forward_page_to_normal_pane() {
+    fn autoscroll_does_not_forward_to_normal_pane() {
         let mut env = live_env_with_cursor(alt_screen_cursor(false, false, false));
         stage_edge_drag_no_scrollback(&mut env, true);
         assert!(
             !env.view.tick_preview_autoscroll(),
-            "a non-alternate-screen pane never gets a forwarded page key"
+            "a non-alternate-screen pane never gets forwarded scroll input"
         );
         assert_eq!(env.view.preview_scroll_offset, 0);
     }
@@ -10337,6 +10398,93 @@ mod click_to_select {
         );
     }
 
+    /// A double-click on the preview pane produces the SAME activation Action a
+    /// sidebar double-click would (parity gesture): the first press is a no-op
+    /// that records timing, the second within threshold attaches the previewed
+    /// session.
+    #[test]
+    #[serial]
+    fn preview_double_click_attaches_like_sidebar() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        env.view.preview_area = Rect::new(30, 0, 100, 40);
+        env.view.cursor = 1;
+        env.view.update_selected();
+        let expected_id = env
+            .view
+            .selected_session
+            .clone()
+            .expect("a session is selected");
+
+        // (50, 10) is inside preview_area (30, 0, 100, 40).
+        let t0 = Instant::now();
+        assert_eq!(
+            env.view.preview_double_click_action_at(
+                t0,
+                MouseEventKind::Down(MouseButton::Left),
+                KeyModifiers::NONE,
+                50,
+                10
+            ),
+            None,
+            "a single preview press does not activate"
+        );
+        let t1 = t0 + Duration::from_millis(150);
+        assert_eq!(
+            env.view.preview_double_click_action_at(
+                t1,
+                MouseEventKind::Down(MouseButton::Left),
+                KeyModifiers::NONE,
+                50,
+                10
+            ),
+            Some(crate::tui::app::Action::AttachSession(expected_id)),
+            "a double-click on the preview attaches the session, same as the sidebar"
+        );
+    }
+
+    /// Shift+press (aoe's own selection escape hatch) and presses outside the
+    /// preview never activate, even repeated within the double-click window.
+    #[test]
+    #[serial]
+    fn preview_shift_and_off_pane_presses_never_activate() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        env.view.preview_area = Rect::new(30, 0, 100, 40);
+        env.view.cursor = 1;
+        env.view.update_selected();
+
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_millis(150);
+        let down = MouseEventKind::Down(MouseButton::Left);
+        // Shift falls through to aoe selection: never tracked, never activates.
+        assert_eq!(
+            env.view
+                .preview_double_click_action_at(t0, down, KeyModifiers::SHIFT, 50, 10),
+            None
+        );
+        assert_eq!(
+            env.view
+                .preview_double_click_action_at(t1, down, KeyModifiers::SHIFT, 50, 10),
+            None
+        );
+        // A press in the list area (5, 3), outside the preview, is ignored too.
+        assert_eq!(
+            env.view
+                .preview_double_click_action_at(t0, down, KeyModifiers::NONE, 5, 3),
+            None
+        );
+        assert_eq!(
+            env.view
+                .preview_double_click_action_at(t1, down, KeyModifiers::NONE, 5, 3),
+            None
+        );
+    }
+
     #[test]
     #[serial]
     fn two_clicks_on_different_rows_do_not_activate() {
@@ -10957,9 +11105,11 @@ mod preview_drag_select {
         let total_lines = text.lines.len();
         env.view.preview_cache.parsed_text = Some(text);
         env.view.preview_cache.captured_lines = total_lines;
-        // `dimensions.1 - 1` is the visible-height the scroll clamp uses;
-        // pin it to the pane height so the auto-scroll max offset matches
-        // what `first_line` implies.
+        // `scroll_preview_offset` clamps the auto-scroll max offset against
+        // `preview_visible_rows` (the rendered output-body height, same as the
+        // per-frame `clamp_scroll_to_capture`); pin it to the pane height so the
+        // max offset matches what `first_line` implies.
+        env.view.preview_visible_rows = pane.height as usize;
         env.view.preview_cache.dimensions = (pane.width, pane.height + 1);
         env.view.preview_area = pane;
         env.view.preview_scroll_offset = total_lines


### PR DESCRIPTION
## Description

Makes the live preview pane behave like a real attach: a previewed full-screen agent now takes mouse input, scrolls smoothly, restores edge auto-scroll for Shift selections, and opens on double-click. This started as just the #2421 edge auto-scroll fix, then grew to cover the surrounding preview-pane interaction gaps that surfaced while testing it.

### Edge auto-scroll over full-screen agents (Fixes #2421)

`tick_preview_autoscroll` grows a Shift+drag selection past one page by scrolling aoe's captured window. That window only has scrollback for normal-buffer panes; a full-screen alternate-screen agent (Claude Code's fullscreen renderer) exposes only its visible screen to capture, so the capture-window scroll is inert and holding a selection at the edge did nothing. Two stacked bugs kept it broken:

- `scroll_preview_offset` clamped its max offset against `dimensions.1 - 1` instead of the rendered `preview_visible_rows` the per-frame clamp uses. The extra row granted a phantom offset that render erased every frame, so the inert aoe-side scroll falsely reported success and the agent fallback was never reached.
- The fallback then forwarded a bare PageUp, which a mouse-tracking agent ignores. It now reuses `wheel_forward_key`, sending a wheel notch to mouse agents and PageUp/PageDown only to no-mouse ones (the method was renamed `forward_page_to_preview` to `forward_scroll_to_preview`). The selection extent stays pinned to the screen edge; the agent's redraw is what reveals more text under the held selection.

Cadence is split by agent type: a mouse agent scrolls at the fine 40ms line cadence (each notch is a few lines, so it reads as smooth), while a no-mouse agent stays slow (each press is a whole page, which would otherwise rocket through the transcript).

### Forward drag-select into the agent in passive preview

Plain (no-Shift) drag now forwards to a mouse-tracking agent when merely hovering the preview, not only during live-send, so its native selection / scroll works exactly like a direct attach. Shift stays the escape hatch for aoe-side text selection and OSC52 copy (the path that also works on Mosh and mobile, where mouse forwarding does not reach the agent).

### Double-click the preview to attach

A double-click on the preview pane opens / attaches the previewed session, producing the same Action a sidebar double-click or Enter would, so the two gestures match. It is checked before forwarding so the agent does not swallow the second press; a single press records its timing and still forwards.

### Smooth preview scroll for any selected pane

The capture worker only sampled at the fast 25ms cadence when the previewed pane was the live-send target; any other previewed pane (passive hover, or live-send aimed elsewhere) sat on the 250ms idle cadence, so scrolling / streaming there stepped visibly instead of gliding like the active live pane. That throttle dates from the capture-pane era, where each sample forked a tmux process. A vt channel samples an in-process grid (no fork) and dedups unchanged frames, so it now always samples fast. Input forwarding is unchanged: only the active pane receives keystrokes / mouse.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs affected)
- [x] For UI changes: included screenshot or recording (interaction-only change; verified end-to-end against a real tmux full-screen mouse agent instead, see below)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a `tests/e2e/` test, because: the new behavior is covered by deterministic unit tests in `src/tui/home/tests.rs` (edge auto-scroll forwards a wheel notch to a mouse agent and PageUp/PageDown to a no-mouse one, and never to a normal-buffer pane; plain drag forwards to the agent in passive preview as well as live-send; a double-click on the preview produces the same attach Action a sidebar double-click does, while Shift and off-pane presses never activate). I also verified the full runtime path by hand against a real tmux full-screen mouse agent: aoe's cursor probe detected `alternate_on/mouse_tracking/mouse_sgr`, the edge auto-scroll forwarded wheel bytes through the real `LiveSendWorker`, the agent's transcript scrolled, and the preview rendered smoothly off the in-process vt grid. A scripted `tests/e2e/` version would need a live mouse-tracking agent plus synthetic SGR-mouse injection into the TUI, which the unit tests model directly.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented and verified via Claude Code in back-and-forth with @njbrake. The design decisions (forward scroll input to the agent rather than treat the edge as a hard boundary, forward drag in passive preview while keeping Shift as the selection escape hatch, double-click to attach, and sampling a live vt channel fast for smooth preview scroll) are his.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #2421


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785063536&installation_id=139138837&pr_number=2425&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2425&signature=abb5bab65af82e2c767cff58e63ff7bdac67b9222063730eb96314d909a6d1c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### High-level summary
This PR improves the TUI’s preview pane interactions: mouse events are forwarded more reliably to fullscreen preview agents (including in passive preview), edge auto-scrolling works again when Shift-based selection hits the top/bottom border, and double-clicking in the preview attaches/activates the selected session. It also makes preview scrolling/streaming smoother by capturing preview VT output at a faster cadence and fixing edge-case scroll clamping.

### What changed
- **Preview mouse forwarding improvements (fullscreen agents):**
  - Plain mouse press/drag/release actions in the preview are forwarded to the fullscreen previewed agent even when the preview isn’t the live-send target (passive preview included).
  - Forwarding now works based on the preview pane’s mouse-tracking capabilities rather than assuming the live-send state.
- **Restored edge auto-scroll for Shift selections:**
  - When Shift-based selection reaches the preview pane edge and the preview capture window can’t advance, the PR routes the “keep scrolling” input to the previewed agent again.
  - The fallback behavior is updated:
    - **Mouse-tracking agents** receive **wheel input** when the edge can’t advance.
    - **Non-mouse agents** receive **PageUp/PageDown-style** input instead.
- **Smoother preview capture + scrolling:**
  - The preview capture worker samples live VT channels at a **fast cadence** even when that pane isn’t currently the live-send target, reducing stutter and improving continuous rendering.
  - Preview scroll offset clamping is corrected for alternate-screen/no-scrollback scenarios to avoid phantom/incorrect offsets.
- **Double-click to attach from the preview pane:**
  - Double-clicking inside the preview triggers the same attach/activation behavior as other attach entry points, with Shift and “outside preview” gating preserved.
- **Behavior alignment for selection:**
  - **Plain drag-select in passive preview** forwards to the agent.
  - **Shift remains the escape hatch** for aoe’s own selection/auto-scroll behavior (and OSC52 copy path).
- **Tests expanded:**
  - Added/extended coverage for passive-preview forwarding, edge auto-scroll behavior across agent types, and preview double-click activation timing/gating.

### Benefits
- Fixes a broken workflow when Shift-selecting at the **preview edge** over fullscreen renderers by restoring the expected “reveal more content” behavior.
- Makes preview interaction more consistent (mouse forwarding works for passive preview and avoids selection-mode interference).
- Reduces preview stutter by improving VT sampling cadence and fixing scroll clamping edge cases.

### Technical notes (optional)
- Auto-scroll forwarding now uses **separate pacing** for “capture-window line scroll” vs “forward-to-agent edge fallback”.
- The edge fallback behavior is chosen based on whether the target fullscreen agent supports **mouse-tracking**.
- Preview capture sampling switches to a **fast interval** when the relevant in-process VT channel is active (Unix), ensuring smoother scrolling/streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
