### PR TITLE
feat(cli): show trust/validation in plugin install output

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -80,9 +80,9 @@ rejected rather than granted; upgrade aoe.
 A grant is pinned to the installed manifest. If an update changes the
 capability set, the plugin is left installed but inactive and
 `aoe plugin update <id>` re-prompts you to approve the new set. `aoe plugin
-install` reports the resolved trust level (`featured`, `community`, or `local`)
-in its success output, and `aoe plugin list` and `aoe plugin info <id>` show
-each plugin's trust level and whether it is granted. An external plugin cannot use the reserved `aoe.*` /
+install` and `aoe plugin update` report the resolved trust level (`featured`,
+`community`, or `local`) in their success output, and `aoe plugin list` and
+`aoe plugin info <id>` show each plugin's trust level and whether it is granted. An external plugin cannot use the reserved `aoe.*` /
 `agent-of-empires.*` id namespace.
 
 Resolved versions live in `<app_dir>/plugins.lock` (the exact commit, manifest

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -80,8 +80,9 @@ rejected rather than granted; upgrade aoe.
 A grant is pinned to the installed manifest. If an update changes the
 capability set, the plugin is left installed but inactive and
 `aoe plugin update <id>` re-prompts you to approve the new set. `aoe plugin
-list` and `aoe plugin info <id>` show each plugin's trust level and whether it
-is granted. An external plugin cannot use the reserved `aoe.*` /
+install` reports the resolved trust level (`featured`, `community`, or `local`)
+in its success output, and `aoe plugin list` and `aoe plugin info <id>` show
+each plugin's trust level and whether it is granted. An external plugin cannot use the reserved `aoe.*` /
 `agent-of-empires.*` id namespace.
 
 Resolved versions live in `<app_dir>/plugins.lock` (the exact commit, manifest

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -177,18 +177,19 @@ fn run_set_enabled(id: &str, enabled: bool) -> Result<()> {
 fn format_report(report: &crate::plugin::install::InstallReport, verb: &str) -> String {
     let mut out = format!("{verb} {} {}.\n", report.id, report.version);
     out.push_str(&format!("  validation: {}\n", report.validation.as_str()));
+    out.push_str("  capabilities: ");
     if report.capabilities.is_empty() {
-        out.push_str("  capabilities: none");
+        out.push_str("none");
     } else {
-        out.push_str(&format!(
-            "  capabilities: {} ({})",
-            report.capabilities.join(", "),
-            if report.granted {
-                "granted"
-            } else {
-                "not granted, plugin inactive"
-            }
-        ));
+        out.push_str(&report.capabilities.join(", "));
+    }
+    // Surface inactivity whenever the grant did not cover the install, including
+    // the empty-capabilities case (declining a UI-only manifest change leaves a
+    // plugin ungranted with no capabilities to list).
+    if !report.granted {
+        out.push_str(" (not granted, plugin inactive)");
+    } else if !report.capabilities.is_empty() {
+        out.push_str(" (granted)");
     }
     out
 }
@@ -295,6 +296,24 @@ mod tests {
         assert!(
             out.contains("\n  validation: local\n"),
             "local install surfaces its validation: {out:?}"
+        );
+    }
+
+    #[test]
+    fn inactive_with_no_capabilities_still_warns() {
+        // An ungranted update with no capabilities (e.g. a declined UI-only
+        // manifest change) must still flag that the plugin is inactive.
+        let report = InstallReport {
+            id: "acme.foo".into(),
+            version: "0.1.0".into(),
+            capabilities: vec![],
+            granted: false,
+            validation: ValidationState::Community,
+        };
+        let out = format_report(&report, "Updated");
+        assert!(
+            out.ends_with("  capabilities: none (not granted, plugin inactive)"),
+            "inactivity is surfaced with no capabilities: {out:?}"
         );
     }
 }

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -174,12 +174,13 @@ fn run_set_enabled(id: &str, enabled: bool) -> Result<()> {
     Ok(())
 }
 
-fn print_report(report: &crate::plugin::install::InstallReport, verb: &str) {
-    println!("{verb} {} {}.", report.id, report.version);
+fn format_report(report: &crate::plugin::install::InstallReport, verb: &str) -> String {
+    let mut out = format!("{verb} {} {}.\n", report.id, report.version);
+    out.push_str(&format!("  validation: {}\n", report.validation.as_str()));
     if report.capabilities.is_empty() {
-        println!("  capabilities: none");
+        out.push_str("  capabilities: none");
     } else {
-        println!(
+        out.push_str(&format!(
             "  capabilities: {} ({})",
             report.capabilities.join(", "),
             if report.granted {
@@ -187,8 +188,13 @@ fn print_report(report: &crate::plugin::install::InstallReport, verb: &str) {
             } else {
                 "not granted, plugin inactive"
             }
-        );
+        ));
     }
+    out
+}
+
+fn print_report(report: &crate::plugin::install::InstallReport, verb: &str) {
+    println!("{}", format_report(report, verb));
 }
 
 async fn run_install(source: &str, yes: bool) -> Result<()> {
@@ -252,4 +258,43 @@ async fn run_outdated() -> Result<()> {
         println!("\nUpdate with:\n  aoe plugin update <id>");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_report;
+    use crate::plugin::install::InstallReport;
+    use crate::plugin::registry::ValidationState;
+
+    #[test]
+    fn report_shows_validation_line() {
+        let report = InstallReport {
+            id: "acme.foo".into(),
+            version: "1.2.3".into(),
+            capabilities: vec!["session.read".into(), "filesystem.read".into()],
+            granted: true,
+            validation: ValidationState::Community,
+        };
+        let out = format_report(&report, "Installed");
+        assert_eq!(
+            out,
+            "Installed acme.foo 1.2.3.\n  validation: community\n  capabilities: session.read, filesystem.read (granted)"
+        );
+    }
+
+    #[test]
+    fn local_install_validation_labelled_local() {
+        let report = InstallReport {
+            id: "acme.foo".into(),
+            version: "0.1.0".into(),
+            capabilities: vec![],
+            granted: true,
+            validation: ValidationState::Local,
+        };
+        let out = format_report(&report, "Installed");
+        assert!(
+            out.contains("\n  validation: local\n"),
+            "local install surfaces its validation: {out:?}"
+        );
+    }
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -13,6 +13,7 @@ use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
 use super::featured::FeaturedIndex;
 use super::fetch::{self, FetchedPlugin};
 use super::lockfile::{LockedPlugin, Lockfile};
+use super::registry::ValidationState;
 use super::source::PluginSource;
 
 /// Set the enabled flag for a known plugin id in the global config, then reload
@@ -46,6 +47,23 @@ pub struct InstallReport {
     pub capabilities: Vec<String>,
     /// Whether the plugin is granted and live after the operation.
     pub granted: bool,
+    /// Resolved trust / validation provenance, for the success output.
+    pub validation: ValidationState,
+}
+
+/// Resolve the display validation for a just-installed plugin, mirroring
+/// `registry::validation_for`: a featured-verified source is `Featured`, any
+/// other `gh:` source is `Community`, and a local directory is `Local`. The
+/// content hash is already verified upstream (`featured_verified`), so this maps
+/// from that decision rather than re-hashing the tree.
+fn install_validation(featured_verified: bool, source: &str) -> ValidationState {
+    if featured_verified {
+        ValidationState::Featured
+    } else if source.starts_with("gh:") {
+        ValidationState::Community
+    } else {
+        ValidationState::Local
+    }
 }
 
 /// How an update treats a version that would need fresh consent (changed
@@ -113,12 +131,8 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     }
 
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
-    persist_install(
-        &persisted_source(&resolved.source, input),
-        &id,
-        &capabilities,
-        &manifest_hash,
-    )?;
+    let persisted = persisted_source(&resolved.source, input);
+    persist_install(&persisted, &id, &capabilities, &manifest_hash)?;
     write_lock(&id, &fetched, &manifest_hash, featured_verified)?;
     super::reload_registry();
 
@@ -127,6 +141,7 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
         version: fetched.manifest.version.clone(),
         capabilities,
         granted: true,
+        validation: install_validation(featured_verified, &persisted),
     })
 }
 
@@ -281,6 +296,7 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
         version: fetched.manifest.version.clone(),
         capabilities,
         granted,
+        validation: install_validation(featured_verified, &source_str),
     }))
 }
 

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -285,6 +285,11 @@ api_version = 2
     // --yes bypasses the unverified confirmation.
     let report = install::install("gh:acme/widget@main", true).await.unwrap();
     assert_eq!(report.id, "acme.widget");
