### PR TITLE
feat(telemetry): add plugin-adoption census to usage_snapshot

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -32,6 +32,10 @@ kinds:
     allow/deny mix, agent switches, plan-mode use, queued prompts),
   - for `aoe serve` only, coarse deployment enums: auth mode (`token` /
     `passphrase` / `none`) and exposure (`tunnel` / `tailscale` / `local`),
+  - a plugin census: installed count per source (`builtin` / `featured` /
+    `community` / `local`) and the active state of builtin and featured
+    plugins by id. Unfeatured GitHub and local installs are counted by source
+    but never named,
   - the version-health signals below.
 
 Model names are mapped to a coarse family vocabulary (`claude`, `openai`,

--- a/src/telemetry/events.rs
+++ b/src/telemetry/events.rs
@@ -35,7 +35,11 @@ use serde::Serialize;
 /// trigger in the shipped UI (structured view is the default since #1925), so it
 /// only ever reported zero. The `acp_enable` / `acp_disable` endpoints stay; they
 /// just no longer feed a dead metric.
-pub const SCHEMA_VERSION: u32 = 12;
+/// v13 (#2367): added the plugin census `plugins_by_source` (installed count per
+/// source bucket) and `plugins_active` (active state for builtin + featured ids
+/// only; unfeatured GitHub and local installs are counted by source but never
+/// named).
+pub const SCHEMA_VERSION: u32 = 13;
 
 /// Which surface emitted the event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -268,6 +272,22 @@ pub struct UsageSnapshot {
     /// since the last snapshot. Reported by the browser, the only surface that
     /// owns the prompt queue; the daemon never sees the queue directly.
     pub prompts_queued: u32,
+
+    /// Installed-plugin census: source bucket (`builtin` / `featured` /
+    /// `community` / `local`) -> count. Counts the whole installed population
+    /// per source, no identity, so it is safe for every source. Empty (and so
+    /// omitted) when no plugins are loaded, e.g. a TUI-only build with no
+    /// installs. See `telemetry::plugins`.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub plugins_by_source: BTreeMap<String, u32>,
+    /// Active-state for the plugins whose identity is safe to name: builtin
+    /// (compiled in) and featured (in the curated index). Allowlisted id ->
+    /// active. Unfeatured GitHub (possibly private) and local installs are
+    /// counted in [`Self::plugins_by_source`] but never named here, per the
+    /// telemetry privacy rule. Empty (and so omitted) when no nameable plugin
+    /// is loaded. See `telemetry::plugins`.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub plugins_active: BTreeMap<String, bool>,
 }
 
 /// Resolved structured-interaction counts for one snapshot window, the input the

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -22,6 +22,7 @@ pub mod aggregate;
 pub mod events;
 pub mod features;
 pub mod form_factor;
+pub mod plugins;
 pub mod sanitize;
 mod state;
 pub mod usage_signals;
@@ -415,6 +416,12 @@ pub fn build_usage_snapshot(
     snapshot.data_schema_version = crate::migrations::current_schema_version();
     snapshot.update_status = update_status;
     snapshot.update_releases_behind = update_releases_behind;
+    // Plugin census reads the loaded registry (disk-backed), so it is layered
+    // here rather than in the disk-free assembler, like the version-health
+    // fields above. Both the TUI and serve surfaces route through here.
+    let (plugins_by_source, plugins_active) = plugins::census(crate::plugin::registry().all());
+    snapshot.plugins_by_source = plugins_by_source;
+    snapshot.plugins_active = plugins_active;
     Some(snapshot)
 }
 
@@ -488,6 +495,10 @@ fn assemble_usage_snapshot(
         agent_switches: acp_counts.agent_switches,
         plan_mode_seen: acp_counts.plan_mode_seen,
         prompts_queued: acp_counts.prompts_queued,
+        // Plugin census reads the disk-backed registry; the disk-free assembler
+        // leaves these empty and `build_usage_snapshot` fills them.
+        plugins_by_source: BTreeMap::new(),
+        plugins_active: BTreeMap::new(),
     }
 }
 
