### PR TITLE
fix(session): skip corrupt group rows on load

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -406,7 +406,15 @@ impl Storage {
     /// complete, deduplicated snapshot.
     fn quarantine_corrupt_rows(&self, rows: &[serde_json::Value]) {
         let path = self.sessions_path.with_file_name("sessions.corrupt.jsonl");
+        Self::write_corrupt_rows_quarantine(&path, rows, "session");
+    }
 
+    fn quarantine_corrupt_group_rows(&self, rows: &[serde_json::Value]) {
+        let path = self.sessions_path.with_file_name("groups.corrupt.jsonl");
+        Self::write_corrupt_rows_quarantine(&path, rows, "group");
+    }
+
+    fn write_corrupt_rows_quarantine(path: &Path, rows: &[serde_json::Value], row_kind: &str) {
         let mut buf = String::new();
         for row in rows {
             match serde_json::to_string(row) {
@@ -416,7 +424,8 @@ impl Storage {
                 }
                 Err(e) => tracing::warn!(
                     error = %e,
-                    "failed to serialise corrupt session row for quarantine"
+                    row_kind,
+                    "failed to serialise corrupt row for quarantine"
                 ),
             }
         }
@@ -425,17 +434,16 @@ impl Storage {
         }
 
         // `atomic_write` (not `fs::write`) so the sidecar matches the
-        // durability and privacy guarantees of `sessions.json`: a crash
-        // mid-write cannot tear the only surviving copy of the lost row,
-        // the file lands at 0o600 (it can echo tokens from
-        // `Instance.command`) instead of umask-default 0o644, and the
-        // unlocked, concurrently-reachable `load()` callers collapse to a
-        // benign last-writer-wins instead of interleaving bytes.
-        if let Err(e) = atomic_write(&path, buf.as_bytes()) {
+        // durability and privacy guarantees of the source JSON file: a crash
+        // mid-write cannot tear the only surviving copy of the lost row, the
+        // file lands at 0o600, and concurrently-reachable read callers
+        // collapse to a benign last-writer-wins instead of interleaving bytes.
+        if let Err(e) = atomic_write(path, buf.as_bytes()) {
             tracing::warn!(
                 error = %e,
                 path = %path.display(),
-                "failed to write session quarantine file"
+                row_kind,
+                "failed to write quarantine file"
             );
         }
     }
@@ -449,7 +457,30 @@ impl Storage {
             if content.trim().is_empty() {
                 Vec::new()
             } else {
-                serde_json::from_str(&content)?
+                let rows: Vec<serde_json::Value> = serde_json::from_str(&content)?;
+                let mut groups = Vec::with_capacity(rows.len());
+                let mut corrupt: Vec<serde_json::Value> = Vec::new();
+                for (idx, row) in rows.into_iter().enumerate() {
+                    match <Group as serde::Deserialize>::deserialize(&row) {
+                        Ok(group) => groups.push(group),
+                        Err(e) => {
+                            tracing::warn!(
+                                profile = %self.profile,
+                                row = idx,
+                                error = %e,
+                                path = %groups_path.display(),
+                                "skipping corrupt group row"
+                            );
+                            corrupt.push(row);
+                        }
+                    }
+                }
+
+                if !corrupt.is_empty() {
+                    self.quarantine_corrupt_group_rows(&corrupt);
+                }
+
+                groups
             }
         } else {
             Vec::new()
@@ -1115,6 +1146,119 @@ mod tests {
         assert_eq!(loaded_instances.len(), 1);
         assert_eq!(loaded_instances[0].group_path, "work/projects");
         assert!(!loaded_groups.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_with_groups_skips_corrupt_row_and_quarantines() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        let storage = Storage::new_unwatched("test-groups-corrupt-row")?;
+        fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
+        let expected_instances = [Instance::new("session", "/tmp/session")];
+        fs::write(
+            &storage.sessions_path,
+            serde_json::to_vec_pretty(&expected_instances)?,
+        )?;
+
+        let groups_path = storage.sessions_path.with_file_name("groups.json");
+        let valid = [
+            Group::new("alpha", "work/alpha"),
+            Group::new("beta", "work/beta"),
+        ];
+        let mut rows: Vec<serde_json::Value> = valid
+            .iter()
+            .map(|group| serde_json::to_value(group).unwrap())
+            .collect();
+        rows.insert(1, serde_json::json!({ "name": "corrupt-no-path" }));
+        fs::write(&groups_path, serde_json::to_vec_pretty(&rows)?)?;
+
+        let (instances, groups) = storage.load_with_groups()?;
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].title, "session");
+        assert_eq!(instances[0].project_path, "/tmp/session");
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].name, "alpha");
+        assert_eq!(groups[0].path, "work/alpha");
+        assert_eq!(groups[1].name, "beta");
+        assert_eq!(groups[1].path, "work/beta");
+
+        let quarantine = storage.sessions_path.with_file_name("groups.corrupt.jsonl");
+        assert!(quarantine.exists(), "quarantine sidecar should be created");
+        let q = fs::read_to_string(&quarantine)?;
+        assert_eq!(q.lines().count(), 1, "exactly one row quarantined");
+        assert!(q.contains("corrupt-no-path"), "malformed row is preserved");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&quarantine)?.permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "quarantine sidecar must be owner-only");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_with_groups_repeated_read_overwrites_quarantine() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        let storage = Storage::new_unwatched("test-groups-corrupt-row-repeat")?;
+        fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
+        fs::write(&storage.sessions_path, "[]")?;
+
+        let groups_path = storage.sessions_path.with_file_name("groups.json");
+        let rows = serde_json::json!([
+            Group::new("alpha", "work/alpha"),
+            { "name": "corrupt-no-path" },
+            Group::new("beta", "work/beta")
+        ]);
+        fs::write(&groups_path, serde_json::to_vec_pretty(&rows)?)?;
+
+        assert_eq!(storage.load_with_groups()?.1.len(), 2);
+        let quarantine = storage.sessions_path.with_file_name("groups.corrupt.jsonl");
+        let first = fs::read_to_string(&quarantine)?;
+
+        assert_eq!(storage.load_with_groups()?.1.len(), 2);
+        let second = fs::read_to_string(&quarantine)?;
+        assert_eq!(second, first);
+        assert_eq!(
+            second.lines().count(),
+            1,
+            "repeated load must not duplicate"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_with_groups_top_level_corruption_still_errors() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        let storage = Storage::new_unwatched("test-groups-top-level-corrupt")?;
+        fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
+        fs::write(&storage.sessions_path, "[]")?;
+
+        let groups_path = storage.sessions_path.with_file_name("groups.json");
+        let quarantine = storage.sessions_path.with_file_name("groups.corrupt.jsonl");
+        for bad in [&b"{}"[..], &b"{ this is not valid json ]"[..]] {
+            fs::write(&groups_path, bad)?;
+            assert!(
+                storage.load_with_groups().is_err(),
+                "top-level corruption should still surface as Err"
+            );
+            assert!(
+                !quarantine.exists(),
+                "no quarantine file for top-level corruption"
+            );
+        }
+
         Ok(())
     }
 

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -392,18 +392,6 @@ impl Storage {
         Ok(instances)
     }
 
