### PR TITLE
feat(plugin): feature plugin-github 1.0.0 and 1.1.0 releases

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -27,4 +27,4 @@
 
 [plugins."agent-of-empires.github"]
 source = "gh:agent-of-empires/plugin-github"
-versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc" }
+versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.1.0" = "sha256:2a13a901314e4061616ad68e5923a807c0841387ec065036eb972acc8c3703e0" }


### PR DESCRIPTION
## Description

Follows up #2472 (per-version featured verification). Adds vetted tree-hash pins for the `v1.0.0` and `v1.1.0` release trees of `gh:agent-of-empires/plugin-github` to `plugins/featured.toml`, keeping the existing `0.1.0` pin. Both releases are now featured-verified, so install/update accepts either under the reserved `agent-of-empires.github` namespace.

Hashes were computed with `aoe plugin hash` on clean tag checkouts and independently cross-checked against a replica of `tree_hash`:

- `1.0.0` -> `sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388`
- `1.1.0` -> `sha256:2a13a901314e4061616ad68e5923a807c0841387ec065036eb972acc8c3703e0`

Note: the `v1.0.0` git tag ships `version = "0.1.0"` in its manifest; verification is by tree-hash, not the version label, so this is informational only.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. The featured index is data; existing `featured` lib tests cover hash-membership verification and embedded-index parse.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** AI computed and verified the tree hashes and edited the featured index.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785174326&installation_id=139138837&pr_number=2479&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2479&signature=f098a34e2abf7600b88c013437102f2a9a41d65db258b55bbd0cbc55bf048486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Expanded the featured plugin registry to recognize two additional vetted releases of `agent-of-empires.github` (`1.0.0` and `1.1.0`) alongside the existing `0.1.0` entry. This means installs and updates can now accept more release versions under the reserved namespace without losing featured verification.

Benefit: broader version support with the same trusted validation model.

Technical note: the new entries are pinned by tree hash in `plugins/featured.toml`, and verification is based on the release tree contents rather than the manifest’s version label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->