@@ -792,6 +803,8 @@ mod tests {
             agent_switches: 0,
             plan_mode_seen: false,
             prompts_queued: 0,
+            plugins_by_source: BTreeMap::new(),
+            plugins_active: BTreeMap::new(),
         }
     }
 

--- a/src/telemetry/plugins.rs
+++ b/src/telemetry/plugins.rs
@@ -1,0 +1,125 @@
+//! Plugin-adoption census for `usage_snapshot` (#2367).
+//!
+//! Two maps, both fed straight from the loaded [`PluginRegistry`]:
+//! - `plugins_by_source`: installed count per source bucket
+//!   (`builtin` / `featured` / `community` / `local`). A count by category,
+//!   never an identity, so it is safe for every source.
+//! - `plugins_active`: active state for the plugins whose identity is safe to
+//!   name, builtin (compiled in) and featured (in the curated index). An
+//!   unfeatured GitHub install (possibly a private repo) or a local-directory
+//!   install is counted in `plugins_by_source` but never named here.
+//!
+//! The named-id allowlist rests on [`ValidationState`]: `Featured` is
+//! re-derived live from the embedded index and the on-disk tree hash, so a
+//! community plugin cannot reach the `Featured` arm by reusing a featured id.
+
+use std::collections::BTreeMap;
+
+use crate::plugin::registry::{LoadedPlugin, ValidationState};
+
+/// Build the `(plugins_by_source, plugins_active)` census from the loaded
+/// plugins. Pure over the slice, no disk reads.
+pub fn census(plugins: &[LoadedPlugin]) -> (BTreeMap<String, u32>, BTreeMap<String, bool>) {
+    let mut by_source: BTreeMap<String, u32> = BTreeMap::new();
+    let mut active: BTreeMap<String, bool> = BTreeMap::new();
+    for p in plugins {
+        *by_source
+            .entry(p.validation.as_str().to_string())
+            .or_insert(0) += 1;
+        if matches!(
+            p.validation,
+            ValidationState::Builtin | ValidationState::Featured
+        ) {
+            active.insert(p.id().to_string(), p.active());
+        }
+    }
+    (by_source, active)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aoe_plugin_api::{PluginManifest, TrustLevel};
+
+    fn plugin(id: &str, validation: ValidationState, enabled: bool, granted: bool) -> LoadedPlugin {
+        let manifest = PluginManifest::from_toml_str(&format!(
+            "id = \"{id}\"\nname = \"n\"\nversion = \"1.0.0\"\napi_version = 1\ndescription = \"d\"\n"
+        ))
+        .expect("valid manifest");
+        let trust = match validation {
+            ValidationState::Builtin => TrustLevel::Builtin,
+            _ => TrustLevel::Community,
+        };
+        LoadedPlugin {
+            manifest,
+            enabled,
+            trust,
+            validation,
+            source: None,
+            dir: None,
+            manifest_hash: "sha256:0".to_string(),
+            granted,
+        }
+    }
+
+    #[test]
+    fn by_source_counts_every_source_active_names_only_safe_ids() {
+        let plugins = vec![
+            plugin("aoe.web", ValidationState::Builtin, true, true),
+            plugin("acme.featured", ValidationState::Featured, true, true),
+            plugin("acme.community", ValidationState::Community, true, true),
+            plugin("acme.local", ValidationState::Local, true, true),
+        ];
+        let (by_source, active) = census(&plugins);
+
+        assert_eq!(by_source.get("builtin"), Some(&1));
+        assert_eq!(by_source.get("featured"), Some(&1));
+        assert_eq!(by_source.get("community"), Some(&1));
+        assert_eq!(by_source.get("local"), Some(&1));
+
+        // Only builtin + featured ids are named; community / local never are.
+        assert_eq!(active.get("aoe.web"), Some(&true));
+        assert_eq!(active.get("acme.featured"), Some(&true));
+        assert_eq!(active.get("acme.community"), None);
+        assert_eq!(active.get("acme.local"), None);
+    }
+
+    #[test]
+    fn active_reflects_enabled_and_granted() {
+        let plugins = vec![
+            plugin("on", ValidationState::Featured, true, true),
+            plugin("disabled", ValidationState::Featured, false, true),
+            plugin("ungranted", ValidationState::Featured, true, false),
+        ];
+        let (_by_source, active) = census(&plugins);
+        assert_eq!(active.get("on"), Some(&true));
+        assert_eq!(active.get("disabled"), Some(&false));
+        assert_eq!(active.get("ungranted"), Some(&false));
+    }
+
+    #[test]
+    fn community_plugin_reusing_a_featured_id_is_not_named() {
+        // A community install cannot reach the Featured arm, so even an id
+        // collision with a real featured plugin stays anonymous.
+        let plugins = vec![plugin(
+            "acme.featured",
+            ValidationState::Community,
+            true,
+            true,
+        )];
+        let (by_source, active) = census(&plugins);
+        assert_eq!(by_source.get("community"), Some(&1));
+        assert!(active.is_empty());
+    }
+
+    #[test]
+    fn same_source_twice_accumulates() {
+        let plugins = vec![
+            plugin("a", ValidationState::Community, true, true),
+            plugin("b", ValidationState::Community, true, true),
+        ];
+        let (by_source, active) = census(&plugins);
+        assert_eq!(by_source.get("community"), Some(&2));
+        assert!(active.is_empty());
+    }
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a plugin-adoption signal to the `usage_snapshot` telemetry event (Plugins 11 of #268), so maintainers can see whether the plugin system is being adopted and which curated plugins are live.

Two additive maps land on the snapshot (telemetry schema bumped to v13):

- `plugins_by_source`: count of installed plugins per source bucket (`builtin` / `featured` / `community` / `local`). A count by category, no identity, so it is safe for every source.
- `plugins_active`: active state (`enabled && granted`) for the plugins whose identity is safe to name, builtin (compiled in) and featured (in the curated index), keyed by id.

Unfeatured GitHub (possibly private) and local installs are counted in `plugins_by_source` but never named, per the telemetry privacy rule. The named-id allowlist rests on `ValidationState`, where `Featured` is re-derived live from the embedded index and the on-disk tree hash, so a community install cannot reach the named arm by reusing a featured id.

The census reads the disk-backed plugin registry, so it is layered in `build_usage_snapshot` alongside the version-health fields, keeping the pure assembler disk-free. The aoe-telemetry gateway forwards shallow id->num/bool maps generically, so this lands in agent-of-empires only, with no gateway change.

Closes #2367

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Opt into telemetry, point `AOE_TELEMETRY_ENDPOINT` at a local sink, launch `aoe serve`, and confirm the `usage_snapshot` payload carries `plugins_by_source` with `{"builtin": 1}` (the `aoe.web` builtin) and `plugins_active` with `{"aoe.web": true}`.
- [ ] `aoe plugin disable aoe.web` (then re-enable a serve-capable build), trigger a snapshot, and confirm `plugins_active["aoe.web"]` flips to `false`.
- [ ] Install a community (unfeatured GitHub) or local plugin, trigger a snapshot, and confirm it is counted in `plugins_by_source` under `community` / `local` but its id appears nowhere in `plugins_active`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Covered by Rust unit tests in `src/telemetry/plugins.rs` (source bucketing, the builtin/featured naming allowlist, enabled/granted active state, and a community id colliding with a featured id staying anonymous).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (installed-count census plus a named-id allowlist) and reviewed each change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785161404&installation_id=139138837&pr_number=2471&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2471&signature=7a9922b0f568640b85159f0827575b81ff5434f5379473701011bd9806f0a76c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change adds a new plugin adoption snapshot to telemetry and updates the telemetry schema to v13.

What changed:
- Added a plugin census to the `usage_snapshot` event.
- Reported plugin totals by source: builtin, featured, community, and local.
- Reported active status only for allowlisted builtin and featured plugin IDs.
- Kept community and local plugins counted but unnamed to preserve privacy.
- Wired the new data into usage snapshot building and added tests/docs updates.

Benefits:
- Gives visibility into plugin-system adoption.
- Preserves user privacy by limiting which plugin IDs can appear in telemetry.
- Stays backward-friendly by using additive fields, so no gateway change is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->