### PR TITLE
fix(git): lock aoe-created worktrees so a cross-boundary prune can't reap them

### DIFF
--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -365,6 +365,10 @@ pub fn manual_submodule_worktree_cleanup(
 ) -> Vec<String> {
     let mut errors = Vec::new();
 
+    // This path reaps the admin entry with `prune` (below), which skips locked
+    // worktrees; unlock first so an aoe-locked entry is actually removed.
+    git_wt.unlock_worktree(worktree_path);
+
     if let Some(name) = read_linked_worktree_name(worktree_path) {
         let modules_dir = main_repo.join(".git/worktrees").join(&name).join("modules");
         if modules_dir.exists() {
@@ -486,6 +490,12 @@ pub fn remove_managed_worktree(
         // For non-sandboxed sessions, missing `.git` typically means
         // the user did something manual; keep strict behavior gated on
         // the explicit `force` flag.
+        // This branch removes the directory by hand and reaps the admin entry
+        // with `prune`, which skips locked worktrees. Unlock first (best-effort;
+        // resolves from the admin side even though `.git` is already gone) so
+        // the aoe lock does not strand the entry.
+        git_wt.unlock_worktree(worktree_path);
+
         let effective_force = force || instance.is_sandboxed();
         match remove_worktree_dir(worktree_path, main_repo, effective_force) {
             Ok(()) => {

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -182,6 +182,33 @@ pub fn clone_bare_repo(url: &str, destination: &Path) -> Result<String> {
         )));
     }
 
+    // Lock the `main` worktree for the same cross-boundary prune protection
+    // `GitWorktree::create_worktree` applies to every session worktree (#2414):
+    // this is the one aoe-created worktree that does not go through
+    // `create_worktree`, so without this a prune from a context that cannot see
+    // `<destination>/main` would reap its admin entry. Best-effort: a lock
+    // failure only forfeits that protection, so warn and keep the clone.
+    match super::GitWorktree::new(destination.to_path_buf()) {
+        Ok(git_wt) => {
+            if let Err(e) = git_wt.lock_worktree(&worktree_path) {
+                tracing::warn!(
+                    target: "git.fetch",
+                    path = %worktree_path.display(),
+                    error = %e,
+                    "Bare clone: could not lock main worktree (cross-boundary prune protection unavailable)"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "git.fetch",
+                path = %destination.display(),
+                error = %e,
+                "Bare clone: could not open repo to lock main worktree (cross-boundary prune protection unavailable)"
+            );
+        }
+    }
+
     tracing::info!(
         target: "git.fetch",
         "Bare clone complete: {} -> {}",
@@ -516,6 +543,52 @@ mod tests {
         // Verify main is a valid worktree
         let main_path = dest_path.join("main");
         assert!(main_path.join(".git").exists(), "worktree .git missing");
+    }
+
+    #[test]
+    fn test_clone_bare_repo_locks_main_worktree() {
+        use tempfile::TempDir;
+
+        // Regression for #2414: the `main` worktree the bare clone creates is
+        // the one aoe-created worktree that does not go through
+        // `create_worktree`, so it must still be locked or a prune from a
+        // context that cannot see it would reap its admin entry.
+        let source_dir = TempDir::new().unwrap();
+        let source_repo = git2::Repository::init(source_dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = source_repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = source_repo.find_tree(tree_id).unwrap();
+        source_repo
+            .commit(Some("HEAD"), &sig, &sig, "Initial", &tree, &[])
+            .unwrap();
+
+        let dest_dir = TempDir::new().unwrap();
+        let dest_path = dest_dir.path().join("test-bare-clone");
+        let url = format!("file://{}", source_dir.path().display());
+        clone_bare_repo(&url, &dest_path).unwrap();
+
+        let admin_dir = dest_path.join(".bare/worktrees/main");
+        assert!(
+            admin_dir.join("locked").exists(),
+            "clone_bare_repo should lock the main worktree"
+        );
+
+        // Hide the checkout so a prune sees it as missing; the locked admin
+        // entry must survive.
+        let hidden = dest_path.join("main-HIDDEN");
+        std::fs::rename(dest_path.join("main"), &hidden).unwrap();
+        std::process::Command::new("git")
+            .args(["worktree", "prune"])
+            .current_dir(&dest_path)
+            .output()
+            .unwrap();
+        assert!(
+            admin_dir.exists(),
+            "locked main worktree admin entry must survive a prune while its checkout is unreachable"
+        );
     }
 
     #[test]

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -56,6 +56,14 @@ fn classify_worktree_add_failure(combined: &str, branch: &str) -> GitError {
 /// yet" path.
 const FETCH_REMOTE: &str = "origin";
 
+/// Reason recorded on every aoe-created worktree's `git worktree lock`. The
+/// lock makes `git worktree prune` skip the admin entry, so a prune run from a
+/// context that cannot see this checkout (a sibling sandbox, or the host when
+/// the worktree lives inside a container mount) cannot reap its
+/// `<main>/.git/worktrees/<name>` entry and break the git linkage (#2414 root
+/// cause). aoe unlocks again before every intentional remove/move.
+const WORKTREE_LOCK_REASON: &str = "aoe-managed worktree (prevents cross-boundary prune)";
+
 pub struct WorktreeEntry {
     pub path: PathBuf,
     pub branch: Option<String>,
@@ -494,7 +502,13 @@ impl GitWorktree {
         }
 
         // Prune stale worktree entries so git doesn't reject a path that was
-        // previously used by a now-deleted worktree directory.
+        // previously used by a now-deleted worktree directory. A stale entry at
+        // exactly this path may be one aoe locked (the directory was removed
+        // out-of-band, bypassing the unlock-on-remove path); `prune` skips
+        // locked entries, so unlock this path first (best-effort, resolves from
+        // the admin side even with the checkout gone) so its stale entry is
+        // reaped. Sibling locks stay intact: only the colliding path is touched.
+        self.unlock_worktree(path);
         let t = std::time::Instant::now();
         self.prune_worktrees()?;
         tracing::info!(target: "git.worktree", "worktree create: prune done in {:?}", t.elapsed());
@@ -723,6 +737,22 @@ impl GitWorktree {
             t.elapsed()
         );
 
+        // Lock the freshly-created worktree so a `git worktree prune` issued
+        // from a sandbox/host context that cannot see this checkout can no
+        // longer reap its admin entry and break the git linkage (#2414). The
+        // intentional remove/move paths unlock first. Best-effort: a lock
+        // failure is surfaced as a warning, never an abort, so session
+        // creation still succeeds without prune protection.
+        if let Err(e) = self.lock_worktree(path) {
+            let warning = format!(
+                "could not lock worktree {} (cross-boundary prune protection unavailable): {}",
+                path.display(),
+                e
+            );
+            tracing::warn!(target: "git.worktree", "worktree create: {}", warning);
+            warnings.push(warning);
+        }
+
         tracing::info!(target: "git.worktree",
             "worktree create: TOTAL {:?} branch={} path={} warnings={}",
             total_start.elapsed(),
@@ -744,6 +774,47 @@ impl GitWorktree {
         }
 
         Ok(())
+    }
+
+    /// Lock `path`'s linked-worktree admin entry so `git worktree prune` skips
+    /// it (see [`WORKTREE_LOCK_REASON`]). Called once at the end of
+    /// `create_worktree`. Returns an error the caller can surface as a
+    /// non-fatal warning; a missing lock only forfeits prune protection, it
+    /// does not make the worktree unusable.
+    pub fn lock_worktree(&self, path: &Path) -> Result<()> {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
+        let output = super::command::run_git(
+            &self.repo_path,
+            [
+                "worktree",
+                "lock",
+                "--reason",
+                WORKTREE_LOCK_REASON,
+                path_str,
+            ],
+        )?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(GitError::WorktreeCommandFailed(stderr));
+        }
+        Ok(())
+    }
+
+    /// Unlock `path`'s admin entry, idempotently. MUST run before any
+    /// `git worktree remove`/`move` (git refuses both on a locked worktree even
+    /// with a single `--force`) and before any cleanup path that reaps the
+    /// entry via `prune` (prune skips locked entries). Best-effort by design:
+    /// `git worktree unlock` resolves the entry from the admin side, so it
+    /// still clears the lock when the checkout directory is already gone, and a
+    /// non-zero exit (already unlocked, or no such worktree) is a harmless
+    /// no-op rather than an error.
+    pub fn unlock_worktree(&self, path: &Path) {
+        let Some(path_str) = path.to_str() else {
+            return;
+        };
+        let _ = super::command::run_git(&self.repo_path, ["worktree", "unlock", path_str]);
     }
 
     /// Convert a worktree's .git file from absolute to relative path.
@@ -902,6 +973,12 @@ impl GitWorktree {
             return Err(GitError::WorktreeNotFound(path.to_path_buf()));
         }
 
+        // aoe locks every worktree it creates; `git worktree remove` refuses a
+        // locked tree even with a single `--force` (it wants `-f -f`). Unlock
+        // first so the existing single-`--force` semantics (dirty-tree
+        // override) are preserved unchanged.
+        self.unlock_worktree(path);
+
         let path_str = path
             .to_str()
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
@@ -1045,11 +1122,25 @@ impl GitWorktree {
             to = %to.display(),
             "move_worktree: invoking `git worktree move`"
         );
+        // `git worktree move` also refuses a locked tree; unlock, move, then
+        // re-lock at the destination so the relocated checkout keeps its prune
+        // protection.
+        self.unlock_worktree(from);
         let output =
             super::command::run_git(&self.repo_path, ["worktree", "move", from_str, to_str])?;
         if !output.status.success() {
+            // Restore the lock on the unmoved source so a failed move does not
+            // silently leave it unprotected.
+            let _ = self.lock_worktree(from);
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             return Err(GitError::WorktreeCommandFailed(stderr));
+        }
+        if let Err(e) = self.lock_worktree(to) {
+            tracing::warn!(target: "git.worktree",
+                to = %to.display(),
+                error = %e,
+                "move_worktree: could not re-lock worktree at new path"
+            );
         }
         Ok(())
     }
@@ -1876,6 +1967,52 @@ mod tests {
             .create_worktree("stale-branch", &wt_path, false, None)
             .unwrap();
         assert!(wt_path.exists());
+    }
+
+    #[test]
+    fn test_created_worktree_is_locked_and_survives_prune_when_unreachable() {
+        // Regression for #2414: a `git worktree prune` issued from a context
+        // that cannot see a sibling's checkout (a separate sandbox, or the host
+        // when the worktree lives in a container mount) must not reap that
+        // sibling's admin entry. aoe locks every worktree it creates; prune
+        // skips locked entries.
+        let (dir, repo) = setup_test_repo();
+        let repo_path = repo.path().parent().unwrap();
+        let head = repo.head().unwrap();
+        let commit = head.peel_to_commit().unwrap();
+        repo.branch("locked-branch", &commit, false).unwrap();
+
+        let wt_path = dir.path().join("locked-worktree");
+        let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
+        git_wt
+            .create_worktree("locked-branch", &wt_path, false, None)
+            .unwrap();
+
+        let admin_dir = repo_path.join(".git/worktrees").join("locked-worktree");
+        assert!(
+            admin_dir.join("locked").exists(),
+            "create_worktree should lock the new worktree"
+        );
+
+        // Simulate the pruning process being unable to see the checkout by
+        // moving it aside, then prune. The locked admin entry must survive.
+        let hidden = dir.path().join("locked-worktree-HIDDEN");
+        std::fs::rename(&wt_path, &hidden).unwrap();
+        git_wt.prune_worktrees().unwrap();
+        assert!(
+            admin_dir.exists(),
+            "locked worktree admin entry must survive a prune while its checkout is unreachable"
+        );
+
+        // Restore the checkout; the git linkage is intact, and the managed
+        // remove path still works because it unlocks first.
+        std::fs::rename(&hidden, &wt_path).unwrap();
+        git_wt.remove_worktree(&wt_path, true).unwrap();
+        assert!(!wt_path.exists());
+        assert!(
+            !admin_dir.exists(),
+            "remove_worktree should unlock and reap the admin entry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`GitWorktree::create_worktree` runs `git worktree prune` on every create (and several cleanup paths do too). `git worktree prune` deletes the admin entry of any registered worktree whose checkout it cannot see on the local filesystem. That is correct when every worktree lives on one visible filesystem, but it is destructive when an aoe worktree set spans a host/sandbox path boundary: several sandboxes share one `.git` (the main repo is mounted everywhere) while each sandbox mounts only its own worktree. A prune issued from one sandbox then reads a sibling's checkout as "missing," removes that sibling's `<main>/.git/worktrees/<name>` admin entry, and breaks its git linkage (`fatal: not a git repository: .../.git/worktrees/<name>`).

This is the root cause behind the symptom that #2414 worked around by pinning the container workdir; #2414 made `docker exec` survive a broken linkage but did not stop the linkage from breaking.

### Fix

Lock every worktree aoe creates with `git worktree lock`. `git worktree prune` skips locked entries, so a prune from a context that cannot see a sibling can no longer reap it. The lock is paired with an unlock everywhere it would otherwise block an intended operation:

- **Create:** lock at the end of `create_worktree` (best-effort; a lock failure becomes a warning, never an abort). Unlock the target path immediately before the create-time prune so re-creating at a path whose checkout was deleted out-of-band still succeeds, while sibling locks stay intact.
- **Remove:** unlock at the top of `remove_worktree`. git refuses to remove a locked tree even with a single `--force` (it wants `-f -f`); unlocking first preserves the existing single-`--force` dirty-override semantics unchanged.
- **Move:** unlock, move, re-lock around `git worktree move`; restore the source lock if the move fails.
- **Cleanup:** unlock before the `src/git/cleanup.rs` paths that delete the directory by hand and reap the entry via prune.

`list_worktrees` does not read the locked flag, so there is no UI or status effect. git's lock/`--reason`/prune-skips-locked semantics all date to git 2.10 (2016), so there is no version concern.

### Follow-ups (not in this PR)

- A one-time migration to lock worktrees created before this change (they remain vulnerable until recreated).
- A focused test for the move + re-lock pairing (currently exercised only via higher-level rename paths).

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- no user-facing docs; behavior change for raw `git worktree` users noted in code comments -->
- [ ] For UI changes: included screenshot or recording <!-- N/A, no UI change -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the change is at the git layer, below the TUI/CLI/session-lifecycle surface. It is covered by a new git unit regression test, `test_created_worktree_is_locked_and_survives_prune_when_unreachable`, which asserts a created worktree is locked, survives a prune while its checkout is unreachable, and is still cleanly removable. The existing `create`/`remove`/stale-directory worktree tests all pass and now exercise the lock/unlock pairing.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code.

**Any Additional AI Details you'd like to share:** Drafted by Claude through back-and-forth with @njbrake. The investigation (root-cause tracing, git lock/prune semantics verified empirically against real git) and decisions are his; the prose and code are Claude's.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785083413&installation_id=139138837&pr_number=2440&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2440&signature=485520117c5f076029213411669add628f515cb53238655b50ba466f18d09c44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change makes managed `git` worktrees much safer to clean up by protecting them from being accidentally removed during prune operations—especially when multiple sandboxes share the same underlying `.git` data.

### What changed
- Worktrees created by the app are now explicitly locked after creation to prevent cross-boundary `git worktree prune` from deleting their admin entries.
- The `clone_bare_repo` flow was updated to also lock the `main` worktree (best-effort) after creating it, since it previously bypassed the usual worktree creation path.
- Cleanup/removal code now unlocks worktrees temporarily before removing directories and running prune, so existing single-worktree “force” behavior isn’t disrupted.
- Worktree moves now temporarily unlock the source, then re-lock it (and best-effort lock the destination after the move).
- Recreation flows temporarily unlock the target path so previously deleted checkouts can still be rebuilt using prune-friendly cleanup.

### Benefits
- Prevents one sandbox from breaking another sandbox’s worktree metadata.
- Ensures prune doesn’t delete the admin bookkeeping for actively managed worktrees when the checkout directory is temporarily unreachable.
- Keeps remove/move behavior working as before while adding protection against cross-boundary cleanup issues.

### Technical notes
- Added AOE-specific worktree locking using a dedicated lock reason, with best-effort handling for lock/unlock steps.
- Lock/unlock calls were added around create, move, remove, and cleanup/prune paths (plus targeted unlock/re-lock behavior during move and directory-pruning cleanup).
- Added regression coverage for both standard worktree creation and the `clone_bare_repo` path, including “prune survival when checkout is unreachable” and “proper removal afterwards.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->