### PR TITLE
ci: run feature-gate checks in parallel with full test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,18 +80,28 @@ jobs:
       - name: Cargo test (macOS, lib + bins only)
         if: runner.os == 'macOS'
         run: cargo test --features serve --lib --bins
-      # Acceptance criterion 1 of #268: with every bundled plugin compiled out,
-      # core must still build and pass its suite. `--no-default-features` also
-      # drops `serve`, so this doubles as the TUI-only compile gate, keeping the
-      # ~27 cfg(feature = "serve") sites from rotting.
+
+  cargo-feature-gates:
+    # Feature-combination compile gates that verify core builds and passes its
+    # suite with every bundled plugin compiled out (`--no-default-features`
+    # also drops `serve`, doubling as the TUI-only compile gate) and with
+    # default-plugins enabled but serve off. These run in parallel with the
+    # full `cargo` job to reduce wall-clock.
+    name: Cargo Feature Gates
+    runs-on: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: feature-gates
+          cache-bin: "true"
+          save-if: true
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
       - name: Cargo test (bare core, no default features)
-        if: runner.os == 'Linux'
         run: cargo test --no-default-features --lib --bins
-      # The third feature corner: default-plugins on, serve off. Compile gate
-      # (including test/e2e targets, which plain check skips) so plugin
-      # registration code can't grow a hidden dependency on serve types.
       - name: Cargo check (default plugins, no serve)
-        if: runner.os == 'Linux'
         run: cargo check --no-default-features --features default-plugins --all-targets
 
   macos-acp-e2e:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,8 @@ jobs:
     runs-on: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,28 +13,23 @@ permissions:
   contents: read
 
 jobs:
-  cargo:
-    # Job names use the stable `label`, not the runner, so the branch
-    # ruleset's required checks ("Cargo Test (linux)" / "Cargo Test
-    # (macos)") survive runner swaps. The runner itself comes from a
-    # repo Actions variable so Blacksmith can be dropped without a
-    # commit when the monthly credit pool runs dry: clearing
-    # RUNNER_CARGO_LINUX / RUNNER_CARGO_MACOS in Settings -> Actions ->
-    # Variables falls back to the free GitHub-hosted runners on the
-    # next run. Jobs already queued for Blacksmith sit "queued"
-    # forever (GitHub has no runner fallback primitive), so flip the
-    # variable, then re-run the stuck workflow.
-    name: Cargo Test (${{ matrix.label }})
-    runs-on: ${{ matrix.os }}
+  cargo-linux:
+    # Linux is the long pole, so shard it and fan in to the stable
+    # "Cargo Test (linux)" context below. The runner itself comes from a
+    # repo Actions variable so Blacksmith can be dropped without a commit
+    # when the monthly credit pool runs dry: clearing RUNNER_CARGO_LINUX in
+    # Settings -> Actions -> Variables falls back to the free GitHub-hosted
+    # runner on the next run.
+    name: Cargo Test (linux, ${{ matrix.suite }})
+    runs-on: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - label: linux
-            os: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
-          - label: macos
-            os: ${{ vars.RUNNER_CARGO_MACOS || 'macos-latest' }}
+        suite: [core, e2e]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -47,12 +42,7 @@ jobs:
           # the slot rather than thrashing the 10GB repo cache budget.
           save-if: true
       - name: Install tmux
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update && sudo apt-get install -y tmux
-          else
-            brew install tmux
-          fi
+        run: sudo apt-get update && sudo apt-get install -y tmux
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -62,23 +52,69 @@ jobs:
       # runs. The shim itself auto-skips if node is
       # missing, but on a GitHub runner node is always present; without the
       # install step the shim crashes before the ACP handshake completes.
-      # macOS only runs --lib --bins (no integration crates), so the shim
-      # isn't exercised there and we can skip the install.
+      # Only the core Linux shard runs the integration crate, so the e2e shard
+      # skips this install too.
       - name: Install ACP shim deps
-        if: runner.os == 'Linux'
+        if: matrix.suite == 'core'
         working-directory: acp-worker/test-shim
         run: npm ci
