### PR TITLE
feat(plugin): per-version featured verification and load-path hash memo

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -317,12 +317,11 @@ vs `local` is derived from the install source. The lockfile records the tree
 hash and the install-time `trust` as a resolved record, but the load path does
 not depend on them for validation. The recompute is cheap (only ids the index
 names, and a featured plugin ships no release-binary, so its installed tree
-equals its source tree) and memoized in process by `integrity::cached_tree_hash`
-behind a `(path, len, mtime)` signature, so a registry rebuild skips re-hashing
-an unchanged tree; the memo is in-memory only and falls back to a full re-hash on
-any signature miss, never gating the verified decision on a cache. The
-manifest-hash grant check still catches a community plugin tampered after
-install.
+equals its source tree) and is done live on every load from the on-disk tree,
+never from a cache: a metadata-keyed cache could be forged to return a stale
+vetted hash for a tampered tree, so the verified decision always re-hashes
+content. The manifest-hash grant check still catches a community plugin tampered
+after install.
 
 `aoe plugin hash <dir>` prints the tree hash for a plugin directory so an author
 can produce the value a maintainer pins. Run it on a clean checkout.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -287,16 +287,24 @@ install-time value; the downloaded worker stays pinned separately by the lock's
 `asset_sha256`.
 
 `plugins/featured.toml` is the curated index, compiled into the binary. Each
-entry pins one vetted release per plugin id to its `{source, tree_hash}`: a
-maintainer's attestation that this exact tree was reviewed. When a plugin id
-appears in the index, install and update **refuse** unless the fetched source
-slug (case-insensitive) and tree hash both match the pin, and a release-binary
-manifest is refused outright (its worker bytes are not covered by the tree hash
-yet). A featured-verified install is the one case allowed to claim a reserved
-(`aoe.*` / `agent-of-empires.*`) namespace; a builtin-id collision is always
-rejected. In debug builds `AOE_FEATURED_INDEX_PATH` overrides the embedded index
-for tests; a release binary always uses the compiled-in index, since the curated
-set is a root of trust and must not be redefinable by the environment.
+entry holds a plugin's `source` slug and a `version -> tree_hash` map of vetted
+releases: a maintainer's attestation that each listed tree was reviewed. When a
+plugin id appears in the index, install and update **refuse** if the fetched
+source slug (case-insensitive) does not match, or if the manifest ships a
+release-binary worker (its bytes are not covered by the tree hash yet). The tree
+hash is then checked against the entry's set of vetted hashes: a match is
+featured-verified. An id-in-index install at a hash that is **not** in the set is
+an unvetted version, not a tamper-refuse: it installs as a non-featured plugin
+(community for a GitHub install), so a maintainer can vet a new release by
+appending its hash without un-verifying older ones. The reserved-namespace gate
+is unchanged, so an unvetted version of a reserved-namespace plugin is still
+refused (only a vetted release lifts that gate). A featured-verified install is
+the one case allowed to claim a reserved (`aoe.*` / `agent-of-empires.*`)
+namespace; a builtin-id collision is always rejected. To ship a new release, run
+`aoe plugin hash` against the new tag and add its `version = "sha256:..."` line
+to the entry. In debug builds `AOE_FEATURED_INDEX_PATH` overrides the embedded
+index for tests; a release binary always uses the compiled-in index, since the
+curated set is a root of trust and must not be redefinable by the environment.
 
 Every surface (CLI `aoe plugin list` / `info`, the TUI plugin manager, the web
 Plugins panel) shows a `ValidationState`: `builtin`, `featured`, `community` (an

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -316,8 +316,12 @@ vs `local` is derived from the install source. The lockfile records the tree
 hash and the install-time `trust` as a resolved record, but the load path does
 not depend on them for validation. The recompute is cheap (only ids the index
 names, and a featured plugin ships no release-binary, so its installed tree
-equals its source tree). The manifest-hash grant check still catches a community
-plugin tampered after install.
+equals its source tree) and memoized in process by `integrity::cached_tree_hash`
+behind a `(path, len, mtime)` signature, so a registry rebuild skips re-hashing
+an unchanged tree; the memo is in-memory only and falls back to a full re-hash on
+any signature miss, never gating the verified decision on a cache. The
+manifest-hash grant check still catches a community plugin tampered after
+install.
 
 `aoe plugin hash <dir>` prints the tree hash for a plugin directory so an author
 can produce the value a maintainer pins. Run it on a clean checkout.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -301,8 +301,9 @@ is unchanged, so an unvetted version of a reserved-namespace plugin is still
 refused (only a vetted release lifts that gate). A featured-verified install is
 the one case allowed to claim a reserved (`aoe.*` / `agent-of-empires.*`)
 namespace; a builtin-id collision is always rejected. To ship a new release, run
