### PR TITLE
feat(web): show spinner for plugin refresh actions (manual and auto)

### DIFF
--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -6,11 +6,11 @@
 // sort-key and filter-facet slots render as sidebar sort options and a facet
 // filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
-import { createElement, useId, useState } from "react";
+import { createElement, useId, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { invokePluginAction } from "../../lib/api";
-import { usePluginUiEntries } from "../../lib/pluginUiContext";
+import { usePluginUiEntries, usePluginUiRefreshing } from "../../lib/pluginUiContext";
 import {
   accentStyle,
   entryText,
@@ -279,22 +279,42 @@ function BlockRow({ block }: { block: Record<string, unknown> }) {
   );
 }
 
+/** The repo's inline spinner glyph (same shape as the dialog buttons), sized to
+ *  fit alongside slot text. `currentColor` so it inherits the surrounding tone. */
+function Spinner({ className }: { className: string }) {
+  return (
+    <svg className={`animate-spin ${className}`} viewBox="0 0 24 24" aria-hidden>
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  );
+}
+
 /** An `action` pane block: a button that forwards a worker method (named by the
  *  plugin) to that plugin's worker. Fire-and-forget; the worker re-pushes its
- *  UI state, which the next poll renders. Disabled briefly so a double-click
- *  does not double-fire. An icon is optional. */
+ *  UI state, which the next poll renders. While the POST is in flight the button
+ *  disables and swaps its icon for a spinner, so a refresh shows it is underway;
+ *  `invokePluginAction` never rejects (it returns false on failure), so the
+ *  `finally` always restores the button to an actionable state. An icon is
+ *  optional. */
 function BlockAction({ block, pluginId }: { block: Record<string, unknown>; pluginId: string }) {
   const label = str(block, "label");
   const method = str(block, "method");
   const iconComp = lucideIcon(str(block, "icon"));
   const [busy, setBusy] = useState(false);
+  // A ref guard, not just `busy`: two clicks in the same tick both see the old
+  // `busy` state before React commits the update, so the boolean alone would
+  // double-fire. The ref flips synchronously.
+  const busyRef = useRef(false);
   if (!label || !method) return null;
   const onClick = async () => {
-    if (busy) return;
+    if (busyRef.current) return;
+    busyRef.current = true;
     setBusy(true);
     try {
       await invokePluginAction(pluginId, method);
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
   };
@@ -303,10 +323,15 @@ function BlockAction({ block, pluginId }: { block: Record<string, unknown>; plug
       type="button"
       onClick={onClick}
       disabled={busy}
+      aria-busy={busy || undefined}
       data-testid="plugin-pane-action"
       className="self-start inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer bg-surface-700/50 text-text-secondary hover:text-text-primary hover:bg-surface-700 disabled:opacity-50 disabled:cursor-default transition-colors"
     >
-      {iconComp && createElement(iconComp, { className: "size-3.5", "aria-hidden": true })}
+      {busy ? (
+        <Spinner className="size-3.5" />
+      ) : (
+        iconComp && createElement(iconComp, { className: "size-3.5", "aria-hidden": true })
+      )}
       {label}
     </button>
   );
@@ -456,8 +481,20 @@ export function PluginPaneBody({ entry }: { entry: PluginUiEntry }) {
   const blocks = objectList(entry.payload, "blocks");
   const title = payloadStr(entry, "title");
   const body = payloadStr(entry, "body");
+  // A background poll only flips this once it outlasts the indicator delay, so
+  // this surfaces a slow auto-refresh without strobing on every 3s cadence.
+  const refreshing = usePluginUiRefreshing();
   return (
     <div className="flex-1 min-h-0 overflow-auto p-3" data-testid="plugin-pane-body" data-plugin-id={entry.plugin_id}>
+      {refreshing && (
+        <div
+          className="sticky top-0 z-10 mb-1.5 flex items-center justify-end gap-1 text-[10px] text-text-dim"
+          data-testid="plugin-pane-refreshing"
+        >
+          <Spinner className="size-3" />
+          Refreshing…
+        </div>
+      )}
       {blocks ? (
         <div className="flex flex-col gap-1.5">
           {blocks.map((b, i) => (

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -1,15 +1,19 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { PluginUiEntry } from "../../../lib/api";
 import { PluginCards, PluginPaneBody, PluginRowBadges, PluginStatusBarSegments } from "../PluginSlots";
 
-// The slot components read entries from context; mock that hook so each test
-// drives a fixed snapshot.
-const { entriesRef } = vi.hoisted(() => ({ entriesRef: { current: [] as PluginUiEntry[] } }));
+// The slot components read entries (and the refresh flag) from context; mock
+// those hooks so each test drives a fixed snapshot.
+const { entriesRef, refreshingRef } = vi.hoisted(() => ({
+  entriesRef: { current: [] as PluginUiEntry[] },
+  refreshingRef: { current: false },
+}));
 vi.mock("../../../lib/pluginUiContext", () => ({
   usePluginUiEntries: () => entriesRef.current,
+  usePluginUiRefreshing: () => refreshingRef.current,
 }));
 
 // The action block forwards to the worker via this; stub it.
@@ -99,6 +103,68 @@ describe("plugin slot renderers", () => {
     expect(btn.textContent).toContain("Refresh");
     fireEvent.click(btn);
     await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh"));
+  });
+
+  it("pane action shows a spinner while the request is in flight, then clears it", async () => {
+    // Defer the action so the in-flight state is observable.
+    let resolve!: (v: boolean) => void;
+    invokeMock.mockImplementationOnce(() => new Promise<boolean>((r) => (resolve = r)));
+    const entry: PluginUiEntry = {
+      plugin_id: "acme.kit",
+      slot: "pane",
+      id: "p",
+      session_id: "s1",
+      payload: { blocks: [{ kind: "action", label: "Refresh", method: "github.refresh" }] },
+    };
+    const { container } = render(<PluginPaneBody entry={entry} />);
+    const btn = screen.getByTestId("plugin-pane-action") as HTMLButtonElement;
+    expect(container.querySelector("svg.animate-spin")).toBeNull();
+
+    fireEvent.click(btn);
+    await waitFor(() => expect(container.querySelector("svg.animate-spin")).toBeTruthy());
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+    expect(btn.disabled).toBe(true);
+
+    await act(async () => resolve(true));
+    await waitFor(() => expect(container.querySelector("svg.animate-spin")).toBeNull());
+    expect(btn.getAttribute("aria-busy")).toBeNull();
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("pane action stops the spinner and stays actionable when the request fails", async () => {
+    invokeMock.mockImplementationOnce(async () => false);
+    const entry: PluginUiEntry = {
+      plugin_id: "acme.kit",
+      slot: "pane",
+      id: "p",
+      session_id: "s1",
+      payload: { blocks: [{ kind: "action", label: "Refresh", method: "github.refresh" }] },
+    };
+    const { container } = render(<PluginPaneBody entry={entry} />);
+    const btn = screen.getByTestId("plugin-pane-action") as HTMLButtonElement;
+    fireEvent.click(btn);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(container.querySelector("svg.animate-spin")).toBeNull();
+      expect(btn.disabled).toBe(false);
+    });
+  });
+
+  it("pane shows a background-refresh indicator only while a poll is in flight", () => {
+    const entry: PluginUiEntry = {
+      plugin_id: "acme.kit",
+      slot: "pane",
+      id: "p",
+      session_id: "s1",
+      payload: { title: "GitHub", body: "ok" },
+    };
+    refreshingRef.current = true;
+    const { rerender } = render(<PluginPaneBody entry={entry} />);
+    expect(screen.getByTestId("plugin-pane-refreshing")).toBeTruthy();
+
+    refreshingRef.current = false;
+    rerender(<PluginPaneBody entry={{ ...entry, payload: { ...entry.payload } }} />);
+    expect(screen.queryByTestId("plugin-pane-refreshing")).toBeNull();
   });
 
   it("pane action block without a method renders nothing", () => {

--- a/web/src/hooks/usePluginUiState.test.tsx
+++ b/web/src/hooks/usePluginUiState.test.tsx
@@ -108,3 +108,64 @@ describe("usePluginUiState notifications", () => {
     expect(reportInfo).toHaveBeenCalledWith("fresh");
   });
 });
+
+describe("usePluginUiState refresh indicator", () => {
+  it("does not flip isRefreshing for a poll that settles before the delay", async () => {
+    fetchMock.mockResolvedValue(snapshot([]));
+    const { result } = renderHook(() => usePluginUiState());
+
+    // Mount poll resolves on a microtask, before the threshold timer fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+
+    // Past where the threshold would have fired: still false (timer was cleared).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("flips isRefreshing on once a poll outlasts the delay, off when it settles", async () => {
+    let resolve!: (v: PluginUiState | null) => void;
+    fetchMock.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+    fetchMock.mockResolvedValue(snapshot([]));
+    const { result } = renderHook(() => usePluginUiState());
+
+    // Still in flight, before the threshold.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+
+    // Crossing the threshold while the poll is still pending shows the indicator.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(result.current.isRefreshing).toBe(true);
+
+    // Settling clears it.
+    await act(async () => {
+      resolve(snapshot([]));
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("clears isRefreshing even when a slow poll fails (returns null)", async () => {
+    let resolve!: (v: PluginUiState | null) => void;
+    fetchMock.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+    fetchMock.mockResolvedValue(snapshot([]));
+    const { result } = renderHook(() => usePluginUiState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.isRefreshing).toBe(true);
+
+    await act(async () => {
+      resolve(null);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});

--- a/web/src/hooks/usePluginUiState.ts
+++ b/web/src/hooks/usePluginUiState.ts
@@ -20,8 +20,15 @@ function toast(n: PluginUiNotification): void {
   }
 }
 
+// A poll faster than this shows no refresh indicator: a background fetch that
+// settles in tens of milliseconds would otherwise strobe the indicator on and
+// off every cadence. Only a poll slow enough to be worth surfacing (network
+// latency, a rate-limited GitHub refresh) crosses the threshold and shows.
+const REFRESH_INDICATOR_DELAY = 250;
+
 export function usePluginUiState() {
   const [entries, setEntries] = useState<PluginUiEntry[]>([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   // Highest notification seq already toasted. Seeded from the first snapshot so
   // a page load does not replay the whole backlog as fresh toasts.
   const lastNotifySeqRef = useRef<number | null>(null);
@@ -29,6 +36,7 @@ export function usePluginUiState() {
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let slowTimer: ReturnType<typeof setTimeout> | null = null;
 
     const apply = (notifications: PluginUiNotification[]) => {
       const maxSeq = notifications.reduce((m, n) => Math.max(m, n.seq), 0);
@@ -52,21 +60,32 @@ export function usePluginUiState() {
     // response cannot land after a newer one and roll the dashboard back to
     // stale plugin UI. A failed fetch (null) just skips this round.
     const tick = async () => {
+      // Flip the indicator on only once the poll outlasts the threshold, so a
+      // fast fetch never shows it. Cleared in finally whether the fetch
+      // succeeds, returns null, or the threshold never fires.
+      slowTimer = setTimeout(() => {
+        if (!cancelled) setIsRefreshing(true);
+      }, REFRESH_INDICATOR_DELAY);
       try {
         const state = await fetchPluginUiState();
         if (cancelled || state === null) return;
         setEntries(state.entries);
         apply(state.notifications);
       } finally {
-        if (!cancelled) timer = setTimeout(() => void tick(), POLL_INTERVAL);
+        if (slowTimer) clearTimeout(slowTimer);
+        if (!cancelled) {
+          setIsRefreshing(false);
+          timer = setTimeout(() => void tick(), POLL_INTERVAL);
+        }
       }
     };
     void tick();
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
+      if (slowTimer) clearTimeout(slowTimer);
     };
   }, []);
 
-  return entries;
+  return { entries, isRefreshing };
 }

--- a/web/src/lib/pluginUiContext.tsx
+++ b/web/src/lib/pluginUiContext.tsx
@@ -9,14 +9,29 @@ import { createContext, useContext, type ReactNode } from "react";
 import { usePluginUiState } from "../hooks/usePluginUiState";
 import type { PluginUiEntry } from "./api";
 
-const PluginUiContext = createContext<PluginUiEntry[]>([]);
+// Entries and the refresh flag live in separate contexts: the flag toggles on
+// every slow poll, and folding it into the entries context would re-render all
+// entry consumers (rows, badges, cards, top bar) on each toggle even though
+// they never read it.
+const PluginUiEntriesContext = createContext<PluginUiEntry[]>([]);
+const PluginUiRefreshingContext = createContext(false);
 
 export function PluginUiProvider({ children }: { children: ReactNode }) {
-  const entries = usePluginUiState();
-  return <PluginUiContext.Provider value={entries}>{children}</PluginUiContext.Provider>;
+  const { entries, isRefreshing } = usePluginUiState();
+  return (
+    <PluginUiEntriesContext.Provider value={entries}>
+      <PluginUiRefreshingContext.Provider value={isRefreshing}>{children}</PluginUiRefreshingContext.Provider>
+    </PluginUiEntriesContext.Provider>
+  );
 }
 
 /** All current plugin UI entries. Filter with the selectors in `pluginUi.ts`. */
 export function usePluginUiEntries(): PluginUiEntry[] {
-  return useContext(PluginUiContext);
+  return useContext(PluginUiEntriesContext);
+}
+
+/** True while a background ui-state poll has been in flight past the indicator
+ *  delay. Lets a pane renderer show a refresh-in-progress affordance. */
+export function usePluginUiRefreshing(): boolean {
+  return useContext(PluginUiRefreshingContext);
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The plugin pane `Refresh` action gave no visible in-flight feedback. On a manual click the button only dimmed and disabled; on the shared 3s background poll there was no way for a pane to show a reload was underway. For the GitHub plugin, where network latency and rate-limit retries make a refresh visibly non-instant, that reads as "did my click do anything?".

This adds in-flight affordances on both paths:

- **Manual click:** `BlockAction` now swaps its icon for the repo's inline spinner and sets `aria-busy` while the action POST is in flight. A `busyRef` guard blocks a double-fire before the `busy` state commits. `invokePluginAction` never rejects (it returns `false` on failure), so the `finally` always restores an actionable button, including on a failed refresh.
- **Background auto-refresh:** the shared `usePluginUiState` poller now tracks an `isRefreshing` flag, gated behind a 250ms threshold so a fast poll never strobes the indicator on and off every cadence. It is exposed through a dedicated `PluginUiRefreshingContext`, kept separate from the entries context so the flag's toggles do not re-render every entry consumer (rows, badges, cards, top bar). `PluginPaneBody` renders a low-contrast `Refreshing…` indicator while a slow poll runs.

Scope note: the action API stays a notification-style forwarder, so the spinner means "request/poll in flight", not "the worker finished refreshing GitHub". Worker-published completion state (the issue's Part C) is intentionally out of scope; it would require reworking the `/action` contract, which the issue excludes.

Closes #2492

## How to test

- [ ] Open the web dashboard with the GitHub plugin pane docked, click its `Refresh` action, and confirm the button shows a spinner and is disabled until the request settles, then returns to normal.
- [ ] Disconnect the network (or otherwise make the action fail), click `Refresh`, and confirm the spinner stops and the button is clickable again rather than looking stuck.
- [ ] Throttle the network so a background `ui-state` poll takes longer than ~250ms and confirm the pane shows a `Refreshing…` indicator while that poll is in flight; with a fast connection confirm no indicator flickers on every 3s poll.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Note: the regression tests are Vitest + RTL, not Playwright. Per `AGENTS.md`, this is UI logic (spinner/indicator state, hook toggling), not browser-specific behavior, so it belongs in Vitest, and the existing `plugins.ui-slots` coverage-matrix entry already maps `PluginSlots.test.tsx` and `usePluginUiState.test.tsx`, so no matrix change was needed. Added: spinner appears then clears on a settled request, spinner clears on a failed request, the pane indicator shows only while refreshing, and the hook flips `isRefreshing` only once a poll outlasts the 250ms delay and always clears it (success, null, or failure).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a `/debate` between two models), and implementation drafted by Claude under my direction. I made the scope and design calls (skip the worker-completion contract change, threshold the background indicator to avoid strobe, split the context to avoid re-render churn), reviewed each commit, and ran the test steps.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785182506&installation_id=139138837&pr_number=2496&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2496&signature=899ec619f64795ea42c6be93eff50f6cd0a7b2e0ef3625a62426fad22ec29758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds visible refresh feedback to the plugin dashboard.

- The plugin pane now shows a loading spinner and disables the refresh action while a manual refresh is in progress, then returns to normal after success or failure.
- Background plugin polling now exposes a separate “refreshing” state, allowing the pane to show a subtle “Refreshing…” indicator during slower auto-refreshes.
- The shared plugin UI state was split so refresh status can be consumed independently from the plugin entries list.
- Tests were expanded to cover successful, failed, and delayed refresh cases.

Benefit: users get clearer progress feedback for both manual and automatic refreshes, with less confusion during slow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->