### PR TITLE
feat(acp): resume rate-limited structured sessions

### DIFF
--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -10,6 +10,7 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::acp::approvals::Nonce;
@@ -20,7 +21,7 @@ use crate::acp::protocol::{
     FilesResponse, PromptAttachmentUpload, PromptRequest, ReplayQuery, ReplayResponse,
     ResolveApprovalRequest, SwitchAgentRequest, SwitchAgentResponse,
 };
-use crate::acp::state::PromptAttachmentKind;
+use crate::acp::state::{Event, PromptAttachmentKind, RateLimitInfo};
 use crate::acp::supervisor::SupervisorError;
 use crate::server::AppState;
 
@@ -201,6 +202,21 @@ fn validate_attachments(
     Ok(blobs)
 }
 
+fn rate_limit_resume_marker_resets_at(
+    latest_status: Option<&Event>,
+    latest_rate_limit: Option<&RateLimitInfo>,
+    fallback_resets_at: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    match latest_status {
+        Some(Event::Stopped { reason }) if reason == "rate_limited" => Some(
+            latest_rate_limit
+                .map(|info| info.resets_at.clone())
+                .unwrap_or(fallback_resets_at),
+        ),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SpawnAcpRequest {
     /// Optional override; falls back to the acp_default_agent
@@ -321,7 +337,29 @@ pub async fn spawn_acp(
     // profile for non-sandbox sessions too.
     let source_profile = Some(instance.source_profile.clone());
     let agent_for_response = agent.clone();
-    match state
+
+    let rate_limit_resume_resets_at = {
+        let store = Arc::clone(&state.acp_event_store);
+        let id_for_probe = id.clone();
+        tokio::task::spawn_blocking(move || {
+            let latest_status = store.latest_status_event(&id_for_probe);
+            let latest_rate_limit = store
+                .latest_rate_limit_event(&id_for_probe)
+                .map(|(info, _created_at)| info);
+            rate_limit_resume_marker_resets_at(
+                latest_status.as_ref(),
+                latest_rate_limit.as_ref(),
+                Utc::now(),
+            )
+        })
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(target: "http.api.acp", session = %id, "rate-limit resume probe failed: {e}");
+            None
+        })
+    };
+
+    let spawn_result = state
         .acp_supervisor
         .spawn(crate::acp::supervisor::SpawnRequest {
             session_id: id.clone(),
@@ -341,14 +379,35 @@ pub async fn spawn_acp(
             ),
             seed_history_replay,
         })
-        .await
-    {
-        Ok(()) => Json(SpawnAcpResponse {
-            session_id: id,
-            agent: agent_for_response,
-            status: "running",
-        })
-        .into_response(),
+        .await;
+
+    match spawn_result {
+        Ok(()) => {
+            if let Some(resets_at) = rate_limit_resume_resets_at {
+                state
+                    .acp_supervisor
+                    .publish_rate_limit_auto_resumed(&id, resets_at);
+            }
+            Json(SpawnAcpResponse {
+                session_id: id,
+                agent: agent_for_response,
+                status: "running",
+            })
+            .into_response()
+        }
+        Err(SupervisorError::AlreadyRunning(_)) if rate_limit_resume_resets_at.is_some() => {
+            if let Some(resets_at) = rate_limit_resume_resets_at {
+                state
+                    .acp_supervisor
+                    .publish_rate_limit_auto_resumed(&id, resets_at);
+            }
+            Json(SpawnAcpResponse {
+                session_id: id,
+                agent: agent_for_response,
+                status: "running",
+            })
+            .into_response()
+        }
         Err(SupervisorError::AlreadyRunning(_)) => (
             StatusCode::CONFLICT,
             "structured view already running for session",
@@ -2196,6 +2255,12 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    fn utc_ts(raw: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(raw)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
     #[test]
     fn mime_allowlist_gates_by_kind() {
         assert!(mime_allowed(PromptAttachmentKind::Image, "image/png"));
@@ -2225,6 +2290,55 @@ mod tests {
         assert!(!is_plan_mode_value("yolo"));
         assert!(!is_plan_mode_value("Plan"));
         assert!(!is_plan_mode_value(""));
+    }
+
+    #[test]
+    fn rate_limit_resume_marker_requires_latest_rate_limit_park() {
+        let fallback = utc_ts("2099-01-01T00:00:00Z");
+        assert_eq!(
+            rate_limit_resume_marker_resets_at(None, None, fallback),
+            None
+        );
+
+        let stopped = Event::Stopped {
+            reason: "user_stopped".to_string(),
+        };
+        assert_eq!(
+            rate_limit_resume_marker_resets_at(Some(&stopped), None, fallback),
+            None
+        );
+    }
+
+    #[test]
+    fn rate_limit_resume_marker_uses_latest_rate_limit_reset() {
+        let stopped = Event::Stopped {
+            reason: "rate_limited".to_string(),
+        };
+        let resets_at = utc_ts("2099-02-03T04:05:06Z");
+        let fallback = utc_ts("2099-01-01T00:00:00Z");
+        let info = RateLimitInfo {
+            status: "limited".to_string(),
+            resets_at: resets_at.clone(),
+            kind: "rate_limit".to_string(),
+        };
+
+        assert_eq!(
+            rate_limit_resume_marker_resets_at(Some(&stopped), Some(&info), fallback),
+            Some(resets_at)
+        );
+    }
+
+    #[test]
+    fn rate_limit_resume_marker_falls_back_when_rate_limit_event_missing() {
+        let stopped = Event::Stopped {
+            reason: "rate_limited".to_string(),
+        };
+        let fallback = utc_ts("2099-01-01T00:00:00Z");
+
+        assert_eq!(
+            rate_limit_resume_marker_resets_at(Some(&stopped), None, fallback.clone()),
+            Some(fallback)
+        );
     }
 
     #[test]

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -210,7 +210,7 @@ fn rate_limit_resume_marker_resets_at(
     match latest_status {
         Some(Event::Stopped { reason }) if reason == "rate_limited" => Some(
             latest_rate_limit
-                .map(|info| info.resets_at.clone())
+                .map(|info| info.resets_at)
                 .unwrap_or(fallback_resets_at),
         ),
         _ => None,
@@ -2318,7 +2318,7 @@ mod tests {
         let fallback = utc_ts("2099-01-01T00:00:00Z");
         let info = RateLimitInfo {
             status: "limited".to_string(),
-            resets_at: resets_at.clone(),
+            resets_at,
             kind: "rate_limit".to_string(),
         };
 
@@ -2336,7 +2336,7 @@ mod tests {
         let fallback = utc_ts("2099-01-01T00:00:00Z");
 
         assert_eq!(
-            rate_limit_resume_marker_resets_at(Some(&stopped), None, fallback.clone()),
+            rate_limit_resume_marker_resets_at(Some(&stopped), None, fallback),
             Some(fallback)
         );
     }

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -49,7 +49,7 @@ import { useAcpPrefs } from "../../lib/acpPrefs";
 import { AgentProfileProvider, useAgentProfile } from "../../lib/agentProfileContext";
 import { isClearAlias } from "../../lib/agentProfiles";
 import { AttentionChime } from "./AttentionChime";
-import { useRespawnSession } from "../../hooks/useRespawnSession";
+import { useRespawnSession, type RespawnState } from "../../hooks/useRespawnSession";
 import { useIsCoarsePointer } from "../../hooks/useIsCoarsePointer";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { dispatchFocusTerminal } from "../../lib/terminalFocus";
@@ -262,6 +262,11 @@ function AcpChrome({
       id: `rate-limit-recovery-${Date.now()}`,
       text,
     });
+  const {
+    state: rateLimitResumeState,
+    error: rateLimitResumeError,
+    respawn: resumeRateLimitedSession,
+  } = useRespawnSession(sessionId);
 
   // Re-pin the chat viewport to the bottom when the composer (or any
   // sibling below it: queued strip, primer banner) grows. assistant-ui's
@@ -436,6 +441,9 @@ function AcpChrome({
               maxRetries={maxRetries}
               manualReconnect={manualReconnect}
               onSwitchAgent={onSwitchAgent}
+              onResumeRateLimit={() => void resumeRateLimitedSession()}
+              rateLimitResumeState={rateLimitResumeState}
+              rateLimitResumeError={rateLimitResumeError}
             />
           ) : null
         }
@@ -1368,6 +1376,9 @@ export function SystemNotices({
   maxRetries,
   manualReconnect,
   onSwitchAgent,
+  onResumeRateLimit,
+  rateLimitResumeState = "idle",
+  rateLimitResumeError = null,
 }: {
   status: AcpContext["status"];
   lagged: boolean;
@@ -1379,6 +1390,9 @@ export function SystemNotices({
   maxRetries: number;
   manualReconnect: () => void;
   onSwitchAgent?: () => void;
+  onResumeRateLimit?: () => void;
+  rateLimitResumeState?: RespawnState;
+  rateLimitResumeError?: string | null;
 }) {
   const messages: { kind: string; text: string }[] = [];
   // Retry envelope exhausted: the auto-reconnect chain stopped after
@@ -1428,6 +1442,7 @@ export function SystemNotices({
       text: `Rate-limited (${rateLimit.kind}); resets at ${reset}.`,
     });
   }
+  const resumePending = rateLimitResumeState === "retrying" || rateLimitResumeState === "ok";
   if (messages.length === 0 && !retriesExhausted) return null;
   return (
     <div className="border-b border-surface-800 px-4 py-2 space-y-1">
@@ -1436,16 +1451,38 @@ export function SystemNotices({
           {m.text}
         </div>
       ))}
-      {rateLimit && onSwitchAgent && (
-        <div className="flex items-center justify-end pt-1">
-          <button
-            type="button"
-            onClick={onSwitchAgent}
-            className="shrink-0 rounded-md border border-brand-700 bg-brand-900/40 px-2 py-1 text-[10px] font-mono uppercase tracking-wide text-brand-100 hover:bg-brand-900/60"
-          >
-            Continue in another agent
-          </button>
+      {rateLimit && (onResumeRateLimit || onSwitchAgent) && (
+        <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+          {onResumeRateLimit && (
+            <button
+              type="button"
+              onClick={onResumeRateLimit}
+              disabled={resumePending}
+              className="shrink-0 rounded-md border border-brand-700 bg-brand-900/40 px-2 py-1 text-[10px] font-mono uppercase tracking-wide text-brand-100 hover:bg-brand-900/60 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {rateLimitResumeState === "retrying"
+                ? "Resuming…"
+                : rateLimitResumeState === "ok"
+                  ? "Resume requested"
+                  : "Resume now"}
+            </button>
+          )}
+          {onSwitchAgent && (
+            <button
+              type="button"
+              onClick={onSwitchAgent}
+              className="shrink-0 rounded-md border border-brand-700 bg-brand-900/40 px-2 py-1 text-[10px] font-mono uppercase tracking-wide text-brand-100 hover:bg-brand-900/60"
+            >
+              Continue in another agent
+            </button>
+          )}
         </div>
+      )}
+      {rateLimit && rateLimitResumeState === "ok" && (
+        <div className="pt-1 text-xs text-text-muted">Resume requested. New events should start streaming shortly.</div>
+      )}
+      {rateLimit && rateLimitResumeState === "failed" && rateLimitResumeError && (
+        <div className="pt-1 text-xs text-brand-400">Resume failed: {rateLimitResumeError}</div>
       )}
       {retriesExhausted && (
         <div className="flex items-center justify-between gap-3 text-xs text-brand-400">

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -266,7 +266,7 @@ function AcpChrome({
     state: rateLimitResumeState,
     error: rateLimitResumeError,
     respawn: resumeRateLimitedSession,
-  } = useRespawnSession(sessionId);
+  } = useRespawnSession(sessionId, state.rateLimit?.resets_at ?? null);
 
   // Re-pin the chat viewport to the bottom when the composer (or any
   // sibling below it: queued strip, primer banner) grows. assistant-ui's

--- a/web/src/components/acp/SystemNotices.test.tsx
+++ b/web/src/components/acp/SystemNotices.test.tsx
@@ -1,16 +1,10 @@
 // @vitest-environment jsdom
 //
-// Wiring contract for the rate-limit recovery handoff button. StructuredView
+// Wiring contract for the rate-limit recovery buttons. StructuredView
 // passes `onSwitchAgent={() => setRecoveryOpen(true)}` and the only way
-// the user reaches the SwitchAgentModal from here is by clicking the button
-// SystemNotices conditionally renders below the rate-limit banner. This
-// test pins:
-//   1. The button shows up exactly when both `rateLimit` and
-//      `onSwitchAgent` are present (the modal-trigger path).
-//   2. Clicking it invokes the handler with no args.
-//   3. The button stays hidden when rateLimit is null or onSwitchAgent
-//      is undefined, so a plain reconnect banner does not gain a
-//      dangling "Continue in another agent" affordance.
+// the user reaches the SwitchAgentModal from here is by clicking the handoff
+// button SystemNotices conditionally renders below the rate-limit banner. The
+// same banner now also exposes the same-agent Resume now callback.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render } from "@testing-library/react";
@@ -41,6 +35,7 @@ function mount(overrides?: Partial<React.ComponentProps<typeof SystemNotices>>) 
 describe("SystemNotices rate-limit handoff", () => {
   it("renders the switch-agent button only when rateLimit + handler are set", () => {
     const onSwitchAgent = vi.fn();
+    const onResumeRateLimit = vi.fn();
     const { getByRole, queryByRole, rerender } = mount({
       rateLimit: {
         status: "limited",
@@ -48,9 +43,11 @@ describe("SystemNotices rate-limit handoff", () => {
         kind: "rate_limit",
       },
       onSwitchAgent,
+      onResumeRateLimit,
     });
     const button = getByRole("button", { name: /continue in another agent/i });
     expect(button).toBeDefined();
+    expect(getByRole("button", { name: /resume now/i })).toBeDefined();
 
     // Re-render with onSwitchAgent unset; button should disappear.
     rerender(
@@ -80,8 +77,10 @@ describe("SystemNotices rate-limit handoff", () => {
       retryCount: 1,
       retryCountdown: 3,
       onSwitchAgent: vi.fn(),
+      onResumeRateLimit: vi.fn(),
     });
     expect(queryByRole("button", { name: /continue in another agent/i })).toBeNull();
+    expect(queryByRole("button", { name: /resume now/i })).toBeNull();
   });
 
   it("invokes onSwitchAgent on click", () => {
@@ -96,6 +95,66 @@ describe("SystemNotices rate-limit handoff", () => {
     });
     fireEvent.click(getByRole("button", { name: /continue in another agent/i }));
     expect(onSwitchAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onResumeRateLimit on click", () => {
+    const onResumeRateLimit = vi.fn();
+    const { getByRole } = mount({
+      rateLimit: {
+        status: "limited",
+        resets_at: "2099-01-01T00:00:00Z",
+        kind: "rate_limit",
+      },
+      onResumeRateLimit,
+    });
+    fireEvent.click(getByRole("button", { name: /resume now/i }));
+    expect(onResumeRateLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Resume now while retrying", () => {
+    const { getByRole } = mount({
+      rateLimit: {
+        status: "limited",
+        resets_at: "2099-01-01T00:00:00Z",
+        kind: "rate_limit",
+      },
+      onResumeRateLimit: vi.fn(),
+      rateLimitResumeState: "retrying",
+    });
+    const button = getByRole("button", { name: /resuming/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("keeps Resume now disabled after a successful resume request", () => {
+    const { getByRole, getByText } = mount({
+      rateLimit: {
+        status: "limited",
+        resets_at: "2099-01-01T00:00:00Z",
+        kind: "rate_limit",
+      },
+      onResumeRateLimit: vi.fn(),
+      rateLimitResumeState: "ok",
+    });
+    const button = getByRole("button", { name: /resume requested/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(getByText(/Resume requested\. New events should start streaming shortly/i)).toBeDefined();
+  });
+
+  it("shows failed resume feedback while retaining both actions", () => {
+    const { getByRole, getByText } = mount({
+      rateLimit: {
+        status: "limited",
+        resets_at: "2099-01-01T00:00:00Z",
+        kind: "rate_limit",
+      },
+      onResumeRateLimit: vi.fn(),
+      onSwitchAgent: vi.fn(),
+      rateLimitResumeState: "failed",
+      rateLimitResumeError: "Server returned 500. spawn failed",
+    });
+    expect(getByText(/Resume failed: Server returned 500\. spawn failed/i)).toBeDefined();
+    expect(getByRole("button", { name: /resume now/i })).toBeDefined();
+    expect(getByRole("button", { name: /continue in another agent/i })).toBeDefined();
   });
 
   it("renders nothing for a healthy session", () => {

--- a/web/src/hooks/useRespawnSession.test.tsx
+++ b/web/src/hooks/useRespawnSession.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRespawnSession } from "./useRespawnSession";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("useRespawnSession resetKey", () => {
+  it("starts fresh for a second incident after a successful respawn", async () => {
+    const { result, rerender } = renderHook(({ resetKey }: { resetKey: string }) => useRespawnSession("s1", resetKey), {
+      initialProps: { resetKey: "reset-1" },
+    });
+
+    await act(async () => {
+      await result.current.respawn();
+    });
+    expect(result.current.state).toBe("ok");
+
+    rerender({ resetKey: "reset-2" });
+
+    expect(result.current.state).toBe("idle");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("starts fresh for a second incident after a failed respawn", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("boom"),
+      }),
+    );
+    const { result, rerender } = renderHook(
+      ({ resetKey }: { resetKey: string | null }) => useRespawnSession("s1", resetKey),
+      {
+        initialProps: { resetKey: "reset-1" },
+      },
+    );
+
+    await act(async () => {
+      await result.current.respawn();
+    });
+    expect(result.current.state).toBe("failed");
+    expect(result.current.error).toContain("boom");
+
+    rerender({ resetKey: null });
+    expect(result.current.state).toBe("idle");
+    expect(result.current.error).toBeNull();
+
+    rerender({ resetKey: "reset-2" });
+    expect(result.current.state).toBe("idle");
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/web/src/hooks/useRespawnSession.ts
+++ b/web/src/hooks/useRespawnSession.ts
@@ -2,20 +2,34 @@ import { useState } from "react";
 
 export type RespawnState = "idle" | "retrying" | "ok" | "failed";
 
+interface RespawnSnapshot {
+  resetKey: string | null;
+  state: RespawnState;
+  error: string | null;
+}
+
 /** Shared respawn machine for the structured-view recovery banners.
  *  POSTs to `/acp/spawn` (which re-runs the ACP handshake) and tracks the
  *  idle/retrying/ok/failed lifecycle. The next `AcpSessionAssigned` (or
  *  user prompt) clears the banner on the reducer side, so callers only need
  *  to fire `respawn` and reflect `state`/`error`. Extracted so the
  *  WorkerStopped, StartupError, and compat-failure screens share one
- *  implementation instead of three copies. See #2109. */
-export function useRespawnSession(sessionId: string) {
-  const [state, setState] = useState<RespawnState>("idle");
-  const [error, setError] = useState<string | null>(null);
+ *  implementation instead of three copies. `resetKey` lets callers scope
+ *  status to one recovery incident, e.g. a specific rate-limit reset time,
+ *  without one render of stale ok or failed state. See #2109. */
+export function useRespawnSession(sessionId: string, resetKey: string | null = null) {
+  const [snapshot, setSnapshot] = useState<RespawnSnapshot>({
+    resetKey,
+    state: "idle",
+    error: null,
+  });
+  const isCurrent = snapshot.resetKey === resetKey;
+  const state = isCurrent ? snapshot.state : "idle";
+  const error = isCurrent ? snapshot.error : null;
 
   const respawn = async (): Promise<boolean> => {
-    setState("retrying");
-    setError(null);
+    const activeResetKey = resetKey;
+    setSnapshot({ resetKey: activeResetKey, state: "retrying", error: null });
     try {
       const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/acp/spawn`, {
         method: "POST",
@@ -23,16 +37,22 @@ export function useRespawnSession(sessionId: string) {
         body: JSON.stringify({}),
       });
       if (res.ok) {
-        setState("ok");
+        setSnapshot({ resetKey: activeResetKey, state: "ok", error: null });
         return true;
       }
       const detail = (await res.text().catch(() => "")).slice(0, 200);
-      setState("failed");
-      setError(`Server returned ${res.status}. ${detail}`.trim());
+      setSnapshot({
+        resetKey: activeResetKey,
+        state: "failed",
+        error: `Server returned ${res.status}. ${detail}`.trim(),
+      });
       return false;
     } catch (e) {
-      setState("failed");
-      setError(e instanceof Error ? e.message : String(e));
+      setSnapshot({
+        resetKey: activeResetKey,
+        state: "failed",
+        error: e instanceof Error ? e.message : String(e),
+      });
       return false;
     }
   };

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1522,8 +1522,20 @@
       "id": "acp.rate-limit-recovery",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/lib/acpTypes.test.ts", "src/components/acp/SwitchAgentModal.test.tsx"],
-      "components": ["web/src/components/acp/SwitchAgentModal.tsx"]
+      "specs": [
+        "src/lib/acpTypes.test.ts",
+        "src/hooks/useAcpSession.queue.test.ts",
+        "src/components/acp/SystemNotices.test.tsx",
+        "src/components/acp/RateLimitRecoverySection.test.tsx",
+        "src/components/acp/SwitchAgentModal.test.tsx"
+      ],
+      "components": [
+        "src/server/api/acp.rs",
+        "web/src/components/acp/StructuredView.tsx",
+        "web/src/components/acp/SwitchAgentModal.tsx",
+        "web/src/hooks/useRespawnSession.ts",
+        "web/src/lib/acpTypes.ts"
+      ]
     },
     {
       "id": "acp.switch-agent-manual",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1525,6 +1525,7 @@
       "specs": [
         "src/lib/acpTypes.test.ts",
         "src/hooks/useAcpSession.queue.test.ts",
+        "src/hooks/useRespawnSession.test.tsx",
         "src/components/acp/SystemNotices.test.tsx",
         "src/components/acp/RateLimitRecoverySection.test.tsx",
         "src/components/acp/SwitchAgentModal.test.tsx"


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

Adds a same-agent `Resume now` action to the structured-view rate-limit banner. Users can now recover a session parked on `Stopped { reason: "rate_limited" }` after the quota issue is resolved without switching agents or waiting for the auto-resume path.

The existing `/api/sessions/{id}/acp/spawn` endpoint remains the recovery path. The server now detects when the latest durable status is a rate-limit park, respawns the same agent, and publishes the existing `RateLimitAutoResumed` marker only after the respawn succeeds. A parked `AlreadyRunning` race is treated as success so a live worker does not leave the banner stuck.

The dashboard wires the banner to `useRespawnSession`, adds retrying, success, and failure states, keeps the existing `Continue in another agent` action, and disables duplicate clicks while a resume request is pending.

Closes #2460

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session that is parked on a rate-limit banner and confirm both `Resume now` and `Continue in another agent` are visible.
- [ ] After resolving the account or quota limit, click `Resume now` and confirm the same agent starts streaming again and the rate-limit banner clears.
- [ ] Force a failed resume request and confirm the banner keeps both actions visible while showing the failure text.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the new behavior is covered by focused Vitest component and reducer tests (`SystemNotices`, `RateLimitRecoverySection`, `useAcpSession.queue`, and `acpTypes`), plus `web/tests/coverage-matrix.json`; no browser-only behavior is involved.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenCode with GPT-5.5

**Any Additional AI Details you'd like to share:**

Implementation and PR prose were drafted by OpenCode under my direction. I reviewed the design, commits, and validation results.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785153051&installation_id=139138837&pr_number=2465&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2465&signature=2d46b5a687db3efc302d4522947944792d41c4e9cccc2a548d34105e8d489b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### What changed
- Added a new **“Resume now”** action to the structured-view rate-limit banner.
- Kept the existing **“Continue in another agent”** option available.
- Updated the server recovery flow so a rate-limited session can be resumed through the same spawn path.
- Improved the banner states to show **resuming, success, and failure** feedback.
- Expanded tests and coverage tracking for the new recovery flow.

### Why it matters
- Users can now recover a parked session **without switching agents** or waiting for automatic resume.
- Successful recovery now clears the stale rate-limit state more reliably.
- Duplicate resume attempts are prevented while a request is in progress.

### Technical notes
- The server now detects the parked rate-limit state before respawning and publishes the auto-resume marker only after a successful restart.
- An “already running” response is treated as a successful recovery to avoid leaving the UI stuck.
- The UI wires the banner to the respawn hook and surfaces pending/error/success states for the new action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->