-`aoe plugin hash` against the new tag and add its `version = "sha256:..."` line
-to the entry. In debug builds `AOE_FEATURED_INDEX_PATH` overrides the embedded
+`aoe plugin hash` against the new tag and add a `"<version>" = "sha256:..."`
+entry inside the entry's `versions` map alongside the existing ones. In debug
+builds `AOE_FEATURED_INDEX_PATH` overrides the embedded
 index for tests; a release binary always uses the compiled-in index, since the
 curated set is a root of trust and must not be redefinable by the environment.
 

--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -2,21 +2,29 @@
 #
 # This file is compiled into the aoe binary. Each entry is a maintainer's
 # attestation that an exact plugin source tree was reviewed: install and update
-# refuse unless the plugin's fetched source slug and tree hash match the pin,
-# and a featured entry is the only thing that lets a community install claim a
-# reserved (`aoe.*` / `agent-of-empires.*`) namespace.
+# refuse unless the plugin's fetched source slug matches, and a featured entry
+# is the only thing that lets a community install claim a reserved (`aoe.*` /
+# `agent-of-empires.*`) namespace.
 #
-# An entry's `tree_hash` is produced by `aoe plugin hash <plugin-dir>` on a
-# clean checkout. Generate it on a canonical platform with LF line endings; the
-# hash covers source files only (a release-binary worker is not pinned here, so
-# release-binary plugins cannot be featured yet).
+# Each entry lists one or more vetted releases as `version -> tree_hash`. An
+# install whose fetched source tree hashes to any listed value is
+# featured-verified; an install of the same id at an unlisted hash is treated as
+# an unvetted version (community), not a tamper-refuse (the reserved-namespace
+# gate still blocks an unvetted version of a reserved-namespace plugin).
 #
-# Schema (one vetted pin per plugin id):
+# A `tree_hash` is produced by `aoe plugin hash <plugin-dir>` on a clean
+# checkout. Generate it on a canonical platform with LF line endings; the hash
+# covers source files only (a release-binary worker is not pinned here, so
+# release-binary plugins cannot be featured yet). To ship a new release, run
+# `aoe plugin hash` against the new tag and add its `version = "sha256:..."`
+# line alongside the existing ones.
+#
+# Schema (one or more vetted releases per plugin id):
 #
 #   [plugins."agent-of-empires.example"]
 #   source = "gh:agent-of-empires/example"
-#   tree_hash = "sha256:<hex>"
+#   versions = { "1.0" = "sha256:<hex>", "1.1" = "sha256:<hex>" }
 
 [plugins."agent-of-empires.github"]
 source = "gh:agent-of-empires/plugin-github"
-tree_hash = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc"
+versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc" }

--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -16,8 +16,8 @@
 # checkout. Generate it on a canonical platform with LF line endings; the hash
 # covers source files only (a release-binary worker is not pinned here, so
 # release-binary plugins cannot be featured yet). To ship a new release, run
