### PR TITLE
feat(plugin): pane 64KB payload budget and expandable comment bodies

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -546,7 +546,13 @@ Two slots carry more than a single value, so one entry (one declared
   optional `icon` (any lucide icon name, kebab-case) for its activity-bar
   button, falling back to a generic plugin icon. The host renders each `pane` as
   a dockable tool-window (activity-bar toggle, move, close) alongside the
-  built-in diff and terminal panes.
+  built-in diff and terminal panes. Each pane's body scrolls, and a long
+  `comment` body is clamped with a "more"/"less" toggle, so a full PR comment
+  list stays browsable.
+
+  A pane entry gets a larger payload budget than the other slots: its normalized
+  JSON may be up to 64KB, against 8KB for the small badge/column slots, so a
+  plugin can push a full comment list in one entry without truncating to fit.
 
 **Block parsing is forward-compatible by design.** The host stores `blocks` as
 opaque JSON (`Vec<Value>`); it validates only that the payload envelope is

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -551,8 +551,9 @@ Two slots carry more than a single value, so one entry (one declared
   list stays browsable.
 
   A pane entry gets a larger payload budget than the other slots: its normalized
-  JSON may be up to 64KB, against 8KB for the small badge/column slots, so a
-  plugin can push a full comment list in one entry without truncating to fit.
+  JSON may be up to 64KB, against 8KB for every other slot (`status-bar`,
+  `row-badge`, `row-column`, `card`, `detail-badge`), so a plugin can push a full
+  comment list in one pane entry without truncating to fit.
 
 **Block parsing is forward-compatible by design.** The host stores `blocks` as
 opaque JSON (`Vec<Value>`); it validates only that the payload envelope is

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -27,8 +27,11 @@ use serde_json::Value;
 /// bound (the model is honest, not adversarial), enough to keep a buggy plugin
 /// from growing host memory without limit.
 const MAX_ENTRIES_PER_PLUGIN: usize = 256;
-/// Largest normalized payload accepted for one entry, in bytes of JSON.
+/// Largest normalized payload accepted for one entry, in bytes of JSON. The
+/// pane slot gets a much larger budget than the small badge/column slots: a
+/// pane can carry a full PR comment list, where a badge is a few words.
 const MAX_PAYLOAD_BYTES: usize = 8 * 1024;
+const MAX_PANE_PAYLOAD_BYTES: usize = 64 * 1024;
 /// Notifications kept on the shared ring before the oldest are dropped.
 const NOTIFICATION_RING: usize = 200;
 /// Caps on notification text, so one notify cannot post an unbounded blob.
@@ -344,7 +347,7 @@ impl UiStore {
     ) -> Result<(), UiError> {
         check_scope(slot, session_id)?;
         let normalized = validate_payload(slot, payload).map_err(UiError::BadRequest)?;
-        if normalized.to_string().len() > MAX_PAYLOAD_BYTES {
+        if normalized.to_string().len() > max_payload_bytes(slot) {
             return Err(UiError::BadRequest("payload too large".into()));
         }
         let key = EntryKey {
@@ -487,6 +490,15 @@ impl UiStore {
     }
     fn write(&self) -> std::sync::RwLockWriteGuard<'_, Inner> {
         self.inner.write().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// Per-slot payload ceiling. The pane carries lists (a full PR comment set), so
+/// it gets a larger budget than the small single-value slots.
+fn max_payload_bytes(slot: UiSlot) -> usize {
+    match slot {
+        UiSlot::Pane => MAX_PANE_PAYLOAD_BYTES,
+        _ => MAX_PAYLOAD_BYTES,
     }
 }
 
@@ -835,6 +847,50 @@ mod tests {
                 "gh",
                 Some("s1"),
                 &json!({"default_location": "sideways"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn pane_payload_cap_is_larger_than_other_slots() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // A pane body that would blow the 8KB badge cap but fits the 64KB pane
+        // cap: a long comment list. ~40KB of note text well over MAX_PAYLOAD_BYTES.
+        let big = "x".repeat(40 * 1024);
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Pane,
+            "gh",
+            Some("s1"),
+            &json!({"blocks": [{"kind": "note", "text": big}]}),
+        )
+        .unwrap();
+        // Past the pane cap is still rejected.
+        let too_big = "x".repeat(64 * 1024);
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::Pane,
+                "gh",
+                Some("s1"),
+                &json!({"blocks": [{"kind": "note", "text": too_big}]})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // A non-pane slot keeps the small 8KB cap.
+        let over_badge = "x".repeat(9 * 1024);
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "b",
+                Some("s1"),
+                &json!({"text": over_badge})
             ),
             Err(UiError::BadRequest(_))
         ));

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -312,10 +312,11 @@ function BlockAction({ block, pluginId }: { block: Record<string, unknown>; plug
   );
 }
 
-/** A read-only PR review comment: author, optional file:line, a wrapped body
- *  excerpt, and an unresolved/resolved marker. Wrapped in a link when `href` is
- *  a safe http(s) URL. There are no reply/resolve controls; this only surfaces
- *  what is already on the PR. */
+/** A read-only PR review comment: author, optional file:line, a wrapped body,
+ *  and an unresolved/resolved marker. Wrapped in a link when `href` is a safe
+ *  http(s) URL. A long body is clamped to 3 lines with a "more"/"less" toggle so
+ *  the full text is reachable without leaving the pane. There are no
+ *  reply/resolve controls; this only surfaces what is already on the PR. */
 function BlockComment({ block }: { block: Record<string, unknown> }) {
   const author = str(block, "author");
   const body = str(block, "body");
@@ -323,8 +324,14 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
   const line = typeof block.line === "number" ? block.line : undefined;
   const resolved = block.resolved === true;
   const safe = safeHref(str(block, "href"));
+  const [expanded, setExpanded] = useState(false);
   if (!author && !body) return null;
   const where = path ? `${path}${line ? `:${line}` : ""}` : undefined;
+  // ponytail: cheap length/newline heuristic instead of measuring layout, so the
+  // toggle works in jsdom and needs no ref/effect. Ceiling: a short-but-wide body
+  // that wraps past 3 lines under 200 chars misses the toggle; raise the bound if
+  // that bites.
+  const longBody = !!body && (body.length > 200 || (body.match(/\n/g)?.length ?? 0) >= 3);
   const inner = (
     <>
       <div className="flex items-center justify-between gap-2 text-text-secondary">
@@ -336,7 +343,24 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
           </span>
         </span>
       </div>
-      {body && <div className="mt-0.5 line-clamp-3 whitespace-pre-wrap text-text-primary">{body}</div>}
+      {body && (
+        <div className={`mt-0.5 whitespace-pre-wrap text-text-primary ${expanded ? "" : "line-clamp-3"}`}>{body}</div>
+      )}
+      {longBody && (
+        <button
+          type="button"
+          data-testid="plugin-comment-toggle"
+          onClick={(e) => {
+            // Don't let the click follow the card's PR link.
+            e.preventDefault();
+            e.stopPropagation();
+            setExpanded((v) => !v);
+          }}
+          className="mt-0.5 text-[10px] text-text-dim hover:text-text-primary cursor-pointer"
+        >
+          {expanded ? "less" : "more"}
+        </button>
+      )}
     </>
   );
   const className = "block rounded bg-surface-700/30 p-2 text-xs";

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -332,7 +332,9 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
   // that wraps past 3 lines under 200 chars misses the toggle; raise the bound if
   // that bites.
   const longBody = !!body && (body.length > 200 || (body.match(/\n/g)?.length ?? 0) >= 3);
-  const inner = (
+  // The linkable content (header + body); the toggle stays a sibling so it is
+  // never an interactive child of the <a> (invalid nesting, odd keyboard focus).
+  const linkContent = (
     <>
       <div className="flex items-center justify-between gap-2 text-text-secondary">
         <span className="min-w-0 truncate font-medium">{author}</span>
@@ -344,32 +346,34 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
         </span>
       </div>
       {body && (
-        <div className={`mt-0.5 whitespace-pre-wrap text-text-primary ${expanded ? "" : "line-clamp-3"}`}>{body}</div>
+        // Clamp only when there is a toggle to undo it, so a short body that
+        // still wraps past three lines is not truncated with no way to expand.
+        <div className={`mt-0.5 whitespace-pre-wrap text-text-primary ${longBody && !expanded ? "line-clamp-3" : ""}`}>
+          {body}
+        </div>
+      )}
+    </>
+  );
+  return (
+    <div className="rounded bg-surface-700/30 p-2 text-xs">
+      {safe ? (
+        <a className="block rounded hover:bg-surface-700/50" href={safe} target="_blank" rel="noopener noreferrer">
+          {linkContent}
+        </a>
+      ) : (
+        linkContent
       )}
       {longBody && (
         <button
           type="button"
           data-testid="plugin-comment-toggle"
-          onClick={(e) => {
-            // Don't let the click follow the card's PR link.
-            e.preventDefault();
-            e.stopPropagation();
-            setExpanded((v) => !v);
-          }}
+          onClick={() => setExpanded((v) => !v)}
           className="mt-0.5 text-[10px] text-text-dim hover:text-text-primary cursor-pointer"
         >
           {expanded ? "less" : "more"}
         </button>
       )}
-    </>
-  );
-  const className = "block rounded bg-surface-700/30 p-2 text-xs";
-  return safe ? (
-    <a className={`${className} hover:bg-surface-700/50`} href={safe} target="_blank" rel="noopener noreferrer">
-      {inner}
-    </a>
-  ) : (
-    <div className={className}>{inner}</div>
+    </div>
   );
 }
 

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -6,7 +6,7 @@
 // sort-key and filter-facet slots render as sidebar sort options and a facet
 // filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
-import { createElement, useState } from "react";
+import { createElement, useId, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { invokePluginAction } from "../../lib/api";
@@ -325,6 +325,7 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
   const resolved = block.resolved === true;
   const safe = safeHref(str(block, "href"));
   const [expanded, setExpanded] = useState(false);
+  const bodyId = useId();
   if (!author && !body) return null;
   const where = path ? `${path}${line ? `:${line}` : ""}` : undefined;
   // ponytail: cheap length/newline heuristic instead of measuring layout, so the
@@ -348,16 +349,19 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
       {body && (
         // Clamp only when there is a toggle to undo it, so a short body that
         // still wraps past three lines is not truncated with no way to expand.
-        <div className={`mt-0.5 whitespace-pre-wrap text-text-primary ${longBody && !expanded ? "line-clamp-3" : ""}`}>
+        <div
+          id={bodyId}
+          className={`mt-0.5 whitespace-pre-wrap text-text-primary ${longBody && !expanded ? "line-clamp-3" : ""}`}
+        >
           {body}
         </div>
       )}
     </>
   );
   return (
-    <div className="rounded bg-surface-700/30 p-2 text-xs">
+    <div className="rounded-md bg-surface-700/30 p-2 text-xs">
       {safe ? (
-        <a className="block rounded hover:bg-surface-700/50" href={safe} target="_blank" rel="noopener noreferrer">
+        <a className="block rounded-md hover:bg-surface-700/50" href={safe} target="_blank" rel="noopener noreferrer">
           {linkContent}
         </a>
       ) : (
@@ -367,6 +371,8 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
         <button
           type="button"
           data-testid="plugin-comment-toggle"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
           onClick={() => setExpanded((v) => !v)}
           className="mt-0.5 text-[10px] text-text-dim hover:text-text-primary cursor-pointer"
         >

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -348,7 +348,29 @@ describe("plugin slot renderers", () => {
     expect(screen.getByText("unresolved")).toBeTruthy();
     const link = screen.getByRole("link");
     expect(link.getAttribute("href")).toBe("https://github.com/o/r/pull/1#c1");
-    // Read-only: no reply/resolve controls.
+    // Read-only: no reply/resolve controls, and a short body needs no toggle.
     expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByTestId("plugin-comment-toggle")).toBeNull();
+  });
+
+  it("a long comment body is clamped with a more/less toggle", () => {
+    const longBody = "x".repeat(250);
+    const entry: PluginUiEntry = {
+      plugin_id: "acme.kit",
+      slot: "pane",
+      id: "gh",
+      session_id: "s1",
+      payload: { blocks: [{ kind: "comment", author: "bob", body: longBody }] },
+    };
+    render(<PluginPaneBody entry={entry} />);
+    const body = screen.getByText(longBody);
+    expect(body.className).toContain("line-clamp-3");
+    const toggle = screen.getByTestId("plugin-comment-toggle");
+    expect(toggle.textContent).toBe("more");
+    fireEvent.click(toggle);
+    expect(body.className).not.toContain("line-clamp-3");
+    expect(toggle.textContent).toBe("less");
+    fireEvent.click(toggle);
+    expect(body.className).toContain("line-clamp-3");
   });
 });

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -367,9 +367,14 @@ describe("plugin slot renderers", () => {
     expect(body.className).toContain("line-clamp-3");
     const toggle = screen.getByTestId("plugin-comment-toggle");
     expect(toggle.textContent).toBe("more");
+    // Toggle state and the controlled body are exposed to assistive tech.
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-controls")).toBe(body.id);
+    expect(body.id).toBeTruthy();
     fireEvent.click(toggle);
     expect(body.className).not.toContain("line-clamp-3");
     expect(toggle.textContent).toBe("less");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     fireEvent.click(toggle);
     expect(body.className).toContain("line-clamp-3");
   });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A PR with many review comments (a big CodeRabbit pass) could not be shown in full in a plugin pane: a single UI-state entry was capped at 8KB, so a plugin had to truncate its comment list to fit one entry. This raises the cap for the `pane` slot specifically and finishes the in-pane fold affordance.

- **Per-slot payload budget.** `MAX_PAYLOAD_BYTES` was one global 8KB ceiling for every slot. It is now per-slot: the `pane` slot gets 64KB (it carries lists, a full PR comment set), while the small badge/column slots keep 8KB so a buggy plugin still cannot grow host memory with oversized badges.
- **Expandable comment bodies.** A long `comment` block body was clamped to three lines with no way to read the rest. It now has a "more"/"less" toggle that un-clamps in place; the toggle stops click propagation so the card's PR link still works.

Pane scrolling and collapsible sections already shipped (#2432, #2442), so no change was needed there. This is the host enabler the paired plugin-github change needs: it will stop truncating and send the full unresolved-comment list once this lands (tracked separately).

Closes #2474

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] A plugin pushing a `pane` entry whose normalized JSON is ~40KB (a long comment list) is accepted, where before it was rejected with "payload too large".
- [ ] A `pane` entry over 64KB is still rejected.
- [ ] A non-pane slot (e.g. `row-badge`) over 8KB is still rejected.
- [ ] In a plugin pane, a `comment` block with a long body shows a "more" control; clicking it reveals the full body and shows "less"; clicking "less" re-collapses it; the comment's PR link still opens when the card is clicked.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test for the dashboard flow. (Vitest + RTL: a new `PluginSlots.test.tsx` case drives the comment more/less toggle. Per AGENTS.md, component-logic flows belong in Vitest, and `PluginSlots.tsx` is already mapped in `web/tests/coverage-matrix.json` via `app-shell.pane-docking`, so no matrix entry was added.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. (The Rust change is a host-side payload cap, covered by a unit test in `src/plugin/ui_state.rs`.)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the scope call (cap + expandable comments, since scroll and collapsible sections already shipped), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785169743&installation_id=139138837&pr_number=2476&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2476&signature=78965578a85d57765441be62f8428b169aeabf7d82424d36a89e41603e01466f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update improves plugin panes for large review threads by increasing the amount of data they can carry and by making long comment bodies easier to read. The `pane` slot now supports a larger payload budget (up to 64KB) so plugins can include full comment lists without truncation, while smaller slots keep tighter limits (e.g., 8KB for common UI slots like badges/columns). On the UI side, long PR review `comment` blocks now get an in-place **more/less** expand/collapse toggle with sensible clamping, while preserving the existing PR link click behavior.

**Benefits:**
- enables plugins to show fuller unresolved comment lists in panes without cutting off content
- keeps other slot payloads constrained to avoid bloating smaller UI areas
- improves readability and navigation of long comment bodies with an optional expand/collapse control
- adds accessibility metadata for the toggle (so screen readers understand the expanded/collapsed state)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->