### PR TITLE
fix(notifications): retract handled approval/question pushes on other devices

### DIFF
--- a/src/server/acp_ws.rs
+++ b/src/server/acp_ws.rs
@@ -22,7 +22,7 @@ use axum::extract::{
     Path, Query, State,
 };
 use axum::response::IntoResponse;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::select;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::time::Instant;
@@ -329,6 +329,7 @@ pub async fn trigger_approval_push(
     session_id: &str,
     approval_title: &str,
     destructive: bool,
+    seq: u64,
 ) {
     let badge = if destructive {
         "DESTRUCTIVE"
@@ -341,8 +342,45 @@ pub async fn trigger_approval_push(
     } else {
         approval_title.to_string()
     };
-    let tag = format!("acp-approval-{session_id}");
-    send_acp_attention_push(state, session_id, title, body, tag).await;
+    let tag = approval_tag(session_id);
+    send_acp_push(state, session_id, |url| AcpNotifyPayload {
+        kind: "notify",
+        title: title.clone(),
+        body: body.clone(),
+        url,
+        tag: tag.clone(),
+        session_id: session_id.to_string(),
+        seq,
+    })
+    .await;
+}
+
+/// Retract a previously shown approval notification on every device once
+/// the approval is handled. Mirrors `trigger_approval_push`'s tag so the
+/// service worker can match and close the live notification. See #2491.
+pub async fn trigger_approval_clear_push(state: &AppState, session_id: &str, seq: u64) {
+    let tag = approval_tag(session_id);
+    send_acp_push(state, session_id, |url| AcpClearPayload {
+        kind: "clear",
+        title: "Resolved",
+        body: "Handled on another device",
+        url,
+        tag: tag.clone(),
+        session_id: session_id.to_string(),
+        seq,
+    })
+    .await;
+}
+
+/// Tag shared by the approval show and clear pushes for a session.
+/// Single-sourced so the clear path can never drift from the show path.
+fn approval_tag(session_id: &str) -> String {
+    format!("acp-approval-{session_id}")
+}
+
+/// Tag shared by the question show and clear pushes for a session.
+fn question_tag(session_id: &str) -> String {
+    format!("acp-question-{session_id}")
 }
 
 /// Push-notification trigger for "agent asked you a question." Called by
@@ -351,10 +389,68 @@ pub async fn trigger_approval_push(
 /// on the user exactly like an approval, so it gets the same dedicated,
 /// suppression-bypassing push rather than only the generic Waiting one.
 /// See #2146.
-pub async fn trigger_question_push(state: &AppState, session_id: &str, question: &str) {
+pub async fn trigger_question_push(state: &AppState, session_id: &str, question: &str, seq: u64) {
     let title = format!("{} has a question", session_id);
-    let tag = format!("acp-question-{session_id}");
-    send_acp_attention_push(state, session_id, title, push_body_snippet(question), tag).await;
+    let body = push_body_snippet(question);
+    let tag = question_tag(session_id);
+    send_acp_push(state, session_id, |url| AcpNotifyPayload {
+        kind: "notify",
+        title: title.clone(),
+        body: body.clone(),
+        url,
+        tag: tag.clone(),
+        session_id: session_id.to_string(),
+        seq,
+    })
+    .await;
+}
+
+/// Retract a previously shown question notification once the question is
+/// answered. Mirrors `trigger_question_push`'s tag. See #2491.
+pub async fn trigger_question_clear_push(state: &AppState, session_id: &str, seq: u64) {
+    let tag = question_tag(session_id);
+    send_acp_push(state, session_id, |url| AcpClearPayload {
+        kind: "clear",
+        title: "Resolved",
+        body: "Handled on another device",
+        url,
+        tag: tag.clone(),
+        session_id: session_id.to_string(),
+        seq,
+    })
+    .await;
+}
+
+/// Payload for a dedicated ACP attention push (approval / question).
+/// `kind: "notify"` lets the service worker tell a show from a clear; an
+/// old service worker ignores the unknown field and falls back to showing
+/// `title`/`body`. `seq` is the originating event seq, stored in the
+/// notification so a later clear can avoid closing a newer notification.
+#[derive(Serialize)]
+struct AcpNotifyPayload {
+    kind: &'static str,
+    title: String,
+    body: String,
+    url: String,
+    tag: String,
+    session_id: String,
+    seq: u64,
+}
+
+/// Payload telling the service worker to retract a shown ACP attention
+/// notification once the request is handled. Carries `title`/`body` so a
+/// not-yet-updated service worker degrades to a benign "Resolved"
+/// notification (replacing the stale one via `tag`) rather than a blank
+/// one. `seq` lets the worker skip closing a newer notification. See #2491.
+#[derive(Serialize)]
+struct AcpClearPayload {
+    kind: &'static str,
+    title: &'static str,
+    body: &'static str,
+    url: String,
+    tag: String,
+    session_id: String,
+    seq: u64,
 }
 
 /// Question text can be long and lands on a lock screen, so collapse
@@ -370,17 +466,18 @@ fn push_body_snippet(s: &str) -> String {
 }
 
 /// Shared sender for the dedicated ACP "needs your attention" pushes
-/// (approval and question). Snapshots subscribers and sends one encrypted
-/// payload each, deep-linking to the session's structured view. Bypasses
-/// the status-push active-session suppression on purpose: these are
-/// precise, turn-blocking events, not the coarse Waiting heuristic.
-async fn send_acp_attention_push(
-    state: &AppState,
-    session_id: &str,
-    title: String,
-    body: String,
-    tag: String,
-) {
+/// (approval and question) and their matching clear pushes. Snapshots
+/// subscribers and sends one encrypted payload each, deep-linking to the
+/// session's structured view. `make_payload` builds the per-subscriber
+/// payload from that subscriber's push URL, so a show path and a clear
+/// path share the same fan-out. Bypasses the status-push active-session
+/// suppression on purpose: these are precise, turn-blocking events, not
+/// the coarse Waiting heuristic.
+async fn send_acp_push<T, F>(state: &AppState, session_id: &str, make_payload: F)
+where
+    T: Serialize,
+    F: Fn(String) -> T,
+{
     let Some(push) = state.push.as_ref() else {
         return;
     };
@@ -403,13 +500,7 @@ async fn send_acp_attention_push(
         let Some(url) = super::push::build_push_url(&sub, &path) else {
             continue;
         };
-        let payload = super::push_send::PushPayload {
-            title: title.clone(),
-            body: body.clone(),
-            url,
-            tag: tag.clone(),
-            session_id: session_id.to_string(),
-        };
+        let payload = make_payload(url);
         let body_bytes = match serde_json::to_vec(&payload) {
             Ok(b) => b,
             Err(e) => {
@@ -460,6 +551,51 @@ mod tests {
         let snippet = push_body_snippet(&long);
         assert!(snippet.ends_with('…'));
         assert_eq!(snippet.chars().count(), 120 + 1);
+    }
+
+    #[test]
+    fn attention_tags_are_session_scoped_and_kind_distinct() {
+        // The clear path reuses these helpers, so a drift here would
+        // silently fail to close the matching notification (#2491).
+        assert_eq!(approval_tag("s1"), "acp-approval-s1");
+        assert_eq!(question_tag("s1"), "acp-question-s1");
+        assert_ne!(approval_tag("s1"), question_tag("s1"));
+    }
+
+    #[test]
+    fn clear_payload_carries_kind_and_seq() {
+        let json = serde_json::to_value(AcpClearPayload {
+            kind: "clear",
+            title: "Resolved",
+            body: "Handled on another device",
+            url: "/sessions/s1/acp".into(),
+            tag: approval_tag("s1"),
+            session_id: "s1".into(),
+            seq: 7,
+        })
+        .unwrap();
+        assert_eq!(json["kind"], "clear");
+        assert_eq!(json["tag"], "acp-approval-s1");
+        assert_eq!(json["seq"], 7);
+        // title/body are present so a not-yet-updated service worker
+        // degrades to a benign notification rather than a blank one.
+        assert_eq!(json["title"], "Resolved");
+    }
+
+    #[test]
+    fn notify_payload_tags_kind_notify() {
+        let json = serde_json::to_value(AcpNotifyPayload {
+            kind: "notify",
+            title: "t".into(),
+            body: "b".into(),
+            url: "/sessions/s1/acp".into(),
+            tag: question_tag("s1"),
+            session_id: "s1".into(),
+            seq: 3,
+        })
+        .unwrap();
+        assert_eq!(json["kind"], "notify");
+        assert_eq!(json["seq"], 3);
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3632,14 +3632,32 @@ async fn acp_event_listener(state: Arc<AppState>) {
             let session_id = frame.session_id.clone();
             let approval_title = approval.tool_call.name.clone();
             let destructive = approval.destructive;
+            let seq = frame.seq;
             tokio::spawn(async move {
                 acp_ws::trigger_approval_push(
                     &state_for_push,
                     &session_id,
                     &approval_title,
                     destructive,
+                    seq,
                 )
                 .await;
+            });
+        }
+
+        // Clear push: when the approval is handled (on any device), retract
+        // the "needs approval" notification that the request push raised, so
+        // a backgrounded phone or second computer does not keep showing a
+        // stale alert for an already-resolved request. See #2491.
+        if matches!(
+            frame.event.as_ref(),
+            crate::acp::state::Event::ApprovalResolved { .. }
+        ) {
+            let state_for_push = state.clone();
+            let session_id = frame.session_id.clone();
+            let seq = frame.seq;
+            tokio::spawn(async move {
+                acp_ws::trigger_approval_clear_push(&state_for_push, &session_id, seq).await;
             });
         }
 
@@ -3653,8 +3671,23 @@ async fn acp_event_listener(state: Arc<AppState>) {
             let state_for_push = state.clone();
             let session_id = frame.session_id.clone();
             let question = elicitation.message.clone();
+            let seq = frame.seq;
             tokio::spawn(async move {
-                acp_ws::trigger_question_push(&state_for_push, &session_id, &question).await;
+                acp_ws::trigger_question_push(&state_for_push, &session_id, &question, seq).await;
+            });
+        }
+
+        // Clear push for an answered question, mirroring the approval clear
+        // above. See #2491.
+        if matches!(
+            frame.event.as_ref(),
+            crate::acp::state::Event::ElicitationResolved { .. }
+        ) {
+            let state_for_push = state.clone();
+            let session_id = frame.session_id.clone();
+            let seq = frame.seq;
+            tokio::spawn(async move {
+                acp_ws::trigger_question_clear_push(&state_for_push, &session_id, seq).await;
             });
         }
 

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -37,6 +37,26 @@ self.addEventListener("activate", (e) => {
 // focused tab is rare enough for pushes that revocation hasn't been
 // an issue. If it becomes one, fall back to showing the notification
 // anyway and let the client suppress its own toast.
+// Per-tag high-water mark of the latest seq we've shown or cleared. Lets an
+// out-of-order older notify (delivered AFTER a newer clear) be dropped instead
+// of resurrecting a handled request's notification: getNotifications only sees
+// what is open right now, so a clear cannot close a notify that has not arrived
+// yet. See #2491.
+// ponytail: in-memory only, lost if the browser terminates the worker between
+// pushes; reordering only matters when pushes are near-simultaneous (the worker
+// stays warm), so IndexedDB persistence would buy a moot window.
+const seqHighWater = new Map();
+function isStaleSeq(tag, seq) {
+  if (seq == null || !tag) return false;
+  const hw = seqHighWater.get(tag);
+  return hw != null && seq < hw;
+}
+function recordSeq(tag, seq) {
+  if (seq == null || !tag) return;
+  const hw = seqHighWater.get(tag);
+  if (hw == null || seq > hw) seqHighWater.set(tag, seq);
+}
+
 self.addEventListener("push", (event) => {
   let payload = {};
   if (event.data) {
@@ -53,9 +73,12 @@ self.addEventListener("push", (event) => {
   // guard skips closing a NEWER notification when a clear for an earlier
   // request in the same session is delivered out of order. See #2491.
   if (payload.kind === "clear") {
+    const tag = payload.tag;
+    // Record the clear's seq even when getNotifications is unsupported, so a
+    // later older notify for this tag is dropped rather than shown.
+    recordSeq(tag, payload.seq);
     event.waitUntil(
       (async () => {
-        const tag = payload.tag;
         if (!tag || !self.registration.getNotifications) return;
         try {
           const existing = await self.registration.getNotifications({ tag });
@@ -73,10 +96,16 @@ self.addEventListener("push", (event) => {
     return;
   }
 
+  // Drop an out-of-order notify that is older than a clear (or newer notify)
+  // already seen for this tag: the request it announces was already handled.
+  const tag = payload.tag || "aoe";
+  if (isStaleSeq(tag, payload.seq)) return;
+  recordSeq(tag, payload.seq);
+
   const title = payload.title || "Agent of Empires";
   const options = {
     body: payload.body || "",
-    tag: payload.tag || "aoe",
+    tag,
     renotify: true,
     // Store tag + seq so a later "clear" push can match this notification
     // and the seq guard can avoid closing it if a newer one supersedes it.

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -46,12 +46,41 @@ self.addEventListener("push", (event) => {
       payload = { title: "Agent of Empires", body: event.data.text() };
     }
   }
+  // Retract path: a "clear" push closes a previously shown approval or
+  // question notification once that request was handled on another device,
+  // so a backgrounded phone or second computer stops showing a stale alert.
+  // It shows nothing (the request is gone) and is NOT focus-gated. The seq
+  // guard skips closing a NEWER notification when a clear for an earlier
+  // request in the same session is delivered out of order. See #2491.
+  if (payload.kind === "clear") {
+    event.waitUntil(
+      (async () => {
+        const tag = payload.tag;
+        if (!tag || !self.registration.getNotifications) return;
+        try {
+          const existing = await self.registration.getNotifications({ tag });
+          for (const n of existing) {
+            const nseq = n.data && n.data.seq;
+            if (nseq == null || payload.seq == null || nseq <= payload.seq) {
+              n.close();
+            }
+          }
+        } catch {
+          /* getNotifications may be unsupported or throw; never fail the push */
+        }
+      })(),
+    );
+    return;
+  }
+
   const title = payload.title || "Agent of Empires";
   const options = {
     body: payload.body || "",
     tag: payload.tag || "aoe",
     renotify: true,
-    data: { url: payload.url || "/" },
+    // Store tag + seq so a later "clear" push can match this notification
+    // and the seq guard can avoid closing it if a newer one supersedes it.
+    data: { url: payload.url || "/", tag: payload.tag, seq: payload.seq },
     icon: "/icon-192.png",
     badge: "/icon-192.png",
   };

--- a/web/src/__tests__/sw.test.ts
+++ b/web/src/__tests__/sw.test.ts
@@ -125,6 +125,21 @@ describe("service worker push handler (#2491)", () => {
     expect(getNotifications).not.toHaveBeenCalledWith({ tag: QUESTION_TAG });
   });
 
+  it("drops an older notify delivered after a newer clear for the same tag", async () => {
+    // Out-of-order delivery: the clear arrives first, so getNotifications sees
+    // nothing to close, then the stale notify lands. Without a high-water mark
+    // it would resurrect a handled request's notification. See #2491.
+    const { handlers, showNotification } = loadSw();
+    await dispatchPush(handlers, { kind: "clear", tag: APPROVAL_TAG, seq: 10 });
+    await dispatchPush(handlers, {
+      kind: "notify",
+      title: "stale",
+      tag: APPROVAL_TAG,
+      seq: 5,
+    });
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+
   it("ignores a clear with no tag without throwing or showing", async () => {
     const { handlers, showNotification, getNotifications } = loadSw();
     await dispatchPush(handlers, { kind: "clear", seq: 1 });

--- a/web/src/__tests__/sw.test.ts
+++ b/web/src/__tests__/sw.test.ts
@@ -1,0 +1,134 @@
+// Unit coverage for the push/clear contract in web/public/sw.js (#2491).
+// The service worker is a plain classic worker file, not a module, so we
+// load its source into a fresh VM context with the small slice of the SW
+// global surface it touches (self, registration, clients) stubbed, then
+// dispatch synthetic push events and await their waitUntil promises.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+import { describe, expect, it, vi } from "vitest";
+
+const swPath = fileURLToPath(new URL("../../public/sw.js", import.meta.url));
+const swSource = readFileSync(swPath, "utf8");
+
+type Handler = (event: unknown) => void;
+
+function loadSw() {
+  const handlers = new Map<string, Handler[]>();
+  const showNotification = vi.fn();
+  const getNotifications = vi.fn().mockResolvedValue([]);
+  const matchAll = vi.fn().mockResolvedValue([]);
+  const self = {
+    addEventListener: (type: string, fn: Handler) => {
+      const list = handlers.get(type) ?? [];
+      list.push(fn);
+      handlers.set(type, list);
+    },
+    skipWaiting: vi.fn(),
+    location: { origin: "https://aoe.test" },
+    clients: { matchAll, claim: vi.fn(), openWindow: vi.fn() },
+    registration: { showNotification, getNotifications },
+  };
+  // install/activate handlers register here but only run if dispatched; we
+  // only dispatch "push", so caches/skipWaiting are never exercised.
+  vm.runInNewContext(swSource, { self, caches: { keys: vi.fn(), delete: vi.fn() } });
+  return { handlers, showNotification, getNotifications, matchAll };
+}
+
+async function dispatchPush(handlers: Map<string, Handler[]>, payload: unknown) {
+  const pending: Promise<unknown>[] = [];
+  const event = {
+    data: { json: () => payload, text: () => JSON.stringify(payload) },
+    waitUntil: (p: Promise<unknown>) => pending.push(Promise.resolve(p)),
+  };
+  for (const fn of handlers.get("push") ?? []) fn(event);
+  await Promise.all(pending);
+}
+
+const APPROVAL_TAG = "acp-approval-s1";
+const QUESTION_TAG = "acp-question-s1";
+
+describe("service worker push handler (#2491)", () => {
+  it("shows a notification for a normal payload and stores tag + seq", async () => {
+    const { handlers, showNotification, getNotifications } = loadSw();
+    await dispatchPush(handlers, {
+      kind: "notify",
+      title: "needs approval",
+      body: "Bash",
+      url: "/sessions/s1/acp",
+      tag: APPROVAL_TAG,
+      seq: 5,
+    });
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    const [title, options] = showNotification.mock.calls[0];
+    expect(title).toBe("needs approval");
+    expect(options.tag).toBe(APPROVAL_TAG);
+    expect(options.data).toMatchObject({ tag: APPROVAL_TAG, seq: 5, url: "/sessions/s1/acp" });
+    expect(getNotifications).not.toHaveBeenCalled();
+  });
+
+  it("forwards a normal payload to a focused client instead of showing", async () => {
+    const { handlers, showNotification, matchAll } = loadSw();
+    const postMessage = vi.fn();
+    matchAll.mockResolvedValue([{ visibilityState: "visible", focused: true, postMessage }]);
+    const payload = { kind: "notify", title: "t", tag: APPROVAL_TAG, seq: 1 };
+    await dispatchPush(handlers, payload);
+    expect(postMessage).toHaveBeenCalledWith({ type: "aoe-push", payload });
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+
+  it("closes matching notifications on a clear and shows nothing", async () => {
+    const { handlers, showNotification, getNotifications, matchAll } = loadSw();
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+    getNotifications.mockResolvedValue([
+      { data: { seq: 5 }, close: closeA },
+      { data: { seq: 6 }, close: closeB },
+    ]);
+    await dispatchPush(handlers, { kind: "clear", tag: APPROVAL_TAG, seq: 10 });
+    expect(getNotifications).toHaveBeenCalledWith({ tag: APPROVAL_TAG });
+    expect(closeA).toHaveBeenCalled();
+    expect(closeB).toHaveBeenCalled();
+    expect(showNotification).not.toHaveBeenCalled();
+    // clear is not focus-gated, so it never inspects clients.
+    expect(matchAll).not.toHaveBeenCalled();
+  });
+
+  it("does not close a newer notification than the clear's seq", async () => {
+    const { handlers, getNotifications } = loadSw();
+    const closeNewer = vi.fn();
+    const closeOlder = vi.fn();
+    getNotifications.mockResolvedValue([
+      { data: { seq: 20 }, close: closeNewer },
+      { data: { seq: 5 }, close: closeOlder },
+    ]);
+    await dispatchPush(handlers, { kind: "clear", tag: APPROVAL_TAG, seq: 10 });
+    expect(closeOlder).toHaveBeenCalled();
+    expect(closeNewer).not.toHaveBeenCalled();
+  });
+
+  it("still shows a fresh notification after a clear for the same tag", async () => {
+    const { handlers, showNotification, getNotifications } = loadSw();
+    getNotifications.mockResolvedValue([{ data: { seq: 1 }, close: vi.fn() }]);
+    await dispatchPush(handlers, { kind: "clear", tag: APPROVAL_TAG, seq: 1 });
+    await dispatchPush(handlers, { kind: "notify", title: "new", tag: APPROVAL_TAG, seq: 2 });
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification.mock.calls[0][1].tag).toBe(APPROVAL_TAG);
+  });
+
+  it("clears only the targeted (approval) tag, not the question tag", async () => {
+    const { handlers, getNotifications } = loadSw();
+    await dispatchPush(handlers, { kind: "clear", tag: APPROVAL_TAG, seq: 1 });
+    expect(getNotifications).toHaveBeenCalledWith({ tag: APPROVAL_TAG });
+    expect(getNotifications).not.toHaveBeenCalledWith({ tag: QUESTION_TAG });
+  });
+
+  it("ignores a clear with no tag without throwing or showing", async () => {
+    const { handlers, showNotification, getNotifications } = loadSw();
+    await dispatchPush(handlers, { kind: "clear", seq: 1 });
+    expect(getNotifications).not.toHaveBeenCalled();
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -444,6 +444,13 @@
       "components": ["web/src/components/NotificationSettings.tsx"]
     },
     {
+      "id": "notifications.service-worker-clear",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/__tests__/sw.test.ts"],
+      "components": ["web/public/sw.js"]
+    },
+    {
       "id": "settings.security-readonly",
       "kind": "vitest",
       "risk": "low",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

AoE sends Web Push notifications when a structured-view session needs an approval or asks a question, so a phone or second computer lights up. But once the request was handled on one device, the notification on the other devices stayed visible forever: the live ACP state and the web reducer both drop the pending item on resolve, yet nothing told the service worker to retract the OS notification it had already shown. AoE had a send path for attention pushes but no unsend path.

This adds the unsend path. On `ApprovalResolved` / `ElicitationResolved`, the ACP event listener now spawns a "clear" push that reuses the same per-session tag as the original request push. `send_acp_attention_push` becomes a generic `send_acp_push` over a payload builder so the show and clear paths share one fan-out, and the tag is single-sourced through `approval_tag` / `question_tag` so a clear can never drift from its matching show. In the service worker, a `kind: "clear"` push looks up notifications by tag via `getNotifications` and closes them, showing nothing and without focus-gating.

Two robustness details: the clear payload carries the originating event `seq`, stored in the notification on the show path, so a clear delivered out of order cannot close a notification newer than itself (which would re-orphan a live request). And it carries a benign `title` / `body` so a not-yet-updated service worker degrades to a "Resolved" notification rather than a blank one.

Session-scoped clearing is a deliberate, issue-sanctioned ceiling: if two same-kind requests coalesce into one session notification, resolving one clears it even if a sibling is still pending. Nonce-scoped tags are the explicit follow-up.

Closes #2491

## How to test

- [ ] Open the dashboard on two devices (e.g. a computer and a phone), enable push on both, and start a structured-view session that hits an approval; confirm both devices show a "needs approval" notification.
- [ ] Approve on one device; confirm the other device's notification disappears.
- [ ] Repeat with an AskUserQuestion: answer on one device, confirm the other device's "has a question" notification clears.
- [ ] After handling a request, trigger a new approval/question in the same session; confirm the new notification still appears (the clear does not suppress later alerts).
- [ ] On a device whose PWA has not reopened since deploy (old service worker), confirm a handled request shows a benign "Resolved" notification rather than a blank one.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a spec and updated `web/tests/coverage-matrix.json` (a vm-based Vitest unit spec, `web/src/__tests__/sw.test.ts`, is the correct layer for the service-worker push/clear contract; matrix entry `notifications.service-worker-clear` maps `web/public/sw.js`)
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (the Rust change is server-side push fan-out, covered by unit tests in `src/server/acp_ws.rs`)
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate, and implementation were drafted by Claude under my direction. I made the design calls (pure-close vs silent-replace, accepting session-scoped clearing, including the seq guard) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785185209&installation_id=139138837&pr_number=2498&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2498&signature=fbb67eb223f32513dc9e9cebc401c6c9d8a2a7009dc5337db0a184753780404e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes structured-view approval/question push notifications clear correctly across devices when a request is resolved.

- **Server-side:** When an approval/question is resolved, the server now sends a matching **“clear”** push (in addition to the existing “notify” push) using the same **session-scoped tag**, along with a **sequence number** so events can be applied in order.
- **Refactor:** The ACP push helper was generalized so both notify and clear payloads share the same matching fields (kind/tag/seq), and the event listener now forwards the sequence from incoming events to the appropriate push functions.
- **Service worker:** The service worker now handles **`kind: "clear"`** by finding and **closing existing notifications with the same tag** instead of showing a new one. It also includes an **out-of-order protection** so stale pushes can’t re-open or remove newer notifications, and adds **safe fallback text** for older workers.
- **Tests & coverage:** New unit tests validate notify vs clear behavior (including ordering/race scenarios) and a coverage-matrix entry was added for the service worker clear path.

**Benefits:** Resolved approvals/questions no longer linger on other devices, and notification updates behave reliably even if web push delivery order changes.  
**Potential enhancement:** Consider persisting the worker’s per-tag “latest seq” state across service worker restarts (currently it’s in-memory), if that’s a concern for long-lived/rare out-of-order scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->