-# `aoe plugin hash` against the new tag and add its `version = "sha256:..."`
-# line alongside the existing ones.
+# `aoe plugin hash` against the new tag and add a `"<version>" = "sha256:..."`
+# entry inside the `versions` map alongside the existing ones.
 #
 # Schema (one or more vetted releases per plugin id):
 #

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -293,7 +293,7 @@ mod tests {
 
     fn featured(slug: &str) -> FeaturedIndex {
         FeaturedIndex::from_toml_str(&format!(
-            "[plugins.\"x.y\"]\nsource = \"{slug}\"\ntree_hash = \"sha256:abc\"\n"
+            "[plugins.\"x.y\"]\nsource = \"{slug}\"\nversions = {{ \"1.0\" = \"sha256:abc\" }}\n"
         ))
         .unwrap()
     }

--- a/src/plugin/featured.rs
+++ b/src/plugin/featured.rs
@@ -1,12 +1,14 @@
 //! The curated / featured plugin index.
 //!
-//! `plugins/featured.toml` is compiled into the binary and pins a vetted plugin
-//! release to its source [`tree_hash`](super::integrity::tree_hash). A featured
-//! entry is the maintainer's attestation that this exact tree was reviewed: it
-//! is what makes "is this plugin safe" answerable, and it is the only thing
-//! that lets a community install claim a reserved (`aoe.*` /
-//! `agent-of-empires.*`) namespace. Install and update refuse on a mismatch
-//! against the pin.
+//! `plugins/featured.toml` is compiled into the binary and pins one or more
+//! vetted plugin releases to their source
+//! [`tree_hash`](super::integrity::tree_hash). A featured entry is the
+//! maintainer's attestation that each listed tree was reviewed: it is what makes
+//! "is this plugin safe" answerable, and it is the only thing that lets a
+//! community install claim a reserved (`aoe.*` / `agent-of-empires.*`)
+//! namespace. An entry holds a `version -> tree_hash` map so a new release can
+//! be vetted alongside older ones; an install whose fetched tree hashes to any
+//! vetted value is featured-verified.
 
 use std::collections::BTreeMap;
 
@@ -17,14 +19,23 @@ use serde::Deserialize;
 /// vet plugin releases.
 const EMBEDDED: &str = include_str!("../../plugins/featured.toml");
 
-/// One vetted pin, keyed by plugin id in the index.
+/// One featured plugin's vetted releases, keyed by plugin id in the index.
 #[derive(Debug, Clone, Deserialize)]
 pub struct FeaturedEntry {
     /// The canonical source slug the plugin must be installed from
     /// (`gh:owner/repo`).
     pub source: String,
-    /// `sha256:<hex>` of the vetted source tree.
-    pub tree_hash: String,
+    /// Vetted releases as `version -> sha256:<hex>` of the source tree. The
+    /// version label is informational (it documents which release each hash
+    /// belongs to); the verified decision is membership in the set of values.
+    pub versions: BTreeMap<String, String>,
+}
+
+impl FeaturedEntry {
+    /// Whether `tree_hash` is one of this entry's vetted release hashes.
+    pub fn verifies(&self, tree_hash: &str) -> bool {
+        self.versions.values().any(|v| v == tree_hash)
+    }
 }
 
 /// The parsed featured index.
@@ -89,18 +100,37 @@ mod tests {
             r#"
 [plugins."agent-of-empires.example"]
 source = "gh:agent-of-empires/example"
-tree_hash = "sha256:abc"
+versions = { "1.0" = "sha256:abc" }
 "#,
         )
         .unwrap();
         let entry = index.get("agent-of-empires.example").expect("present");
         assert_eq!(entry.source, "gh:agent-of-empires/example");
-        assert_eq!(entry.tree_hash, "sha256:abc");
+        assert_eq!(
+            entry.versions.get("1.0").map(String::as_str),
+            Some("sha256:abc")
+        );
         assert!(index.get("acme.absent").is_none());
 
         // Source-slug match is case-insensitive and ignores the keying id.
         assert!(index.is_featured_source("gh:agent-of-empires/example"));
         assert!(index.is_featured_source("gh:Agent-Of-Empires/Example"));
         assert!(!index.is_featured_source("gh:someone/else"));
+    }
+
+    #[test]
+    fn verifies_any_vetted_hash() {
+        let index = FeaturedIndex::from_toml_str(
+            r#"
+[plugins."agent-of-empires.example"]
+source = "gh:agent-of-empires/example"
+versions = { "1.0" = "sha256:aaa", "1.1" = "sha256:bbb" }
+"#,
+        )
+        .unwrap();
+        let entry = index.get("agent-of-empires.example").expect("present");
+        assert!(entry.verifies("sha256:aaa"));
+        assert!(entry.verifies("sha256:bbb"));
+        assert!(!entry.verifies("sha256:ccc"));
     }
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -350,12 +350,15 @@ fn reject_incompatible_host(manifest: &PluginManifest) -> Result<()> {
 /// Check a fetched plugin against the curated index. Returns whether it is a
 /// verified featured plugin.
 ///
-/// If the id is in the index, the install MUST match the pin: the source slug
-/// (case-insensitively, GitHub slugs are not case-sensitive) and the source
-/// tree hash both have to match, and a release-binary worker is refused (its
-/// bytes are not covered by the tree hash yet, so a featured pin cannot vouch
-/// for them). Any mismatch is a hard error, not a silent demotion: a featured
-/// id is only ever installed at its vetted tree.
+/// If the id is in the index, the install must come from the pinned source slug
+/// (case-insensitively, GitHub slugs are not case-sensitive) and must not ship a
+/// release-binary worker (its bytes are not covered by the tree hash yet, so a
+/// featured pin cannot vouch for them); both are hard errors. The tree hash is
+/// checked against the entry's set of vetted release hashes: a match is
+/// featured-verified, while an id-in-index but hash-not-vetted install is simply
+/// an unvetted version (returns `false`, treated as community) rather than a
+/// tamper-refuse. The reserved-namespace gate downstream still blocks an
+/// unvetted version of a reserved-namespace plugin.
 fn verify_featured(featured: &FeaturedIndex, fetched: &FetchedPlugin) -> Result<bool> {
     let id = fetched.manifest.id.as_str();
     let Some(entry) = featured.get(id) else {
@@ -374,10 +377,7 @@ fn verify_featured(featured: &FeaturedIndex, fetched: &FetchedPlugin) -> Result<
             entry.source
         );
     }
-    if fetched.tree_hash != entry.tree_hash {
-        bail!("{id} does not match its featured pin (source tree hash mismatch); refusing install");
-    }
-    Ok(true)
+    Ok(entry.verifies(&fetched.tree_hash))
 }
 
 /// The manifest's capabilities as strings, rejecting any this host does not

