### PR TITLE
fix(web): make structured-view code blocks horizontally scrollable

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -286,7 +286,13 @@ body {
 .acp-markdown pre {
   margin: 0.5rem 0;
   border-radius: 0.375rem;
-  overflow: hidden;
+  /* overflow-x: auto (not hidden) so a fenced code block wider than the
+     bubble scrolls horizontally instead of clipping its long lines. `hidden`
+     here outranked the `overflow-x-auto` utility on the plain <pre> and
+     clipped shiki's inner <pre> before its wrapper could scroll. The radius
+     still clips the corners; no fixed height means no vertical scrollbar.
+     See #2443. */
+  overflow-x: auto;
   border: 1px solid var(--color-surface-700);
   background: var(--color-surface-950);
 }

--- a/web/tests/acp-transcript-render.spec.ts
+++ b/web/tests/acp-transcript-render.spec.ts
@@ -86,24 +86,22 @@ test.describe("chat bubble overflow", () => {
     // targets p/li/blockquote/a only, so the code container is untouched).
     const codeScroller: Locator = viewport.locator(".acp-markdown .overflow-x-auto").first();
     await expect(codeScroller).toBeVisible();
-    // Poll rather than read once: the code block renders as a plain <pre> first,
-    // then shiki async-swaps in a highlighted <div>. In the transient pre state
-    // the bubble's `pre { overflow: hidden }` clobbers the overflow-x-auto
-    // utility, so a single read can catch "hidden" before the swap settles
-    // (CI-only flake). Poll until the settled scroll container reports auto/scroll.
     await expect
       .poll(async () => codeScroller.evaluate((el) => getComputedStyle(el).overflowX))
       .toMatch(/^(auto|scroll)$/);
 
     // The wrap rule must NOT leak into code: the long line stays a single
     // unwrapped line, so the code <pre>'s content is wider than its box.
-    // (scrollWidth reports the full content width even though the bubble's
-    // `pre { overflow: hidden }` clips it.) If overflow-wrap leaked here the
-    // line would wrap and scrollWidth would collapse to clientWidth.
     const codePre: Locator = codeScroller.locator("pre").first();
     await expect
       .poll(async () => codePre.evaluate((el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).clientWidth))
       .toBe(true);
+
+    // #2443: the code <pre> must be horizontally scrollable, not clipped. The
+    // global `.acp-markdown pre` rule used to force `overflow: hidden`, which
+    // outranks the `overflow-x-auto` utility and, on the shiki path, clips the
+    // inner <pre> before its wrapper can scroll. The line was then unreadable.
+    await expect.poll(async () => codePre.evaluate((el) => getComputedStyle(el).overflowX)).toMatch(/^(auto|scroll)$/);
   });
 });
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fenced code/text blocks in the web structured view could not be scrolled horizontally: wide lines (long file paths, seed prompts) were clipped at the right edge with no scrollbar, on both desktop and mobile browsers.

Root cause is the global `.acp-markdown pre { overflow: hidden }` rule in `web/src/index.css`. Its `(0,1,1)` specificity outranks the `overflow-x-auto` utility on the plain fallback `<pre>` (`Markdown.tsx`), so that pre is clipped instead of scrollable. On the shiki path it lands on the inner highlighted `<pre>`, which clips its own long content before the wrapper `div.overflow-x-auto` ever overflows, so the wrapper never scrolls either. The rule was almost certainly added to clip the block's rounded corners, but it broke the horizontal-scroll affordance the adjacent comment claims fenced blocks keep.

The fix switches that rule to `overflow-x: auto`. The block now scrolls horizontally, the border radius still clips the corners, and because these blocks have no fixed height no vertical scrollbar appears. The existing #1469 overflow spec is extended to assert the code `<pre>`'s computed `overflow-x` is `auto`/`scroll`; that assertion fails against the old `overflow: hidden` and passes with the fix. The viewport-level clamp from #1469 stays intact, so the transcript itself still does not grow a horizontal scrollbar.

Closes #2443

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web structured view and have an agent emit a fenced code block with lines wider than the chat column (e.g. a long absolute path or a seed prompt).
- [ ] Confirm the code block shows a horizontal scrollbar and you can scroll sideways to read the full line, on both a desktop browser and a narrow/mobile viewport.
- [ ] Confirm the transcript itself does not grow a page-level horizontal scrollbar (long prose URLs/paths still wrap).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

<!-- The behavior is already mapped by the `acp.story.chat-bubble-overflow` entry in coverage-matrix.json (spec tests/acp-transcript-render.spec.ts); the spec was extended in place, so no new matrix entry was needed. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (CSS rule fix over per-component overrides), reviewed each commit, and ran the manual scroll check plus the red/green test proof.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785087404&installation_id=139138837&pr_number=2444&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2444&signature=247c561e648d35f00419e4a382897429a8a1dcd22ccb24c6aacdcaf304794138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes fenced code and text blocks in the web structured view so long lines can scroll horizontally instead of getting cut off on the right edge.

What changed:
- Updated the global markdown `pre` styling to allow horizontal scrolling rather than hiding overflow.
- Strengthened the regression test to check both the code block wrapper and the inner `<pre>` element for the correct horizontal overflow behavior.

Benefits:
- Wide code blocks, long paths, and similar content are no longer clipped.
- Scrolling works consistently on desktop and mobile.
- The existing layout behavior is preserved while preventing the old clipping issue from coming back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->