### PR TITLE
feat(plugins): add status manifest section and aoe_version host compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "aoe-plugin-api"
 version = "0.1.0"
 dependencies = [
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/aoe-plugin-api/Cargo.toml
+++ b/aoe-plugin-api/Cargo.toml
@@ -17,3 +17,7 @@ serde_json = "1.0"
 toml = "1.1"
 thiserror = "2.0"
 sha2 = "0.11"
+# Parses and matches the manifest's `aoe_version` host-compatibility range.
+# Direct dep here (not via the host) because plugin install/load runs in
+# TUI-only builds, where the main crate's `serve`-gated semver is absent.
+semver = "1"

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -7,8 +7,9 @@
 //! themes, ui, runtime worker) are defined here. Settings and themes are
 //! consumed by the Tier 0 registries (#2094); keybinds/commands resolve and
 //! graft at Tier 0 but execute only with the runtime host (#2095); ui slots
-//! land with #2366. Status and panes are deferred until a consumer exists
-//! (#2386). See `docs/development/internals/plugin-system.md`.
+//! land with #2366; the status section's consumer is the status reference
+//! plugin (#2096). Panes are not a manifest section: they ship as a `ui` slot
+//! kind (#2432). See `docs/development/internals/plugin-system.md`.
 
 mod capability;
 mod id;
@@ -18,7 +19,8 @@ pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
     BuildStep, CommandContribution, KeybindContribution, ManifestError, PluginManifest,
-    RuntimeSpec, SettingContribution, SettingType, ThemeContribution, UiContribution, UiSlot,
+    RuntimeSpec, SettingContribution, SettingType, StatusContribution, ThemeContribution,
+    UiContribution, UiSlot,
 };
 
 /// Version of the manifest schema and host API this crate describes.
@@ -27,5 +29,6 @@ pub use manifest::{
 /// refuses manifests targeting a newer version than it understands. Bumped to
 /// 2 when the contribution sections and capability taxonomy were added; 3 when
 /// the `detail-panel` slot became the dockable `pane` slot (with
-/// `default_location`).
-pub const API_VERSION: u32 = 3;
+/// `default_location`); 4 when the `status` contribution section and the
+/// `aoe_version` host-compatibility field were added.
+pub const API_VERSION: u32 = 4;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -60,6 +60,12 @@ pub struct PluginManifest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub themes: Vec<ThemeContribution>,
 
+    /// Status segments the plugin contributes. Each is a labelled id the host
+    /// renders in a status surface; consumed by the status reference plugin
+    /// (#2096). Requires `api_version >= 4`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<StatusContribution>,
+
     /// UI slots the plugin renders into. Consumed by #2366.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ui: Vec<UiContribution>,
@@ -68,6 +74,16 @@ pub struct PluginManifest {
     /// release-binary worker; actually launching it is #2095.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime: Option<RuntimeSpec>,
+
+    /// Optional range of aoe (host app) versions this plugin version supports,
+    /// as a semver requirement like `">=0.10, <0.12"`. Distinct from
+    /// `api_version` (the manifest schema version): `api_version` gates the
+    /// manifest shape, `aoe_version` gates the host's app behaviour. The host
+    /// refuses to install and skips loading a plugin when its running version
+    /// is outside this range. Absent means no constraint. Requires
+    /// `api_version >= 4`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aoe_version: Option<String>,
 }
 
 /// A command the plugin contributes. The host namespaces it as
@@ -145,6 +161,17 @@ pub struct ThemeContribution {
     pub name: String,
     /// Theme TOML path, relative to the plugin directory.
     pub path: String,
+}
+
+/// A status segment the plugin contributes. The host namespaces it by plugin
+/// id and renders `label` in a status surface; consumed by #2096.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusContribution {
+    /// Stable identifier the host addresses this segment by.
+    pub id: String,
+    /// Human-readable text shown in the status surface.
+    #[serde(default)]
+    pub label: String,
 }
 
 /// A host-rendered UI slot a plugin may push state into (#2366). A closed set,
@@ -355,6 +382,30 @@ impl PluginManifest {
         out
     }
 
