### PR TITLE
feat(tui): render plugin UI slots in the structured view

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -464,9 +464,11 @@ change to the resolver or the supervisor.
 ## UI extension points (#2366)
 
 A plugin worker pushes typed UI state to the host over capability-gated RPCs;
-the **host** renders every slot, on the web dashboard. No plugin code runs in
-the dashboard and the render path never awaits a worker: the host keeps an
-in-memory snapshot the dashboard reads synchronously.
+the **host** renders every slot, on the web dashboard and (the
+terminal-applicable subset) in the daemon-connected TUI. No plugin code runs in
+either surface and the render path never awaits a worker: the host keeps an
+in-memory snapshot each surface reads synchronously (see Delivery below for what
+the TUI renders).
 
 The nine slots are a closed `UiSlot` set (`aoe-plugin-api`), kebab-case on the
 wire: `status-bar`, `row-badge`, `row-column`, `sort-key`, `filter-facet`,
@@ -563,9 +565,19 @@ incremental cursor. The dashboard polls it on the same cadence as
 the live list. Notifications surface as toasts, deduped by `seq`.
 
 `sort-key` and `filter-facet` are accepted and stored by the host but their
-dashboard rendering (which needs changes to the sidebar's sort/filter core),
-and TUI rendering of any slot (the standalone TUI has no daemon link), are
-deferred to follow-ups.
+dashboard rendering (which needs changes to the sidebar's sort/filter core) is
+deferred to a follow-up.
+
+The native **structured-view** TUI (`aoe acp attach`, the remote-home picker)
+polls the same endpoint on a 3-second cadence and renders the slots a terminal
+can show: global `status-bar` segments and the open session's `detail-badge`
+entries, tone-colored, in its status line, plus `notification`s as toasts
+(deduped by `seq`, queued so a burst shows one at a time). It renders text and
+tone only; `icon`, `tooltip`, and `href` are dropped, and `card`, `pane`,
+`row-badge`, `row-column`, `sort-key`, and `filter-facet` have no structured-view
+surface. The standalone home screen reads local session storage and has no
+daemon link, so it renders no plugin slots; rendering there is a follow-up
+(#2402).
 
 ## What comes next
 
@@ -574,8 +586,9 @@ contribution registries (issue 2094), the UI extension points (issue 2366,
 above), the builtin worker self-exec path and worker SDK (with the first
 builtin worker that needs them), and the discovery / featured supply-chain
 layer with integrity hashing (issues 2364 and 2365). Within #2366, dashboard
-rendering of the `sort-key` and `filter-facet` slots and TUI rendering of any
-slot are themselves follow-ups. Pinning a featured plugin's
+rendering of the `sort-key` and `filter-facet` slots is itself a follow-up, as
+is rendering plugin slots in the standalone (non-daemon) home screen (the
+structured-view TUI already renders them, #2402). Pinning a featured plugin's
 release-binary asset hash in `featured.toml` (so a featured worker is attested,
 not just its source) is a follow-up; today a release-binary plugin cannot be
 featured.

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -17,6 +17,7 @@ use crate::acp::protocol::{
     ApprovalDecisionWire, FilesResponse, PromptRequest, ReplayResponse, ResolveApprovalRequest,
     SwitchAgentRequest, SwitchAgentResponse,
 };
+use crate::plugin::ui_state::UiSnapshot;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -204,6 +205,18 @@ impl HttpClient {
         )
     }
 
+    /// `GET /api/plugins/ui-state`. The daemon-wide plugin UI snapshot
+    /// (host-rendered slots + notifications) the web dashboard polls; the
+    /// native structured view renders the TUI-applicable subset (#2402).
+    /// Global, not session-scoped, so a miss must not be classified as a
+    /// session-not-found.
+    pub async fn plugin_ui_state(&self) -> Result<UiSnapshot, HttpError> {
+        let url = format!("{}/api/plugins/ui-state", self.endpoint.base_url);
+        let res = self.auth(self.http.get(&url)).send().await?;
+        let res = check_global_status(res).await?;
+        Ok(res.json::<UiSnapshot>().await?)
+    }
+
     /// `POST /api/sessions/{id}/acp/cancel`.
     pub async fn cancel(&self, session_id: &str) -> Result<(), HttpError> {
         let url = format!(
@@ -341,6 +354,25 @@ async fn check_status(
     }
     let body = res.text().await.unwrap_or_default();
     Err(classify_error(status, &body, session_id))
+}
+
+/// Status check for daemon-wide (non-session) endpoints. Like
+/// [`check_status`] but never mints `SessionNotFound`: a 404 here means the
+/// route is absent (e.g. an older daemon without the plugin UI endpoint),
+/// not a missing session, so it maps to a plain `Server` error.
+async fn check_global_status(res: reqwest::Response) -> Result<reqwest::Response, HttpError> {
+    let status = res.status();
+    if status.is_success() {
+        return Ok(res);
+    }
+    let body = res.text().await.unwrap_or_default();
+    match status {
+        StatusCode::UNAUTHORIZED => Err(HttpError::Unauthorized),
+        StatusCode::FORBIDDEN if body.contains("read-only") || body.contains("read_only") => {
+            Err(HttpError::ReadOnly)
+        }
+        _ => Err(HttpError::Server { status, body }),
+    }
 }
 
 /// Map a non-success daemon response onto a typed error. Split out from

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -246,25 +246,27 @@ struct EntryKey {
 }
 
 /// A notification as rendered: the seq lets the client toast each one once.
-#[derive(Debug, Clone, Serialize)]
+/// `Deserialize` so daemon-connected clients (the native TUI structured view,
+/// #2402) can decode the same wire shape the web frontend consumes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Notification {
     pub seq: u64,
     pub plugin_id: String,
     pub tone: Tone,
     pub title: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
 }
 
 /// One entry in the snapshot the web renders.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiEntry {
     pub plugin_id: String,
     pub slot: UiSlot,
     pub id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     /// Normalized, slot-validated payload. The `slot` tells the client its
     /// shape.
@@ -273,7 +275,7 @@ pub struct UiEntry {
 
 /// The full UI state the dashboard polls each tick. Bounded and small, so it is
 /// sent whole rather than incrementally (verdict: no since_seq/tombstones).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiSnapshot {
     pub entries: Vec<UiEntry>,
     pub notifications: Vec<Notification>,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,6 +10,8 @@ pub mod dialogs;
 pub mod diff;
 pub(crate) mod home;
 #[cfg(feature = "serve")]
+pub(crate) mod plugin_ui;
+#[cfg(feature = "serve")]
 pub(crate) mod remote_home;
 pub(crate) mod responsive;
 mod restart_poller;

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -1,0 +1,230 @@
+//! Pure selectors for rendering the daemon's plugin UI-state snapshot in the
+//! native TUI (#2402). Mirrors the web selectors in `web/src/lib/pluginUi.ts`,
+//! narrowed to what a terminal can render: the structured view shows
+//! `StatusBar` (global) and `DetailBadge` (per-session) text, tone-colored,
+//! plus `Notification` toasts. Icons, tooltips, hrefs, and the
+//! `Card`/`Pane`/`RowBadge`/`RowColumn`/`SortKey`/`FilterFacet` slots have no
+//! TUI surface here and are ignored.
+//!
+//! Kept side-effect-free so the render layer can borrow the snapshot and so the
+//! filtering / tone-mapping logic is unit-testable without a daemon.
+
+use aoe_plugin_api::UiSlot;
+use ratatui::style::{Color, Style};
+
+use crate::plugin::ui_state::{Notification, Tone, UiEntry, UiSnapshot};
+use crate::tui::styles::Theme;
+
+/// Global entries for `slot`: those a plugin pushed without a `session_id`.
+pub fn global_entries(snapshot: &UiSnapshot, slot: UiSlot) -> impl Iterator<Item = &UiEntry> {
+    snapshot
+        .entries
+        .iter()
+        .filter(move |e| e.slot == slot && e.session_id.is_none())
+}
+
+/// Per-session entries for `slot` whose `session_id` matches exactly. The
+/// exact match is a tearing guard: a snapshot can momentarily carry entries
+/// for a session other than the one on screen, and showing those would
+/// mislabel another session's state as this one's.
+pub fn session_entries<'a>(
+    snapshot: &'a UiSnapshot,
+    slot: UiSlot,
+    session_id: &'a str,
+) -> impl Iterator<Item = &'a UiEntry> {
+    snapshot
+        .entries
+        .iter()
+        .filter(move |e| e.slot == slot && e.session_id.as_deref() == Some(session_id))
+}
+
+/// The renderable `text` of a `StatusBar` / `DetailBadge` entry, if present
+/// and a non-empty string. Defensive: the daemon validates payloads, but a
+/// malformed or schema-skewed entry must not panic the renderer.
+pub fn entry_text(entry: &UiEntry) -> Option<&str> {
+    entry
+        .payload
+        .get("text")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+/// The entry's tone, if it carries a valid one.
+pub fn entry_tone(entry: &UiEntry) -> Option<Tone> {
+    entry
+        .payload
+        .get("tone")
+        .and_then(|v| serde_json::from_value::<Tone>(v.clone()).ok())
+}
+
+/// Map a tone to a foreground style against the active theme. `None` (no tone)
+/// renders neutral. Reuses existing theme status colors rather than inventing
+/// new fields, matching how the home view tones session rows.
+pub fn tone_style(tone: Option<Tone>, theme: &Theme) -> Style {
+    let color = tone_color(tone, theme);
+    Style::default().fg(color)
+}
+
+fn tone_color(tone: Option<Tone>, theme: &Theme) -> Color {
+    match tone {
+        None | Some(Tone::Neutral) => theme.dimmed,
+        Some(Tone::Info) => theme.accent,
+        Some(Tone::Success) => theme.running,
+        Some(Tone::Warn) => theme.waiting,
+        Some(Tone::Danger) => theme.error,
+    }
+}
+
+/// The highest notification seq in the snapshot, or 0 when there are none.
+/// Used to initialize the "already seen" watermark so notifications that
+/// predate opening the view do not toast on first load.
+pub fn max_notification_seq(snapshot: &UiSnapshot) -> u64 {
+    snapshot
+        .notifications
+        .iter()
+        .map(|n| n.seq)
+        .max()
+        .unwrap_or(0)
+}
+
+/// Notifications newer than `since_seq` that target this session (global ones,
+/// `session_id == None`, always count), in ascending seq order so they toast
+/// in the order the plugin posted them.
+pub fn new_notifications<'a>(
+    snapshot: &'a UiSnapshot,
+    since_seq: u64,
+    session_id: &str,
+) -> Vec<&'a Notification> {
+    let mut out: Vec<&Notification> = snapshot
+        .notifications
+        .iter()
+        .filter(|n| n.seq > since_seq)
+        .filter(|n| {
+            n.session_id.as_deref().is_none() || n.session_id.as_deref() == Some(session_id)
+        })
+        .collect();
+    out.sort_by_key(|n| n.seq);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn snapshot(entries: serde_json::Value, notifications: serde_json::Value) -> UiSnapshot {
+        serde_json::from_value(json!({
+            "entries": entries,
+            "notifications": notifications,
+        }))
+        .expect("snapshot deserializes")
+    }
+
+    #[test]
+    fn deserializes_wire_shape_with_omitted_optionals() {
+        // session_id / body omitted on the wire (skip_serializing_if) must
+        // still decode, not error.
+        let snap = snapshot(
+            json!([{
+                "plugin_id": "p",
+                "slot": "status-bar",
+                "id": "x",
+                "payload": {"text": "ok", "tone": "success"}
+            }]),
+            json!([{"seq": 1, "plugin_id": "p", "tone": "info", "title": "hi"}]),
+        );
+        assert_eq!(snap.entries.len(), 1);
+        assert!(snap.entries[0].session_id.is_none());
+        assert!(snap.notifications[0].body.is_none());
+    }
+
+    #[test]
+    fn global_entries_exclude_per_session() {
+        let snap = snapshot(
+            json!([
+                {"plugin_id": "p", "slot": "status-bar", "id": "g", "payload": {"text": "global"}},
+                {"plugin_id": "p", "slot": "status-bar", "id": "s", "session_id": "sess-1", "payload": {"text": "scoped"}}
+            ]),
+            json!([]),
+        );
+        let got: Vec<&str> = global_entries(&snap, UiSlot::StatusBar)
+            .filter_map(entry_text)
+            .collect();
+        assert_eq!(got, vec!["global"]);
+    }
+
+    #[test]
+    fn session_entries_require_exact_match() {
+        let snap = snapshot(
+            json!([
+                {"plugin_id": "p", "slot": "detail-badge", "id": "a", "session_id": "sess-1", "payload": {"text": "mine"}},
+                {"plugin_id": "p", "slot": "detail-badge", "id": "b", "session_id": "sess-2", "payload": {"text": "other"}},
+                {"plugin_id": "p", "slot": "detail-badge", "id": "c", "payload": {"text": "no-session"}}
+            ]),
+            json!([]),
+        );
+        let got: Vec<&str> = session_entries(&snap, UiSlot::DetailBadge, "sess-1")
+            .filter_map(entry_text)
+            .collect();
+        assert_eq!(got, vec!["mine"]);
+    }
+
+    #[test]
+    fn entry_text_ignores_missing_blank_or_nonstring() {
+        let snap = snapshot(
+            json!([
+                {"plugin_id": "p", "slot": "status-bar", "id": "1", "payload": {"text": "   "}},
+                {"plugin_id": "p", "slot": "status-bar", "id": "2", "payload": {"text": 42}},
+                {"plugin_id": "p", "slot": "status-bar", "id": "3", "payload": {}}
+            ]),
+            json!([]),
+        );
+        assert_eq!(global_entries(&snap, UiSlot::StatusBar).count(), 3);
+        assert_eq!(
+            global_entries(&snap, UiSlot::StatusBar)
+                .filter_map(entry_text)
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn entry_tone_parses_valid_and_drops_invalid() {
+        let snap = snapshot(
+            json!([
+                {"plugin_id": "p", "slot": "status-bar", "id": "1", "payload": {"text": "a", "tone": "danger"}},
+                {"plugin_id": "p", "slot": "status-bar", "id": "2", "payload": {"text": "b", "tone": "chartreuse"}},
+                {"plugin_id": "p", "slot": "status-bar", "id": "3", "payload": {"text": "c"}}
+            ]),
+            json!([]),
+        );
+        let tones: Vec<Option<Tone>> = snap.entries.iter().map(entry_tone).collect();
+        assert_eq!(tones, vec![Some(Tone::Danger), None, None]);
+    }
+
+    #[test]
+    fn new_notifications_filters_by_seq_and_session_in_order() {
+        let snap = snapshot(
+            json!([]),
+            json!([
+                {"seq": 1, "plugin_id": "p", "tone": "info", "title": "old"},
+                {"seq": 3, "plugin_id": "p", "tone": "info", "title": "global-new"},
+                {"seq": 2, "plugin_id": "p", "tone": "info", "title": "mine", "session_id": "sess-1"},
+                {"seq": 4, "plugin_id": "p", "tone": "info", "title": "other", "session_id": "sess-2"}
+            ]),
+        );
+        let titles: Vec<&str> = new_notifications(&snap, 1, "sess-1")
+            .iter()
+            .map(|n| n.title.as_str())
+            .collect();
+        // seq>1, global or sess-1, ascending: seq 2 (mine) then seq 3 (global).
+        assert_eq!(titles, vec!["mine", "global-new"]);
+    }
+
+    #[test]
+    fn max_seq_handles_empty() {
+        let snap = snapshot(json!([]), json!([]));
+        assert_eq!(max_notification_seq(&snap), 0);
+    }
+}

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -35,6 +35,7 @@ use crate::acp::client::{
 };
 use crate::acp::elicitations::ElicitationResolution;
 use crate::acp::protocol::ApprovalDecisionWire;
+use crate::plugin::ui_state::{Tone, UiSnapshot};
 use crate::session::config::{resolve_theme_name, resolve_theme_palette_mode};
 use crate::tui::styles::Theme;
 
@@ -44,6 +45,11 @@ use crate::tui::styles::Theme;
 const REDRAW_INTERVAL: Duration = Duration::from_millis(120);
 /// Toasts auto-clear after this long.
 const TOAST_TTL: Duration = Duration::from_secs(4);
+/// How often to poll the daemon's plugin UI-state snapshot (#2402). Matches
+/// the web dashboard's cadence. The fetch runs on its own task so a slow or
+/// unreachable daemon never blocks the event loop on the HTTP client's
+/// 15-second timeout.
+const PLUGIN_UI_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 /// Set up an alternate-screen terminal, run the structured view against
 /// the given session, and tear it back down on exit. Used by the
@@ -232,6 +238,34 @@ pub async fn run_for_endpoint(
     let mut redraw_ticker = tokio::time::interval(REDRAW_INTERVAL);
     redraw_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    // Poll the daemon's plugin UI-state on its own task and stream snapshots
+    // back over a channel, so a slow daemon stalls neither input nor render.
+    // The task exits once the view returns and drops the receiver.
+    let (plugin_tx, mut plugin_rx) = tokio::sync::mpsc::channel::<UiSnapshot>(8);
+    {
+        let http = state.http.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(PLUGIN_UI_POLL_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                match http.plugin_ui_state().await {
+                    Ok(snapshot) => {
+                        if plugin_tx.send(snapshot).await.is_err() {
+                            break; // view exited; receiver gone.
+                        }
+                    }
+                    // Transient or older-daemon-without-the-endpoint: keep the
+                    // last good snapshot and retry on the next tick rather than
+                    // toasting repeatedly.
+                    Err(e) => {
+                        tracing::debug!(target: "acp.tui", "plugin ui-state poll failed: {e}");
+                    }
+                }
+            }
+        });
+    }
+
     loop {
         tokio::select! {
             biased;
@@ -338,6 +372,11 @@ pub async fn run_for_endpoint(
                     }
                 }
             }
+            Some(snapshot) = plugin_rx.recv() => {
+                state.ingest_plugin_ui(snapshot);
+                drain_plugin_toast(&mut state, &mut toast_deadline);
+                redraw(terminal, theme, &state)?;
+            }
             _ = redraw_ticker.tick() => {
                 let now = Instant::now();
                 if let Some(deadline) = toast_deadline {
@@ -346,10 +385,33 @@ pub async fn run_for_endpoint(
                         toast_deadline = None;
                     }
                 }
+                // A freed slot lets the next buffered plugin notification show.
+                drain_plugin_toast(&mut state, &mut toast_deadline);
                 redraw(terminal, theme, &state)?;
             }
         }
     }
