### PR TITLE
fix(acp): surface OpenCode prompt runtime errors

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Duration;
 
 use agent_client_protocol::schema::ErrorCode;
 use agent_client_protocol::schema::{
@@ -492,6 +493,111 @@ const BETWEEN_PROMPT_IDLE_GRACE: std::time::Duration = std::time::Duration::from
 /// between prompts, so the extra wakeups are cheap. See #2325.
 const BETWEEN_PROMPT_IDLE_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
+fn opencode_data_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("opencode"));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    Some(
+        PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("opencode"),
+    )
+}
+
+fn opencode_db_path() -> Option<PathBuf> {
+    if let Ok(raw) = std::env::var("OPENCODE_DB") {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == ":memory:" {
+            return None;
+        }
+        let path = PathBuf::from(trimmed);
+        if path.is_absolute() {
+            return Some(path);
+        }
+        return opencode_data_dir().map(|dir| dir.join(path));
+    }
+
+    let data_dir = opencode_data_dir()?;
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    let entries = std::fs::read_dir(&data_dir).ok()?;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let is_candidate =
+            name == "opencode.db" || (name.starts_with("opencode-") && name.ends_with(".db"));
+        if !is_candidate {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        if best
+            .as_ref()
+            .map(|(best_mtime, _)| modified > *best_mtime)
+            .unwrap_or(true)
+        {
+            best = Some((modified, path));
+        }
+    }
+    best.map(|(_, path)| path)
+        .or_else(|| Some(data_dir.join("opencode.db")))
+}
+
+fn recover_opencode_prompt_error_from_sqlite_at(
+    db_path: &Path,
+    acp_session_id: &str,
+    prompt_started_at_ms: i64,
+) -> Option<String> {
+    use rusqlite::{Connection, OpenFlags};
+
+    if !db_path.exists() {
+        return None;
+    }
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    let _ = conn.busy_timeout(Duration::from_millis(100));
+    let mut stmt = conn
+        .prepare(
+            "SELECT json_extract(data, '$.error.data.message')
+             FROM message
+             WHERE session_id = ?1
+               AND json_extract(data, '$.role') = 'assistant'
+               AND CAST(json_extract(data, '$.time.created') AS INTEGER) >= ?2
+               AND json_extract(data, '$.error.data.message') IS NOT NULL
+             ORDER BY CAST(json_extract(data, '$.time.created') AS INTEGER) DESC
+             LIMIT 1",
+        )
+        .ok()?;
+    let message: String = stmt
+        .query_row(
+            rusqlite::params![acp_session_id, prompt_started_at_ms],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let trimmed = message.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn recover_opencode_prompt_error(
+    acp_session_id: &str,
+    prompt_started_at_ms: i64,
+) -> Option<String> {
+    let db_path = opencode_db_path()?;
+    recover_opencode_prompt_error_from_sqlite_at(&db_path, acp_session_id, prompt_started_at_ms)
+}
+
 /// Classification of an inbound ACP `SessionUpdate` for the silent-
 /// orphan watchdog state machine. Sent from the notification handler
 /// to the prompt loop via a dedicated mpsc; the prompt loop owns the
@@ -878,6 +984,10 @@ impl SilentOrphanWatchdog {
     /// cancel-and-restart orphan. See #2237.
     fn cost_seen(&self) -> bool {
         self.cost_seen
+    }
+
+    fn saw_progress(&self) -> bool {
+        self.saw_first_progress
     }
 }
 
@@ -2991,6 +3101,7 @@ fn is_transcript_event(event: &Event) -> bool {
             | Event::ApprovalRequested { .. }
             | Event::ApprovalResolved { .. }
             | Event::RawAgentUpdate { .. }
+            | Event::PromptRuntimeError { .. }
     )
 }
 
@@ -3014,6 +3125,7 @@ fn transcript_event_kind(event: &Event) -> &'static str {
         Event::ApprovalRequested { .. } => "approval_requested",
         Event::ApprovalResolved { .. } => "approval_resolved",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
+        Event::PromptRuntimeError { .. } => "prompt_runtime_error",
         _ => "other",
     }
 }