+    /// Check the running host (aoe app) version against the manifest's declared
+    /// `aoe_version` range. `host` is a semver version string (the host's
+    /// `CARGO_PKG_VERSION`). No declared range means no constraint. Returns an
+    /// actionable message when the host is outside the range, so install can
+    /// refuse and load can skip with a reason. The range is re-parsed here
+    /// rather than cached because [`validate`] already gated its syntax, so a
+    /// loaded manifest's range is known-valid.
+    pub fn host_compat(&self, host: &str) -> Result<(), String> {
+        let Some(req) = &self.aoe_version else {
+            return Ok(());
+        };
+        let req = semver::VersionReq::parse(req)
+            .map_err(|e| format!("aoe_version {req:?} is not a valid semver requirement: {e}"))?;
+        let host_version = semver::Version::parse(host)
+            .map_err(|e| format!("host aoe version {host:?} is not valid semver: {e}"))?;
+        if req.matches(&host_version) {
+            Ok(())
+        } else {
+            Err(format!(
+                "plugin requires aoe {req}; this host is {host_version}"
+            ))
+        }
+    }
+
     /// Structural validation; collects every problem instead of stopping at
     /// the first so a plugin author sees the full list in one pass.
     ///
@@ -537,6 +588,36 @@ impl PluginManifest {
             check(
                 !t.path.is_empty(),
                 format!("themes[{i}].path must not be empty"),
+            );
+        }
+        for (i, s) in self.status.iter().enumerate() {
+            check(
+                !s.id.is_empty(),
+                format!("status[{i}].id must not be empty"),
+            );
+        }
+        // `aoe_version` is the host-app compatibility range, gated by the host
+        // at install and load; reject a malformed requirement at parse so the
+        // author learns of it before publishing rather than at a user's install.
+        if let Some(req) = &self.aoe_version {
+            check(
+                semver::VersionReq::parse(req).is_ok(),
+                format!("aoe_version {req:?} is not a valid semver requirement"),
+            );
+        }
+        // `status` and `aoe_version` are api_version 4 fields. A manifest using
+        // them while declaring an older api_version would parse fine on this
+        // host but fail with a confusing "unknown field" on a pre-4 host (which
+        // never reaches the "upgrade aoe" path because the declared version is
+        // not newer). Force the bump so older hosts emit the right message.
+        if self.api_version < 4 {
+            check(
+                self.status.is_empty(),
+                "status contributions require api_version >= 4".into(),
+            );
+            check(
+                self.aoe_version.is_none(),
+                "aoe_version requires api_version >= 4".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -247,30 +247,156 @@ default = "turbo"
 }
 
 #[test]
-fn deferred_sections_are_rejected() {
-    // status / panes are still deferred until a consumer exists (#2386); with
-    // deny_unknown_fields a manifest declaring one must fail to parse. themes
-    // is now consumed (#2094) and parses, asserted above.
-    for section in ["status", "panes"] {
-        let toml = format!(
-            r#"
+fn panes_section_is_rejected() {
+    // panes is not a manifest section: it ships as a `ui` slot kind (#2432).
+    // deny_unknown_fields makes a `[[panes]]` block a hard parse error. status
+    // is now a real section (#2386), asserted separately below.
+    let toml = r#"
 id = "acme.thing"
 name = "Thing"
 version = "0.1.0"
-api_version = 2
+api_version = 4
 
-[[{section}]]
+[[panes]]
 id = "x"
-name = "x"
-path = "x"
-"#
-        );
-        let err = PluginManifest::from_toml_str(&toml).unwrap_err();
-        assert!(
-            matches!(err, ManifestError::Parse(_)),
-            "[[{section}]] should be a hard parse error, got {err:?}"
-        );
-    }
+title = "x"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(err, ManifestError::Parse(_)),
+        "[[panes]] should be a hard parse error, got {err:?}"
+    );
+}
+
+#[test]
+fn status_section_parses() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 4
+
+[[status]]
+id = "queue"
+label = "Queue depth"
+
+[[status]]
+id = "nolabel"
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("status section parses");
+    assert_eq!(m.status[0].id, "queue");
+    assert_eq!(m.status[0].label, "Queue depth");
+    assert_eq!(m.status[1].id, "nolabel");
+    assert_eq!(m.status[1].label, "", "label defaults to empty");
+}
+
+#[test]
+fn invalid_status_collects_problem() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 4
+
+[[status]]
+id = ""
+label = "x"
+"#;
+    let messages = match PluginManifest::from_toml_str(toml).unwrap_err() {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages.iter().any(|m| m.contains("status[0].id")),
+        "{messages:?}"
+    );
+}
+
+#[test]
+fn aoe_version_parses_and_validates() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 4
+aoe_version = ">=0.10, <0.12"
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("valid aoe_version parses");
+    assert_eq!(m.aoe_version.as_deref(), Some(">=0.10, <0.12"));
+
+    let bad = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 4
+aoe_version = "not a range"
+"#;
+    let messages = match PluginManifest::from_toml_str(bad).unwrap_err() {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages.iter().any(|m| m.contains("aoe_version")),
+        "{messages:?}"
+    );
+}
+
+#[test]
+fn host_compat_in_and_out_of_range() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 4
+aoe_version = ">=0.10, <0.12"
+"#;
+    let m = PluginManifest::from_toml_str(toml).unwrap();
+    assert!(m.host_compat("0.11.0").is_ok());
+    let err = m.host_compat("0.13.0").unwrap_err();
+    assert!(err.contains("plugin requires aoe"), "{err}");
+    assert!(err.contains("0.13.0"), "{err}");
+
+    // A manifest with no declared range is always compatible.
+    let unbounded = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 4
+"#;
+    let m = PluginManifest::from_toml_str(unbounded).unwrap();
+    assert!(m.host_compat("99.0.0").is_ok());
+}
+
+#[test]
+fn api_version_4_fields_require_bump() {
+    // Using a v4 field at an older api_version is rejected, so an author bumps
+    // to 4 and pre-4 hosts route to "upgrade aoe" instead of "unknown field".
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 3
+aoe_version = ">=0.10"
+
+[[status]]
+id = "queue"
+"#;
+    let messages = match PluginManifest::from_toml_str(toml).unwrap_err() {
+        ManifestError::Invalid(m) => m,
+        other => panic!("expected Invalid, got {other:?}"),
+    };
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("status contributions require api_version >= 4")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("aoe_version requires api_version >= 4")),
+        "{messages:?}"
+    );
 }
 
 #[test]

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -114,15 +114,29 @@ declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
 declares; they are defined in `aoe-plugin-api` and parsed/validated by the
 host, but consumed by later issues (the settings registry in #2094, the runtime
 host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is now
-3 (bumped to 2 for the contribution sections, then 3 when the `detail-panel`
-slot became the dockable `pane` slot); an older `api_version` manifest still
-loads as long as it targets no newer slot. Unknown top-level keys remain a hard
-parse error (`deny_unknown_fields`).
+4 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
+became the dockable `pane` slot, then 4 for the `status` section and the
+`aoe_version` field); an older `api_version` manifest still loads as long as it
+targets no newer field. Unknown top-level keys remain a hard parse error
+(`deny_unknown_fields`).
 
