### PR TITLE
fix(hooks): gate macos-only TempDir import

### DIFF
--- a/src/hooks/dir_guard.rs
+++ b/src/hooks/dir_guard.rs
@@ -690,6 +690,7 @@ mod tests {
     use serial_test::serial;
     use std::io::Read;
     use std::os::unix::fs::PermissionsExt;
+    #[cfg(target_os = "macos")]
     use tempfile::TempDir;
 
     #[test]


### PR DESCRIPTION
## Description
Gate the `tempfile::TempDir` test import behind `#[cfg(target_os = "macos")]`, matching the only test that uses it. This keeps non-macOS test builds from warning about an unused import.

Testing:
- `cargo check --tests` passed before PR prep.
- `cargo fmt --check` passed before PR prep.
- `cargo clippy --all-targets` passed before `cargo test` in the same command.
- Full local verification skipped after maintainer request to skip local checks and push the PR. Earlier `cargo test` without `serve` stopped at `tests/acp_runner_keepalive.rs` because the hidden `__acp-runner` subcommand is serve-feature gated.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary, N/A for this warning-only test cfg cleanup
- [x] For UI changes: included screenshot or recording, N/A because this is not a UI change

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
OpenCode, gpt-5.5

**Any Additional AI Details you would like to share:**
Applied a scoped cfg cleanup and created this PR.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785172505&installation_id=139138837&pr_number=2478&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2478&signature=bdf89dbafc655146a870a8feed7eefd1e6bbed9a4a675e3396e7090f7f1c90e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a macOS-only guard around the `TempDir` test import in `src/hooks/dir_guard.rs`, so the import is only compiled where it’s actually used. This removes unused-import warnings on non-macOS test builds and keeps the hooks test code platform-appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->