--- a/src/plugin/integrity.rs
+++ b/src/plugin/integrity.rs
@@ -10,7 +10,11 @@
 //! later (for example folding in the executable bit once #2095 launches
 //! workers) without a new value silently colliding with an old pin.
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+use std::time::UNIX_EPOCH;
 
 use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
@@ -42,6 +46,96 @@ pub fn tree_hash(dir: &Path) -> Result<String> {
         hasher.update(contents);
     }
     Ok(format_digest(&hasher.finalize()))
+}
+
+/// [`tree_hash`] memoized for the registry load path, where validation re-hashes
+/// every featured-and-installed plugin on each rebuild. The result is keyed by
+/// plugin dir and guarded by a cheap `(path, len, mtime)` signature: a hit
+/// returns the previously computed hash only when the on-disk tree is unchanged,
+/// otherwise it falls back to a full re-hash.
+///
+/// This is an in-memory optimization, not a root of trust. The cache lives only
+/// for the process, is never persisted, and is never read by anything but this
+/// function; the value it returns is always either a fresh `tree_hash` or the
+/// exact hash a fresh `tree_hash` produced for the same tree. A signature is
+/// content-independent and therefore forgeable (mtime can be reset), which is
+/// why a persisted cache could not gate the verified decision; keeping it
+/// in-process sidesteps that, since an attacker who can write the tree and forge
+/// mtimes mid-process could equally just install a vetted tree.
+//
+// ponytail: in-process memo only. A persistent cross-launch cache would need a
+// tamper-evident key the content-integrity decision cannot safely trust, so it
+// is deliberately not built; revisit only if a benchmark on a large featured set
+// shows the per-load re-hash actually hurts.
+pub fn cached_tree_hash(dir: &Path) -> Result<String> {
+    let Some(sig) = tree_signature(dir) else {
+        return tree_hash(dir);
+    };
+    let key = dir.to_path_buf();
+    if let Some((cached_sig, hash)) = cache().read().ok().and_then(|c| c.get(&key).cloned()) {
+        if cached_sig == sig {
+            return Ok(hash);
+        }
+    }
+    let hash = tree_hash(dir)?;
+    if let Ok(mut c) = cache().write() {
+        c.insert(key, (sig, hash.clone()));
+    }
+    Ok(hash)
+}
+
+fn cache() -> &'static RwLock<HashMap<PathBuf, (u64, String)>> {
+    static CACHE: OnceLock<RwLock<HashMap<PathBuf, (u64, String)>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// A cheap, content-independent signature of `dir`: every file's relative path,
+/// length, and mtime folded together. Returns `None` on any IO error, a
+/// symlink, or a non-UTF-8 path so the caller re-hashes directly (those are the
+/// cases [`tree_hash`] treats as hard errors anyway).
+fn tree_signature(dir: &Path) -> Option<u64> {
+    let mut files: Vec<(String, u64, u128)> = Vec::new();
+    sig_collect(dir, dir, &mut files).ok()?;
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for (rel, len, mtime) in &files {
+        rel.hash(&mut hasher);
+        len.hash(&mut hasher);
+        mtime.hash(&mut hasher);
+    }
+    Some(hasher.finish())
+}
+
+fn sig_collect(root: &Path, dir: &Path, out: &mut Vec<(String, u64, u128)>) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry.file_name() == ".git" {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            bail!("symlink in plugin tree; cannot signature, will re-hash");
+        }
+        if file_type.is_dir() {
+            sig_collect(root, &path, out)?;
+        } else {
+            let metadata = entry.metadata()?;
+            let mtime = metadata
+                .modified()?
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| anyhow!("mtime before unix epoch: {e}"))?
+                .as_nanos();
+            let rel = path
+                .strip_prefix(root)
+                .expect("entry path is under root")
+                .to_str()
+                .ok_or_else(|| anyhow!("non-UTF-8 path in plugin tree: {}", path.display()))?
+                .replace('\\', "/");
+            out.push((rel, metadata.len(), mtime));
+        }
+    }
+    Ok(())
 }
 
 fn collect(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> Result<()> {
@@ -140,6 +234,30 @@ mod tests {
             tree_hash(with_git.path()).unwrap(),
             tree_hash(without_git.path()).unwrap()
         );
+    }
+
+    #[test]
+    fn cached_matches_tree_hash_and_refreshes() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "f.txt", b"one");
+        let cached = cached_tree_hash(dir.path()).unwrap();
+        assert_eq!(cached, tree_hash(dir.path()).unwrap());
+
+        // A content change of a different length flips the signature, so the
+        // memo recomputes rather than returning the stale hash.
+        write(dir.path(), "f.txt", b"a much longer body");
+        let after = cached_tree_hash(dir.path()).unwrap();
+        assert_ne!(cached, after);
+        assert_eq!(after, tree_hash(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn signature_tracks_content_length() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "f.txt", b"one");
+        let before = tree_signature(dir.path()).unwrap();
+        write(dir.path(), "f.txt", b"two longer");
+        assert_ne!(before, tree_signature(dir.path()).unwrap());
     }
 
     #[cfg(unix)]