-    /// Write corrupt session rows to a sibling `sessions.corrupt.jsonl`
-    /// quarantine file (one JSON object per line) for later inspection and
-    /// manual recovery. Best-effort: a failure to write the sidecar is
-    /// logged but never fails the load, since the whole point is to keep the
-    /// surviving sessions reachable.
-    ///
-    /// Truncates rather than appends: `load()` runs on read-only refresh
-    /// paths (TUI reconcile, web list, CLI) that never rewrite
-    /// `sessions.json`, so a persistently corrupt row would otherwise be
-    /// re-appended on every load and grow the sidecar without bound. Each
-    /// load sees the full current corrupt set, so an overwrite is a
-    /// complete, deduplicated snapshot.
     fn quarantine_corrupt_rows(&self, rows: &[serde_json::Value]) {
         let path = self.sessions_path.with_file_name("sessions.corrupt.jsonl");
         Self::write_corrupt_rows_quarantine(&path, rows, "session");
@@ -414,6 +402,18 @@ impl Storage {
         Self::write_corrupt_rows_quarantine(&path, rows, "group");
     }
 
+    /// Write corrupt rows to a sibling quarantine sidecar for later inspection
+    /// and manual recovery. Each line preserves one original JSON value; rows
+    /// are not limited to objects because a malformed element can be any JSON
+    /// value. Best-effort: a failure to write the sidecar is logged but never
+    /// fails the load, since the whole point is to keep surviving sessions and
+    /// groups reachable.
+    ///
+    /// Truncates rather than appends: load paths can run on read-only refresh
+    /// flows (TUI reconcile, web list, CLI) that never rewrite the source JSON,
+    /// so a persistently corrupt row would otherwise be re-appended on every
+    /// load and grow the sidecar without bound. Each load sees the full current
+    /// corrupt set, so an overwrite is a complete, deduplicated snapshot.
     fn write_corrupt_rows_quarantine(path: &Path, rows: &[serde_json::Value], row_kind: &str) {
         let mut buf = String::new();
         for row in rows {
@@ -435,9 +435,10 @@ impl Storage {
 
         // `atomic_write` (not `fs::write`) so the sidecar matches the
         // durability and privacy guarantees of the source JSON file: a crash
-        // mid-write cannot tear the only surviving copy of the lost row, the
-        // file lands at 0o600, and concurrently-reachable read callers
-        // collapse to a benign last-writer-wins instead of interleaving bytes.
+        // mid-write cannot tear the only surviving copy of the lost row, fresh
+        // sidecars land at 0o600 while existing permissions are preserved, and
+        // concurrently-reachable read callers collapse to a benign
+        // last-writer-wins instead of interleaving bytes.
         if let Err(e) = atomic_write(path, buf.as_bytes()) {
             tracing::warn!(
                 error = %e,

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -424,7 +424,7 @@ impl Storage {
                 }
                 Err(e) => tracing::warn!(
                     error = %e,
-                    row_kind,
+                    row_kind = %row_kind,
                     "failed to serialise corrupt row for quarantine"
                 ),
             }
@@ -442,7 +442,7 @@ impl Storage {
             tracing::warn!(
                 error = %e,
                 path = %path.display(),
-                row_kind,
+                row_kind = %row_kind,
                 "failed to write quarantine file"
             );
         }

--- a/src/tui/dialogs/tips.rs
+++ b/src/tui/dialogs/tips.rs
@@ -262,12 +262,11 @@ impl TipsDialog {
             .position(|r| r.width > 0 && r.contains(pos));
         if let Some(vis_idx) = hit {
             match self.visible_rows().get(vis_idx) {
-                Some(Row::Tip(_)) => {
-                    if vis_idx != self.cursor {
-                        self.cursor = vis_idx;
-                        self.mark_current_seen();
-                    }
+                Some(Row::Tip(_)) if vis_idx != self.cursor => {
+                    self.cursor = vis_idx;
+                    self.mark_current_seen();
                 }
+                Some(Row::Tip(_)) => {}
                 Some(Row::SeenHeader) => {
                     self.cursor = vis_idx;
                     self.set_seen_collapsed(!self.seen_collapsed);


### PR DESCRIPTION
## Description
Fixes #2159.

`Storage::load_with_groups()` now mirrors the resilient `Storage::load()` behavior for row-level corruption: it parses `groups.json` as a valid outer array, loads valid `Group` rows, skips malformed rows, logs the skipped row with profile/index/error/path, and writes skipped rows to `groups.corrupt.jsonl` through the same best-effort `atomic_write` snapshot path used by session quarantine.

Top-level invalid or non-array `groups.json` still returns an error and does not create a quarantine sidecar. The write schema and migration behavior are unchanged.

This branch also includes a tiny unrelated clippy cleanup in the tips dialog because the local commit hook runs `cargo clippy -- -D warnings` and rejected the storage commit until that existing warning was fixed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No docs update was needed; this is storage load-path behavior. The screenshot/recording checklist item is intentionally unchecked because this PR has no user-facing UI change; the TUI diff is a mechanical clippy-only match cleanup with no rendering or interaction change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

No UI/e2e coverage is needed for #2159 because the bug fix is pure storage load-path logic covered by in-module storage tests and group persistence integration tests.

## Tests run

- `cargo test --lib test_load_with_groups_skips_corrupt_row_and_quarantines` (red before implementation with `missing field path`, green after)
- `cargo test --lib test_load_with_groups_repeated_read_overwrites_quarantine`
- `cargo test --lib test_load_with_groups_top_level_corruption_still_errors`
- `cargo test --lib test_load_with_groups`
- `cargo test --lib test_load_skips_corrupt_row_and_quarantines`
- `cargo test --lib test_load_top_level_corruption_still_errors`
- `cargo test --lib test_storage_save_and_load_with_groups`
- `cargo test --lib test_storage_groups_file_empty`
- `cargo test --test integration group_persistence`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

Diagnostics note: Rust LSP diagnostics were not available in this session. Serena was indexed as TypeScript-only for this checkout, and targeted diagnostics returned unusably large non-Rust output.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Sisyphus / GPT-5.5 via OhMyOpenCode.

**Any Additional AI Details you'd like to share:**

Used three independent design subagents before implementation and three independent review subagents after the diff, then reconciled their findings before opening this draft PR.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785105707&installation_id=139138837&pr_number=2453&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2453&signature=734dcaa8dc23198af31c8eea693334f53a80aebdafe790a0de9fc7ff71db166b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### What changed
- Made group loading more resilient: a single bad row in `groups.json` no longer fails the whole load.
- Valid group entries are kept, malformed rows are skipped, and skipped rows are saved to a `groups.corrupt.jsonl` sidecar for later inspection.
- Top-level invalid `groups.json` files still fail to load, so file-level corruption is still treated as a hard error.
- Reused the existing corruption-handling flow instead of adding a separate path.
- Included a small cleanup in the tips dialog click handling.

### Benefits
- Prevents one broken group entry from blocking access to all other groups.
- Improves recovery and debugging by preserving bad rows separately.
- Keeps the existing write/migration behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->