### PR TITLE
fix(acp): enrich opencode approval context

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -11,7 +11,7 @@
 //! initialize once, create one ACP session, then pump commands from an
 //! mpsc channel into ACP requests until shutdown.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -1477,6 +1477,141 @@ struct ElicitationResolutionMessage {
 }
 
 type PendingResponders = Arc<Mutex<HashMap<Nonce, PendingResponder>>>;
+
+type ToolContextCache = Arc<std::sync::Mutex<ToolCallContextCache>>;
+
+const TOOL_CONTEXT_CACHE_LIMIT: usize = 256;
+
+#[derive(Debug, Default)]
+struct ToolCallContextCache {
+    raw_inputs: HashMap<String, serde_json::Value>,
+    insertion_order: VecDeque<String>,
+}
+
+impl ToolCallContextCache {
+    fn record(&mut self, tool_call_id: String, raw_input: serde_json::Value) {
+        if raw_input_has_no_user_context(&raw_input) {
+            return;
+        }
+        if !self.raw_inputs.contains_key(&tool_call_id) {
+            self.insertion_order.push_back(tool_call_id.clone());
+        }
+        self.raw_inputs.insert(tool_call_id, raw_input);
+        self.enforce_limit();
+    }
+
+    fn get(&self, tool_call_id: &str) -> Option<serde_json::Value> {
+        self.raw_inputs.get(tool_call_id).cloned()
+    }
+
+    fn remove(&mut self, tool_call_id: &str) {
+        self.raw_inputs.remove(tool_call_id);
+    }
+
+    fn enforce_limit(&mut self) {
+        while self.raw_inputs.len() > TOOL_CONTEXT_CACHE_LIMIT {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.raw_inputs.remove(&oldest);
+        }
+    }
+}
+
+fn permission_raw_input_with_context(
+    permission_raw: Option<&serde_json::Value>,
+    cached_raw: Option<&serde_json::Value>,
+) -> Option<serde_json::Value> {
+    let cached_raw =
+        cached_raw.and_then(|cached| (!raw_input_has_no_user_context(cached)).then_some(cached));
+    match (permission_raw, cached_raw) {
+        (Some(permission), Some(cached)) => Some(merge_permission_raw_input(permission, cached)),
+        (Some(permission), None) if permission.is_null() => None,
+        (Some(permission), None) => Some(permission.clone()),
+        (None, Some(cached)) => Some(cached.clone()),
+        (None, None) => None,
+    }
+}
+
+fn merge_permission_raw_input(
+    permission_raw: &serde_json::Value,
+    cached_raw: &serde_json::Value,
+) -> serde_json::Value {
+    if let (serde_json::Value::Object(permission), serde_json::Value::Object(cached)) =
+        (permission_raw, cached_raw)
+    {
+        let mut merged = cached.clone();
+        for (key, value) in permission {
+            merged.insert(key.clone(), value.clone());
+        }
+        return serde_json::Value::Object(merged);
+    }
+
+    if raw_input_has_no_user_context(permission_raw) {
+        cached_raw.clone()
+    } else {
+        permission_raw.clone()
+    }
+}
+
+fn raw_input_has_no_user_context(raw_input: &serde_json::Value) -> bool {
+    match raw_input {
+        serde_json::Value::Null => true,
+        serde_json::Value::Object(map) => map.keys().all(|key| key.starts_with("_aoe_")),
+        _ => false,
+    }
+}
+
+fn update_tool_context_cache(
+    cache: &ToolContextCache,
+    event: &Event,
+    source_update: &SessionUpdate,
+) {
+    match event {
+        Event::ToolCallStarted { tool_call } => {
+            if let Some(raw_input) = raw_input_for_tool_event(source_update, &tool_call.id) {
+                cache
+                    .lock()
+                    .expect("tool context cache mutex poisoned")
+                    .record(tool_call.id.clone(), raw_input);
+            }
+        }
+        Event::ToolCallUpdated { tool_call_id, .. } => {
+            if let Some(raw_input) = raw_input_for_tool_event(source_update, tool_call_id) {
+                cache
+                    .lock()
+                    .expect("tool context cache mutex poisoned")
+                    .record(tool_call_id.clone(), raw_input);
+            }
+        }
+        Event::ToolCallCompleted { tool_call_id, .. } => {
+            cache
+                .lock()
+                .expect("tool context cache mutex poisoned")
+                .remove(tool_call_id);
+        }
+        _ => {}
+    }
+}
+
+fn raw_input_for_tool_event(
+    source_update: &SessionUpdate,
+    tool_call_id: &str,
+) -> Option<serde_json::Value> {
+    match source_update {
+        SessionUpdate::ToolCall(tool_call)
+            if tool_call.tool_call_id.0.to_string() == tool_call_id =>
+        {
+            tool_call.raw_input.clone()
+        }
+        SessionUpdate::ToolCallUpdate(update)
+            if update.tool_call_id.0.to_string() == tool_call_id =>
+        {
+            update.fields.raw_input.clone()
+        }
+        _ => None,
+    }
+}
 
 /// Top-level ACP client. Owns the subprocess lifetime and pumps events
 /// from the connection task.
