### PR TITLE
docs: fix 16 broken_intra_doc_links warnings

### DIFF
--- a/src/acp/node.rs
+++ b/src/acp/node.rs
@@ -11,7 +11,7 @@
 //! For 5 we have a real `download` function, but it is opt-in: the
 //! caller must explicitly invoke it. Resolving at session-spawn time
 //! returns a typed error if no Node is present, and the CLI surfaces
-//! the doctor's "[!! ] Node runtime missing" message.
+//! the doctor's `[!! ] Node runtime missing` message.
 
 use std::path::{Path, PathBuf};
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -7,13 +7,13 @@
 //! storage, and topic deletion. Events are opaque JSON strings keyed by an
 //! arbitrary `topic` (the partition key), with a caller-assigned monotonic
 //! `seq`. The consumer owns its payload type, its replay semantics, and any
-//! payload-aware queries; it holds the [`Connection`] and threads it plus a
-//! [`Schema`] into these free functions. The dependency arrow runs consumer
+//! payload-aware queries; it holds the [`rusqlite::Connection`] and threads it plus a
+//! [`crate::events::Schema`] into these free functions. The dependency arrow runs consumer
 //! -> here, never the reverse.
 //!
 //! ## On-disk shape
 //!
-//! Two tables per [`Schema`], named `<prefix>_events` and
+//! Two tables per [`crate::events::Schema`], named `<prefix>_events` and
 //! `<prefix>_attachments`. The partition key is physically the `session_id`
 //! column (kept under that name so an existing ACP database loads without a
 //! migration) even though the API speaks of "topics". The payload column is