+    assert_eq!(
+        report.validation.as_str(),
+        "community",
+        "the install report surfaces community trust for an unfeatured gh: install"
+    );
 
     let lock = Lockfile::load().unwrap();
     let locked = lock.get("acme.widget").expect("lock entry");
@@ -603,7 +608,12 @@ api_version = 2
         "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     );
 
-    install::install(dir.to_str().unwrap(), true).await.unwrap();
+    let report = install::install(dir.to_str().unwrap(), true).await.unwrap();
+    assert_eq!(
+        report.validation.as_str(),
+        "local",
+        "the install report surfaces a local-directory install as local"
+    );
 
     // It installs (not refused) and is not featured. The non-featured label
     // ("local" here, since the install source is a local dir; "community" for a


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`aoe plugin install` (and `update`) already resolve a plugin's trust provenance: a curated release lands as `featured`, a non-featured GitHub install as `community`, and a local-directory install as `local`. That value is written to the lockfile and shown by `aoe plugin list` / `aoe plugin info`, but the install success output printed only the id, version, and capabilities. The user had to run a separate `aoe plugin info <id>` to learn what actually landed, even right after the command warned them about unverified code and capability grants.

This carries the resolved `ValidationState` on `InstallReport` and prints a `validation:` line in the success output, between the verb line and capabilities, using the same wording `aoe plugin info` already uses:

