### PR TITLE
fix(hooks): recover Claude session to Idle after an Esc interrupt

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -95,6 +95,13 @@ pub fn detect_status_from_content(content: &str, tool: &str) -> Status {
 /// reduced-motion mode renders a static `●`.
 const CLAUDE_SPINNER_CHARS: &[char] = &['·', '✢', '✳', '✶', '✻', '✽', '*', '●'];
 
+/// The banner Claude renders after the user cancels a turn with Esc:
+/// `⎿  Interrupted · What should Claude do instead?`. We key on the
+/// distinctive tail so a differently rendered separator doesn't break the
+/// match. This is the positive signal that an interrupted turn has parked at
+/// the prompt; see `reconcile_claude_hook_status`.
+const CLAUDE_INTERRUPT_MARKER: &str = "what should claude do instead";
+
 /// Claude Code status is primarily detected via hooks (file-based) installed
 /// in `~/.claude/settings.json`. When hooks aren't reachable (first few
 /// seconds before a hook fires, custom `--cmd` wrappers, `docker exec` into
@@ -132,21 +139,31 @@ pub fn detect_claude_status(content: &str) -> Status {
         return Status::Waiting;
     }
 
-    if recent_lower.contains("esc to interrupt") || recent_lower.contains("ctrl+c to interrupt") {
+    if claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower) {
         return Status::Running;
-    }
-
-    if has_claude_live_token_counter(&recent_joined) {
-        return Status::Running;
-    }
-
-    for line in &recent {
-        if claude_line_is_active_spinner(line) {
-            return Status::Running;
-        }
     }
 
     Status::Idle
+}
+
+/// True when the recent pane lines show that a turn is actively generating:
+/// the interrupt hint, the live token counter, or the spinner+verb shape.
+/// `recent_joined` and `recent_lower` are the join/lowercased-join of `recent`,
+/// passed in so callers that already computed them don't redo the work.
+fn claude_pane_has_running_signal(
+    recent: &[&str],
+    recent_joined: &str,
+    recent_lower: &str,
+) -> bool {
+    if recent_lower.contains("esc to interrupt") || recent_lower.contains("ctrl+c to interrupt") {
+        return true;
+    }
+    if has_claude_live_token_counter(recent_joined) {
+        return true;
+    }
+    recent
+        .iter()
+        .any(|line| claude_line_is_active_spinner(line))
 }
 
 /// Detect the live token counter Claude Code prints during generation,
@@ -237,16 +254,49 @@ fn claude_pane_has_approval_prompt(raw_content: &str) -> bool {
     claude_has_approval_prompt(&recent, &recent_lower)
 }
 
-/// When Claude's status hook reports Running, the pane can still be parked on a
-/// blocking approval prompt. Claude keeps its live spinner rendered below the
-/// prompt and re-emits running-mapped hook events (`PreToolUse`,
-/// `UserPromptSubmit`) while the prompt is up, so the last hook write stays
-/// `running` even though the agent is blocked on the user. Mirrors
-/// `reconcile_codex_hook_status`: downgrade Running -> Waiting when the pane
-/// shows an approval prompt, otherwise trust the hook. See #1913.
+/// Claude has parked at the prompt after the user cancelled a turn with Esc.
+/// That path fires neither `Stop` nor an `idle_prompt` notification (verified
+/// against Claude Code 2.1.193: the `idle_prompt` timer is armed by turn
+/// completion, and an interrupt produces no completion), so the hook status
+/// file stays on its last `running` write. We require the interrupt banner
+/// *and* the absence of any active-turn signal so that a fresh turn started
+/// right after the interrupt (banner still in scrollback, spinner now showing)
+/// still reads as Running.
+fn claude_pane_shows_interrupted_turn(raw_content: &str) -> bool {
+    let clean = strip_ansi(raw_content);
+    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
+    let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
+    let recent_joined = recent.join("\n");
+    let recent_lower = recent_joined.to_lowercase();
+    recent_lower.contains(CLAUDE_INTERRUPT_MARKER)
+        && !claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower)
+}
+
+/// When Claude's status hook reports Running, the pane is consulted to catch two
+/// cases the hook stream can't express on its own:
+///
+/// 1. A blocking approval prompt: Claude keeps its live spinner rendered below
+///    the prompt and re-emits running-mapped hook events (`PreToolUse`,
+///    `UserPromptSubmit`) while it waits, so the last hook write stays
+///    `running` even though the agent is blocked on the user. Downgrade to
+///    Waiting. See #1913.
+/// 2. An Esc-interrupted turn: cancelling a turn fires no `Stop` and no
+///    `idle_prompt`, so the status file sticks on `running` indefinitely.
+///    Downgrade to Idle when the pane shows the interrupt banner and no
+///    active-turn signal.
+///
+/// Otherwise trust the hook. Mirrors `reconcile_codex_hook_status`'s
+/// positive-evidence approach so an active turn whose pane hasn't rendered a
+/// spinner yet keeps Running rather than flickering Idle.
 pub(crate) fn reconcile_claude_hook_status(hook_status: Status, raw_content: &str) -> Status {
-    if hook_status == Status::Running && claude_pane_has_approval_prompt(raw_content) {
+    if hook_status != Status::Running {
+        return hook_status;
+    }
+    if claude_pane_has_approval_prompt(raw_content) {
         return Status::Waiting;
+    }
+    if claude_pane_shows_interrupted_turn(raw_content) {
+        return Status::Idle;
     }
     hook_status
 }
@@ -1734,6 +1784,49 @@ enter to select · esc to cancel";
         assert_eq!(
             reconcile_claude_hook_status(Status::Idle, "Do you want to proceed?\n1. Yes"),
             Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_idle_on_esc_interrupt() {
+        // The user cancelled a turn with Esc. Claude fires neither Stop nor an
+        // idle_prompt notification, so the hook stream is stuck on its last
+        // `running` write. The pane shows the interrupt banner and the idle
+        // footer with no active-turn signal, so the reconciler must fall to
+        // Idle. ANSI is preserved to exercise the strip path the live capture
+        // goes through.
+        let pane = "\x1b[2m  ⎿  Interrupted · What should Claude do instead?\x1b[0m\n\n\
+\x1b[1m❯ \x1b[0m\n\n  ? for shortcuts · ← for agents";
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Running, pane),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_keeps_running_when_new_turn_follows_interrupt() {
+        // The interrupt banner lingers in scrollback, but the user has already
+        // started another turn (spinner + interrupt hint now showing). The
+        // active-turn signal must win so we don't flicker Idle mid-turn.
+        let pane = "  ⎿  Interrupted · What should Claude do instead?\n\
+● Picking up where we left off\n\
+✶ Herding… (3s · ↓ 42 tokens)\n  esc to interrupt";
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Running, pane),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_trusts_running_without_interrupt_banner() {
+        // No interrupt banner and no active-turn signal yet: the gap right
+        // after UserPromptSubmit before the spinner renders. We trust the
+        // hook's Running rather than flickering Idle on missing pane evidence
+        // (mirrors the conservative codex reconciler).
+        let pane = "❯ \n\n  ? for shortcuts · ← for agents";
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Running, pane),
+            Status::Running
         );
     }
 


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Cancelling a Claude turn with Esc leaves the session stuck showing **Running** in aoe. This downgrades the hook status to **Idle** when the pane shows the interrupt banner.

