### PR TITLE
test(plugins): run core e2e with all default plugins disabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,13 +80,23 @@ jobs:
       - name: Cargo test (macOS, lib + bins only)
         if: runner.os == 'macOS'
         run: cargo test --features serve --lib --bins
-      # Acceptance criterion 1 of #268: with every bundled plugin compiled out,
-      # core must still build and pass its suite. `--no-default-features` also
-      # drops `serve`, so this doubles as the TUI-only compile gate, keeping the
-      # ~27 cfg(feature = "serve") sites from rotting.
+      # With every bundled plugin compiled out, core must still build and pass
+      # its unit/integration suite. `--no-default-features` also drops `serve`,
+      # so this doubles as the TUI-only compile gate, keeping the ~27
+      # cfg(feature = "serve") sites from rotting.
       - name: Cargo test (bare core, no default features)
         if: runner.os == 'Linux'
         run: cargo test --no-default-features --lib --bins
+      # Acceptance criterion 1 of #268 (issue #2097): with all default plugins
+      # disabled, aoe still creates, attaches to, and destroys a tmux + worktree
+      # session from CLI and TUI. The --lib --bins leg above never spawns the
+      # binary under tmux, so the e2e crate is what actually proves the
+      # invariant; the serve-gated e2e modules self-gate to empty here. This is
+      # the forcing function that makes "default plugin" mean something: a
+      # default plugin that grows an undeclared core dependency turns this red.
+      - name: Cargo test (bare core e2e, no default features)
+        if: runner.os == 'Linux'
+        run: cargo test --no-default-features --test e2e
       # The third feature corner: default-plugins on, serve off. Compile gate
       # (including test/e2e targets, which plain check skips) so plugin
       # registration code can't grow a hidden dependency on serve types.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
         if: runner.os == 'macOS'
         run: cargo test --features serve --lib --bins
       # With every bundled plugin compiled out, core must still build and pass
-      # its unit/integration suite. `--no-default-features` also drops `serve`,
+      # its lib/bin unit tests. `--no-default-features` also drops `serve`,
       # so this doubles as the TUI-only compile gate, keeping the ~27
       # cfg(feature = "serve") sites from rotting.
       - name: Cargo test (bare core, no default features)

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -31,7 +31,12 @@ schema/host version this crate understands.
   TOML via `include_str!`. The `aoe.web` marker is gated on the `serve` cargo
   feature, so it is present in every dashboard/release build and absent from a
   TUI-only build. `default-plugins` (on by default) reserves the on-by-default
-  slot for bundled plugins that do not require the dashboard.
+  slot for bundled plugins that do not require the dashboard. CI runs a
+  `--no-default-features` leg (`.github/workflows/tests.yml`) that builds with
+  every default plugin compiled out and runs the e2e suite, so a default plugin
+  cannot silently grow an undeclared core dependency: core must still create,
+  attach to, and destroy a tmux + worktree session from CLI and TUI with all
+  default plugins disabled (invariant 1 of #268).
 - `PluginRegistry::load(config)` parses every builtin manifest, resolves each
   plugin's enabled flag from `[plugins."<id>"]` in `config.toml` (default
   enabled), and collects any parse errors as non-fatal `load_errors`.

--- a/tests/e2e/plugins.rs
+++ b/tests/e2e/plugins.rs
@@ -3,6 +3,12 @@
 //! config, `plugin info` prints the manifest details, `aoe serve` refuses to
 //! start while the `aoe.web` plugin is disabled, and the command palette opens
 //! the plugin manager listing the builtins.
+//!
+//! Compiled only under `serve`: the sole bundled plugin is the serve-gated
+//! `aoe.web`, so without that feature the builtin set is empty and there is
+//! nothing for these management-surface tests to exercise. The bare-core
+//! `--no-default-features` e2e leg skips this module by design.
+#![cfg(feature = "serve")]
 
 use serial_test::serial;
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds the CI forcing function that makes "default plugin" mean something: a Linux `cargo` step that runs the e2e suite with every default plugin (and `serve`) compiled out (`cargo test --no-default-features --test e2e`).

The bare-core leg already in `tests.yml` only ran `--lib --bins`, which never spawns the `aoe` binary under tmux, so invariant 1 of #268 (with all default plugins disabled, core still creates, attaches to, and destroys a tmux + worktree session from CLI and TUI) was never actually exercised plugin-free. The e2e crate's `serve`-gated modules self-gate to empty under `--no-default-features`, so the new run covers exactly the core lifecycle. As first-party default plugins land behind `#[cfg(feature = "default-plugins")]`, this leg compiles them out and turns red if one grows an undeclared core dependency.

Also corrects the prior step's comment, which over-claimed `--lib --bins` satisfied that acceptance criterion, and adds a terse note to the plugin-system design doc.

Verified locally under `--no-default-features`: the e2e crate compiles, and `test_cli_add_and_list`, `test_cli_rm_kills_agent_tmux_session`, and `test_tui_launches_and_shows_home_screen` pass.

Closes #2097

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] `cargo test --no-default-features --test e2e` passes locally (tmux required)
- [ ] On the PR, the Linux "Cargo Test (linux)" job shows a green "Cargo test (bare core e2e, no default features)" step
- [ ] Temporarily add a `#[cfg(feature = "default-plugins")]` builtin with a core dependency and confirm the new step goes red while the default `--features serve` suite stays green (sanity-check the forcing function; revert after)

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR adds a CI feature-corner that runs the existing e2e suite; it changes no TUI rendering, CLI subcommand, or session lifecycle behavior

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (full e2e crate over a hand-picked subset, step in the required Linux job over a separate job) and reviewed the diff.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785181165&installation_id=139138837&pr_number=2495&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2495&signature=e01cf76200e30d50b555644ce38ff376ad21be7cce6de84e4d00619dbdada1a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves Linux CI coverage for the “no default plugins” configuration by adding a dedicated end-to-end test run that compiles core with all default plugins disabled (`cargo test --no-default-features --test e2e`). The previous “bare core” CI leg still runs core lib/bin checks, but it no longer bypasses the real `aoe` binary behavior under tmux.

Key updates:
- **CI:** Replaces the limited bare-core step with a full **e2e** run under `--no-default-features`, ensuring the tmux + worktree **create/attach/destroy** flow is exercised from both **CLI and TUI** with default plugins compiled out.
- **CI docs/comments:** Adjusts the nearby acceptance-criteria note to reflect that the invariant is validated by the e2e suite, including the fact that serve-gated e2e plugin-management tests self-skip when `serve` is not enabled.
- **Plugin docs:** Updates the plugin-system design doc to explicitly describe this CI guardrail and the intended invariant.
- **e2e tests:** Gates the `tests/e2e/plugins.rs` module behind the `serve` feature so it doesn’t run in the no-default-plugins configuration where the bundled builtin set is empty.

Benefits:
- Catches accidental coupling between core and “default plugins” earlier.
- Validates the **real end-to-end lifecycle** (not just compilation) when default plugins are disabled.
- Keeps **serve-feature** e2e coverage separate while still ensuring the core lifecycle works without default plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->