### PR TITLE
feat(web): render plugin sort-key and filter-facet slots in the dashboard sidebar

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -603,7 +603,7 @@ above), the builtin worker self-exec path and worker SDK (with the first
 builtin worker that needs them), and the discovery / featured supply-chain
 layer with integrity hashing (issues 2364 and 2365). Rendering plugin slots in
 the standalone (non-daemon) home screen is still a follow-up (the
-structured-view TUI already renders them, #2402). Pinning a featured plugin's
+structured-view TUI already renders the terminal-applicable subset, #2402). Pinning a featured plugin's
 release-binary asset hash in `featured.toml` (so a featured worker is attested,
 not just its source) is a follow-up; today a release-binary plugin cannot be
 featured.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -574,9 +574,15 @@ incremental cursor. The dashboard polls it on the same cadence as
 `/api/sessions` and renders per-session entries only for sessions present in
 the live list. Notifications surface as toasts, deduped by `seq`.
 
-`sort-key` and `filter-facet` are accepted and stored by the host but their
-dashboard rendering (which needs changes to the sidebar's sort/filter core) is
-deferred to a follow-up.
+`sort-key` and `filter-facet` render in the dashboard sidebar (#2401): each
+global `sort-key` is an extra option in the sort picker that orders rows by the
+referenced `row-column`'s `sort_value` (best value per direction at the
+workspace and group level, unvalued rows sink), and each `filter-facet` is a
+facet control that filters rows by the referenced `row-column`'s
+`filter_values` (AND across facets, OR within one). Both selections are
+client-side and ephemeral: they read the already-fetched scalars, run no plugin
+code, and are not persisted, so a daemon restart falls back to the built-in
+sort.
 
 The native **structured-view** TUI (`aoe acp attach`, the remote-home picker)
 polls the same endpoint on a 3-second cadence and renders the slots a terminal
@@ -595,9 +601,8 @@ Each deferred piece returns as its own PR once the core is proven: the Tier 0
 contribution registries (issue 2094), the UI extension points (issue 2366,
 above), the builtin worker self-exec path and worker SDK (with the first
 builtin worker that needs them), and the discovery / featured supply-chain
-layer with integrity hashing (issues 2364 and 2365). Within #2366, dashboard
-rendering of the `sort-key` and `filter-facet` slots is itself a follow-up, as
-is rendering plugin slots in the standalone (non-daemon) home screen (the
+layer with integrity hashing (issues 2364 and 2365). Rendering plugin slots in
+the standalone (non-daemon) home screen is still a follow-up (the
 structured-view TUI already renders them, #2402). Pinning a featured plugin's
 release-binary asset hash in `featured.toml` (so a featured worker is attested,
 not just its source) is a follow-up; today a release-binary plugin cannot be

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,9 @@ import { useLastSessionRestore } from "./hooks/useLastSessionRestore";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useSessionGroups } from "./hooks/useSessionGroups";
 import { useNestedSidebarGroups } from "./hooks/useNestedSidebarGroups";
-import { PluginUiProvider } from "./lib/pluginUiContext";
+import { PluginUiProvider, usePluginUiEntries } from "./lib/pluginUiContext";
+import { buildSortValueMap, pluginSortSpecs } from "./lib/pluginUi";
+import type { PluginSortContext, SidebarSortMode } from "./lib/sidebarSort";
 import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
 import { useSidebarAxis } from "./hooks/useSidebarAxis";
 import { repoGroupToSidebarGroup, type SidebarGroup } from "./lib/sidebarGroups";
@@ -303,6 +305,40 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [sidebarSortMode, setSidebarSortMode] = useSidebarSortMode();
   const [sidebarAxis, setSidebarAxis] = useSidebarAxis();
 
+  // Active plugin sort (#2401): an ephemeral selection of a live `sort-key`
+  // entry. Not persisted (plugin entries die with the daemon). The ref is only
+  // ever read by resolving it against the live snapshot, so a stale ref (entry
+  // gone after a daemon restart) is inert and the sidebar falls back to the
+  // built-in sort; if the entry reappears on a later poll the selection
+  // resumes. Selecting a built-in mode clears it via `selectSidebarSortMode`.
+  const pluginUiEntries = usePluginUiEntries();
+  const [pluginSortRef, setPluginSortRef] = useState<{ pluginId: string; entryId: string } | null>(null);
+  const activePluginSort = useMemo(() => {
+    if (!pluginSortRef) return null;
+    return (
+      pluginSortSpecs(pluginUiEntries).find(
+        (s) => s.pluginId === pluginSortRef.pluginId && s.entryId === pluginSortRef.entryId,
+      ) ?? null
+    );
+  }, [pluginUiEntries, pluginSortRef]);
+  const pluginSort = useMemo<PluginSortContext | undefined>(
+    () =>
+      activePluginSort
+        ? {
+            direction: activePluginSort.direction,
+            values: buildSortValueMap(pluginUiEntries, activePluginSort.pluginId, activePluginSort.column),
+          }
+        : undefined,
+    [activePluginSort, pluginUiEntries],
+  );
+  const selectSidebarSortMode = useCallback(
+    (mode: SidebarSortMode) => {
+      setPluginSortRef(null);
+      setSidebarSortMode(mode);
+    },
+    [setSidebarSortMode],
+  );
+
   const { projects, refresh: refreshProjects } = useProjects();
   const {
     groups: repoGroups,
@@ -310,13 +346,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     toggleRepoCollapsed,
     updateRepoAppearance,
     reorderRepoGroups,
-  } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode, projects);
-  const { groups: sessionGroups, toggleGroupCollapsed } = useSessionGroups(workspaces, sidebarSortMode);
+  } = useRepoGroups(workspaces, workspaceOrdering, sidebarSortMode, projects, pluginSort);
+  const { groups: sessionGroups, toggleGroupCollapsed } = useSessionGroups(workspaces, sidebarSortMode, pluginSort);
   // The nested `repo+group` axis reuses the already-built repo groups for
   // its top level (so repo collapse, appearance, and ordering are shared
   // with the repo axis) and splits each repo by `group_path` underneath.
   // See #1720.
-  const { groups: nestedGroups, toggleSubgroupCollapsed } = useNestedSidebarGroups(repoGroups, sidebarSortMode);
+  const { groups: nestedGroups, toggleSubgroupCollapsed } = useNestedSidebarGroups(
+    repoGroups,
+    sidebarSortMode,
+    pluginSort,
+  );
 
   // The sidebar render path consumes one honest model (SidebarGroup): the
   // repo axis maps in via an adapter, the user-group axis is already in
@@ -1671,7 +1711,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
               onStartSession={handleStartSession}
               readOnly={serverAbout?.read_only}
               sortMode={sidebarSortMode}
-              onSortModeChange={setSidebarSortMode}
+              onSortModeChange={selectSidebarSortMode}
+              pluginSortRef={pluginSortRef}
+              onPluginSortChange={setPluginSortRef}
               axis={sidebarAxis}
               onAxisChange={setSidebarAxis}
             />

--- a/web/src/components/SidebarSortPicker.tsx
+++ b/web/src/components/SidebarSortPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, Clock, ListOrdered, Siren } from "lucide-react";
+import { Check, Clock, ListOrdered, SlidersHorizontal, Siren } from "lucide-react";
 import type { SidebarSortMode } from "../lib/sidebarSort";
+import type { PluginSortSpec } from "../lib/pluginUi";
 import { Tooltip } from "./Tooltip";
 
 // Sidebar sort picker (#1640). Replaces the former two-state Clock /
@@ -9,6 +10,11 @@ import { Tooltip } from "./Tooltip";
 // trigger shows the active mode's icon and tints brand when any non-manual
 // (computed) mode is active, matching the axis toggle's affordance. Outside
 // click and Escape close it, mirroring OverflowMenu.
+//
+// Plugin `sort-key` entries (#2401) appear as extra options below the
+// built-ins; selecting one activates an ephemeral plugin sort (a computed
+// mode, so drag is disabled while it is active). Selecting a built-in clears
+// it via `onSortModeChange`.
 
 interface ModeSpec {
   mode: SidebarSortMode;
@@ -22,18 +28,32 @@ const MODES: readonly ModeSpec[] = [
   { mode: "attention", label: "Attention", Icon: Siren },
 ];
 
-const TRIGGER_TOOLTIP: Record<SidebarSortMode, string> = {
+const BUILTIN_TOOLTIP: Record<SidebarSortMode, string> = {
   manual: "Sort: manual, drag enabled",
   lastActivity: "Sort: last activity, drag disabled",
   attention: "Sort: attention, drag disabled",
 };
 
+interface PluginSortRef {
+  pluginId: string;
+  entryId: string;
+}
+
 interface Props {
   sortMode: SidebarSortMode;
   onSortModeChange: (mode: SidebarSortMode) => void;
+  pluginSorts?: PluginSortSpec[];
+  pluginSortRef?: PluginSortRef | null;
+  onPluginSortChange?: (ref: PluginSortRef) => void;
 }
 
-export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
+export function SidebarSortPicker({
+  sortMode,
+  onSortModeChange,
+  pluginSorts = [],
+  pluginSortRef = null,
+  onPluginSortChange,
+}: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -53,22 +73,31 @@ export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
     };
   }, [open]);
 