+}
+
+/// Show the next buffered plugin notification as a toast, but only when no
+/// toast is currently up, so app toasts (errors, send confirmations) are not
+/// pre-empted and queued notifications show one at a time.
+fn drain_plugin_toast(state: &mut StructuredViewState, toast_deadline: &mut Option<Instant>) {
+    if state.toast.is_some() {
+        return;
+    }
+    let Some(n) = state.next_plugin_toast() else {
+        return;
+    };
+    let kind = match n.tone {
+        Tone::Warn | Tone::Danger => ToastKind::Error,
+        _ => ToastKind::Info,
+    };
+    let text = match &n.body {
+        Some(body) => format!("{}: {body}", n.title),
+        None => n.title.clone(),
+    };
+    set_toast(state, toast_deadline, text, kind);
 }
 
 async fn handle_terminal_event(

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -16,10 +16,13 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wr
 use ratatui::Frame;
 use similar::{ChangeTag, TextDiff};
 
+use aoe_plugin_api::UiSlot;
+
 use super::input::Focus;
 use super::reducer::{AcpTranscript, ActivityRow, NoteKind, ToolCallRow};
 use super::state::{FileIndex, StructuredViewState};
 use crate::acp::approvals::ApprovalDecision;
+use crate::tui::plugin_ui;
 use crate::tui::styles::Theme;
 
 pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
@@ -407,6 +410,19 @@ fn render_status(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structure
             ),
             Style::default().fg(theme.error),
         ));