@@ -4483,6 +4618,10 @@ async fn run_connection_task<W, R>(
     let event_tx_for_block = event_tx.clone();
     let pending_for_perm = pending_responders.clone();
     let pending_for_elicit = pending_responders.clone();
+    let tool_context_cache: ToolContextCache =
+        Arc::new(std::sync::Mutex::new(ToolCallContextCache::default()));
+    let tool_context_cache_for_notif = tool_context_cache.clone();
+    let tool_context_cache_for_perm = tool_context_cache.clone();
     let mut cmd_rx = cmd_rx;
     let session_label_for_log = session_label.clone();
 
@@ -4624,6 +4763,7 @@ async fn run_connection_task<W, R>(
                 let between_prompt_off_protocol =
                     between_prompt_off_protocol_for_notif.clone();
                 let prompt_in_flight = prompt_in_flight_for_notif.clone();
+                let tool_context_cache = tool_context_cache_for_notif.clone();
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
@@ -4740,8 +4880,8 @@ async fn run_connection_task<W, R>(
                             _ => {}
                         }
                     }
-                    let mapped_events =
-                        map_update_to_events(notification.update, profile);
+                    let update_for_tool_context = notification.update.clone();
+                    let mapped_events = map_update_to_events(notification.update, profile);
                     // Deliver lifecycle signals BEFORE publishing the
                     // user-visible event vector. The watchdog uses
                     // ToolStarted / ToolCompleted / WakeupPending /
@@ -4794,6 +4934,11 @@ async fn run_connection_task<W, R>(
                             );
                             continue;
                         }
+                        update_tool_context_cache(
+                            &tool_context_cache,
+                            &event,
+                            &update_for_tool_context,
+                        );
                         if event_tx.send(event).await.is_err() {
                             break;
                         }
