### PR TITLE
feat(plugin): default install to latest release and fix featured build-tree load

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -682,7 +682,7 @@ Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `info` — Show one plugin's manifest details
 * `enable` — Enable a plugin's contributions
 * `disable` — Disable a plugin; its settings stay on disk for re-enabling
-* `install` — Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. Community plugins run at your own risk
+* `install` — Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. With no `@ref`, installs the repo's latest release; an explicit `@ref` installs unverified, un-audited code. Community plugins run at your own risk
 * `update` — Update an installed external plugin from its recorded source. Prompts to re-approve capabilities if the update changes the capability set
 * `uninstall` — Uninstall an external plugin, removing its files and capability grant
 * `hash` — Print the deterministic source tree hash for a plugin directory, the value a maintainer pins in the featured index
@@ -737,13 +737,13 @@ Disable a plugin; its settings stay on disk for re-enabling
 
 ## `aoe plugin install`
 
-Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. Community plugins run at your own risk
+Install an external plugin from a `gh:owner/repo[@ref]` slug or a local directory. With no `@ref`, installs the repo's latest release; an explicit `@ref` installs unverified, un-audited code. Community plugins run at your own risk
 
 **Usage:** `aoe plugin install [OPTIONS] <SOURCE>`
 
 ###### **Arguments:**
 
