### PR TITLE
fix(acp): stdin keepalive to unstick a stalled agent mid-turn

### DIFF
--- a/src/acp/runner.rs
+++ b/src/acp/runner.rs
@@ -112,6 +112,13 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
 /// Why the runner is tearing down. Drives whether teardown deletes the
 /// registry entry: a superseded runner must NOT delete, since the files
 /// now belong to the fresh runner that replaced it.
@@ -141,6 +148,87 @@ const FAST_EXIT_THRESHOLD: Duration = Duration::from_secs(10);
 /// Pipe-read buffer for the agent's stdout. 64KB matches the default
 /// pipe size on macOS/Linux.
 const STDOUT_READ_BUF: usize = 64 * 1024;
+
+/// Stdout-silence keepalive (see #2455). `claude-agent-acp` (<= 0.52.0)
+/// wraps `process.stdout.write` in a Web Streams writable with no
+/// backpressure handling, so a mid-turn stdout write can stall until a
+/// stdin `data` event wakes the Node event loop and lets libuv flush. The
+/// runner writes a harmless `\n` to the agent's stdin once stdout goes
+/// silent, which wakes the adapter and flushes the stalled output; the
+/// adapter's ndjson decoder skips blank lines, so the nudge is never
+/// parsed as a message or a user prompt. Temporary mitigation; remove once
+/// the adapter handles stdout backpressure (upstream fix tracked
+/// separately). Fast burst clears a transient stall quickly; the slow
+/// unbounded tail guarantees a stall that begins after a long legitimate
+/// silence (e.g. a multi-minute model think with zero output) is still
+/// eventually flushed.
+const STDOUT_NUDGE_FAST_INTERVAL: Duration = Duration::from_secs(2);
+const STDOUT_NUDGE_FAST_BURST: u32 = 3;
+const STDOUT_NUDGE_SLOW_INTERVAL: Duration = Duration::from_secs(30);
+/// Cap on a single nudge write so a wedged adapter that stopped reading
+/// stdin cannot park the keepalive while it holds the shared stdin mutex
+/// (which would block real daemon -> agent traffic).
+const STDOUT_NUDGE_WRITE_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// Resolved keepalive timing for a runner. `None` (from
+/// [`stdout_nudge_config`]) disables the keepalive entirely.
+struct StdoutNudgeConfig {
+    fast_interval: Duration,
+    fast_burst: u32,
+    slow_interval: Duration,
+    write_timeout: Duration,
+}
+
+/// Decide whether and how to run the stdout-silence keepalive for this
+/// agent. Enabled by default only for `claude-agent-acp` (the adapter the
+/// `\n`-is-safely-skipped behavior was verified against); other agents
+/// might treat a blank line as a protocol error, so they stay off unless
+/// `AOE_ACP_STDOUT_NUDGE=1` forces it. `AOE_ACP_STDOUT_NUDGE=0` disables it
+/// even for claude. `AOE_ACP_STDOUT_NUDGE_MS` / `_SLOW_MS` shrink the
+/// intervals for tests, mirroring `AOE_ACP_WATCHDOG_POLL_MS`.
+fn stdout_nudge_config(args: &AcpRunnerArgs) -> Option<StdoutNudgeConfig> {
+    let enabled = match std::env::var("AOE_ACP_STDOUT_NUDGE").ok().as_deref() {
+        Some("0") | Some("false") | Some("off") => return None,
+        Some("1") | Some("true") | Some("on") => true,
+        _ => stdout_nudge_default_for_agent(args),
+    };
+    if !enabled {
+        return None;
+    }
+    let fast_interval =
+        env_duration_ms("AOE_ACP_STDOUT_NUDGE_MS").unwrap_or(STDOUT_NUDGE_FAST_INTERVAL);
+    // A zero fast interval is an explicit kill switch.
+    if fast_interval.is_zero() {
+        return None;
+    }
+    let slow_interval = env_duration_ms("AOE_ACP_STDOUT_NUDGE_SLOW_MS")
+        .unwrap_or(STDOUT_NUDGE_SLOW_INTERVAL)
+        // Never tighter than the fast cadence (also rules out zero).
+        .max(fast_interval);
+    Some(StdoutNudgeConfig {
+        fast_interval,
+        fast_burst: STDOUT_NUDGE_FAST_BURST,
+        slow_interval,
+        write_timeout: STDOUT_NUDGE_WRITE_TIMEOUT,
+    })
+}
+
+fn stdout_nudge_default_for_agent(args: &AcpRunnerArgs) -> bool {
+    args.agent_key == "claude"
+        || args.agent_name.contains("claude-agent-acp")
+        || args
+            .agent_argv
+            .first()
+            .map(|s| s.contains("claude-agent-acp"))
+            .unwrap_or(false)
+}
+
+fn env_duration_ms(key: &str) -> Option<Duration> {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_millis)
+}
 
 #[derive(Args, Debug, Clone)]
 pub struct AcpRunnerArgs {
@@ -297,6 +385,10 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
 
     let shared = Arc::new(RunnerShared::new());
 
+    // Last time (epoch millis) the agent wrote to stdout; drives the
+    // stdout-silence keepalive (#2455).
+    let stdout_activity = Arc::new(AtomicU64::new(now_millis()));
+
     // Fan-out task: reads agent stdout and either forwards to the
     // currently-attached daemon or buffers in the ring. Single owner of
     // the read half of the agent's stdout pipe.
@@ -304,6 +396,7 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         agent_stdout,
         Arc::clone(&shared),
         args.session_id.clone(),
+        Arc::clone(&stdout_activity),
     ));
 
     // Wrap agent stdin in a tokio Mutex so the accept loop can hand it
