### PR TITLE
fix(worktree): dedupe generated civ branches

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3697,29 +3697,19 @@ pub async fn create_session(
             body.trust_hooks.unwrap_or(false),
         )?;
 
-        // When worktree_branch is empty string, generate a name from civilizations.
-        // The generated name is used as both title and branch.
         let title = body.title.unwrap_or_default();
-        let worktree_branch = match body.worktree_branch {
-            Some(b) if b.is_empty() => {
-                let generated = crate::session::civilizations::generate_random_title(&title_refs);
-                Some(generated)
-            }
-            other => other,
-        };
-        // If title is empty and we generated a branch name, use it as the title too
-        let title = if title.is_empty() {
-            worktree_branch.clone().unwrap_or_default()
-        } else {
-            title
-        };
+        let worktree_enabled = body.worktree_branch.is_some();
+        let worktree_branch = body
+            .worktree_branch
+            .map(|b| b.trim().to_string())
+            .filter(|b| !b.is_empty());
 
         let params = InstanceParams {
             title,
             path: body.path,
             group: body.group,
             tool: body.tool,
-            worktree_enabled: worktree_branch.is_some(),
+            worktree_enabled,
             worktree_branch,
             create_new_branch: body.create_new_branch,
             base_branch: if body.create_new_branch {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -455,7 +455,7 @@ pub fn build_instance(
         params.worktree_enabled,
         existing_titles,
         &taken_branches,
-    );
+    )?;
     let branch_source = resolve_worktree_branch(
         params.worktree_enabled,
         params.worktree_branch.as_deref(),
@@ -797,8 +797,8 @@ pub(crate) fn resolve_title(
     worktree_enabled: bool,
     existing_titles: &[&str],
     taken_branches: &HashSet<String>,
-) -> String {
-    if title.is_empty() {
+) -> Result<String> {
+    let resolved = if title.is_empty() {
         if worktree_enabled {
             if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
                 branch.trim().to_string()
@@ -809,13 +809,20 @@ pub(crate) fn resolve_title(
                         taken_branches,
                     )
                 })
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Could not generate a unique worktree title or branch; please enter one manually."
+                    )
+                })?
             }
         } else {
             civilizations::generate_random_title(existing_titles)
         }
     } else {
         title.to_string()
-    }
+    };
+
+    Ok(resolved)
 }
 
 pub(crate) fn collect_taken_branches_for_derived_dedupe(
@@ -1043,15 +1050,41 @@ pub(crate) fn branch_name_from_title(title: &str) -> String {
 mod tests {
     use super::*;
 
+    fn roman_for_test(n: u32) -> String {
+        let mut remaining = n;
+        let mut result = String::new();
+        for (value, numeral) in [
+            (1000, "M"),
+            (900, "CM"),
+            (500, "D"),
+            (400, "CD"),
+            (100, "C"),
+            (90, "XC"),
+            (50, "L"),
+            (40, "XL"),
+            (10, "X"),
+            (9, "IX"),
+            (5, "V"),
+            (4, "IV"),
+            (1, "I"),
+        ] {
+            while remaining >= value {
+                result.push_str(numeral);
+                remaining -= value;
+            }
+        }
+        result
+    }
+
     #[test]
     fn test_empty_title_with_worktree_uses_branch_name() {
-        let title = resolve_title("", Some("feature-auth"), true, &[], &HashSet::new());
+        let title = resolve_title("", Some("feature-auth"), true, &[], &HashSet::new()).unwrap();
         assert_eq!(title, "feature-auth");
     }
 
     #[test]
     fn test_empty_title_without_worktree_uses_civilization() {
-        let title = resolve_title("", None, false, &[], &HashSet::new());
+        let title = resolve_title("", None, false, &[], &HashSet::new()).unwrap();
         assert!(
             civilizations::CIVILIZATIONS.contains(&title.as_str()),
             "Expected a civilization name, got: {}",
@@ -1067,13 +1100,14 @@ mod tests {
             true,
             &[],
             &HashSet::new(),
-        );
+        )
+        .unwrap();
         assert_eq!(title, "My Session");
     }
 
     #[test]
     fn test_provided_title_without_worktree_keeps_title() {
-        let title = resolve_title("Custom Name", None, false, &[], &HashSet::new());
+        let title = resolve_title("Custom Name", None, false, &[], &HashSet::new()).unwrap();
         assert_eq!(title, "Custom Name");
     }
 
@@ -1087,12 +1121,39 @@ mod tests {
         let mut taken = HashSet::new();
         taken.insert("tatars".to_string());
 
-        let title = resolve_title("", None, true, &existing, &taken);
+        let title = resolve_title("", None, true, &existing, &taken).unwrap();
 
         assert_ne!(title, "Tatars");
         assert!(
             title.contains(" II"),
             "expected suffixed fallback after the only bare civ branch was taken, got: {title}"
+        );
+    }
+
+    #[test]
+    fn test_empty_worktree_title_errors_when_generation_exhausts() {
+        let existing: Vec<&str> = civilizations::CIVILIZATIONS.iter().copied().collect();
+        let mut taken = HashSet::new();
+        let timestamp = chrono::Utc::now().timestamp();
+
+        for civ in civilizations::CIVILIZATIONS {
+            for n in 2..=1000 {
+                taken.insert(branch_name_from_title(&format!(
+                    "{} {}",
+                    civ,
+                    roman_for_test(n)
+                )));
+            }
+            for n in timestamp - 60..timestamp + 1060 {
+                taken.insert(branch_name_from_title(&format!("{} {}", civ, n)));
+            }
+        }
+
+        let err = resolve_title("", None, true, &existing, &taken).unwrap_err();
+
+        assert!(
+            err.to_string().contains("please enter one manually"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -798,16 +798,14 @@ pub(crate) fn resolve_title(
     existing_titles: &[&str],
     taken_branches: &HashSet<String>,
 ) -> Result<String> {
+    let taken_branch_keys = branch_collision_keys(taken_branches);
     let resolved = if title.is_empty() {
         if worktree_enabled {
             if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
                 branch.trim().to_string()
             } else {
                 civilizations::generate_random_title_filtered(existing_titles, |candidate| {
-                    branch_name_taken_case_insensitive(
-                        &branch_name_from_title(candidate),
-                        taken_branches,
-                    )
+                    branch_key_taken(&branch_name_from_title(candidate), &taken_branch_keys)
                 })
                 .ok_or_else(|| {
                     anyhow::anyhow!(
@@ -935,25 +933,26 @@ fn branch_collision_key(branch: &str) -> String {
     branch.to_ascii_lowercase()
 }
 
-fn branch_name_taken_case_insensitive(branch: &str, taken: &HashSet<String>) -> bool {
-    let key = branch_collision_key(branch);
+fn branch_collision_keys(taken: &HashSet<String>) -> HashSet<String> {
     taken
         .iter()
-        .any(|candidate| branch_collision_key(candidate) == key)
+        .map(|branch| branch_collision_key(branch))
+        .collect()
+}
+
+fn branch_key_taken(branch: &str, taken_keys: &HashSet<String>) -> bool {
+    taken_keys.contains(&branch_collision_key(branch))
 }
 
 fn dedupe_branch_name(base: &str, taken: &HashSet<String>) -> String {
-    let taken_keys: HashSet<String> = taken
-        .iter()
-        .map(|branch| branch_collision_key(branch))
-        .collect();
-    if !taken_keys.contains(&branch_collision_key(base)) {
+    let taken_keys = branch_collision_keys(taken);
+    if !branch_key_taken(base, &taken_keys) {
         return base.to_string();
     }
     let mut n = 2usize;
     loop {
         let candidate = format!("{}-{}", base, n);
-        if !taken_keys.contains(&branch_collision_key(&candidate)) {
+        if !branch_key_taken(&candidate, &taken_keys) {
             return candidate;
         }
         n += 1;
@@ -1132,9 +1131,8 @@ mod tests {
 
     #[test]
     fn test_empty_worktree_title_errors_when_generation_exhausts() {
-        let existing: Vec<&str> = civilizations::CIVILIZATIONS.iter().copied().collect();
+        let existing: Vec<&str> = civilizations::CIVILIZATIONS.to_vec();
         let mut taken = HashSet::new();
-        let timestamp = chrono::Utc::now().timestamp();
 
         for civ in civilizations::CIVILIZATIONS {
             for n in 2..=1000 {
@@ -1144,6 +1142,10 @@ mod tests {
                     roman_for_test(n)
                 )));
             }
+        }
+
+        let timestamp = chrono::Utc::now().timestamp();
+        for civ in civilizations::CIVILIZATIONS {
             for n in timestamp - 60..timestamp + 1060 {
                 taken.insert(branch_name_from_title(&format!("{} {}", civ, n)));
             }

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -3,7 +3,7 @@
 //! This module provides shared logic for building new session instances,
 //! used by both synchronous (TUI operations) and asynchronous (background poller) code paths.
 
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use anyhow::{bail, Result};
 use chrono::Utc;
@@ -441,11 +441,20 @@ pub fn build_instance(
     let mut workspace_info = None;
     let mut created_workspace_worktrees: Vec<CreatedWorktree> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
+    let taken_branches = collect_taken_branches_for_derived_dedupe(
+        existing_branches,
+        &params.path,
+        &params.extra_repo_paths,
+        params.worktree_enabled,
+        params.create_new_branch,
+        params.scratch,
+    );
     let final_title = resolve_title(
         &params.title,
         params.worktree_branch.as_deref(),
         params.worktree_enabled,
         existing_titles,
+        &taken_branches,
     );
     let branch_source = resolve_worktree_branch(
         params.worktree_enabled,
@@ -458,14 +467,7 @@ pub fn build_instance(
         Some(BranchSource::Explicit(name)) => Some(name),
         Some(BranchSource::Derived(name)) => {
             if params.create_new_branch {
-                let mut taken: std::collections::HashSet<String> =
-                    existing_branches.iter().map(|s| (*s).to_string()).collect();
-                if let Ok(local) =
-                    crate::git::diff::list_branches(std::path::Path::new(&params.path))
-                {
-                    taken.extend(local);
-                }
-                Some(dedupe_branch_name(&name, &taken))
+                Some(dedupe_branch_name(&name, &taken_branches))
             } else {
                 Some(name)
             }
@@ -794,13 +796,19 @@ pub(crate) fn resolve_title(
     worktree_branch: Option<&str>,
     worktree_enabled: bool,
     existing_titles: &[&str],
+    taken_branches: &HashSet<String>,
 ) -> String {
     if title.is_empty() {
         if worktree_enabled {
             if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
                 branch.trim().to_string()
             } else {
-                civilizations::generate_random_title(existing_titles)
+                civilizations::generate_random_title_filtered(existing_titles, |candidate| {
+                    branch_name_taken_case_insensitive(
+                        &branch_name_from_title(candidate),
+                        taken_branches,
+                    )
+                })
             }
         } else {
             civilizations::generate_random_title(existing_titles)
@@ -808,6 +816,30 @@ pub(crate) fn resolve_title(
     } else {
         title.to_string()
     }
+}
+
+pub(crate) fn collect_taken_branches_for_derived_dedupe(
+    existing_branches: &[&str],
+    path: &str,
+    extra_repo_paths: &[String],
+    worktree_enabled: bool,
+    create_new_branch: bool,
+    scratch: bool,
+) -> HashSet<String> {
+    let mut taken: HashSet<String> = existing_branches.iter().map(|s| (*s).to_string()).collect();
+
+    if worktree_enabled && create_new_branch && !scratch {
+        for repo in std::iter::once(path)
+            .chain(extra_repo_paths.iter().map(String::as_str))
+            .filter(|s| !s.trim().is_empty())
+        {
+            if let Ok(local) = crate::git::diff::list_branches(std::path::Path::new(repo)) {
+                taken.extend(local);
+            }
+        }
+    }
+
+    taken
 }
 
 /// Origin of an effective worktree branch name. The builder uses this to decide
@@ -892,14 +924,29 @@ pub(crate) fn git_sanitize_branch_name(s: &str) -> String {
 /// Find the next branch name not present in `taken`.
 /// If `base` is free, returns it unchanged. Otherwise appends `-2`, `-3`, …
 /// until a free name is found.
-fn dedupe_branch_name(base: &str, taken: &std::collections::HashSet<String>) -> String {
-    if !taken.contains(base) {
+fn branch_collision_key(branch: &str) -> String {
+    branch.to_ascii_lowercase()
+}
+
+fn branch_name_taken_case_insensitive(branch: &str, taken: &HashSet<String>) -> bool {
+    let key = branch_collision_key(branch);
+    taken
+        .iter()
+        .any(|candidate| branch_collision_key(candidate) == key)
+}
+
+fn dedupe_branch_name(base: &str, taken: &HashSet<String>) -> String {
+    let taken_keys: HashSet<String> = taken
+        .iter()
+        .map(|branch| branch_collision_key(branch))
+        .collect();
+    if !taken_keys.contains(&branch_collision_key(base)) {
         return base.to_string();
     }
     let mut n = 2usize;
     loop {
         let candidate = format!("{}-{}", base, n);
-        if !taken.contains(&candidate) {
+        if !taken_keys.contains(&branch_collision_key(&candidate)) {
             return candidate;
         }
         n += 1;
@@ -998,13 +1045,13 @@ mod tests {
 
     #[test]
     fn test_empty_title_with_worktree_uses_branch_name() {
-        let title = resolve_title("", Some("feature-auth"), true, &[]);
+        let title = resolve_title("", Some("feature-auth"), true, &[], &HashSet::new());
         assert_eq!(title, "feature-auth");
     }
 
     #[test]
     fn test_empty_title_without_worktree_uses_civilization() {
-        let title = resolve_title("", None, false, &[]);
+        let title = resolve_title("", None, false, &[], &HashSet::new());
         assert!(
             civilizations::CIVILIZATIONS.contains(&title.as_str()),
             "Expected a civilization name, got: {}",
@@ -1014,14 +1061,39 @@ mod tests {
 
     #[test]
     fn test_provided_title_with_worktree_keeps_title() {
-        let title = resolve_title("My Session", Some("feature-auth"), true, &[]);
+        let title = resolve_title(
+            "My Session",
+            Some("feature-auth"),
+            true,
+            &[],
+            &HashSet::new(),
+        );
         assert_eq!(title, "My Session");
     }
 
     #[test]
     fn test_provided_title_without_worktree_keeps_title() {
-        let title = resolve_title("Custom Name", None, false, &[]);
+        let title = resolve_title("Custom Name", None, false, &[], &HashSet::new());
         assert_eq!(title, "Custom Name");
+    }
+
+    #[test]
+    fn test_empty_worktree_title_skips_civ_with_taken_branch() {
+        let existing: Vec<&str> = civilizations::CIVILIZATIONS
+            .iter()
+            .copied()
+            .filter(|civ| *civ != "Tatars")
+            .collect();
+        let mut taken = HashSet::new();
+        taken.insert("tatars".to_string());
+
+        let title = resolve_title("", None, true, &existing, &taken);
+
+        assert_ne!(title, "Tatars");
+        assert!(
+            title.contains(" II"),
+            "expected suffixed fallback after the only bare civ branch was taken, got: {title}"
+        );
     }
 
     #[test]
@@ -1158,13 +1230,21 @@ mod tests {
 
     #[test]
     fn test_dedupe_branch_name_appends_suffix_on_collision() {
-        let mut taken = std::collections::HashSet::new();
+        let mut taken = HashSet::new();
         taken.insert("fix-bug".to_string());
         assert_eq!(dedupe_branch_name("fix-bug", &taken), "fix-bug-2");
 
         taken.insert("fix-bug-2".to_string());
         taken.insert("fix-bug-3".to_string());
         assert_eq!(dedupe_branch_name("fix-bug", &taken), "fix-bug-4");
+    }
+
+    #[test]
+    fn test_dedupe_branch_name_matches_case_insensitively() {
+        let mut taken = HashSet::new();
+        taken.insert("Tatars".to_string());
+
+        assert_eq!(dedupe_branch_name("tatars", &taken), "tatars-2");
     }
 
     /// Init a non-bare repo named `name` inside its own TempDir with one

--- a/src/session/civilizations.rs
+++ b/src/session/civilizations.rs
@@ -86,10 +86,22 @@ fn to_roman(n: u32) -> String {
 }
 
 pub fn generate_random_title(existing_titles: &[&str]) -> String {
-    generate_random_title_filtered(existing_titles, |_| false)
+    generate_random_title_filtered(existing_titles, |_| false).unwrap_or_else(|| {
+        let timestamp = chrono::Utc::now().timestamp();
+        for n in timestamp.. {
+            let candidate = format!("Session {}", n);
+            if !existing_titles.contains(&candidate.as_str()) {
+                return candidate;
+            }
+        }
+        unreachable!("an unbounded suffix range always yields a free candidate")
+    })
 }
 
-pub fn generate_random_title_filtered<F>(existing_titles: &[&str], is_unavailable: F) -> String
+pub fn generate_random_title_filtered<F>(
+    existing_titles: &[&str],
+    is_unavailable: F,
+) -> Option<String>
 where
     F: Fn(&str) -> bool,
 {
@@ -102,14 +114,14 @@ where
         .collect();
 
     if let Some(&civ) = available.choose(&mut rng) {
-        return civ.to_string();
+        return Some(civ.to_string());
     }
 
     let base = CIVILIZATIONS.choose(&mut rng).unwrap_or(&"Session");
     for n in 2..=1000 {
         let candidate = format!("{} {}", base, to_roman(n));
         if !existing_titles.contains(&candidate.as_str()) && !is_unavailable(&candidate) {
-            return candidate;
+            return Some(candidate);
         }
     }
 
@@ -117,11 +129,11 @@ where
     for n in timestamp..timestamp + 1000 {
         let candidate = format!("{} {}", base, n);
         if !existing_titles.contains(&candidate.as_str()) && !is_unavailable(&candidate) {
-            return candidate;
+            return Some(candidate);
         }
     }
 
-    format!("{} {}", base, timestamp)
+    None
 }
 
 /// True when `title` is one this module could have produced via
@@ -198,13 +210,21 @@ mod tests {
             .filter(|civ| *civ != "Tatars")
             .collect();
 
-        let title = generate_random_title_filtered(&existing, |candidate| candidate == "Tatars");
+        let title = generate_random_title_filtered(&existing, |candidate| candidate == "Tatars")
+            .expect("filtered title should fall back to a suffixed civilization");
 
         assert_ne!(title, "Tatars");
         assert!(
             title.contains(" II"),
             "expected suffixed fallback after the only bare civ was filtered, got: {title}"
         );
+    }
+
+    #[test]
+    fn test_generate_random_title_filtered_returns_none_when_exhausted() {
+        let title = generate_random_title_filtered(&[], |_| true);
+
+        assert!(title.is_none());
     }
 
     #[test]

--- a/src/session/civilizations.rs
+++ b/src/session/civilizations.rs
@@ -86,11 +86,18 @@ fn to_roman(n: u32) -> String {
 }
 
 pub fn generate_random_title(existing_titles: &[&str]) -> String {
+    generate_random_title_filtered(existing_titles, |_| false)
+}
+
+pub fn generate_random_title_filtered<F>(existing_titles: &[&str], is_unavailable: F) -> String
+where
+    F: Fn(&str) -> bool,
+{
     let mut rng = rand::rng();
 
     let available: Vec<&str> = CIVILIZATIONS
         .iter()
-        .filter(|civ| !existing_titles.contains(*civ))
+        .filter(|civ| !existing_titles.contains(*civ) && !is_unavailable(civ))
         .copied()
         .collect();
 
@@ -101,12 +108,20 @@ pub fn generate_random_title(existing_titles: &[&str]) -> String {
     let base = CIVILIZATIONS.choose(&mut rng).unwrap_or(&"Session");
     for n in 2..=1000 {
         let candidate = format!("{} {}", base, to_roman(n));
-        if !existing_titles.contains(&candidate.as_str()) {
+        if !existing_titles.contains(&candidate.as_str()) && !is_unavailable(&candidate) {
             return candidate;
         }
     }
 
-    format!("{} {}", base, chrono::Utc::now().timestamp())
+    let timestamp = chrono::Utc::now().timestamp();
+    for n in timestamp..timestamp + 1000 {
+        let candidate = format!("{} {}", base, n);
+        if !existing_titles.contains(&candidate.as_str()) && !is_unavailable(&candidate) {
+            return candidate;
+        }
+    }
+
+    format!("{} {}", base, timestamp)
 }
 
 /// True when `title` is one this module could have produced via
@@ -173,6 +188,23 @@ mod tests {
         let existing: Vec<&str> = CIVILIZATIONS.to_vec();
         let title = generate_random_title(&existing);
         assert!(title.contains(" II"));
+    }
+
+    #[test]
+    fn test_generate_random_title_filtered_skips_unavailable_civ() {
+        let existing: Vec<&str> = CIVILIZATIONS
+            .iter()
+            .copied()
+            .filter(|civ| *civ != "Tatars")
+            .collect();
+
+        let title = generate_random_title_filtered(&existing, |candidate| candidate == "Tatars");
+
+        assert_ne!(title, "Tatars");
+        assert!(
+            title.contains(" II"),
+            "expected suffixed fallback after the only bare civ was filtered, got: {title}"
+        );
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3154,11 +3154,26 @@ impl HomeView {
                 .filter(|i| i.source_profile == data.profile)
                 .map(|i| i.title.as_str())
                 .collect();
+            let existing_branches: Vec<&str> = self
+                .instances()
+                .iter()
+                .filter(|i| i.source_profile == data.profile)
+                .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.as_str()))
+                .collect();
+            let taken_branches = crate::session::builder::collect_taken_branches_for_derived_dedupe(
+                &existing_branches,
+                &data.path,
+                &data.extra_repo_paths,
+                data.worktree_enabled,
+                data.create_new_branch,
+                data.scratch,
+            );
             data.title = crate::session::builder::resolve_title(
                 &data.title,
                 data.worktree_branch.as_deref(),
                 data.worktree_enabled,
                 &existing_titles,
+                &taken_branches,
             );
         }
         let stub_title = data.title.clone();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3168,13 +3168,15 @@ impl HomeView {
                 data.create_new_branch,
                 data.scratch,
             );
-            data.title = crate::session::builder::resolve_title(
+            if let Ok(title) = crate::session::builder::resolve_title(
                 &data.title,
                 data.worktree_branch.as_deref(),
                 data.worktree_enabled,
                 &existing_titles,
                 &taken_branches,
-            );
+            ) {
+                data.title = title;
+            }
         }
         let stub_title = data.title.clone();
         let mut stub = Instance::new(&stub_title, &data.path);

--- a/tests/acp_runner_orphan.rs
+++ b/tests/acp_runner_orphan.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 
 /// App data dir for the debug binary, which uses the `-dev` namespace.
 fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
-    if cfg!(target_os = "linux") {
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
         xdg.join("agent-of-empires-dev")
     } else {
         home.join(".agent-of-empires-dev")

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -36,11 +36,14 @@
       ]
     },
     {
-      "id": "session.create-duplicate-worktree-error",
+      "id": "session.create-worktree-name-collisions",
       "kind": "live-playwright",
       "risk": "medium",
       "specs": ["tests/live/session-create-duplicate-worktree.spec.ts"],
-      "components": ["web/src/components/session-wizard/LaunchFooter.tsx"]
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/LaunchFooter.tsx"
+      ]
     },
     {
       "id": "terminal.mobile-backspace-autorepeat",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -39,11 +39,7 @@
       "id": "session.create-worktree-name-collisions",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/session-create-duplicate-worktree.spec.ts"],
-      "components": [
-        "web/src/components/session-wizard/SessionWizard.tsx",
-        "web/src/components/session-wizard/LaunchFooter.tsx"
-      ]
+      "specs": ["tests/live/session-create-duplicate-worktree.spec.ts"]
     },
     {
       "id": "terminal.mobile-backspace-autorepeat",

--- a/web/tests/live/session-create-duplicate-worktree.spec.ts
+++ b/web/tests/live/session-create-duplicate-worktree.spec.ts
@@ -13,6 +13,59 @@ import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { spawnAoeServe } from "../helpers/aoeServe";
 
+const CIVILIZATION_NAMES = [
+  "Armenians",
+  "Aztecs",
+  "Bengalis",
+  "Berbers",
+  "Bohemians",
+  "Britons",
+  "Bulgarians",
+  "Burgundians",
+  "Burmese",
+  "Byzantines",
+  "Celts",
+  "Chinese",
+  "Cumans",
+  "Dravidians",
+  "Ethiopians",
+  "Franks",
+  "Georgians",
+  "Goths",
+  "Gurjaras",
+  "Hindustanis",
+  "Huns",
+  "Incas",
+  "Italians",
+  "Japanese",
+  "Jurchens",
+  "Khitans",
+  "Khmer",
+  "Koreans",
+  "Lithuanians",
+  "Magyars",
+  "Malay",
+  "Malians",
+  "Mayans",
+  "Mongols",
+  "Persians",
+  "Poles",
+  "Portuguese",
+  "Romans",
+  "Saracens",
+  "Shu",
+  "Sicilians",
+  "Slavs",
+  "Spanish",
+  "Tatars",
+  "Teutons",
+  "Turks",
+  "Vietnamese",
+  "Vikings",
+  "Wei",
+  "Wu",
+];
+
 test("duplicate worktree branch returns the real collision error, not a generic one", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
     authMode: "none",
@@ -61,6 +114,53 @@ test("duplicate worktree branch returns the real collision error, not a generic 
     const body = await second.json();
     expect(body.message).toContain("Worktree already exists");
     expect(body.message).not.toBe("Failed to create session");
+  } finally {
+    await serve.stop();
+  }
+});
+
+test("auto-generated worktree branch avoids civilization branch collisions", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir, env });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+      for (const civ of CIVILIZATION_NAMES) {
+        spawnSync("git", ["branch", civ], { cwd: projectDir, env });
+      }
+    },
+  });
+
+  try {
+    const res = await fetch(`${serve.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: join(serve.home, "project"),
+        tool: "claude",
+        worktree_branch: "",
+        create_new_branch: true,
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.title).toMatch(/\bII\b/);
+    expect(body.branch).toBeTruthy();
+    expect(CIVILIZATION_NAMES).not.toContain(body.branch);
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/session-create-duplicate-worktree.spec.ts
+++ b/web/tests/live/session-create-duplicate-worktree.spec.ts
@@ -160,7 +160,7 @@ test("auto-generated worktree branch avoids civilization branch collisions", asy
     const body = await res.json();
     expect(body.title).toMatch(/\bII\b/);
     expect(body.branch).toBeTruthy();
-    expect(CIVILIZATION_NAMES).not.toContain(body.branch);
+    expect(CIVILIZATION_NAMES.map((civ) => civ.toLowerCase())).not.toContain(String(body.branch).toLowerCase());
   } finally {
     await serve.stop();
   }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes auto-generated worktree sessions whose civilization title would derive to an already-taken branch name. The web API now treats an empty `worktree_branch` as worktree intent without an explicit branch, leaving generated title and derived branch resolution to the shared session builder.

The builder now collects branch names that generated branches must avoid, including existing sessions and local repo branches when creating a new branch. Civilization title generation filters out names whose derived branch would collide, and derived branch suffixing compares case-insensitively so `Tatars` and `tatars` are treated as the same collision.

The TUI creating stub uses the same branch availability set, so its preview title matches the final session. This also includes a test-only ACP runner harness correction for macOS debug builds with `XDG_CONFIG_HOME` set, which unblocked the full validation sweep and has no runtime behavior change.

Closes #2434

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the web dashboard, create a worktree session with title blank, branch blank, and create-new-branch enabled in a repo that already has a branch named after a civilization. Confirm session creation succeeds and uses a generated title/branch that does not collide.
- [ ] In the web dashboard, create a worktree session with an explicit duplicate branch name. Confirm the dashboard shows the real branch collision error and does not create a session.
- [ ] In the TUI, start a worktree session with title blank and branch blank in the same kind of repo. Confirm the temporary creating row and final session use a non-colliding generated title.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the TUI creation stub now mirrors the shared builder path covered by Rust unit tests and the live web regression; no separate TUI interaction path was introduced.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, implementation, and validation were drafted by Claude under my direction. I reviewed the changes, made the design calls, and ran the validation steps.

- [x] I am an AI Agent filling out this form (check box if true)
