### PR TITLE
docs: clarify projects vs groups and rename sidebar repo heading to Sessions

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -35,6 +35,22 @@ aoe add /path/to/project
 
 The session appears in the dashboard with status **Idle**.
 
+## Projects and Groups
+
+These two words show up around the dashboard and mean different things.
+
+A **project** is a saved directory path, usually a git repository, that you register once so you can start sessions from it without retyping the path. It is an AoE registry entry, not a Claude Code project (which is tied to a directory by Claude itself). You do not have to register your repos; `n` and `aoe add <path>` work on any path. Registering is only a convenience for repos you reach for often.
+
+Add a project two ways:
+
+```bash
+aoe project add /path/to/repo        # CLI
+```
+
+In the TUI, press `p` to open **Manage projects**, then `a` to add one. Once a project is registered, `b` starts a new session from it (this is why `b` reports "No Projects" until you have added at least one). See [Multi-Repo Workspaces](guides/multi-repo-workspaces.md#the-project-registry) for scopes and multi-repo sessions.
+
+A **group** is unrelated to projects. It is a label you assign to existing sessions to sort them in the sidebar (for example `fix` and `feature`), set from the session rename dialog or with `aoe group move`. Projects are where sessions start; groups are how sessions are bucketed once they exist. See the [Web Dashboard grouping section](guides/web/dashboard.md#sidebar-grouping-by-repo-by-group-or-both) for the grouping axes.
+
 ## Attach to a Session
 
 Select a session and press `Enter` to attach. You're now inside a tmux session running your AI agent (Claude Code by default).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -12,6 +12,7 @@ This opens the dashboard. You'll see an empty session list on first run.
 |-----|--------|
 | `n` | New session |
 | `b` | New session from saved project |
+| `p` | Manage saved projects (add/remove) |
 | `Enter` | Attach to session |
 | `d` | Delete session |
 | `t` | Toggle Agent/Terminal view |

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2261,9 +2261,9 @@ const NEXT_AXIS: Record<SidebarAxis, SidebarAxis> = {
 };
 
 const AXIS_HEADING: Record<SidebarAxis, string> = {
-  repo: "Projects",
+  repo: "Sessions",
   group: "Groups",
-  "repo+group": "Projects",
+  "repo+group": "Sessions",
 };
 
 const AXIS_TOOLTIP: Record<SidebarAxis, string> = {
@@ -2765,7 +2765,9 @@ export function WorkspaceSidebar({
         }`}
       >
         <div className="px-3 pt-3 pb-1 flex items-center">
-          <span className="text-sm text-text-muted flex-1">{AXIS_HEADING[axis]}</span>
+          <span data-testid="sidebar-axis-heading" className="text-sm text-text-muted flex-1">
+            {AXIS_HEADING[axis]}
+          </span>
           <Tooltip text={AXIS_TOOLTIP[axis]}>
             <button
               onClick={() => onAxisChange(NEXT_AXIS[axis])}

--- a/web/tests/capture/screenshots.spec.ts
+++ b/web/tests/capture/screenshots.spec.ts
@@ -247,10 +247,10 @@ base("structured view surfaces", async ({ page }, testInfo) => {
     await waitForStructuredView(page);
     // The mobile drawer mounts open; tap the content area to the right of
     // it (the backdrop) so it slides away and the structured view is clear.
-    const sidebarHeading = page.getByText("Sessions", { exact: true });
-    if (await sidebarHeading.isVisible().catch(() => false)) {
+    const sidebarHeading = page.getByTestId("sidebar-axis-heading");
+    if (await sidebarHeading.isVisible()) {
       await page.mouse.click(340, 450);
-      await sidebarHeading.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+      await sidebarHeading.waitFor({ state: "hidden", timeout: 5_000 });
     }
     await page.waitForTimeout(600);
     await shot(page, "structured view/interface.png");

--- a/web/tests/capture/screenshots.spec.ts
+++ b/web/tests/capture/screenshots.spec.ts
@@ -247,10 +247,10 @@ base("structured view surfaces", async ({ page }, testInfo) => {
     await waitForStructuredView(page);
     // The mobile drawer mounts open; tap the content area to the right of
     // it (the backdrop) so it slides away and the structured view is clear.
-    const projects = page.getByText("Projects", { exact: true });
-    if (await projects.isVisible().catch(() => false)) {
+    const sidebarHeading = page.getByText("Sessions", { exact: true });
+    if (await sidebarHeading.isVisible().catch(() => false)) {
       await page.mouse.click(340, 450);
-      await projects.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+      await sidebarHeading.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
     }
     await page.waitForTimeout(600);
     await shot(page, "structured view/interface.png");

--- a/web/tests/sidebar-grouping.spec.ts
+++ b/web/tests/sidebar-grouping.spec.ts
@@ -152,10 +152,15 @@ test.describe("sidebar user-group axis (#1234)", () => {
     await expect(headers).toHaveCount(1);
     await expect(page.locator(ROW)).toHaveCount(3);
 
+    // The control-row heading names the repo axis "Sessions", not "Projects".
+    const axisHeading = page.getByTestId("sidebar-axis-heading");
+    await expect(axisHeading).toHaveText("Sessions");
+
     const axisToggle = page.locator(AXIS_TOGGLE);
     await expect(axisToggle).toHaveAttribute("data-axis", "repo");
     await axisToggle.click();
     await expect(axisToggle).toHaveAttribute("data-axis", "group");
+    await expect(axisHeading).toHaveText("Groups");
 
     // Group axis: two headers, keyed by group_path. All three rows stay
     // visible, now nested under their group.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A user reading the Quick Start hit the `b` shortcut ("New session from saved project"), saw the "No Projects" message, and had no idea what a saved project was, how to create one, or whether it mapped to a Claude Code project. The docs named "saved project" without ever defining it, and never mentioned how it differs from "groups".

This PR does two things:

**Docs.** Adds a short **Projects and Groups** section to `docs/quick-start.md`:

- A project is an AoE registry path (usually a git repo) you save so you can start sessions from it without retyping the path. It is not a Claude Code project, and registering is optional convenience, not a requirement.
- How to add one: CLI `aoe project add <path>`, or in the TUI press `p` (Manage projects) then `a`. This explains why `b` reports "No Projects" until at least one is added.
- A group is unrelated: a label for sorting existing sessions in the sidebar, set from the rename dialog or `aoe group move`. Projects are where sessions start; groups are how they are bucketed.

**Web sidebar.** Renames the top-left sidebar control-row heading for the repository grouping axis from "Projects" to "Sessions" (`web/src/components/WorkspaceSidebar.tsx`). That heading sits next to the sort and grouping toggles and labels the session list, not the project registry, so "Projects" was misleading. The user-group axis keeps its "Groups" heading. A test id is added to the heading and the grouping Playwright spec asserts the label.

The TUI side (the `b` empty-state dialog only points at the CLI, never at the in-app `p` then `a` flow) is tracked separately as a discoverability follow-up in #2463.

Closes #2462

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

(Also a small web UI copy change; no new feature surface.)

## How to test

- [ ] Open `docs/quick-start.md` and confirm the new "Projects and Groups" section defines a project as an AoE registry path, distinct from a Claude Code project.
- [ ] Confirm both add paths are shown: CLI `aoe project add <path>` and TUI `p` then `a`.
- [ ] Confirm the section explains how groups differ and links to the grouping docs.
- [ ] Run `aoe serve`, open the web dashboard, and confirm the top-left sidebar heading reads "Sessions" on the default (repo) grouping, and "Groups" after toggling to the user-group axis.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

(Extended `tests/sidebar-grouping.spec.ts` to assert the heading label. `WorkspaceSidebar.tsx` is already mapped by the existing `sidebar.groups` matrix entry, so no new matrix row was needed.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and the doc wording were drafted by Claude under my direction. I made the scope calls (docs clarification plus the sidebar heading rename here, TUI affordance follow-up filed as #2463), reviewed the change, and ran the manual checks.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated `docs/quick-start.md` with a new **Projects and Groups** section that clearly distinguishes:
  - **Projects** = AoE registry paths (saved directories, typically repos) used as start points for sessions; not Claude Code projects; registration is optional.
  - **Groups** = labels used to organize/sort existing sessions in the sidebar (set via the rename dialog or `aoe group move`).
- Documented how to add projects in both places:
  - CLI: `aoe project add <path>`
  - TUI: press `p` (Manage projects) then `a`
- Clarified the user-facing behavior that `b` reports **“No Projects”** until at least one project is registered.
- Updated the web sidebar UI so the repository-based heading is renamed from **“Projects”** to **“Sessions”** (while the group axis remains **“Groups”**), and added a stable test hook (`data-testid="sidebar-axis-heading"`).
- Updated related web tests to match the new **Sessions** heading and to use the new test hook for the mobile screenshot flow.

Benefits:
- Reduces confusion about what “project” means in AoE vs Claude Code.
- Makes it easier for users to start sessions from saved locations without retyping paths.
- Improves clarity and consistency in how sessions are organized in the UI.
- Strengthens test reliability around sidebar heading/visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->