-The `themes`, `status`, and `panes` sections are deferred until a consumer
-exists, so no schema lands in core ahead of one (#2386). With
-`deny_unknown_fields`, a manifest declaring `[[themes]]`, `[[status]]`, or
-`[[panes]]` is a hard parse error today.
+The `themes` section ships and is consumed by the theme registry (#2094); the
+`status` section (`id`, `label`) is parsed and validated here, its consumer is
+the status reference plugin (#2096). `panes` is not a manifest section: panes
+ship as a `ui` slot of kind `pane` (#2432), so `[[panes]]` stays a hard parse
+error. `status` and `aoe_version` (below) require `api_version >= 4`: under
+`deny_unknown_fields` a pre-4 host would otherwise report a bare "unknown
+field" instead of the "upgrade aoe" message, so the host gates them behind the
+bump.
+
+`aoe_version` is an optional semver requirement (`">=0.10, <0.12"`) naming
+which aoe (host app) versions this plugin version supports. It is distinct from
+`api_version`: `api_version` gates the manifest schema shape, `aoe_version`
+gates the host's app behaviour. The host refuses to install or update a plugin
+whose range excludes the running aoe, and skips loading one (into the
+registry's load errors) rather than bailing, so an aoe upgrade cannot brick
+startup. Builtins are exempt (they ship with aoe). An absent range means no
+constraint.
 
 The `runtime` section is one of two kinds: `command` (an argv launched from the
 plugin directory) or `release-binary` (a compiled worker shipped as a GitHub

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -57,6 +57,7 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     let id = fetched.manifest.id.as_str().to_string();
     let featured_verified = verify_featured(&FeaturedIndex::load()?, &fetched)?;
     reject_reserved_or_builtin(&fetched.manifest, featured_verified)?;
+    reject_incompatible_host(&fetched.manifest)?;
 
     let final_dir = super::plugins_dir()?.join(&id);
     if final_dir.exists() {
@@ -127,6 +128,7 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     }
     let featured_verified = verify_featured(&FeaturedIndex::load()?, &fetched)?;
     reject_reserved_or_builtin(&fetched.manifest, featured_verified)?;
+    reject_incompatible_host(&fetched.manifest)?;
 
     let capabilities = capability_strings(&fetched)?;
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
@@ -263,6 +265,18 @@ fn reject_reserved_or_builtin(manifest: &PluginManifest, featured_verified: bool
         bail!("plugin id {id:?} uses a reserved namespace (aoe.* / agent-of-empires.*); only a featured-verified plugin may claim one");
     }
     Ok(())
+}
+
+/// Refuse a plugin whose declared `aoe_version` range excludes this host. A
+/// plugin author states which aoe versions a plugin version was tested against;
+/// installing outside that range invites runtime failure, so block it at
+/// install/update with the manifest's own actionable message. The load-time
+/// twin in the registry scan skips rather than bails so an aoe upgrade cannot
+/// brick startup.
+fn reject_incompatible_host(manifest: &PluginManifest) -> Result<()> {
+    manifest
+        .host_compat(env!("CARGO_PKG_VERSION"))
+        .map_err(|msg| anyhow!("{}: {msg}", manifest.id.as_str()))
 }
 
 /// Check a fetched plugin against the curated index. Returns whether it is a
@@ -629,6 +643,34 @@ mod tests {
             slot,
             id: id.to_string(),
         }
+    }
+
+    fn manifest_with_aoe_version(range: Option<&str>) -> PluginManifest {
+        let aoe = range
+            .map(|r| format!("aoe_version = \"{r}\"\n"))
+            .unwrap_or_default();
+        PluginManifest::from_toml_str(&format!(
+            "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"1.0.0\"\napi_version = 4\n{aoe}"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn reject_incompatible_host_blocks_out_of_range_and_allows_in_range() {
+        // The host is this crate's CARGO_PKG_VERSION (a 1.x release); a range
+        // bracketing 1.x installs, a future-major-only range is refused with an
+        // id-prefixed message. Keep the literals semver-free so this compiles in
+        // a TUI-only build, where the host crate's semver dep is serve-gated.
+        let in_range = manifest_with_aoe_version(Some(">=1.0.0, <2.0.0"));
+        assert!(reject_incompatible_host(&in_range).is_ok());
+
+        let out = manifest_with_aoe_version(Some(">=2.0.0"));
+        let err = reject_incompatible_host(&out).unwrap_err().to_string();
+        assert!(err.contains("acme.thing"), "{err}");
+        assert!(err.contains("plugin requires aoe"), "{err}");
+
+        // No declared range installs everywhere.
+        assert!(reject_incompatible_host(&manifest_with_aoe_version(None)).is_ok());
     }
 
     #[test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -287,6 +287,16 @@ fn load_external(
         };
         let id = manifest.id.as_str().to_string();
 
+        // Skip a plugin the running aoe is too old/new for. Unlike install, a
+        // load-time mismatch must not be fatal: an aoe upgrade can move the host
+        // outside a still-installed plugin's range, and bailing would brick
+        // startup. Report it and carry on. Builtins never reach here (they load
+        // from the embedded BUILTINS set, not this directory scan).
+        if let Err(msg) = manifest.host_compat(env!("CARGO_PKG_VERSION")) {
+            load_errors.push(format!("plugin {id:?} at {}: {msg}", dir.display()));
+            continue;
+        }
+
         let plugin_config = config.plugins.get(&id);
         let source = plugin_config.and_then(|p| p.source.clone());
         let validation = validation_for(featured, &id, &dir, source.as_deref());


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two plugin-manifest schema changes from the #268 epic, landed together because they share the same `aoe-plugin-api` surface (`PluginManifest` struct, `validate()`, the manifest tests, and the API version).

**#2386 (`[[status]]` section).** Reinstates the last deferred contribution section from #2093: `StatusContribution { id, label }`, with the collected validation `status[i].id must not be empty`. Themes already shipped (#2389) and panes turned out to ship as a `ui` slot of kind `pane` (#2432), not a manifest section, so `[[panes]]` stays a hard parse error. Status is parsed and validated by the host here; its consumer is the status reference plugin (#2096), matching how `commands`/`keybinds` are defined ahead of their #2366 consumer.

**#2393 (`aoe_version` host compatibility).** Adds an optional `aoe_version` semver requirement to the manifest (e.g. `">=0.10, <0.12"`) naming which aoe (host app) versions a plugin version supports. This is a different axis from `api_version`: `api_version` gates the manifest schema shape, `aoe_version` gates the host's app behaviour. The host refuses to install or update a plugin whose range excludes the running aoe (with the manifest's own actionable message), and at load skips an incompatible plugin into the registry's load errors rather than bailing, so an aoe upgrade that moves the host outside a still-installed plugin's range cannot brick startup. Builtins load from the embedded set, never the directory scan, so they are inherently exempt.

**API version bump.** Both `status` and `aoe_version` are gated behind `api_version >= 4` (a collected validation error otherwise) and `API_VERSION` is bumped 3 → 4. The reason is `deny_unknown_fields`: a pre-4 host seeing a manifest that uses these fields would report a bare "unknown field" instead of the intended "upgrade aoe" message, which only fires when the manifest declares a newer `api_version` than the host supports. Forcing the bump routes old hosts to the right message. This follows the precedent set when `API_VERSION` was bumped to 2 for the first additive contribution sections.

`semver` is added as a direct dependency of `aoe-plugin-api` (not pulled through the host) because plugin install/load runs in TUI-only builds, where the main crate's `semver` is `serve`-gated.

Closes #2386
Closes #2393

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Write an `aoe-plugin.toml` with `api_version = 4` and a `[[status]]` block (`id = "queue"`, `label = "Queue depth"`); confirm it parses (install a local plugin dir via `aoe plugin install <dir>`).
- [ ] Add a second `[[status]]` with an empty `id`; confirm install fails with `status[0].id must not be empty`.
- [ ] Put `[[status]]` in a manifest that still declares `api_version = 3`; confirm it is rejected with `status contributions require api_version >= 4`.
- [ ] Keep `[[panes]]` in a manifest; confirm it is still a hard parse error (unknown field).
- [ ] Set `aoe_version = ">=2.0.0"` (you are on aoe 1.x) and run `aoe plugin install <dir>`; confirm it refuses with `<id>: plugin requires aoe >=2.0.0; this host is 1.x`.
- [ ] Set `aoe_version = ">=1.0.0, <2.0.0"`; confirm install succeeds.
- [ ] Install a plugin in range, then (simulating an aoe upgrade past the range) confirm the daemon still starts and the plugin is listed under load errors via `aoe plugin list`, rather than crashing startup.
- [ ] Set a malformed `aoe_version = "not a range"`; confirm parse fails with `aoe_version "not a range" is not a valid semver requirement`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR changes manifest schema and plugin install/load policy, covered by unit and integration tests (`aoe-plugin-api/tests/manifest.rs`, `src/plugin/install.rs` tests); no TUI rendering or session lifecycle change.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. A `/debate` between two models settled the three design calls (semver location, the api_version bump, and refuse-vs-warn). I reviewed each commit, made the design decisions, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785160003&installation_id=139138837&pr_number=2469&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2469&signature=13abce2aa731de1b4179f6b201ce0d3c34af1699ee27567a70641ffd91fcf457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added support for two new plugin manifest features: a restored `status` contribution section and an optional `aoe_version` compatibility range for host app versions.

Also bumped the plugin API version to 4, updated docs, and added validation so older manifests can’t use the new fields.

Host behavior now checks compatibility both when installing/updating plugins and when loading installed plugins:
- incompatible installs are rejected with a clear message
- incompatible installed plugins are skipped with load errors so startup can continue

Tests were expanded to cover parsing, validation, and version-compatibility handling.

Benefits:
- makes status contributions available again
- lets plugins declare supported host versions
- avoids startup failures from incompatible plugins
- improves manifest validation and error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->