```
Installed acme.foo 1.2.3.
  validation: community
  capabilities: session.read, filesystem.read (granted)
```

A local-directory install reads `validation: local`, making it clear the plugin is an external local install rather than a bundled, builtin-trusted one. The printer was extracted into a `format_report` helper so the line is unit-testable, and the docs note that install now reports the trust level alongside `list` / `info`.

Closes #2490

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `aoe plugin install ./path/to/local/plugin` and confirm the success output includes `  validation: local`.
- [ ] `aoe plugin install gh:owner/repo@ref` for a non-featured source and confirm the output includes `  validation: community`.
- [ ] Install a featured/curated plugin and confirm the output includes `  validation: featured`.
- [ ] `aoe plugin update <id>` on an installed plugin and confirm its success output also carries the `validation:` line.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Skipped a full tmux e2e, because: the install output shape is asserted at the source instead. `tests/plugin_install.rs` now asserts `report.validation` for the community (`gh:`) and local-directory install paths, and a `format_report` unit test in `src/cli/plugin.rs` asserts the exact `validation:` line the CLI prints.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (match `aoe plugin info` wording, no special-cased local phrasing) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785182581&installation_id=139138837&pr_number=2497&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2497&signature=e18f72607abe7c644bc0de735559ce83b007cb825877c678b2431567efdf7862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added resolved trust/validation status (`featured`, `community`, or `local`) to the success output of `aoe plugin install` and `aoe plugin update`, with the wording matching existing `aoe plugin info`. Output is now explicitly labeled with a `validation:` line (including `validation: local` for local-directory installs), and it still includes the inactivity/not-granted messaging when applicable. The report rendering was refactored into a reusable `format_report` helper and covered with new/expanded unit tests, and the plugins documentation was updated to note the added trust reporting.

Benefits: users can confirm what trust level was installed immediately from the install/update command without needing an extra `aoe plugin list`/`aoe plugin info` lookup, while keeping the output consistent with the rest of the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->