+  // A plugin sort is active only when the ref resolves to a live `sort-key`
+  // entry; a stale ref (daemon restart) falls back to the built-in trigger.
+  const activePlugin = pluginSortRef
+    ? pluginSorts.find((s) => s.pluginId === pluginSortRef.pluginId && s.entryId === pluginSortRef.entryId)
+    : undefined;
+
   // MODES is non-empty by construction, so the fallback is always defined.
-  const active = MODES.find((m) => m.mode === sortMode) ?? MODES[0]!;
-  const ActiveIcon = active.Icon;
+  const activeBuiltin = MODES.find((m) => m.mode === sortMode) ?? MODES[0]!;
+  const ActiveIcon = activePlugin ? SlidersHorizontal : activeBuiltin.Icon;
+  const activeLabel = activePlugin ? activePlugin.label : activeBuiltin.label;
+  const computed = activePlugin != null || sortMode !== "manual";
+  const triggerTooltip = activePlugin ? `Sort: ${activePlugin.label}, drag disabled` : BUILTIN_TOOLTIP[sortMode];
 
   return (
     <div ref={ref} className="relative">
-      <Tooltip text={TRIGGER_TOOLTIP[sortMode]}>
+      <Tooltip text={triggerTooltip}>
         <button
           onClick={() => setOpen((o) => !o)}
           aria-haspopup="menu"
           aria-expanded={open}
-          aria-label={`Sort sessions, current: ${active.label}`}
+          aria-label={`Sort sessions, current: ${activeLabel}`}
           data-testid="sidebar-sort-toggle"
-          data-sort-mode={sortMode}
+          data-sort-mode={activePlugin ? "plugin" : sortMode}
           className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
-            sortMode !== "manual" ? "text-brand-500" : "text-text-dim hover:text-text-secondary"
+            computed ? "text-brand-500" : "text-text-dim hover:text-text-secondary"
           }`}
         >
           <ActiveIcon className="h-3.5 w-3.5" />
@@ -82,7 +111,7 @@ export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
           className="absolute right-0 top-full mt-1 min-w-[160px] bg-surface-800 border border-surface-700/50 rounded-md shadow-xl py-1 z-50 animate-fade-in"
         >
           {MODES.map(({ mode, label, Icon }) => {
-            const selected = mode === sortMode;
+            const selected = !activePlugin && mode === sortMode;
             return (
               <button
                 key={mode}
@@ -91,7 +120,7 @@ export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
                 data-testid={`sidebar-sort-option-${mode}`}
                 onClick={() => {
                   setOpen(false);
-                  if (mode !== sortMode) onSortModeChange(mode);
+                  if (activePlugin || mode !== sortMode) onSortModeChange(mode);
                 }}
                 className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer hover:bg-surface-700/60 ${
                   selected ? "text-brand-500" : "text-text-secondary hover:text-text-primary"
@@ -103,6 +132,36 @@ export function SidebarSortPicker({ sortMode, onSortModeChange }: Props) {
               </button>
             );
           })}
+          {pluginSorts.length > 0 && (
+            <>
+              <div className="my-1 border-t border-surface-700/50" role="separator" />
+              {pluginSorts.map((spec) => {
+                const selected =
+                  activePlugin != null &&
+                  activePlugin.pluginId === spec.pluginId &&
+                  activePlugin.entryId === spec.entryId;
+                return (
+                  <button
+                    key={`${spec.pluginId}:${spec.entryId}`}
+                    role="menuitemradio"
+                    aria-checked={selected}
+                    data-testid={`sidebar-sort-option-plugin-${spec.entryId}`}
+                    onClick={() => {
+                      setOpen(false);
+                      if (!selected) onPluginSortChange?.({ pluginId: spec.pluginId, entryId: spec.entryId });
+                    }}
+                    className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer hover:bg-surface-700/60 ${
+                      selected ? "text-brand-500" : "text-text-secondary hover:text-text-primary"
+                    }`}
+                  >
+                    <SlidersHorizontal className="h-3.5 w-3.5 shrink-0" />
+                    <span className="flex-1 text-left truncate">{spec.label}</span>
+                    {selected && <Check className="h-3.5 w-3.5 shrink-0" />}
+                  </button>
+                );
+              })}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -21,6 +21,7 @@ import {
   Folder,
   Hourglass,
   Layers,
+  ListFilter,
   Moon,
   Pencil,
   Pin,
@@ -28,6 +29,14 @@ import {
   Plus,
   Sparkles,
 } from "lucide-react";
+import { usePluginUiEntries } from "../lib/pluginUiContext";
+import {
+  type ActiveFacet,
+  pluginFacetSpecs,
+  pluginSortSpecs,
+  sessionMatchesFacets,
+  toneTextClass,
+} from "../lib/pluginUi";
 import {
   DndContext,
   MouseSensor,
@@ -50,6 +59,7 @@ import {
   sidebarGroupShouldRender,
   type NestedSidebarGroup,
   type SidebarGroup,
+  type SidebarWorkspaceView,
 } from "../lib/sidebarGroups";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import { menuBus, closeOtherContextMenus } from "../lib/menuBus";
@@ -289,6 +299,8 @@ interface Props {
   readOnly?: boolean;
   sortMode: SidebarSortMode;
   onSortModeChange: (mode: SidebarSortMode) => void;
+  pluginSortRef: { pluginId: string; entryId: string } | null;
+  onPluginSortChange: (ref: { pluginId: string; entryId: string }) => void;
   axis: SidebarAxis;
   onAxisChange: (axis: SidebarAxis) => void;
 }
@@ -2305,10 +2317,53 @@ export function WorkspaceSidebar({
   readOnly,
   sortMode,
   onSortModeChange,
+  pluginSortRef,
+  onPluginSortChange,
   axis,
   onAxisChange,
 }: Props) {
-  const dragDisabled = !!readOnly || sortMode === "lastActivity";
+  // Plugin sort/filter slots (#2401). Read the live snapshot here so the facet
+  // control and the sort-picker options stay local to the sidebar; the active
+  // plugin sort comparator itself is built and threaded by AppContent.
+  const pluginUiEntries = usePluginUiEntries();
+  const pluginSorts = useMemo(() => pluginSortSpecs(pluginUiEntries), [pluginUiEntries]);
+  const facetSpecs = useMemo(() => pluginFacetSpecs(pluginUiEntries), [pluginUiEntries]);
+  const pluginSortActive =
+    pluginSortRef != null &&
+    pluginSorts.some((s) => s.pluginId === pluginSortRef.pluginId && s.entryId === pluginSortRef.entryId);
+  // Selected facet values keyed by `${pluginId}\0${entryId}`; ephemeral, like
+  // the plugin entries themselves. A selection for a facet that vanishes from
+  // the snapshot is simply ignored: `activeFacets` below only reads live
+  // `facetSpecs`, so a stale entry never filters and resumes if the facet
+  // reappears on a later poll.
+  const [facetSelection, setFacetSelection] = useState<Map<string, Set<string>>>(new Map());
+  const toggleFacetValue = useCallback((pluginId: string, entryId: string, value: string) => {
+    const key = `${pluginId}\u0000${entryId}`;
+    setFacetSelection((prev) => {
+      const next = new Map(prev);
+      const values = new Set(next.get(key));
+      if (values.has(value)) values.delete(value);
+      else values.add(value);
+      if (values.size === 0) next.delete(key);
+      else next.set(key, values);
+      return next;
+    });
+  }, []);
+  const activeFacets = useMemo<ActiveFacet[]>(() => {
+    const out: ActiveFacet[] = [];
+    for (const f of facetSpecs) {
+      const values = facetSelection.get(`${f.pluginId}\u0000${f.entryId}`);
+      if (values && values.size > 0) out.push({ pluginId: f.pluginId, column: f.column, values });
+    }
+    return out;
+  }, [facetSpecs, facetSelection]);
+  const workspaceMatchesFacets = useCallback(
+    (ws: Workspace) =>
+      activeFacets.length === 0 || ws.sessions.some((s) => sessionMatchesFacets(pluginUiEntries, s.id, activeFacets)),
+    [activeFacets, pluginUiEntries],
+  );
+
+  const dragDisabled = !!readOnly || sortMode === "lastActivity" || pluginSortActive;
   // Reorder (group drag + row drag) is also off whenever any visible group
   // forbids it, which is the whole user-group axis: groups have no manual
   // order in v1. Gating here keeps the shared DndContext from firing a
@@ -2326,6 +2381,7 @@ export function WorkspaceSidebar({
   }, [width]);
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [facetOpen, setFacetOpen] = useState(false);
   const [sunkExpanded, setSunkExpanded] = useState<boolean>(loadSunkExpanded);
   const toggleSunkExpanded = useCallback(() => {
     setSunkExpanded((prev) => {
@@ -2437,13 +2493,19 @@ export function WorkspaceSidebar({
 
   const isNested = axis === "repo+group";
 
-  const filteredGroups = q
+  // A row survives the text query when there is none, or it matches the
+  // workspace/group name; a plugin facet filter (#2401) is ANDed on top, so an
+  // active facet narrows rows even with an empty text query. `hasFilter` gates
+  // whether the list is filtered at all.
+  const hasFilter = !!q || activeFacets.length > 0;
+  const textMatches = (v: SidebarWorkspaceView, ...groupNames: string[]) =>
+    !q || workspaceMatchesFilter(v.workspace, q) || groupNames.some((n) => n.toLowerCase().includes(q));
+
+  const filteredGroups = hasFilter
     ? groups
         .map((g) => ({
           ...g,
-          workspaces: g.workspaces.filter(
-            (v) => workspaceMatchesFilter(v.workspace, q) || g.displayName.toLowerCase().includes(q),
-          ),
+          workspaces: g.workspaces.filter((v) => textMatches(v, g.displayName) && workspaceMatchesFacets(v.workspace)),
         }))
         .filter((g) => g.workspaces.length > 0)
     : groups;
@@ -2451,7 +2513,7 @@ export function WorkspaceSidebar({
   // Filter the nested model the same way the flat list is filtered: a row
   // survives if it matches, or if its subgroup or repo header name matches;
   // empty subgroups and then empty repos drop out. See #1720.
-  const filteredNested: NestedSidebarGroup[] = q
+  const filteredNested: NestedSidebarGroup[] = hasFilter
     ? nestedGroups
         .map((ng) => ({
           repo: ng.repo,
@@ -2459,10 +2521,7 @@ export function WorkspaceSidebar({
             .map((sg) => ({
               ...sg,
               workspaces: sg.workspaces.filter(
-                (v) =>
-                  workspaceMatchesFilter(v.workspace, q) ||
-                  sg.displayName.toLowerCase().includes(q) ||
-                  ng.repo.displayName.toLowerCase().includes(q),
+                (v) => textMatches(v, sg.displayName, ng.repo.displayName) && workspaceMatchesFacets(v.workspace),
               ),
             }))
             .filter((sg) => sg.workspaces.length > 0),
@@ -2499,7 +2558,7 @@ export function WorkspaceSidebar({
     };
     for (const g of filteredGroups) {
       if (!sidebarGroupHasLiveWorkspace(g)) continue;
-      const expanded = q ? true : !g.collapsed;
+      const expanded = hasFilter ? true : !g.collapsed;
       if (!expanded) continue;
       for (const v of g.workspaces) {
         if (!workspaceIsSunk(v.workspace)) push(v.workspace.id);
@@ -2513,7 +2572,7 @@ export function WorkspaceSidebar({
       }
     }
     return ids;
-  }, [filteredGroups, q, sunkExpanded]);
+  }, [filteredGroups, hasFilter, sunkExpanded]);
 
   // Drop selected ids for workspaces that no longer exist (a session was
   // deleted or moved). Existence-based, not visibility-based: collapsing a
@@ -2782,7 +2841,32 @@ export function WorkspaceSidebar({
               <Layers className="h-3.5 w-3.5" />
             </button>
           </Tooltip>
-          <SidebarSortPicker sortMode={sortMode} onSortModeChange={onSortModeChange} />
+          <SidebarSortPicker
+            sortMode={sortMode}
+            onSortModeChange={onSortModeChange}
+            pluginSorts={pluginSorts}
+            pluginSortRef={pluginSortRef}
+            onPluginSortChange={onPluginSortChange}
+          />
+          {facetSpecs.length > 0 && (
+            <Tooltip text="Plugin facets">
+              <button
+                onClick={() => setFacetOpen((o) => !o)}
+                aria-haspopup="true"
+                aria-expanded={facetOpen}
+                aria-label="Plugin facet filters"
+                data-testid="sidebar-facet-toggle"
+                className={`relative w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
+                  activeFacets.length > 0 || facetOpen ? "text-brand-500" : "text-text-dim hover:text-text-secondary"
+                }`}
+              >
+                <ListFilter className="h-3.5 w-3.5" />
+                {activeFacets.length > 0 && (
+                  <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-brand-500" aria-hidden />
+                )}
+              </button>
+            </Tooltip>
+          )}
           <Tooltip text="Filter">
             <button
               onClick={toggleFilter}
@@ -2853,6 +2937,42 @@ export function WorkspaceSidebar({
           </div>
         )}
 
+        {facetOpen && facetSpecs.length > 0 && (
+          <div className="px-3 pb-2 flex flex-col gap-2" data-testid="sidebar-facet-panel">
+            {facetSpecs.map((facet) => {
+              const selected = facetSelection.get(`${facet.pluginId}\u0000${facet.entryId}`);
+              return (
+                <div key={`${facet.pluginId}:${facet.entryId}`} data-plugin-id={facet.pluginId}>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-text-dim mb-1">
+                    {facet.label}
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {facet.options.map((opt) => {
+                      const on = selected?.has(opt.value) ?? false;
+                      return (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          aria-pressed={on}
+                          data-testid={`sidebar-facet-option-${facet.entryId}-${opt.value}`}
+                          onClick={() => toggleFacetValue(facet.pluginId, facet.entryId, opt.value)}
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                            on
+                              ? "bg-brand-500/15 text-brand-500 ring-1 ring-brand-500/40"
+                              : `bg-surface-700/40 hover:bg-surface-700/70 ${toneTextClass(opt.tone)}`
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
         <div className="flex-1 overflow-y-auto overflow-x-hidden border-t border-surface-700/60">
           {!isNested && (
             <DragSuppressContext.Provider value={dragSuppressRef}>
@@ -2874,7 +2994,7 @@ export function WorkspaceSidebar({
                   const groupDragDisabled = reorderDisabled || q.length > 0;
 
                   const renderGroupBody = (group: SidebarGroup, dragHandle?: DragHandleProps) => {
-                    const showExpanded = q ? true : !group.collapsed;
+                    const showExpanded = hasFilter ? true : !group.collapsed;
                     const hasActiveChild = group.workspaces.some((v) => v.workspace.id === displayedActiveId);
                     // Header archive count + action operate on the full group,
                     // not the filter-sliced one, so "Archive all" never silently
@@ -2970,7 +3090,7 @@ export function WorkspaceSidebar({
           {isNested &&
             filteredNested.filter(nestedSidebarGroupShouldRender).map((ng) => {
               const repo = ng.repo;
-              const repoExpanded = q ? true : !repo.collapsed;
+              const repoExpanded = hasFilter ? true : !repo.collapsed;
               const repoHasActiveChild = ng.subgroups.some((sg) =>
                 sg.workspaces.some((v) => v.workspace.id === displayedActiveId),
               );
@@ -2992,7 +3112,7 @@ export function WorkspaceSidebar({
                   {repoExpanded &&
                     ng.subgroups.filter(sidebarGroupHasLiveWorkspace).map((sg) => {
                       const groupPath = sg.groupPath ?? "";
-                      const subExpanded = q ? true : !sg.collapsed;
+                      const subExpanded = hasFilter ? true : !sg.collapsed;
                       const subHasActiveChild = sg.workspaces.some((v) => v.workspace.id === displayedActiveId);
                       // Sunk rows are pulled into the single global
                       // footer below, exactly like the flat axes, so

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2363,7 +2363,11 @@ export function WorkspaceSidebar({
     [activeFacets, pluginUiEntries],
   );
 
-  const dragDisabled = !!readOnly || sortMode === "lastActivity" || pluginSortActive;
+  // A facet filter narrows the visible rows, but handleDragEnd rebuilds order
+  // from the full group list, so a drag inside a filtered subset could move
+  // hidden rows and persist an order the user never saw. Gate reorder off while
+  // facets are active, like the computed sort modes. See #2401.
+  const dragDisabled = !!readOnly || sortMode === "lastActivity" || pluginSortActive || activeFacets.length > 0;
   // Reorder (group drag + row drag) is also off whenever any visible group
   // forbids it, which is the whole user-group axis: groups have no manual
   // order in v1. Gating here keeps the shared DndContext from firing a
@@ -3005,7 +3009,7 @@ export function WorkspaceSidebar({
                         <SidebarGroupHeader
                           group={{ ...fullGroup, collapsed: !showExpanded }}
                           hasActiveChild={!showExpanded && hasActiveChild}
-                          onClick={() => !q && onToggleGroup(group.id)}
+                          onClick={() => !hasFilter && onToggleGroup(group.id)}
                           onUpdateAppearance={onUpdateRepoAppearance}
                           onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(fullGroup)}
                           onPin={readOnly || offline ? undefined : onPinProject}
@@ -3099,7 +3103,7 @@ export function WorkspaceSidebar({
                   <SidebarGroupHeader
                     group={{ ...repo, collapsed: !repoExpanded }}
                     hasActiveChild={!repoExpanded && repoHasActiveChild}
-                    onClick={() => !q && onToggleGroup(repo.id)}
+                    onClick={() => !hasFilter && onToggleGroup(repo.id)}
                     onUpdateAppearance={onUpdateRepoAppearance}
                     onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(repo)}
                     onPin={readOnly || offline ? undefined : onPinProject}
@@ -3134,7 +3138,7 @@ export function WorkspaceSidebar({
                           <SidebarGroupHeader
                             group={{ ...fullSubgroup, collapsed: !subExpanded }}
                             hasActiveChild={!subExpanded && subHasActiveChild}
-                            onClick={() => !q && onToggleSubgroup(repo.id, groupPath)}
+                            onClick={() => !hasFilter && onToggleSubgroup(repo.id, groupPath)}
                             onUpdateAppearance={onUpdateRepoAppearance}
                             onArchiveAll={readOnly || offline ? undefined : () => onArchiveGroup(fullSubgroup)}
                             onNewSession={onNew}
@@ -3245,13 +3249,13 @@ export function WorkspaceSidebar({
             );
           })()}
 
-          {!hasResults && filterQuery && (
+          {!hasResults && hasFilter && (
             <div className="px-4 py-8 text-center">
               <p className="text-sm text-text-muted">No matches for &ldquo;{filterQuery}&rdquo;</p>
             </div>
           )}
 
-          {!hasResults && !filterQuery && (
+          {!hasResults && !hasFilter && (
             <div className="px-4 py-10 text-center" data-testid="sidebar-empty-state">
               <p className="text-sm font-medium text-text-secondary">No sessions yet</p>
               <p className="mt-1 text-[13px] text-text-muted">Create a session to start working in a repo.</p>

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -2,8 +2,9 @@
 // typed display state; these components draw it. No plugin code runs here.
 // Each reads the shared snapshot via context and the pure selectors in
 // `pluginUi.ts`. Slots shipped here: status-bar, row-badge, row-column, card,
-// pane, detail-badge. Notifications surface as toasts via the hook;
-// sort-key and filter-facet are deferred (see #2366 follow-ups).
+// pane, detail-badge. Notifications surface as toasts via the hook; the
+// sort-key and filter-facet slots render as sidebar sort options and a facet
+// filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
 import { createElement, useState } from "react";
 import { ChevronRight } from "lucide-react";
@@ -158,8 +159,9 @@ export function PluginRowBadges({ sessionId }: { sessionId: string }) {
 }
 
 /** row-column: per-session text column, right-aligned on a session row. The
- *  payload may also carry sort/filter scalars; rendering those as interactive
- *  controls is the deferred sort-key/filter-facet work. */
+ *  payload may also carry `sort_value` / `filter_values` scalars, which the
+ *  sidebar's sort-key and filter-facet controls consume (#2401); this renders
+ *  only the visible text. */
 export function PluginRowColumn({ sessionId }: { sessionId: string }) {
   const entries = sessionEntries(usePluginUiEntries(), "row-column", sessionId);
   if (entries.length === 0) return null;

--- a/web/src/hooks/useNestedSidebarGroups.ts
+++ b/web/src/hooks/useNestedSidebarGroups.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { RepoGroup } from "../lib/types";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
 import { buildNestedSidebarGroups, type NestedSidebarGroup } from "../lib/sidebarGroups";
-import type { SidebarSortMode } from "../lib/sidebarSort";
+import type { PluginSortContext, SidebarSortMode } from "../lib/sidebarSort";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 
 // Distinct from both the repo prefix (`aoe-repo-collapsed-`) and the flat
@@ -26,6 +26,7 @@ function loadCollapsed(key: string): boolean {
 export function useNestedSidebarGroups(
   repoGroups: RepoGroup[],
   sortMode: SidebarSortMode,
+  pluginSort?: PluginSortContext,
 ): {
   groups: NestedSidebarGroup[];
   toggleSubgroupCollapsed: (repoId: string, groupPath: string) => void;
@@ -38,12 +39,13 @@ export function useNestedSidebarGroups(
       buildNestedSidebarGroups(repoGroups, {
         idleDecayWindowMs,
         sortMode,
+        pluginSort,
         isSubgroupCollapsed: (repoId, groupPath) => {
           const key = subgroupKey(repoId, groupPath);
           return collapsedMap[key] ?? loadCollapsed(key);
         },
       }),
-    [repoGroups, idleDecayWindowMs, sortMode, collapsedMap],
+    [repoGroups, idleDecayWindowMs, sortMode, pluginSort, collapsedMap],
   );
 
   // The updater stays pure and persistence runs in an effect, for the same

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -9,13 +9,17 @@ import {
   type RepoAppearanceUpdate,
 } from "../lib/repoAppearance";
 import { loadRepoGroupOrder, persistRepoGroupOrder } from "../lib/repoGroupOrder";
+import { compareSortValues, type PluginSortValue } from "../lib/pluginUi";
 import {
   compareWorkspacesByAttention,
   compareWorkspacesByLastActivityDesc,
+  compareWorkspacesByPluginSort,
+  type PluginSortContext,
   repoGroupAttentionRank,
   repoGroupIsFavorited,
   repoGroupIsUrgent,
   repoGroupLastActivityMs,
+  repoGroupPluginSortValue,
   workspaceTriageTier,
   type SidebarSortMode,
 } from "../lib/sidebarSort";
@@ -61,6 +65,12 @@ export function useRepoGroups(
   workspaceOrdering: readonly string[] = [],
   sortMode: SidebarSortMode = "manual",
   projects: readonly ProjectInfo[] = [],
+  // When set, an active plugin sort (#2401) overrides the built-in `sortMode`
+  // for both within-group workspace order and group order. It is a computed
+  // mode like `lastActivity`, so manual drag order does not apply; synthetic
+  // and registered-empty groups stay pinned to the bottom as in every computed
+  // mode.
+  pluginSort?: PluginSortContext,
 ): {
   groups: RepoGroup[];
   /** Saved (registered) projects that are not pinned and have no live
@@ -105,7 +115,11 @@ export function useRepoGroups(
         if (ar > br) return 1;
         return a.id.localeCompare(b.id);
       });
+    const pluginCompare = pluginSort ? compareWorkspacesByPluginSort(pluginSort) : null;
     const sortWorkspaces = (list: Workspace[]) => {
+      if (pluginCompare) {
+        return [...list].sort(pluginCompare);
+      }
       if (sortMode === "attention") {
         return [...list].sort(compareWorkspacesByAttention);
       }
@@ -231,6 +245,29 @@ export function useRepoGroups(
     const isRegisteredEmpty = (g: RepoGroup) => g.workspaces.length === 0 && g.registeredProjects.length > 0;
 
     merged.sort((a, b) => {
+      if (pluginSort) {
+        // Computed order like lastActivity: manual group drag does not apply,
+        // synthetic groups stay pinned to the bottom (real repos, then
+        // multi-repo, then scratch), and registered-empty groups sink below
+        // populated real repos. Among real groups: best plugin scalar in the
+        // chosen direction (unvalued groups sink), then most-recent activity,
+        // then a deterministic repoPath tie-break. See #2401.
+        if (a.id === SCRATCH_GROUP_ID) return 1;
+        if (b.id === SCRATCH_GROUP_ID) return -1;
+        if (a.id === MULTI_REPO_GROUP_ID) return 1;
+        if (b.id === MULTI_REPO_GROUP_ID) return -1;
+        const ae = isRegisteredEmpty(a);
+        const be = isRegisteredEmpty(b);
+        if (ae !== be) return ae ? 1 : -1;
+        const av: PluginSortValue | undefined = repoGroupPluginSortValue(a.workspaces, pluginSort);
+        const bv: PluginSortValue | undefined = repoGroupPluginSortValue(b.workspaces, pluginSort);
+        const cmp = compareSortValues(av, bv, pluginSort.direction);
+        if (cmp !== 0) return cmp;
+        const ak = repoGroupLastActivityMs(a.workspaces);
+        const bk = repoGroupLastActivityMs(b.workspaces);
+        if (ak !== bk) return bk - ak;
+        return a.repoPath.localeCompare(b.repoPath);
+      }
       if (sortMode === "attention") {
         // Computed order, like lastActivity: manual group drag does not
         // apply and synthetic groups stay pinned to the bottom in a stable
@@ -320,7 +357,7 @@ export function useRepoGroups(
     });
 
     return { groups: merged, savedProjects };
-  }, [workspaces, workspaceOrdering, sortMode, projects, collapsedMap, appearanceMap, groupOrder]);
+  }, [workspaces, workspaceOrdering, sortMode, pluginSort, projects, collapsedMap, appearanceMap, groupOrder]);
 
   const toggleRepoCollapsed = useCallback((repoId: string) => {
     setCollapsedMap((prev) => {

--- a/web/src/hooks/useSessionGroups.ts
+++ b/web/src/hooks/useSessionGroups.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Workspace } from "../lib/types";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
 import { buildSessionGroups, type SidebarGroup } from "../lib/sidebarGroups";
-import type { SidebarSortMode } from "../lib/sidebarSort";
+import type { PluginSortContext, SidebarSortMode } from "../lib/sidebarSort";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 
 // Distinct from the repo axis prefix (`aoe-repo-collapsed-`) so collapse
@@ -17,6 +17,7 @@ function loadCollapsed(id: string): boolean {
 export function useSessionGroups(
   workspaces: Workspace[],
   sortMode: SidebarSortMode,
+  pluginSort?: PluginSortContext,
 ): {
   groups: SidebarGroup[];
   toggleGroupCollapsed: (groupId: string) => void;
@@ -29,9 +30,10 @@ export function useSessionGroups(
       buildSessionGroups(workspaces, {
         idleDecayWindowMs,
         sortMode,
+        pluginSort,
         isCollapsed: (id) => collapsedMap[id] ?? loadCollapsed(id),
       }),
-    [workspaces, idleDecayWindowMs, sortMode, collapsedMap],
+    [workspaces, idleDecayWindowMs, sortMode, pluginSort, collapsedMap],
   );
 
   // The updater stays pure: it reads the current value but performs no

--- a/web/src/lib/__tests__/pluginUi.test.ts
+++ b/web/src/lib/__tests__/pluginUi.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, it } from "vitest";
 import type { PluginUiEntry, PluginUiSlot } from "../api";
 import {
   accentStyle,
+  buildSortValueMap,
+  compareSortValues,
+  entryFilterValues,
+  entrySortValue,
   entryText,
   entryTone,
   globalEntries,
   payloadStr,
+  pluginFacetSpecs,
+  pluginSortSpecs,
   sessionEntries,
+  sessionMatchesFacets,
   toneClasses,
   validColor,
 } from "../pluginUi";
@@ -80,5 +87,113 @@ describe("pluginUi selectors", () => {
     expect(filled?.color).toBe("#8957e5");
     expect(String(filled?.backgroundColor)).toContain("#8957e5");
     expect(accentStyle("red")).toBeUndefined();
+  });
+});
+
+describe("pluginUi sort-key / filter-facet (#2401)", () => {
+  it("entrySortValue accepts finite numbers and strings, rejects the rest", () => {
+    expect(entrySortValue(entry("row-column", { payload: { sort_value: 42 } }))).toBe(42);
+    expect(entrySortValue(entry("row-column", { payload: { sort_value: "b" } }))).toBe("b");
+    expect(entrySortValue(entry("row-column", { payload: { sort_value: 0 } }))).toBe(0);
+    expect(entrySortValue(entry("row-column", { payload: { sort_value: Infinity } }))).toBeUndefined();
+    expect(entrySortValue(entry("row-column", { payload: { sort_value: { x: 1 } } }))).toBeUndefined();
+    expect(entrySortValue(entry("row-column"))).toBeUndefined();
+  });
+
+  it("entryFilterValues keeps only string tokens", () => {
+    expect(entryFilterValues(entry("row-column", { payload: { filter_values: ["a", 1, "b", null] } }))).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(entryFilterValues(entry("row-column", { payload: { filter_values: "nope" } }))).toEqual([]);
+    expect(entryFilterValues(entry("row-column"))).toEqual([]);
+  });
+
+  it("compareSortValues sinks missing values regardless of direction", () => {
+    expect(compareSortValues(undefined, 5, "asc")).toBeGreaterThan(0);
+    expect(compareSortValues(undefined, 5, "desc")).toBeGreaterThan(0);
+    expect(compareSortValues(5, undefined, "asc")).toBeLessThan(0);
+    expect(compareSortValues(5, undefined, "desc")).toBeLessThan(0);
+    expect(compareSortValues(undefined, undefined, "asc")).toBe(0);
+  });
+
+  it("compareSortValues orders numbers and strings by direction", () => {
+    expect(compareSortValues(1, 2, "asc")).toBeLessThan(0);
+    expect(compareSortValues(1, 2, "desc")).toBeGreaterThan(0);
+    expect(compareSortValues("a", "b", "asc")).toBeLessThan(0);
+    expect(compareSortValues("a", "b", "desc")).toBeGreaterThan(0);
+    // Mixed types are deterministic: a number sorts before a string (asc).
+    expect(compareSortValues(1, "a", "asc")).toBeLessThan(0);
+  });
+
+  it("pluginSortSpecs reads global sort-key entries and defaults direction to asc", () => {
+    const entries = [
+      entry("sort-key", { id: "cpu", payload: { label: "CPU", column: "col-cpu", direction: "desc" } }),
+      entry("sort-key", { id: "mem", payload: { label: "Mem", column: "col-mem" } }),
+      entry("sort-key", { id: "bad", payload: { label: "", column: "x" } }), // no label => skipped
+      entry("sort-key", { id: "perses", session_id: "s1", payload: { label: "L", column: "c" } }), // per-session => skipped
+    ];
+    const specs = pluginSortSpecs(entries);
+    expect(specs.map((s) => [s.entryId, s.column, s.direction])).toEqual([
+      ["cpu", "col-cpu", "desc"],
+      ["mem", "col-mem", "asc"],
+    ]);
+  });
+
+  it("pluginFacetSpecs reads global filter-facet entries and drops valueless options", () => {
+    const entries = [
+      entry("filter-facet", {
+        id: "status",
+        payload: {
+          label: "Status",
+          column: "col-st",
+          options: [
+            { value: "run", label: "Running", tone: "success" },
+            { value: "idle" }, // label defaults to value
+            { label: "no value" }, // dropped
+          ],
+        },
+      }),
+    ];
+    const specs = pluginFacetSpecs(entries);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.options).toEqual([
+      { value: "run", label: "Running", tone: "success" },
+      { value: "idle", label: "idle", tone: undefined },
+    ]);
+  });
+
+  it("buildSortValueMap scopes to the same plugin_id and column", () => {
+    const entries = [
+      entry("row-column", { id: "col", session_id: "s1", payload: { sort_value: 1 } }),
+      entry("row-column", { id: "col", session_id: "s2", payload: { sort_value: 2 } }),
+      // Same column id but a different plugin must not bleed in.
+      entry("row-column", { id: "col", session_id: "s3", plugin_id: "other.kit", payload: { sort_value: 9 } }),
+      // Different column id, ignored.
+      entry("row-column", { id: "elsewhere", session_id: "s4", payload: { sort_value: 5 } }),
+    ];
+    const map = buildSortValueMap(entries, "acme.kit", "col");
+    expect([...map.entries()].sort()).toEqual([
+      ["s1", 1],
+      ["s2", 2],
+    ]);
+  });
+
+  it("sessionMatchesFacets ANDs across facets and ORs within one (same-plugin column)", () => {
+    const entries = [
+      entry("row-column", { id: "st", session_id: "s1", payload: { filter_values: ["run"] } }),
+      entry("row-column", { id: "lang", session_id: "s1", payload: { filter_values: ["rust"] } }),
+      entry("row-column", { id: "st", session_id: "s2", payload: { filter_values: ["idle"] } }),
+    ];
+    const facetStatus = { pluginId: "acme.kit", column: "st", values: new Set(["run", "idle"]) };
+    const facetLang = { pluginId: "acme.kit", column: "lang", values: new Set(["rust"]) };
+    // s1 matches both facets.
+    expect(sessionMatchesFacets(entries, "s1", [facetStatus, facetLang])).toBe(true);
+    // s2 matches status (idle) but has no lang row-column => fails the AND.
+    expect(sessionMatchesFacets(entries, "s2", [facetStatus, facetLang])).toBe(false);
+    // s2 matches status alone.
+    expect(sessionMatchesFacets(entries, "s2", [facetStatus])).toBe(true);
+    // No active facets => trivially true.
+    expect(sessionMatchesFacets(entries, "s2", [])).toBe(true);
   });
 });

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -6,7 +6,10 @@ import {
   SIDEBAR_SORT_MODE_KEY,
   compareWorkspacesByAttention,
   compareWorkspacesByLastActivityDesc,
+  compareWorkspacesByPluginSort,
   compareWorkspacesForComputedSortMode,
+  repoGroupPluginSortValue,
+  workspacePluginSortValue,
   loadSidebarSortMode,
   repoGroupAttentionRank,
   repoGroupHasLiveWorkspace,
@@ -731,5 +734,60 @@ describe("loadSidebarSortMode accepts attention (#1640)", () => {
   it("falls back to manual for an unknown stored value", () => {
     window.localStorage.setItem(SIDEBAR_SORT_MODE_KEY, "bogus");
     expect(loadSidebarSortMode()).toBe("manual");
+  });
+});
+
+describe("plugin sort comparators (#2401)", () => {
+  const wsA = workspace("a", [session({ id: "a1" }), session({ id: "a2" })]);
+  const wsB = workspace("b", [session({ id: "b1" })]);
+
+  it("workspacePluginSortValue picks the min for asc and the max for desc", () => {
+    const values = new Map([
+      ["a1", 30],
+      ["a2", 10],
+    ]);
+    expect(workspacePluginSortValue(wsA, { direction: "asc", values })).toBe(10);
+    expect(workspacePluginSortValue(wsA, { direction: "desc", values })).toBe(30);
+  });
+
+  it("workspacePluginSortValue is undefined when no session carries a value", () => {
+    expect(workspacePluginSortValue(wsA, { direction: "asc", values: new Map() })).toBeUndefined();
+  });
+
+  it("compareWorkspacesByPluginSort orders by the workspace's best value and sinks unvalued", () => {
+    const values = new Map([
+      ["a1", 5],
+      ["b1", 1],
+    ]);
+    const ascList = [wsA, wsB].slice().sort(compareWorkspacesByPluginSort({ direction: "asc", values }));
+    expect(ascList.map((w) => w.id)).toEqual(["b", "a"]);
+    const descList = [wsA, wsB].slice().sort(compareWorkspacesByPluginSort({ direction: "desc", values }));
+    expect(descList.map((w) => w.id)).toEqual(["a", "b"]);
+    // An unvalued workspace sinks to the bottom in both directions.
+    const wsC = workspace("c", [session({ id: "c1" })]);
+    const sunk = [wsC, wsA, wsB].slice().sort(compareWorkspacesByPluginSort({ direction: "desc", values }));
+    expect(sunk[sunk.length - 1]!.id).toBe("c");
+  });
+
+  it("compareWorkspacesByPluginSort keeps triage tier ahead of the plugin scalar", () => {
+    // wsB is sunk (its only session archived) but has the best asc value; tier
+    // still pushes it below the live wsA.
+    const archivedB = workspace("b", [session({ id: "b1", archived_at: "2025-01-01T00:00:00Z" })]);
+    const values = new Map([
+      ["a1", 99],
+      ["b1", 1],
+    ]);
+    const list = [archivedB, wsA].slice().sort(compareWorkspacesByPluginSort({ direction: "asc", values }));
+    expect(list.map((w) => w.id)).toEqual(["a", "b"]);
+  });
+
+  it("repoGroupPluginSortValue takes the best across the group's workspaces", () => {
+    const values = new Map([
+      ["a1", 30],
+      ["a2", 10],
+      ["b1", 50],
+    ]);
+    expect(repoGroupPluginSortValue([wsA, wsB], { direction: "asc", values })).toBe(10);
+    expect(repoGroupPluginSortValue([wsA, wsB], { direction: "desc", values })).toBe(50);
   });
 });

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -139,9 +139,8 @@ export function toneTextClass(tone: PluginUiTone | undefined): string {
   );
 }
 
-// --- sort-key / filter-facet support (#2401) ---------------------------------
-// `sort-key` and `filter-facet` are global entries that reference a per-session
-// `row-column` entry by its `id` (the payload `column` field). The dashboard
+// `sort-key` and `filter-facet` (#2401) are global entries that reference a
+// per-session `row-column` entry by its `id` (the payload `column` field). The dashboard
 // orders/filters session rows client-side over the already-fetched scalars; no
 // plugin code runs and the render path never awaits a worker. Lookups are
 // scoped to the referencing plugin's own `plugin_id`, since a `column` id is

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -138,3 +138,154 @@ export function toneTextClass(tone: PluginUiTone | undefined): string {
       .find((c) => c.startsWith("text-")) ?? "text-text-dim"
   );
 }
+
+// --- sort-key / filter-facet support (#2401) ---------------------------------
+// `sort-key` and `filter-facet` are global entries that reference a per-session
+// `row-column` entry by its `id` (the payload `column` field). The dashboard
+// orders/filters session rows client-side over the already-fetched scalars; no
+// plugin code runs and the render path never awaits a worker. Lookups are
+// scoped to the referencing plugin's own `plugin_id`, since a `column` id is
+// only unique within one plugin.
+
+/** A comparable scalar a `row-column` exposes for client-side sorting, matching
+ *  the host's untagged `SortValue` (number | string). */
+export type PluginSortValue = number | string;
+
+/** A `row-column`'s `sort_value`, validated to a finite number or a string;
+ *  undefined when absent or not a comparable scalar. */
+export function entrySortValue(entry: PluginUiEntry): PluginSortValue | undefined {
+  const v = entry.payload.sort_value;
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") return v;
+  return undefined;
+}
+
+/** A `row-column`'s `filter_values`, as the string tokens it matches. */
+export function entryFilterValues(entry: PluginUiEntry): string[] {
+  const v = entry.payload.filter_values;
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+/** Compare two scalar sort values for a direction. Missing values (undefined)
+ *  always sort to the bottom regardless of direction, so an unvalued row sinks.
+ *  Numbers compare numerically, strings via `localeCompare`; when the two are
+ *  mixed a number sorts before a string, so the order stays deterministic.
+ *  Returns a negative number when `a` should rank before `b`. */
+export function compareSortValues(
+  a: PluginSortValue | undefined,
+  b: PluginSortValue | undefined,
+  direction: "asc" | "desc",
+): number {
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  let cmp: number;
+  if (typeof a === "number" && typeof b === "number") cmp = a < b ? -1 : a > b ? 1 : 0;
+  else if (typeof a === "string" && typeof b === "string") cmp = a.localeCompare(b);
+  else cmp = typeof a === "number" ? -1 : 1;
+  return direction === "desc" ? -cmp : cmp;
+}
+
+/** A renderable plugin sort option, resolved from a global `sort-key` entry. */
+export interface PluginSortSpec {
+  pluginId: string;
+  entryId: string;
+  label: string;
+  /** The `row-column` id whose `sort_value` this orders by. */
+  column: string;
+  direction: "asc" | "desc";
+}
+
+/** Global `sort-key` entries as renderable sort options, in snapshot order.
+ *  Entries missing a label or column are skipped; an omitted direction defaults
+ *  to ascending. */
+export function pluginSortSpecs(entries: PluginUiEntry[]): PluginSortSpec[] {
+  const out: PluginSortSpec[] = [];
+  for (const e of entries) {
+    if (e.slot !== "sort-key" || e.session_id != null) continue;
+    const label = payloadStr(e, "label");
+    const column = payloadStr(e, "column");
+    if (!label || !column) continue;
+    out.push({
+      pluginId: e.plugin_id,
+      entryId: e.id,
+      label,
+      column,
+      direction: e.payload.direction === "desc" ? "desc" : "asc",
+    });
+  }
+  return out;
+}
+
+/** A renderable facet control, resolved from a global `filter-facet` entry. */
+export interface PluginFacetSpec {
+  pluginId: string;
+  entryId: string;
+  label: string;
+  /** The `row-column` id whose `filter_values` this filters over. */
+  column: string;
+  options: { value: string; label: string; tone: PluginUiTone | undefined }[];
+}
+
+/** Global `filter-facet` entries as renderable facet controls, in snapshot
+ *  order. Entries missing a label or column, and options missing a value, are
+ *  skipped. */
+export function pluginFacetSpecs(entries: PluginUiEntry[]): PluginFacetSpec[] {
+  const out: PluginFacetSpec[] = [];
+  for (const e of entries) {
+    if (e.slot !== "filter-facet" || e.session_id != null) continue;
+    const label = payloadStr(e, "label");
+    const column = payloadStr(e, "column");
+    if (!label || !column) continue;
+    const raw = Array.isArray(e.payload.options) ? e.payload.options : [];
+    const options = raw
+      .filter((o): o is Record<string, unknown> => typeof o === "object" && o !== null && !Array.isArray(o))
+      .map((o) => ({
+        value: typeof o.value === "string" ? o.value : "",
+        label: typeof o.label === "string" && o.label ? o.label : typeof o.value === "string" ? o.value : "",
+        tone: validTone(o.tone),
+      }))
+      .filter((o) => o.value !== "");
+    out.push({ pluginId: e.plugin_id, entryId: e.id, label, column, options });
+  }
+  return out;
+}
+
+/** Map of `session_id` -> `sort_value` for one plugin's `row-column` id, for
+ *  the active sort. Sessions whose entry carries no comparable scalar are
+ *  omitted (they sink to the bottom at compare time). */
+export function buildSortValueMap(
+  entries: PluginUiEntry[],
+  pluginId: string,
+  column: string,
+): Map<string, PluginSortValue> {
+  const map = new Map<string, PluginSortValue>();
+  for (const e of entries) {
+    if (e.slot !== "row-column" || e.plugin_id !== pluginId || e.id !== column || e.session_id == null) continue;
+    const v = entrySortValue(e);
+    if (v !== undefined) map.set(e.session_id, v);
+  }
+  return map;
+}
+
+/** One active facet selection: the referencing plugin/column plus the chosen
+ *  values (OR within this set). */
+export interface ActiveFacet {
+  pluginId: string;
+  column: string;
+  values: Set<string>;
+}
+
+/** Whether a session satisfies every active facet: for each facet the
+ *  session's matching `row-column` entry shares at least one `filter_value`
+ *  with the facet's selected set. AND across facets, OR within one facet. A
+ *  session with no matching row-column for an active facet fails that facet. */
+export function sessionMatchesFacets(entries: PluginUiEntry[], sessionId: string, active: ActiveFacet[]): boolean {
+  return active.every((f) => {
+    const rc = entries.find(
+      (e) => e.slot === "row-column" && e.plugin_id === f.pluginId && e.id === f.column && e.session_id === sessionId,
+    );
+    if (!rc) return false;
+    return entryFilterValues(rc).some((v) => f.values.has(v));
+  });
+}

--- a/web/src/lib/sidebarGroups.ts
+++ b/web/src/lib/sidebarGroups.ts
@@ -1,7 +1,13 @@
 import type { RepoColor } from "./repoAppearance";
 import type { ProjectInfo, RepoGroup, SessionResponse, Workspace, WorkspaceStatus } from "./types";
 import { isSessionActive } from "./session";
-import { compareWorkspacesForComputedSortMode, type SidebarSortMode, workspaceIsSunk } from "./sidebarSort";
+import {
+  compareWorkspacesByPluginSort,
+  compareWorkspacesForComputedSortMode,
+  type PluginSortContext,
+  type SidebarSortMode,
+  workspaceIsSunk,
+} from "./sidebarSort";
 import { MULTI_REPO_GROUP_ID, SCRATCH_GROUP_ID } from "../hooks/useRepoGroups";
 
 // Synthetic id for the bucket that collects sessions with no user-assigned
@@ -134,6 +140,9 @@ export function buildSessionGroups(
     // last-activity here (this axis has no manual drag order), while
     // `lastActivity` and `attention` are honored. See #1640.
     sortMode: SidebarSortMode;
+    // When set, an active plugin sort overrides the built-in `sortMode`
+    // comparator for the within-group rows. See #2401.
+    pluginSort?: PluginSortContext;
     // `groupPath` is the normalized path ("" for Ungrouped), passed
     // alongside the synthetic id so nested callers can key collapse state
     // on the path and dodge the `UNGROUPED_GROUP_ID` sentinel. Flat callers
@@ -141,7 +150,9 @@ export function buildSessionGroups(
     isCollapsed: (groupId: string, groupPath: string) => boolean;
   },
 ): SidebarGroup[] {
-  const compareWorkspace = compareWorkspacesForComputedSortMode(opts.sortMode);
+  const compareWorkspace = opts.pluginSort
+    ? compareWorkspacesByPluginSort(opts.pluginSort)
+    : compareWorkspacesForComputedSortMode(opts.sortMode);
   const byGroup = new Map<string, SidebarWorkspaceView[]>();
   const order: string[] = [];
 
@@ -264,6 +275,8 @@ export function buildNestedSidebarGroups(
     // selected sort mode. Top-level repo order is inherited from the repo
     // axis (already sorted by `useRepoGroups`), so it is not re-sorted here.
     sortMode: SidebarSortMode;
+    // Forwarded so subgroup rows honor an active plugin sort. See #2401.
+    pluginSort?: PluginSortContext;
     isSubgroupCollapsed: (repoId: string, groupPath: string) => boolean;
   },
 ): NestedSidebarGroup[] {
@@ -272,6 +285,7 @@ export function buildNestedSidebarGroups(
     const subgroups = buildSessionGroups(repoGroup.workspaces, {
       idleDecayWindowMs: opts.idleDecayWindowMs,
       sortMode: opts.sortMode,
+      pluginSort: opts.pluginSort,
       isCollapsed: (_groupId, groupPath) => opts.isSubgroupCollapsed(repo.id, groupPath),
     });
     return {

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -1,5 +1,6 @@
 import type { RepoGroup, SessionResponse, Workspace } from "./types";
 import { safeGetItem, safeSetItem } from "./safeStorage";
+import { compareSortValues, type PluginSortValue } from "./pluginUi";
 
 export type SidebarSortMode = "manual" | "lastActivity" | "attention";
 
@@ -354,4 +355,62 @@ export function repoGroupIsUrgent(workspaces: readonly Workspace[]): boolean {
 /** True when any workspace in the group is favorited. */
 export function repoGroupIsFavorited(workspaces: readonly Workspace[]): boolean {
   return workspaces.some(workspaceIsFavorited);
+}
+
+/** An active plugin sort: the chosen direction plus a `session_id -> sort_value`
+ *  map for the referenced `row-column` column. Built at the component boundary
+ *  from the live snapshot and threaded into the sidebar builders so the pure
+ *  grouping code never reads plugin context directly. See #2401. */
+export interface PluginSortContext {
+  direction: "asc" | "desc";
+  values: Map<string, PluginSortValue>;
+}
+
+/** Best plugin sort value across a workspace's sessions: the value that ranks
+ *  first for the direction (the min for asc, the max for desc), so a
+ *  workspace's strongest row pulls it toward the top, mirroring how the
+ *  attention sort keys on a workspace's most-urgent session. `undefined` when
+ *  no session carries a value, so the workspace sinks. */
+export function workspacePluginSortValue(ws: Workspace, ctx: PluginSortContext): PluginSortValue | undefined {
+  let best: PluginSortValue | undefined;
+  for (const s of ws.sessions) {
+    const v = ctx.values.get(s.id);
+    if (v === undefined) continue;
+    if (best === undefined || compareSortValues(v, best, ctx.direction) < 0) best = v;
+  }
+  return best;
+}
+
+/** Best plugin sort value across a repo group's workspaces, so a group holding
+ *  the top-ranked row floats above one whose best row ranks lower. */
+export function repoGroupPluginSortValue(
+  workspaces: readonly Workspace[],
+  ctx: PluginSortContext,
+): PluginSortValue | undefined {
+  let best: PluginSortValue | undefined;
+  for (const ws of workspaces) {
+    const v = workspacePluginSortValue(ws, ctx);
+    if (v === undefined) continue;
+    if (best === undefined || compareSortValues(v, best, ctx.direction) < 0) best = v;
+  }
+  return best;
+}
+
+/** Plugin-sort comparator. Triage tier wins first (pinned floats, sunk sinks,
+ *  the same invariant as every built-in mode), then the workspace's best plugin
+ *  scalar in the chosen direction (unvalued workspaces sink), then last activity
+ *  descending and an id tie-break so equal keys never flake the render order. */
+export function compareWorkspacesByPluginSort(ctx: PluginSortContext): (a: Workspace, b: Workspace) => number {
+  return (a, b) => {
+    const aTier = workspaceTriageTier(a);
+    const bTier = workspaceTriageTier(b);
+    if (aTier !== bTier) return aTier - bTier;
+    const cmp = compareSortValues(workspacePluginSortValue(a, ctx), workspacePluginSortValue(b, ctx), ctx.direction);
+    if (cmp !== 0) return cmp;
+    const aMs = workspaceLastActivityMs(a);
+    const bMs = workspaceLastActivityMs(b);
+    if (aMs < bMs) return 1;
+    if (aMs > bMs) return -1;
+    return a.id.localeCompare(b.id);
+  };
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1020,6 +1020,17 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/components/SidebarSortPicker.tsx"]
     },
     {
+      "id": "sidebar.plugin-sort-filter",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/plugin-sort-filter.spec.ts"],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/SidebarSortPicker.tsx",
+        "web/src/components/plugin/PluginSlots.tsx"
+      ]
+    },
+    {
       "id": "sidebar.group-axis-pure",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/plugin-sort-filter.spec.ts
+++ b/web/tests/plugin-sort-filter.spec.ts
@@ -1,0 +1,171 @@
+// Mocked-Playwright coverage for the plugin sort-key and filter-facet slots in
+// the sidebar (#2401).
+//
+// Drives the WorkspaceSidebar against fully-stubbed /api responses, including
+// /api/plugins/ui-state, so the only thing under test is the React wiring:
+//   1. A plugin sort-key appears in the sort picker and reorders rows by the
+//      referenced row-column's sort_value in the declared direction.
+//   2. A plugin filter-facet renders a facet control that filters rows by the
+//      referenced row-column's filter_values, combined with the text filter.
+//
+// The fallback-when-entries-vanish and the comparator math live in the unit
+// tests (src/lib/__tests__/pluginUi.test.ts, sidebarSort.test.ts).
+
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+interface MockSession {
+  id: string;
+  title: string;
+  branch: string;
+  created_at: string;
+}
+
+function sessionResponse(s: MockSession) {
+  return {
+    id: s.id,
+    title: s.title,
+    project_path: "/tmp/repo",
+    group_path: "/tmp/repo",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: s.created_at,
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: s.branch,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    urgent: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+  };
+}
+
+// A row-column with a sort scalar, a status facet token, plus the global
+// sort-key and filter-facet that reference them, for one session.
+function entriesForSession(sessionId: string, sortValue: number, status: string) {
+  return [
+    {
+      plugin_id: "acme.kit",
+      slot: "row-column",
+      id: "metric",
+      session_id: sessionId,
+      payload: { text: String(sortValue), sort_value: sortValue },
+    },
+    {
+      plugin_id: "acme.kit",
+      slot: "row-column",
+      id: "status-col",
+      session_id: sessionId,
+      payload: { text: status, filter_values: [status] },
+    },
+  ];
+}
+
+const GLOBAL_ENTRIES = [
+  {
+    plugin_id: "acme.kit",
+    slot: "sort-key",
+    id: "by-metric",
+    payload: { label: "Metric", column: "metric", direction: "desc" },
+  },
+  {
+    plugin_id: "acme.kit",
+    slot: "filter-facet",
+    id: "by-status",
+    payload: {
+      label: "Status",
+      column: "status-col",
+      options: [
+        { value: "running", label: "Running", tone: "success" },
+        { value: "idle", label: "Idle" },
+      ],
+    },
+  },
+];
+
+async function mockApis(page: Page, sessions: MockSession[], ordering: string[], uiEntries: unknown[]) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({ json: { sessions: sessions.map(sessionResponse), workspace_ordering: ordering } });
+  });
+  await page.route("**/api/plugins/ui-state", (r) => r.fulfill({ json: { entries: uiEntries, notifications: [] } }));
+  for (const path of ["settings", "themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
+    await page.route(`**/api/${path}`, (r) => r.fulfill({ json: path === "docker/status" ? {} : [] }));
+  }
+}
+
+async function readWorkspaceTitles(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll<HTMLAnchorElement>("[data-testid='sidebar-session-row']"));
+    return rows.map((a) => a.querySelector("[title]")?.getAttribute("title") ?? "").filter(Boolean);
+  });
+}
+
+const TOGGLE = "[data-testid='sidebar-sort-toggle']";
+
+const SESSIONS: MockSession[] = [
+  { id: "s-low", title: "low-ws", branch: "feature/low", created_at: "2025-01-01T00:00:00Z" },
+  { id: "s-high", title: "high-ws", branch: "feature/high", created_at: "2025-01-02T00:00:00Z" },
+  { id: "s-mid", title: "mid-ws", branch: "feature/mid", created_at: "2025-01-03T00:00:00Z" },
+];
+// Manual order pins low, then high, then mid; absent the plugin sort this is
+// the render order.
+const ORDERING = ["/tmp/repo::feature/low", "/tmp/repo::feature/high", "/tmp/repo::feature/mid"];
+
+const UI_ENTRIES = [
+  ...GLOBAL_ENTRIES,
+  ...entriesForSession("s-low", 1, "idle"),
+  ...entriesForSession("s-high", 100, "running"),
+  ...entriesForSession("s-mid", 50, "running"),
+];
+
+test.describe("Plugin sort-key and filter-facet slots (#2401)", () => {
+  test("a plugin sort-key reorders rows by sort_value desc", async ({ page }) => {
+    await mockApis(page, SESSIONS, ORDERING, UI_ENTRIES);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    // Manual order first.
+    await expect.poll(() => readWorkspaceTitles(page), { timeout: 8000 }).toEqual(["low-ws", "high-ws", "mid-ws"]);
+
+    // Open the picker; the plugin option appears below the built-ins.
+    await page.locator(TOGGLE).click();
+    await page.locator("[data-testid='sidebar-sort-option-plugin-by-metric']").click();
+    await expect(page.locator(TOGGLE)).toHaveAttribute("data-sort-mode", "plugin");
+
+    // Rows now order by sort_value descending: 100, 50, 1.
+    await expect.poll(() => readWorkspaceTitles(page), { timeout: 4000 }).toEqual(["high-ws", "mid-ws", "low-ws"]);
+
+    // The plugin sort is ephemeral: not persisted to localStorage.
+    const stored = await page.evaluate(() => window.localStorage.getItem("aoe-sidebar-sort-mode"));
+    expect(stored).not.toBe("plugin");
+  });
+
+  test("a plugin filter-facet filters rows by filter_values", async ({ page }) => {
+    await mockApis(page, SESSIONS, ORDERING, UI_ENTRIES);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect(page.locator("[data-testid='sidebar-session-row']")).toHaveCount(3, { timeout: 8000 });
+
+    // Open the facet panel and select "running".
+    await page.locator("[data-testid='sidebar-facet-toggle']").click();
+    await page.locator("[data-testid='sidebar-facet-option-by-status-running']").click();
+
+    // Only the two running sessions remain (high, mid); idle low-ws drops.
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
+      .toEqual(expect.arrayContaining(["high-ws", "mid-ws"]));
+    await expect.poll(() => readWorkspaceTitles(page), { timeout: 4000 }).not.toContain("low-ws");
+
+    // Deselecting restores all three rows.
+    await page.locator("[data-testid='sidebar-facet-option-by-status-running']").click();
+    await expect.poll(() => readWorkspaceTitles(page), { timeout: 4000 }).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #2405 (the #2366 work) that wired the host backend for all nine plugin UI slots and rendered seven of them. This lands the last two interactive slots in the dashboard sidebar.

A plugin `sort-key` now renders as an extra option in the sidebar sort picker; selecting it orders the session rows by the referenced `row-column`'s `sort_value`, in the declared direction, entirely client-side over the already-fetched scalars. A plugin `filter-facet` renders as a facet control next to the text filter; selecting values keeps only sessions whose referenced `row-column` `filter_values` match. Both are aggregated to the workspace and group level the same way the built-in `lastActivity` / `attention` modes are, so a sort by a plugin metric reorders whole repo groups too rather than leaving the top row buried.

Design notes:

- `SidebarSortMode` stays the closed `manual | lastActivity | attention` union. The plugin sort is a separate, ephemeral selection (`pluginSortRef`) resolved against the live snapshot, so a daemon restart (entries gone) falls back to the built-in sort with no zombie persisted state. Facet selection is likewise ephemeral; a selection for a vanished facet is simply ignored.
- The grouping hooks stay pure: the active plugin comparator is built at the `AppContent` boundary from `usePluginUiEntries()` and threaded into the sidebar builders, rather than the hooks reading plugin context themselves.
- `row-column` lookups are scoped to the referencing plugin's own `plugin_id`, since a `column` id is only unique within one plugin. Unvalued rows sink, triage tier (pinned / sunk) still wins first, and facet matching is same-session (a workspace survives if some session matches all active facets: AND across facets, OR within one).
- Sessions within a workspace are never reordered (`sessions[0]` stays the primary session).

The approach was pressure-tested with a two-model design debate; the consensus corrected an earlier within-group-only scope to full group-level aggregation and confirmed keeping the sort-mode union closed over widening it to a string token.

Closes #2401

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run a plugin that pushes a global `sort-key` plus per-session `row-column` `sort_value`s, open the sidebar sort picker, and confirm the sort-key's label appears below the three built-in modes.
- [ ] Select the plugin sort option and confirm rows (and repo groups) reorder by the scalar in the declared direction, with unvalued rows sinking to the bottom; confirm drag-to-reorder is disabled while it is active.
- [ ] Run a plugin that pushes a global `filter-facet` plus per-session `filter_values`, click the facet button next to the filter input, select one or more values, and confirm only matching sessions remain (combined with the text filter).
- [ ] Deselect the facet values and confirm all rows return; restart the daemon while a plugin sort is active and confirm the sidebar falls back to the built-in sort with no crash.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model design debate to settle the sort-mode encoding and sort granularity. I made the design calls, reviewed each commit, and ran the validation locally (tsc, ESLint, oxfmt, the full Vitest suite, and the new plus existing sidebar Playwright specs).

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785160658&installation_id=139138837&pr_number=2470&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2470&signature=8175a624f5abbaa3189670b5c3dba96c87a19fca33ce514b6bf5ddd247f188a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR completes the dashboard sidebar’s support for the two remaining interactive plugin UI slots: `sort-key` and `filter-facet`.

- **Plugin `sort-key`** now shows up as extra options in the sidebar sort picker. Selecting one **reorders sessions client-side** using the target column’s `sort_value`, and the same sort behavior is applied consistently at the **workspace and group levels**.
- **Plugin `filter-facet`** now renders as **facet controls next to the existing text filter**. Selecting facet options **filters sessions client-side** by matching the target column’s `filter_values` (AND across different facets; OR within a facet).

To keep behavior predictable, both the selected plugin sort and facet filters are treated as **ephemeral (not persisted)**—so if plugin entries aren’t available after a daemon restart, the UI naturally falls back to built-in behavior. The sidebar sorting/facet logic was also refactored so the plugin-driven comparator is built at the **top-level App boundary** and threaded into sidebar group builders cleanly.

The PR includes **unit tests** for the new client-side helpers/comparators and adds **Playwright coverage** (plus a coverage-matrix entry) to verify both the plugin sort and plugin facet UI interactions.

**Benefits**
- Finishes the host-supported plugin UI extension points in the dashboard.
- Lets plugins influence how sessions are ordered and narrowed down without extra backend round-trips.
- Keeps selections safe and resilient by not persisting plugin UI state.

**Technical notes (optional)**
- Adds/uses helpers for extracting and comparing plugin `sort_value` and matching plugin `filter_values`.
- Threads optional plugin sort context through sidebar grouping and sorting hooks.
- Extends sidebar UI components to render plugin sort options and plugin facet panels, while disabling related reordering when plugin sort/facets are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->