### PR TITLE
feat(web): drag-and-drop pane reordering and cross-dock move

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -83,6 +83,7 @@ const StructuredView = lazy(() =>
 );
 import { Dock, type PaneDisplay } from "./components/Dock";
 import { BottomDock } from "./components/BottomDock";
+import { PaneDndController } from "./components/PaneDndController";
 import { DiffPane } from "./components/DiffPane";
 import { PairedShellPane } from "./components/PairedTerminal";
 import { BUILTIN_PANES, isTerminalTabId, terminalIndexOf, terminalTabId, type DockLocation } from "./lib/panes";
@@ -370,6 +371,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     closeTab,
     activateTab,
     moveTab,
+    placeTab,
     toggleKind,
     togglePlugin,
     syncPlugins,
@@ -387,17 +389,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     syncPlugins(pluginPanes.map((p) => ({ id: p.id, defaultDock: p.defaultDock })));
   }, [pluginPanes, syncPlugins]);
 
-  const paneDescriptor = (id: string): PaneDisplay => {
-    const plugin = pluginPaneById.get(id);
-    if (plugin) return { title: plugin.title, icon: plugin.icon ?? Puzzle };
-    if (isTerminalTabId(id)) {
-      const idx = terminalIndexOf(id);
-      const term = BUILTIN_PANES.find((p) => p.id === "terminal")!;
-      return { title: idx === 0 ? term.title : `${term.title} ${idx + 1}`, icon: term.icon };
-    }
-    const d = BUILTIN_PANES.find((p) => p.id === id)!;
-    return { title: d.title, icon: d.icon };
-  };
+  const paneDescriptor = useCallback(
+    (id: string): PaneDisplay => {
+      const plugin = pluginPaneById.get(id);
+      if (plugin) return { title: plugin.title, icon: plugin.icon ?? Puzzle };
+      if (isTerminalTabId(id)) {
+        const idx = terminalIndexOf(id);
+        const term = BUILTIN_PANES.find((p) => p.id === "terminal")!;
+        return { title: idx === 0 ? term.title : `${term.title} ${idx + 1}`, icon: term.icon };
+      }
+      const d = BUILTIN_PANES.find((p) => p.id === id)!;
+      return { title: d.title, icon: d.icon };
+    },
+    [pluginPaneById],
+  );
 
   // A persisted tab is visible only if its backing pane currently exists: diff
   // and terminals always do; a plugin tab does only while its plugin is loaded.
@@ -420,6 +425,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const rightTabs = visibleTabs("right");
   const bottomTabs = visibleTabs("bottom");