+    }
+    // Plugin host-rendered slots (#2402): global status-bar segments and this
+    // session's detail badges, tone-colored. Icons / tooltips / hrefs have no
+    // terminal surface and are dropped; malformed entries are skipped.
+    for entry in plugin_ui::global_entries(&state.plugin_ui, UiSlot::StatusBar).chain(
+        plugin_ui::session_entries(&state.plugin_ui, UiSlot::DetailBadge, &state.session_id),
+    ) {
+        if let Some(text) = plugin_ui::entry_text(entry) {
+            spans.push(Span::styled(
+                format!(" {text} "),
+                plugin_ui::tone_style(plugin_ui::entry_tone(entry), theme),
+            ));
+        }
     }
     if spans.is_empty() {
         // Footer help when nothing else is going on.

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -4,6 +4,8 @@
 //! happen from [`super::mod`]'s async loop; this struct stays a plain
 //! POD so the render layer can borrow it freely.
 
+use std::collections::VecDeque;
+
 use ratatui_textarea::TextArea;
 
 use super::input::Focus;
@@ -12,7 +14,15 @@ use super::reducer::AcpTranscript;
 use super::slash;
 use crate::acp::client::{DaemonEndpoint, HttpClient, WsHandle};
 use crate::acp::state::AvailableCommand;
+use crate::plugin::ui_state::{Notification, UiSnapshot};
 use crate::session::config::QueueDrainMode;
+use crate::tui::plugin_ui;
+
+/// Most plugin notifications buffered locally awaiting a free toast slot. The
+/// daemon already bounds its notification ring; this is a second guard so a
+/// burst can't grow the view's memory, and old un-shown toasts drop rather
+/// than the newest.
+const MAX_PENDING_PLUGIN_TOASTS: usize = 20;
 
 pub struct StructuredViewState {
     pub session_id: String,
@@ -68,6 +78,30 @@ pub struct StructuredViewState {
     /// Active ArrowUp/ArrowDown queue-recall browse, or `None` when the
     /// composer is in its normal typing mode. See [`RecallState`].
     pub recall: Option<RecallState>,
+    /// Latest plugin UI-state snapshot polled from the daemon (#2402). Empty
+    /// until the first poll lands; the status line renders the
+    /// TUI-applicable slots (global `StatusBar`, this session's
+    /// `DetailBadge`) from it.
+    pub plugin_ui: UiSnapshot,
+    /// Notification bookkeeping so each `ui.notify` toasts once. See
+    /// [`PluginNotifyState`].
+    pub plugin_notify: PluginNotifyState,
+}
+
+/// Tracks which plugin notifications have been shown and buffers any awaiting
+/// a free toast slot, so a poll that returns several new notifications shows
+/// them in turn instead of clobbering the single-slot banner down to the last.
+#[derive(Debug, Default)]
+pub struct PluginNotifyState {
+    /// Highest notification seq already accounted for. Notifications at or
+    /// below this are not re-toasted.
+    pub last_seen_seq: u64,
+    /// False until the first snapshot establishes the baseline. The first
+    /// snapshot only sets `last_seen_seq` (pre-existing notifications must not
+    /// toast on open); subsequent ones enqueue what is genuinely new.
+    pub initialized: bool,
+    /// Notifications waiting to be shown, oldest first.
+    pub pending: VecDeque<Notification>,
 }
 
 /// In-progress shell-history-style browse of the prompt queue. The user
@@ -147,7 +181,44 @@ impl StructuredViewState {
             mention: None,
             dismissed_mention: None,
             recall: None,
+            plugin_ui: UiSnapshot {
+                entries: Vec::new(),
+                notifications: Vec::new(),
+            },
+            plugin_notify: PluginNotifyState::default(),
         }
+    }
+
+    /// Fold a freshly-polled plugin UI snapshot into state: store it for the
+    /// renderer and enqueue any genuinely-new notifications for this session
+    /// as toasts. The first snapshot only baselines the seq watermark (so
+    /// notifications that predate opening the view stay silent); a snapshot
+    /// whose max seq regressed below the watermark is treated as a daemon
+    /// restart (seq ring reset) and re-baselines without toasting.
+    pub fn ingest_plugin_ui(&mut self, snapshot: UiSnapshot) {
+        let max_seq = plugin_ui::max_notification_seq(&snapshot);
+        if !self.plugin_notify.initialized || max_seq < self.plugin_notify.last_seen_seq {
+            self.plugin_notify.last_seen_seq = max_seq;
+            self.plugin_notify.initialized = true;
+        } else {
+            for n in plugin_ui::new_notifications(
+                &snapshot,
+                self.plugin_notify.last_seen_seq,
+                &self.session_id,
+            ) {
+                self.plugin_notify.pending.push_back(n.clone());
+                while self.plugin_notify.pending.len() > MAX_PENDING_PLUGIN_TOASTS {
+                    self.plugin_notify.pending.pop_front();
+                }
+            }
+            self.plugin_notify.last_seen_seq = max_seq;
+        }
+        self.plugin_ui = snapshot;
+    }
+
+    /// Pop the next buffered plugin notification to show, if any.
+    pub fn next_plugin_toast(&mut self) -> Option<Notification> {
+        self.plugin_notify.pending.pop_front()
     }
 
     /// Whether a fresh Enter should park in the queue rather than send
@@ -636,5 +707,79 @@ mod tests {
         state.transcript.available_commands = vec![cmd("compact")];
         state.reconcile_slash_selection();
         assert_eq!(state.slash_selected, 0);
+    }
+
+    fn notify_snapshot(notifications: serde_json::Value) -> UiSnapshot {
+        serde_json::from_value(serde_json::json!({
+            "entries": [],
+            "notifications": notifications,
+        }))
+        .expect("snapshot deserializes")
+    }
+
+    #[test]
+    fn first_snapshot_baselines_without_toasting() {
+        // test_state uses session "s-1".
+        let mut state = test_state(None);
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([
+            {"seq": 5, "plugin_id": "p", "tone": "info", "title": "old"}
+        ])));
+        assert!(
+            state.next_plugin_toast().is_none(),
+            "pre-open notifications stay silent"
+        );
+        assert_eq!(state.plugin_notify.last_seen_seq, 5);
+    }
+
+    #[test]
+    fn later_snapshot_enqueues_only_new_matching_once() {
+        let mut state = test_state(None);
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([
+            {"seq": 1, "plugin_id": "p", "tone": "info", "title": "old"}
+        ])));
+        // seq 2 (global) and seq 3 (this session) are new; seq 4 targets
+        // another session and must not toast here.
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([
+            {"seq": 1, "plugin_id": "p", "tone": "info", "title": "old"},
+            {"seq": 2, "plugin_id": "p", "tone": "info", "title": "global"},
+            {"seq": 3, "plugin_id": "p", "tone": "warn", "title": "mine", "session_id": "s-1"},
+            {"seq": 4, "plugin_id": "p", "tone": "info", "title": "other", "session_id": "s-2"}
+        ])));
+        assert_eq!(state.next_plugin_toast().unwrap().title, "global");
+        assert_eq!(state.next_plugin_toast().unwrap().title, "mine");
+        assert!(state.next_plugin_toast().is_none());
+
+        // Re-polling the same snapshot enqueues nothing new.
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([
+            {"seq": 4, "plugin_id": "p", "tone": "info", "title": "other", "session_id": "s-2"}
+        ])));
+        assert!(state.next_plugin_toast().is_none());
+    }
+
+    #[test]
+    fn pending_queue_is_bounded_dropping_oldest() {
+        let mut state = test_state(None);
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([])));
+        let many: Vec<serde_json::Value> = (1..=MAX_PENDING_PLUGIN_TOASTS as u64 + 5)
+            .map(|seq| serde_json::json!({"seq": seq, "plugin_id": "p", "tone": "info", "title": format!("n{seq}")}))
+            .collect();
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!(many)));
+        assert_eq!(state.plugin_notify.pending.len(), MAX_PENDING_PLUGIN_TOASTS);
+        // Oldest dropped: the front is n6, not n1.
+        assert_eq!(state.next_plugin_toast().unwrap().title, "n6");
+    }
+
+    #[test]
+    fn seq_rollback_rebaselines_without_toasting() {
+        let mut state = test_state(None);
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([
+            {"seq": 50, "plugin_id": "p", "tone": "info", "title": "high"}
+        ])));
+        // Daemon restarts: seq ring resets, max seq drops below the watermark.
+        state.ingest_plugin_ui(notify_snapshot(serde_json::json!([
+            {"seq": 1, "plugin_id": "p", "tone": "info", "title": "fresh"}
+        ])));
+        assert!(state.next_plugin_toast().is_none());
+        assert_eq!(state.plugin_notify.last_seen_seq, 1);
     }
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #2366 / #2405, which rendered the plugin UI-state slots on the web dashboard only. The native TUI was deferred because the standalone home view reads local session storage and never talks to the `aoe serve` daemon, where the plugin host and its UI-state store live.