@@ -311,6 +404,19 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
     // alive across reconnects; closing it would cause aoe-agent to
     // `process.exit(0)`.
     let agent_stdin = Arc::new(Mutex::new(agent_stdin));
+
+    // Stdout-silence keepalive (#2455): nudge the agent's stdin with a
+    // harmless `\n` when its stdout stalls mid-turn, so a buffering bug in
+    // the upstream adapter can't freeze the session. Disabled for agents
+    // it isn't verified safe for (see `stdout_nudge_config`).
+    let keepalive_task = stdout_nudge_config(&args).map(|cfg| {
+        tokio::spawn(stdout_silence_nudge(
+            cfg,
+            Arc::clone(&stdout_activity),
+            Arc::clone(&agent_stdin),
+            args.session_id.clone(),
+        ))
+    });
 
     // Signal handling: SIGTERM/SIGINT → kill agent, cleanup, exit.
     let shutdown_signal = wait_for_shutdown();
@@ -444,6 +550,9 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
 
     watchdog_handle.abort();
     agent_stdout_task.abort();
+    if let Some(task) = keepalive_task {
+        task.abort();
+    }
     if !preserve_registry {
         worker_registry::delete(&session_id).ok();
     }
@@ -842,6 +951,7 @@ async fn fanout_agent_stdout(
     stdout: tokio::process::ChildStdout,
     shared: Arc<RunnerShared>,
     session_id: String,
+    stdout_activity: Arc<AtomicU64>,
 ) {
     let mut reader = BufReader::with_capacity(STDOUT_READ_BUF, stdout);
     let mut line = Vec::with_capacity(4096);
@@ -855,12 +965,105 @@ async fn fanout_agent_stdout(
                 break;
             }
             Ok(_) => {
+                // Mark progress for the stdout-silence keepalive (#2455).
+                stdout_activity.store(now_millis(), Ordering::Relaxed);
                 shared.deliver_line(&line).await;
             }
             Err(e) => {
                 warn!(target: "acp.runner", session = %session_id, "stdout read error: {e}");
                 break;
             }
+        }
+    }
+}
+
+/// Stdout-silence keepalive loop (#2455). Watches `stdout_activity`; when
+/// the agent has produced no stdout for `fast_interval`, writes a harmless
+/// `\n` to its stdin to wake a stalled upstream adapter. Nudges in a fast
+/// burst, then a slow unbounded tail, until stdout resumes (which re-arms
+/// the burst). Runs regardless of daemon attachment: a stall while
+/// detached would otherwise leave the runner's replay ring missing the
+/// gap. Ends when the agent's stdin closes (agent gone); the runner's
+/// teardown also aborts it.
+async fn stdout_silence_nudge(
+    cfg: StdoutNudgeConfig,
+    stdout_activity: Arc<AtomicU64>,
+    agent_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
+    session_id: String,
+) {
+    loop {
+        let mut last = stdout_activity.load(Ordering::Relaxed);
+        tokio::time::sleep(cfg.fast_interval).await;
+        if stdout_activity.load(Ordering::Relaxed) != last {
+            continue; // stdout flowed within the interval; not silent
+        }
+        // Silent past the fast interval. Nudge, then keep nudging at the
+        // fast cadence for the burst and the slow cadence after, until
+        // stdout activity resumes.
+        let mut sent: u32 = 0;
+        loop {
+            if !write_stdin_nudge(&agent_stdin, cfg.write_timeout, &session_id, sent).await {
+                return; // stdin write failed: agent gone
+            }
+            sent += 1;
+            let wait = if sent < cfg.fast_burst {
+                cfg.fast_interval
+            } else {
+                cfg.slow_interval
+            };
+            last = stdout_activity.load(Ordering::Relaxed);
+            tokio::time::sleep(wait).await;
+            if stdout_activity.load(Ordering::Relaxed) != last {
+                break; // a nudge flushed output (or output resumed); re-arm
+            }
+        }
+    }
+}
+
+/// Write a single `\n` keepalive to the agent's stdin under the shared
+/// mutex (so it never interleaves a daemon-originated JSON-RPC line),
+/// bounded by `write_timeout`. Returns false only on a write error (the
+/// pipe is broken: the agent exited), which ends the keepalive loop. A
+/// timeout returns true so the loop keeps trying at the slow cadence;
+/// process lifecycle is owned by the main `select!`, not here.
+async fn write_stdin_nudge(
+    agent_stdin: &Mutex<tokio::process::ChildStdin>,
+    write_timeout: Duration,
+    session_id: &str,
+    sent: u32,
+) -> bool {
+    let mut stdin = agent_stdin.lock().await;
+    match tokio::time::timeout(write_timeout, async {
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await
+    })
+    .await
+    {
+        Ok(Ok(())) => {
+            debug!(
+                target: "acp.runner",
+                session = %session_id,
+                nudge = sent + 1,
+                "stdout-silence keepalive nudge"
+            );
+            true
+        }
+        Ok(Err(e)) => {
+            warn!(
+                target: "acp.runner",
+                session = %session_id,
+                "keepalive nudge write failed; agent likely exited: {e}"
+            );
+            false
+        }
+        Err(_) => {
+            warn!(
+                target: "acp.runner",
+                session = %session_id,
+                write_timeout_ms = write_timeout.as_millis(),
+                "keepalive nudge write timed out; agent not reading stdin"
+            );
+            true
         }
     }
 }