@@ -5455,6 +5567,7 @@ async fn run_connection_task<W, R>(
                             tokio::time::sleep(silent_orphan_check_period);
                         tokio::pin!(silent_orphan_check);
 
+                        let prompt_started_at_ms = chrono::Utc::now().timestamp_millis();
                         let prompt_fut = connection
                             .send_request(PromptRequest::new(acp_session_id.clone(), blocks))
                             .block_task();
@@ -5975,6 +6088,20 @@ async fn run_connection_task<W, R>(
                         let finished_after_orphan_cancel = orphan_cancel_sent
                             && watchdog.cost_seen()
                             && watchdog.off_protocol_work_seen().is_none();
+                        if profile.key == "opencode"
+                            && watchdog.cost_seen()
+                            && !watchdog.saw_progress()
+                            && watchdog.off_protocol_work_seen().is_none()
+                        {
+                            if let Some(message) = recover_opencode_prompt_error(
+                                acp_session_id.as_ref(),
+                                prompt_started_at_ms,
+                            ) {
+                                let _ = event_tx_for_block
+                                    .send(Event::PromptRuntimeError { message })
+                                    .await;
+                            }
+                        }
                         let reason = terminal_stop_reason(
                             rate_limited,
                             force_stopped,
@@ -6835,6 +6962,7 @@ async fn handle_elicitation_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::Connection;
 
     #[tokio::test]
     async fn fake_client_round_trips_events() {
@@ -6868,6 +6996,74 @@ mod tests {
         // ellipsis. "ééé" is 6 bytes total, so we expect "éé...".
         let out = truncate_for_log("ééé", 5);
         assert_eq!(out, "éé...");
+    }
+
+    fn create_opencode_error_test_db(rows: &[(&str, i64, Option<&str>)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        for (idx, (session_id, created, error_message)) in rows.iter().enumerate() {
+            let data = if let Some(message) = error_message {
+                serde_json::json!({
+                    "role": "assistant",
+                    "time": { "created": created },
+                    "error": { "data": { "message": message } },
+                })
+            } else {
+                serde_json::json!({
+                    "role": "assistant",
+                    "time": { "created": created },
+                })
+            };
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, time_updated, data)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    format!("msg-{idx}"),
+                    session_id,
+                    created,
+                    created,
+                    data.to_string()
+                ],
+            )
+            .unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn recover_opencode_prompt_error_from_sqlite_returns_latest_matching_error() {
+        let dir = create_opencode_error_test_db(&[
+            ("ses-1", 99, Some("old error")),
+            ("ses-1", 100, None),
+            ("ses-1", 110, Some("new error")),
+            ("ses-2", 120, Some("wrong session")),
+        ]);
+        let db_path = dir.path().join("opencode.db");
+        let result = recover_opencode_prompt_error_from_sqlite_at(&db_path, "ses-1", 100);
+        assert_eq!(result.as_deref(), Some("new error"));
+    }
+
+    #[test]
+    fn recover_opencode_prompt_error_from_sqlite_returns_none_without_match() {
+        let dir = create_opencode_error_test_db(&[
+            ("ses-1", 90, Some("too early")),
+            ("ses-1", 100, None),
+            ("ses-2", 110, Some("wrong session")),
+        ]);
+        let db_path = dir.path().join("opencode.db");
+        let result = recover_opencode_prompt_error_from_sqlite_at(&db_path, "ses-1", 100);
+        assert_eq!(result, None);
     }
 
     // -------------------------------------------------------------------

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -6094,7 +6094,7 @@ async fn run_connection_task<W, R>(
                             && watchdog.off_protocol_work_seen().is_none()
                         {
                             if let Some(message) = recover_opencode_prompt_error(
-                                acp_session_id.as_ref(),
+                                &acp_session_id.0,
                                 prompt_started_at_ms,
                             ) {
                                 let _ = event_tx_for_block

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1265,6 +1265,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::ConfigOptionsUpdated { .. } => "config_options_updated",
         Event::ConfigOptionSwitchFailed { .. } => "config_option_switch_failed",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
+        Event::PromptRuntimeError { .. } => "prompt_runtime_error",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
         Event::CancelRequested { .. } => "cancel_requested",
         Event::Stopped { .. } => "stopped",

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -733,6 +733,13 @@ pub enum Event {
     RawAgentUpdate {
         payload: serde_json::Value,
     },
+    /// A prompt reached the adapter, but the adapter-side runtime failed
+    /// before any assistant transcript or tool event was emitted. Used
+    /// for recoverable turn failures, distinct from startup/handshake
+    /// errors that block the whole structured-view session. See #2426.
+    PromptRuntimeError {
+        message: String,
+    },
     /// An assistant message chunk (text). In ACP this comes as an
     /// `agent_message_chunk` session update.
     AgentMessageChunk {
@@ -1045,6 +1052,7 @@ impl AcpState {
             // clients see them in the replay buffer and know the session
             // made progress.
             Event::RawAgentUpdate { .. } => {}
+            Event::PromptRuntimeError { .. } => {}
             Event::AgentMessageChunk { .. } => {}
             // No in-memory mutation: the turn is still active (turnActive
             // stays true until a real `Stopped`). The reducer/UI derive the

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -904,6 +904,7 @@ fn event_kind(event: &crate::acp::Event) -> &'static str {
         Event::ConfigOptionsUpdated { .. } => "config_options_updated",
         Event::ConfigOptionSwitchFailed { .. } => "config_option_switch_failed",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
+        Event::PromptRuntimeError { .. } => "prompt_runtime_error",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
         Event::CancelRequested { .. } => "cancel_requested",
         Event::Stopped { .. } => "stopped",

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -479,6 +479,15 @@ impl AcpTranscript {
                 });
                 self.turn_active = false;
             }
+            Event::PromptRuntimeError { message } => {
+                self.flush_pending_chunk();
+                self.status_text = Some("prompt error".to_string());
+                self.rows.push(ActivityRow::Note {
+                    kind: NoteKind::Error,
+                    text: format!("prompt failed: {message}"),
+                });
+                self.turn_active = false;
+            }
             Event::IncompatibleAgent { .. } => {
                 // Structured detail for the web structured view's StartupErrorScreen.
                 // The TUI mirrors the textual signal via the parallel

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -869,6 +869,30 @@ describe("applyEvent / Stopped empty-output fallback", () => {
     });
     expect(state.activity.find((r) => r.kind === "empty_output")).toBeUndefined();
   });
+
+  it("suppresses the notice when a prompt runtime error was surfaced first", () => {
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "/aoe-investigate bug" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        PromptRuntimeError: {
+          message: "Bad Request: model is not supported for this account.",
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { Stopped: {} },
+    });
+    expect(state.lastError).toBe("Bad Request: model is not supported for this account.");
+    expect(state.activity.find((r) => r.kind === "empty_output")).toBeUndefined();
+  });
 });
 
 describe("applyEvent / Stopped user_stopped", () => {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -470,6 +470,7 @@ export type AcpEvent =
   | { CancelRequested: { escalates_at: string } }
   | { Stopped: { reason: string } }
   | { AgentStartupError: { message: string } }
+  | { PromptRuntimeError: { message: string } }
   | { IncompatibleAgent: { detail: IncompatibleAgentDetail } }
   | {
       UserPromptSent: { text: string; attachments?: PromptAttachmentRefWire[] };
@@ -1588,6 +1589,14 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // submitted. See #1170.
     next.lastStoppedSeq = Math.min(next.lastStoppedSeq + 1, next.pendingUserPromptSeq);
     next.turnActive = isTurnActive(next);
+    return next;
+  }
+  if ("PromptRuntimeError" in event) {
+    next.lastError = event.PromptRuntimeError.message;
+    // A real turn-level failure was surfaced, so the generic
+    // "Command produced no output." fallback must stay suppressed when
+    // the terminal Stopped arrives for the same turn.
+    next.turnHasOutput = true;
     return next;
   }
   if ("PromptCapabilities" in event) {

--- a/web/tests/live/acp-replay-catchup.spec.ts
+++ b/web/tests/live/acp-replay-catchup.spec.ts
@@ -3,8 +3,8 @@
 // `GET /api/sessions/:id/acp/replay?since=N` returns
 // `{ frames, lost, highest_seq, lowest_seq }` out of the disk-backed
 // event store. This spec seeds a deterministic event stream via
-// `structured view/force_end_turn` (each call publishes a `Stopped` event with a
-// fresh seq), then verifies:
+// `structured view/force_end_turn` without starting the ACP worker. Each call
+// publishes a `Stopped` event with a fresh seq, then verifies:
 //   - replay from since=0 returns every seeded frame
 //   - replay from since=highest returns no frames but reports highest_seq
 //   - replay from a since cursor predating the lowest stored seq sets
@@ -12,7 +12,7 @@
 //     session; lowest_seq starts at 1 so since=0 alone is not enough)
 //
 // Independent of #1237: force_end_turn writes straight to the event
-// store without going through the prompt path.
+// store without going through the prompt path or a running worker.
 
 import { test, expect } from "@playwright/test";
 import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
@@ -32,19 +32,15 @@ test("structured view/replay surfaces seeded events and signals lost frames", as
     const sessions = await listSessions(serve.baseUrl);
     const sessionId = sessions[0]!.id;
 
-    await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/enable`, {
-      method: "POST",
-    });
+    // Keep the worker stopped. Replay is a store contract, and worker startup
+    // can append unrelated frames between the head snapshot and tail probe.
 
     for (let i = 0; i < SEED_EVENTS; i++) {
       const r = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/force_end_turn`, { method: "POST" });
       expect(r.status).toBe(202);
     }
 
-    // Poll for at least SEED_EVENTS user_forced events to land in the
-    // store. Other events (ModesAvailable, AvailableCommandsUpdated)
-    // may interleave from the supervisor startup; we just care that the
-    // user_forced count reaches the seeded value.
+    // Poll for at least SEED_EVENTS user_forced events to land in the store.
     let body: {
       frames: { seq: number }[];
       lost: boolean;
@@ -86,8 +82,8 @@ test("structured view/replay surfaces seeded events and signals lost frames", as
     // pages plus `next_cursor`/`has_more`, and following the cursor to
     // exhaustion reassembles the same transcript a single unbounded
     // (default-page) replay returns. `target` caps the loop at the
-    // snapshot head so a stray startup event appended mid-loop can't
-    // make the two reads disagree.
+    // snapshot head so any future append mid-loop can't make the two reads
+    // disagree.
     const full = body!;
     const target = full.highest_seq!;
     const fullSeqs = full.frames.map((f) => f.seq).filter((s) => s <= target);


### PR DESCRIPTION
## Description
Fixes the OpenCode structured-view failure mode where a prompt-time provider/model error was rendered as `Command produced no output.`

AoE now recovers the real assistant error from OpenCode's local SQLite session store when a turn ends with terminal usage but no transcript output, emits a typed `PromptRuntimeError` event, and lets the web reducer show that message instead of the generic empty-output fallback.

Closes #2426.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the behavior change is reducer-level structured-view fallback logic, and it is covered directly in `web/src/lib/acpTypes.test.ts` without changing a browser flow that needs Playwright coverage.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped a test, because: the fix depends on recovering OpenCode account-specific prompt errors from the adapter's local SQLite store, which is covered by Rust unit tests around the ACP client helper rather than a stable e2e harness path.

## Testing

- `cargo test --lib`
- `cargo fmt --check`
- `cd web && npx vitest run src/lib/acpTypes.test.ts`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
OpenAI Codex (GPT-5-based coding agent)

**Any Additional AI Details you'd like to share:**
AI was used to investigate the failure path, implement the fix, and run the listed verification commands.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785065291&installation_id=139138837&pr_number=2427&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2427&signature=6991573edec76cab2b1b90b5b82b56f9fc1b7e2beb3d0114836234acdc8bd927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves how OpenCode prompt-time failures are shown in the structured view.

It adds a new “prompt runtime error” event that carries the real upstream/provider error message. When a turn ends with no transcript output, AoE now recovers the matching assistant error from OpenCode’s local SQLite session store (instead of treating it as a normal “no output” case), and the web structured-view reducer suppresses the generic “Command produced no output” notice while showing the actual failure message.

The change is wired end-to-end through the backend event pipeline, the web ACP event types/reducer, and the TUI structured-view reducer. It also includes regression tests covering the empty-output fallback suppression and SQLite-based error recovery.

Benefits:
- Users see the actual model/provider error (e.g., unsupported-model/API failures)
- Prevents misleading “no output” messaging for real prompt-time errors
- Adds safer recovery for adapter-side prompt failures
- Improves confidence with reducer + client helper unit test coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->