--- a/src/file_watch.rs
+++ b/src/file_watch.rs
@@ -314,7 +314,7 @@ impl FileWatchService {
     /// Per-process single-instance rule: each process constructs exactly
     /// one live service at bootstrap and threads `Arc<Self>` through every
     /// consumer rather than building its own. Integration tests outside
-    /// the crate go through [`test_support::new_filewatch`] for clarity.
+    /// the crate go through `test_support::new_filewatch` for clarity.
     pub fn new() -> Result<Arc<Self>, WatchError> {
         if std::env::var("AOE_FILE_WATCH").as_deref() == Ok("off") {
             tracing::info!(
@@ -412,10 +412,10 @@ impl FileWatchService {
     /// return). [`Self::notify_local_change`] is silently a no-op: the
     /// dispatcher channel's receiver is dropped at construction so any
     /// `send` Errs, and `dispatcher_dead` is pre-set so the error log path
-    /// short-circuits. Used by [`Storage::new_unwatched`] and as the
+    /// short-circuits. Used by `Storage::new_unwatched` and as the
     /// graceful-degradation fallback when the live constructor fails.
     /// Integration tests outside the crate construct via
-    /// [`Storage::new_unwatched`] or [`test_support::noop_filewatch`].
+    /// `Storage::new_unwatched` or `test_support::noop_filewatch`.
     pub fn noop() -> Arc<Self> {
         let (tokio_tx, tokio_rx) = mpsc::unbounded_channel::<DispatchMsg>();
         // Drop the receiver before returning so any future `tokio_tx.send`

--- a/src/plugin/protocol.rs
+++ b/src/plugin/protocol.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// JSON-RPC error codes. The negative range below `-32000` is reserved by the
-/// spec for implementation-defined server errors; [`FORBIDDEN`] is ours, for a
+/// spec for implementation-defined server errors; [`codes::FORBIDDEN`] is ours, for a
 /// method whose capability the plugin did not declare or was not granted.
 pub mod codes {
     pub const PARSE_ERROR: i64 = -32700;

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -141,7 +141,7 @@ pub fn merge_configs_generic(global: &Config, overrides: &serde_json::Value) -> 
     serde_json::from_value(base).expect("merged config deserializes")
 }
 
-/// Validate Docker volume format (host:container[:options])
+/// Validate Docker volume format (`host:container[:options]`)
 pub fn validate_volume_format(volume: &str) -> Result<(), String> {
     if volume.is_empty() {
         return Err("Volume cannot be empty".to_string());

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1129,7 +1129,7 @@ pub fn execute_hooks_in_container(
 
 /// Resolve `host_hooks.before_start` from global + profile config only.
 ///
-/// Deliberately resolved without repo overrides ([`resolve_config_or_warn`]
+/// Deliberately resolved without repo overrides ([`super::profile_config::resolve_config_or_warn`]
 /// rather than [`resolve_config_with_repo_or_warn`]) so a repo can never
 /// contribute host commands; this is belt-and-suspenders on top of
 /// `host_hooks` being excluded from [`REPO_OVERRIDABLE_SECTIONS`].

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -581,7 +581,7 @@ pub fn build_cli_usage() -> Option<CliUsage> {
 /// Record one CLI subcommand invocation and flush the accumulated `cli_usage`
 /// event if a send is due. Called once per `aoe <subcommand>` run.
 ///
-/// Side-effect-free unless the install is opted in: the [`app_dir_exists`] gate
+/// Side-effect-free unless the install is opted in: the [`crate::session::app_dir_exists`] gate
 /// is a non-creating check, so app-data-free commands (`aoe completion`,
 /// `aoe init`, ...) on a not-opted-in install never materialize the app dir and
 /// keep working in read-only / sandboxed environments. The daily slot is claimed

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -208,7 +208,7 @@ pub fn get_session_info_for_current() -> Option<SessionInfo> {
 }
 
 /// Get formatted status string for the current tmux session.
-/// Returns a plain text string like "aoe: Title | branch | [container]"
+/// Returns a plain text string like `aoe: Title | branch | [container]`
 pub fn get_status_for_current_session() -> Option<String> {
     let info = get_session_info_for_current()?;
 

--- a/src/tui/dialogs/intro.rs
+++ b/src/tui/dialogs/intro.rs
@@ -170,7 +170,7 @@ impl IntroDialog {
     /// True on every page of the wizard so xterm mouse tracking stays
     /// off and the terminal can do native drag-to-select on the docs /
     /// YouTube / Discord URLs (and any other text). The trade is that
-    /// the footer [Skip] / [Back] / [Next →] / [Finish] buttons aren't
+    /// the footer `[Skip]` / `[Back]` / `[Next →]` / `[Finish]` buttons aren't
     /// clickable; navigation is keyboard-only (Enter / ← / Esc), which
     /// the hint on each page advertises.
     pub fn wants_text_selection(&self) -> bool {


### PR DESCRIPTION
## Description

Closes #2419.

Eliminates 16 pre-existing `rustdoc::broken_intra_doc_links` warnings surfaced by `cargo doc --features serve --no-deps`. Pure doc-polish; zero behavior change.

**Category A: display-string brackets mis-parsed (6 warnings)**

Display strings whose `[X]` was read by rustdoc as a broken intra-doc link, wrapped in backticks so they render as code spans:

- `src/acp/node.rs:14`: doctor status token `[!! ]`
- `src/session/profile_config.rs:144`: Docker volume format `host:container[:options]`
- `src/tmux/status_bar.rs:211`: tmux status example `[container]`
- `src/tui/dialogs/intro.rs:173`: intro wizard footer button labels `[Skip]`, `[Back]`, `[Finish]`

**Category B: unresolved intra-doc links (10 warnings)**

Per-site resolution between backticks (when the cross-ref adds no navigation value) and full-path qualification (when the link is useful and resolves):

- `src/file_watch.rs:317,415,418`: refs to `test_support::new_filewatch`, `test_support::noop_filewatch` (gated behind `cfg(any(test, feature = "test-support"))`, `#[doc(hidden)]`) and `Storage::new_unwatched` (different module). Converted to backticks.
- `src/events/mod.rs:10,11,16`: module-level `//!` refs to `Connection` and `Schema`. `Connection` qualified to [`rusqlite::Connection`]; `Schema` (defined in the same module 24 lines below) qualified to [`crate::events::Schema`] (×2), so the link resolves and rustdoc renders a navigable cross-ref consistent with the file's existing `///` intra-doc style.
- `src/plugin/protocol.rs:18`: `[`FORBIDDEN`]` lives in the nested `codes` module. Qualified to `[`codes::FORBIDDEN`]`.
- `src/session/repo_config.rs:1132`: `[`resolve_config_or_warn`]` lives in `super::profile_config`. Qualified to `[`super::profile_config::resolve_config_or_warn`]`.
- `src/telemetry/mod.rs:584`: `[`app_dir_exists`]` lives in `crate::session`. Qualified to `[`crate::session::app_dir_exists`]`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 4.7 (`claude-opus-4-7`) via opencode.

**Any Additional AI Details you'd like to share:**

Triage, per-site resolution choice (backticks vs full-path qualification), edits, and validation commands ran through the agent. Diff inspected before push.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

## How tested

- `cargo doc --features serve --no-deps 2>&1 | grep -c "broken_intra_doc_links"` returns `0` (was 16 on `upstream/main`).
- Total lib-doc warnings: 51 to 35; diff against baseline contains only removals.
- `cargo fmt --all -- --check` clean.
- `cargo build --features serve --lib` clean.
- Diff touches only `///` and `//!` doc comments across 9 files (13 lines changed).

Pre-existing failures on `upstream/main` (commit `aaf91f0b`), unrelated to this PR, surfaced during validation:

- `cargo clippy --features serve --tests --all-targets -- -D warnings`: two `clippy::identity_op` errors inside `#[cfg(test)]` tests at `src/tui/home/input.rs:5549,5557`, introduced by #2425.
- `cargo test --features serve --lib`: 4 environment-dependent failures in `tmux::session::tests` (pane capture / pane-base-index) and `session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt`. Reproduce on a clean checkout of `upstream/main` with the changes stashed.

Activating `RUSTDOCFLAGS=-D warnings` in CI remains a separate follow-up, as documented in #2419.

## Out of scope

- No tests added, removed, or modified.
- No `#[allow(rustdoc::broken_intra_doc_links)]`.
- No code outside `///` / `//!` doc comments.
- No paragraph reflow or doc-comment rewriting beyond the minimum required for warning elimination.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785094459&installation_id=139138837&pr_number=2452&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2452&signature=8dbb05dcf3e45e6a45ec40ab5f3f3910a72a467867b7eeaabb006dd3a92aca68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR cleans up existing Rustdoc warnings by improving documentation formatting and fixing broken links, without changing any runtime behavior.

The main changes are:
- Reformatted doc comments so example text and UI labels are no longer misread as links.
- Fixed doc references by using fully qualified paths where needed.
- Adjusted a few wording/formatting details in module and function docs for consistency.

As a result, the documentation build warnings were reduced from 16 broken intra-doc links to zero, making the docs cleaner and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->