+  const tabsByDock = useMemo(() => ({ right: rightTabs, bottom: bottomTabs }), [rightTabs, bottomTabs]);
   const rightDockCollapsed = rightTabs.length === 0;
   const terminalOpen = (["right", "bottom"] as DockLocation[]).some((d) =>
     dockTabs(paneLayout, d).some(isTerminalTabId),
@@ -1331,77 +1337,79 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     };
     return (
       <div className="flex-1 flex flex-col min-h-0">
-        <ContentSplit
-          collapsed={rightDockCollapsed}
-          onToggleCollapse={toggleDiff}
-          left={
-            <div className="flex-1 flex flex-col min-h-0 overflow-hidden relative">
-              <div className={selectedFilePath ? "hidden" : "flex-1 flex flex-col min-h-0 overflow-hidden"}>
-                {activeSession?.view === "structured" ? (
-                  <Suspense fallback={<AcpLoadingFallback />}>
-                    <StructuredView
-                      key={activeSessionId}
-                      sessionId={activeSessionId!}
-                      acpWorkerState={activeSession.acp_worker_state ?? "absent"}
-                      tool={activeSession.tool}
-                      archivedAt={activeSession.archived_at ?? null}
-                      snoozedUntil={activeSession.snoozed_until ?? null}
-                      onOpenFileRef={handleOpenFileRef}
-                      fileRefSession={activeSession}
+        <PaneDndController tabsByDock={tabsByDock} descriptorFor={paneDescriptor} onPlaceTab={placeTab}>
+          <ContentSplit
+            collapsed={rightDockCollapsed}
+            onToggleCollapse={toggleDiff}
+            left={
+              <div className="flex-1 flex flex-col min-h-0 overflow-hidden relative">
+                <div className={selectedFilePath ? "hidden" : "flex-1 flex flex-col min-h-0 overflow-hidden"}>
+                  {activeSession?.view === "structured" ? (
+                    <Suspense fallback={<AcpLoadingFallback />}>
+                      <StructuredView
+                        key={activeSessionId}
+                        sessionId={activeSessionId!}
+                        acpWorkerState={activeSession.acp_worker_state ?? "absent"}
+                        tool={activeSession.tool}
+                        archivedAt={activeSession.archived_at ?? null}
+                        snoozedUntil={activeSession.snoozed_until ?? null}
+                        onOpenFileRef={handleOpenFileRef}
+                        fileRefSession={activeSession}
+                      />
+                    </Suspense>
+                  ) : (
+                    <TerminalSessionStack
+                      activeSessionId={activeSessionId!}
+                      sessions={sessions.filter((session) => session.view !== "structured")}
+                      persistent={webSettings.persistentTerminals}
+                      maxPersistentTerminals={webSettings.maxPersistentTerminals}
                     />
-                  </Suspense>
-                ) : (
-                  <TerminalSessionStack
-                    activeSessionId={activeSessionId!}
-                    sessions={sessions.filter((session) => session.view !== "structured")}
-                    persistent={webSettings.persistentTerminals}
-                    maxPersistentTerminals={webSettings.maxPersistentTerminals}
+                  )}
+                </div>
+
+                {selectedFilePath && activeSessionId && (
+                  <DiffFileViewer
+                    sessionId={activeSessionId}
+                    filePath={selectedFilePath}
+                    repoName={selectedRepoName}
+                    targetLine={selectedFileLine}
+                    revision={revision}
+                    onClose={handleCloseFile}
+                    commentsEnabled={commentsEnabled}
+                    commentsStore={diffComments}
                   />
                 )}
               </div>
-
-              {selectedFilePath && activeSessionId && (
-                <DiffFileViewer
-                  sessionId={activeSessionId}
-                  filePath={selectedFilePath}
-                  repoName={selectedRepoName}
-                  targetLine={selectedFileLine}
-                  revision={revision}
-                  onClose={handleCloseFile}
-                  commentsEnabled={commentsEnabled}
-                  commentsStore={diffComments}
+            }
+            right={
+              <div {...tourAnchor(TOUR_ANCHORS.rightPanel)} className="flex min-h-0 min-w-0 flex-1">
+                <Dock
+                  location="right"
+                  tabs={rightTabs}
+                  active={visibleActive("right")}
+                  descriptorFor={paneDescriptor}
+                  renderBody={renderPaneBody}
+                  onActivate={(id) => activateTab("right", id)}
+                  onMove={movePaneAny}
+                  onClose={closePaneAny}
+                  onNewTerminal={serverAbout?.read_only ? undefined : () => addTerminal("right")}
                 />
-              )}
-            </div>
-          }
-          right={
-            <div {...tourAnchor(TOUR_ANCHORS.rightPanel)} className="flex min-h-0 min-w-0 flex-1">
-              <Dock
-                location="right"
-                tabs={rightTabs}
-                active={visibleActive("right")}
-                descriptorFor={paneDescriptor}
-                renderBody={renderPaneBody}
-                onActivate={(id) => activateTab("right", id)}
-                onMove={movePaneAny}
-                onClose={closePaneAny}
-                onNewTerminal={serverAbout?.read_only ? undefined : () => addTerminal("right")}
-              />
-            </div>
-          }
-        />
-        {bottomTabs.length > 0 && (
-          <BottomDock
-            tabs={bottomTabs}
-            active={visibleActive("bottom")}
-            descriptorFor={paneDescriptor}
-            renderBody={renderPaneBody}
-            onActivate={(id) => activateTab("bottom", id)}
-            onMove={movePaneAny}
-            onClose={closePaneAny}
-            onNewTerminal={serverAbout?.read_only ? undefined : () => addTerminal("bottom")}
+              </div>
+            }
           />
-        )}
+          {bottomTabs.length > 0 && (
+            <BottomDock
+              tabs={bottomTabs}
+              active={visibleActive("bottom")}
+              descriptorFor={paneDescriptor}
+              renderBody={renderPaneBody}
+              onActivate={(id) => activateTab("bottom", id)}
+              onMove={movePaneAny}
+              onClose={closePaneAny}
+              onNewTerminal={serverAbout?.read_only ? undefined : () => addTerminal("bottom")}
+            />
+          )}
+        </PaneDndController>
         {sendDialogOpen && commentsEnabled && activeSessionId && (
           <SendCommentsDialog
             sessionId={activeSessionId}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,6 +84,7 @@ const StructuredView = lazy(() =>
 import { Dock, type PaneDisplay } from "./components/Dock";
 import { BottomDock } from "./components/BottomDock";
 import { PaneDndController } from "./components/PaneDndController";
+import { visibleToFullIndex } from "./components/paneDnd";
 import { DiffPane } from "./components/DiffPane";
 import { PairedShellPane } from "./components/PairedTerminal";
 import { BUILTIN_PANES, isTerminalTabId, terminalIndexOf, terminalTabId, type DockLocation } from "./lib/panes";
@@ -471,6 +472,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     [closeTab, activeSessionId],
   );
   const movePaneAny = useCallback((id: string, dock: DockLocation) => moveTab(id, dock), [moveTab]);
+  // The dnd controller works in visible-tab space; map its drop index back to
+  // the full persisted dock list, since a hidden (unloaded) plugin tab still
+  // holds a slot the visible index does not count.
+  const placeVisibleTab = useCallback(
+    (id: string, toDock: DockLocation, visibleIndex: number) => {
+      const fullBase = dockTabs(paneLayout, toDock).filter((tab) => tab !== id);
+      placeTab(id, toDock, visibleToFullIndex(fullBase, visibleIndex, tabAvailable));
+    },
+    [paneLayout, placeTab, tabAvailable],
+  );
   // Layout topology is width-driven so it stays aligned with the `md:`
   // Tailwind classes the rest of the layout uses. At md and up the
   // side-by-side ContentSplit renders; below md a single full-viewport
@@ -1337,7 +1348,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     };
     return (
       <div className="flex-1 flex flex-col min-h-0">
-        <PaneDndController tabsByDock={tabsByDock} descriptorFor={paneDescriptor} onPlaceTab={placeTab}>
+        <PaneDndController tabsByDock={tabsByDock} descriptorFor={paneDescriptor} onPlaceTab={placeVisibleTab}>
           <ContentSplit
             collapsed={rightDockCollapsed}
             onToggleCollapse={toggleDiff}

--- a/web/src/components/Dock.tsx
+++ b/web/src/components/Dock.tsx
@@ -1,7 +1,11 @@
-import { createElement, type ReactNode } from "react";
+import { createElement, Fragment, type ReactNode } from "react";
 import { PanelBottom, PanelRight, Plus, X, type LucideIcon } from "lucide-react";
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, horizontalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import type { DockLocation } from "../lib/panes";
+import { usePaneDnd, type PaneTabData } from "./paneDnd";
 
 export interface PaneDisplay {
   title: string;
@@ -30,6 +34,73 @@ interface Props {
 const btn =
   "w-5 h-5 flex items-center justify-center shrink-0 rounded text-text-dim hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors";
 
+/** A vertical bar marking where a dragged tab would land. Rendered inline
+ *  between tabs (cross-dock drops only, see Dock), so it costs 2px of strip
+ *  width and no reflow of the tab bodies. */
+function InsertionMarker() {
+  return <div data-testid="pane-insertion-marker" className="w-0.5 self-stretch bg-brand-500 shrink-0" />;
+}
+
+interface SortableTabProps {
+  id: string;
+  location: DockLocation;
+  isActive: boolean;
+  desc: PaneDisplay;
+  onActivate: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+/** One draggable tab. The drag listeners sit on the activation button (not the
+ *  close button), and the MouseSensor's 8px distance means a stationary click
+ *  still activates rather than starting a drag. Only `listeners` are spread,
+ *  not dnd-kit's `attributes`, which would inject a conflicting role/aria onto
+ *  the role="tab" button. */
+function SortableTab({ id, location, isActive, desc, onActivate, onClose }: SortableTabProps) {
+  const { setNodeRef, listeners, transform, transition, isDragging } = useSortable({
+    id,
+    data: { type: "pane-tab", dock: location } satisfies PaneTabData,
+  });
+  const name = desc.title.toLowerCase();
+  const style = { transform: CSS.Transform.toString(transform), transition };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group flex items-center border-r border-surface-700/20 transition-colors ${
+        isDragging ? "opacity-40" : ""
+      } ${
+        isActive
+          ? "bg-surface-800 text-text-secondary"
+          : "text-text-dim hover:text-text-secondary hover:bg-surface-800/40"
+      }`}
+    >
+      {/* A real button so the tab is keyboard-reachable and Enter / Space
+          activate it, not a click-only div. */}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={isActive}
+        data-testid={`pane-tab-${id}`}
+        onClick={() => onActivate(id)}
+        {...listeners}
+        className="flex items-center gap-1 pl-2 pr-1 cursor-pointer min-w-0 touch-none"
+      >
+        {createElement(desc.icon, { className: "size-3.5 shrink-0", "aria-hidden": true })}
+        <span className="text-[11px] font-medium truncate max-w-[10rem]">{desc.title}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onClose(id)}
+        className={`${btn} mr-1`}
+        title={`Close ${name}`}
+        aria-label={`Close ${name}`}
+      >
+        <X className="size-3" aria-hidden />
+      </button>
+    </div>
+  );
+}
+
 /** Renders one dock location as a tabbed group: a tab strip plus the active
  *  tab's body. Each tab carries its pane's icon, title, and a close control;
  *  the strip also offers move-to-other-dock and a new-terminal button. Only the
@@ -37,9 +108,11 @@ const btn =
  *  (tmux session, diff API), so re-mounting on a tab switch is cheap. The
  *  parent hides the dock entirely when it has no tabs.
  *
- *  ponytail: a single tab group per dock. Multiple split groups within a dock
- *  arrive with the drag-and-drop follow-up; the layout storage is already
- *  group-shaped for it. */
+ *  Tabs reorder within the dock and move across docks via drag-and-drop (the
+ *  shared DndContext lives in PaneDndController); the move button stays as the
+ *  keyboard/click affordance. A within-dock reorder is shown by the tabs
+ *  sliding apart; a cross-dock drop adds a destination ring plus an insertion
+ *  marker, since the destination strip does not shift to preview the insert. */
 export function Dock({
   location,
   tabs,
@@ -51,54 +124,47 @@ export function Dock({
   onMove,
   onNewTerminal,
 }: Props) {
+  const { sourceDock, dropTarget } = usePaneDnd();
+  const { setNodeRef: setDockRef } = useDroppable({
+    id: `dock-body:${location}`,
+    data: { type: "pane-dock", dock: location },
+  });
   if (tabs.length === 0) return null;
   const activeId = active && tabs.includes(active) ? active : tabs[0]!;
   const target: DockLocation = location === "right" ? "bottom" : "right";
   const MoveIcon = location === "right" ? PanelBottom : PanelRight;
   const activeName = descriptorFor(activeId).title.toLowerCase();
+  // Highlight + mark only a cross-dock drop: a within-dock reorder reads from
+  // the tabs sliding apart, so a marker there would double up with the gap.
+  const isDropTarget = dropTarget?.dock === location && sourceDock !== location;
+  const markerIndex = isDropTarget ? dropTarget!.index : null;
 
   return (
-    <section className="flex flex-col min-h-0 flex-1 overflow-hidden" data-pane-dock={location}>
+    <section
+      ref={setDockRef}
+      className={`flex flex-col min-h-0 flex-1 overflow-hidden ${
+        isDropTarget ? "ring-2 ring-inset ring-brand-500/70" : ""
+      }`}
+      data-pane-dock={location}
+    >
       <div role="tablist" className="flex items-stretch h-7 shrink-0 bg-surface-900 border-b border-surface-700/20">
         <div className="flex items-stretch min-w-0 overflow-x-auto">
-          {tabs.map((id) => {
-            const desc = descriptorFor(id);
-            const isActive = id === activeId;
-            const name = desc.title.toLowerCase();
-            return (
-              <div
-                key={id}
-                className={`group flex items-center border-r border-surface-700/20 transition-colors ${
-                  isActive
-                    ? "bg-surface-800 text-text-secondary"
-                    : "text-text-dim hover:text-text-secondary hover:bg-surface-800/40"
-                }`}
-              >
-                {/* A real button so the tab is keyboard-reachable and Enter /
-                    Space activate it, not a click-only div. */}
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive}
-                  data-testid={`pane-tab-${id}`}
-                  onClick={() => onActivate(id)}
-                  className="flex items-center gap-1 pl-2 pr-1 cursor-pointer min-w-0"
-                >
-                  {createElement(desc.icon, { className: "size-3.5 shrink-0", "aria-hidden": true })}
-                  <span className="text-[11px] font-medium truncate max-w-[10rem]">{desc.title}</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onClose(id)}
-                  className={`${btn} mr-1`}
-                  title={`Close ${name}`}
-                  aria-label={`Close ${name}`}
-                >
-                  <X className="size-3" aria-hidden />
-                </button>
-              </div>
-            );
-          })}
+          <SortableContext items={tabs} strategy={horizontalListSortingStrategy}>
+            {tabs.map((id, i) => (
+              <Fragment key={id}>
+                {markerIndex === i && <InsertionMarker />}
+                <SortableTab
+                  id={id}
+                  location={location}
+                  isActive={id === activeId}
+                  desc={descriptorFor(id)}
+                  onActivate={onActivate}
+                  onClose={onClose}
+                />
+              </Fragment>
+            ))}
+            {markerIndex === tabs.length && <InsertionMarker />}
+          </SortableContext>
         </div>
         <div className="flex items-center ml-auto px-1 gap-0.5 shrink-0">
           <button

--- a/web/src/components/PaneDndController.tsx
+++ b/web/src/components/PaneDndController.tsx
@@ -14,12 +14,12 @@ import {
   type DragOverEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { arrayMove } from "@dnd-kit/sortable";
 
 import type { DockLocation } from "../lib/panes";
 import type { PaneDisplay } from "./Dock";
 import {
   PaneDndStateContext,
+  resolvePlacement,
   type DockDropData,
   type DropTarget,
   type PaneDndState,
@@ -75,18 +75,18 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
     (e: DragOverEvent | DragEndEvent): DropTarget | null => {
       const overData = e.over?.data.current as PaneTabData | DockDropData | undefined;
       if (!overData) return null;
-      const draggedId = String(e.active.id);
-      const dock = overData.dock;
-      // The destination's tabs without the dragged one: this is the index
-      // space placeTab inserts into, and (cross-dock) it has no gap to map.
-      const base = tabsByDock[dock].filter((id) => id !== draggedId);
-      if (overData.type !== "pane-tab") return { dock, index: base.length };
-      const overIndex = base.indexOf(String(e.over!.id));
-      if (overIndex < 0) return { dock, index: base.length };
       const activeC = centerX(e.active.rect.current.translated);
       const overC = centerX(e.over!.rect);
-      const after = activeC !== null && overC !== null && activeC > overC;
-      return { dock, index: overIndex + (after ? 1 : 0) };
+      return resolvePlacement(
+        {
+          type: overData.type,
+          dock: overData.dock,
+          tabId: String(e.over!.id),
+          after: activeC !== null && overC !== null && activeC > overC,
+        },
+        String(e.active.id),
+        tabsByDock,
+      );
     },
     [tabsByDock],
   );
@@ -111,17 +111,11 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
       const tabId = String(e.active.id);
       const target = resolveTarget(e);
       if (target) {
-        if (target.dock === sourceDock) {
-          // Within-dock reorder: arrayMove gives the final order, and the
-          // dragged tab's index in it is exactly placeTab's post-removal index.
-          const arr = tabsByDock[target.dock];
-          const from = arr.indexOf(tabId);
-          const over = e.over ? arr.indexOf(String(e.over.id)) : -1;
-          if (from >= 0 && over >= 0 && from !== over) {
-            const finalIndex = arrayMove(arr, from, over).indexOf(tabId);
-            onPlaceTab(tabId, target.dock, finalIndex);
-          }
-        } else {
+        // resolveTarget already gives the post-removal insertion index for both
+        // cases (before/after the hovered tab, or append on a dock-body drop), so
+        // a within-dock reorder only needs a no-op guard against its own slot.
+        const from = tabsByDock[target.dock].indexOf(tabId);
+        if (target.dock !== sourceDock || (from >= 0 && from !== target.index)) {
           onPlaceTab(tabId, target.dock, target.index);
         }
       }

--- a/web/src/components/PaneDndController.tsx
+++ b/web/src/components/PaneDndController.tsx
@@ -19,7 +19,9 @@ import type { DockLocation } from "../lib/panes";
 import type { PaneDisplay } from "./Dock";
 import {
   PaneDndStateContext,
+  pointerInsertsAfter,
   resolvePlacement,
+  shouldApplyPlacement,
   type DockDropData,
   type DropTarget,
   type PaneDndState,
@@ -40,10 +42,6 @@ const panesCollision: CollisionDetection = (args) => {
   const tabHits = hits.filter((h) => h.data?.droppableContainer?.data.current?.type === "pane-tab");
   return tabHits.length > 0 ? tabHits : hits;
 };
-
-function centerX(rect: { left: number; width: number } | null | undefined): number | null {
-  return rect ? rect.left + rect.width / 2 : null;
-}
 
 interface Props {
   /** The rendered tab order per dock (already availability-filtered), so drop
@@ -75,14 +73,12 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
     (e: DragOverEvent | DragEndEvent): DropTarget | null => {
       const overData = e.over?.data.current as PaneTabData | DockDropData | undefined;
       if (!overData) return null;
-      const activeC = centerX(e.active.rect.current.translated);
-      const overC = centerX(e.over!.rect);
       return resolvePlacement(
         {
           type: overData.type,
           dock: overData.dock,
           tabId: String(e.over!.id),
-          after: activeC !== null && overC !== null && activeC > overC,
+          after: pointerInsertsAfter(e.active.rect.current.translated, e.over!.rect),
         },
         String(e.active.id),
         tabsByDock,
@@ -110,14 +106,11 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
     (e: DragEndEvent) => {
       const tabId = String(e.active.id);
       const target = resolveTarget(e);
-      if (target) {
-        // resolveTarget already gives the post-removal insertion index for both
-        // cases (before/after the hovered tab, or append on a dock-body drop), so
-        // a within-dock reorder only needs a no-op guard against its own slot.
-        const from = tabsByDock[target.dock].indexOf(tabId);
-        if (target.dock !== sourceDock || (from >= 0 && from !== target.index)) {
-          onPlaceTab(tabId, target.dock, target.index);
-        }
+      // resolveTarget already gives the post-removal insertion index for both
+      // cases (before/after the hovered tab, or append on a dock-body drop);
+      // shouldApplyPlacement skips a within-dock drop onto the tab's own slot.
+      if (target && shouldApplyPlacement(tabsByDock, tabId, target, sourceDock)) {
+        onPlaceTab(tabId, target.dock, target.index);
       }
       reset();
     },

--- a/web/src/components/PaneDndController.tsx
+++ b/web/src/components/PaneDndController.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  MeasuringStrategy,
+  MouseSensor,
+  TouchSensor,
+  pointerWithin,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+
+import type { DockLocation } from "../lib/panes";
+import type { PaneDisplay } from "./Dock";
+import {
+  PaneDndStateContext,
+  type DockDropData,
+  type DropTarget,
+  type PaneDndState,
+  type PaneTabData,
+} from "./paneDnd";
+
+// Prefer the droppable the pointer is actually inside, and only among pane
+// droppables, so a drag in the right column never magnetically snaps to a tab
+// in the distant bottom strip the way a global closestCenter would. A tab hit
+// wins over a dock-body hit so dropping onto a sibling tab reorders rather than
+// appends. Mirrors the filtered-collision approach in WorkspaceSidebar (#1644).
+const panesCollision: CollisionDetection = (args) => {
+  const paneContainers = args.droppableContainers.filter((c) => {
+    const t = c.data.current?.type;
+    return t === "pane-tab" || t === "pane-dock" || t === "pane-empty-dock";
+  });
+  const hits = pointerWithin({ ...args, droppableContainers: paneContainers });
+  const tabHits = hits.filter((h) => h.data?.droppableContainer?.data.current?.type === "pane-tab");
+  return tabHits.length > 0 ? tabHits : hits;
+};
+
+function centerX(rect: { left: number; width: number } | null | undefined): number | null {
+  return rect ? rect.left + rect.width / 2 : null;
+}
+
+interface Props {
+  /** The rendered tab order per dock (already availability-filtered), so drop
+   *  indices line up with what the docks actually show. */
+  tabsByDock: Record<DockLocation, string[]>;
+  descriptorFor: (id: string) => PaneDisplay;
+  /** Reorder within a dock or move across docks, landing at `toIndex`. */
+  onPlaceTab: (tabId: string, toDock: DockLocation, toIndex: number) => void;
+  children: ReactNode;
+}
+
+/** Owns the single DndContext spanning both docks: sensors, the pane-aware
+ *  collision policy, the live drop target, a DragOverlay replica that follows
+ *  the cursor across the distant docks, and the empty-dock landing zones. Docks
+ *  stay presentational and read the drop state through usePaneDnd. */
+export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, children }: Props) {
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+  const [sourceDock, setSourceDock] = useState<DockLocation | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
+  );
+
+  // Resolve the destination dock + post-removal insertion index from the
+  // hovered droppable. Returns null when the pointer is not over a pane target.
+  const resolveTarget = useCallback(
+    (e: DragOverEvent | DragEndEvent): DropTarget | null => {
+      const overData = e.over?.data.current as PaneTabData | DockDropData | undefined;
+      if (!overData) return null;
+      const draggedId = String(e.active.id);
+      const dock = overData.dock;
+      // The destination's tabs without the dragged one: this is the index
+      // space placeTab inserts into, and (cross-dock) it has no gap to map.
+      const base = tabsByDock[dock].filter((id) => id !== draggedId);
+      if (overData.type !== "pane-tab") return { dock, index: base.length };
+      const overIndex = base.indexOf(String(e.over!.id));
+      if (overIndex < 0) return { dock, index: base.length };
+      const activeC = centerX(e.active.rect.current.translated);
+      const overC = centerX(e.over!.rect);
+      const after = activeC !== null && overC !== null && activeC > overC;
+      return { dock, index: overIndex + (after ? 1 : 0) };
+    },
+    [tabsByDock],
+  );
+
+  const onDragStart = useCallback((e: DragStartEvent) => {
+    const data = e.active.data.current as PaneTabData | undefined;
+    setActiveTab(String(e.active.id));
+    setSourceDock(data?.dock ?? null);
+    setDropTarget(null);
+  }, []);
+
+  const onDragOver = useCallback((e: DragOverEvent) => setDropTarget(resolveTarget(e)), [resolveTarget]);
+
+  const reset = useCallback(() => {
+    setActiveTab(null);
+    setSourceDock(null);
+    setDropTarget(null);
+  }, []);
+
+  const onDragEnd = useCallback(
+    (e: DragEndEvent) => {
+      const tabId = String(e.active.id);
+      const target = resolveTarget(e);
+      if (target) {
+        if (target.dock === sourceDock) {
+          // Within-dock reorder: arrayMove gives the final order, and the
+          // dragged tab's index in it is exactly placeTab's post-removal index.
+          const arr = tabsByDock[target.dock];
+          const from = arr.indexOf(tabId);
+          const over = e.over ? arr.indexOf(String(e.over.id)) : -1;
+          if (from >= 0 && over >= 0 && from !== over) {
+            const finalIndex = arrayMove(arr, from, over).indexOf(tabId);
+            onPlaceTab(tabId, target.dock, finalIndex);
+          }
+        } else {
+          onPlaceTab(tabId, target.dock, target.index);
+        }
+      }
+      reset();
+    },
+    [resolveTarget, sourceDock, tabsByDock, onPlaceTab, reset],
+  );
+
+  const state = useMemo<PaneDndState>(
+    () => ({ activeTab, sourceDock, dropTarget }),
+    [activeTab, sourceDock, dropTarget],
+  );
+
+  const overlayDesc = activeTab ? descriptorFor(activeTab) : null;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={panesCollision}
+      measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragEnd={onDragEnd}
+      onDragCancel={reset}
+    >
+      <PaneDndStateContext.Provider value={state}>
+        <div className="relative flex flex-col min-h-0 flex-1">
+          {children}
+          {activeTab &&
+            (["right", "bottom"] as DockLocation[])
+              .filter((d) => tabsByDock[d].length === 0)
+              .map((d) => <EmptyDockDropZone key={d} location={d} />)}
+        </div>
+        <DragOverlay dropAnimation={null}>
+          {overlayDesc && (
+            <div className="flex items-center gap-1 h-7 px-2 bg-surface-800 text-text-secondary border border-brand-600/60 rounded shadow-lg">
+              <overlayDesc.icon className="size-3.5 shrink-0" aria-hidden />
+              <span className="text-[11px] font-medium truncate max-w-[10rem]">{overlayDesc.title}</span>
+            </div>
+          )}
+        </DragOverlay>
+      </PaneDndStateContext.Provider>
+    </DndContext>
+  );
+}
+
+/** A landing zone for a dock that currently has no tabs (so its Dock is not in
+ *  the DOM to drop onto). Pinned to the dock's screen edge, shown only while a
+ *  pane tab is dragged. MeasuringStrategy.Always on the context measures it
+ *  even though it mounts on drag start. */
+function EmptyDockDropZone({ location }: { location: DockLocation }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `empty-dock:${location}`,
+    data: { type: "pane-empty-dock", dock: location } satisfies DockDropData,
+  });
+  const edge = location === "right" ? "top-0 right-0 h-full w-12 border-l" : "bottom-0 left-0 w-full h-12 border-t";
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`empty-dock-dropzone-${location}`}
+      className={`absolute z-30 flex items-center justify-center border-dashed transition-colors ${edge} ${
+        isOver ? "border-brand-500 bg-brand-600/20" : "border-brand-600/40 bg-surface-900/40"
+      }`}
+    >
+      <span className="text-[10px] font-medium text-text-dim uppercase tracking-wide">Dock here</span>
+    </div>
+  );
+}

--- a/web/src/components/PaneDndController.tsx
+++ b/web/src/components/PaneDndController.tsx
@@ -177,7 +177,7 @@ function EmptyDockDropZone({ location }: { location: DockLocation }) {
     id: `empty-dock:${location}`,
     data: { type: "pane-empty-dock", dock: location } satisfies DockDropData,
   });
-  const edge = location === "right" ? "top-0 right-0 h-full w-12 border-l" : "bottom-0 left-0 w-full h-12 border-t";
+  const edge = location === "right" ? "top-0 right-0 h-full w-24 border-l" : "bottom-0 left-0 w-full h-24 border-t";
   return (
     <div
       ref={setNodeRef}
@@ -186,7 +186,7 @@ function EmptyDockDropZone({ location }: { location: DockLocation }) {
         isOver ? "border-brand-500 bg-brand-600/20" : "border-brand-600/40 bg-surface-900/40"
       }`}
     >
-      <span className="text-[10px] font-medium text-text-dim uppercase tracking-wide">Dock here</span>
+      <span className="text-xs font-medium text-text-dim uppercase tracking-wide">Dock here</span>
     </div>
   );
 }

--- a/web/src/components/__tests__/paneDnd.test.ts
+++ b/web/src/components/__tests__/paneDnd.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { resolvePlacement, visibleToFullIndex, type PlacementOver } from "../paneDnd";
+import {
+  centerX,
+  pointerInsertsAfter,
+  resolvePlacement,
+  shouldApplyPlacement,
+  visibleToFullIndex,
+  type PlacementOver,
+} from "../paneDnd";
 
 const tabsByDock = { right: ["diff", "terminal:0", "terminal:1"], bottom: ["plugin:p:a"] };
 
@@ -45,6 +52,44 @@ describe("resolvePlacement", () => {
       dock: "bottom",
       index: 1,
     });
+  });
+});
+
+describe("centerX", () => {
+  it("returns the horizontal center", () => {
+    expect(centerX({ left: 10, width: 40 })).toBe(30);
+  });
+  it("returns null for a missing rect", () => {
+    expect(centerX(null)).toBeNull();
+    expect(centerX(undefined)).toBeNull();
+  });
+});
+
+describe("pointerInsertsAfter", () => {
+  it("is true when the dragged center is past the hovered center", () => {
+    expect(pointerInsertsAfter({ left: 50, width: 20 }, { left: 0, width: 20 })).toBe(true);
+  });
+  it("is false on the leading half", () => {
+    expect(pointerInsertsAfter({ left: 0, width: 20 }, { left: 50, width: 20 })).toBe(false);
+  });
+  it("is false when a rect is unknown", () => {
+    expect(pointerInsertsAfter(null, { left: 0, width: 20 })).toBe(false);
+  });
+});
+
+describe("shouldApplyPlacement", () => {
+  it("applies a cross-dock move", () => {
+    expect(shouldApplyPlacement(tabsByDock, "diff", { dock: "bottom", index: 0 }, "right")).toBe(true);
+  });
+  it("applies a within-dock move to a different slot", () => {
+    expect(shouldApplyPlacement(tabsByDock, "diff", { dock: "right", index: 2 }, "right")).toBe(true);
+  });
+  it("skips a within-dock drop onto the tab's own slot", () => {
+    // diff is at index 0; a post-removal target index of 0 is a no-op.
+    expect(shouldApplyPlacement(tabsByDock, "diff", { dock: "right", index: 0 }, "right")).toBe(false);
+  });
+  it("skips when the tab is not in the target dock", () => {
+    expect(shouldApplyPlacement(tabsByDock, "ghost", { dock: "right", index: 0 }, "right")).toBe(false);
   });
 });
 

--- a/web/src/components/__tests__/paneDnd.test.ts
+++ b/web/src/components/__tests__/paneDnd.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePlacement, visibleToFullIndex, type PlacementOver } from "../paneDnd";
+
+const tabsByDock = { right: ["diff", "terminal:0", "terminal:1"], bottom: ["plugin:p:a"] };
+
+function over(partial: Partial<PlacementOver>): PlacementOver {
+  return { type: "pane-tab", dock: "right", tabId: "diff", after: false, ...partial };
+}
+
+describe("resolvePlacement", () => {
+  it("inserts before the hovered tab when the pointer is on its leading half", () => {
+    // Dragging terminal:1 onto diff's leading half; base (without the dragged
+    // tab) is [diff, terminal:0], so before diff is index 0.
+    expect(resolvePlacement(over({ tabId: "diff", after: false }), "terminal:1", tabsByDock)).toEqual({
+      dock: "right",
+      index: 0,
+    });
+  });
+
+  it("inserts after the hovered tab when the pointer is on its trailing half", () => {
+    expect(resolvePlacement(over({ tabId: "diff", after: true }), "terminal:1", tabsByDock)).toEqual({
+      dock: "right",
+      index: 1,
+    });
+  });
+
+  it("appends when dropping on a dock body rather than a tab", () => {
+    // base without the dragged diff is [terminal:0, terminal:1], so append is 2.
+    expect(resolvePlacement(over({ type: "pane-dock", tabId: "" }), "diff", tabsByDock)).toEqual({
+      dock: "right",
+      index: 2,
+    });
+  });
+
+  it("appends to an empty-dock zone", () => {
+    expect(resolvePlacement(over({ type: "pane-empty-dock", dock: "bottom", tabId: "" }), "diff", tabsByDock)).toEqual({
+      dock: "bottom",
+      index: 1,
+    });
+  });
+
+  it("appends when the hovered tab is not in the destination (cross-dock to a stale id)", () => {
+    expect(resolvePlacement(over({ dock: "bottom", tabId: "ghost" }), "diff", tabsByDock)).toEqual({
+      dock: "bottom",
+      index: 1,
+    });
+  });
+});
+
+describe("visibleToFullIndex", () => {
+  const visible = (id: string) => !id.startsWith("plugin:");
+
+  it("is the identity when every tab is visible", () => {
+    expect(visibleToFullIndex(["diff", "terminal:0"], 1, visible)).toBe(1);
+  });
+
+  it("skips a hidden tab that still holds a persisted slot", () => {
+    // Full base [diff, plugin:p:x(hidden), terminal:0]: visible slot 1 is the
+    // terminal at full index 2.
+    expect(visibleToFullIndex(["diff", "plugin:p:x", "terminal:0"], 1, visible)).toBe(2);
+  });
+
+  it("appends to the full length when the visible index is at or past the end", () => {
+    expect(visibleToFullIndex(["diff", "plugin:p:x"], 1, visible)).toBe(2);
+  });
+});

--- a/web/src/components/paneDnd.ts
+++ b/web/src/components/paneDnd.ts
@@ -1,0 +1,42 @@
+import { createContext, useContext } from "react";
+
+import type { DockLocation } from "../lib/panes";
+
+/** Drag payloads. A tab carries the dock it currently lives in; the two dock
+ *  droppables (the rendered dock body and the empty-dock landing zone) carry
+ *  their location. onDragEnd branches on `type`, never on the id shape. */
+export interface PaneTabData {
+  type: "pane-tab";
+  dock: DockLocation;
+}
+export interface DockDropData {
+  type: "pane-dock" | "pane-empty-dock";
+  dock: DockLocation;
+}
+
+/** The live insertion point while a pane tab is dragged: which dock and the
+ *  index it would land at within that dock (after the tab is removed from its
+ *  source). Null when there is no valid target. */
+export interface DropTarget {
+  dock: DockLocation;
+  index: number;
+}
+
+export interface PaneDndState {
+  activeTab: string | null;
+  sourceDock: DockLocation | null;
+  dropTarget: DropTarget | null;
+}
+
+export const PaneDndStateContext = createContext<PaneDndState>({
+  activeTab: null,
+  sourceDock: null,
+  dropTarget: null,
+});
+
+/** Dock reads this to show its destination ring and (cross-dock only) its
+ *  insertion marker. Within-dock order is conveyed by the sortable shift, so
+ *  the marker is suppressed when the target dock is the source dock. */
+export function usePaneDnd(): PaneDndState {
+  return useContext(PaneDndStateContext);
+}

--- a/web/src/components/paneDnd.ts
+++ b/web/src/components/paneDnd.ts
@@ -67,6 +67,39 @@ export function resolvePlacement(
   return { dock: over.dock, index: overIndex + (over.after ? 1 : 0) };
 }
 
+interface Rect {
+  left: number;
+  width: number;
+}
+
+/** Horizontal center of a rect, or null when the rect is missing (dnd-kit hands
+ *  a null translated rect before the first move). */
+export function centerX(rect: Rect | null | undefined): number | null {
+  return rect ? rect.left + rect.width / 2 : null;
+}
+
+/** True when the dragged tab's center has passed the hovered tab's center, so
+ *  the drop should insert after it rather than before. False if either rect is
+ *  unknown, biasing toward inserting before. */
+export function pointerInsertsAfter(activeRect: Rect | null | undefined, overRect: Rect | null | undefined): boolean {
+  const a = centerX(activeRect);
+  const o = centerX(overRect);
+  return a !== null && o !== null && a > o;
+}
+
+/** Whether a resolved drop is worth persisting: a cross-dock move always is, but
+ *  a within-dock reorder onto the tab's own slot is a no-op to skip. */
+export function shouldApplyPlacement(
+  tabsByDock: Record<DockLocation, string[]>,
+  tabId: string,
+  target: DropTarget,
+  sourceDock: DockLocation | null,
+): boolean {
+  if (target.dock !== sourceDock) return true;
+  const from = tabsByDock[target.dock].indexOf(tabId);
+  return from >= 0 && from !== target.index;
+}
+
 /** Translate an insertion index in a dock's *visible* tab list to the index in
  *  its *full* persisted list. They differ when the dock holds a tab that is
  *  currently hidden (an unloaded plugin pane), which still occupies a persisted

--- a/web/src/components/paneDnd.ts
+++ b/web/src/components/paneDnd.ts
@@ -40,3 +40,43 @@ export const PaneDndStateContext = createContext<PaneDndState>({
 export function usePaneDnd(): PaneDndState {
   return useContext(PaneDndStateContext);
 }
+
+/** The droppable the pointer is over, reduced to the bits placement needs. */
+export interface PlacementOver {
+  type: "pane-tab" | "pane-dock" | "pane-empty-dock";
+  dock: DockLocation;
+  /** The hovered tab id (only meaningful when `type` is "pane-tab"). */
+  tabId: string;
+  /** Pointer is past the hovered tab's center, so insert after it. */
+  after: boolean;
+}
+
+/** Where a dragged tab lands: the destination dock and the index in that dock's
+ *  visible tab list *after* the dragged tab is removed. Dropping on a tab
+ *  inserts before or after it; dropping on a dock body or empty-dock zone
+ *  appends. Pure so the drag handler stays a thin adapter over the event. */
+export function resolvePlacement(
+  over: PlacementOver,
+  draggedId: string,
+  tabsByDock: Record<DockLocation, string[]>,
+): DropTarget {
+  const base = tabsByDock[over.dock].filter((id) => id !== draggedId);
+  if (over.type !== "pane-tab") return { dock: over.dock, index: base.length };
+  const overIndex = base.indexOf(over.tabId);
+  if (overIndex < 0) return { dock: over.dock, index: base.length };
+  return { dock: over.dock, index: overIndex + (over.after ? 1 : 0) };
+}
+
+/** Translate an insertion index in a dock's *visible* tab list to the index in
+ *  its *full* persisted list. They differ when the dock holds a tab that is
+ *  currently hidden (an unloaded plugin pane), which still occupies a persisted
+ *  slot. `fullBase` is the full dock list with the dragged tab already removed.
+ *  An index at or past the visible end appends to the full list. */
+export function visibleToFullIndex(
+  fullBase: string[],
+  visibleIndex: number,
+  isVisible: (id: string) => boolean,
+): number {
+  const visibleSlots = fullBase.map((id, index) => ({ id, index })).filter(({ id }) => isVisible(id));
+  return visibleIndex >= visibleSlots.length ? fullBase.length : visibleSlots[visibleIndex]!.index;
+}

--- a/web/src/lib/__tests__/paneLayout.test.ts
+++ b/web/src/lib/__tests__/paneLayout.test.ts
@@ -195,6 +195,26 @@ describe("usePaneLayout migration + persistence", () => {
     expect(dockTabs(result.current.layout, "bottom")).toEqual([]);
   });
 
+  it("drops a tab id duplicated within one group on load", () => {
+    localStorage.setItem(
+      "aoe-pane-layout-v2",
+      JSON.stringify({
+        version: 2,
+        template: { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [] },
+        sessions: {
+          s1: {
+            right: [{ tabs: ["diff", "diff", "terminal:0"], active: "diff" }],
+            bottom: [],
+            nextTerminalIndex: 1,
+            closedPlugins: [],
+          },
+        },
+      }),
+    );
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    expect(dockTabs(result.current.layout, "right")).toEqual(["diff", "terminal:0"]);
+  });
+
   it("toggleKind adds then removes the terminal tabs", () => {
     localStorage.setItem("aoe-right-collapsed", "1"); // start empty
     const { result } = renderHook(() => usePaneLayout("s1"));

--- a/web/src/lib/__tests__/paneLayout.test.ts
+++ b/web/src/lib/__tests__/paneLayout.test.ts
@@ -8,6 +8,7 @@ import {
   dockOf,
   dockTabs,
   moveTab,
+  placeTab,
   removeAllTerminals,
   removeTab,
   setActive,
@@ -56,6 +57,67 @@ describe("pane layout pure ops", () => {
     l = moveTab(l, "diff", "bottom");
     expect(dockOf(l, "diff")).toBe("bottom");
     expect(dockTabs(l, "right")).toEqual([]);
+  });
+
+  it("placeTab reorders within a dock without changing the active tab", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = addTab(l, "right", "c");
+    l = setActive(l, "right", "a");
+    // Drag "a" to the end. toIndex is the post-removal index, so end == 2.
+    l = placeTab(l, "a", "right", 2);
+    expect(dockTabs(l, "right")).toEqual(["b", "c", "a"]);
+    // Reordering the active tab keeps it active.
+    expect(l.right[0]!.active).toBe("a");
+  });
+
+  it("placeTab reordering a background tab keeps the existing active tab", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = addTab(l, "right", "c");
+    l = setActive(l, "right", "a");
+    l = placeTab(l, "c", "right", 0);
+    expect(dockTabs(l, "right")).toEqual(["c", "a", "b"]);
+    expect(l.right[0]!.active).toBe("a");
+  });
+
+  it("placeTab moves a tab across docks at an index and activates it there", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = addTab(l, "bottom", "x");
+    l = addTab(l, "bottom", "y");
+    l = setActive(l, "right", "a");
+    l = setActive(l, "bottom", "x");
+    // Move right's active "a" between x and y.
+    l = placeTab(l, "a", "bottom", 1);
+    expect(dockTabs(l, "right")).toEqual(["b"]);
+    expect(dockTabs(l, "bottom")).toEqual(["x", "a", "y"]);
+    // Moved tab activates in its destination.
+    expect(l.bottom[0]!.active).toBe("a");
+    // Source falls back to a neighbor.
+    expect(l.right[0]!.active).toBe("b");
+  });
+
+  it("placeTab clamps an out-of-range index and prunes an emptied source dock", () => {
+    let l = addTab(emptyLayout(), "right", "only");
+    l = placeTab(l, "only", "bottom", 99);
+    expect(l.right).toEqual([]);
+    expect(dockTabs(l, "bottom")).toEqual(["only"]);
+  });
+
+  it("placeTab does not mark a moved plugin tab as closed", () => {
+    let l = addTab(emptyLayout(), "right", "plugin:p:a");
+    l = placeTab(l, "plugin:p:a", "bottom", 0);
+    expect(dockOf(l, "plugin:p:a")).toBe("bottom");
+    expect(l.closedPlugins).not.toContain("plugin:p:a");
+  });
+
+  it("moveTab appends to the destination and is a no-op within the same dock", () => {
+    let l = addTab(emptyLayout(), "bottom", "x");
+    l = addTab(l, "right", "a");
+    l = moveTab(l, "a", "bottom");
+    expect(dockTabs(l, "bottom")).toEqual(["x", "a"]);
+    expect(moveTab(l, "a", "bottom")).toBe(l);
   });
 
   it("removeAllTerminals clears every terminal tab but keeps others", () => {
@@ -110,6 +172,27 @@ describe("usePaneLayout migration + persistence", () => {
     // s1's addition round-trips through localStorage.
     const reloaded = renderHook(() => usePaneLayout("s1"));
     expect(dockTabs(reloaded.result.current.layout, "right")).toContain("terminal:1");
+  });
+
+  it("drops a tab id duplicated across docks on load (keeps the first dock)", () => {
+    localStorage.setItem(
+      "aoe-pane-layout-v2",
+      JSON.stringify({
+        version: 2,
+        template: { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [] },
+        sessions: {
+          s1: {
+            right: [{ tabs: ["diff", "terminal:0"], active: "diff" }],
+            bottom: [{ tabs: ["diff"], active: "diff" }],
+            nextTerminalIndex: 1,
+            closedPlugins: [],
+          },
+        },
+      }),
+    );
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    expect(dockTabs(result.current.layout, "right")).toEqual(["diff", "terminal:0"]);
+    expect(dockTabs(result.current.layout, "bottom")).toEqual([]);
   });
 
   it("toggleKind adds then removes the terminal tabs", () => {

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -281,8 +281,11 @@ function normalizeGroups(v: unknown): PaneGroup[] {
 function dropDuplicates(group: PaneGroup[], seen: Set<TabId>): PaneGroup[] {
   return group
     .map((g) => {
-      const tabs = g.tabs.filter((t) => !seen.has(t));
-      tabs.forEach((t) => seen.add(t));
+      const tabs = g.tabs.filter((t) => {
+        if (seen.has(t)) return false;
+        seen.add(t);
+        return true;
+      });
       const active = g.active && tabs.includes(g.active) ? g.active : (tabs[0] ?? null);
       return { tabs, active };
     })

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -127,10 +127,46 @@ export function setActive(layout: DockLayout, dock: DockLocation, tabId: TabId):
   return next;
 }
 
+function clampIndex(index: number, max: number): number {
+  return Math.max(0, Math.min(Math.floor(index), max));
+}
+
+/** Move `tabId` to position `toIndex` in `toDock`. Subsumes both within-dock
+ *  reorder (toDock equals the source dock) and cross-dock move. `toIndex` is the
+ *  index in the destination group *after* the tab is removed from its source.
+ *
+ *  Active-tab rule: a within-dock reorder keeps whatever was active (including
+ *  the dragged tab itself), so dragging a background tab never steals focus; a
+ *  cross-dock move activates the tab in its destination, since it would
+ *  otherwise land hidden behind the destination's active tab. Implemented
+ *  directly rather than via removeTab so a move never marks a plugin tab as
+ *  explicitly closed. */
+export function placeTab(layout: DockLayout, tabId: TabId, toDock: DockLocation, toIndex: number): DockLayout {
+  const fromDock = dockOf(layout, tabId);
+  if (!fromDock) return layout;
+  const next = clone(layout);
+  const source = next[fromDock][0]!;
+  const fromIndex = source.tabs.indexOf(tabId);
+  if (fromIndex < 0) return layout;
+  const wasActive = source.active === tabId;
+  source.tabs.splice(fromIndex, 1);
+  if (wasActive) {
+    // Source loses its active tab: prefer the tab that shifted into the slot,
+    // else the new last tab. (Overridden below for a within-dock reorder.)
+    source.active = source.tabs[fromIndex] ?? source.tabs[source.tabs.length - 1] ?? null;
+  }
+  pruneEmpty(next, fromDock);
+  const dest = ensureGroup(next, toDock);
+  dest.tabs.splice(clampIndex(toIndex, dest.tabs.length), 0, tabId);
+  if (fromDock !== toDock || wasActive || dest.active === null) dest.active = tabId;
+  next.closedPlugins = next.closedPlugins.filter((id) => id !== tabId);
+  return next;
+}
+
 export function moveTab(layout: DockLayout, tabId: TabId, toDock: DockLocation): DockLayout {
   const from = dockOf(layout, tabId);
   if (!from || from === toDock) return layout;
-  return addTab(removeTab(layout, tabId), toDock, tabId);
+  return placeTab(layout, tabId, toDock, dockTabs(layout, toDock).length);
 }
 
 /** Allocate a fresh terminal tab in `dock` and return its id + new layout. */
@@ -239,11 +275,26 @@ function normalizeGroups(v: unknown): PaneGroup[] {
   return [merged];
 }
 
+/** Drop from `group` any tab id already claimed by an earlier dock. A tab must
+ *  live in exactly one dock; a corrupted store with the same id in both would
+ *  hand dnd-kit duplicate sortable ids and break dragging. */
+function dropDuplicates(group: PaneGroup[], seen: Set<TabId>): PaneGroup[] {
+  return group
+    .map((g) => {
+      const tabs = g.tabs.filter((t) => !seen.has(t));
+      tabs.forEach((t) => seen.add(t));
+      const active = g.active && tabs.includes(g.active) ? g.active : (tabs[0] ?? null);
+      return { tabs, active };
+    })
+    .filter((g) => g.tabs.length > 0);
+}
+
 function normalizeDock(v: unknown): DockLayout {
   const o = (v && typeof v === "object" ? v : {}) as Record<string, unknown>;
+  const seen = new Set<TabId>();
   return {
-    right: normalizeGroups(o.right),
-    bottom: normalizeGroups(o.bottom),
+    right: dropDuplicates(normalizeGroups(o.right), seen),
+    bottom: dropDuplicates(normalizeGroups(o.bottom), seen),
     nextTerminalIndex:
       typeof o.nextTerminalIndex === "number" && o.nextTerminalIndex >= 1 ? Math.floor(o.nextTerminalIndex) : 1,
     closedPlugins: Array.isArray(o.closedPlugins)
@@ -281,6 +332,8 @@ export interface PaneLayoutApi {
   closeTab: (tabId: TabId) => void;
   activateTab: (dock: DockLocation, tabId: TabId) => void;
   moveTab: (tabId: TabId, toDock: DockLocation) => void;
+  /** Reorder within a dock or move across docks, landing at `toIndex`. */
+  placeTab: (tabId: TabId, toDock: DockLocation, toIndex: number) => void;
   /** Activity-bar toggle for a built-in kind ("diff" or "terminal"). */
   toggleKind: (kind: "diff" | "terminal", defaultDock: DockLocation) => void;
   /** Add/remove a plugin pane tab (activity-bar toggle). */
@@ -325,6 +378,10 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     (tabId: TabId, toDock: DockLocation) => mutate((l) => moveTab(l, tabId, toDock)),
     [mutate],
   );
+  const placeTabCb = useCallback(
+    (tabId: TabId, toDock: DockLocation, toIndex: number) => mutate((l) => placeTab(l, tabId, toDock, toIndex)),
+    [mutate],
+  );
   const toggleKind = useCallback(
     (kind: "diff" | "terminal", defaultDock: DockLocation) =>
       mutate((l) => {
@@ -353,6 +410,7 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     closeTab,
     activateTab,
     moveTab: moveTabCb,
+    placeTab: placeTabCb,
     toggleKind,
     togglePlugin,
     syncPlugins,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -32,6 +32,8 @@
         "web/src/components/ActivityBar.tsx",
         "web/src/components/Dock.tsx",
         "web/src/components/BottomDock.tsx",
+        "web/src/components/PaneDndController.tsx",
+        "web/src/components/paneDnd.ts",
         "web/src/components/plugin/PluginSlots.tsx"
       ]
     },

--- a/web/tests/pane-docking.spec.ts
+++ b/web/tests/pane-docking.spec.ts
@@ -26,12 +26,7 @@ async function dockTabOrder(page: Page, dock: "right" | "bottom"): Promise<strin
 /** Press on a tab's activation button (where the drag listeners live), move past
  *  the 8px MouseSensor threshold, run `mid` while held, then drop on `target`.
  *  Playwright's mouse maps to dnd-kit's MouseSensor, so no press-hold delay. */
-async function dragTab(
-  page: Page,
-  fromId: string,
-  target: { x: number; y: number },
-  mid?: () => Promise<void>,
-) {
+async function dragTab(page: Page, fromId: string, target: { x: number; y: number }, mid?: () => Promise<void>) {
   const from = await page.getByTestId(`pane-tab-${fromId}`).boundingBox();
   if (!from) throw new Error(`missing tab ${fromId}`);
   await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);

--- a/web/tests/pane-docking.spec.ts
+++ b/web/tests/pane-docking.spec.ts
@@ -16,6 +16,38 @@ async function openSession(page: Page) {
   await page.setViewportSize({ width: 1280, height: 720 });
 }
 
+/** Tab ids in a dock, in rendered (left-to-right) order. */
+async function dockTabOrder(page: Page, dock: "right" | "bottom"): Promise<string[]> {
+  return page.$$eval(`[data-pane-dock="${dock}"] [data-testid^="pane-tab-"]`, (els) =>
+    els.map((el) => (el.getAttribute("data-testid") ?? "").replace("pane-tab-", "")),
+  );
+}
+
+/** Press on a tab's activation button (where the drag listeners live), move past
+ *  the 8px MouseSensor threshold, run `mid` while held, then drop on `target`.
+ *  Playwright's mouse maps to dnd-kit's MouseSensor, so no press-hold delay. */
+async function dragTab(
+  page: Page,
+  fromId: string,
+  target: { x: number; y: number },
+  mid?: () => Promise<void>,
+) {
+  const from = await page.getByTestId(`pane-tab-${fromId}`).boundingBox();
+  if (!from) throw new Error(`missing tab ${fromId}`);
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(from.x + from.width / 2 + 12, from.y + from.height / 2, { steps: 4 });
+  await page.mouse.move(target.x, target.y, { steps: 12 });
+  if (mid) await mid();
+  await page.mouse.up();
+}
+
+async function tabCenter(page: Page, id: string): Promise<{ x: number; y: number }> {
+  const b = await page.getByTestId(`pane-tab-${id}`).boundingBox();
+  if (!b) throw new Error(`missing tab ${id}`);
+  return { x: b.x + b.width / 2, y: b.y + b.height / 2 };
+}
+
 test.describe("Dockable pane system", () => {
   test("the activity bar toggles the built-in diff and terminal panes", async ({ page }) => {
     await openSession(page);
@@ -99,6 +131,65 @@ test.describe("Dockable pane system", () => {
     // Clicking the pane's action button forwards its method to the worker.
     await page.getByTestId("plugin-pane-action").click();
     await expect.poll(() => actionBody?.method).toBe("demo.reload");
+  });
+
+  test("dragging a tab reorders it within a dock and the order persists across reload", async ({ page }) => {
+    await openSession(page);
+    await page.goto(`/session/${SESSION}`);
+
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    await expect(page.getByTestId("pane-tab-terminal:0")).toBeVisible();
+    expect(await dockTabOrder(page, "right")).toEqual(["diff", "terminal:0"]);
+
+    // Drag the terminal tab onto diff's left half so it lands first.
+    const diff = await page.getByTestId("pane-tab-diff").boundingBox();
+    if (!diff) throw new Error("missing diff tab");
+    await dragTab(page, "terminal:0", { x: diff.x + 4, y: diff.y + diff.height / 2 });
+    await expect.poll(() => dockTabOrder(page, "right")).toEqual(["terminal:0", "diff"]);
+
+    // The reordered layout round-trips through localStorage.
+    await page.reload();
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    await expect.poll(() => dockTabOrder(page, "right")).toEqual(["terminal:0", "diff"]);
+  });
+
+  test("dragging a tab onto the empty bottom dock opens it there", async ({ page }) => {
+    await openSession(page);
+    await page.goto(`/session/${SESSION}`);
+    await expect(page.getByTestId("bottom-dock-resize")).toHaveCount(0);
+
+    // The empty-dock landing zone exists only while a pane tab is dragged.
+    await dragTab(page, "diff", { x: 640, y: 715 }, async () => {
+      const zone = page.getByTestId("empty-dock-dropzone-bottom");
+      await expect(zone).toBeVisible();
+      const box = await zone.boundingBox();
+      if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 4 });
+    });
+
+    await expect(page.getByTestId("bottom-dock-resize")).toBeVisible();
+    await expect.poll(() => dockTabOrder(page, "bottom")).toEqual(["diff"]);
+    expect(await dockTabOrder(page, "right")).toEqual(["terminal:0"]);
+  });
+
+  test("a cross-dock drag shows an insertion marker and moves the pane", async ({ page }) => {
+    await openSession(page);
+    await page.goto(`/session/${SESSION}`);
+
+    // Split the docks: the active diff tab moves to the bottom, terminal stays.
+    await page.getByLabel("Move diff to bottom dock").click();
+    await expect(page.getByTestId("bottom-dock-resize")).toBeVisible();
+    expect(await dockTabOrder(page, "right")).toEqual(["terminal:0"]);
+    expect(await dockTabOrder(page, "bottom")).toEqual(["diff"]);
+
+    // Drag terminal onto the bottom dock's diff tab; the marker appears because
+    // the destination strip does not shift to preview a cross-dock insert.
+    const diff = await tabCenter(page, "diff");
+    await dragTab(page, "terminal:0", diff, async () => {
+      await expect(page.getByTestId("pane-insertion-marker")).toBeVisible();
+    });
+
+    await expect.poll(() => dockTabOrder(page, "right")).toEqual([]);
+    await expect.poll(() => dockTabOrder(page, "bottom")).toContain("terminal:0");
   });
 
   test("the new-terminal button opens a second terminal tab that can be closed", async ({ page }) => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Pane tabs in the web dashboard can now be dragged. Drag a tab past its siblings to reorder it within a dock, or drag it onto the other dock to move the pane across. This builds on the dockable tool-windows (#2432) and the tabbed pane groups (#2446), bringing the docks closer to the JetBrains-like target.

A single `DndContext` (the new `PaneDndController`) spans both docks so a tab can cross between them. A pane-aware `pointerWithin` collision keeps a drag in the right column from snapping to the distant bottom strip the way a global collision would. A within-dock reorder is shown by the tabs sliding apart; a cross-dock drop adds a destination ring plus a thin insertion marker, since the destination strip does not shift to preview the insert. A drag overlay follows the cursor, and an empty dock (otherwise not rendered) shows an edge landing zone while a tab is dragged, so a pane can be popped into it. Reordering a background tab never steals focus; a cross-dock move activates the moved tab in its destination. The layout persists per session through the existing pane-layout storage.

The existing move button, close button, and activity-bar toggles are unchanged; drag-and-drop is additive. No new dependencies (`@dnd-kit` was already in use, following the same conventions as the sidebar reorder).

Closes #2436

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard on a session with the right dock showing Diff and Terminal tabs.
- [ ] Drag the Terminal tab to the left of Diff; the order changes. Reload the page and confirm the new order persists.
- [ ] Use the title-bar move button to send one pane to the bottom dock, then drag a tab from the right dock onto a bottom-dock tab; confirm a ring and a thin insertion marker show before release and the pane lands where the marker indicated.
- [ ] With the bottom dock empty, start dragging a right-dock tab; confirm a "Dock here" edge zone appears at the bottom and dropping on it opens the bottom dock with that pane.
- [ ] Confirm the activity-bar toggles, the move button, and the close button all still work, and that a plain click on a tab still just activates it (no accidental drag).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The architecture was pressure-tested with a multi-model debate (single DndContext, pointer-aware collision, insertion marker, empty-dock landing zone). I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785143753&installation_id=139138837&pr_number=2458&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2458&signature=bbae72fd6a1155a14c46d79c15204013cde8f36f04d224e6b4e982e14dc66dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added drag-and-drop support for pane tabs in the web dashboard.

- Tabs can be reordered within the same dock with clear “slide” drop feedback.
- Tabs can be moved between the right and bottom docks, including dropping onto an empty dock, with a destination ring and an insertion marker indicating where the tab will land.
- A unified drag preview and empty-dock landing zones ensure drops work even when the destination has no visible tab strip.
- The resulting dock placement and tab order persist via the existing pane-layout storage, including correct handling of tabs that are hidden/unloaded.
- Existing behaviors (click-to-activate, move/close buttons, and activity-bar toggles) are preserved so drag-and-drop is additive rather than replacing current interactions.
- Automated coverage was expanded with both unit tests for placement/index logic and end-to-end tests for same-dock reordering, cross-dock moves, and empty-dock drops.

Benefits: users can rearrange their workspace faster and more naturally with visible drop targets, while the app keeps state consistent and durable across reloads.

```technical
- Added PaneDndController to wrap the desktop/tablet pane layout with a single shared dnd-kit DndContext and pane-aware collision/placement resolution.
- Refactored Dock.tsx tab strip to sortable tabs (drag handle is the activation control) plus insertion marker + empty-dock drop highlighting.
- Enhanced paneDnd helpers with pure functions (e.g., resolvePlacement, shouldApplyPlacement, visibleToFullIndex) and unit tests to cover edge cases.
- Added placeTab() to paneLayout to apply correct ordering/activation semantics and avoid plugin closedPlugins side effects; hardened normalization by de-duplicating tab IDs across right/bottom.
- Added Playwright helpers + end-to-end tests to verify persistence and cross-dock/empty-dock behavior.
```

Potential follow-ups:
- Validate keyboard and screen-reader behavior for reordering/moving (focus management, announcements, and ARIA correctness) beyond pointer dragging.
- Stress-test rapid drag/cancel and mixed visible/hidden tab states under unusual layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->