### PR TITLE
fix(serve): drop passphrase elevation for plugin pane actions

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -538,8 +538,12 @@ no reply) via `PluginHost::notify_worker`. The worker runs the method (e.g.
 `github.refresh`) and re-pushes its UI state, which the next `ui-state` poll
 renders. The plugin names the `method` in its own block, and the worker is the
 trust boundary: it acts only on methods it implements and ignores the rest (the
-honest-plugin model). The endpoint is gated like other mutations (read-write
-mode plus an elevated session when login is on).
+honest-plugin model). The endpoint is gated on read-write mode only, not on
+passphrase elevation: a pane action mutates no host-managed state (config,
+registry, grants, lockfile) and grants no new host capability, so it does not
+warrant the step-up the way enable/disable does (the worker's own behavior may
+still have plugin-defined side effects). If an action ever needs elevation,
+make it opt-in per action rather than blanket-gating every action.
 
 ### Store and lifecycle (`src/plugin/ui_state.rs`)
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -239,6 +239,11 @@ mod tests {
                     "post_telemetry_structured_interaction",
                 ],
             ),
+            (
+                "api/plugins.rs",
+                include_str!("plugins.rs"),
+                &["invoke_plugin_action"],
+            ),
         ];
 
         let guard_patterns: &[&str] = &[
@@ -286,6 +291,39 @@ mod tests {
             "Read-only audit failed:\n{}",
             missing.join("\n")
         );
+    }
+
+    /// A plugin pane action is forwarded to the worker (the trust boundary)
+    /// and mutates no host-managed state, so it is gated on read-write mode
+    /// only, never on passphrase elevation (#2454). This static check guards
+    /// against a refactor re-introducing the elevation gate on the action
+    /// path and re-breaking the refresh button under login. Same body-boundary
+    /// walk as `every_mutating_handler_has_read_only_guard`.
+    #[test]
+    fn plugin_action_does_not_require_elevation() {
+        let source = include_str!("plugins.rs");
+        let needle = "fn invoke_plugin_action(";
+        let start = source
+            .find(needle)
+            .expect("handler `invoke_plugin_action` not found (rename/refactor?)");
+        let rest = &source[start + needle.len()..];
+        let body_terminators: &[&str] = &["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn "];
+        let end = body_terminators
+            .iter()
+            .filter_map(|t| rest.find(t))
+            .min()
+            .unwrap_or(rest.len());
+        let body = &rest[..end];
+        // `mutation_gate` bundles the elevation check; `is_elevated` /
+        // `elevation_required` would mean elevation was reintroduced inline.
+        for marker in ["mutation_gate", "is_elevated", "elevation_required"] {
+            assert!(
+                !body.contains(marker),
+                "invoke_plugin_action must not elevation-gate (found `{marker}`). \
+                 A pane action mutates no host state; keep the read-only gate only. \
+                 If an action ever needs elevation, make it opt-in per action (#2454)."
+            );
+        }
     }
 
     /// Companion to `every_mutating_handler_has_read_only_guard`: enforce

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -91,14 +91,23 @@ pub struct PluginActionBody {
 /// button) to the plugin's worker as a fire-and-forget JSON-RPC notification.
 /// The worker is the trust boundary: it acts only on methods it implements and
 /// ignores the rest, so this never waits for or returns a worker result.
+///
+/// Gated on read-write mode only, not elevation. Unlike enable/disable, a pane
+/// action does not mutate host-managed state (config, registry, grants,
+/// lockfile) and grants no new host capability, so it does not warrant the
+/// passphrase step-up, the same reasoning as `update_theme` in `system.rs`.
+/// A routine `github.refresh` should not prompt for the passphrase.
 pub async fn invoke_plugin_action(
     State(state): State<std::sync::Arc<AppState>>,
-    session: Option<axum::Extension<AuthenticatedSession>>,
     Path(id): Path<String>,
     Json(body): Json<PluginActionBody>,
 ) -> Response {
-    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
-        return resp;
+    if state.read_only {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            "read_only",
+            "Server is in read-only mode".into(),
+        );
     }
     let Some(host) = state.plugin_host.as_ref() else {
         return error_response(


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

With the dashboard running under login, clicking a plugin pane's action button (for example the GitHub plugin's **refresh**) popped "Confirm passphrase" / "Re-enter the passphrase to continue" instead of just running the action.

`invoke_plugin_action` (`src/server/api/plugins.rs`) ran the same `mutation_gate` as enable/disable, which requires read-write mode AND an elevated session when login is enabled. But a pane action is not a host-state mutation: it is forwarded to the plugin's worker as a fire-and-forget JSON-RPC notification, and the worker is the trust boundary (the honest-plugin model from #2432). It changes no host config, registry, grants, or lockfile and grants no new host capability, so the passphrase step-up is wrong, the same reasoning that already keeps `update_theme` and `mark_web_tour_seen` elevation-free.

This drops the elevation requirement from the action path and keeps only the read-write-mode gate (still a write to the worker, so it stays blocked in read-only mode). `enable/disable` keeps the full `mutation_gate`. Per-action opt-in elevation is deferred: if a future action genuinely needs it, the plugin should declare it in its action block rather than blanket-gating every action.

The cookie auth uses `SameSite=Strict; HttpOnly`, so cross-site requests carry no session and dropping the prompt opens no CSRF surface. No web change is needed: the dashboard's passphrase prompt is driven generically by the fetch interceptor on `403 elevation_required`, which the action endpoint no longer returns.

Two anti-regression guards: `invoke_plugin_action` joins the `every_mutating_handler_has_read_only_guard` source audit (read-only stays enforced), and a new `plugin_action_does_not_require_elevation` source audit fails if a refactor re-introduces elevation on the action path. AppState is too heavy to build in a unit test (tmux runtime, login/token managers, app-data dir), so these mirror the existing static-audit pattern; the read-only runtime path stays covered by `web/tests/live/read-only-mode.spec.ts`.

Closes #2454

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve` with login enabled, install + enable the GitHub plugin, sign in WITHOUT elevating, click the plugin pane's **refresh** action: it runs and the pane updates, with no "Confirm passphrase" prompt.
- [ ] With `aoe serve --read-only`, POST `/api/plugins/{id}/action`: still returns `403 read_only`.
- [ ] Toggle the plugin enable/disable from the web settings under login while non-elevated: still prompts for the passphrase (unchanged).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the change is a backend authorization gate, not a dashboard render/flow. It is pinned by two Rust source-audit tests (`every_mutating_handler_has_read_only_guard`, `plugin_action_does_not_require_elevation`); a full plugin + worker + login Playwright setup would be disproportionate, and the read-only runtime path is already covered by `web/tests/live/read-only-mode.spec.ts`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:** Investigation, plan (cross-checked with a `/debate` between two models), and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and own the testing steps.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785140670&installation_id=139138837&pr_number=2456&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2456&signature=d3f180c87ecb8223772e45329d473154a02fe9d3b24a1f22becf4197cf401d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change stops plugin pane actions from triggering the passphrase prompt during login. Pane actions are now treated as worker notifications, so they only respect read-only mode and no longer require an elevated session.

It also keeps existing enable/disable protections unchanged, and adds coverage to make sure this action path stays blocked in read-only mode but never regains elevation gating.

Benefits:
- Fewer unnecessary login prompts
- Pane actions work as expected in normal read-write sessions
- Better protection against regressions in access control rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->