### PR TITLE
fix(plugins): feature plugin-github 1.2.0, unpin broken 1.1.0

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -27,4 +27,9 @@
 
 [plugins."agent-of-empires.github"]
 source = "gh:agent-of-empires/plugin-github"
-versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.1.0" = "sha256:2a13a901314e4061616ad68e5923a807c0841387ec065036eb972acc8c3703e0" }
+# 1.1.0 is intentionally unpinned: its `.venv`-in-source-root build bricked at
+# load (load-time tree_hash trips over the venv symlink, so the reserved
+# namespace gate skips it). Dropping the pin downgrades it to community so the
+# reserved-namespace install gate blocks it outright. Fixed in 1.2.0, which
+# builds under `.aoe-build/`.
+versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a" }


### PR DESCRIPTION
> **AI disclosure:** this PR was authored by Claude (Opus 4.8) on behalf of the repo owner.

## Description

`aoe plugin install gh:agent-of-empires/plugin-github` (1.1.0) installed cleanly but bricked at load:

```
plugin "agent-of-empires.github" at ... uses a reserved namespace and was skipped
```

Root cause: 1.1.0's build steps created the Python venv at `.venv` in the plugin **source root** instead of under `.aoe-build/` (the host's `BUILD_OUTPUT_DIR`, excluded from `tree_hash`). The clean downloaded tree matched the featured pin so the install-time gate passed, but the load-time re-hash (`registry.rs` `validation_for` -> `integrity::tree_hash`) tripped over the venv's `bin/python3` symlink (tree_hash hard-errors on symlinks). The manifest then no longer verified as `Featured`, so the reserved-namespace gate (`registry.rs:307`) skipped it.

[plugin-github 1.2.0](https://github.com/agent-of-empires/plugin-github/releases/tag/v1.2.0) fixes this by building the venv under `.aoe-build/`, keeping it out of the hashed tree.

This PR:
- Pins 1.2.0 (`sha256:e5fe509a...`, from `aoe plugin hash` on the `v1.2.0` tag).
- Drops the 1.1.0 pin so an explicit install of the broken version is treated as community and blocked at the reserved-namespace install gate, rather than half-installing then failing to load.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: data-only change to the compiled featured-plugin index; no TUI/CLI/session-lifecycle change

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785178734&installation_id=139138837&pr_number=2482&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2482&signature=02b9b27519b5e2e7b0dbf6ba3b36522b63b9f643c15cafbfd2fdacc72d5102e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the featured GitHub plugin entry to move the package from 1.1.0 to 1.2.0 and remove the old 1.1.0 pin.

This fixes a broken featured release path, so the plugin is now recognized and loaded correctly again. It also helps block the problematic 1.1.0 build earlier when someone tries to install it directly.

Technical note: the featured index now keeps vetted releases for 0.1.0, 1.0.0, and 1.2.0 only, and drops the 1.1.0 tree hash entry tied to the `.venv`/symlink validation issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->