@@ -4809,9 +4954,17 @@ async fn run_connection_task<W, R>(
                   _conn| {
                 let event_tx = event_tx_for_perm.clone();
                 let pending = pending_for_perm.clone();
+                let tool_context_cache = tool_context_cache_for_perm.clone();
                 async move {
-                    handle_permission_request(request, responder, event_tx, pending, profile)
-                        .await
+                    handle_permission_request(
+                        request,
+                        responder,
+                        event_tx,
+                        pending,
+                        profile,
+                        tool_context_cache,
+                    )
+                    .await
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -6718,6 +6871,7 @@ async fn handle_permission_request(
     event_tx: mpsc::Sender<Event>,
     pending: PendingResponders,
     profile: &'static agent_profiles::AgentProfile,
+    tool_context_cache: ToolContextCache,
 ) -> agent_client_protocol::Result<()> {
     let enter_ns = enter_timestamp_ns();
     let tool_call_id = request.tool_call.tool_call_id.0.to_string();
@@ -6735,10 +6889,20 @@ async fn handle_permission_request(
         .title
         .clone()
         .unwrap_or_else(|| "tool call".into());
-    // Empty (not the literal "null") when the permission request ships no
-    // raw_input, which Gemini's confirm-required tools routinely do. The
-    // approval card then renders a clean empty-state. See #1713.
-    let args_preview = preview_optional_args(request.tool_call.fields.raw_input.as_ref());
+    let cached_raw_input = tool_context_cache
+        .lock()
+        .expect("tool context cache mutex poisoned")
+        .get(&tool_call_id);
+    // Empty (not the literal "null") when neither the permission request nor a
+    // previously forwarded tool update has raw_input. Gemini's confirm-required
+    // tools routinely do this. See #1713. opencode sometimes sends an
+    // external_directory permission reusing a tool_call_id whose earlier tool
+    // update had the command, so merge that context before emitting events.
+    let enriched_raw_input = permission_raw_input_with_context(
+        request.tool_call.fields.raw_input.as_ref(),
+        cached_raw_input.as_ref(),
+    );
+    let args_preview = preview_optional_args(enriched_raw_input.as_ref());
     let tool_call = ToolCall {
         id: request.tool_call.tool_call_id.0.to_string(),
         name: title,
@@ -8717,6 +8881,91 @@ mod tests {
         assert_eq!(preview_optional_args(Some(&serde_json::Value::Null)), "");
         let obj = serde_json::json!({ "command": "ls" });
         assert_eq!(preview_optional_args(Some(&obj)), r#"{"command":"ls"}"#);
+    }
+
+    #[test]
+    fn permission_raw_input_uses_cached_context_when_request_is_empty() {
+        let cached = serde_json::json!({ "command": "mkdir -p /tmp/opencode", "workdir": "/tmp" });
+        let enriched = permission_raw_input_with_context(None, Some(&cached))
+            .expect("cached context should be used");
+
+        assert_eq!(enriched.get("command"), cached.get("command"));
+        assert_eq!(enriched.get("workdir"), cached.get("workdir"));
+    }
+
+    #[test]
+    fn permission_raw_input_merges_cached_context_without_overwriting_request() {
+        let permission =
+            serde_json::json!({ "filepath": "/tmp/opencode", "command": "permission command" });
+        let cached = serde_json::json!({ "command": "mkdir -p /tmp/opencode", "workdir": "/tmp" });
+        let enriched = permission_raw_input_with_context(Some(&permission), Some(&cached))
+            .expect("non-empty permission args should remain present");
+
+        assert_eq!(enriched.get("command"), permission.get("command"));
+        assert_eq!(enriched.get("filepath"), permission.get("filepath"));
+        assert_eq!(enriched.get("workdir"), cached.get("workdir"));
+    }
+
+    #[test]
+    fn permission_raw_input_preserves_aoe_metadata_when_falling_back() {
+        let permission = serde_json::json!({ "_aoe_title": "external_directory" });
+        let cached = serde_json::json!({ "command": "mkdir -p /tmp/opencode" });
+        let enriched = permission_raw_input_with_context(Some(&permission), Some(&cached))
+            .expect("cached context should enrich bookkeeping-only requests");
+
+        assert_eq!(enriched.get("_aoe_title"), permission.get("_aoe_title"));
+        assert_eq!(enriched.get("command"), cached.get("command"));
+    }
+
+    #[test]
+    fn permission_raw_input_keeps_non_empty_non_object_request() {
+        let permission = serde_json::json!(["already", "specific"]);
+        let cached = serde_json::json!({ "command": "mkdir -p /tmp/opencode" });
+        let enriched = permission_raw_input_with_context(Some(&permission), Some(&cached))
+            .expect("non-empty permission args should remain present");
+
+        assert_eq!(enriched, permission);
+    }
+
+    #[test]
+    fn permission_raw_input_ignores_empty_cached_context() {
+        let cached = serde_json::json!({});
+        let enriched = permission_raw_input_with_context(None, Some(&cached));
+
+        assert!(enriched.is_none());
+    }
+
+    #[test]
+    fn tool_context_cache_ignores_empty_context_entries() {
+        let mut cache = ToolCallContextCache::default();
+        cache.record("tc-1".to_string(), serde_json::json!({}));
+
+        assert!(cache.get("tc-1").is_none());
+    }
+
+    #[test]
+    fn tool_context_cache_removes_completed_entries() {
+        let mut cache = ToolCallContextCache::default();
+        cache.record("tc-1".to_string(), serde_json::json!({ "command": "ls" }));
+        assert!(cache.get("tc-1").is_some());
+
+        cache.remove("tc-1");
+
+        assert!(cache.get("tc-1").is_none());
+    }
+
+    #[test]
+    fn tool_context_cache_enforces_bounded_size() {
+        let mut cache = ToolCallContextCache::default();
+        for idx in 0..=TOOL_CONTEXT_CACHE_LIMIT {
+            cache.record(format!("tc-{idx}"), serde_json::json!({ "idx": idx }));
+        }
+
+        assert_eq!(cache.raw_inputs.len(), TOOL_CONTEXT_CACHE_LIMIT);
+        assert!(cache.get("tc-0").is_none());
+        assert!(cache
+            .get(&format!("tc-{TOOL_CONTEXT_CACHE_LIMIT}"))
+            .is_some());
     }
 
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -1506,6 +1506,7 @@ impl ToolCallContextCache {
 
     fn remove(&mut self, tool_call_id: &str) {
         self.raw_inputs.remove(tool_call_id);
+        self.insertion_order.retain(|id| id != tool_call_id);
     }
 
     fn enforce_limit(&mut self) {
@@ -8952,6 +8953,7 @@ mod tests {
         cache.remove("tc-1");
 
         assert!(cache.get("tc-1").is_none());
+        assert!(!cache.insertion_order.iter().any(|id| id == "tc-1"));
     }
 
     #[test]

--- a/tests/acp_runner_orphan.rs
+++ b/tests/acp_runner_orphan.rs
@@ -19,7 +19,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
-/// App data dir for the debug binary, which uses the `-dev` namespace.
+/// App data dir for the debug binary under this test's env. The runner sees
+/// `XDG_CONFIG_HOME`, so macOS follows the same XDG path as Linux.
 fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
     if cfg!(any(target_os = "linux", target_os = "macos")) {
         xdg.join("agent-of-empires-dev")

--- a/web/src/components/acp/ApprovalCard.test.tsx
+++ b/web/src/components/acp/ApprovalCard.test.tsx
@@ -78,6 +78,26 @@ describe("ApprovalCard (benign)", () => {
     expect(screen.getByText("Deny")).toBeTruthy();
   });
 
+  it("collapses opencode filepath metadata to a path preview", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "external_directory",
+            kind: "other",
+            args_preview: JSON.stringify({ filepath: "/tmp/opencode", parentDir: "/tmp" }),
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.getByText("/tmp/opencode")).toBeTruthy();
+    expect(screen.queryByText("filepath")).toBeNull();
+  });
+
   it("renders the args JSON as a key/value list once expanded", () => {
     const onResolve = vi.fn().mockResolvedValue(undefined);
     render(

--- a/web/src/lib/acpArgs.test.ts
+++ b/web/src/lib/acpArgs.test.ts
@@ -126,6 +126,7 @@ describe("previewFromArgs", () => {
 
   it("falls back to a file path for read/edit shapes", () => {
     expect(previewFromArgs(JSON.stringify({ file_path: "src/a.ts" }))).toBe("src/a.ts");
+    expect(previewFromArgs(JSON.stringify({ filepath: "/tmp/opencode" }))).toBe("/tmp/opencode");
   });
 
   it("surfaces query/pattern and url shapes", () => {

--- a/web/src/lib/acpArgs.ts
+++ b/web/src/lib/acpArgs.ts
@@ -45,7 +45,7 @@ export function previewFromArgs(argsPreview: string): string | null {
   const args = parseJsonObject(argsPreview);
   return pickFirst(
     pickStr(args, "command", "cmd", "args"),
-    pickStr(args, "path", "file_path", "filePath", "filename"),
+    pickStr(args, "path", "file_path", "filePath", "filepath", "filename"),
     pickStr(args, "query", "pattern"),
     pickStr(args, "url"),
     pickStr(args, "_aoe_title"),


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

Fixes opencode `external_directory` approvals that reached AoE with little or no `raw_input` on the permission request itself. The ACP connection now keeps a small bounded cache of useful raw input from the live tool-call events it has already forwarded, keyed by `tool_call_id`, and merges that context into the permission approval before emitting the durable `ApprovalRequested` event.

The merge preserves permission-request fields when both sides provide a value, fills only missing context from the cached tool update, and keeps the existing clean empty-state behavior for tools that truly provide no user-facing arguments. The web approval preview also recognizes opencode's lowercase `filepath` key so filepath-only metadata collapses to a concise path preview instead of exposing raw JSON labels.

During final validation, `tests/acp_runner_orphan.rs` exposed an unrelated deterministic macOS test-helper mismatch: the test sets `XDG_CONFIG_HOME`, but still waited under `$HOME/.agent-of-empires-dev`. That helper now follows the same XDG debug app-dir path as the runner under this test environment.

Closes #1907

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Start an opencode structured-view session in the web dashboard and trigger an `external_directory` approval for a path outside the workspace, for example by asking opencode to create or use `/tmp/opencode`.
- [ ] Confirm the pending approval card shows the relevant path or command context instead of an empty card.
- [ ] Expand the approval details and confirm existing permission metadata is still present when the request provides it.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: targeted Vitest coverage in `web/src/lib/acpArgs.test.ts` and `web/src/components/acp/ApprovalCard.test.tsx` covers this pure approval-preview rendering path; no browser-specific interaction changed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenCode agent powered by gpt-5.5, using the agent-of-empires implementation workflow.

**Any Additional AI Details you'd like to share:**

Investigation, implementation, tests, and PR prose were drafted by the AI agent under user direction. The user made the product decision to open this as ready for review after validation passed.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785090353&installation_id=139138837&pr_number=2450&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2450&signature=0d2d9ae5cbb1cc900b292411b7f01228d849f93dca4ec0a8c4d3d970fd6faf5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves opencode “external_directory” permission approvals by carrying forward useful details from the earlier tool run. When the permission request arrives with empty or incomplete `rawInput`, the UI now shows a meaningful preview (such as the originating filepath like `/tmp/opencode` and related context) instead of only the internal title.

On the backend, the ACP client now keeps a small bounded cache of non-empty `rawInput` snippets keyed by `tool_call_id`. When it emits the durable permission approval, it merges any missing context from the cached tool-call updates into the permission approval—without overwriting fields the permission request already provides.

On the frontend, the approval preview logic now treats opencode’s lowercase `filepath` as a primary “path” field, so filepath-only metadata collapses into a clean path preview rather than showing raw JSON labels.

Regression coverage was added for the preview behavior and for the cache/merge semantics, including cache eviction/removal/bounds behavior. A small macOS test-helper adjustment makes the orphan ACP runner follow the same XDG-based app-dir path as the main runner, keeping the tests deterministic.

Technical note (optional details): adds a per-`tool_call_id` bounded `raw_input` context cache, updates notification→event mapping to populate/clear it from tool lifecycle events, and merges cached context into permission approval arguments; updates `previewFromArgs` to recognize `filepath` alongside existing path aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->