This renders the daemon's plugin UI-state snapshot (`GET /api/plugins/ui-state`) in the **structured-view** TUI, which already holds a daemon `HttpClient`, a session id, a status line, and a toast banner. The backend and endpoint from #2366 are reused as-is; this is rendering only.

What lands:
- The structured view polls the snapshot on a 3-second background task streamed over a channel, so a slow or unreachable daemon never blocks input or render.
- Global `status-bar` segments and the open session's `detail-badge` entries render tone-colored in the status line (text and tone only; a per-session tearing guard keeps another session's badges from showing here).
- `ui.notify` notifications surface as toasts through the existing single-slot banner, fed by a small bounded queue so a burst shows one at a time rather than collapsing to the last. Notifications that predate opening the view stay silent, each shows once (seq-deduped), and a seq rollback (daemon restart) re-baselines without spurious toasts.

Out of scope, as agreed in the design pass: the remote-home picker (no recurring poll, so badges would go stale and mislead) and the standalone home screen (no daemon link). Icons, tooltips, hrefs, and the `card` / `pane` / `row-badge` / `row-column` / `sort-key` / `filter-facet` slots have no structured-view surface. These are noted in the plugin-system internals doc as follow-ups.

Closes #2402

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run a daemon with a plugin that pushes a `status-bar` entry, attach the structured view (`aoe acp attach <id>`), and confirm a tone-colored segment appears in the status line.
- [ ] Push a `detail-badge` for the attached session and confirm it shows; push one for a different session and confirm it does NOT show in this view.
- [ ] Have the plugin post a `ui.notify` and confirm it toasts once, and does not re-toast on later polls.
- [ ] Post several notifications in quick succession and confirm they show one at a time rather than only the last.
- [ ] With notifications already present before attaching, confirm none toast on first open.
- [ ] Point the view at a slow or unreachable daemon and confirm typing and redraw stay responsive (no freeze on the HTTP timeout).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI-only Rust; the web dashboard is untouched)

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the pure logic (entry filtering with the per-session tearing guard, tone mapping, notification seq dedup, the bounded toast queue, pre-open suppression, and seq-rollback re-baselining) is covered by unit tests in `src/tui/plugin_ui.rs` and `src/tui/structured_view/state.rs`. A full e2e would need a live daemon plus a plugin worker pushing UI-state over the host RPCs; that harness is a reasonable follow-up rather than a blocker here.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction; the plan was pressure-tested with a multi-model debate. I made the scope and design calls (structured-view-only, bounded toast queue, background poll) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785088242&installation_id=139138837&pr_number=2447&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2447&signature=f4d4485666c9312efa7fc57b6c4674122af6595d5784d76b4a84e70133f9cb70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change brings plugin-provided UI content into the structured-view TUI.