--- a/src/plugin/integrity.rs
+++ b/src/plugin/integrity.rs
@@ -10,11 +10,7 @@
 //! later (for example folding in the executable bit once #2095 launches
 //! workers) without a new value silently colliding with an old pin.
 
-use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
-use std::sync::{OnceLock, RwLock};
-use std::time::UNIX_EPOCH;
+use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
@@ -46,96 +42,6 @@ pub fn tree_hash(dir: &Path) -> Result<String> {
         hasher.update(contents);
     }
     Ok(format_digest(&hasher.finalize()))
-}
-
-/// [`tree_hash`] memoized for the registry load path, where validation re-hashes
-/// every featured-and-installed plugin on each rebuild. The result is keyed by
-/// plugin dir and guarded by a cheap `(path, len, mtime)` signature: a hit
-/// returns the previously computed hash only when the on-disk tree is unchanged,
-/// otherwise it falls back to a full re-hash.
-///
-/// This is an in-memory optimization, not a root of trust. The cache lives only
-/// for the process, is never persisted, and is never read by anything but this
-/// function; the value it returns is always either a fresh `tree_hash` or the
-/// exact hash a fresh `tree_hash` produced for the same tree. A signature is
-/// content-independent and therefore forgeable (mtime can be reset), which is
-/// why a persisted cache could not gate the verified decision; keeping it
-/// in-process sidesteps that, since an attacker who can write the tree and forge
-/// mtimes mid-process could equally just install a vetted tree.
-//
-// ponytail: in-process memo only. A persistent cross-launch cache would need a
-// tamper-evident key the content-integrity decision cannot safely trust, so it
-// is deliberately not built; revisit only if a benchmark on a large featured set
-// shows the per-load re-hash actually hurts.
-pub fn cached_tree_hash(dir: &Path) -> Result<String> {
-    let Some(sig) = tree_signature(dir) else {
-        return tree_hash(dir);
-    };
-    let key = dir.to_path_buf();
-    if let Some((cached_sig, hash)) = cache().read().ok().and_then(|c| c.get(&key).cloned()) {
-        if cached_sig == sig {
-            return Ok(hash);
-        }
-    }
-    let hash = tree_hash(dir)?;
-    if let Ok(mut c) = cache().write() {
-        c.insert(key, (sig, hash.clone()));
-    }
-    Ok(hash)
-}
-
-fn cache() -> &'static RwLock<HashMap<PathBuf, (u64, String)>> {
-    static CACHE: OnceLock<RwLock<HashMap<PathBuf, (u64, String)>>> = OnceLock::new();
-    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
-}
-
-/// A cheap, content-independent signature of `dir`: every file's relative path,
-/// length, and mtime folded together. Returns `None` on any IO error, a
-/// symlink, or a non-UTF-8 path so the caller re-hashes directly (those are the
-/// cases [`tree_hash`] treats as hard errors anyway).
-fn tree_signature(dir: &Path) -> Option<u64> {
-    let mut files: Vec<(String, u64, u128)> = Vec::new();
-    sig_collect(dir, dir, &mut files).ok()?;
-    files.sort_by(|a, b| a.0.cmp(&b.0));
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for (rel, len, mtime) in &files {
-        rel.hash(&mut hasher);
-        len.hash(&mut hasher);
-        mtime.hash(&mut hasher);
-    }
-    Some(hasher.finish())
-}
-
-fn sig_collect(root: &Path, dir: &Path, out: &mut Vec<(String, u64, u128)>) -> Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        if entry.file_name() == ".git" {
-            continue;
-        }
-        let file_type = entry.file_type()?;
-        let path = entry.path();
-        if file_type.is_symlink() {
-            bail!("symlink in plugin tree; cannot signature, will re-hash");
-        }
-        if file_type.is_dir() {
-            sig_collect(root, &path, out)?;
-        } else {
-            let metadata = entry.metadata()?;
-            let mtime = metadata
-                .modified()?
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| anyhow!("mtime before unix epoch: {e}"))?
-                .as_nanos();
-            let rel = path
-                .strip_prefix(root)
-                .expect("entry path is under root")
-                .to_str()
-                .ok_or_else(|| anyhow!("non-UTF-8 path in plugin tree: {}", path.display()))?
-                .replace('\\', "/");
-            out.push((rel, metadata.len(), mtime));
-        }
-    }
-    Ok(())
 }
 
 fn collect(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> Result<()> {
@@ -234,30 +140,6 @@ mod tests {
             tree_hash(with_git.path()).unwrap(),
             tree_hash(without_git.path()).unwrap()
         );
-    }
-
-    #[test]
-    fn cached_matches_tree_hash_and_refreshes() {
-        let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "f.txt", b"one");
-        let cached = cached_tree_hash(dir.path()).unwrap();
-        assert_eq!(cached, tree_hash(dir.path()).unwrap());
-
-        // A content change of a different length flips the signature, so the
-        // memo recomputes rather than returning the stale hash.
-        write(dir.path(), "f.txt", b"a much longer body");
-        let after = cached_tree_hash(dir.path()).unwrap();
-        assert_ne!(cached, after);
-        assert_eq!(after, tree_hash(dir.path()).unwrap());
-    }
-
-    #[test]
-    fn signature_tracks_content_length() {
-        let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "f.txt", b"one");
-        let before = tree_signature(dir.path()).unwrap();
-        write(dir.path(), "f.txt", b"two longer");
-        assert_ne!(before, tree_signature(dir.path()).unwrap());
     }
 
     #[cfg(unix)]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -216,7 +216,7 @@ fn validation_for(
     source: Option<&str>,
 ) -> ValidationState {
     if let Some(entry) = featured.get(id) {
-        if integrity::tree_hash(dir).is_ok_and(|h| h == entry.tree_hash) {
+        if integrity::tree_hash(dir).is_ok_and(|h| entry.verifies(&h)) {
             return ValidationState::Featured;
         }
     }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -216,7 +216,7 @@ fn validation_for(
     source: Option<&str>,
 ) -> ValidationState {
     if let Some(entry) = featured.get(id) {
-        if integrity::cached_tree_hash(dir).is_ok_and(|h| entry.verifies(&h)) {
+        if integrity::tree_hash(dir).is_ok_and(|h| entry.verifies(&h)) {
             return ValidationState::Featured;
         }
     }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -216,7 +216,7 @@ fn validation_for(
     source: Option<&str>,
 ) -> ValidationState {
     if let Some(entry) = featured.get(id) {
-        if integrity::tree_hash(dir).is_ok_and(|h| entry.verifies(&h)) {
+        if integrity::cached_tree_hash(dir).is_ok_and(|h| entry.verifies(&h)) {
             return ValidationState::Featured;
         }
     }

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -266,16 +266,32 @@ api_version = 2
 }
 
 /// Write a featured index file and point `AOE_FEATURED_INDEX_PATH` at it (debug
-/// builds only; tests run in debug).
-fn write_featured(dir: &Path, id: &str, source: &str, tree_hash: &str) -> PathBuf {
+/// builds only; tests run in debug). `versions` is a list of `(label, hash)`
+/// vetted releases for the single entry.
+fn write_featured_versions(
+    dir: &Path,
+    id: &str,
+    source: &str,
+    versions: &[(&str, &str)],
+) -> PathBuf {
+    let body: String = versions
+        .iter()
+        .map(|(label, hash)| format!("\"{label}\" = \"{hash}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
     let path = dir.join("featured.toml");
     std::fs::write(
         &path,
-        format!("[plugins.\"{id}\"]\nsource = \"{source}\"\ntree_hash = \"{tree_hash}\"\n"),
+        format!("[plugins.\"{id}\"]\nsource = \"{source}\"\nversions = {{ {body} }}\n"),
     )
     .unwrap();
     std::env::set_var("AOE_FEATURED_INDEX_PATH", &path);
     path
+}
+
+/// Convenience: a single vetted release at `tree_hash`.
+fn write_featured(dir: &Path, id: &str, source: &str, tree_hash: &str) -> PathBuf {
+    write_featured_versions(dir, id, source, &[("1.0.0", tree_hash)])
 }
 
 #[tokio::test]
@@ -317,7 +333,7 @@ api_version = 2
 
 #[tokio::test]
 #[serial]
-async fn featured_hash_mismatch_is_refused() {
+async fn featured_unvetted_version_installs_as_community() {
     let _home = isolate();
     let src = tempfile::tempdir().unwrap();
     let dir = write_plugin_dir(
@@ -329,10 +345,87 @@ version = "1.0.0"
 api_version = 2
 "#,
     );
-    // Pin a hash that does not match the actual tree.
+    // The id is featured but pinned to a different (unvetted) hash. For a
+    // non-reserved id this is not tamper-refuse: it installs as an unvetted
+    // version (community).
     write_featured(
         src.path(),
         "acme.featured",
+        dir.to_str().unwrap(),
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    );
+
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    // It installs (not refused) and is not featured. The non-featured label
+    // ("local" here, since the install source is a local dir; "community" for a
+    // gh: install) is derived from the source, not the hash mismatch.
+    let reg = load_registry();
+    let plugin = reg.get("acme.featured").expect("installed");
+    assert_ne!(plugin.validation.as_str(), "featured");
+    assert_eq!(plugin.validation.as_str(), "local");
+
+    std::env::remove_var("AOE_FEATURED_INDEX_PATH");
+}
+
+#[tokio::test]
+#[serial]
+async fn featured_second_vetted_version_verifies() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "agent-of-empires.official"
+name = "Official"
+version = "1.1.0"
+api_version = 2
+"#,
+    );
+    let tree_hash = agent_of_empires::plugin::integrity::tree_hash(&dir).unwrap();
+    // The actual tree is the second vetted release; an earlier release is also
+    // listed and must not un-verify this one.
+    write_featured_versions(
+        src.path(),
+        "agent-of-empires.official",
+        dir.to_str().unwrap(),
+        &[
+            (
+                "1.0.0",
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            ),
+            ("1.1.0", &tree_hash),
+        ],
+    );
+
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    let reg = load_registry();
+    let plugin = reg.get("agent-of-empires.official").expect("installed");
+    assert_eq!(plugin.validation.as_str(), "featured");
+
+    std::env::remove_var("AOE_FEATURED_INDEX_PATH");
+}
+
+#[tokio::test]
+#[serial]
+async fn featured_reserved_namespace_unvetted_is_refused() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    // A reserved-namespace id at an unvetted hash is still refused: only a
+    // vetted release lifts the reserved-namespace gate.
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "agent-of-empires.official"
+name = "Official"
+version = "1.0.0"
+api_version = 2
+"#,
+    );
+    write_featured(
+        src.path(),
+        "agent-of-empires.official",
         dir.to_str().unwrap(),
         "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     );
@@ -341,8 +434,8 @@ api_version = 2
         .await
         .unwrap_err()
         .to_string();
-    assert!(err.contains("featured pin"), "got: {err}");
-    assert!(load_registry().get("acme.featured").is_none());
+    assert!(err.contains("reserved"), "got: {err}");
+    assert!(load_registry().get("agent-of-empires.official").is_none());
 
     std::env::remove_var("AOE_FEATURED_INDEX_PATH");
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two related changes to the featured plugin index, both built on the integrity hashing and curated index from #2364 (PR #2388).

**Per-version featured verification (#2392).** A `FeaturedEntry` pinned a single `tree_hash`, and `verify_featured` refused any fetched tree that did not match that one pin. A featured plugin could therefore never be updated: releasing v1.1 was refused until a maintainer flipped the pin, and once flipped, v1.0 was refused. `plugin-github` is already featured, so this was a live blocker on its next release. The entry now holds a `version -> tree_hash` map, and an install is featured-verified when its fetched source tree hashes to any listed value. Vetting a new release is appending its hash, with the old ones left in place. An id-in-index install at an unlisted hash is now treated as an unvetted version (it installs as a non-featured plugin) rather than a tamper-refuse; source-slug mismatch and release-binary manifests still refuse, and the reserved-namespace gate still blocks an unvetted version of a reserved-namespace plugin, so only a vetted release lifts that gate.

**Load-path re-hash caching (#2394): investigated, deferred.** I prototyped an in-process memo of `validation_for`'s tree hash keyed by a `(path, len, mtime)` signature, but review surfaced that it weakens a security invariant: a same-length / restored-mtime tamper of an installed featured plugin would keep the stale vetted hash and thus its `Featured` status (and reserved-namespace lift) until the process restarts, which in a long-lived `aoe serve` daemon is a real window. No metadata-cheap cache can be content-authenticated (any key cheaper than re-hashing is forgeable), so the memo was backed out and `validation_for` re-hashes content live on every load, as #2364 intended. The cost is already bounded to installed-and-featured ids. #2394 stays open with this finding rather than being closed by this PR.

Closes #2392

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In `plugins/featured.toml`, add a second `version = "sha256:..."` entry for a plugin whose source tree hashes to it (use `aoe plugin hash <dir>`); install that tree and confirm `aoe plugin list` shows it as `featured`.
- [ ] Install the same featured id from a tree whose hash is in neither version (and is NOT a reserved namespace); confirm it installs as `community`/`local`, not refused.
- [ ] Install a reserved-namespace featured id (e.g. `agent-of-empires.*`) at an unvetted hash; confirm it is still refused.
- [ ] Install a featured id from the wrong source slug; confirm it is still refused.
- [ ] Toggle a featured plugin enabled/disabled a few times (rebuilds the registry) and confirm the validation label stays `featured` with no behavior change.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (covered by `tests/plugin_install.rs` integration tests and `src/plugin/{featured,integrity}.rs` unit tests)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (version-keyed map over a flat hash list; and, after review flagged the security trade-off, backing out the load-path cache rather than shipping it) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the featured-plugin verification system to support **multiple vetted releases per plugin** instead of relying on a single pinned hash. Featured entries now store a **version → tree-hash mapping**, and an install is considered “featured” only if the plugin’s fetched source tree matches **any** of the vetted hashes for that plugin/version set.

Key changes:
- **Featured index format & documentation**: `plugins/featured.toml` is updated to list a `versions` map per plugin, and the install/update rules are clarified (including how the embedded index can be overridden for tests).
- **Featured verification behavior**: the featured verification logic now uses a `verifies` check against the vetted set, and **unlisted hashes are treated as unvetted/community** (so they become **non-featured** rather than being rejected as tampered). Other protections remain strict, including refusing installs when the source slug doesn’t match and when release-binary expectations don’t line up.
- **Registry/install flow**: validation now consults the multi-hash `verifies` result for featured entries, while keeping the existing reserved-namespace gating behavior.
- **Tests**: test helpers and scenarios are updated to cover multiple vetted versions per plugin and to ensure reserved-namespace rules still block unvetted reserved plugins.

Benefits:
- Lets maintainers **add new vetted releases without invalidating previously vetted ones**
- Keeps integrity guarantees focused on the **actual fetched plugin contents**
- Preserves strict refusal behavior for **source-slug mismatches**, **release-binary/manifest mismatches**, and **reserved-namespace** violations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->