### PR TITLE
fix(hooks): leave Running via Claude idle_prompt + StopFailure hooks

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -243,6 +243,15 @@ pub struct AgentDef {
 /// its session UUID (`/clear`, `/new`, `--fork-session`, resume, compact).
 /// `claude_poll_fn` reads this sidecar before falling back to its disk
 /// scan.
+///
+/// `idle` has two sources, not just `Stop`. `Stop` does not fire on every
+/// turn-end path: a turn killed by an API error fires `StopFailure` instead,
+/// and a user interrupt fires nothing. Without a second idle signal the status
+/// file stays on the last `running` write and the session sticks on Running.
+/// `Notification` with matcher `idle_prompt` is Claude's explicit "done
+/// working, waiting for the user" signal and fires whenever Claude parks at the
+/// prompt regardless of why the turn ended, so it backstops `Stop`;
+/// `StopFailure` covers the API-error path deterministically.
 const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "SessionStart",
@@ -269,9 +278,21 @@ const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
         session_id_capture: false,
     },
     HookEvent {
+        name: "StopFailure",
+        matcher: None,
+        status: Some("idle"),
+        session_id_capture: false,
+    },
+    HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some("waiting"),
+        session_id_capture: false,
+    },
+    HookEvent {
+        name: "Notification",
+        matcher: Some("idle_prompt"),
+        status: Some("idle"),
         session_id_capture: false,
     },
     HookEvent {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -759,6 +759,12 @@ fn kiro_config_has_aoe_marker(path: &Path) -> bool {
 ///
 /// An event with both produces two `hooks` array entries under the same
 /// matcher block. An event with neither is skipped.
+///
+/// Multiple events may share a `name` with different matchers (e.g. Claude's
+/// `Notification` splits `permission_prompt|elicitation_dialog` → waiting from
+/// `idle_prompt` → idle). Each becomes its own matcher block appended to that
+/// event name's array, so they coexist instead of the later one clobbering the
+/// earlier.
 fn build_aoe_hooks(events: &[crate::agents::HookEvent], target: HookInstallTarget) -> Value {
     let mut hooks_obj = serde_json::Map::new();
     for event in events {
@@ -787,10 +793,14 @@ fn build_aoe_hooks(events: &[crate::agents::HookEvent], target: HookInstallTarge
             })
             .collect();
         entry.insert("hooks".to_string(), Value::Array(hook_entries));
-        hooks_obj.insert(
-            event.name.to_string(),
-            Value::Array(vec![Value::Object(entry)]),
-        );
+        match hooks_obj
+            .entry(event.name.to_string())
+            .or_insert_with(|| Value::Array(Vec::new()))
+        {
+            Value::Array(groups) => groups.push(Value::Object(entry)),
+            // or_insert_with only ever seeds an Array, so this arm is unreachable.
+            _ => unreachable!("hook event group is always a JSON array"),
+        }
     }
 
     Value::Object(hooks_obj)
@@ -2984,11 +2994,40 @@ command = "echo user-hook"
     fn test_notification_hook_has_matcher() {
         let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Sandbox);
         let notification = hooks["Notification"].as_array().unwrap();
-        assert_eq!(notification.len(), 1);
-        let matcher = notification[0]["matcher"].as_str().unwrap();
-        assert!(matcher.contains("permission_prompt"));
-        assert!(matcher.contains("elicitation_dialog"));
-        assert!(!matcher.contains("idle_prompt"));
+        // Two matcher groups: permission/elicitation → waiting, idle_prompt → idle.
+        assert_eq!(notification.len(), 2);
+
+        let waiting = notification
+            .iter()
+            .find(|g| {
+                g["matcher"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("permission_prompt"))
+            })
+            .expect("waiting matcher group present");
+        let waiting_matcher = waiting["matcher"].as_str().unwrap();
+        assert!(waiting_matcher.contains("permission_prompt"));
+        assert!(waiting_matcher.contains("elicitation_dialog"));
+        assert!(!waiting_matcher.contains("idle_prompt"));
+        assert!(
+            waiting["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+                .contains("printf waiting"),
+            "permission/elicitation notification should write waiting"
+        );
+
+        let idle = notification
+            .iter()
+            .find(|g| g["matcher"].as_str() == Some("idle_prompt"))
+            .expect("idle_prompt matcher group present");
+        assert!(
+            idle["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+                .contains("printf idle"),
+            "idle_prompt notification should write idle"
+        );
     }
 
     #[test]
@@ -2999,6 +3038,21 @@ command = "echo user-hook"
         assert!(
             cmd.contains("printf idle"),
             "Stop hook should write idle status: {}",
+            cmd
+        );
+    }
+
+    #[test]
+    fn test_stop_failure_hook_writes_idle() {
+        // A turn killed by an API error fires StopFailure, not Stop, so this is
+        // the only thing that clears the trailing `running` write in that path.
+        let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Sandbox);
+        let stop_failure = hooks["StopFailure"].as_array().unwrap();
+        assert_eq!(stop_failure.len(), 1);
+        let cmd = stop_failure[0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(
+            cmd.contains("printf idle"),
+            "StopFailure hook should write idle status: {}",
             cmd
         );
     }

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -317,17 +317,29 @@ mod tests {
                     if !cmd.contains("aoe-hooks") {
                         continue;
                     }
-                    let event_def = claude_events
+                    // An event name may declare several matcher groups with
+                    // different statuses (Claude's `Notification` splits
+                    // permission/elicitation → waiting from idle_prompt →
+                    // idle), so the canonical set is the union over every event
+                    // def sharing this name, not just the first.
+                    let event_defs: Vec<_> = claude_events
                         .iter()
-                        .find(|e| e.name == event_name)
-                        .unwrap_or_else(|| panic!("unknown Claude event: {event_name}"));
+                        .filter(|e| e.name == event_name)
+                        .collect();
+                    assert!(
+                        !event_defs.is_empty(),
+                        "unknown Claude event: {event_name}"
+                    );
                     let mut canonical_set: Vec<String> = Vec::new();
-                    if event_def.session_id_capture {
-                        canonical_set.push(canonical_session_id_command(HookInstallTarget::Host));
-                    }
-                    if let Some(status) = event_def.status {
-                        canonical_set
-                            .push(canonical_status_command(status, HookInstallTarget::Host));
+                    for event_def in event_defs {
+                        if event_def.session_id_capture {
+                            canonical_set
+                                .push(canonical_session_id_command(HookInstallTarget::Host));
+                        }
+                        if let Some(status) = event_def.status {
+                            canonical_set
+                                .push(canonical_status_command(status, HookInstallTarget::Host));
+                        }
                     }
                     assert!(
                         canonical_set.iter().any(|c| c == cmd),

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -326,10 +326,7 @@ mod tests {
                         .iter()
                         .filter(|e| e.name == event_name)
                         .collect();
-                    assert!(
-                        !event_defs.is_empty(),
-                        "unknown Claude event: {event_name}"
-                    );
+                    assert!(!event_defs.is_empty(), "unknown Claude event: {event_name}");
                     let mut canonical_set: Vec<String> = Vec::new();
                     for event_def in event_defs {
                         if event_def.session_id_capture {


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Claude agents were sticking on **Running** when they should have fallen back to **Idle**.

aoe derives Claude status from a per-instance hook status file that each installed hook overwrites (`running` from `PreToolUse` / `UserPromptSubmit`, `waiting` from `Notification:permission_prompt|elicitation_dialog`, `idle` from `Stop`). The only writer of `idle` was the `Stop` hook. Newer Claude Code has turn-end paths where `Stop` never fires:

- A turn killed by an API error fires **`StopFailure`**, not `Stop`.
- A user interrupt fires nothing.

In those paths the status file keeps its last `running` write, so the session is stuck on Running until the next prompt.

This subscribes Claude to two more hook events, both writing `idle`:

- **`Notification` matcher `idle_prompt`**: Claude's explicit "done working, waiting for the user" signal (confirmed in the current hooks reference). It fires whenever Claude parks at the prompt regardless of why the turn ended, so it backstops every non-`Stop` path.
- **`StopFailure`**: covers the API-error turn-end deterministically.

`idle_prompt` needs its own `Notification` matcher group, separate from the existing `permission_prompt|elicitation_dialog` group, because it maps to a different status. `build_aoe_hooks` keyed its JSON object by event name and overwrote on collision, so it could only emit one matcher group per event name; it now appends groups under the same event name instead.

Existing installs pick this up on the next session start, which reinstalls the full hook set via `install_hooks`. No migration is needed, mirroring how `ElicitationResult` was added (#524).

This is the same class of fix as #524 ("subscribe to ElicitationResult hook to unstick waiting status"): Claude ships a new hook event, and aoe's status file needs to consume it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no doc enumerates the event to status mapping; the `adding-agents.md` example is illustrative)
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR changes which hooks are installed into Claude's `settings.json`, not TUI rendering, a CLI subcommand, or session lifecycle. Covered by unit tests in `src/hooks/mod.rs`:
  - `test_notification_hook_has_matcher` updated to assert both matcher groups (`permission_prompt|elicitation_dialog` to waiting, `idle_prompt` to idle).
  - `test_stop_failure_hook_writes_idle` added.
  - `test_build_aoe_hooks_status_only_events_unchanged` still green.
  - v015 migration canonical check updated to allow multiple statuses per event name.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any Additional AI Details you'd like to share:** Root cause investigation and implementation done with Claude Code, driven by @njbrake. Current Claude Code hook list and the `idle_prompt` / `StopFailure` semantics were verified against the official hooks reference at code.claude.com before implementing.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785069241&installation_id=139138837&pr_number=2429&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2429&signature=0abea4aeab46a45162b5f6fb4739b38ebfe0171ceb1f8b860d60a5b564c65b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes Claude’s status tracking so sessions return to **Idle** more reliably instead of getting stuck on **Running**.

### What changed
- Added a new fallback that marks Claude as **Idle** when a turn ends via **StopFailure**.
- Added a new `idle_prompt` notification rule that also marks Claude as **Idle** when Claude parks at the prompt.
- Kept the existing prompt-related rule that marks Claude as **waiting** for `permission_prompt` / `elicitation_dialog`.
- Updated hook construction so multiple matcher groups can be emitted under the same hook event name (instead of overwriting each other).
- Updated and added tests to cover the new idle paths and the updated hook layout.
- Updated the migration test helper to handle cases where multiple hook definitions share the same event name.

### Benefit
- More accurate status updates across newer Claude Code turn-end paths.
- Fewer cases where sessions appear stuck in the wrong state.
- Existing installs pick up the updated hooks automatically on the next session start.

### Technical note
- `StopFailure` now maps to `idle`.
- `Notification` includes a separate `idle_prompt` matcher group that writes `idle` (while `permission_prompt|elicitation_dialog` continues to write `waiting`).
- Hook builder appends same-name matcher groups rather than overwriting them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->