### PR TITLE
fix(serve): reject native title prompt echoes

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3666,7 +3666,7 @@ async fn acp_event_listener(state: Arc<AppState>) {
                     let session_id = frame.session_id.clone();
                     let title = title.clone();
                     tokio::spawn(async move {
-                        crate::session::smart_rename::apply_auto_title(
+                        crate::session::smart_rename::apply_native_title_suggestion(
                             &state_for_title,
                             &session_id,
                             &profile,
@@ -4296,7 +4296,7 @@ mod tests {
 
         // First native push: a still-default civ name is renamed and the
         // applied title is recorded as the last auto title.
-        crate::session::smart_rename::apply_auto_title(
+        crate::session::smart_rename::apply_native_title_suggestion(
             &state,
             &id,
             "native-title",
@@ -4311,7 +4311,7 @@ mod tests {
         );
 
         // A later turn pushes a new title; it keeps tracking the agent.
-        crate::session::smart_rename::apply_auto_title(
+        crate::session::smart_rename::apply_native_title_suggestion(
             &state,
             &id,
             "native-title",
@@ -4328,7 +4328,7 @@ mod tests {
                 Ok(())
             })
             .expect("manual rename");
-        crate::session::smart_rename::apply_auto_title(
+        crate::session::smart_rename::apply_native_title_suggestion(
             &state,
             &id,
             "native-title",
@@ -4336,6 +4336,75 @@ mod tests {
         )
         .await;
         assert_eq!(load()[0].title, "Production hotfix");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn native_title_prompt_echo_is_dropped_but_later_summary_applies() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialized test; no other test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", temp.path()) };
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+
+        let mut inst = Instance::new("Britons", "/tmp/native-title-echo");
+        inst.source_profile = "native-title-echo".to_string();
+        let id = inst.id.clone();
+
+        let storage = crate::session::Storage::new_unwatched("native-title-echo").expect("storage");
+        storage
+            .update(|instances, _groups| {
+                *instances = vec![inst.clone()];
+                Ok(())
+            })
+            .expect("seed write");
+
+        let state = test_support::build_test_app_state(vec![inst]);
+        let first_prompt = "Please fix the login redirect by updating auth middleware";
+        state
+            .acp_event_store
+            .record(
+                &id,
+                1,
+                &crate::acp::Event::UserPromptSent {
+                    text: first_prompt.to_string(),
+                    attachments: vec![],
+                },
+            )
+            .expect("record prompt");
+        let load = || {
+            crate::session::Storage::new_unwatched("native-title-echo")
+                .unwrap()
+                .load()
+                .unwrap()
+        };
+
+        crate::session::smart_rename::apply_native_title_suggestion(
+            &state,
+            &id,
+            "native-title-echo",
+            first_prompt,
+        )
+        .await;
+        let loaded = load();
+        assert_eq!(loaded[0].title, "Britons");
+        assert_eq!(loaded[0].last_auto_title, None);
+
+        crate::session::smart_rename::apply_native_title_suggestion(
+            &state,
+            &id,
+            "native-title-echo",
+            "Fix login redirect",
+        )
+        .await;
+        let loaded = load();
+        assert_eq!(loaded[0].title, "Fix login redirect");
+        assert_eq!(
+            loaded[0].last_auto_title.as_deref(),
+            Some("Fix login redirect")
+        );
     }
 
     #[tokio::test]

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -241,6 +241,15 @@ const MAX_NATIVE_TITLE_CHARS: usize = 120;
 /// real title (possibly a user-set one), it just needs to be safe to persist.
 #[cfg(feature = "serve")]
 pub(crate) fn normalize_native_title(raw: &str) -> Option<String> {
+    let capped = clean_capped_native_title(raw)?;
+    if capped.is_empty() || is_default_civ_name(&capped) {
+        return None;
+    }
+    Some(capped)
+}
+
+#[cfg(feature = "serve")]
+fn clean_capped_native_title(raw: &str) -> Option<String> {
     let cleaned = strip_ansi(raw);
     let line = cleaned.lines().map(clean_line).find(|l| !l.is_empty())?;
     let capped = line
@@ -248,10 +257,18 @@ pub(crate) fn normalize_native_title(raw: &str) -> Option<String> {
         .take(MAX_NATIVE_TITLE_CHARS)
         .collect::<String>();
     let capped = capped.trim().to_string();
-    if capped.is_empty() || is_default_civ_name(&capped) {
-        return None;
-    }
-    Some(capped)
+    (!capped.is_empty()).then_some(capped)
+}
+
+#[cfg(feature = "serve")]
+fn native_title_echoes_first_prompt(title: &str, first_prompt: &str) -> bool {
+    let Some(title_key) = clean_capped_native_title(title).map(|s| s.to_lowercase()) else {
+        return false;
+    };
+    let Some(prompt_key) = clean_capped_native_title(first_prompt).map(|s| s.to_lowercase()) else {
+        return false;
+    };
+    title_key == prompt_key
 }
 
 /// Strip leading markdown markers / list numbering, wrapping quotes and
@@ -325,7 +342,7 @@ fn truncate_bytes(s: &str, max: usize) -> &str {
 }
 
 #[cfg(feature = "serve")]
-pub(crate) use serve::apply_auto_title;
+pub(crate) use serve::apply_native_title_suggestion;
 #[cfg(feature = "serve")]
 pub use serve::try_smart_rename;
 
@@ -580,6 +597,24 @@ mod serve {
         }
     }
 
+    pub(crate) async fn apply_native_title_suggestion(
+        state: &Arc<AppState>,
+        id: &str,
+        profile: &str,
+        title: &str,
+    ) {
+        let Some(new_title) = normalize_native_title(title) else {
+            return;
+        };
+        if let Some(first_prompt) = state.acp_event_store.first_user_prompt(id) {
+            if native_title_echoes_first_prompt(&new_title, &first_prompt) {
+                tracing::debug!(target: "smart_rename", session = %id, "skip: native title echoes first prompt");
+                return;
+            }
+        }
+        apply_auto_title(state, id, profile, &new_title).await;
+    }
+
     /// Whether an automatic renamer may overwrite this session's title: either
     /// it is still a default civ name (never explicitly set), or it still
     /// matches the last title an auto renamer wrote (so native pushes keep
@@ -645,6 +680,26 @@ mod serve {
             let long = "word ".repeat(80);
             let out = normalize_native_title(&long).expect("non-empty");
             assert!(out.chars().count() <= 120);
+        }
+
+        #[test]
+        fn native_title_echo_compare_uses_capped_normalized_equality() {
+            let prompt = format!(
+                "Please refactor the authentication middleware to fix login redirects. {}",
+                "extra detail ".repeat(30)
+            );
+            let echoed = normalize_native_title(&prompt).expect("echo normalizes");
+            assert!(native_title_echoes_first_prompt(&echoed, &prompt));
+
+            assert!(!native_title_echoes_first_prompt(
+                "Fix login redirects",
+                "Fix login redirects and update the auth middleware"
+            ));
+
+            assert!(native_title_echoes_first_prompt(
+                "# FIX LOGIN REDIRECT.",
+                "fix login redirect"
+            ));
         }
     }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

Claude native ACP title updates can echo the user's first prompt. AoE previously accepted those native title pushes as automatic session names, so a default civ title such as `Britons` could be renamed to the prompt and prevent later, better summaries from applying.

This changes native title handling to normalize and cap the suggested title, compare it against the durable first user prompt with the same normalization, and drop exact prompt echoes. Later concise native summaries still apply, and manual user renames remain protected from automatic overwrites.

Closes #2428

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a Claude native structured-view session with a default civ title, send a first prompt, and confirm the session title does not change to that prompt if Claude pushes it back as a native title.
- [ ] Confirm a later concise native title suggestion, such as `Fix login redirect`, renames the session from its default title.
- [ ] Manually rename the session after an automatic native title, then confirm a later native title suggestion does not overwrite the manual title.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Validation note: targeted validation for this change passes. The existing `cargo test --features serve --test acp_runner_orphan` suite still fails locally because the runner never writes its registry record under `/tmp/.../.agent-of-empires-dev/acp-workers/`; this appears unrelated to the native-title change.

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: backend title-suggestion filtering is covered by Rust regression tests in `src/server/mod.rs`; no browser-only dashboard behavior changed.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: native ACP title filtering is deterministic server state logic covered by Rust tests; a tmux e2e would not add coverage for the comparison path.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenCode with OpenAI GPT-5.5, using the AoE `/aoe-implement` workflow.

**Any Additional AI Details you'd like to share:**

Investigation, implementation, tests, and PR prose were drafted by AI under my direction. I reviewed the plan, made the design calls, and checked the validation results.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785069542&installation_id=139138837&pr_number=2430&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2430&signature=be1948658e0146163c87d6206f3d614ce247aabf5c9d8e4ac0845621f58a5cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR improves how Claude-native session titles are applied so they no longer overwrite a conversation with the user’s own first prompt. It now recognizes and ignores prompt-like title suggestions, while still allowing later real summaries to update the session title.

It also preserves manual session renames, so user-set titles are no longer replaced by later automatic updates.

Changes made:
- Switched native title handling to a new native-title update path
- Added prompt-echo detection and title cleanup/capping
- Kept later valid native summaries working as expected
- Added regression tests for:
  - first prompt echoes being ignored
  - later summary titles being applied
  - manual renames staying protected

Benefits:
- Prevents confusing session titles that just repeat the user’s prompt
- Keeps automatic titles useful without overriding user changes
- Makes native Claude title behavior more predictable and safer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->