-* `<SOURCE>` — `gh:owner/repo[@ref]` or a local directory path
+* `<SOURCE>` — `gh:owner/repo` (latest release) or `gh:owner/repo@ref` (unverified) or a local directory path
 
 ###### **Options:**
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -152,19 +152,27 @@ registered. This is how an interpreted worker sets itself up (create a venv,
 ```toml
 [runtime]
 kind = "command"
-command = [".venv/bin/aoe-github-worker"]   # plugin-relative: PATH-independent
+command = [".aoe-build/venv/bin/aoe-github-worker"]   # plugin-relative
 
 [[runtime.build]]
-command = ["python3", "-m", "venv", ".venv"]
+command = ["python3", "-m", "venv", ".aoe-build/venv"]
 
 [[runtime.build]]
-command = [".venv/bin/pip", "install", "."]
+command = [".aoe-build/venv/bin/pip", "install", "."]
 platforms = ["linux", "macos"]              # optional; omitted runs everywhere
 ```
 
+Build output must go under the reserved `.aoe-build/` directory, never directly
+into the source tree. That directory is excluded from `tree_hash` (see below), so
+a build that mutates the install tree (a venv, `node_modules`, compiled
+artifacts) does not change the source hash and a featured plugin still
+re-derives `Featured` at load. A source tree that ships `.aoe-build` is refused
+at install.
+
 Each step's argv resolves through the host's argv resolver (bare name on PATH,
 separator path relative to the plugin dir, absolute rejected), evaluated just
-before the step runs so `.venv/bin/pip` resolves once the prior step created it.
+before the step runs so `.aoe-build/venv/bin/pip` resolves once the prior step
+created it.
 Build steps are free to name bare PATH programs (`python3`, `node`, `uv`): they
 run in the user's interactive shell where PATH is reliable, which is exactly why
 the worker entrypoint, launched later by the daemon, is not. A step's optional `platforms` (`linux` / `macos` / `windows`)
@@ -277,8 +285,16 @@ reads (the field defaults) and is repopulated on the next install/update.
 `plugin::integrity::tree_hash` is a deterministic `sha256:<hex>` over a plugin's
 source tree. Files are sorted by their forward-slash relative path and hashed
 under a versioned header (`aoe-plugin-tree-hash-v1`) as `file\0<path>\0<len>
-<content>`. `.git` is skipped (it is stripped from an installed tree); a symlink
-or non-UTF-8 path is a hard error so nothing installed escapes the hash. File
+<content>`. `.git` and the reserved `.aoe-build/` build-output directory are skipped
+(the first is stripped from an installed tree, the second is generated into it by
+build steps and is not part of the source); a symlink or non-UTF-8 path outside
+those is a hard error so nothing installed escapes the hash. Skipping
+`.aoe-build` is what lets a build-mutating plugin (a venv holds ~thousands of
+files and a `python3` symlink) re-derive the same hash at load that the author's
+`aoe plugin hash` of a clean checkout produced; a fixed reserved name keeps the
+exclusion out of attacker control, where a manifest-declared list a tampered
+manifest could widen would not. A source that ships `.aoe-build` is refused at
+fetch, so the excluded subtree can never hide vetted source. File
 mode is excluded for cross-platform determinism, and `git clone` runs with
 `core.autocrlf=false` so line endings never differ by platform. The hash is
 computed over the staged source **before** any release-binary worker is
@@ -316,8 +332,10 @@ gates the reserved-namespace lift and the lockfile is user-writable; `community`
 vs `local` is derived from the install source. The lockfile records the tree
 hash and the install-time `trust` as a resolved record, but the load path does
 not depend on them for validation. The recompute is cheap (only ids the index
-names, and a featured plugin ships no release-binary, so its installed tree
-equals its source tree) and is done live on every load from the on-disk tree,
+names, and a featured plugin ships no release-binary, so its installed source
+equals its pinned source; build output under `.aoe-build` is excluded, so a
+build-mutating plugin re-derives the same hash) and is done live on every load
+from the on-disk tree,
 never from a cache: a metadata-keyed cache could be forged to return a stale
 vetted hash for a tampered tree, so the verified decision always re-hashes
 content. The manifest-hash grant check still catches a community plugin tampered

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,12 +47,20 @@ update, and uninstall are CLI-only (`aoe plugin` is reserved for management);
 the TUI and web surfaces show the result but do not install.
 
 ```sh
-aoe plugin install gh:owner/repo          # latest default branch
-aoe plugin install gh:owner/repo@v1.2.3   # a tag, branch, or commit
+aoe plugin install gh:owner/repo          # latest release (the audited default)
+aoe plugin install gh:owner/repo@v1.2.3   # an explicit tag, branch, or commit
 aoe plugin install ./path/to/plugin       # a local directory
 aoe plugin update <id>
 aoe plugin uninstall <id>
 ```
+
+With no `@ref`, install resolves the repo's latest stable GitHub release (the
+audited default path) and installs that tag. An explicit `@ref` installs
+unverified, un-audited code and asks you to confirm first (`--yes` skips the
+prompt). If the repo has published no release, install warns and falls back to
+the default branch behind the same confirmation. The recorded source stays
+ref-less, so `aoe plugin update` keeps tracking the latest release; an `@ref`
+install keeps following that ref.
 
 A plugin lands under `<app_dir>/plugins/<id>/`. A GitHub source is cloned and
 pinned to the exact commit; if the plugin ships a compiled worker as a release

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -24,9 +24,12 @@ pub enum PluginCommands {
         id: String,
     },
     /// Install an external plugin from a `gh:owner/repo[@ref]` slug or a local
-    /// directory. Community plugins run at your own risk.
+    /// directory. With no `@ref`, installs the repo's latest release; an
+    /// explicit `@ref` installs unverified, un-audited code. Community plugins
+    /// run at your own risk.
     Install {
-        /// `gh:owner/repo[@ref]` or a local directory path
+        /// `gh:owner/repo` (latest release) or `gh:owner/repo@ref` (unverified)
+        /// or a local directory path
         source: String,
         /// Grant all requested capabilities without prompting
         #[arg(long)]

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use aoe_plugin_api::{PluginManifest, RuntimeSpec};
 
-use crate::github::{GitHubClient, GitHubClientConfig, DEFAULT_USER_AGENT};
+use crate::github::{GitHubClient, GitHubClientConfig, GitHubError, DEFAULT_USER_AGENT};
 
 use super::source::PluginSource;
 
@@ -80,6 +80,16 @@ pub async fn fetch(source: &PluginSource) -> Result<FetchedPlugin> {
     };
 
     let (manifest, manifest_bytes) = read_manifest(&tree)?;
+
+    // The reserved build-output dir is excluded from the tree hash, so a source
+    // that ships it could hide files from the pin. It must only ever be created
+    // by build steps, never committed; refuse a source tree that contains it.
+    if tree.join(super::integrity::BUILD_OUTPUT_DIR).exists() {
+        bail!(
+            "plugin source ships the reserved build-output directory {:?}; it must only be produced by build steps, not committed",
+            super::integrity::BUILD_OUTPUT_DIR
+        );
+    }
 
     // Hash the source tree before any release-binary is injected below, so the
     // value matches `aoe plugin hash` run on the author's checkout (which has
@@ -178,6 +188,24 @@ pub fn ls_remote(url: &str, reference: Option<&str>) -> Result<String> {
     let target = reference.unwrap_or("HEAD");
     let out = run_git(&["ls-remote", url, target], None)?;
     parse_ls_remote(&out, target)
+}
+
+/// The tag of the repo's latest stable GitHub release, or `None` when the repo
+/// has published no release. `GET /releases/latest` already excludes prereleases
+/// and drafts, so this is the stable channel; a 404 (no releases) maps to `None`
+/// while any other API error propagates. Used by the default install path
+/// (no `@ref`) and the rolling update check.
+pub async fn latest_release_tag(owner: &str, repo: &str) -> Result<Option<String>> {
+    let client = GitHubClient::unauthenticated(GitHubClientConfig {
+        api_base: github_api_base(),
+        user_agent: DEFAULT_USER_AGENT.to_string(),
+        timeout: Duration::from_secs(60),
+    })?;
+    match client.latest_release(owner, repo).await {
+        Ok(release) => Ok(Some(release.tag_name)),
+        Err(GitHubError::NotFound { .. }) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
 }
 
 fn is_full_commit_sha(s: &str) -> bool {

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -74,7 +74,12 @@ pub enum UpdateOutcome {
 /// dir). Prompts once for the manifest's capabilities unless `assume_yes`.
 pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     let source = PluginSource::parse(input)?;
-    let fetched = fetch::fetch(&source).await?;
+    let resolved = resolve_source(source, true).await?;
+    eprintln!("{}", resolved.notice);
+    if resolved.unverified && !assume_yes && !confirm_unverified()? {
+        bail!("install cancelled; the unverified source was not approved");
+    }
+    let fetched = fetch::fetch(&resolved.source).await?;
 
     let id = fetched.manifest.id.as_str().to_string();
     let featured_verified = verify_featured(&FeaturedIndex::load()?, &fetched)?;
@@ -109,7 +114,7 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
 
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
     persist_install(
-        &persisted_source(&source, input),
+        &persisted_source(&resolved.source, input),
         &id,
         &capabilities,
         &manifest_hash,
@@ -160,7 +165,13 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
     let prior_grant = plugin_config.grant.clone();
 
     let source = PluginSource::parse(&source_str)?;
-    let fetched = fetch::fetch(&source).await?;
+    // A no-`@ref` install tracks the release channel: re-resolve the latest
+    // release each update (rolling). Disallow the default-branch fallback here
+    // so an update never silently switches a release-tracking install onto the
+    // moving default branch; an explicit `@ref` install keeps following its ref.
+    let resolved = resolve_source(source, false).await?;
+    eprintln!("{}", resolved.notice);
+    let fetched = fetch::fetch(&resolved.source).await?;
     if fetched.manifest.id.as_str() != id {
         bail!(
             "source {source_str:?} now resolves to plugin {:?}, not {id}",
@@ -345,6 +356,104 @@ fn reject_incompatible_host(manifest: &PluginManifest) -> Result<()> {
     manifest
         .host_compat(env!("CARGO_PKG_VERSION"))
         .map_err(|msg| anyhow!("{}: {msg}", manifest.id.as_str()))
+}
+
+/// What [`resolve_source`] decided to fetch.
+struct ResolvedSource {
+    /// The source to actually fetch. A no-`@ref` GitHub source is rewritten to
+    /// the resolved release tag; everything else is passed through unchanged.
+    source: PluginSource,
+    /// The install is off the audited-release default path: an explicit `@ref`,
+    /// or the no-release default-branch fallback. The install path confirms
+    /// before proceeding; update ignores it (it has its own consent flow).
+    unverified: bool,
+    /// One line stating what is being installed, printed by the caller.
+    notice: String,
+}
+
+/// Resolve what to fetch for an install or update.
+///
+/// A no-`@ref` GitHub source installs the latest stable release, the audited
+/// default path. With no published release, `allow_branch_fallback` (install)
+/// falls back to the default branch as an unverified install; without it
+/// (update) that is an error, so a release-tracking install never silently
+/// switches onto the moving default branch. An explicit `@ref` is an unverified
+/// opt-in fetched as-is; a local source is unchanged.
+async fn resolve_source(
+    source: PluginSource,
+    allow_branch_fallback: bool,
+) -> Result<ResolvedSource> {
+    match &source {
+        PluginSource::Local(_) => Ok(ResolvedSource {
+            unverified: false,
+            notice: "installing from a local directory".to_string(),
+            source,
+        }),
+        PluginSource::Github {
+            reference: Some(reference),
+            ..
+        } => {
+            let notice =
+                format!("installing the explicit ref {reference:?} (not an audited release)");
+            Ok(ResolvedSource {
+                unverified: true,
+                notice,
+                source,
+            })
+        }
+        PluginSource::Github {
+            owner,
+            repo,
+            reference: None,
+        } => match fetch::latest_release_tag(owner, repo).await? {
+            Some(tag) => {
+                let notice = format!("installing the latest release {tag}");
+                let source = PluginSource::Github {
+                    owner: owner.clone(),
+                    repo: repo.clone(),
+                    reference: Some(tag),
+                };
+                Ok(ResolvedSource {
+                    unverified: false,
+                    notice,
+                    source,
+                })
+            }
+            None if allow_branch_fallback => Ok(ResolvedSource {
+                unverified: true,
+                notice: format!(
+                    "{owner}/{repo} has no published release; falling back to the unverified default branch"
+                ),
+                source,
+            }),
+            None => bail!(
+                "{owner}/{repo} has no published release to update to; the prior version is kept"
+            ),
+        },
+    }
+}
+
+/// Confirm an install that is off the audited-release default path (an explicit
+/// ref, or the no-release default-branch fallback). Mirrors
+/// [`confirm_capabilities`]: a non-interactive stdin without `--yes` is an
+/// error, not a silent yes. The caller has already printed what is being
+/// installed, so this only states the trust caveat and prompts.
+fn confirm_unverified() -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        bail!("this is unverified, un-audited code; re-run with --yes to install it");
+    }
+    println!(
+        "This is unverified, un-audited code: it does not come from a vetted release and is\n\
+         not covered by the featured index. Install it only if you trust the source."
+    );
+    print!("Continue? [y/N] ");
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
 }
 
 /// Check a fetched plugin against the curated index. Returns whether it is a

--- a/src/plugin/integrity.rs
+++ b/src/plugin/integrity.rs
@@ -60,11 +60,16 @@ pub fn tree_hash(dir: &Path) -> Result<String> {
 fn collect(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> Result<()> {
     for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
         let entry = entry?;
-        // Skip git history and the reserved build-output dir before inspecting
-        // the entry's type: a build output like a `.venv` holds symlinks, which
-        // the symlink check below would otherwise reject, and its contents are
-        // not part of the hashed source.
-        if entry.file_name() == ".git" || entry.file_name() == BUILD_OUTPUT_DIR {
+        // Skip git history at every level. Skip the reserved build-output dir
+        // before inspecting the entry's type (a build output like a `.venv`
+        // holds symlinks the check below would reject, and is not hashed
+        // source), but ONLY at the root: it is a single top-level dir, so a
+        // nested `<sub>/.aoe-build` is ordinary source, hashed and
+        // symlink-checked like anything else rather than silently dropped.
+        if entry.file_name() == ".git" {
+            continue;
+        }
+        if dir == root && entry.file_name() == BUILD_OUTPUT_DIR {
             continue;
         }
         let file_type = entry.file_type()?;
@@ -174,6 +179,37 @@ mod tests {
             tree_hash(with_build.path()).unwrap(),
             tree_hash(without_build.path()).unwrap()
         );
+    }
+
+    #[test]
+    fn nested_build_output_dir_is_hashed_not_skipped() {
+        // The reserved dir is excluded only at the root. A nested
+        // `sub/.aoe-build` is ordinary source: it must change the hash, so it
+        // cannot be used to hide files from the pin.
+        let without = tempfile::tempdir().unwrap();
+        write(without.path(), "aoe-plugin.toml", b"x");
+        let with_nested = tempfile::tempdir().unwrap();
+        write(with_nested.path(), "aoe-plugin.toml", b"x");
+        write(with_nested.path(), "sub/.aoe-build/hidden", b"payload");
+        assert_ne!(
+            tree_hash(without.path()).unwrap(),
+            tree_hash(with_nested.path()).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nested_build_output_symlink_is_rejected() {
+        // A symlink under a nested (non-root) `.aoe-build` is still rejected:
+        // only the root build-output dir escapes the symlink check.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "aoe-plugin.toml", b"x");
+        let nested = dir.path().join("sub").join(".aoe-build");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("real"), b"x").unwrap();
+        std::os::unix::fs::symlink("real", nested.join("link")).unwrap();
+        let err = tree_hash(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("symlink"), "got: {err}");
     }
 
     #[cfg(unix)]

--- a/src/plugin/integrity.rs
+++ b/src/plugin/integrity.rs
@@ -18,14 +18,27 @@ use sha2::{Digest, Sha256};
 /// Domain-separation header. Bump the version when the hashed fields change.
 const HASH_PREFIX: &[u8] = b"aoe-plugin-tree-hash-v1\0";
 
+/// Reserved directory for a plugin's build output. A `command` runtime's build
+/// steps (a Python `.venv`, `node_modules`, compiled artifacts) must write here,
+/// never into the source tree. It is excluded from the hash at every level, like
+/// `.git`, so a build that mutates the install tree does not change the source
+/// hash: an author's `aoe plugin hash` of a clean checkout and the live load-path
+/// re-derivation over the built tree produce the same value, keeping a featured
+/// pin verifiable after the build runs. Build output is therefore not attested by
+/// the pin (build steps already run unsandboxed at the user's trust); a fixed
+/// reserved name keeps the exclusion out of attacker control, unlike a
+/// manifest-declared list which a tampered manifest could widen to hide source.
+pub const BUILD_OUTPUT_DIR: &str = ".aoe-build";
+
 /// Deterministic `sha256:<hex>` over the files in `dir`.
 ///
 /// Files are sorted by their forward-slash relative path; each contributes
 /// `file\0<path>\0<len><content>` to the digest, where `<len>` is the content
 /// length as 8 little-endian bytes so a path/content boundary is unambiguous.
-/// `.git` is skipped at every level (it is stripped from an installed tree). A
-/// symlink or a non-UTF-8 path is an error, not a silent skip, so nothing that
-/// would be installed escapes the hash. File mode is deliberately excluded for
+/// `.git` and the reserved [`BUILD_OUTPUT_DIR`] are skipped at every level (both
+/// are stripped from, or generated into, an installed tree). A symlink or a
+/// non-UTF-8 path is an error, not a silent skip, so nothing that would be
+/// installed escapes the hash. File mode is deliberately excluded for
 /// cross-platform determinism (Windows has no executable bit).
 pub fn tree_hash(dir: &Path) -> Result<String> {
     let mut files = Vec::new();
@@ -47,7 +60,11 @@ pub fn tree_hash(dir: &Path) -> Result<String> {
 fn collect(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) -> Result<()> {
     for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
         let entry = entry?;
-        if entry.file_name() == ".git" {
+        // Skip git history and the reserved build-output dir before inspecting
+        // the entry's type: a build output like a `.venv` holds symlinks, which
+        // the symlink check below would otherwise reject, and its contents are
+        // not part of the hashed source.
+        if entry.file_name() == ".git" || entry.file_name() == BUILD_OUTPUT_DIR {
             continue;
         }
         let file_type = entry.file_type()?;
@@ -140,6 +157,38 @@ mod tests {
             tree_hash(with_git.path()).unwrap(),
             tree_hash(without_git.path()).unwrap()
         );
+    }
+
+    #[test]
+    fn build_output_dir_is_skipped() {
+        let with_build = tempfile::tempdir().unwrap();
+        write(with_build.path(), "aoe-plugin.toml", b"x");
+        write(
+            with_build.path(),
+            &format!("{BUILD_OUTPUT_DIR}/venv/pyvenv.cfg"),
+            b"junk",
+        );
+        let without_build = tempfile::tempdir().unwrap();
+        write(without_build.path(), "aoe-plugin.toml", b"x");
+        assert_eq!(
+            tree_hash(with_build.path()).unwrap(),
+            tree_hash(without_build.path()).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_inside_build_output_is_not_rejected() {
+        // A build like a Python venv places a symlink under the build-output
+        // dir; the hash must skip it rather than hard-error, so a built tree
+        // still re-derives the source hash.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "aoe-plugin.toml", b"x");
+        let build = dir.path().join(BUILD_OUTPUT_DIR).join("bin");
+        std::fs::create_dir_all(&build).unwrap();
+        std::fs::write(build.join("real"), b"x").unwrap();
+        std::os::unix::fs::symlink("real", build.join("python3")).unwrap();
+        assert!(tree_hash(dir.path()).is_ok());
     }
 
     #[cfg(unix)]

--- a/src/plugin/update_check.rs
+++ b/src/plugin/update_check.rs
@@ -94,7 +94,18 @@ async fn check_one(target: &Target, lock: Result<&Lockfile, &anyhow::Error>) -> 
             let Some(current_commit) = locked.resolved_commit.clone() else {
                 return err("lockfile has no resolved commit".to_string());
             };
-            let reference = source.reference().map(String::from);
+            // A no-`@ref` install tracks the latest-release channel, so compare
+            // against the latest release tag rather than the moving default
+            // branch HEAD. An explicit `@ref` is compared as-is. A no-`@ref`
+            // source whose repo has no release has nothing to update to.
+            let reference = match source.reference() {
+                Some(r) => Some(r.to_string()),
+                None => match resolve_latest_release(&source).await {
+                    Ok(Some(tag)) => Some(tag),
+                    Ok(None) => return status(short(&current_commit), None, None),
+                    Err(e) => return err(format!("{e:#}")),
+                },
+            };
             let remote = tokio::task::spawn_blocking(move || {
                 super::fetch::ls_remote(&url, reference.as_deref())
             })
@@ -131,6 +142,17 @@ async fn check_one(target: &Target, lock: Result<&Lockfile, &anyhow::Error>) -> 
             }
         }
         Err(e) => err(format!("unparseable source {:?}: {e:#}", target.source)),
+    }
+}
+
+/// The latest stable release tag for a GitHub source, or `None` when the repo
+/// has none. Non-GitHub sources never reach this.
+async fn resolve_latest_release(source: &PluginSource) -> anyhow::Result<Option<String>> {
+    match source {
+        PluginSource::Github { owner, repo, .. } => {
+            super::fetch::latest_release_tag(owner, repo).await
+        }
+        PluginSource::Local(_) => Ok(None),
     }
 }
 

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -91,6 +91,54 @@ fn push_new_commit(base: &Path, owner: &str, repo: &str, files: &[(&str, &str)])
     git(&["push", "-q", bare.to_str().unwrap(), "main"], &work);
 }
 
+/// Tag the work tree behind a bare repo at its current HEAD and push the tag,
+/// so a clone of `tag` resolves. `force` moves an existing tag to a new HEAD.
+fn tag_bare_repo(base: &Path, owner: &str, repo: &str, tag: &str, force: bool) {
+    let work = base.join("work");
+    let mut args = vec!["tag"];
+    if force {
+        args.push("-f");
+    }
+    args.push(tag);
+    git(&args, &work);
+    let bare = base.join(owner).join(format!("{repo}.git"));
+    let refspec = format!("refs/tags/{tag}:refs/tags/{tag}");
+    git(
+        &["push", "-q", "-f", bare.to_str().unwrap(), &refspec],
+        &work,
+    );
+}
+
+/// Spawn a fake GitHub releases API serving `tag` as the latest stable release
+/// (and at `releases/tags/{tag}`), point `AOE_UPDATE_API_BASE` at it, and return
+/// the server handle so the caller can abort it. Assets are empty (source-only
+/// plugins); a release-binary test serves its own assets.
+async fn spawn_latest_release(owner: &str, repo: &str, tag: &str) -> tokio::task::JoinHandle<()> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+    let body = format!(r#"{{"tag_name":"{tag}","assets":[]}}"#);
+    let json = move || {
+        let body = body.clone();
+        async move {
+            (
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                body,
+            )
+        }
+    };
+    let app = axum::Router::new()
+        .route(
+            &format!("/repos/{owner}/{repo}/releases/latest"),
+            axum::routing::get(json.clone()),
+        )
+        .route(
+            &format!("/repos/{owner}/{repo}/releases/tags/{tag}"),
+            axum::routing::get(json),
+        );
+    std::env::set_var("AOE_UPDATE_API_BASE", &base_url);
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() })
+}
+
 #[tokio::test]
 #[serial]
 async fn local_install_lists_and_uninstalls() {
@@ -233,12 +281,15 @@ api_version = 2
         )],
     );
 
-    let report = install::install("gh:acme/widget", true).await.unwrap();
+    // An explicit `@ref` installs that ref directly (no release resolution);
+    // --yes bypasses the unverified confirmation.
+    let report = install::install("gh:acme/widget@main", true).await.unwrap();
     assert_eq!(report.id, "acme.widget");
 
     let lock = Lockfile::load().unwrap();
     let locked = lock.get("acme.widget").expect("lock entry");
     assert_eq!(locked.source, "gh:acme/widget");
+    assert_eq!(locked.requested_ref.as_deref(), Some("main"));
     assert!(
         locked
             .resolved_commit
@@ -263,6 +314,201 @@ api_version = 2
     );
 
     std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn github_no_ref_installs_latest_release() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "rel",
+        &[(
+            "aoe-plugin.toml",
+            r#"
+id = "acme.rel"
+name = "Rel"
+version = "1.0.0"
+api_version = 2
+"#,
+        )],
+    );
+    tag_bare_repo(base.path(), "acme", "rel", "v1.0.0", false);
+    let server = spawn_latest_release("acme", "rel", "v1.0.0").await;
+
+    // No `@ref`: resolves and installs the latest release tag.
+    install::install("gh:acme/rel", true).await.unwrap();
+
+    let lock = Lockfile::load().unwrap();
+    let locked = lock.get("acme.rel").expect("lock entry");
+    // The resolved release tag is recorded, but the config source stays ref-less
+    // so `update` keeps tracking the latest-release channel (rolling).
+    assert_eq!(locked.requested_ref.as_deref(), Some("v1.0.0"));
+    assert_eq!(
+        Config::load()
+            .unwrap()
+            .plugins
+            .get("acme.rel")
+            .and_then(|p| p.source.clone())
+            .as_deref(),
+        Some("gh:acme/rel"),
+    );
+
+    server.abort();
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+    std::env::remove_var("AOE_UPDATE_API_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn github_no_ref_no_release_bails_without_yes() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "norel",
+        &[(
+            "aoe-plugin.toml",
+            r#"
+id = "acme.norel"
+name = "NoRel"
+version = "1.0.0"
+api_version = 2
+"#,
+        )],
+    );
+    // A releases API with no matching route returns 404 -> no release found ->
+    // default-branch fallback, which is unverified and (non-interactively,
+    // without --yes) must bail rather than silently install.
+    let server = spawn_latest_release("other", "repo", "v9").await;
+
+    let err = install::install("gh:acme/norel", false)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unverified"), "got: {err}");
+    assert!(load_registry().get("acme.norel").is_none());
+
+    server.abort();
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+    std::env::remove_var("AOE_UPDATE_API_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn explicit_ref_requires_confirmation_without_yes() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "widget",
+        &[(
+            "aoe-plugin.toml",
+            r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 2
+"#,
+        )],
+    );
+
+    // An explicit `@ref` is unverified; without --yes on a non-terminal stdin it
+    // bails rather than installing un-audited code.
+    let err = install::install("gh:acme/widget@main", false)
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unverified"), "got: {err}");
+    assert!(load_registry().get("acme.widget").is_none());
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn outdated_tracks_release_not_default_branch() {
+    let _home = isolate();
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "rel",
+        &[(
+            "aoe-plugin.toml",
+            PLAIN_MANIFEST.replace("acme.upd", "acme.rel").as_str(),
+        )],
+    );
+    tag_bare_repo(base.path(), "acme", "rel", "v1.0.0", false);
+    let server = spawn_latest_release("acme", "rel", "v1.0.0").await;
+    install::install("gh:acme/rel", true).await.unwrap();
+
+    // Advance the default branch but leave the release tag at v1.0.0. A
+    // release-tracking install must NOT report this as an update.
+    push_new_commit(base.path(), "acme", "rel", &[("extra.txt", "new")]);
+    let after = update_check::outdated().await;
+    let s = after.iter().find(|s| s.id == "acme.rel").expect("present");
+    assert!(
+        !s.needs_update,
+        "tracks the release tag, not default-branch HEAD: {s:?}"
+    );
+    assert!(s.error.is_none(), "no check error: {s:?}");
+
+    server.abort();
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+    std::env::remove_var("AOE_UPDATE_API_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn featured_reserved_namespace_loads_after_tree_mutating_build() {
+    // Regression for #2475: a featured plugin whose build mutates the install
+    // tree (a `.venv`-style dir with a symlink) must still re-derive Featured at
+    // load. Before the reserved-build-output skip, tree_hash hard-errored on the
+    // symlink, so the plugin was not Featured and the reserved-namespace gate
+    // skipped it.
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "agent-of-empires.official"
+name = "Official"
+version = "1.0.0"
+api_version = 2
+"#,
+    );
+    let tree_hash = agent_of_empires::plugin::integrity::tree_hash(&dir).unwrap();
+    write_featured(
+        src.path(),
+        "agent-of-empires.official",
+        dir.to_str().unwrap(),
+        &tree_hash,
+    );
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    // Simulate a build that creates the reserved build-output dir with a symlink
+    // inside the installed plugin, the way plugin-github's venv build would.
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("agent-of-empires.official");
+    let build = installed.join(".aoe-build").join("bin");
+    std::fs::create_dir_all(&build).unwrap();
+    std::fs::write(build.join("real"), b"x").unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink("real", build.join("python3")).unwrap();
+
+    let reg = load_registry();
+    let plugin = reg
+        .get("agent-of-empires.official")
+        .expect("featured plugin still loads after a tree-mutating build");
+    assert_eq!(plugin.validation.as_str(), "featured");
+
+    std::env::remove_var("AOE_FEATURED_INDEX_PATH");
 }
 
 /// Write a featured index file and point `AOE_FEATURED_INDEX_PATH` at it (debug
@@ -454,18 +700,25 @@ async fn release_binary_is_downloaded_and_placed() {
     let release_json = format!(
         r#"{{"tag_name":"v1.0.0","assets":[{{"name":"{asset_name}","browser_download_url":"{base_url}/dl"}}]}}"#
     );
+    let json_handler = move || {
+        let body = release_json.clone();
+        async move {
+            (
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                body,
+            )
+        }
+    };
     let app = axum::Router::new()
+        // No `@ref` resolves the latest release tag, then pins source + asset to
+        // it, so both the latest and the by-tag endpoints are hit.
         .route(
             "/repos/acme/bin/releases/latest",
-            axum::routing::get(move || {
-                let body = release_json.clone();
-                async move {
-                    (
-                        [(axum::http::header::CONTENT_TYPE, "application/json")],
-                        body,
-                    )
-                }
-            }),
+            axum::routing::get(json_handler.clone()),
+        )
+        .route(
+            "/repos/acme/bin/releases/tags/v1.0.0",
+            axum::routing::get(json_handler),
         )
         .route(
             "/dl",
@@ -493,6 +746,7 @@ asset = "bin-${os}-${arch}"
 "#,
         )],
     );
+    tag_bare_repo(base.path(), "acme", "bin", "v1.0.0", false);
 
     install::install("gh:acme/bin", true).await.unwrap();
 
@@ -843,7 +1097,9 @@ async fn outdated_detects_new_github_commit() {
         "upd",
         &[("aoe-plugin.toml", PLAIN_MANIFEST)],
     );
-    install::install("gh:acme/upd", true).await.unwrap();
+    // Branch tracking is now an explicit-ref opt-in: `@main` follows the default
+    // branch (no release resolution), which these update-mechanics tests need.
+    install::install("gh:acme/upd@main", true).await.unwrap();
 
     let before = update_check::outdated().await;
     let s = before.iter().find(|s| s.id == "acme.upd").expect("present");
@@ -895,7 +1151,9 @@ async fn auto_update_applies_clean_github_update() {
         "upd",
         &[("aoe-plugin.toml", PLAIN_MANIFEST)],
     );
-    install::install("gh:acme/upd", true).await.unwrap();
+    // Branch tracking is now an explicit-ref opt-in: `@main` follows the default
+    // branch (no release resolution), which these update-mechanics tests need.
+    install::install("gh:acme/upd@main", true).await.unwrap();
 
     // A clean (no consent change) newer version on the remote.
     push_new_commit(base.path(), "acme", "upd", &[("aoe-plugin.toml", &v2)]);
@@ -926,7 +1184,9 @@ async fn clean_update_skips_capability_change() {
         "upd",
         &[("aoe-plugin.toml", PLAIN_MANIFEST)],
     );
-    install::install("gh:acme/upd", true).await.unwrap();
+    // Branch tracking is now an explicit-ref opt-in: `@main` follows the default
+    // branch (no release resolution), which these update-mechanics tests need.
+    install::install("gh:acme/upd@main", true).await.unwrap();
 
     // The new version adds a capability, so a non-interactive clean update must
     // skip it and leave the prior version installed.

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -338,8 +338,10 @@ api_version = 2
     tag_bare_repo(base.path(), "acme", "rel", "v1.0.0", false);
     let server = spawn_latest_release("acme", "rel", "v1.0.0").await;
 
-    // No `@ref`: resolves and installs the latest release tag.
-    install::install("gh:acme/rel", true).await.unwrap();
+    // No `@ref`: resolves and installs the latest release tag. `false` (no
+    // --yes) proves the resolved-release path is not treated as unverified, so
+    // it installs without an interactive confirmation.
+    install::install("gh:acme/rel", false).await.unwrap();
 
     let lock = Lockfile::load().unwrap();
     let locked = lock.get("acme.rel").expect("lock entry");


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two coupled supply-chain changes to plugin install and trust, landed together because they share `src/plugin/` (install.rs / fetch.rs / integrity.rs / registry-load path).

**Safe-by-default install (#2477).** `aoe plugin install gh:owner/repo` with no `@ref` now resolves the repo's latest stable GitHub release (`/releases/latest`, prereleases and drafts excluded) and installs that tag, the audited default path. An explicit `@ref` is an unverified, un-audited opt-in that prompts for confirmation first (bypassed by `--yes`, bails on a non-interactive stdin). When a repo has published no release, install warns and falls back to the default branch behind the same confirmation. The recorded config source stays ref-less, so `aoe plugin update` and `aoe plugin outdated` keep tracking the latest-release channel (rolling): both resolve the latest release tag rather than comparing against default-branch HEAD. An explicit `@ref` install keeps following its ref, and `update` refuses rather than silently switching a release-tracking install onto the moving default branch. Source checkout and any release-binary asset are pinned to the same resolved tag.

**Featured plugin with a tree-mutating build (#2475).** A featured plugin whose build mutates the install tree (plugin-github creates a Python `.venv` with ~1800 files and a `.venv/bin/python3` symlink) could never re-derive `Featured` at load: `tree_hash` over the built tree saw the build output and hard-errored on the symlink, so the reserved-namespace gate skipped it and the one shipped featured plugin never loaded. Fix: reserve `.aoe-build/` for build output and skip it in `tree_hash` like `.git`, so an author's `aoe plugin hash` of a clean checkout and the live load-path re-derivation over the built tree produce the same value. A fetched source that ships `.aoe-build` is refused, so the excluded subtree can never hide vetted source.

A fixed reserved directory is deliberate over a manifest-declared `build_output` list: an external `/debate` flagged that a tampered installed manifest could set `build_output = ["aoe-plugin.toml"]` (or `"."`) to exclude itself from the hash and sever the root of trust. A hardcoded name keeps the exclusion out of attacker control and needs no manifest-schema change.

Closes #2477
Closes #2475

### Coordination / follow-ups

- A separate in-flight session owns #2392 (per-version featured verification, already merged here as #2472) plus #2394 (cache validation). This branch is off `main` and does not include the #2394 work. There is **direct overlap territory** around `verify_featured` and the load-path featured re-derivation: this PR deliberately takes the no-persisted-store route (a content-excluded reserved dir), so it should not duplicate or revert the #2394 cache. The one likely conflict point on rebase is `src/plugin/registry.rs` `validation_for` / the install path if #2394 reworks them; flagging so the merge is reviewed rather than auto-resolved.
- **Cross-repo (not in this PR):** the shipped `agent-of-empires.github` featured plugin will not load until `plugin-github` moves its venv build into `.aoe-build/venv` and `plugins/featured.toml` is re-pinned to the new source hash. This PR delivers the host capability; the re-pin is a mechanical follow-up in the other repo.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `aoe plugin install gh:owner/repo` (a repo with a release) installs the latest release tag; `aoe plugin list` shows it.
- [ ] `aoe plugin install gh:owner/repo` (a repo with no release) warns and asks to confirm a default-branch install; declining cancels, `--yes` proceeds.
- [ ] `aoe plugin install gh:owner/repo@some-branch` prompts "unverified, un-audited code" before installing; `--yes` skips the prompt.
- [ ] After a no-`@ref` install, `aoe plugin outdated` reports an update only when a newer release is published, not when the default branch moves.
- [ ] A featured plugin whose build creates a `.aoe-build/` dir (with a symlink inside) still shows `featured` in `aoe plugin list` after install, rather than being skipped at load.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (plugin install/update are CLI-only)

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a tmux/subprocess e2e, because: the change is install-resolution and hashing logic, covered in-process by `tests/plugin_install.rs` (latest-release resolution, no-release fallback bail, explicit-ref confirmation, rolling `outdated`, and a reproduce-then-fix #2475 regression that fails on the pre-fix tree). A full-binary e2e would add no signal over these.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with an external multi-model `/debate` used to pressure-test the trust model (it caught the manifest self-exclusion bypass and steered the fix to a hardcoded reserved dir). I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785175289&installation_id=139138837&pr_number=2480&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2480&signature=3f4b3991a2f1478febf18541e0abd8a724f851b24e35f3fdd22cb14399abce2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves plugin safety defaults and fixes featured-plugin loading for build-mutating plugins.

- **Safer `aoe plugin install` defaults:** `aoe plugin install gh:owner/repo` (no `@ref`) now resolves to the repo’s **latest GitHub release**.  
- **Stricter handling of explicit refs:** `gh:owner/repo@ref` installs are treated as **unverified/un-audited**, prompting for confirmation unless `--yes` is used (and they fail in non-interactive contexts).  
- **Graceful fallback when no release exists:** if there is **no GitHub release**, installs warn and fall back to the default branch using the same confirmation flow.  
- **More predictable updates:** ref-less installs remain tracked as a “latest release channel” (rather than silently switching to the default branch during updates). Update checks now compare against the latest release tag when no `@ref` is recorded.
- **Featured plugin load fix:** featured plugins that modify the install tree during build can now be re-derived as *Featured* correctly.

- **Reserved build output directory:** build artifacts are required to live under a reserved `.aoe-build/` directory, and this directory is excluded from the plugin integrity/tree hashing in a way that preserves deterministic hashes for featured pinning. Sources that already include `.aoe-build/` are rejected to prevent tampering.

**Benefits**
- Reduces the risk of installing code that hasn’t been audited via GitHub releases.
- Makes plugin updates more consistent and less surprising.
- Restores reliable featured-plugin loading for plugins that generate build output during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->