### What changed
- The structured view now polls the daemon for the plugin UI-state snapshot in the background (every ~3 seconds) so the UI stays responsive even if the daemon is slow or unreachable.
- The status line is extended to render supported plugin slots:
  - global `status-bar` segments
  - session-specific `detail-badge` entries (from the currently open session only), with tone-based coloring
- Plugin `ui.notify` notifications are surfaced as in-app toasts using a bounded queue so messages appear one at a time, suppressing notifications that existed before the view opened and re-baselining when the notification sequence rolls back (e.g., daemon restart).
- The shared data model and endpoint support were added so the TUI can decode the same plugin snapshot shape as the web side.
- Documentation was updated to clarify the host-rendered UI-slot model and which slot subsets the structured-view TUI renders (terminal-applicable subset only).

### What was added
- Daemon-wide HTTP support for fetching `GET /api/plugins/ui-state`.
- A new TUI-focused “plugin UI” helper module for selecting/filtering snapshot entries, extracting display text/tone, and ordering notifications.
- Structured-view state and logic to ingest snapshots, suppress duplicates, cap pending notifications, and drive toast display as the UI redraws.

### Potential follow-ups
- Rendering remains limited to the structured-view subset; other slot types and non-daemon/standalone surfaces are still deferred (e.g., icons/tooltips/hrefs and other slot categories not yet wired into structured view).

### Benefits
- Plugin UI is now visible in the terminal experience (not just the web dashboard).
- Polling and queued-toasts design prevents plugin rendering and daemon hiccups from blocking input or redraws.
- Notifications are delivered in a controlled, readable way without spamming older messages after opening the view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->