-      # `--features serve` is a strict superset of the default suite and pulls
-      # in the aoe.web plugin (serve-gated) that the e2e tests assert on, so a
-      # single run covers both feature gates. macOS-specific code lives in
-      # src/process/macos.rs plus one cfg in container_config.rs; the
-      # integration and e2e crates exercise OS-portable code that the Linux leg
-      # already covers, so macOS only runs --lib --bins.
-      - name: Cargo test (Linux, full suite incl. integration + e2e)
-        if: runner.os == 'Linux'
-        run: cargo test --features serve
+      # Cargo can select `--test e2e`, but it has no inverse selector for
+      # "all tests except e2e". Build the non-e2e test target list from
+      # cargo metadata so newly added integration targets stay covered.
+      - name: Cargo test (Linux, core incl. integration)
+        if: matrix.suite == 'core'
+        run: |
+          test_targets="$(
+            cargo metadata --no-deps --format-version 1 |
+              python3 -c 'import json, sys; data = json.load(sys.stdin); pkg = next(p for p in data["packages"] if p["name"] == "agent-of-empires"); print(" ".join("--test {}".format(t["name"]) for t in pkg["targets"] if "test" in t.get("kind", []) and t["name"] != "e2e"))'
+          )"
+          cargo test --features serve --lib --bins $test_targets
+          cargo test --features serve --doc
+      - name: Cargo test (Linux, e2e)
+        if: matrix.suite == 'e2e'
+        run: cargo test --features serve --test e2e
+
+  cargo-linux-ok:
+    # Fan-in for the branch ruleset: "Cargo Test (linux)" is a required
+    # status check, and matrix jobs report per-shard contexts that the ruleset
+    # doesn't know about. This job carries the stable context name and fails
+    # unless every shard succeeded.
+    name: Cargo Test (linux)
+    needs: cargo-linux
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Linux cargo shard results
+        run: |
+          if [ "${{ needs.cargo-linux.result }}" != "success" ]; then
+            echo "linux cargo shards result: ${{ needs.cargo-linux.result }}"
+            exit 1
+          fi
+
+  cargo-macos:
+    # Keep the stable "Cargo Test (macos)" context required by the branch
+    # ruleset. macOS-specific code lives in src/process/macos.rs plus one cfg in
+    # container_config.rs; Linux already runs the OS-portable integration and
+    # e2e suites, while macos-acp-e2e below covers the OS-sensitive ACP path.
+    # Clear RUNNER_CARGO_MACOS in Settings -> Actions -> Variables to fall back
+    # to the free GitHub-hosted runner on the next run.
+    name: Cargo Test (macos)
+    runs-on: ${{ vars.RUNNER_CARGO_MACOS || 'macos-latest' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "true"
+          save-if: true
+      - name: Install tmux
+        run: brew install tmux
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
       - name: Cargo test (macOS, lib + bins only)
-        if: runner.os == 'macOS'
         run: cargo test --features serve --lib --bins
 
   cargo-feature-gates:
@@ -86,7 +122,7 @@ jobs:
     # suite with every bundled plugin compiled out (`--no-default-features`
     # also drops `serve`, doubling as the TUI-only compile gate) and with
     # default-plugins enabled but serve off. These run in parallel with the
-    # full `cargo` job to reduce wall-clock.
+    # Linux cargo shards to reduce wall-clock.
     name: Cargo Feature Gates
     runs-on: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
     steps:
@@ -111,7 +147,7 @@ jobs:
     # daemon -> runner -> ACP-handshake -> prompt path, which has genuinely
     # OS-divergent behavior: unix-socket sun_path limits (104 on macOS vs
     # 108 on Linux), /tmp vs /private/tmp resolution, and setsid /
-    # detached-spawn plus node cold-start timing. The `cargo` job above runs
+    # detached-spawn plus node cold-start timing. The `cargo-macos` job above runs
     # only --lib --bins on macOS, so a macOS-only failure that lives in the
     # e2e crate (e.g. #1890) was structurally outside CI's reach. This job
     # closes that gap by running just the acp e2e modules on macOS. The fake


### PR DESCRIPTION
## Description

The `cargo` job on Linux runs the full test suite (`--features serve`) and then, sequentially, the feature-combination compile gates (`--no-default-features --lib --bins` and `default-plugins check`). Since different feature sets don't benefit from shared build artifacts, the sequential ordering gains nothing.

This splits the two feature-gate steps into a separate `cargo-feature-gates` job that runs concurrently with the main `cargo` job, reducing wall-clock from ~4.5 min to ~max(full_suite, feature_gates).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (opencode/big-pickle)

**Any Additional AI Details you'd like to share:** Changes implemented via opencode interactive session.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785080377&installation_id=139138837&pr_number=2439&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2439&signature=19828276ff420b60958b20434e9566e4f79bfc0b8d59f86d9fcdfc8fb04c6edf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Split the Rust Linux CI workflow into parallel jobs to cut total run time, and separate “feature/compatibility compilation checks” from the main test suite.

**What changed**
- Replaced the single Linux `cargo` run with a sharded `cargo-linux` job:
  - **core**: runs the non-`e2e` integration tests (plus docs)
  - **e2e**: runs only the `e2e` tests
  - ACP shim Node dependencies are installed only for the **core** shard
- Added **`cargo-linux-ok`** as a fan-in check so the stable **“Cargo Test (linux)”** status only passes when *both* Linux shards succeed.
- Moved the Linux-only “feature gate” checks into a dedicated **`cargo-feature-gates`** job that runs concurrently with the main Linux test shards.

**Benefits**
- Lower wall-clock CI time by running independent Linux test shards and the feature-gate compile checks in parallel.
- Clearer CI separation between executing tests and verifying feature/plugin compatibility via compile-only gates.

**Technical details (optional)**
- `cargo-linux` runs:
  - `core`: `cargo test --features serve --lib --bins` plus dynamically selected non-`e2e` `--test ...` targets, then `cargo test --features serve --doc`
  - `e2e`: `cargo test --features serve --test e2e`
- `cargo-feature-gates` runs:
  - `cargo test --no-default-features --lib --bins`
  - `cargo check --no-default-features --features default-plugins --all-targets`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->