@@ -1082,6 +1285,49 @@ fn open_log_file(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn args_with_agent(agent_key: &str, agent_name: &str, argv0: &str) -> AcpRunnerArgs {
+        AcpRunnerArgs {
+            socket: PathBuf::from("/tmp/x.sock"),
+            session_id: "s".into(),
+            agent_name: agent_name.into(),
+            agent_key: agent_key.into(),
+            cwd: PathBuf::from("/tmp"),
+            model: None,
+            additional_dirs: vec![],
+            provider_env_keys: vec![],
+            stored_acp_session_id: None,
+            source_profile: String::new(),
+            agent_argv: vec![argv0.into()],
+        }
+    }
+
+    /// The keepalive defaults on only for claude-agent-acp, the adapter the
+    /// blank-line-safe behavior was verified against. Other agents stay off
+    /// so a stray `\n` can't corrupt a transport that rejects blank lines.
+    #[test]
+    fn stdout_nudge_default_scoped_to_claude_adapter() {
+        assert!(stdout_nudge_default_for_agent(&args_with_agent(
+            "claude",
+            "claude-agent-acp",
+            "claude-agent-acp"
+        )));
+        // Matched by agent_name / argv even when the key differs.
+        assert!(stdout_nudge_default_for_agent(&args_with_agent(
+            "",
+            "claude-agent-acp",
+            "/usr/bin/claude-agent-acp"
+        )));
+        // Other adapters are off by default.
+        assert!(!stdout_nudge_default_for_agent(&args_with_agent(
+            "codex",
+            "codex-acp",
+            "codex-acp"
+        )));
+        assert!(!stdout_nudge_default_for_agent(&args_with_agent(
+            "opencode", "opencode", "opencode"
+        )));
+    }
 
     #[test]
     fn parse_request_extracts_id_and_method() {

--- a/src/acp/runner.rs
+++ b/src/acp/runner.rs
@@ -214,8 +214,7 @@ fn stdout_nudge_config(args: &AcpRunnerArgs) -> Option<StdoutNudgeConfig> {
 }
 
 fn stdout_nudge_default_for_agent(args: &AcpRunnerArgs) -> bool {
-    args.agent_key == "claude"
-        || args.agent_name.contains("claude-agent-acp")
+    args.agent_name.contains("claude-agent-acp")
         || args
             .agent_argv
             .first()
@@ -1317,6 +1316,11 @@ mod tests {
             "",
             "claude-agent-acp",
             "/usr/bin/claude-agent-acp"
+        )));
+        // A bare `claude` key without the claude-agent-acp binary is not
+        // enough: the keepalive defaults on only for the verified adapter.
+        assert!(!stdout_nudge_default_for_agent(&args_with_agent(
+            "claude", "claude", "claude"
         )));
         // Other adapters are off by default.
         assert!(!stdout_nudge_default_for_agent(&args_with_agent(

--- a/tests/acp_runner_keepalive.rs
+++ b/tests/acp_runner_keepalive.rs
@@ -13,6 +13,11 @@
 //! keepalive the runner supplies the stdin byte automatically and the
 //! second line is forwarded to the attached daemon; without it the fake
 //! agent blocks forever and the second line never arrives.
+//!
+//! Unix-only: the harness drives the runner's unix socket directly, so the
+//! whole file is gated rather than guarded at runtime (the `UnixStream`
+//! import alone would otherwise break non-Unix compilation).
+#![cfg(unix)]
 
 use std::io::{BufRead, BufReader, Read};
 use std::os::unix::net::UnixStream;
@@ -62,10 +67,6 @@ impl Drop for KillOnDrop {
 
 #[test]
 fn keepalive_unsticks_agent_blocked_on_stdin() {
-    if cfg!(not(unix)) {
-        return;
-    }
-
     let scratch = Scratch::new("k2455");
     let (home, xdg) = (scratch.0.clone(), scratch.0.clone());
     let workers = app_dir(&home, &xdg).join("acp-workers");

--- a/tests/acp_runner_keepalive.rs
+++ b/tests/acp_runner_keepalive.rs
@@ -1,0 +1,164 @@
+//! Regression test for #2455: the runner's stdout-silence keepalive must
+//! unstick an agent whose stdout stalled mid-turn.
+//!
+//! The upstream `claude-agent-acp` adapter buffers its stdout with no
+//! backpressure handling, so a mid-turn write can stall until a stdin
+//! `data` event wakes its event loop. The runner now writes a harmless
+//! `\n` to the agent's stdin after stdout goes silent, which flushes the
+//! stall. Without that keepalive the session freezes until a human types
+//! something.
+//!
+//! This spawns a real runner with a fake agent that writes one line, then
+//! BLOCKS reading a line from stdin, then writes a second line. With the
+//! keepalive the runner supplies the stdin byte automatically and the
+//! second line is forwarded to the attached daemon; without it the fake
+//! agent blocks forever and the second line never arrives.
+
+use std::io::{BufRead, BufReader, Read};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// App data dir for the debug binary, which uses the `-dev` namespace.
+fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
+        xdg.join("agent-of-empires-dev")
+    } else {
+        home.join(".agent-of-empires-dev")
+    }
+}
+
+/// Unique scratch dir under `/tmp`, kept short so the worker unix socket
+/// path stays under the macOS `SUN_LEN` limit. Removed on drop.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let base = if cfg!(unix) {
+            PathBuf::from("/tmp")
+        } else {
+            std::env::temp_dir()
+        };
+        let dir = base.join(format!("ao{}{label}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        Scratch(dir)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct KillOnDrop(Child);
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn keepalive_unsticks_agent_blocked_on_stdin() {
+    if cfg!(not(unix)) {
+        return;
+    }
+
+    let scratch = Scratch::new("k2455");
+    let (home, xdg) = (scratch.0.clone(), scratch.0.clone());
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let session_id = "s2455";
+    let socket = workers.join(format!("{session_id}.sock"));
+
+    // Fake agent: emit one ndjson-ish line, block on a stdin read (this is
+    // the stall the keepalive must break), emit a second line, then keep
+    // stdin open so the runner doesn't tear down before we read it.
+    let fake = r#"printf 'LINE1\n'; IFS= read -r _; printf 'LINE2\n'; cat >/dev/null"#;
+
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let child = Command::new(bin)
+        .args([
+            "__acp-runner",
+            "--socket",
+            socket.to_str().unwrap(),
+            "--session-id",
+            session_id,
+            "--agent-name",
+            "fake-agent",
+            "--cwd",
+            home.to_str().unwrap(),
+            "--",
+            "sh",
+            "-c",
+            fake,
+        ])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        // Force the keepalive on for this non-claude fake agent, and shrink
+        // the cadence so the test runs in well under a second.
+        .env("AOE_ACP_STDOUT_NUDGE", "1")
+        .env("AOE_ACP_STDOUT_NUDGE_MS", "150")
+        .env("AOE_ACP_STDOUT_NUDGE_SLOW_MS", "150")
+        .spawn()
+        .expect("spawn acp runner");
+    let mut child = KillOnDrop(child);
+
+    // Connect to the runner's socket as the daemon; it forwards agent
+    // stdout to us (replaying the ring for anything buffered pre-attach).
+    let stream = connect_with_retry(&socket, Duration::from_secs(10), &mut child.0);
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+    let line1 = read_line(&mut reader);
+    assert!(
+        line1.contains("LINE1"),
+        "expected the agent's first line, got {line1:?}"
+    );
+
+    // The agent is now blocked on its stdin read. Only the runner's
+    // keepalive can unblock it; if it does not, this read times out.
+    let line2 = read_line(&mut reader);
+    assert!(
+        line2.contains("LINE2"),
+        "second line never arrived; the stalled agent was not unstuck by the keepalive (got {line2:?})"
+    );
+}
+
+fn connect_with_retry(socket: &Path, within: Duration, child: &mut Child) -> UnixStream {
+    let deadline = Instant::now() + within;
+    loop {
+        if let Ok(s) = UnixStream::connect(socket) {
+            return s;
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("runner exited before its socket was connectable: {status}");
+        }
+        if Instant::now() > deadline {
+            panic!(
+                "runner socket {} never became connectable",
+                socket.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Read one `\n`-terminated line; panic on timeout/EOF so a stall surfaces
+/// as a clear failure rather than a hang.
+fn read_line(reader: &mut BufReader<UnixStream>) -> String {
+    let mut line = String::new();
+    match reader.read_line(&mut line) {
+        Ok(0) => panic!("socket closed before a line arrived"),
+        Ok(_) => line,
+        Err(e) => {
+            // Drain anything buffered for a better failure message.
+            let mut rest = Vec::new();
+            let _ = reader.get_mut().read_to_end(&mut rest);
+            panic!("read failed (likely a timeout from the stalled agent): {e}");
+        }
+    }
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A structured-view / ACP session could freeze mid-turn: the agent stopped streaming stdout partway through a message or tool run, the UI stayed "running" (green), and it only resumed when a byte was written to the agent's stdin (typing a single character flushed everything and the turn completed).

Root cause is upstream, in the `claude-agent-acp@0.52.0` Node adapter. Its stdout write path wraps `process.stdout.write(buf, cb)` in a Web Streams writable with no backpressure handling (no `drain` check, no check of `write()`'s return value), so a mid-turn write can stall until a stdin `data` event wakes the Node event loop and lets libuv flush. aoe's runner was just parked at `read_until` on the agent's stdout pipe. The aoe daemon-side ingest is provably fast (one SQLite insert plus a non-blocking broadcast), so it is not the bottleneck; this is a runner-local mitigation for an upstream buffering bug.

The runner now tracks the time of the last agent stdout byte and, once stdout goes silent past a short interval, writes a harmless `\n` to the agent's stdin. That wakes the adapter and flushes the stalled output. The adapter's ndjson decoder skips blank lines (verified in `stream.js`: an empty line is trimmed and never reaches `JSON.parse`), so the nudge is never parsed as a message or a user prompt. Nudges fire in a fast burst then a slow unbounded tail, so a stall that begins after a long legitimate silence (for example a multi-minute model think with zero output) is still flushed; they reset on any new stdout activity, write through the existing stdin mutex under a short timeout (so a wedged adapter that stopped reading stdin cannot park the keepalive while holding that mutex), and are enabled by default only for `claude-agent-acp` (`AOE_ACP_STDOUT_NUDGE=0/1` overrides; `AOE_ACP_STDOUT_NUDGE_MS` / `_SLOW_MS` tune the cadence for tests).

The durable fix is stdout backpressure handling in the adapter; that is an upstream ask, noted in a code comment. Proposals B (daemon ingest) and C (UI degraded state) from the issue remain valid follow-ups but are not needed for this P0.

Closes #2455

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run a `claude-agent-acp` structured-view session that streams a long message or a long tool run; confirm it no longer freezes mid-stream and reaches a terminal state without you typing anything.
- [ ] Reproduce a stall deterministically: `AOE_ACP_STDOUT_NUDGE=1 AOE_ACP_STDOUT_NUDGE_MS=150 AOE_ACP_STDOUT_NUDGE_SLOW_MS=150 cargo test --features serve --test acp_runner_keepalive` passes (a fake agent that blocks on a stdin read gets unstuck by the keepalive).
- [ ] Confirm the keepalive is off for non-claude agents by default: a session for another agent key gets no stdin nudges unless `AOE_ACP_STDOUT_NUDGE=1` is set.
- [ ] Confirm no regression in runner lifecycle: `cargo test --features serve --test acp_runner_orphan` passes (the orphan/superseded self-termination paths still work after the `run()` and stdout-fanout changes).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:
  - Added a full-binary integration test `tests/acp_runner_keepalive.rs` (a real `aoe __acp-runner` spawned against a fake agent that stalls on a stdin read, asserting the keepalive delivers the post-stall output). It lives under `tests/` like the sibling `tests/acp_runner_orphan.rs`, not `tests/e2e/`, matching where runner integration tests already live. It is reproduce-then-fix: it fails on the pre-fix tree (the stalled agent never delivers the second line) and passes after.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, vendor-adapter inspection, plan, and implementation drafted by Claude under my direction, with a `/debate` round to pressure-test the keepalive design. I made the design calls (fast-burst + slow-tail, claude-scoped, write timeout) and reviewed each change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785144558&installation_id=139138837&pr_number=2459&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2459&signature=caf5f69dbc3fa547f734211c4b62bb153379fe150869f11c9e3c21e426ecc3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a runner-side safeguard for ACP agent sessions that can freeze mid-turn when the agent’s stdout stops flowing. The runner now monitors how long stdout has been silent, then periodically “nudges” the agent by sending a harmless newline to stdin to wake up the adapter and flush stalled output—preventing the session from remaining stuck until someone manually types input.

It also:
- Enables the workaround by default only for the verified `claude-agent-acp` adapter (not broadly for all matching agent keys), with environment variables to force on/off or tune timing.
- Uses a fast-then-slow cadence, resets the nudge behavior whenever stdout activity resumes, and treats a zero fast interval as a kill switch.
- Ensures the background keepalive/nudge task is aborted cleanly during runner shutdown.
- Adds a Unix-only regression test (`#2455`) that reproduces an agent blocking on stdin after initial output and verifies later output still arrives without manual intervention.

Benefit: fewer mid-stream stalls, more reliable turn completion/streaming, and reduced need for operators to “poke” stdin to recover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->