### Root cause

Claude Code status is hook-driven. When a hook status exists, `update_status` trusts it and returns before the pane-content fallback (`src/session/instance.rs`). The reconciler only ever downgraded Running to Waiting (approval prompts, #1913), never to Idle.

The problem: pressing Esc to interrupt a turn fires no hook at all. `Stop` only fires on normal turn completion, and the `idle_prompt` Notification timer is armed by turn completion, so an interrupt produces neither. Verified empirically against Claude Code 2.1.193:

| Scenario | What fired | Timing |
|---|---|---|
| Normal turn ends, then sit idle | idle_prompt | +60s after Stop |
| Normal turn | UserPromptSubmit, Stop | instant |
| Esc interrupt | UserPromptSubmit only | nothing for 285s |

So the `idle_prompt` backstop added in #2429 does not cover the Esc path. With `read_hook_status` having no staleness check, the status file stays on its last `running` write and the session sticks on Running until the next hook fires.

### Fix

`reconcile_claude_hook_status` now downgrades Running to Idle when the pane shows the interrupt banner (`Interrupted · What should Claude do instead?`) and no active-turn signal (no "esc to interrupt", no live token counter, no spinner). It keeps the existing Running to Waiting downgrade for approval prompts.

It uses the same positive-evidence pattern as the codex reconciler: it requires the banner rather than blindly re-deriving from the pane, so the brief gap right after a prompt submit, before the spinner renders, still trusts the hook's Running and does not flicker Idle.

Caveat worth flagging: this keys on the banner wording, so a future Claude change to that text would silently revert to the old stuck-on-Running behavior (no harm, just no fix). Re-verify the marker on Claude upgrades.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a, internal logic)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test under `tests/e2e/`, because: the change is pure pane-string reconciliation logic with no new TUI rendering or CLI surface. It is covered by in-module unit tests (active turn stays Running, interrupted pane goes Idle, post-submit gap trusts the hook), plus a manual check that ran real ANSI pane captures from a live interrupted Claude session through the actual reconciler (Running pane stays Running, interrupted pane goes Idle).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root cause was found by empirically testing Claude Code's hook behavior in tmux. The fix and tests were written by Claude and verified against real captured panes.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785089451&installation_id=139138837&pr_number=2449&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2449&signature=7f19740572b2358c1060c4ff8e37cd249bde3715f9a099ef3d8238d1e558d12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Claude session status handling so interrupted turns no longer get stuck showing as Running in aoe. The change adds logic to recognize the interrupt banner in the tmux pane and downgrade a stale running state to Idle when the turn was canceled, while keeping the existing behavior for approval prompts and active turns.

The status checks were also reorganized to separate the “still running” signals from the interrupt handling, and tests were added for the new interrupted-turn cases.

Benefits:
- Fixes misleading session status after Esc interruptions
- Keeps active turns from being downgraded too early
- Preserves existing approval-prompt behavior

Technical note:
- `reconcile_claude_hook_status` now uses pane-based evidence to reconcile stale hook state more safely, including a new interrupt-banner matcher and active-turn signal check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->