### PR TITLE
feat(plugins): add GitHub discovery and update checks (#2365)

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -47,6 +47,8 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe plugin update`↴](#aoe-plugin-update)
 * [`aoe plugin uninstall`↴](#aoe-plugin-uninstall)
 * [`aoe plugin hash`↴](#aoe-plugin-hash)
+* [`aoe plugin discover`↴](#aoe-plugin-discover)
+* [`aoe plugin outdated`↴](#aoe-plugin-outdated)
 * [`aoe profile`↴](#aoe-profile)
 * [`aoe profile list`↴](#aoe-profile-list)
 * [`aoe profile create`↴](#aoe-profile-create)
@@ -684,6 +686,8 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `update` — Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
 * `uninstall` — Uninstall an external plugin, removing its files and capability grant
 * `hash` — Print the deterministic source tree hash for a plugin directory, the value a maintainer pins in the featured index
+* `discover` — Search GitHub's `aoe-plugin` topic for installable plugins
+* `outdated` — List installed external plugins that have an update available
 
 
 
@@ -780,6 +784,26 @@ Print the deterministic source tree hash for a plugin directory, the value a mai
 ###### **Arguments:**
 
 * `<PATH>` — Path to the plugin directory
+
+
+
+## `aoe plugin discover`
+
+Search GitHub's `aoe-plugin` topic for installable plugins
+
+**Usage:** `aoe plugin discover [QUERY]`
+
+###### **Arguments:**
+
+* `<QUERY>` — Optional free-text term to narrow the search
+
+
+
+## `aoe plugin outdated`
+
+List installed external plugins that have an update available
+
+**Usage:** `aoe plugin outdated`
 
 
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -639,6 +639,15 @@ Unauthenticated GitHub search is rate limited (about 10 requests/minute/IP); the
 client maps a 403/429 to a `RateLimited` error so each surface reports it plainly
 rather than as a generic failure.
 
+`GET /api/plugins/details?source=gh:owner/repo` backs the dashboard's detail
+modal (opened from a discovery result or an installed-plugin row). It reads the
+plugin's `aoe-plugin.toml` via the GitHub contents API (no clone) and lists the
+repo's release tags as the available versions. The manifest is parsed leniently
+(unknown and future keys ignored, `api_version` not range-checked), so a plugin
+targeting a newer host than the one installed still renders; a missing or
+unparseable manifest is reported in `manifest_error` while the release tags still
+load.
+
 ### Update checks
 
 `plugin::update_check::outdated()` checks every installed external plugin against

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -609,15 +609,78 @@ surface. The standalone home screen reads local session storage and has no
 daemon link, so it renders no plugin slots; rendering there is a follow-up
 (#2402).
 
+## Discovery and update checks (#2365)
+
+Discovery and update checks are **explicit actions, never background work** (the
+one exception is the opt-in auto-update sweep below). Both are repo/source level
+and reuse the existing install trust model rather than weakening it.
+
+### Discovery
+
+`plugin::discover::discover(query)` runs one GitHub search over the `aoe-plugin`
+topic (`topic:aoe-plugin fork:false archived:false`, plus an optional free-text
+term) and badges each result by matching the repo slug against the featured
+index source slugs and the installed plugins' sources (case-insensitive). It does
+**not** fetch each repo's `aoe-plugin.toml`: cloning N search results to read a
+manifest would be an N+1 blowup against the unauthenticated search rate limit. So
+a result is "a GitHub repository tagged `aoe-plugin`", and a `featured` badge
+means "a curated source slug", not "the current tree matches the pin". Results
+rank featured-first then by stars (#2105 will add popularity ranking). Install
+stays the trust boundary: `aoe plugin install` fetches the manifest, prompts for
+capabilities, and enforces the featured pin.
+
+Surfaces: `aoe plugin discover [query]`, the TUI plugin manager `d` key, and the
+dashboard "Search GitHub" button (`GET /api/plugins/discover?q=`). The dashboard
+has no install path (capability approval needs a terminal), so each result shows
+a copyable `aoe plugin install gh:owner/repo` command instead of an install
+button.
+
+Unauthenticated GitHub search is rate limited (about 10 requests/minute/IP); the
+client maps a 403/429 to a `RateLimited` error so each surface reports it plainly
+rather than as a generic failure.
+
+### Update checks
+
+`plugin::update_check::outdated()` checks every installed external plugin against
+its `plugins.lock` entry. A GitHub source compares the locked `resolved_commit`
+to `git ls-remote <clone_url> <ref|HEAD>` (no clone, no REST rate limit; honors
+`AOE_GITHUB_CLONE_BASE`, and an annotated tag's peeled `^{}` target wins). A local
+source re-hashes its source directory with `integrity::tree_hash` and compares to
+the locked `tree_hash`. Builtins are skipped; a missing lock entry, absent `git`,
+or dead remote is reported per-plugin, never silently treated as up to date. A
+commit-pinned install is never "outdated". Limitation: a `release-binary` plugin
+whose release asset is replaced without a source-commit change is not detected
+(ls-remote only sees the source tree).
+
+Surfaces: `aoe plugin outdated`, the TUI plugin manager `c` key, and
+`GET /api/plugins/updates`. The web endpoint is separate from the always-on
+`GET /api/plugins` list so a settings render never blocks on git or the network;
+the dashboard paints update-available badges only after the user clicks "Check
+for updates".
+
+### Auto-update sweep
+
+The opt-in `updates.auto_update_plugins` setting (off by default) runs a sweep at
+TUI and `aoe serve` startup (`plugin::auto_update::spawn_if_enabled`), spawned
+non-blocking so a slow remote never delays startup. It applies only **clean**
+updates, those that need no new consent; any version that changes the capability
+set, build steps, or UI slots is skipped and left for a manual `aoe plugin
+update` so the new grant is reviewed (`install::ConsentMode::CleanOnlyNonInteractive`).
+A background sweep therefore never grants new capabilities, runs a changed build
+step unattended, or deactivates a working plugin. Applied updates take effect on
+the next launch / daemon restart.
+
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the Tier 0
 contribution registries (issue 2094), the UI extension points (issue 2366,
 above), the builtin worker self-exec path and worker SDK (with the first
-builtin worker that needs them), and the discovery / featured supply-chain
-layer with integrity hashing (issues 2364 and 2365). Rendering plugin slots in
-the standalone (non-daemon) home screen is still a follow-up (the
-structured-view TUI already renders the terminal-applicable subset, #2402). Pinning a featured plugin's
+builtin worker that needs them); the integrity-hashing / featured supply-chain
+layer landed in #2364 and the discovery / update-check layer in #2365 (both
+above). Rendering plugin slots in the standalone (non-daemon) home screen is
+still a follow-up (the structured-view TUI already renders the
+terminal-applicable subset, #2402). Pinning a featured plugin's
 release-binary asset hash in `featured.toml` (so a featured worker is attested,
 not just its source) is a follow-up; today a release-binary plugin cannot be
-featured.
+featured. Popularity-based discovery ranking and a `release-binary` asset-drift
+update check are tracked in #2105 and remain out of scope here.

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -49,6 +49,13 @@ pub enum PluginCommands {
         /// Path to the plugin directory
         path: String,
     },
+    /// Search GitHub's `aoe-plugin` topic for installable plugins
+    Discover {
+        /// Optional free-text term to narrow the search
+        query: Option<String>,
+    },
+    /// List installed external plugins that have an update available
+    Outdated,
 }
 
 pub async fn run(command: PluginCommands) -> Result<()> {
@@ -61,6 +68,8 @@ pub async fn run(command: PluginCommands) -> Result<()> {
         PluginCommands::Update { id } => run_update(&id).await,
         PluginCommands::Uninstall { id } => run_uninstall(&id),
         PluginCommands::Hash { path } => run_hash(&path),
+        PluginCommands::Discover { query } => run_discover(query.as_deref()).await,
+        PluginCommands::Outdated => run_outdated().await,
     }
 }
 
@@ -194,5 +203,50 @@ async fn run_update(id: &str) -> Result<()> {
 fn run_uninstall(id: &str) -> Result<()> {
     crate::plugin::install::uninstall(id)?;
     println!("Uninstalled {id}.");
+    Ok(())
+}
+
+async fn run_discover(query: Option<&str>) -> Result<()> {
+    let results = crate::plugin::discover::discover(query).await?;
+    if results.is_empty() {
+        println!("No plugins found on the `aoe-plugin` topic.");
+        return Ok(());
+    }
+    println!("{:<11} {:<6} {:<32} ABOUT", "BADGE", "STARS", "SOURCE");
+    for r in &results {
+        let about = r.description.as_deref().unwrap_or("");
+        println!(
+            "{:<11} {:<6} {:<32} {}",
+            r.badge.as_str(),
+            r.stars,
+            r.slug,
+            about
+        );
+    }
+    println!("\nInstall with:\n  aoe plugin install <source>");
+    Ok(())
+}
+
+async fn run_outdated() -> Result<()> {
+    let statuses = crate::plugin::update_check::outdated().await;
+    if statuses.is_empty() {
+        println!("No external plugins installed.");
+        return Ok(());
+    }
+    let mut any_outdated = false;
+    for s in &statuses {
+        if let Some(err) = &s.error {
+            println!("error         {:<20} {}", s.id, err);
+        } else if s.needs_update {
+            any_outdated = true;
+            let available = s.available.as_deref().unwrap_or("modified");
+            println!("needs update  {:<20} {} -> {}", s.id, s.current, available);
+        } else {
+            println!("up to date    {:<20} {}", s.id, s.current);
+        }
+    }
+    if any_outdated {
+        println!("\nUpdate with:\n  aoe plugin update <id>");
+    }
     Ok(())
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -170,15 +170,26 @@ impl GitHubClient {
         Ok(response.items)
     }
 
-    /// Fetch a single file's raw contents from a repo's default branch via the
-    /// contents API (`Accept: application/vnd.github.raw`). Used to read a
-    /// plugin's `aoe-plugin.toml` for the details view without cloning.
-    pub async fn get_repo_file(&self, owner: &str, repo: &str, path: &str) -> Result<String> {
+    /// Fetch a single file's raw contents via the contents API (`Accept:
+    /// application/vnd.github.raw`). Used to read a plugin's `aoe-plugin.toml`
+    /// for the details view without cloning. `reference` pins the branch, tag,
+    /// or commit (`?ref=`); `None` reads the repo's default branch.
+    pub async fn get_repo_file(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        reference: Option<&str>,
+    ) -> Result<String> {
         let path = utf8_percent_encode(path, TAG_SEGMENT);
-        let url = format!(
+        let mut url = format!(
             "{}/repos/{}/{}/contents/{}",
             self.api_base, owner, repo, path
         );
+        if let Some(reference) = reference {
+            url.push_str("?ref=");
+            url.extend(utf8_percent_encode(reference, TAG_SEGMENT));
+        }
         self.send_text(self.http.get(url).header(
             ACCEPT,
             HeaderValue::from_static("application/vnd.github.raw"),

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -170,11 +170,38 @@ impl GitHubClient {
         Ok(response.items)
     }
 
+    /// Fetch a single file's raw contents from a repo's default branch via the
+    /// contents API (`Accept: application/vnd.github.raw`). Used to read a
+    /// plugin's `aoe-plugin.toml` for the details view without cloning.
+    pub async fn get_repo_file(&self, owner: &str, repo: &str, path: &str) -> Result<String> {
+        let path = utf8_percent_encode(path, TAG_SEGMENT);
+        let url = format!(
+            "{}/repos/{}/{}/contents/{}",
+            self.api_base, owner, repo, path
+        );
+        self.send_text(self.http.get(url).header(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github.raw"),
+        ))
+        .await
+    }
+
     async fn send_json<T: DeserializeOwned>(&self, request: reqwest::RequestBuilder) -> Result<T> {
         let response = request.send().await.map_err(classify_transport_error)?;
         let status = response.status();
         if status.is_success() {
             return response.json::<T>().await.map_err(GitHubError::Decode);
+        }
+        let headers = response.headers().clone();
+        let body = response.text().await.unwrap_or_default();
+        Err(classify_status(status, &headers, &body))
+    }
+
+    async fn send_text(&self, request: reqwest::RequestBuilder) -> Result<String> {
+        let response = request.send().await.map_err(classify_transport_error)?;
+        let status = response.status();
+        if status.is_success() {
+            return response.text().await.map_err(GitHubError::Http);
         }
         let headers = response.headers().clone();
         let body = response.text().await.unwrap_or_default();

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -5,7 +5,7 @@
 //! typed [`GitHubError`] taxonomy. Only unauthenticated public reads (such as
 //! the update check) are wired up today via [`GitHubClient::unauthenticated`].
 
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS, NON_ALPHANUMERIC};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT};
 use reqwest::StatusCode;
 
@@ -20,6 +20,11 @@ const TAG_SEGMENT: &AsciiSet = &CONTROLS
     .add(b'%')
     .add(b'&')
     .add(b'+');
+/// Encode a search `q` value: encode everything non-alphanumeric (spaces,
+/// `:`, etc.) so the qualifier syntax (`topic:aoe-plugin fork:false`) survives
+/// into the query string intact.
+const QUERY_VALUE: &AsciiSet = NON_ALPHANUMERIC;
+
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::time::Duration;
@@ -59,6 +64,27 @@ pub struct GitHubRelease {
 pub struct GitHubAsset {
     pub name: String,
     pub browser_download_url: String,
+}
+
+/// A repository returned by the search API (the subset plugin discovery shows).
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubRepo {
+    /// `owner/repo`.
+    pub full_name: String,
+    #[serde(default)]
+    pub html_url: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub stargazers_count: u64,
+    #[serde(default)]
+    pub topics: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct SearchReposResponse {
+    #[serde(default)]
+    items: Vec<GitHubRepo>,
 }
 
 #[derive(Deserialize)]
@@ -127,6 +153,21 @@ impl GitHubClient {
             self.api_base, owner, repo, tag
         );
         self.send_json(self.http.get(url)).await
+    }
+
+    /// `GET /search/repositories?q={query}&sort=stars&order=desc`
+    ///
+    /// Unauthenticated search is heavily rate limited (about 10 requests per
+    /// minute per IP); a 403/429 surfaces as [`GitHubError::RateLimited`] so the
+    /// caller can say so plainly rather than reporting a generic API error.
+    pub async fn search_repositories(&self, query: &str, per_page: u8) -> Result<Vec<GitHubRepo>> {
+        let q = utf8_percent_encode(query, QUERY_VALUE);
+        let url = format!(
+            "{}/search/repositories?q={q}&sort=stars&order=desc&per_page={per_page}",
+            self.api_base
+        );
+        let response: SearchReposResponse = self.send_json(self.http.get(url)).await?;
+        Ok(response.items)
     }
 
     async fn send_json<T: DeserializeOwned>(&self, request: reqwest::RequestBuilder) -> Result<T> {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -9,7 +9,7 @@
 pub mod client;
 pub mod error;
 
-pub use client::{GitHubAsset, GitHubClient, GitHubClientConfig, GitHubRelease};
+pub use client::{GitHubAsset, GitHubClient, GitHubClientConfig, GitHubRelease, GitHubRepo};
 pub use error::{GitHubError, Result};
 
 /// Default GitHub REST API base.

--- a/src/plugin/auto_update.rs
+++ b/src/plugin/auto_update.rs
@@ -1,0 +1,96 @@
+//! Opt-in clean-only plugin auto-update sweep at startup.
+//!
+//! Gated on `updates.auto_update_plugins` (off by default). When on, the TUI and
+//! `aoe serve` spawn [`spawn_if_enabled`] at startup; it checks installed
+//! external plugins for updates and applies only the ones that need no new
+//! consent. Anything that changes capabilities, build steps, or UI slots is
+//! skipped and left for a manual `aoe plugin update`, so a background sweep never
+//! grants new capabilities or runs a changed build step unattended, and never
+//! deactivates a working plugin.
+//!
+//! ponytail: no cross-process lock around the sweep; it runs once at startup and
+//! the pre-existing install/update path is itself unguarded. Add an on-disk
+//! plugin-op lock if concurrent CLI/daemon mutation becomes a real problem.
+
+use crate::session::Config;
+
+use super::{install, update_check};
+
+/// What a sweep did, for logging and tests.
+#[derive(Debug, Default)]
+pub struct SweepSummary {
+    pub applied: Vec<String>,
+    pub skipped: Vec<(String, String)>,
+    pub errors: Vec<(String, String)>,
+}
+
+/// Check outdated external plugins and apply only the clean updates. Logs each
+/// outcome. Safe to call regardless of the setting; callers gate on it via
+/// [`spawn_if_enabled`].
+pub async fn sweep() -> SweepSummary {
+    let mut summary = SweepSummary::default();
+    for status in update_check::outdated().await {
+        if let Some(error) = &status.error {
+            tracing::warn!(
+                target: "plugin.auto_update",
+                plugin = %status.id,
+                %error,
+                "could not check plugin for updates",
+            );
+            continue;
+        }
+        if !status.needs_update {
+            continue;
+        }
+        match install::update_clean(&status.id).await {
+            Ok(install::UpdateOutcome::Applied(report)) => {
+                tracing::info!(
+                    target: "plugin.auto_update",
+                    plugin = %report.id,
+                    version = %report.version,
+                    "auto-updated plugin",
+                );
+                summary.applied.push(report.id);
+            }
+            Ok(install::UpdateOutcome::Skipped { id, reason }) => {
+                tracing::info!(
+                    target: "plugin.auto_update",
+                    plugin = %id,
+                    %reason,
+                    "skipped plugin auto-update; run `aoe plugin update` to review",
+                );
+                summary.skipped.push((id, reason));
+            }
+            Err(e) => {
+                let error = format!("{e:#}");
+                tracing::warn!(
+                    target: "plugin.auto_update",
+                    plugin = %status.id,
+                    %error,
+                    "plugin auto-update failed",
+                );
+                summary.errors.push((status.id, error));
+            }
+        }
+    }
+    summary
+}
+
+/// Spawn the sweep in the background when the setting opts in. Non-blocking so
+/// startup is never delayed by network or git; the registry is reloaded inside
+/// `install::update_clean` as each update lands.
+pub fn spawn_if_enabled(config: &Config) {
+    if !config.updates.auto_update_plugins {
+        return;
+    }
+    tokio::spawn(async move {
+        let summary = sweep().await;
+        tracing::info!(
+            target: "plugin.auto_update",
+            applied = summary.applied.len(),
+            skipped = summary.skipped.len(),
+            errors = summary.errors.len(),
+            "plugin auto-update sweep complete",
+        );
+    });
+}

--- a/src/plugin/auto_update.rs
+++ b/src/plugin/auto_update.rs
@@ -37,6 +37,7 @@ pub async fn sweep() -> SweepSummary {
                 %error,
                 "could not check plugin for updates",
             );
+            summary.errors.push((status.id.clone(), error.clone()));
             continue;
         }
         if !status.needs_update {

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -227,9 +227,15 @@ pub async fn details(source: &str) -> Result<PluginDetail> {
     let PluginSource::Github { owner, repo, .. } = &parsed else {
         bail!("details are only available for a gh:owner/repo source");
     };
+    // Honor a pinned tag/commit so a ref-pinned installed plugin's modal shows
+    // the installed version, not whatever is on HEAD today.
+    let reference = parsed.reference();
     let client = client()?;
 
-    let manifest = match client.get_repo_file(owner, repo, "aoe-plugin.toml").await {
+    let manifest = match client
+        .get_repo_file(owner, repo, "aoe-plugin.toml", reference)
+        .await
+    {
         Ok(text) => toml::from_str::<RawManifest>(&text)
             .map(|m| DetailManifest {
                 id: m.id,

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -55,6 +55,10 @@ pub struct DiscoveryResult {
     pub description: Option<String>,
     pub stars: u64,
     pub badge: DiscoveryBadge,
+    /// Whether this source is in the featured index, tracked independently of
+    /// `badge`: an installed-and-featured repo shows the `Installed` badge but
+    /// must still rank as featured (the badge is one-of, ranking is not).
+    pub featured: bool,
     /// The exact command to install this plugin (web has no install path, so it
     /// shows this for the user to copy into a terminal).
     pub install_command: String,
@@ -76,7 +80,11 @@ pub async fn discover(query: Option<&str>) -> Result<Vec<DiscoveryResult>> {
     }
     let repos = client.search_repositories(&q, 30).await?;
 
-    let featured = FeaturedIndex::load().unwrap_or_default();
+    // Treat a featured-index load failure as fatal, matching install-time
+    // `verify_featured`: silently defaulting to an empty index would re-badge
+    // every curated plugin as unvetted and drop featured-first ordering, so
+    // discovery and install would disagree about the same trust signal.
+    let featured = FeaturedIndex::load()?;
     let installed = installed_slugs();
     Ok(rank(badge_repos(repos, &featured, &installed)))
 }
@@ -110,9 +118,13 @@ fn badge_repos(
             }
             let slug = format!("gh:{}", repo.full_name);
             let normalized = slug.to_ascii_lowercase();
-            let badge = if installed.contains(&normalized) {
+            let is_installed = installed.contains(&normalized);
+            let is_featured = featured.is_featured_source(&slug);
+            // Installed wins the one-of display badge, but `featured` is kept
+            // separately so an installed-and-featured repo still ranks featured.
+            let badge = if is_installed {
                 DiscoveryBadge::Installed
-            } else if featured.is_featured_source(&slug) {
+            } else if is_featured {
                 DiscoveryBadge::Featured
             } else {
                 DiscoveryBadge::Unvetted
@@ -121,6 +133,7 @@ fn badge_repos(
                 install_command: format!("aoe plugin install {slug}"),
                 slug,
                 html_url: repo.html_url,
+                featured: is_featured,
                 description: repo.description.filter(|d| !d.is_empty()),
                 stars: repo.stargazers_count,
                 badge,
@@ -133,9 +146,8 @@ fn badge_repos(
 /// popularity ranking; until then this is the issue's "featured status + stars").
 fn rank(mut results: Vec<DiscoveryResult>) -> Vec<DiscoveryResult> {
     results.sort_by(|a, b| {
-        let featured = |r: &DiscoveryResult| r.badge == DiscoveryBadge::Featured;
-        featured(b)
-            .cmp(&featured(a))
+        b.featured
+            .cmp(&a.featured)
             .then(b.stars.cmp(&a.stars))
             .then(a.slug.cmp(&b.slug))
     });
@@ -200,6 +212,19 @@ mod tests {
         let out = rank(badge_repos(repos, &index, &[]));
         assert_eq!(out[0].slug, "gh:acme/vetted");
         assert_eq!(out[1].slug, "gh:acme/popular");
+    }
+
+    #[test]
+    fn installed_and_featured_still_ranks_featured() {
+        // A repo that is both installed and featured shows the Installed badge
+        // but must still outrank a high-star unvetted repo (#2473 review).
+        let repos = vec![repo("acme/popular", 999), repo("acme/vetted", 1)];
+        let index = featured("gh:acme/vetted");
+        let installed = vec!["gh:acme/vetted".to_string()];
+        let out = rank(badge_repos(repos, &index, &installed));
+        assert_eq!(out[0].slug, "gh:acme/vetted");
+        assert_eq!(out[0].badge, DiscoveryBadge::Installed);
+        assert!(out[0].featured);
     }
 
     #[test]

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -1,0 +1,215 @@
+//! GitHub plugin discovery over the `aoe-plugin` topic.
+//!
+//! Discovery is an explicit action (CLI `aoe plugin discover`, TUI `d`, the
+//! dashboard "Search GitHub" button), never a background task. It is repo-level,
+//! not manifest-level: it runs one GitHub search and badges each result by
+//! matching the repo slug against the featured index and the installed set. It
+//! deliberately does NOT clone or read each repo's `aoe-plugin.toml` (an N+1
+//! network blowup that would burn the unauthenticated search rate limit), so a
+//! result is "a GitHub repository tagged `aoe-plugin`", not "a verified plugin".
+//! Install remains the trust boundary: it fetches the manifest, prompts for
+//! capabilities, and enforces the featured pin (`install::install`).
+
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::github::{GitHubClient, GitHubClientConfig, GitHubRepo, DEFAULT_USER_AGENT};
+
+use super::featured::FeaturedIndex;
+use super::source::PluginSource;
+
+/// The GitHub topic plugins are published under.
+const PLUGIN_TOPIC: &str = "aoe-plugin";
+
+/// How a discovered repository relates to what the host already knows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscoveryBadge {
+    /// This source slug is already installed.
+    Installed,
+    /// This source slug is pinned in the featured index (a curated source; not a
+    /// claim that the current tree matches the pin).
+    Featured,
+    /// A GitHub repo tagged `aoe-plugin` that is neither installed nor featured.
+    Unvetted,
+}
+
+impl DiscoveryBadge {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiscoveryBadge::Installed => "installed",
+            DiscoveryBadge::Featured => "featured",
+            DiscoveryBadge::Unvetted => "unvetted",
+        }
+    }
+}
+
+/// One discovery result, repo-level and ready to render on any surface.
+#[derive(Debug, Clone)]
+pub struct DiscoveryResult {
+    /// `gh:owner/repo`, the slug `aoe plugin install` accepts.
+    pub slug: String,
+    pub html_url: String,
+    pub description: Option<String>,
+    pub stars: u64,
+    pub badge: DiscoveryBadge,
+    /// The exact command to install this plugin (web has no install path, so it
+    /// shows this for the user to copy into a terminal).
+    pub install_command: String,
+}
+
+/// Search the `aoe-plugin` topic and badge each result. `query` is an optional
+/// free-text term ANDed with the topic filter.
+pub async fn discover(query: Option<&str>) -> Result<Vec<DiscoveryResult>> {
+    let client = GitHubClient::unauthenticated(GitHubClientConfig {
+        api_base: api_base(),
+        user_agent: DEFAULT_USER_AGENT.to_string(),
+        timeout: Duration::from_secs(30),
+    })?;
+
+    let mut q = format!("topic:{PLUGIN_TOPIC} fork:false archived:false");
+    if let Some(term) = query.map(str::trim).filter(|t| !t.is_empty()) {
+        q.push(' ');
+        q.push_str(term);
+    }
+    let repos = client.search_repositories(&q, 30).await?;
+
+    let featured = FeaturedIndex::load().unwrap_or_default();
+    let installed = installed_slugs();
+    Ok(rank(badge_repos(repos, &featured, &installed)))
+}
+
+/// The normalized `gh:owner/repo` slugs of every installed external GitHub
+/// plugin, lower-cased for case-insensitive matching.
+fn installed_slugs() -> Vec<String> {
+    super::registry()
+        .all()
+        .iter()
+        .filter_map(|p| p.source.as_deref())
+        .filter_map(|s| PluginSource::parse(s).ok())
+        .filter(|s| matches!(s, PluginSource::Github { .. }))
+        .map(|s| s.slug().to_ascii_lowercase())
+        .collect()
+}
+
+/// Map raw repos to badged results. Pure given the featured index and the
+/// installed slug set, so it is unit-tested without the network.
+fn badge_repos(
+    repos: Vec<GitHubRepo>,
+    featured: &FeaturedIndex,
+    installed: &[String],
+) -> Vec<DiscoveryResult> {
+    repos
+        .into_iter()
+        .filter_map(|repo| {
+            // A search result is `owner/repo`; anything else is not installable.
+            if repo.full_name.split('/').filter(|s| !s.is_empty()).count() != 2 {
+                return None;
+            }
+            let slug = format!("gh:{}", repo.full_name);
+            let normalized = slug.to_ascii_lowercase();
+            let badge = if installed.contains(&normalized) {
+                DiscoveryBadge::Installed
+            } else if featured.is_featured_source(&slug) {
+                DiscoveryBadge::Featured
+            } else {
+                DiscoveryBadge::Unvetted
+            };
+            Some(DiscoveryResult {
+                install_command: format!("aoe plugin install {slug}"),
+                slug,
+                html_url: repo.html_url,
+                description: repo.description.filter(|d| !d.is_empty()),
+                stars: repo.stargazers_count,
+                badge,
+            })
+        })
+        .collect()
+}
+
+/// Rank featured sources first, then by GitHub stars descending (#2105 will add
+/// popularity ranking; until then this is the issue's "featured status + stars").
+fn rank(mut results: Vec<DiscoveryResult>) -> Vec<DiscoveryResult> {
+    results.sort_by(|a, b| {
+        let featured = |r: &DiscoveryResult| r.badge == DiscoveryBadge::Featured;
+        featured(b)
+            .cmp(&featured(a))
+            .then(b.stars.cmp(&a.stars))
+            .then(a.slug.cmp(&b.slug))
+    });
+    results
+}
+
+fn api_base() -> String {
+    std::env::var("AOE_UPDATE_API_BASE")
+        .unwrap_or_else(|_| crate::github::DEFAULT_GITHUB_API_BASE.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo(full_name: &str, stars: u64) -> GitHubRepo {
+        GitHubRepo {
+            full_name: full_name.to_string(),
+            html_url: format!("https://github.com/{full_name}"),
+            description: Some("a plugin".to_string()),
+            stargazers_count: stars,
+            topics: vec!["aoe-plugin".to_string()],
+        }
+    }
+
+    fn featured(slug: &str) -> FeaturedIndex {
+        FeaturedIndex::from_toml_str(&format!(
+            "[plugins.\"x.y\"]\nsource = \"{slug}\"\ntree_hash = \"sha256:abc\"\n"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn badges_installed_featured_unvetted() {
+        let repos = vec![
+            repo("acme/installed", 5),
+            repo("acme/vetted", 10),
+            repo("acme/random", 100),
+        ];
+        let index = featured("gh:acme/vetted");
+        let installed = vec!["gh:acme/installed".to_string()];
+        let out = badge_repos(repos, &index, &installed);
+        let by_slug = |slug: &str| out.iter().find(|r| r.slug == slug).unwrap().badge;
+        assert_eq!(by_slug("gh:acme/installed"), DiscoveryBadge::Installed);
+        assert_eq!(by_slug("gh:acme/vetted"), DiscoveryBadge::Featured);
+        assert_eq!(by_slug("gh:acme/random"), DiscoveryBadge::Unvetted);
+    }
+
+    #[test]
+    fn installed_match_is_case_insensitive() {
+        let repos = vec![repo("Acme/Widget", 1)];
+        let installed = vec!["gh:acme/widget".to_string()];
+        let out = badge_repos(repos, &FeaturedIndex::default(), &installed);
+        assert_eq!(out[0].badge, DiscoveryBadge::Installed);
+    }
+
+    #[test]
+    fn ranks_featured_first_then_stars() {
+        // A low-star featured result outranks a high-star unvetted one.
+        let repos = vec![repo("acme/popular", 999), repo("acme/vetted", 1)];
+        let index = featured("gh:acme/vetted");
+        let out = rank(badge_repos(repos, &index, &[]));
+        assert_eq!(out[0].slug, "gh:acme/vetted");
+        assert_eq!(out[1].slug, "gh:acme/popular");
+    }
+
+    #[test]
+    fn drops_non_owner_repo_results() {
+        let repos = vec![repo("not-a-slug", 1), repo("a/b/c", 1)];
+        let out = badge_repos(repos, &FeaturedIndex::default(), &[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn install_command_uses_the_slug() {
+        let out = badge_repos(vec![repo("acme/widget", 1)], &FeaturedIndex::default(), &[]);
+        assert_eq!(out[0].install_command, "aoe plugin install gh:acme/widget");
+    }
+}

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -13,6 +13,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::github::{GitHubClient, GitHubClientConfig, GitHubRepo, DEFAULT_USER_AGENT};
 
@@ -23,7 +24,8 @@ use super::source::PluginSource;
 const PLUGIN_TOPIC: &str = "aoe-plugin";
 
 /// How a discovered repository relates to what the host already knows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DiscoveryBadge {
     /// This source slug is already installed.
     Installed,
@@ -45,7 +47,7 @@ impl DiscoveryBadge {
 }
 
 /// One discovery result, repo-level and ready to render on any surface.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DiscoveryResult {
     /// `gh:owner/repo`, the slug `aoe plugin install` accepts.
     pub slug: String,

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -12,8 +12,8 @@
 
 use std::time::Duration;
 
-use anyhow::Result;
-use serde::Serialize;
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
 
 use crate::github::{GitHubClient, GitHubClientConfig, GitHubRepo, DEFAULT_USER_AGENT};
 
@@ -67,11 +67,7 @@ pub struct DiscoveryResult {
 /// Search the `aoe-plugin` topic and badge each result. `query` is an optional
 /// free-text term ANDed with the topic filter.
 pub async fn discover(query: Option<&str>) -> Result<Vec<DiscoveryResult>> {
-    let client = GitHubClient::unauthenticated(GitHubClientConfig {
-        api_base: api_base(),
-        user_agent: DEFAULT_USER_AGENT.to_string(),
-        timeout: Duration::from_secs(30),
-    })?;
+    let client = client()?;
 
     let mut q = format!("topic:{PLUGIN_TOPIC} fork:false archived:false");
     if let Some(term) = query.map(str::trim).filter(|t| !t.is_empty()) {
@@ -154,9 +150,125 @@ fn rank(mut results: Vec<DiscoveryResult>) -> Vec<DiscoveryResult> {
     results
 }
 
+fn client() -> Result<GitHubClient> {
+    Ok(GitHubClient::unauthenticated(GitHubClientConfig {
+        api_base: api_base(),
+        user_agent: DEFAULT_USER_AGENT.to_string(),
+        timeout: Duration::from_secs(30),
+    })?)
+}
+
 fn api_base() -> String {
     std::env::var("AOE_UPDATE_API_BASE")
         .unwrap_or_else(|_| crate::github::DEFAULT_GITHUB_API_BASE.to_string())
+}
+
+/// The manifest fields a detail view shows, parsed leniently (unknown and
+/// future keys are ignored) so a plugin targeting a newer `api_version` than
+/// this host can install still renders in the modal.
+#[derive(Debug, Clone, Serialize)]
+pub struct DetailManifest {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub api_version: u32,
+    pub capabilities: Vec<String>,
+    pub ui_contributions: Vec<UiSlotView>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UiSlotView {
+    pub slot: String,
+    pub id: String,
+}
+
+/// The on-demand detail for one plugin source: its manifest fields plus the
+/// repo's published release tags (the available versions).
+#[derive(Debug, Clone, Serialize)]
+pub struct PluginDetail {
+    pub source: String,
+    pub manifest: Option<DetailManifest>,
+    /// Why the manifest could not be read/parsed, if it could not.
+    pub manifest_error: Option<String>,
+    /// Published GitHub release tags, newest first (the available versions).
+    pub release_tags: Vec<String>,
+}
+
+/// Lenient `aoe-plugin.toml` shape for the detail view. Unlike the strict host
+/// parser it ignores unknown fields and does not range-check `api_version`, so a
+/// not-yet-installable plugin still shows its version/description/capabilities.
+#[derive(Deserialize)]
+struct RawManifest {
+    id: String,
+    name: String,
+    version: String,
+    #[serde(default)]
+    description: String,
+    api_version: u32,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    ui: Vec<RawUi>,
+}
+
+#[derive(Deserialize)]
+struct RawUi {
+    slot: String,
+    id: String,
+}
+
+/// Fetch the detail for a `gh:owner/repo` source: its `aoe-plugin.toml` (read
+/// via the contents API, no clone) and the repo's release tags. A manifest that
+/// is missing or unparseable is reported in `manifest_error` while the release
+/// tags still load, so the modal degrades gracefully.
+pub async fn details(source: &str) -> Result<PluginDetail> {
+    let parsed = PluginSource::parse(source)?;
+    let PluginSource::Github { owner, repo, .. } = &parsed else {
+        bail!("details are only available for a gh:owner/repo source");
+    };
+    let client = client()?;
+
+    let manifest = match client.get_repo_file(owner, repo, "aoe-plugin.toml").await {
+        Ok(text) => toml::from_str::<RawManifest>(&text)
+            .map(|m| DetailManifest {
+                id: m.id,
+                name: m.name,
+                version: m.version,
+                description: m.description,
+                api_version: m.api_version,
+                capabilities: m.capabilities,
+                ui_contributions: m
+                    .ui
+                    .into_iter()
+                    .map(|u| UiSlotView {
+                        slot: u.slot,
+                        id: u.id,
+                    })
+                    .collect(),
+            })
+            .map_err(|e| format!("aoe-plugin.toml is invalid: {e}")),
+        Err(e) => Err(format!("{e}")),
+    };
+
+    // Release tags are best-effort: a repo with no releases is normal, so a
+    // failure here just yields an empty list rather than failing the request.
+    let release_tags = client
+        .list_releases(owner, repo, 30)
+        .await
+        .map(|rs| rs.into_iter().map(|r| r.tag_name).collect())
+        .unwrap_or_default();
+
+    let (manifest, manifest_error) = match manifest {
+        Ok(m) => (Some(m), None),
+        Err(e) => (None, Some(e)),
+    };
+    Ok(PluginDetail {
+        source: parsed.slug(),
+        manifest,
+        manifest_error,
+        release_tags,
+    })
 }
 
 #[cfg(test)]
@@ -232,6 +344,31 @@ mod tests {
         let repos = vec![repo("not-a-slug", 1), repo("a/b/c", 1)];
         let out = badge_repos(repos, &FeaturedIndex::default(), &[]);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn detail_manifest_parse_tolerates_newer_api_version_and_unknown_keys() {
+        // A plugin targeting an api_version this host cannot install must still
+        // render in the detail modal, and unknown/future keys are ignored.
+        let toml = r#"
+id = "acme.future"
+name = "Future"
+version = "9.9.9"
+api_version = 99
+description = "from the future"
+capabilities = ["net"]
+some_unknown_future_key = true
+
+[[ui]]
+slot = "status-bar"
+id = "s"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        assert_eq!(m.version, "9.9.9");
+        assert_eq!(m.api_version, 99);
+        assert_eq!(m.capabilities, vec!["net"]);
+        assert_eq!(m.ui.len(), 1);
+        assert_eq!(m.ui[0].slot, "status-bar");
     }
 
     #[test]

--- a/src/plugin/featured.rs
+++ b/src/plugin/featured.rs
@@ -60,6 +60,17 @@ impl FeaturedIndex {
     pub fn get(&self, id: &str) -> Option<&FeaturedEntry> {
         self.plugins.get(id)
     }
+
+    /// Whether any featured entry is pinned to this source slug (case-insensitive,
+    /// GitHub slugs are not case-sensitive). Discovery uses this to badge a search
+    /// result as a featured *source*, without fetching its manifest; it is not a
+    /// claim that the repo's current tree matches the pinned `tree_hash`, which
+    /// only install-time `verify_featured` enforces.
+    pub fn is_featured_source(&self, slug: &str) -> bool {
+        self.plugins
+            .values()
+            .any(|e| e.source.eq_ignore_ascii_case(slug))
+    }
 }
 
 #[cfg(test)]
@@ -86,5 +97,10 @@ tree_hash = "sha256:abc"
         assert_eq!(entry.source, "gh:agent-of-empires/example");
         assert_eq!(entry.tree_hash, "sha256:abc");
         assert!(index.get("acme.absent").is_none());
+
+        // Source-slug match is case-insensitive and ignores the keying id.
+        assert!(index.is_featured_source("gh:agent-of-empires/example"));
+        assert!(index.is_featured_source("gh:Agent-Of-Empires/Example"));
+        assert!(!index.is_featured_source("gh:someone/else"));
     }
 }

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -161,6 +161,45 @@ fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Resolve the commit a GitHub source's ref currently points at, without
+/// cloning, via `git ls-remote`. `reference` of `None` means the remote `HEAD`.
+/// Used by the update check to tell whether a newer commit exists.
+///
+/// A `reference` that is already a full commit sha is returned as-is: `ls-remote`
+/// cannot resolve a bare sha, and a commit-pinned install can never be outdated.
+/// For a branch or tag, an annotated tag's peeled (`^{}`) target is preferred so
+/// the result is the commit the install would actually check out.
+pub fn ls_remote(url: &str, reference: Option<&str>) -> Result<String> {
+    if let Some(r) = reference {
+        if is_full_commit_sha(r) {
+            return Ok(r.to_ascii_lowercase());
+        }
+    }
+    let target = reference.unwrap_or("HEAD");
+    let out = run_git(&["ls-remote", url, target], None)?;
+    parse_ls_remote(&out, target)
+}
+
+fn is_full_commit_sha(s: &str) -> bool {
+    s.len() == 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Pick the resolved commit from `git ls-remote` output (`<sha>\t<ref>` lines),
+/// preferring an annotated tag's peeled `^{}` target over the tag object itself.
+fn parse_ls_remote(out: &str, target: &str) -> Result<String> {
+    let mut first = None;
+    for line in out.lines() {
+        let Some((sha, name)) = line.split_once('\t') else {
+            continue;
+        };
+        if name.ends_with("^{}") {
+            return Ok(sha.trim().to_string());
+        }
+        first.get_or_insert_with(|| sha.trim().to_string());
+    }
+    first.ok_or_else(|| anyhow!("ref {target:?} not found on the remote"))
+}
+
 fn path_arg(path: &Path) -> Result<&str> {
     path.to_str()
         .ok_or_else(|| anyhow!("non-UTF-8 path: {}", path.display()))
@@ -435,6 +474,36 @@ fn ensure_executable(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_ls_remote_prefers_peeled_tag() {
+        let out = "1111111111111111111111111111111111111111\trefs/tags/v1\n\
+                   2222222222222222222222222222222222222222\trefs/tags/v1^{}";
+        assert_eq!(
+            parse_ls_remote(out, "v1").unwrap(),
+            "2222222222222222222222222222222222222222"
+        );
+    }
+
+    #[test]
+    fn parse_ls_remote_takes_first_when_unpeeled() {
+        let out = "3333333333333333333333333333333333333333\tHEAD";
+        assert_eq!(
+            parse_ls_remote(out, "HEAD").unwrap(),
+            "3333333333333333333333333333333333333333"
+        );
+    }
+
+    #[test]
+    fn parse_ls_remote_errors_when_empty() {
+        assert!(parse_ls_remote("", "nope").is_err());
+    }
+
+    #[test]
+    fn ls_remote_returns_pinned_sha_as_is() {
+        let sha = "abcdef0123456789abcdef0123456789abcdef01";
+        assert_eq!(ls_remote("unused://", Some(sha)).unwrap(), sha);
+    }
 
     #[test]
     fn renders_platform_tokens() {

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -48,6 +48,28 @@ pub struct InstallReport {
     pub granted: bool,
 }
 
+/// How an update treats a version that would need fresh consent (changed
+/// capabilities, build recipe, or UI slots).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsentMode {
+    /// Prompt the user (the manual `aoe plugin update` path).
+    Interactive,
+    /// Apply only a "clean" update that needs no new consent; skip anything that
+    /// would (the opt-in startup auto-update sweep). Never prompts, never runs a
+    /// changed build step or installs a changed capability/UI set unattended.
+    CleanOnlyNonInteractive,
+}
+
+/// The result of an update attempt.
+#[derive(Debug)]
+pub enum UpdateOutcome {
+    /// The update was applied (the tree was replaced and the lockfile rewritten).
+    Applied(InstallReport),
+    /// A `CleanOnlyNonInteractive` update was skipped because it needs consent;
+    /// the prior version stays installed and active.
+    Skipped { id: String, reason: String },
+}
+
 /// Install an external plugin from `input` (`gh:owner/repo[@ref]` or a local
 /// dir). Prompts once for the manifest's capabilities unless `assume_yes`.
 pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
@@ -103,10 +125,29 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     })
 }
 
-/// Re-fetch an installed external plugin from its recorded source. A changed
+/// Re-fetch an installed external plugin from its recorded source, prompting on
+/// a changed capability set (the manual `aoe plugin update` path). A changed
 /// capability set re-prompts; until re-approved the plugin's contributions stay
 /// inactive (the grant no longer covers the installed manifest).
 pub async fn update(id: &str) -> Result<InstallReport> {
+    match update_with_consent(id, ConsentMode::Interactive).await? {
+        UpdateOutcome::Applied(report) => Ok(report),
+        // Interactive mode prompts rather than skipping, so this is unreachable;
+        // map it to an error rather than panicking if that ever changes.
+        UpdateOutcome::Skipped { id, reason } => {
+            bail!("update for {id} was skipped unexpectedly: {reason}")
+        }
+    }
+}
+
+/// Re-fetch an installed external plugin and apply it only if it needs no new
+/// consent (the opt-in startup auto-update sweep). Returns whether it was
+/// applied or skipped; never prompts.
+pub async fn update_clean(id: &str) -> Result<UpdateOutcome> {
+    update_with_consent(id, ConsentMode::CleanOnlyNonInteractive).await
+}
+
+async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcome> {
     let config = Config::load()?;
     let plugin_config = config
         .plugins
@@ -164,6 +205,14 @@ pub async fn update(id: &str) -> Result<InstallReport> {
     // non-interactive prompt bails while the old install, config, and lockfile
     // are still consistent.
     let grant = if needs_prompt {
+        // The auto-update sweep declines anything needing consent: skip without
+        // touching the tree, leaving the working version active.
+        if mode == ConsentMode::CleanOnlyNonInteractive {
+            return Ok(UpdateOutcome::Skipped {
+                id: id.to_string(),
+                reason: skip_reason(caps_changed, build_changed, ui_changed),
+            });
+        }
         if confirm_capabilities(
             id,
             &capabilities,
@@ -216,12 +265,31 @@ pub async fn update(id: &str) -> Result<InstallReport> {
         );
     }
 
-    Ok(InstallReport {
+    Ok(UpdateOutcome::Applied(InstallReport {
         id: id.to_string(),
         version: fetched.manifest.version.clone(),
         capabilities,
         granted,
-    })
+    }))
+}
+
+/// Human-readable reason an auto-update was skipped, for the sweep log.
+fn skip_reason(caps_changed: bool, build_changed: bool, ui_changed: bool) -> String {
+    let mut parts = Vec::new();
+    if caps_changed {
+        parts.push("capability change");
+    }
+    if build_changed {
+        parts.push("build-step change");
+    }
+    if ui_changed {
+        parts.push("UI change");
+    }
+    if parts.is_empty() {
+        "needs approval".to_string()
+    } else {
+        format!("{} needs approval", parts.join(" + "))
+    }
 }
 
 /// Remove an installed external plugin: its tree, its config entry, and its

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,7 +6,9 @@
 //! installs, capability grants, and the Tier 0 / Tier 1 contribution surface
 //! return in follow-up PRs.
 
+pub mod auto_update;
 pub mod contributions;
+pub mod discover;
 pub mod featured;
 pub mod fetch;
 pub mod install;
@@ -14,6 +16,7 @@ pub mod integrity;
 pub mod lockfile;
 pub mod registry;
 pub mod source;
+pub mod update_check;
 pub mod view;
 
 // The Tier 1 worker host runs only in the `aoe serve` daemon, where the event

--- a/src/plugin/update_check.rs
+++ b/src/plugin/update_check.rs
@@ -1,0 +1,144 @@
+//! Update-availability checks for installed external plugins.
+//!
+//! An explicit action (CLI `aoe plugin outdated`, TUI `c`, the dashboard
+//! `GET /api/plugins/updates`), never run during the registry's offline load
+//! path. For a GitHub source it compares the lockfile's resolved commit against
+//! `git ls-remote` of the requested ref (no clone, no REST rate limit); for a
+//! local source it re-hashes the source directory against the lockfile tree
+//! hash. Builtins have nothing to update and are skipped.
+//!
+//! Limitation: a `release-binary` plugin whose GitHub release asset is replaced
+//! without a source-commit change is not detected here; `ls-remote` only sees
+//! the source tree. That asset drift is out of scope for #2365.
+
+use serde::Serialize;
+
+use super::lockfile::Lockfile;
+use super::source::PluginSource;
+
+/// One plugin's update status, rendered identically by CLI / TUI / web.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateStatus {
+    pub id: String,
+    pub source: String,
+    /// The currently installed marker: a short commit (GitHub) or `local`.
+    pub current: String,
+    /// The newer marker when an update exists: a short commit for GitHub. `None`
+    /// for a changed local tree (there is no commit to name) or when current.
+    pub available: Option<String>,
+    pub needs_update: bool,
+    /// Why the check could not run for this plugin (missing lock, git absent,
+    /// dead remote). Never silently treated as up-to-date.
+    pub error: Option<String>,
+}
+
+/// One installed external plugin's identity, pulled off the registry before any
+/// blocking work so nothing non-`Send` is held across an await.
+struct Target {
+    id: String,
+    source: String,
+}
+
+/// Check every installed external plugin for an available update. Results are
+/// sorted by id; per-plugin failures land in `error`, not as a hard error.
+pub async fn outdated() -> Vec<UpdateStatus> {
+    let targets: Vec<Target> = super::registry()
+        .all()
+        .iter()
+        .filter_map(|p| {
+            Some(Target {
+                id: p.id().to_string(),
+                source: p.source.clone()?,
+            })
+        })
+        .collect();
+
+    let lock = Lockfile::load();
+    let mut out = Vec::with_capacity(targets.len());
+    for target in targets {
+        out.push(check_one(&target, lock.as_ref().ok()).await);
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
+}
+
+async fn check_one(target: &Target, lock: Option<&Lockfile>) -> UpdateStatus {
+    let status = |current: String, available: Option<String>, error: Option<String>| UpdateStatus {
+        id: target.id.clone(),
+        source: target.source.clone(),
+        needs_update: available.is_some(),
+        current,
+        available,
+        error,
+    };
+    let err = |msg: String| status(String::new(), None, Some(msg));
+
+    let Some(locked) = lock.and_then(|l| l.get(&target.id)) else {
+        return err(format!(
+            "no lockfile entry for {}; reinstall to record one",
+            target.id
+        ));
+    };
+
+    match PluginSource::parse(&target.source) {
+        Ok(source @ PluginSource::Github { .. }) => {
+            let Some(url) = source.github_clone_url() else {
+                return err("github source without a clone url".to_string());
+            };
+            let Some(current_commit) = locked.resolved_commit.clone() else {
+                return err("lockfile has no resolved commit".to_string());
+            };
+            let reference = source.reference().map(String::from);
+            let remote = tokio::task::spawn_blocking(move || {
+                super::fetch::ls_remote(&url, reference.as_deref())
+            })
+            .await;
+            match remote {
+                Ok(Ok(remote_commit)) => {
+                    let needs = !remote_commit.eq_ignore_ascii_case(&current_commit);
+                    status(
+                        short(&current_commit),
+                        needs.then(|| short(&remote_commit)),
+                        None,
+                    )
+                }
+                Ok(Err(e)) => err(format!("{e:#}")),
+                Err(e) => err(format!("ls-remote task failed: {e}")),
+            }
+        }
+        Ok(PluginSource::Local(path)) => {
+            let pinned = locked.tree_hash.clone();
+            let probe = path.clone();
+            let rehash =
+                tokio::task::spawn_blocking(move || super::integrity::tree_hash(&probe)).await;
+            match rehash {
+                Ok(Ok(hash)) => {
+                    let needs = !pinned.is_empty() && hash != pinned;
+                    status(
+                        "local".to_string(),
+                        needs.then(|| "modified".to_string()),
+                        None,
+                    )
+                }
+                Ok(Err(e)) => err(format!("re-hashing {}: {e:#}", path.display())),
+                Err(e) => err(format!("hash task failed: {e}")),
+            }
+        }
+        Err(e) => err(format!("unparseable source {:?}: {e:#}", target.source)),
+    }
+}
+
+fn short(commit: &str) -> String {
+    commit.chars().take(8).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_truncates() {
+        assert_eq!(short("abcdef0123456789"), "abcdef01");
+        assert_eq!(short("abc"), "abc");
+    }
+}

--- a/src/plugin/update_check.rs
+++ b/src/plugin/update_check.rs
@@ -56,13 +56,13 @@ pub async fn outdated() -> Vec<UpdateStatus> {
     let lock = Lockfile::load();
     let mut out = Vec::with_capacity(targets.len());
     for target in targets {
-        out.push(check_one(&target, lock.as_ref().ok()).await);
+        out.push(check_one(&target, lock.as_ref()).await);
     }
     out.sort_by(|a, b| a.id.cmp(&b.id));
     out
 }
 
-async fn check_one(target: &Target, lock: Option<&Lockfile>) -> UpdateStatus {
+async fn check_one(target: &Target, lock: Result<&Lockfile, &anyhow::Error>) -> UpdateStatus {
     let status = |current: String, available: Option<String>, error: Option<String>| UpdateStatus {
         id: target.id.clone(),
         source: target.source.clone(),
@@ -73,7 +73,13 @@ async fn check_one(target: &Target, lock: Option<&Lockfile>) -> UpdateStatus {
     };
     let err = |msg: String| status(String::new(), None, Some(msg));
 
-    let Some(locked) = lock.and_then(|l| l.get(&target.id)) else {
+    let lock = match lock {
+        Ok(lock) => lock,
+        // A corrupt or unreadable plugins.lock must surface as itself, not be
+        // misreported as a missing entry across every plugin.
+        Err(e) => return err(format!("reading plugins.lock: {e:#}")),
+    };
+    let Some(locked) = lock.get(&target.id) else {
         return err(format!(
             "no lockfile entry for {}; reinstall to record one",
             target.id

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -36,7 +36,10 @@ pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
-pub use plugins::{invoke_plugin_action, list_plugins, plugin_ui_state, set_plugin_enabled};
+pub use plugins::{
+    invoke_plugin_action, list_plugins, plugin_discover, plugin_ui_state, plugin_updates,
+    set_plugin_enabled,
+};
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -37,8 +37,8 @@ pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
 pub use plugins::{
-    invoke_plugin_action, list_plugins, plugin_discover, plugin_ui_state, plugin_updates,
-    set_plugin_enabled,
+    invoke_plugin_action, list_plugins, plugin_details, plugin_discover, plugin_ui_state,
+    plugin_updates, set_plugin_enabled,
 };
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -117,7 +117,11 @@ pub struct DetailsQuery {
 pub async fn plugin_details(Query(query): Query<DetailsQuery>) -> Response {
     match plugin::discover::details(&query.source).await {
         Ok(detail) => Json(detail).into_response(),
-        Err(e) => error_response(StatusCode::BAD_GATEWAY, "details_failed", format!("{e:#}")),
+        // `details()` only hard-errors on an invalid / unsupported `source`; a
+        // GitHub fetch failure is reported in-band (manifest_error / empty
+        // release tags), so a hard error here is bad client input, not an
+        // upstream outage.
+        Err(e) => error_response(StatusCode::BAD_REQUEST, "invalid_source", format!("{e:#}")),
     }
 }
 

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -5,7 +5,7 @@
 //! requires read-write mode AND an elevated session when login is enabled,
 //! mirroring the requires-elevation settings fields.
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -75,6 +75,34 @@ pub async fn plugin_ui_state(
             empty()
         })),
         None => Json(empty()),
+    }
+}
+
+/// `GET /api/plugins/updates`: which installed external plugins have an update
+/// available. An explicit, on-demand network check (the dashboard "Check for
+/// updates" button), kept off the always-on `GET /api/plugins` list path so a
+/// settings render never blocks on git/network. Allowed in read-only mode: it
+/// reads remote state and mutates nothing.
+pub async fn plugin_updates() -> Json<serde_json::Value> {
+    Json(json!({ "updates": plugin::update_check::outdated().await }))
+}
+
+#[derive(Deserialize)]
+pub struct DiscoverQuery {
+    #[serde(default)]
+    pub q: Option<String>,
+}
+
+/// `GET /api/plugins/discover?q=`: search the `aoe-plugin` GitHub topic. The
+/// dashboard "Search GitHub" button. Browse-only: the dashboard has no install
+/// path (capability approval needs a terminal), so each result carries an
+/// `install_command` the user copies. On a GitHub failure (notably the
+/// unauthenticated search rate limit) the message is returned for the UI to
+/// show, rather than a generic 500.
+pub async fn plugin_discover(Query(query): Query<DiscoverQuery>) -> Response {
+    match plugin::discover::discover(query.q.as_deref()).await {
+        Ok(results) => Json(json!({ "results": results })).into_response(),
+        Err(e) => error_response(StatusCode::BAD_GATEWAY, "discover_failed", format!("{e:#}")),
     }
 }
 

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -107,6 +107,21 @@ pub async fn plugin_discover(Query(query): Query<DiscoverQuery>) -> Response {
 }
 
 #[derive(Deserialize)]
+pub struct DetailsQuery {
+    pub source: String,
+}
+
+/// `GET /api/plugins/details?source=gh:owner/repo`: the on-demand detail for one
+/// plugin source (manifest fields + release tags) backing the dashboard detail
+/// modal. Allowed in read-only mode; reads remote state and mutates nothing.
+pub async fn plugin_details(Query(query): Query<DetailsQuery>) -> Response {
+    match plugin::discover::details(&query.source).await {
+        Ok(detail) => Json(detail).into_response(),
+        Err(e) => error_response(StatusCode::BAD_GATEWAY, "details_failed", format!("{e:#}")),
+    }
+}
+
+#[derive(Deserialize)]
 pub struct PluginActionBody {
     /// The worker method to invoke (the plugin names it in its pane's action
     /// block, e.g. `github.refresh`).

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1509,6 +1509,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/plugins/ui-state", get(api::plugin_ui_state))
         .route("/api/plugins/updates", get(api::plugin_updates))
         .route("/api/plugins/discover", get(api::plugin_discover))
+        .route("/api/plugins/details", get(api::plugin_details))
         .route("/api/plugins/{id}/enabled", post(api::set_plugin_enabled))
         .route("/api/plugins/{id}/action", post(api::invoke_plugin_action))
         .route(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1186,6 +1186,11 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         host.start(&crate::plugin::registry()).await;
     }
 
+    // Opt-in clean-only plugin auto-update sweep (off by default). Spawned
+    // non-blocking so daemon startup never waits on git/network; freshly applied
+    // updates are picked up on the next daemon restart.
+    crate::plugin::auto_update::spawn_if_enabled(&crate::session::Config::load_or_warn());
+
     rate_limiter.spawn_cleanup_task(state.shutdown.clone());
     login_manager.spawn_cleanup_task(state.shutdown.clone());
 
@@ -1502,6 +1507,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         // elevation inside the handler.
         .route("/api/plugins", get(api::list_plugins))
         .route("/api/plugins/ui-state", get(api::plugin_ui_state))
+        .route("/api/plugins/updates", get(api::plugin_updates))
+        .route("/api/plugins/discover", get(api::plugin_discover))
         .route("/api/plugins/{id}/enabled", post(api::set_plugin_enabled))
         .route("/api/plugins/{id}/action", post(api::invoke_plugin_action))
         .route(

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1703,6 +1703,14 @@ pub struct UpdatesConfig {
     #[serde(default = "default_web_poll_interval_minutes")]
     #[setting(label = "Web Poll Interval (minutes)", widget = "number", min = 0)]
     pub web_poll_interval_minutes: u64,
+
+    /// Auto-update installed external plugins at TUI and `aoe serve` startup.
+    /// Off by default. The sweep applies only updates that need no new consent;
+    /// any version that changes capabilities, build steps, or UI slots is left
+    /// for a manual `aoe plugin update` so its new grant is reviewed.
+    #[serde(default)]
+    #[setting(label = "Auto-update plugins", widget = "toggle")]
+    pub auto_update_plugins: bool,
 }
 
 impl Default for UpdatesConfig {
@@ -1712,6 +1720,7 @@ impl Default for UpdatesConfig {
             check_interval_hours: 24,
             notify_in_cli: true,
             web_poll_interval_minutes: 60,
+            auto_update_plugins: false,
         }
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1708,8 +1708,11 @@ pub struct UpdatesConfig {
     /// Off by default. The sweep applies only updates that need no new consent;
     /// any version that changes capabilities, build steps, or UI slots is left
     /// for a manual `aoe plugin update` so its new grant is reviewed.
+    // global_only: the startup sweep reads the global config
+    // (`Config::load_or_warn`), so a profile/repo override would be silently
+    // ignored; show it but do not offer non-global scopes.
     #[serde(default)]
-    #[setting(label = "Auto-update plugins", widget = "toggle")]
+    #[setting(label = "Auto-update plugins", widget = "toggle", global_only)]
     pub auto_update_plugins: bool,
 }
 

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -4,12 +4,33 @@
 //! capability approval are CLI-driven (`aoe plugin install`); the TUI shows the
 //! resulting state but does not perform installs.
 
+use std::collections::HashMap;
+
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
+use tokio::sync::oneshot;
 
 use super::{centered_rect, DialogResult};
+use crate::plugin::discover::DiscoveryResult;
+use crate::plugin::update_check::UpdateStatus;
 use crate::tui::styles::Theme;
+
+/// Which view the manager is showing: the installed list or GitHub discovery
+/// results.
+#[derive(PartialEq, Eq)]
+enum Mode {
+    Browse,
+    Discover,
+}
+
+/// A network task running off the event loop, polled by [`PluginManagerDialog::tick`].
+/// The work runs on a spawned tokio task so the TUI never blocks on git or
+/// GitHub (a dead remote would otherwise freeze the whole UI).
+enum Pending {
+    Updates(oneshot::Receiver<Vec<UpdateStatus>>),
+    Discover(oneshot::Receiver<Result<Vec<DiscoveryResult>, String>>),
+}
 
 pub struct PluginManagerDialog {
     /// The shared manager view-model, the same shape the web dashboard renders
@@ -27,6 +48,17 @@ pub struct PluginManagerDialog {
     /// True when hosted inside the settings screen (vs the command-palette
     /// modal). Only changes the footer hint: Esc returns to the category list.
     embedded: bool,
+    mode: Mode,
+    /// An in-flight discovery / update-check task; `None` when idle.
+    pending: Option<Pending>,
+    /// A transient status line shown while a task runs ("Checking for updates…").
+    loading: Option<&'static str>,
+    /// Update statuses from the last `c` check, keyed by plugin id; drives the
+    /// per-row "update!" marker.
+    updates: HashMap<String, UpdateStatus>,
+    /// Discovery results from the last `d` search, plus the cursor into them.
+    discover_rows: Vec<DiscoveryResult>,
+    discover_selected: usize,
 }
 
 impl Default for PluginManagerDialog {
@@ -45,6 +77,12 @@ impl PluginManagerDialog {
             info: None,
             mutated: false,
             embedded: false,
+            mode: Mode::Browse,
+            pending: None,
+            loading: None,
+            updates: HashMap::new(),
+            discover_rows: Vec::new(),
+            discover_selected: 0,
         };
         dialog.reload();
         dialog.mutated = false; // Initial load is not a user mutation.
@@ -79,6 +117,9 @@ impl PluginManagerDialog {
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         self.info = None;
+        if self.mode == Mode::Discover {
+            return self.handle_discover_key(key);
+        }
         match key.code {
             KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
             KeyCode::Down | KeyCode::Char('j') => {
@@ -108,7 +149,136 @@ impl PluginManagerDialog {
                 }
                 DialogResult::Continue
             }
+            // Explicit, on-demand network actions. They run off the event loop
+            // (see `tick`); a second press while one is in flight is ignored.
+            KeyCode::Char('c') => {
+                self.start_update_check();
+                DialogResult::Continue
+            }
+            KeyCode::Char('d') => {
+                self.start_discover();
+                DialogResult::Continue
+            }
             _ => DialogResult::Continue,
+        }
+    }
+
+    fn handle_discover_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        match key.code {
+            // Esc/q leave discovery for the installed list, not the whole dialog.
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = Mode::Browse;
+                DialogResult::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.discover_rows.is_empty() {
+                    self.discover_selected =
+                        (self.discover_selected + 1).min(self.discover_rows.len() - 1);
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.discover_selected = self.discover_selected.saturating_sub(1);
+                DialogResult::Continue
+            }
+            // The dashboard/TUI have no install path (capability approval needs a
+            // terminal prompt); show the command to run instead.
+            KeyCode::Enter => {
+                if let Some(r) = self.discover_rows.get(self.discover_selected) {
+                    self.info = Some(format!("Install with: {}", r.install_command));
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Char('d') => {
+                self.start_discover();
+                DialogResult::Continue
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    fn start_update_check(&mut self) {
+        if self.pending.is_some() {
+            return;
+        }
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = tx.send(crate::plugin::update_check::outdated().await);
+        });
+        self.pending = Some(Pending::Updates(rx));
+        self.loading = Some("Checking for updates…");
+        self.error = None;
+    }
+
+    fn start_discover(&mut self) {
+        if self.pending.is_some() {
+            return;
+        }
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let result = crate::plugin::discover::discover(None)
+                .await
+                .map_err(|e| format!("{e:#}"));
+            let _ = tx.send(result);
+        });
+        self.pending = Some(Pending::Discover(rx));
+        self.loading = Some("Searching GitHub…");
+        self.error = None;
+    }
+
+    /// Poll an in-flight discovery / update-check task. Returns true when the
+    /// result landed (the host should redraw). Called from the event-loop tick.
+    pub fn tick(&mut self) -> bool {
+        use oneshot::error::TryRecvError;
+        let Some(pending) = &mut self.pending else {
+            return false;
+        };
+        match pending {
+            Pending::Updates(rx) => match rx.try_recv() {
+                Ok(statuses) => {
+                    let outdated = statuses.iter().filter(|s| s.needs_update).count();
+                    let errors = statuses.iter().filter(|s| s.error.is_some()).count();
+                    self.updates = statuses.into_iter().map(|s| (s.id.clone(), s)).collect();
+                    self.info = Some(match (outdated, errors) {
+                        (0, 0) => "All plugins up to date.".to_string(),
+                        (n, 0) => format!("{n} plugin(s) have updates available."),
+                        (n, e) => format!("{n} update(s) available, {e} check error(s)."),
+                    });
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.error = Some("Update check failed.".to_string());
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+            },
+            Pending::Discover(rx) => match rx.try_recv() {
+                Ok(Ok(results)) => {
+                    self.discover_rows = results;
+                    self.discover_selected = 0;
+                    self.mode = Mode::Discover;
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+                Ok(Err(message)) => {
+                    self.error = Some(message);
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.error = Some("Discovery failed.".to_string());
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+            },
         }
     }
 
@@ -171,6 +341,12 @@ impl PluginManagerDialog {
             ])
             .split(area);
 
+        if self.mode == Mode::Discover {
+            self.render_discover_list(f, chunks[0], theme);
+            self.render_footer(f, chunks[2], theme);
+            return;
+        }
+
         let items: Vec<ListItem> = self
             .rows
             .iter()
@@ -195,6 +371,10 @@ impl PluginManagerDialog {
                     ),
                     Span::styled(format!("{:<14}", state.0), Style::default().fg(state.1)),
                 ];
+                // Mark a row whose last `c` check found a newer version.
+                if self.updates.get(&row.id).is_some_and(|u| u.needs_update) {
+                    spans.push(Span::styled("update! ", Style::default().fg(theme.accent)));
+                }
                 // Disclose the dashboard UI slots the plugin renders into, so the
                 // manager shows that a plugin modifies the UI (#2366). Distinct
                 // slot names only; ids are in `aoe plugin info`.
@@ -235,22 +415,78 @@ impl PluginManagerDialog {
             f.render_widget(errors, chunks[1]);
         }
 
-        let status = self
-            .error
-            .as_deref()
-            .map(|e| (e, theme.error))
-            .or(self.info.as_deref().map(|i| (i, theme.running)));
-        let footer = match status {
-            Some((message, color)) => Paragraph::new(message.to_string())
-                .style(Style::default().fg(color))
-                .wrap(Wrap { trim: true }),
-            None => Paragraph::new(if self.embedded {
-                "space/enter toggle · esc back"
-            } else {
-                "space/enter toggle · esc close"
+        self.render_footer(f, chunks[2], theme);
+    }
+
+    fn render_discover_list(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+        if self.discover_rows.is_empty() {
+            let empty = Paragraph::new("No plugins found on the aoe-plugin topic.")
+                .style(Style::default().fg(theme.dimmed));
+            f.render_widget(empty, area);
+            return;
+        }
+        let items: Vec<ListItem> = self
+            .discover_rows
+            .iter()
+            .map(|r| {
+                let spans = vec![
+                    Span::styled(
+                        format!("{:<10}", r.badge.as_str()),
+                        Style::default().fg(theme.accent),
+                    ),
+                    Span::styled(
+                        format!("{:<6}", format!("★{}", r.stars)),
+                        Style::default().fg(theme.dimmed),
+                    ),
+                    Span::styled(format!("{:<30}", r.slug), Style::default().fg(theme.text)),
+                    Span::styled(
+                        r.description.clone().unwrap_or_default(),
+                        Style::default().fg(theme.dimmed),
+                    ),
+                ];
+                ListItem::new(Line::from(spans))
             })
-            .style(Style::default().fg(theme.dimmed)),
+            .collect();
+        let list = List::new(items)
+            .highlight_style(
+                Style::default()
+                    .bg(theme.selection)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("> ");
+        let mut state = ListState::default();
+        state.select(Some(self.discover_selected));
+        f.render_stateful_widget(list, area, &mut state);
+    }
+
+    fn render_footer(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+        // A running task wins the footer; then a transient error/info; then the
+        // mode-appropriate key hints.
+        let (text, color) = if let Some(loading) = self.loading {
+            (loading.to_string(), theme.waiting)
+        } else if let Some(e) = self.error.as_deref() {
+            (e.to_string(), theme.error)
+        } else if let Some(i) = self.info.as_deref() {
+            (i.to_string(), theme.running)
+        } else if self.mode == Mode::Discover {
+            (
+                "enter: install command · d: re-search · esc: back".to_string(),
+                theme.dimmed,
+            )
+        } else {
+            let back = if self.embedded {
+                "esc back"
+            } else {
+                "esc close"
+            };
+            (
+                format!("space toggle · c check updates · d discover · {back}"),
+                theme.dimmed,
+            )
         };
-        f.render_widget(footer, chunks[2]);
+        let footer = Paragraph::new(text)
+            .style(Style::default().fg(color))
+            .wrap(Wrap { trim: true });
+        f.render_widget(footer, area);
     }
 }

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -238,11 +238,20 @@ impl PluginManagerDialog {
                 Ok(statuses) => {
                     let outdated = statuses.iter().filter(|s| s.needs_update).count();
                     let errors = statuses.iter().filter(|s| s.error.is_some()).count();
+                    // outdated() skips builtins, so an empty result means there
+                    // are no external plugins; the dialog still lists builtin
+                    // rows, so "all up to date" would read as if they were
+                    // checked. Match the CLI's wording instead.
+                    let empty = statuses.is_empty();
                     self.updates = statuses.into_iter().map(|s| (s.id.clone(), s)).collect();
-                    self.info = Some(match (outdated, errors) {
-                        (0, 0) => "All plugins up to date.".to_string(),
-                        (n, 0) => format!("{n} plugin(s) have updates available."),
-                        (n, e) => format!("{n} update(s) available, {e} check error(s)."),
+                    self.info = Some(if empty {
+                        "No external plugins installed.".to_string()
+                    } else {
+                        match (outdated, errors) {
+                            (0, 0) => "All plugins up to date.".to_string(),
+                            (n, 0) => format!("{n} plugin(s) have updates available."),
+                            (n, e) => format!("{n} update(s) available, {e} check error(s)."),
+                        }
                     });
                     self.pending = None;
                     self.loading = None;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3599,6 +3599,13 @@ impl HomeView {
             }
         }
 
+        // Poll the plugin manager's in-flight discovery / update-check task.
+        if let Some(dialog) = &mut self.plugin_manager_dialog {
+            if dialog.tick() {
+                changed = true;
+            }
+        }
+
         // Drain hook progress into the creating buffer when no dialog is open
         if self.new_dialog.is_none() {
             if let Some(ref stub_id) = self.creating_stub_id {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -227,6 +227,11 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
         }
     }
 
+    // Opt-in clean-only plugin auto-update sweep (off by default). Spawned
+    // non-blocking so a slow remote or git never delays the TUI; applied updates
+    // take effect on the next launch.
+    crate::plugin::auto_update::spawn_if_enabled(&crate::session::Config::load_or_warn());
+
     // Bail early if stdin is not a terminal. Running without a tty would
     // cause the event loop to busy-loop after the parent terminal dies.
     if !io::stdin().is_terminal() {

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -718,14 +718,18 @@ impl SettingsView {
     /// toast was cleared so the caller can request a redraw. Errors are sticky
     /// (no expiry) and clear only on the next keypress.
     pub fn tick_status(&mut self) -> bool {
-        match self.success_message_expires_at {
+        // Poll the embedded plugin manager's in-flight discovery / update-check
+        // task so its results land without waiting for the next keypress.
+        let plugin_changed = self.plugin_manager.tick();
+        let toast_changed = match self.success_message_expires_at {
             Some(expires_at) if std::time::Instant::now() >= expires_at => {
                 self.success_message = None;
                 self.success_message_expires_at = None;
                 true
             }
             _ => false,
-        }
+        };
+        plugin_changed || toast_changed
     }
 
     /// Check if currently in an editing state (text field, list, dialog, etc.)

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -6,9 +6,10 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use agent_of_empires::plugin::install;
+use agent_of_empires::plugin::install::{self, UpdateOutcome};
 use agent_of_empires::plugin::lockfile::Lockfile;
 use agent_of_empires::plugin::registry::PluginRegistry;
+use agent_of_empires::plugin::{auto_update, update_check};
 use agent_of_empires::session::Config;
 use serial_test::serial;
 use tempfile::TempDir;
@@ -75,6 +76,19 @@ fn make_bare_repo(base: &Path, owner: &str, repo: &str, files: &[(&str, &str)]) 
         base,
     );
     std::env::set_var("AOE_GITHUB_CLONE_BASE", base);
+}
+
+/// Add a commit to the working tree behind a bare repo and push it, advancing
+/// the remote `main` so an `ls-remote` check sees a newer commit.
+fn push_new_commit(base: &Path, owner: &str, repo: &str, files: &[(&str, &str)]) {
+    let work = base.join("work");
+    for (name, contents) in files {
+        std::fs::write(work.join(name), contents).unwrap();
+    }
+    git(&["add", "."], &work);
+    git(&["commit", "-q", "-m", "update"], &work);
+    let bare = base.join(owner).join(format!("{repo}.git"));
+    git(&["push", "-q", bare.to_str().unwrap(), "main"], &work);
 }
 
 #[tokio::test]
@@ -716,4 +730,126 @@ command = ["cp", "aoe-plugin.toml", "marker-v2"]
             .version,
         "0.1.0"
     );
+}
+
+const PLAIN_MANIFEST: &str = r#"
+id = "acme.upd"
+name = "Upd"
+version = "1.0.0"
+api_version = 2
+"#;
+
+#[tokio::test]
+#[serial]
+async fn outdated_detects_new_github_commit() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", PLAIN_MANIFEST)],
+    );
+    install::install("gh:acme/upd", true).await.unwrap();
+
+    let before = update_check::outdated().await;
+    let s = before.iter().find(|s| s.id == "acme.upd").expect("present");
+    assert!(!s.needs_update, "fresh install is current: {s:?}");
+    assert!(s.error.is_none(), "no check error: {s:?}");
+
+    // Advance the remote; the same manifest stays so it is a clean update.
+    push_new_commit(base.path(), "acme", "upd", &[("extra.txt", "new")]);
+    let after = update_check::outdated().await;
+    let s = after.iter().find(|s| s.id == "acme.upd").expect("present");
+    assert!(s.needs_update, "new commit detected: {s:?}");
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn outdated_detects_changed_local_tree() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(src.path(), PLAIN_MANIFEST);
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    let before = update_check::outdated().await;
+    assert!(
+        !before
+            .iter()
+            .find(|s| s.id == "acme.upd")
+            .unwrap()
+            .needs_update
+    );
+
+    // Edit the local source tree; the re-hash should diverge from the lock.
+    std::fs::write(dir.join("added.txt"), "changed").unwrap();
+    let after = update_check::outdated().await;
+    let s = after.iter().find(|s| s.id == "acme.upd").expect("present");
+    assert!(s.needs_update, "local tree change detected: {s:?}");
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_update_applies_clean_github_update() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    let v2 = PLAIN_MANIFEST.replace("1.0.0", "2.0.0");
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", PLAIN_MANIFEST)],
+    );
+    install::install("gh:acme/upd", true).await.unwrap();
+
+    // A clean (no consent change) newer version on the remote.
+    push_new_commit(base.path(), "acme", "upd", &[("aoe-plugin.toml", &v2)]);
+    let summary = auto_update::sweep().await;
+    assert_eq!(summary.applied, vec!["acme.upd".to_string()], "{summary:?}");
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "2.0.0",
+    );
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn clean_update_skips_capability_change() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    let with_cap = PLAIN_MANIFEST.replace(
+        "api_version = 2",
+        "api_version = 2\ncapabilities = [\"net\"]",
+    );
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", PLAIN_MANIFEST)],
+    );
+    install::install("gh:acme/upd", true).await.unwrap();
+
+    // The new version adds a capability, so a non-interactive clean update must
+    // skip it and leave the prior version installed.
+    push_new_commit(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", &with_cap)],
+    );
+    match install::update_clean("acme.upd").await.unwrap() {
+        UpdateOutcome::Skipped { id, .. } => assert_eq!(id, "acme.upd"),
+        other => panic!("expected skip on capability change, got {other:?}"),
+    }
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "1.0.0",
+        "prior version kept",
+    );
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
 }

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -821,7 +821,9 @@ async fn auto_update_applies_clean_github_update() {
 async fn clean_update_skips_capability_change() {
     let _home = isolate();
     let base = tempfile::tempdir().unwrap();
-    let with_cap = PLAIN_MANIFEST.replace(
+    // Bump the version too, so the "prior version kept" assertion actually
+    // proves nothing was rewritten (a same-version skip could pass vacuously).
+    let with_cap = PLAIN_MANIFEST.replace("1.0.0", "2.0.0").replace(
         "api_version = 2",
         "api_version = 2\ncapabilities = [\"net\"]",
     );

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+
+import { fetchPluginDetails, type PluginDetail } from "../../lib/api";
+
+interface Fallback {
+  version?: string;
+  description?: string;
+  capabilities?: string[];
+  ui_contributions?: { slot: string; id: string }[];
+}
+
+interface PluginDetailModalProps {
+  /** gh:owner/repo or a local path. Remote detail (manifest + release tags) is
+   *  only fetched for a gh source; a local plugin shows the fallback only. */
+  source: string;
+  /** Name shown in the header immediately, before any fetch resolves. */
+  title: string;
+  /** Already-known fields (an installed plugin's view) shown while the fetch is
+   *  in flight and for a non-gh source. */
+  fallback?: Fallback;
+  /** Shown for a discovery result so the user can copy the install command. */
+  installCommand?: string;
+  onClose: () => void;
+}
+
+/// A modal showing one plugin's detail: version, description, capabilities, UI
+/// slots, and the available release versions. Opened from a discovery result or
+/// an installed-plugin row. For a gh source it fetches the live manifest +
+/// release tags; for a local source it renders the passed-in fallback fields.
+/// Screenshots and richer metadata are a future addition.
+export function PluginDetailModal({ source, title, fallback, installCommand, onClose }: PluginDetailModalProps) {
+  const isGithub = source.startsWith("gh:");
+  const [detail, setDetail] = useState<PluginDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Derived, not stored: avoids a synchronous setState in the effect. The modal
+  // is remounted per source (keyed at the call site), so this resets each open.
+  const loading = isGithub && !detail && !error;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!isGithub) return;
+    let cancelled = false;
+    void fetchPluginDetails(source).then((res) => {
+      if (cancelled) return;
+      if (res.kind === "ok") {
+        setDetail(res.detail);
+      } else {
+        setError(res.message);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [source, isGithub]);
+
+  const manifest = detail?.manifest ?? null;
+  const version = manifest?.version ?? fallback?.version ?? null;
+  const description = manifest?.description ?? fallback?.description ?? null;
+  const capabilities = manifest?.capabilities ?? fallback?.capabilities ?? [];
+  const ui = manifest?.ui_contributions ?? fallback?.ui_contributions ?? [];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${title} details`}
+      onClick={onClose}
+      data-testid="plugin-detail-modal"
+    >
+      <div
+        className="max-h-[80vh] w-full max-w-lg overflow-auto rounded border border-surface-700 bg-surface-900 p-4 text-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="font-semibold">{title}</h2>
+            {version && <p className="text-xs text-text-dim">v{version}</p>}
+            <p className="text-[11px] text-text-dim">{source}</p>
+          </div>
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-2 py-0.5 text-xs hover:bg-surface-800"
+            onClick={onClose}
+            data-testid="plugin-detail-close"
+          >
+            Close
+          </button>
+        </div>
+
+        {loading && <p className="text-xs text-text-dim">Loading details…</p>}
+        {error && (
+          <p className="text-xs text-status-error" data-testid="plugin-detail-error">
+            {error}
+          </p>
+        )}
+
+        {description && <p className="mb-3 text-text-dim">{description}</p>}
+
+        {capabilities.length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Capabilities</p>
+            <p className="text-xs text-text-dim">{capabilities.join(", ")}</p>
+          </div>
+        )}
+
+        {ui.length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">UI slots</p>
+            <p className="text-xs text-text-dim">{[...new Set(ui.map((u) => u.slot))].join(", ")}</p>
+          </div>
+        )}
+
+        {manifest?.api_version != null && (
+          <p className="mb-3 text-[11px] text-text-dim">Manifest api_version: {manifest.api_version}</p>
+        )}
+
+        {detail?.manifest_error && (
+          <p className="mb-3 text-[11px] text-status-warning">Manifest: {detail.manifest_error}</p>
+        )}
+
+        {isGithub && (
+          <div className="mb-3" data-testid="plugin-detail-versions">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Available versions</p>
+            {detail && detail.release_tags.length > 0 ? (
+              <ul className="flex flex-wrap gap-1">
+                {detail.release_tags.map((tag) => (
+                  <li key={tag} className="rounded bg-surface-800 px-1.5 py-0.5 text-[11px] text-text-dim">
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              !loading && <p className="text-xs text-text-dim">No published releases.</p>
+            )}
+          </div>
+        )}
+
+        {installCommand && (
+          <p className="text-[11px] text-text-dim">
+            Install in a terminal: <code>{installCommand}</code>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -138,7 +138,9 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
                 ))}
               </ul>
             ) : (
-              !loading && <p className="text-xs text-text-dim">No published releases.</p>
+              // Only claim "no releases" after a successful fetch; a transport
+              // error already shows above and must not read as zero releases.
+              !loading && !error && <p className="text-xs text-text-dim">No published releases.</p>
             )}
           </div>
         )}

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { fetchPlugins, setPluginEnabled, type PluginListResponse, type PluginView } from "../../lib/api";
+import {
+  discoverPlugins,
+  fetchPluginUpdates,
+  fetchPlugins,
+  setPluginEnabled,
+  type PluginDiscoveryResult,
+  type PluginListResponse,
+  type PluginUpdateStatus,
+  type PluginView,
+} from "../../lib/api";
 import { reportInfo } from "../../lib/toastBus";
 
 /// Plugin management: list every known plugin (name, version, description,
@@ -16,6 +25,16 @@ export function PluginsSettings() {
   const [data, setData] = useState<PluginListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // Update checks (on-demand, never auto). Keyed by plugin id.
+  const [updates, setUpdates] = useState<Record<string, PluginUpdateStatus>>({});
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+
+  // GitHub discovery (browse-only; install is CLI).
+  const [discoverQuery, setDiscoverQuery] = useState("");
+  const [discoverResults, setDiscoverResults] = useState<PluginDiscoveryResult[] | null>(null);
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const [discovering, setDiscovering] = useState(false);
 
   const reload = useCallback(async () => {
     const next = await fetchPlugins();
@@ -61,6 +80,33 @@ export function PluginsSettings() {
     }
   };
 
+  const onCheckUpdates = async () => {
+    setCheckingUpdates(true);
+    try {
+      const res = await fetchPluginUpdates();
+      if (res) {
+        const next: Record<string, PluginUpdateStatus> = {};
+        for (const s of res.updates) next[s.id] = s;
+        setUpdates(next);
+      }
+    } finally {
+      setCheckingUpdates(false);
+    }
+  };
+
+  const onDiscover = async () => {
+    setDiscovering(true);
+    setDiscoverError(null);
+    const res = await discoverPlugins(discoverQuery);
+    if (res.kind === "ok") {
+      setDiscoverResults(res.results);
+    } else {
+      setDiscoverResults(null);
+      setDiscoverError(res.message);
+    }
+    setDiscovering(false);
+  };
+
   if (!data && !error) {
     return <p className="text-sm text-text-dim">Loading plugins…</p>;
   }
@@ -78,70 +124,163 @@ export function PluginsSettings() {
         </div>
       )}
 
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="rounded border border-surface-700 px-2 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
+          disabled={checkingUpdates}
+          onClick={() => void onCheckUpdates()}
+          data-testid="plugins-check-updates"
+        >
+          {checkingUpdates ? "Checking…" : "Check for updates"}
+        </button>
+        <input
+          type="search"
+          value={discoverQuery}
+          onChange={(e) => setDiscoverQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void onDiscover();
+          }}
+          placeholder="Search GitHub (aoe-plugin topic)…"
+          className="min-w-0 flex-1 rounded border border-surface-700 bg-surface-850 px-2 py-1 text-xs"
+          data-testid="plugins-discover-query"
+        />
+        <button
+          type="button"
+          className="rounded border border-surface-700 px-2 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
+          disabled={discovering}
+          onClick={() => void onDiscover()}
+          data-testid="plugins-discover"
+        >
+          {discovering ? "Searching…" : "Search GitHub"}
+        </button>
+      </div>
+
+      {discoverError && (
+        <p className="text-xs text-status-error" data-testid="plugins-discover-error">
+          {discoverError}
+        </p>
+      )}
+
+      {discoverResults && (
+        <div className="space-y-2" data-testid="plugins-discover-results">
+          {discoverResults.length === 0 ? (
+            <p className="text-xs text-text-dim">No plugins found on the aoe-plugin topic.</p>
+          ) : (
+            discoverResults.map((r) => (
+              <div
+                key={r.slug}
+                className="rounded border border-surface-700 bg-surface-850 p-2 text-xs"
+                data-testid={`plugins-discover-result-${r.slug}`}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <a
+                    href={r.html_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium text-accent-400 hover:underline"
+                  >
+                    {r.slug}
+                  </a>
+                  <span className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500">
+                    {r.badge}
+                  </span>
+                  <span className="text-text-dim">★ {r.stars}</span>
+                </div>
+                {r.description && <p className="mt-1 text-text-dim">{r.description}</p>}
+                <p className="mt-1 text-text-dim">
+                  Install in a terminal: <code>{r.install_command}</code>
+                </p>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
       <div className="space-y-3">
         {data && data.plugins.length === 0 && (
           <p className="text-xs text-text-dim" data-testid="plugins-empty">
             No plugins detected.
           </p>
         )}
-        {data?.plugins.map((plugin) => (
-          <div
-            key={plugin.id}
-            className="rounded border border-surface-700 bg-surface-850 p-3"
-            data-testid={`plugin-${plugin.id}`}
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-medium">{plugin.name}</span>
-                  <span className="text-xs text-text-dim">v{plugin.version}</span>
-                  <span
-                    className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
-                    data-testid={`plugin-validation-${plugin.id}`}
-                  >
-                    {plugin.validation}
-                  </span>
-                  {plugin.needs_reapproval && (
+        {data?.plugins.map((plugin) => {
+          const update = updates[plugin.id];
+          return (
+            <div
+              key={plugin.id}
+              className="rounded border border-surface-700 bg-surface-850 p-3"
+              data-testid={`plugin-${plugin.id}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{plugin.name}</span>
+                    <span className="text-xs text-text-dim">v{plugin.version}</span>
                     <span
-                      className="rounded bg-status-warning/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-warning"
-                      data-testid={`plugin-needs-approval-${plugin.id}`}
+                      className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
+                      data-testid={`plugin-validation-${plugin.id}`}
                     >
-                      needs approval
+                      {plugin.validation}
                     </span>
+                    {plugin.needs_reapproval && (
+                      <span
+                        className="rounded bg-status-warning/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-warning"
+                        data-testid={`plugin-needs-approval-${plugin.id}`}
+                      >
+                        needs approval
+                      </span>
+                    )}
+                    {update?.needs_update && (
+                      <span
+                        className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
+                        data-testid={`plugin-update-available-${plugin.id}`}
+                      >
+                        update available
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-text-dim">{plugin.description}</p>
+                  {plugin.capabilities.length > 0 && (
+                    <p className="mt-1 text-[11px] text-text-dim">
+                      Capabilities: {plugin.capabilities.join(", ")}
+                      {plugin.granted ? "" : " (not granted)"}
+                    </p>
+                  )}
+                  {(plugin.ui_contributions ?? []).length > 0 && (
+                    <p className="mt-1 text-[11px] text-text-dim">
+                      UI: {[...new Set((plugin.ui_contributions ?? []).map((u) => u.slot))].join(", ")}
+                    </p>
+                  )}
+                  {plugin.needs_reapproval && (
+                    <p className="mt-1 text-[11px] text-status-warning">
+                      Installed but inactive. Re-approve with <code>aoe plugin update {plugin.id}</code>.
+                    </p>
+                  )}
+                  {update?.needs_update && (
+                    <p className="mt-1 text-[11px] text-text-dim">
+                      Update available ({update.current} → {update.available ?? "modified"}). Update with{" "}
+                      <code>aoe plugin update {plugin.id}</code>.
+                    </p>
+                  )}
+                  {update?.error && (
+                    <p className="mt-1 text-[11px] text-status-error">Update check failed: {update.error}</p>
                   )}
                 </div>
-                <p className="mt-1 text-xs text-text-dim">{plugin.description}</p>
-                {plugin.capabilities.length > 0 && (
-                  <p className="mt-1 text-[11px] text-text-dim">
-                    Capabilities: {plugin.capabilities.join(", ")}
-                    {plugin.granted ? "" : " (not granted)"}
-                  </p>
-                )}
-                {(plugin.ui_contributions ?? []).length > 0 && (
-                  <p className="mt-1 text-[11px] text-text-dim">
-                    UI: {[...new Set((plugin.ui_contributions ?? []).map((u) => u.slot))].join(", ")}
-                  </p>
-                )}
-                {plugin.needs_reapproval && (
-                  <p className="mt-1 text-[11px] text-status-warning">
-                    Installed but inactive. Re-approve with <code>aoe plugin update {plugin.id}</code>.
-                  </p>
-                )}
+                <label className="flex shrink-0 items-center gap-1 text-xs">
+                  <input
+                    type="checkbox"
+                    role="switch"
+                    aria-label={`Enable ${plugin.name}`}
+                    checked={plugin.enabled}
+                    disabled={busy}
+                    onChange={(e) => void onToggle(plugin, e.target.checked)}
+                  />
+                  Enabled
+                </label>
               </div>
-              <label className="flex shrink-0 items-center gap-1 text-xs">
-                <input
-                  type="checkbox"
-                  role="switch"
-                  aria-label={`Enable ${plugin.name}`}
-                  checked={plugin.enabled}
-                  disabled={busy}
-                  onChange={(e) => void onToggle(plugin, e.target.checked)}
-                />
-                Enabled
-              </label>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -52,6 +52,10 @@ export function PluginsSettings() {
   // The plugin whose detail modal is open (null = closed).
   const [detail, setDetail] = useState<DetailTarget | null>(null);
 
+  // Two tabs, JetBrains-style: manage installed plugins vs browse the
+  // marketplace (GitHub discovery).
+  const [tab, setTab] = useState<"installed" | "marketplace">("installed");
+
   const reload = useCallback(async () => {
     const next = await fetchPlugins();
     if (next) {
@@ -135,196 +139,221 @@ export function PluginsSettings() {
 
   return (
     <div className="space-y-4">
-      {error && <p className="text-sm text-status-error">{error}</p>}
-
-      {data && data.load_errors.length > 0 && (
-        <div className="rounded border border-status-warning bg-status-warning/10 p-3 text-xs text-status-warning">
-          <p className="mb-1 font-semibold">Plugin load problems</p>
-          {data.load_errors.map((e) => (
-            <p key={e}>{e}</p>
-          ))}
-        </div>
-      )}
-
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          className="rounded border border-surface-700 px-2 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
-          disabled={checkingUpdates}
-          onClick={() => void onCheckUpdates()}
-          data-testid="plugins-check-updates"
-        >
-          {checkingUpdates ? "Checking…" : "Check for updates"}
-        </button>
-        <input
-          type="search"
-          value={discoverQuery}
-          onChange={(e) => setDiscoverQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") void onDiscover();
-          }}
-          placeholder="Search GitHub (aoe-plugin topic)…"
-          className="min-w-0 flex-1 rounded border border-surface-700 bg-surface-850 px-2 py-1 text-xs"
-          data-testid="plugins-discover-query"
-        />
-        <button
-          type="button"
-          className="rounded border border-surface-700 px-2 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
-          disabled={discovering}
-          onClick={() => void onDiscover()}
-          data-testid="plugins-discover"
-        >
-          {discovering ? "Searching…" : "Search GitHub"}
-        </button>
+      <div role="tablist" className="flex gap-1 border-b border-surface-700">
+        {(["installed", "marketplace"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            data-testid={`plugins-tab-${t}`}
+            className={`px-3 py-1.5 text-xs capitalize ${
+              tab === t ? "border-b-2 border-accent-500 font-medium text-accent-500" : "text-text-dim"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
       </div>
 
-      {discoverError && (
-        <p className="text-xs text-status-error" data-testid="plugins-discover-error">
-          {discoverError}
-        </p>
-      )}
+      {tab === "marketplace" && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="search"
+              value={discoverQuery}
+              onChange={(e) => setDiscoverQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void onDiscover();
+              }}
+              placeholder="Search GitHub (aoe-plugin topic)…"
+              className="min-w-0 flex-1 rounded border border-surface-700 bg-surface-850 px-2 py-1 text-xs"
+              data-testid="plugins-discover-query"
+            />
+            <button
+              type="button"
+              className="rounded border border-surface-700 px-2 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
+              disabled={discovering}
+              onClick={() => void onDiscover()}
+              data-testid="plugins-discover"
+            >
+              {discovering ? "Searching…" : "Search GitHub"}
+            </button>
+          </div>
 
-      {discoverResults && (
-        <div className="space-y-2" data-testid="plugins-discover-results">
-          {discoverResults.length === 0 ? (
-            <p className="text-xs text-text-dim">No plugins found on the aoe-plugin topic.</p>
-          ) : (
-            discoverResults.map((r) => (
-              <div
-                key={r.slug}
-                className="rounded border border-surface-700 bg-surface-850 p-2 text-xs"
-                data-testid={`plugins-discover-result-${r.slug}`}
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    className="font-medium text-accent-500 hover:underline"
-                    onClick={() => setDetail({ source: r.slug, title: r.slug, installCommand: r.install_command })}
-                    data-testid={`plugins-discover-open-${r.slug}`}
+          {discoverError && (
+            <p className="text-xs text-status-error" data-testid="plugins-discover-error">
+              {discoverError}
+            </p>
+          )}
+
+          {discoverResults && (
+            <div className="space-y-2" data-testid="plugins-discover-results">
+              {discoverResults.length === 0 ? (
+                <p className="text-xs text-text-dim">No plugins found on the aoe-plugin topic.</p>
+              ) : (
+                discoverResults.map((r) => (
+                  <div
+                    key={r.slug}
+                    className="rounded border border-surface-700 bg-surface-850 p-2 text-xs"
+                    data-testid={`plugins-discover-result-${r.slug}`}
                   >
-                    {r.slug}
-                  </button>
-                  <span className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500">
-                    {r.badge}
-                  </span>
-                  <span className="text-text-dim">★ {r.stars}</span>
-                  <a href={r.html_url} target="_blank" rel="noreferrer" className="text-text-dim hover:underline">
-                    GitHub ↗
-                  </a>
-                </div>
-                {r.description && <p className="mt-1 text-text-dim">{r.description}</p>}
-                <p className="mt-1 text-text-dim">
-                  Install in a terminal: <code>{r.install_command}</code>
-                </p>
-              </div>
-            ))
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        className="font-medium text-accent-500 hover:underline"
+                        onClick={() => setDetail({ source: r.slug, title: r.slug, installCommand: r.install_command })}
+                        data-testid={`plugins-discover-open-${r.slug}`}
+                      >
+                        {r.slug}
+                      </button>
+                      <span className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500">
+                        {r.badge}
+                      </span>
+                      <span className="text-text-dim">★ {r.stars}</span>
+                      <a href={r.html_url} target="_blank" rel="noreferrer" className="text-text-dim hover:underline">
+                        GitHub ↗
+                      </a>
+                    </div>
+                    {r.description && <p className="mt-1 text-text-dim">{r.description}</p>}
+                    <p className="mt-1 text-text-dim">
+                      Install in a terminal: <code>{r.install_command}</code>
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
           )}
         </div>
       )}
 
-      <div className="space-y-3">
-        {data && data.plugins.length === 0 && (
-          <p className="text-xs text-text-dim" data-testid="plugins-empty">
-            No plugins detected.
-          </p>
-        )}
-        {data?.plugins.map((plugin) => {
-          const update = updates[plugin.id];
-          return (
-            <div
-              key={plugin.id}
-              className="rounded border border-surface-700 bg-surface-850 p-3"
-              data-testid={`plugin-${plugin.id}`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <button
-                      type="button"
-                      className="font-medium hover:underline"
-                      onClick={() =>
-                        setDetail({
-                          source: plugin.source ?? "",
-                          title: plugin.name,
-                          fallback: {
-                            version: plugin.version,
-                            description: plugin.description,
-                            capabilities: plugin.capabilities,
-                            ui_contributions: plugin.ui_contributions,
-                          },
-                        })
-                      }
-                      data-testid={`plugin-open-${plugin.id}`}
-                    >
-                      {plugin.name}
-                    </button>
-                    <span className="text-xs text-text-dim">v{plugin.version}</span>
-                    <span
-                      className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
-                      data-testid={`plugin-validation-${plugin.id}`}
-                    >
-                      {plugin.validation}
-                    </span>
-                    {plugin.needs_reapproval && (
-                      <span
-                        className="rounded bg-status-warning/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-warning"
-                        data-testid={`plugin-needs-approval-${plugin.id}`}
+      {tab === "installed" && (
+        <div className="space-y-3">
+          {error && <p className="text-sm text-status-error">{error}</p>}
+
+          {data && data.load_errors.length > 0 && (
+            <div className="rounded border border-status-warning bg-status-warning/10 p-3 text-xs text-status-warning">
+              <p className="mb-1 font-semibold">Plugin load problems</p>
+              {data.load_errors.map((e) => (
+                <p key={e}>{e}</p>
+              ))}
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-2 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
+            disabled={checkingUpdates}
+            onClick={() => void onCheckUpdates()}
+            data-testid="plugins-check-updates"
+          >
+            {checkingUpdates ? "Checking…" : "Check for updates"}
+          </button>
+
+          {data && data.plugins.length === 0 && (
+            <p className="text-xs text-text-dim" data-testid="plugins-empty">
+              No plugins detected.
+            </p>
+          )}
+          {data?.plugins.map((plugin) => {
+            const update = updates[plugin.id];
+            return (
+              <div
+                key={plugin.id}
+                className="rounded border border-surface-700 bg-surface-850 p-3"
+                data-testid={`plugin-${plugin.id}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        className="font-medium hover:underline"
+                        onClick={() =>
+                          setDetail({
+                            source: plugin.source ?? "",
+                            title: plugin.name,
+                            fallback: {
+                              version: plugin.version,
+                              description: plugin.description,
+                              capabilities: plugin.capabilities,
+                              ui_contributions: plugin.ui_contributions,
+                            },
+                          })
+                        }
+                        data-testid={`plugin-open-${plugin.id}`}
                       >
-                        needs approval
-                      </span>
-                    )}
-                    {update?.needs_update && (
+                        {plugin.name}
+                      </button>
+                      <span className="text-xs text-text-dim">v{plugin.version}</span>
                       <span
                         className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
-                        data-testid={`plugin-update-available-${plugin.id}`}
+                        data-testid={`plugin-validation-${plugin.id}`}
                       >
-                        update available
+                        {plugin.validation}
                       </span>
+                      {plugin.needs_reapproval && (
+                        <span
+                          className="rounded bg-status-warning/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-warning"
+                          data-testid={`plugin-needs-approval-${plugin.id}`}
+                        >
+                          needs approval
+                        </span>
+                      )}
+                      {update?.needs_update && (
+                        <span
+                          className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
+                          data-testid={`plugin-update-available-${plugin.id}`}
+                        >
+                          update available
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-text-dim">{plugin.description}</p>
+                    {plugin.capabilities.length > 0 && (
+                      <p className="mt-1 text-[11px] text-text-dim">
+                        Capabilities: {plugin.capabilities.join(", ")}
+                        {plugin.granted ? "" : " (not granted)"}
+                      </p>
+                    )}
+                    {(plugin.ui_contributions ?? []).length > 0 && (
+                      <p className="mt-1 text-[11px] text-text-dim">
+                        UI: {[...new Set((plugin.ui_contributions ?? []).map((u) => u.slot))].join(", ")}
+                      </p>
+                    )}
+                    {plugin.needs_reapproval && (
+                      <p className="mt-1 text-[11px] text-status-warning">
+                        Installed but inactive. Re-approve with <code>aoe plugin update {plugin.id}</code>.
+                      </p>
+                    )}
+                    {update?.needs_update && (
+                      <p className="mt-1 text-[11px] text-text-dim">
+                        Update available ({update.current} → {update.available ?? "modified"}). Update with{" "}
+                        <code>aoe plugin update {plugin.id}</code>.
+                      </p>
+                    )}
+                    {update?.error && (
+                      <p className="mt-1 text-[11px] text-status-error">Update check failed: {update.error}</p>
                     )}
                   </div>
-                  <p className="mt-1 text-xs text-text-dim">{plugin.description}</p>
-                  {plugin.capabilities.length > 0 && (
-                    <p className="mt-1 text-[11px] text-text-dim">
-                      Capabilities: {plugin.capabilities.join(", ")}
-                      {plugin.granted ? "" : " (not granted)"}
-                    </p>
-                  )}
-                  {(plugin.ui_contributions ?? []).length > 0 && (
-                    <p className="mt-1 text-[11px] text-text-dim">
-                      UI: {[...new Set((plugin.ui_contributions ?? []).map((u) => u.slot))].join(", ")}
-                    </p>
-                  )}
-                  {plugin.needs_reapproval && (
-                    <p className="mt-1 text-[11px] text-status-warning">
-                      Installed but inactive. Re-approve with <code>aoe plugin update {plugin.id}</code>.
-                    </p>
-                  )}
-                  {update?.needs_update && (
-                    <p className="mt-1 text-[11px] text-text-dim">
-                      Update available ({update.current} → {update.available ?? "modified"}). Update with{" "}
-                      <code>aoe plugin update {plugin.id}</code>.
-                    </p>
-                  )}
-                  {update?.error && (
-                    <p className="mt-1 text-[11px] text-status-error">Update check failed: {update.error}</p>
-                  )}
+                  <label className="flex shrink-0 items-center gap-1 text-xs">
+                    <input
+                      type="checkbox"
+                      role="switch"
+                      aria-label={`Enable ${plugin.name}`}
+                      checked={plugin.enabled}
+                      disabled={busy}
+                      onChange={(e) => void onToggle(plugin, e.target.checked)}
+                    />
+                    Enabled
+                  </label>
                 </div>
-                <label className="flex shrink-0 items-center gap-1 text-xs">
-                  <input
-                    type="checkbox"
-                    role="switch"
-                    aria-label={`Enable ${plugin.name}`}
-                    checked={plugin.enabled}
-                    disabled={busy}
-                    onChange={(e) => void onToggle(plugin, e.target.checked)}
-                  />
-                  Enabled
-                </label>
               </div>
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
 
       {detail && (
         <PluginDetailModal

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -11,6 +11,19 @@ import {
   type PluginView,
 } from "../../lib/api";
 import { reportInfo } from "../../lib/toastBus";
+import { PluginDetailModal } from "./PluginDetailModal";
+
+interface DetailTarget {
+  source: string;
+  title: string;
+  fallback?: {
+    version?: string;
+    description?: string;
+    capabilities?: string[];
+    ui_contributions?: { slot: string; id: string }[];
+  };
+  installCommand?: string;
+}
 
 /// Plugin management: list every known plugin (name, version, description,
 /// validation provenance, capabilities, and enabled / approval state) and
@@ -35,6 +48,9 @@ export function PluginsSettings() {
   const [discoverResults, setDiscoverResults] = useState<PluginDiscoveryResult[] | null>(null);
   const [discoverError, setDiscoverError] = useState<string | null>(null);
   const [discovering, setDiscovering] = useState(false);
+
+  // The plugin whose detail modal is open (null = closed).
+  const [detail, setDetail] = useState<DetailTarget | null>(null);
 
   const reload = useCallback(async () => {
     const next = await fetchPlugins();
@@ -180,18 +196,21 @@ export function PluginsSettings() {
                 data-testid={`plugins-discover-result-${r.slug}`}
               >
                 <div className="flex flex-wrap items-center gap-2">
-                  <a
-                    href={r.html_url}
-                    target="_blank"
-                    rel="noreferrer"
+                  <button
+                    type="button"
                     className="font-medium text-accent-500 hover:underline"
+                    onClick={() => setDetail({ source: r.slug, title: r.slug, installCommand: r.install_command })}
+                    data-testid={`plugins-discover-open-${r.slug}`}
                   >
                     {r.slug}
-                  </a>
+                  </button>
                   <span className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500">
                     {r.badge}
                   </span>
                   <span className="text-text-dim">★ {r.stars}</span>
+                  <a href={r.html_url} target="_blank" rel="noreferrer" className="text-text-dim hover:underline">
+                    GitHub ↗
+                  </a>
                 </div>
                 {r.description && <p className="mt-1 text-text-dim">{r.description}</p>}
                 <p className="mt-1 text-text-dim">
@@ -220,7 +239,25 @@ export function PluginsSettings() {
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-medium">{plugin.name}</span>
+                    <button
+                      type="button"
+                      className="font-medium hover:underline"
+                      onClick={() =>
+                        setDetail({
+                          source: plugin.source ?? "",
+                          title: plugin.name,
+                          fallback: {
+                            version: plugin.version,
+                            description: plugin.description,
+                            capabilities: plugin.capabilities,
+                            ui_contributions: plugin.ui_contributions,
+                          },
+                        })
+                      }
+                      data-testid={`plugin-open-${plugin.id}`}
+                    >
+                      {plugin.name}
+                    </button>
                     <span className="text-xs text-text-dim">v{plugin.version}</span>
                     <span
                       className="rounded bg-accent-500/20 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-accent-500"
@@ -288,6 +325,17 @@ export function PluginsSettings() {
           );
         })}
       </div>
+
+      {detail && (
+        <PluginDetailModal
+          key={detail.source}
+          source={detail.source}
+          title={detail.title}
+          fallback={detail.fallback}
+          installCommand={detail.installCommand}
+          onClose={() => setDetail(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -178,7 +178,7 @@ export function PluginsSettings() {
                     href={r.html_url}
                     target="_blank"
                     rel="noreferrer"
-                    className="font-medium text-accent-400 hover:underline"
+                    className="font-medium text-accent-500 hover:underline"
                   >
                     {r.slug}
                   </a>

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -82,12 +82,18 @@ export function PluginsSettings() {
 
   const onCheckUpdates = async () => {
     setCheckingUpdates(true);
+    setError(null);
     try {
       const res = await fetchPluginUpdates();
-      if (res) {
+      if (res.kind === "ok") {
         const next: Record<string, PluginUpdateStatus> = {};
         for (const s of res.updates) next[s.id] = s;
         setUpdates(next);
+      } else {
+        // Clear stale badges and surface the failure, so the button is not a
+        // silent no-op.
+        setUpdates({});
+        setError(res.message);
       }
     } finally {
       setCheckingUpdates(false);

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -9,15 +9,19 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 
-import type { PluginListResponse, PluginToggleResult } from "../../../lib/api";
+import type { DiscoverResult, PluginListResponse, PluginToggleResult, PluginUpdateStatus } from "../../../lib/api";
 
 const fetchPlugins = vi.fn<[], Promise<PluginListResponse | null>>();
 const setPluginEnabled = vi.fn<[string, boolean], Promise<PluginToggleResult>>();
+const fetchPluginUpdates = vi.fn<[], Promise<{ updates: PluginUpdateStatus[] } | null>>();
+const discoverPlugins = vi.fn<[string], Promise<DiscoverResult>>();
 const reportInfo = vi.fn<[string], void>();
 
 vi.mock("../../../lib/api", () => ({
   fetchPlugins: () => fetchPlugins(),
   setPluginEnabled: (id: string, enabled: boolean) => setPluginEnabled(id, enabled),
+  fetchPluginUpdates: () => fetchPluginUpdates(),
+  discoverPlugins: (q: string) => discoverPlugins(q),
 }));
 
 vi.mock("../../../lib/toastBus", () => ({
@@ -70,8 +74,12 @@ function listResponse(overrides: Partial<PluginListResponse> = {}): PluginListRe
 beforeEach(() => {
   fetchPlugins.mockReset();
   setPluginEnabled.mockReset();
+  fetchPluginUpdates.mockReset();
+  discoverPlugins.mockReset();
   reportInfo.mockReset();
   fetchPlugins.mockResolvedValue(listResponse());
+  fetchPluginUpdates.mockResolvedValue({ updates: [] });
+  discoverPlugins.mockResolvedValue({ kind: "ok", results: [] });
 });
 
 describe("PluginsSettings", () => {
@@ -225,5 +233,73 @@ describe("PluginsSettings", () => {
     fetchPlugins.mockResolvedValue(null);
     const { findByText } = render(<PluginsSettings />);
     await findByText("Failed to load plugins.");
+  });
+
+  it("Check for updates calls the endpoint and badges an outdated plugin", async () => {
+    fetchPluginUpdates.mockResolvedValue({
+      updates: [
+        {
+          id: "example.plugin",
+          source: "gh:example/plugin",
+          current: "abc1234",
+          available: "def5678",
+          needs_update: true,
+          error: null,
+        },
+      ],
+    });
+    const { findByTestId, getByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    await waitFor(() => expect(fetchPluginUpdates).toHaveBeenCalled());
+    await findByTestId("plugin-update-available-example.plugin");
+    expect(getByTestId("plugin-example.plugin").textContent).toContain("abc1234 → def5678");
+  });
+
+  it("Check for updates surfaces a per-plugin check error", async () => {
+    fetchPluginUpdates.mockResolvedValue({
+      updates: [
+        {
+          id: "example.plugin",
+          source: "gh:example/plugin",
+          current: "",
+          available: null,
+          needs_update: false,
+          error: "git not found",
+        },
+      ],
+    });
+    const { findByTestId, findByText } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    await findByText(/Update check failed: git not found/);
+  });
+
+  it("Search GitHub renders badged results with a copyable install command", async () => {
+    discoverPlugins.mockResolvedValue({
+      kind: "ok",
+      results: [
+        {
+          slug: "gh:acme/widget",
+          html_url: "https://github.com/acme/widget",
+          description: "A widget plugin.",
+          stars: 42,
+          badge: "unvetted",
+          install_command: "aoe plugin install gh:acme/widget",
+        },
+      ],
+    });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-discover"));
+    await waitFor(() => expect(discoverPlugins).toHaveBeenCalled());
+    const result = await findByTestId("plugins-discover-result-gh:acme/widget");
+    expect(result.textContent).toContain("aoe plugin install gh:acme/widget");
+    expect(result.textContent).toContain("unvetted");
+  });
+
+  it("Search GitHub surfaces a discovery error (e.g. rate limit)", async () => {
+    discoverPlugins.mockResolvedValue({ kind: "error", message: "Rate limited by GitHub." });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-discover"));
+    const err = await findByTestId("plugins-discover-error");
+    expect(err.textContent).toContain("Rate limited by GitHub.");
   });
 });

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -9,12 +9,19 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 
-import type { DiscoverResult, PluginListResponse, PluginToggleResult, PluginUpdatesResult } from "../../../lib/api";
+import type {
+  DiscoverResult,
+  PluginDetailResult,
+  PluginListResponse,
+  PluginToggleResult,
+  PluginUpdatesResult,
+} from "../../../lib/api";
 
 const fetchPlugins = vi.fn<[], Promise<PluginListResponse | null>>();
 const setPluginEnabled = vi.fn<[string, boolean], Promise<PluginToggleResult>>();
 const fetchPluginUpdates = vi.fn<[], Promise<PluginUpdatesResult>>();
 const discoverPlugins = vi.fn<[string], Promise<DiscoverResult>>();
+const fetchPluginDetails = vi.fn<[string], Promise<PluginDetailResult>>();
 const reportInfo = vi.fn<[string], void>();
 
 vi.mock("../../../lib/api", () => ({
@@ -22,6 +29,7 @@ vi.mock("../../../lib/api", () => ({
   setPluginEnabled: (id: string, enabled: boolean) => setPluginEnabled(id, enabled),
   fetchPluginUpdates: () => fetchPluginUpdates(),
   discoverPlugins: (q: string) => discoverPlugins(q),
+  fetchPluginDetails: (source: string) => fetchPluginDetails(source),
 }));
 
 vi.mock("../../../lib/toastBus", () => ({
@@ -76,10 +84,15 @@ beforeEach(() => {
   setPluginEnabled.mockReset();
   fetchPluginUpdates.mockReset();
   discoverPlugins.mockReset();
+  fetchPluginDetails.mockReset();
   reportInfo.mockReset();
   fetchPlugins.mockResolvedValue(listResponse());
   fetchPluginUpdates.mockResolvedValue({ kind: "ok", updates: [] });
   discoverPlugins.mockResolvedValue({ kind: "ok", results: [] });
+  fetchPluginDetails.mockResolvedValue({
+    kind: "ok",
+    detail: { source: "gh:example/plugin", manifest: null, manifest_error: null, release_tags: [] },
+  });
 });
 
 describe("PluginsSettings", () => {
@@ -310,5 +323,57 @@ describe("PluginsSettings", () => {
     fireEvent.click(await findByTestId("plugins-discover"));
     const err = await findByTestId("plugins-discover-error");
     expect(err.textContent).toContain("Rate limited by GitHub.");
+  });
+
+  it("clicking a discovery result opens the detail modal with version and release tags", async () => {
+    discoverPlugins.mockResolvedValue({
+      kind: "ok",
+      results: [
+        {
+          slug: "gh:acme/widget",
+          html_url: "https://github.com/acme/widget",
+          description: "A widget plugin.",
+          stars: 42,
+          badge: "unvetted",
+          install_command: "aoe plugin install gh:acme/widget",
+        },
+      ],
+    });
+    fetchPluginDetails.mockResolvedValue({
+      kind: "ok",
+      detail: {
+        source: "gh:acme/widget",
+        manifest: {
+          id: "acme.widget",
+          name: "Widget",
+          version: "2.3.0",
+          description: "A widget plugin.",
+          api_version: 4,
+          capabilities: ["net"],
+          ui_contributions: [{ slot: "status-bar", id: "s" }],
+        },
+        manifest_error: null,
+        release_tags: ["v2.3.0", "v2.2.0"],
+      },
+    });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-discover"));
+    fireEvent.click(await findByTestId("plugins-discover-open-gh:acme/widget"));
+    await waitFor(() => expect(fetchPluginDetails).toHaveBeenCalledWith("gh:acme/widget"));
+    const modal = await findByTestId("plugin-detail-modal");
+    expect(modal.textContent).toContain("v2.3.0");
+    expect(modal.textContent).toContain("net");
+    const versions = await findByTestId("plugin-detail-versions");
+    expect(versions.textContent).toContain("v2.2.0");
+  });
+
+  it("clicking an installed plugin opens the detail modal and closes it", async () => {
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-open-example.plugin"));
+    const modal = await findByTestId("plugin-detail-modal");
+    // Falls back to the installed view's fields immediately.
+    expect(modal.textContent).toContain("v0.1.0");
+    fireEvent.click(await findByTestId("plugin-detail-close"));
+    await waitFor(() => expect(queryByTestId("plugin-detail-modal")).toBeNull());
   });
 });

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -381,6 +381,17 @@ describe("PluginsSettings", () => {
     expect(queryByTestId("plugins-check-updates")).toBeNull();
   });
 
+  it("a failed details fetch shows the error, not a false 'no releases'", async () => {
+    fetchPluginDetails.mockResolvedValue({ kind: "error", message: "Rate limited by GitHub." });
+    const { findByTestId } = render(<PluginsSettings />);
+    // example.plugin has a gh source, so opening it triggers a details fetch.
+    fireEvent.click(await findByTestId("plugin-open-example.plugin"));
+    const err = await findByTestId("plugin-detail-error");
+    expect(err.textContent).toContain("Rate limited by GitHub.");
+    const modal = await findByTestId("plugin-detail-modal");
+    expect(modal.textContent).not.toContain("No published releases.");
+  });
+
   it("clicking an installed plugin opens the detail modal and closes it", async () => {
     const { findByTestId, queryByTestId } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugin-open-example.plugin"));

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -9,11 +9,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 
-import type { DiscoverResult, PluginListResponse, PluginToggleResult, PluginUpdateStatus } from "../../../lib/api";
+import type { DiscoverResult, PluginListResponse, PluginToggleResult, PluginUpdatesResult } from "../../../lib/api";
 
 const fetchPlugins = vi.fn<[], Promise<PluginListResponse | null>>();
 const setPluginEnabled = vi.fn<[string, boolean], Promise<PluginToggleResult>>();
-const fetchPluginUpdates = vi.fn<[], Promise<{ updates: PluginUpdateStatus[] } | null>>();
+const fetchPluginUpdates = vi.fn<[], Promise<PluginUpdatesResult>>();
 const discoverPlugins = vi.fn<[string], Promise<DiscoverResult>>();
 const reportInfo = vi.fn<[string], void>();
 
@@ -78,7 +78,7 @@ beforeEach(() => {
   discoverPlugins.mockReset();
   reportInfo.mockReset();
   fetchPlugins.mockResolvedValue(listResponse());
-  fetchPluginUpdates.mockResolvedValue({ updates: [] });
+  fetchPluginUpdates.mockResolvedValue({ kind: "ok", updates: [] });
   discoverPlugins.mockResolvedValue({ kind: "ok", results: [] });
 });
 
@@ -237,6 +237,7 @@ describe("PluginsSettings", () => {
 
   it("Check for updates calls the endpoint and badges an outdated plugin", async () => {
     fetchPluginUpdates.mockResolvedValue({
+      kind: "ok",
       updates: [
         {
           id: "example.plugin",
@@ -257,6 +258,7 @@ describe("PluginsSettings", () => {
 
   it("Check for updates surfaces a per-plugin check error", async () => {
     fetchPluginUpdates.mockResolvedValue({
+      kind: "ok",
       updates: [
         {
           id: "example.plugin",
@@ -271,6 +273,13 @@ describe("PluginsSettings", () => {
     const { findByTestId, findByText } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugins-check-updates"));
     await findByText(/Update check failed: git not found/);
+  });
+
+  it("Check for updates surfaces an endpoint failure and clears stale badges", async () => {
+    fetchPluginUpdates.mockResolvedValue({ kind: "error", message: "Update check failed (HTTP 502)." });
+    const { findByTestId, findByText } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    await findByText("Update check failed (HTTP 502).");
   });
 
   it("Search GitHub renders badged results with a copyable install command", async () => {

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -310,6 +310,7 @@ describe("PluginsSettings", () => {
       ],
     });
     const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
     fireEvent.click(await findByTestId("plugins-discover"));
     await waitFor(() => expect(discoverPlugins).toHaveBeenCalled());
     const result = await findByTestId("plugins-discover-result-gh:acme/widget");
@@ -320,6 +321,7 @@ describe("PluginsSettings", () => {
   it("Search GitHub surfaces a discovery error (e.g. rate limit)", async () => {
     discoverPlugins.mockResolvedValue({ kind: "error", message: "Rate limited by GitHub." });
     const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
     fireEvent.click(await findByTestId("plugins-discover"));
     const err = await findByTestId("plugins-discover-error");
     expect(err.textContent).toContain("Rate limited by GitHub.");
@@ -357,6 +359,7 @@ describe("PluginsSettings", () => {
       },
     });
     const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
     fireEvent.click(await findByTestId("plugins-discover"));
     fireEvent.click(await findByTestId("plugins-discover-open-gh:acme/widget"));
     await waitFor(() => expect(fetchPluginDetails).toHaveBeenCalledWith("gh:acme/widget"));
@@ -365,6 +368,17 @@ describe("PluginsSettings", () => {
     expect(modal.textContent).toContain("net");
     const versions = await findByTestId("plugin-detail-versions");
     expect(versions.textContent).toContain("v2.2.0");
+  });
+
+  it("separates installed management from the marketplace into tabs", async () => {
+    const { findByTestId, getByTestId, queryByTestId } = render(<PluginsSettings />);
+    // Installed tab is the default: update controls present, search hidden.
+    await findByTestId("plugins-check-updates");
+    expect(queryByTestId("plugins-discover")).toBeNull();
+    // Switch to the marketplace: search present, update controls hidden.
+    fireEvent.click(getByTestId("plugins-tab-marketplace"));
+    await findByTestId("plugins-discover");
+    expect(queryByTestId("plugins-check-updates")).toBeNull();
   });
 
   it("clicking an installed plugin opens the detail modal and closes it", async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -239,6 +239,57 @@ function isValidPluginListResponse(payload: unknown): payload is PluginListRespo
   );
 }
 
+/** One plugin's update status (`GET /api/plugins/updates`). An on-demand
+ *  network check, kept off the always-on plugin list. `available` is a short
+ *  commit for an outdated GitHub source, "modified" for a changed local tree,
+ *  or null when current. `error` is set when the check could not run. */
+export interface PluginUpdateStatus {
+  id: string;
+  source: string;
+  current: string;
+  available: string | null;
+  needs_update: boolean;
+  error: string | null;
+}
+
+export function fetchPluginUpdates(): Promise<{ updates: PluginUpdateStatus[] } | null> {
+  return fetchJson<{ updates: PluginUpdateStatus[] }>("/api/plugins/updates");
+}
+
+/** One discovery result (`GET /api/plugins/discover`). Repo-level: the dashboard
+ *  has no install path, so it shows `install_command` for the user to copy. */
+export interface PluginDiscoveryResult {
+  slug: string;
+  html_url: string;
+  description: string | null;
+  stars: number;
+  badge: "installed" | "featured" | "unvetted";
+  install_command: string;
+}
+
+export type DiscoverResult = { kind: "ok"; results: PluginDiscoveryResult[] } | { kind: "error"; message: string };
+
+/** Search the `aoe-plugin` GitHub topic. Returns the error message (notably the
+ *  unauthenticated rate limit) so the UI can show it rather than failing
+ *  silently. */
+export async function discoverPlugins(query: string): Promise<DiscoverResult> {
+  const qs = query.trim() ? `?q=${encodeURIComponent(query.trim())}` : "";
+  try {
+    const res = await fetch(`/api/plugins/discover${qs}`, {
+      headers: { Accept: "application/json" },
+    });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && Array.isArray(payload.results)) {
+      return { kind: "ok", results: payload.results as PluginDiscoveryResult[] };
+    }
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Discovery failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
 // Plugin UI extension points (#2366).
 
 /** Display tone a plugin attaches to a slot entry or notification. The host

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -306,6 +306,48 @@ export async function discoverPlugins(query: string): Promise<DiscoverResult> {
   }
 }
 
+/** A plugin's manifest fields as shown in the detail modal (parsed leniently
+ *  server-side, so a plugin targeting a newer api_version still renders). */
+export interface PluginDetailManifest {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  api_version: number;
+  capabilities: string[];
+  ui_contributions: { slot: string; id: string }[];
+}
+
+/** On-demand detail for one plugin source (`GET /api/plugins/details`): manifest
+ *  fields plus the repo's published release tags (the available versions). */
+export interface PluginDetail {
+  source: string;
+  manifest: PluginDetailManifest | null;
+  manifest_error: string | null;
+  release_tags: string[];
+}
+
+export type PluginDetailResult = { kind: "ok"; detail: PluginDetail } | { kind: "error"; message: string };
+
+/** Fetch a plugin source's detail (manifest + release tags) for the modal.
+ *  Only gh:owner/repo sources are supported server-side. */
+export async function fetchPluginDetails(source: string): Promise<PluginDetailResult> {
+  try {
+    const res = await fetch(`/api/plugins/details?source=${encodeURIComponent(source)}`, {
+      headers: { Accept: "application/json" },
+    });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && typeof payload.source === "string") {
+      return { kind: "ok", detail: payload as unknown as PluginDetail };
+    }
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Details failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
 // Plugin UI extension points (#2366).
 
 /** Display tone a plugin attaches to a slot entry or notification. The host

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -252,8 +252,24 @@ export interface PluginUpdateStatus {
   error: string | null;
 }
 
-export function fetchPluginUpdates(): Promise<{ updates: PluginUpdateStatus[] } | null> {
-  return fetchJson<{ updates: PluginUpdateStatus[] }>("/api/plugins/updates");
+export type PluginUpdatesResult = { kind: "ok"; updates: PluginUpdateStatus[] } | { kind: "error"; message: string };
+
+/** Check installed plugins for updates. Returns a discriminated result (like
+ *  discoverPlugins) so this explicit action can report why it failed instead of
+ *  silently doing nothing on an HTTP/network/JSON error. */
+export async function fetchPluginUpdates(): Promise<PluginUpdatesResult> {
+  try {
+    const res = await fetch("/api/plugins/updates", { headers: { Accept: "application/json" } });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && Array.isArray(payload.updates)) {
+      return { kind: "ok", updates: payload.updates as PluginUpdateStatus[] };
+    }
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Update check failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
 }
 
 /** One discovery result (`GET /api/plugins/discover`). Repo-level: the dashboard

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2777,7 +2777,10 @@
       "kind": "vitest",
       "risk": "high",
       "specs": ["src/components/settings/__tests__/PluginsSettings.test.tsx"],
-      "components": ["web/src/components/settings/PluginsSettings.tsx"]
+      "components": [
+        "web/src/components/settings/PluginsSettings.tsx",
+        "web/src/components/settings/PluginDetailModal.tsx"
+      ]
     },
     {
       "id": "settings.plugins-live-toggle",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds the discovery and update-check surfaces for the plugin system (issue #2365, part of #268), building on the install/lockfile layer (#2093) and the featured-index/integrity-hashing layer (#2364).

**Discovery** is an explicit action over the `aoe-plugin` GitHub topic, never background work: `aoe plugin discover [query]`, the TUI plugin manager `d` key, and the dashboard "Search GitHub" button. It runs one GitHub search and badges each result featured / installed / unvetted by matching the repo slug against the featured index and the installed set, ranked featured-first then by stars. It does not fetch each repo's manifest (that would be an N+1 hit on the unauthenticated search rate limit), so a result means "a GitHub repo tagged `aoe-plugin`"; install stays the trust boundary. The dashboard has no install path (capability approval needs a terminal), so each result shows a copyable `aoe plugin install gh:owner/repo` command.

**Update checks** are also explicit: `aoe plugin outdated`, the TUI `c` key, and `GET /api/plugins/updates` (kept off the always-on `GET /api/plugins` list so a settings render never blocks on the network). A GitHub source compares the lockfile's resolved commit to `git ls-remote` of the requested ref; a local source re-hashes its source tree against the lockfile tree hash. Builtins are skipped and per-plugin failures are reported, never silently treated as current.

**Auto-update** adds an opt-in `updates.auto_update_plugins` setting (off by default) that sweeps installed external plugins at TUI and `aoe serve` startup, applying only clean updates that need no new consent; any version that changes capabilities, build steps, or UI slots is skipped and left for a manual `aoe plugin update` so its new grant is reviewed.

The TUI runs the discovery search and update check off the event loop on a spawned task polled each tick, so a slow or dead remote never freezes the UI.

Out of scope (per the issue): popularity-based discovery ranking (#2105; results rank by featured status + stars until then) and a web install path. Known limitation: a `release-binary` plugin whose release asset is replaced without a source-commit change is not detected by the `ls-remote` check.

Closes #2365

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe plugin discover` and confirm it lists `aoe-plugin`-topic repos badged featured / unvetted / installed, ranked featured-first, with an install hint.
- [ ] Install an external plugin (`aoe plugin install gh:owner/repo`), then run `aoe plugin outdated` and confirm it reports up to date; push a new commit upstream and confirm it then reports an available update.
- [ ] In the TUI plugin manager, press `d` and confirm a discovery list appears (with a status line, no UI freeze), Enter shows the install command, Esc returns; press `c` and confirm outdated plugins get an "update!" marker.
- [ ] In the web dashboard Settings → Plugins, click "Check for updates" and confirm update-available badges appear on outdated plugins; click "Search GitHub" and confirm badged results render with a copyable install command (and a clear message on a GitHub rate limit).
- [ ] Set `updates.auto_update_plugins = true`, restart `aoe`/`aoe serve` with an outdated external plugin installed, and confirm a clean update is applied while a capability-changing update is skipped (the prior version stays active).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

<!-- The user-facing dashboard flow (the two new buttons, badges, and discovery
results) is covered by an extended Vitest contract test, which the existing
`settings.plugins` coverage-matrix entry maps; the backend round-trip is covered
by the Rust integration tests below. -->

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

<!-- The new CLI/core behavior (outdated detection, clean auto-update, consent
skip) is covered by `tests/plugin_install.rs` against the hermetic local-git
harness, plus in-module unit tests for discovery badging/ranking and ls-remote
parsing. -->

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a multi-model `/debate`), and implementation were drafted by Claude under my direction. I made the design calls (auto-update scope, browse-only web discovery, TUI async) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785162980&installation_id=139138837&pr_number=2473&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2473&signature=7e98777b26c7d697ad769c81cb249724936664cfed9e9f6312dd19639c99184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added explicit, GitHub-backed plugin discovery and “outdated” update checks across the CLI, TUI, and web dashboard.

Plugin discovery is now on-demand only (no background searching): `aoe plugin discover [query]`, the TUI plugin manager’s **d** key, and the dashboard **Search GitHub** button. Results come from the `aoe-plugin` GitHub topic, are labeled **featured / installed / unvetted**, ranked with featured first (then by stars), and include copyable install command hints plus a web details modal.

Update checking is also explicit (no background checks): `aoe plugin outdated`, the TUI plugin manager’s **c** key, and `GET /api/plugins/updates`. Installed plugins are marked when updates are available, with per-plugin error reporting when checks fail. The PR also adds an opt-in startup “clean-only” auto-update sweep (`updates.auto_update_plugins`) that applies only safe updates and skips changes that would require new consent.

Benefits: user-controlled discovery and clearer update visibility, plus safer unattended updates that respect the existing consent model.

Potential follow-ups: improve coverage for cases where only release binaries change, and consider the currently-out-of-scope discovery ranking and additional update-check coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->