### PR TITLE
feat(plugin): in-app capability-consent popup for plugin updates

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -42,9 +42,11 @@ first-party plugins land as each piece is verified.
 
 ## Installing external plugins
 
-External plugins are community code that you install at your own risk. Install,
-update, and uninstall are CLI-only (`aoe plugin` is reserved for management);
-the TUI and web surfaces show the result but do not install.
+External plugins are community code that you install at your own risk. Install
+and uninstall are CLI-only (`aoe plugin` is reserved for management); the TUI
+and web surfaces show the result but do not install. Updating an already
+installed plugin can be done from the CLI or approved in-app (see Trust and
+capabilities below).
 
 ```sh
 aoe plugin install gh:owner/repo          # latest release (the audited default)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -77,12 +77,19 @@ prompts you once to grant that exact set. Run non-interactively with `--yes` to
 grant without prompting. A capability this version of aoe does not recognize is
 rejected rather than granted; upgrade aoe.
 
-A grant is pinned to the installed manifest. If an update changes the
-capability set, the plugin is left installed but inactive and
-`aoe plugin update <id>` re-prompts you to approve the new set. `aoe plugin
+A grant is pinned to the installed manifest. If an update expands what the
+plugin can do (new capabilities, changed build steps or UI slots, a runtime or
+trust change), it must be approved before the new version becomes active. You
+can approve in a terminal with `aoe plugin update <id>`, or in-app: the web
+dashboard's plugin settings and the TUI plugin manager show an Update action
+that opens an approval popup describing exactly what changed. Declining keeps
+the current version active and stops the prompt from reappearing until the next
+version. The approval is pinned to the exact fetched content, so an update that
+changed since you reviewed it is refused rather than applied. `aoe plugin
 install` and `aoe plugin update` report the resolved trust level (`featured`,
 `community`, or `local`) in their success output, and `aoe plugin list` and
-`aoe plugin info <id>` show each plugin's trust level and whether it is granted. An external plugin cannot use the reserved `aoe.*` /
+`aoe plugin info <id>` show each plugin's trust level and whether it is granted.
+An external plugin cannot use the reserved `aoe.*` /
 `agent-of-empires.*` id namespace.
 
 Resolved versions live in `<app_dir>/plugins.lock` (the exact commit, manifest

--- a/src/plugin/auto_update.rs
+++ b/src/plugin/auto_update.rs
@@ -12,9 +12,30 @@
 //! the pre-existing install/update path is itself unguarded. Add an on-disk
 //! plugin-op lock if concurrent CLI/daemon mutation becomes a real problem.
 
+use std::sync::Arc;
+
 use crate::session::Config;
 
 use super::{install, update_check};
+
+/// Surfaces a consent-needed auto-update skip in-product. Kept abstract so this
+/// module (which compiles in TUI-only builds) never references the serve-gated
+/// plugin host. The `aoe serve` daemon implements it on `PluginHost`.
+pub trait UpdateNotifier: Send + Sync {
+    fn needs_approval(&self, plugin_id: &str, reason: &str);
+}
+
+#[cfg(feature = "serve")]
+impl UpdateNotifier for super::host::PluginHost {
+    fn needs_approval(&self, plugin_id: &str, reason: &str) {
+        self.notify_host(
+            plugin_id,
+            super::ui_state::Tone::Warn,
+            format!("Update for {plugin_id} needs approval"),
+            Some(reason.to_string()),
+        );
+    }
+}
 
 /// What a sweep did, for logging and tests.
 #[derive(Debug, Default)]
@@ -27,7 +48,12 @@ pub struct SweepSummary {
 /// Check outdated external plugins and apply only the clean updates. Logs each
 /// outcome. Safe to call regardless of the setting; callers gate on it via
 /// [`spawn_if_enabled`].
-pub async fn sweep() -> SweepSummary {
+///
+/// When a `notifier` is present (the `aoe serve` daemon), an update skipped
+/// because it needs fresh consent also surfaces a notification so the dashboard
+/// shows it in-product instead of only logging a CLI instruction, unless the
+/// user already dismissed that exact version.
+pub async fn sweep(notifier: Option<&Arc<dyn UpdateNotifier>>) -> SweepSummary {
     let mut summary = SweepSummary::default();
     for status in update_check::outdated().await {
         if let Some(error) = &status.error {
@@ -53,13 +79,22 @@ pub async fn sweep() -> SweepSummary {
                 );
                 summary.applied.push(report.id);
             }
-            Ok(install::UpdateOutcome::Skipped { id, reason }) => {
+            Ok(install::UpdateOutcome::Skipped {
+                id,
+                reason,
+                fingerprint,
+            }) => {
                 tracing::info!(
                     target: "plugin.auto_update",
                     plugin = %id,
                     %reason,
                     "skipped plugin auto-update; run `aoe plugin update` to review",
                 );
+                if let Some(notifier) = notifier {
+                    if !already_dismissed(&id, &fingerprint) {
+                        notifier.needs_approval(&id, &reason);
+                    }
+                }
                 summary.skipped.push((id, reason));
             }
             Err(e) => {
@@ -77,15 +112,27 @@ pub async fn sweep() -> SweepSummary {
     summary
 }
 
+/// Whether the user already dismissed in-app the exact version a sweep skipped,
+/// so the sweep does not re-notify on every daemon restart.
+fn already_dismissed(id: &str, fingerprint: &str) -> bool {
+    Config::load()
+        .ok()
+        .and_then(|c| c.plugins.get(id).and_then(|p| p.dismissed_update.clone()))
+        .as_deref()
+        == Some(fingerprint)
+}
+
 /// Spawn the sweep in the background when the setting opts in. Non-blocking so
 /// startup is never delayed by network or git; the registry is reloaded inside
-/// `install::update_clean` as each update lands.
-pub fn spawn_if_enabled(config: &Config) {
+/// `install::update_clean` as each update lands. `notifier` is the running
+/// plugin host (`aoe serve`), used to surface consent-needed skips as
+/// notifications; `None` in TUI-only contexts, where there is no ring.
+pub fn spawn_if_enabled(config: &Config, notifier: Option<Arc<dyn UpdateNotifier>>) {
     if !config.updates.auto_update_plugins {
         return;
     }
     tokio::spawn(async move {
-        let summary = sweep().await;
+        let summary = sweep(notifier.as_ref()).await;
         tracing::info!(
             target: "plugin.auto_update",
             applied = summary.applied.len(),

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -96,6 +96,18 @@ impl PluginHost {
         self.api.ui_snapshot()
     }
 
+    /// Push a host-originated notification onto the ring (e.g. the auto-update
+    /// sweep telling the user an update needs approval). Best-effort.
+    pub fn notify_host(
+        &self,
+        plugin_id: &str,
+        tone: crate::plugin::ui_state::Tone,
+        title: String,
+        body: Option<String>,
+    ) {
+        self.api.notify_host(plugin_id, tone, title, body);
+    }
+
     /// Push a fire-and-forget JSON-RPC notification (no id, so the worker sends
     /// no reply) to a running worker's stdin. Used to forward a dashboard UI
     /// action (e.g. a pane's "Refresh" button) to the worker method the plugin

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -104,6 +104,21 @@ impl HostApiState {
     pub fn ui_snapshot(&self) -> UiSnapshot {
         self.ui.snapshot()
     }
+
+    /// Push a host-originated notification onto the ring. Unlike the `ui.notify`
+    /// RPC this is the host itself speaking (e.g. the auto-update sweep telling
+    /// the user an update needs approval), so it bypasses the per-worker
+    /// capability check. Errors (an empty or over-long title) are swallowed: a
+    /// notification is best-effort and must never fail a caller.
+    pub fn notify_host(
+        &self,
+        plugin_id: &str,
+        tone: crate::plugin::ui_state::Tone,
+        title: String,
+        body: Option<String>,
+    ) {
+        let _ = self.ui.notify(plugin_id, tone, title, body, None);
+    }
 }
 
 /// Per-worker call context: who is calling and what they were granted. Built

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -420,17 +420,15 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
 
 /// Apply a prepared update with an already-decided grant: replace the tree, run
 /// the build, persist the grant and lockfile, and reload the registry. A `None`
-/// grant on a build-bearing, consent-needing update aborts (the user declined
-/// arbitrary code); a capabilities-only decline keeps the prior behavior (tree
-/// updated, left inactive until re-approved).
+/// grant declines a consent-required update: it leaves the previously trusted
+/// version active without rewriting the tree or lockfile, matching the in-app
+/// decline. (Arbitrary build steps the user just refused must never run, and a
+/// declined capability expansion must not silently replace the install.)
 fn apply_prepared(prepared: &Prepared, grant: Option<CapabilityGrant>) -> Result<InstallReport> {
     let id = prepared.id.as_str();
     let final_dir = super::plugins_dir()?.join(id);
-    if prepared.needs_consent
-        && grant.is_none()
-        && !build_steps(&prepared.fetched.manifest).is_empty()
-    {
-        bail!("update cancelled for {id}; build steps were not approved, prior version kept");
+    if prepared.needs_consent && grant.is_none() {
+        bail!("update cancelled for {id}; the previously trusted version was kept");
     }
     replace_and_build(id, &prepared.fetched, &final_dir)?;
 
@@ -570,16 +568,24 @@ pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
 /// Apply an update that was previewed in-app, granting whatever the fetched
 /// manifest declares. `expected_fingerprint` pins the exact content the user
 /// approved: if the remote moved since the preview, this refuses rather than
-/// silently granting something the user never saw. Clears any recorded
-/// dismissal for the plugin on success (via `persist_update`).
+/// silently granting something the user never saw. A capability-expanding update
+/// MUST carry a fingerprint, so approval cannot bypass the stale-preview guard;
+/// a safe update may omit it. Clears any recorded dismissal on success (via
+/// `persist_update`).
 pub async fn apply_update(id: &str, expected_fingerprint: Option<String>) -> Result<InstallReport> {
     let prepared = prepare_update(id).await?;
-    if let Some(expected) = expected_fingerprint {
-        if expected != prepared.fingerprint {
+    match &expected_fingerprint {
+        Some(expected) if *expected != prepared.fingerprint => {
             bail!(
                 "the available update for {id} changed since it was shown; review it again before approving"
             );
         }
+        // A consent-needing update must be pinned to what the user reviewed;
+        // refuse an unpinned approval rather than grant blind.
+        None if prepared.needs_consent => {
+            bail!("approving the update for {id} requires the fingerprint it was previewed with");
+        }
+        _ => {}
     }
     let grant = Some(CapabilityGrant {
         manifest_hash: prepared.manifest_hash.clone(),

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -7,6 +7,7 @@ use std::process::Stdio;
 
 use anyhow::{anyhow, bail, Context, Result};
 use aoe_plugin_api::{BuildStep, PluginManifest, RuntimeSpec, UiContribution};
+use serde::Serialize;
 
 use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
 
@@ -84,8 +85,76 @@ pub enum UpdateOutcome {
     /// The update was applied (the tree was replaced and the lockfile rewritten).
     Applied(InstallReport),
     /// A `CleanOnlyNonInteractive` update was skipped because it needs consent;
-    /// the prior version stays installed and active.
-    Skipped { id: String, reason: String },
+    /// the prior version stays installed and active. `fingerprint` identifies the
+    /// skipped version so a caller (the auto-update sweep) can compare it to the
+    /// user's recorded dismissal and avoid re-nagging.
+    Skipped {
+        id: String,
+        reason: String,
+        fingerprint: String,
+    },
+}
+
+/// One dashboard UI slot a plugin contributes to, in a consent disclosure.
+#[derive(Debug, Clone, Serialize)]
+pub struct UiView {
+    pub slot: String,
+    pub id: String,
+}
+
+/// The structured disclosure an in-app (web / TUI) update approval renders. The
+/// same payload the terminal prompt describes, so every surface consents to the
+/// identical change. `fingerprint` pins the exact content the user is approving
+/// (the source tree plus any release-binary asset and the trust class), so
+/// `apply_update` can refuse if the remote moved since this was shown.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateConsent {
+    pub id: String,
+    pub from_version: String,
+    pub to_version: String,
+    /// Capabilities currently granted (the prior approval).
+    pub prior_capabilities: Vec<String>,
+    /// Capabilities the new manifest declares.
+    pub new_capabilities: Vec<String>,
+    /// Capabilities present in the new set but not the prior one.
+    pub added_capabilities: Vec<String>,
+    /// Capabilities present in the prior set but not the new one.
+    pub removed_capabilities: Vec<String>,
+    /// The dashboard UI slots the new version contributes to.
+    pub ui: Vec<UiView>,
+    /// Build commands the new version will run, unsandboxed, at apply time.
+    pub build_steps: Vec<String>,
+    /// A human description when the worker runtime kind changes (e.g. a script
+    /// becomes a downloaded release binary), else `None`.
+    pub runtime_change: Option<String>,
+    /// The plugin was a verified featured plugin and the update no longer is.
+    pub trust_downgrade: bool,
+    /// Content fingerprint of the version being approved.
+    pub fingerprint: String,
+    /// Whether declining keeps the current version active (always true for the
+    /// in-app path, which never touches the tree on decline).
+    pub stays_active_if_declined: bool,
+}
+
+/// What a non-interactive update preview found for one installed plugin.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpdatePreview {
+    /// The remote matches the installed content; nothing to do.
+    NoUpdate,
+    /// A newer version that needs no fresh consent; safe to apply directly.
+    SafeUpdate {
+        to_version: String,
+        fingerprint: String,
+    },
+    /// A newer version that expands access (capabilities, build steps, UI,
+    /// runtime, or trust) and must be explicitly approved. `dismissed` is set
+    /// when the user already declined this exact fingerprint. Boxed because the
+    /// consent payload dwarfs the other variants.
+    ConsentRequired {
+        consent: Box<UpdateConsent>,
+        dismissed: bool,
+    },
 }
 
 /// Install an external plugin from `input` (`gh:owner/repo[@ref]` or a local
@@ -154,7 +223,7 @@ pub async fn update(id: &str) -> Result<InstallReport> {
         UpdateOutcome::Applied(report) => Ok(report),
         // Interactive mode prompts rather than skipping, so this is unreachable;
         // map it to an error rather than panicking if that ever changes.
-        UpdateOutcome::Skipped { id, reason } => {
+        UpdateOutcome::Skipped { id, reason, .. } => {
             bail!("update for {id} was skipped unexpectedly: {reason}")
         }
     }
@@ -167,7 +236,48 @@ pub async fn update_clean(id: &str) -> Result<UpdateOutcome> {
     update_with_consent(id, ConsentMode::CleanOnlyNonInteractive).await
 }
 
-async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcome> {
+/// Everything an update needs after fetching and diffing, before any decision
+/// about whether to apply it. Computing the consent decision in exactly one
+/// place is what lets the CLI prompt, the in-app preview/apply flow, and the
+/// auto-update sweep stay in lockstep instead of drifting apart.
+struct Prepared {
+    id: String,
+    source_str: String,
+    fetched: FetchedPlugin,
+    featured_verified: bool,
+    prior_grant: Option<CapabilityGrant>,
+    capabilities: Vec<String>,
+    manifest_hash: String,
+    /// Content fingerprint of the fetched version (tree + release asset + trust).
+    fingerprint: String,
+    /// Content fingerprint of the currently installed version, from the
+    /// lockfile; `None` when no lock entry exists.
+    prior_fingerprint: Option<String>,
+    from_version: String,
+    caps_changed: bool,
+    added_capabilities: Vec<String>,
+    removed_capabilities: Vec<String>,
+    build_changed: bool,
+    ui_changed: bool,
+    runtime_change: Option<String>,
+    trust_downgrade: bool,
+    needs_consent: bool,
+}
+
+/// A content fingerprint of an installed or fetched version: the source tree
+/// hash, the release-binary asset hash (whose bytes the tree hash does not
+/// cover), and the trust class. This pins exactly what a consent approval
+/// covers, so a preview cannot be applied if the remote moved underneath it: a
+/// manifest hash alone would miss a `build.sh` or worker script changing under
+/// an unchanged `aoe-plugin.toml`, which run unsandboxed at apply time.
+fn fingerprint(tree_hash: &str, asset_sha256: Option<&str>, trust: &str) -> String {
+    format!("{tree_hash}|{}|{trust}", asset_sha256.unwrap_or(""))
+}
+
+/// Fetch an installed plugin's recorded source and diff it against what is on
+/// disk, classifying whether the update needs fresh consent. Network-only: it
+/// never touches the installed tree.
+async fn prepare_update(id: &str) -> Result<Prepared> {
     let config = Config::load()?;
     let plugin_config = config
         .plugins
@@ -200,117 +310,318 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
     let capabilities = capability_strings(&fetched)?;
     let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
 
+    // The lockfile is the source of truth for what is installed on disk.
+    let lock = Lockfile::load()?;
+    let prior_locked = lock.get(id);
+    let prior_tree_hash = prior_locked
+        .map(|l| l.tree_hash.clone())
+        .unwrap_or_default();
+    let prior_was_release_binary = prior_locked.is_some_and(|l| l.asset_sha256.is_some());
+    let prior_trust = prior_locked.map(|l| l.trust.clone()).unwrap_or_default();
+    let from_version = prior_locked
+        .map(|l| l.version.clone())
+        .unwrap_or_else(|| "?".to_string());
+
+    let trust = if featured_verified {
+        "featured"
+    } else {
+        "community"
+    };
+    let prior_fingerprint =
+        prior_locked.map(|l| fingerprint(&l.tree_hash, l.asset_sha256.as_deref(), &l.trust));
+    let fingerprint = fingerprint(&fetched.tree_hash, fetched.asset_sha256.as_deref(), trust);
+
     let prior_caps: BTreeSet<&str> = prior_grant
         .as_ref()
         .map(|g| g.capabilities.iter().map(String::as_str).collect())
         .unwrap_or_default();
     let new_caps: BTreeSet<&str> = capabilities.iter().map(String::as_str).collect();
     let caps_changed = prior_caps != new_caps;
+    let added_capabilities: Vec<String> = new_caps
+        .difference(&prior_caps)
+        .map(|s| s.to_string())
+        .collect();
+    let removed_capabilities: Vec<String> = prior_caps
+        .difference(&new_caps)
+        .map(|s| s.to_string())
+        .collect();
 
-    // Build steps run unsandboxed at update time, so a changed build recipe
-    // must re-prompt even when the capability set is unchanged; a static
-    // capability list must not let modified build commands run unattended. The
-    // manifest hash covers the build steps, so a hash change with build steps
-    // present means the recipe could have changed.
+    // Build steps run unsandboxed at apply time, so a changed recipe must
+    // re-prompt. A manifest hash misses a build script changing under an
+    // unchanged `aoe-plugin.toml`, so key this on the source tree hash: if the
+    // tree moved and the new version declares build steps, the recipe could have
+    // changed. Fall back to the manifest-hash heuristic only when no prior tree
+    // hash is recorded (a pre-v2 lock).
     let manifest_changed =
         prior_grant.as_ref().map(|g| g.manifest_hash.as_str()) != Some(manifest_hash.as_str());
-    let build_changed = manifest_changed && !build_steps(&fetched.manifest).is_empty();
+    let tree_changed = if prior_tree_hash.is_empty() {
+        manifest_changed
+    } else {
+        prior_tree_hash != fetched.tree_hash
+    };
+    let build_changed = tree_changed && !build_steps(&fetched.manifest).is_empty();
     // UI contributions are disclosed at install, so an update that changes the
     // manifest while declaring UI slots must re-disclose them: otherwise an
-    // update could add new dashboard slots the user never saw. The manifest
-    // hash covers the `[[ui]]` section, so a hash change with UI present means
-    // the slots could have changed.
+    // update could add dashboard slots the user never saw.
     let ui_changed = manifest_changed && !fetched.manifest.ui.is_empty();
-    // Prompt when there is something to consent to or disclose: capabilities
-    // that changed, build steps that could have changed, or UI slots on a
-    // changed manifest. Dropping all capabilities with no build/UI has nothing
-    // to grant, so it still (re)grants silently.
-    let needs_prompt = (!capabilities.is_empty() && caps_changed) || build_changed || ui_changed;
+    // A worker that switches between an in-tree command and a downloaded release
+    // binary is a meaningful change in auditability, even when capabilities are
+    // unchanged; disclose and re-prompt for it.
+    let new_is_release_binary = matches!(
+        fetched.manifest.runtime,
+        Some(RuntimeSpec::ReleaseBinary { .. })
+    );
+    let runtime_change = if new_is_release_binary && !prior_was_release_binary {
+        Some(
+            "the worker is now a downloaded release binary (opaque, not source-auditable)"
+                .to_string(),
+        )
+    } else if prior_was_release_binary && !new_is_release_binary {
+        Some("the worker is now an in-tree command (was a downloaded release binary)".to_string())
+    } else {
+        None
+    };
+    // A plugin that was a verified featured plugin and no longer is has lost the
+    // curated-index vouch; treat the downgrade as consent-worthy.
+    let trust_downgrade = prior_trust == "featured" && !featured_verified;
+
+    // Re-prompt when there is something to consent to or disclose: capabilities
+    // that changed, a build recipe that could have changed, UI slots on a
+    // changed manifest, a runtime-kind switch, or a trust downgrade. Dropping
+    // all capabilities with no other trigger has nothing to grant, so it still
+    // (re)grants silently.
+    let needs_consent = (!capabilities.is_empty() && caps_changed)
+        || build_changed
+        || ui_changed
+        || runtime_change.is_some()
+        || trust_downgrade;
+
+    Ok(Prepared {
+        id: id.to_string(),
+        source_str,
+        fetched,
+        featured_verified,
+        prior_grant,
+        capabilities,
+        manifest_hash,
+        fingerprint,
+        prior_fingerprint,
+        from_version,
+        caps_changed,
+        added_capabilities,
+        removed_capabilities,
+        build_changed,
+        ui_changed,
+        runtime_change,
+        trust_downgrade,
+        needs_consent,
+    })
+}
+
+/// Apply a prepared update with an already-decided grant: replace the tree, run
+/// the build, persist the grant and lockfile, and reload the registry. A `None`
+/// grant on a build-bearing, consent-needing update aborts (the user declined
+/// arbitrary code); a capabilities-only decline keeps the prior behavior (tree
+/// updated, left inactive until re-approved).
+fn apply_prepared(prepared: &Prepared, grant: Option<CapabilityGrant>) -> Result<InstallReport> {
+    let id = prepared.id.as_str();
+    let final_dir = super::plugins_dir()?.join(id);
+    if prepared.needs_consent
+        && grant.is_none()
+        && !build_steps(&prepared.fetched.manifest).is_empty()
+    {
+        bail!("update cancelled for {id}; build steps were not approved, prior version kept");
+    }
+    replace_and_build(id, &prepared.fetched, &final_dir)?;
+
+    let granted = grant.is_some();
+    persist_update(id, &prepared.source_str, grant)?;
+    write_lock(
+        id,
+        &prepared.fetched,
+        &prepared.manifest_hash,
+        prepared.featured_verified,
+    )?;
+    super::reload_registry();
+
+    if prepared.caps_changed && !granted {
+        eprintln!(
+            "{id} updated but its capability set changed; it stays inactive until you re-approve with `aoe plugin update {id}`."
+        );
+    }
+
+    Ok(InstallReport {
+        id: id.to_string(),
+        version: prepared.fetched.manifest.version.clone(),
+        capabilities: prepared.capabilities.clone(),
+        granted,
+        validation: install_validation(prepared.featured_verified, &prepared.source_str),
+    })
+}
+
+async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcome> {
+    let prepared = prepare_update(id).await?;
 
     // Decide the grant BEFORE touching the installed tree, so a declined or
     // non-interactive prompt bails while the old install, config, and lockfile
     // are still consistent.
-    let grant = if needs_prompt {
+    let grant = if prepared.needs_consent {
         // The auto-update sweep declines anything needing consent: skip without
         // touching the tree, leaving the working version active.
         if mode == ConsentMode::CleanOnlyNonInteractive {
             return Ok(UpdateOutcome::Skipped {
                 id: id.to_string(),
-                reason: skip_reason(caps_changed, build_changed, ui_changed),
+                reason: skip_reason(&prepared),
+                fingerprint: prepared.fingerprint.clone(),
             });
         }
         if confirm_capabilities(
             id,
-            &capabilities,
-            &fetched.manifest.ui,
-            build_steps(&fetched.manifest),
+            &prepared.capabilities,
+            &prepared.fetched.manifest.ui,
+            build_steps(&prepared.fetched.manifest),
         )? {
             Some(CapabilityGrant {
-                manifest_hash: manifest_hash.clone(),
-                capabilities: capabilities.clone(),
+                manifest_hash: prepared.manifest_hash.clone(),
+                capabilities: prepared.capabilities.clone(),
                 granted_at: chrono::Utc::now(),
             })
         } else {
             None
         }
-    } else if capabilities.is_empty() {
+    } else if prepared.capabilities.is_empty() {
         // Nothing to grant; an empty capability set keeps the plugin active.
         Some(CapabilityGrant {
-            manifest_hash: manifest_hash.clone(),
+            manifest_hash: prepared.manifest_hash.clone(),
             capabilities: vec![],
             granted_at: chrono::Utc::now(),
         })
     } else {
         // Capabilities unchanged and the build recipe (if any) unchanged: carry
         // the prior grant forward, refreshed to the new manifest hash.
-        prior_grant.map(|g| CapabilityGrant {
-            manifest_hash: manifest_hash.clone(),
+        prepared.prior_grant.clone().map(|g| CapabilityGrant {
+            manifest_hash: prepared.manifest_hash.clone(),
             capabilities: g.capabilities,
             granted_at: g.granted_at,
         })
     };
 
-    let final_dir = super::plugins_dir()?.join(id);
-    // A declined prompt must not run the plugin's build steps (arbitrary code
-    // the user just refused): abort and keep the prior version. A capabilities
-    // decline with no build steps keeps the prior behavior (tree updated, left
-    // inactive until re-approved).
-    if needs_prompt && grant.is_none() && !build_steps(&fetched.manifest).is_empty() {
-        bail!("update cancelled for {id}; build steps were not approved, prior version kept");
-    }
-    replace_and_build(id, &fetched, &final_dir)?;
-
-    let granted = grant.is_some();
-    persist_update(id, &source_str, grant)?;
-    write_lock(id, &fetched, &manifest_hash, featured_verified)?;
-    super::reload_registry();
-
-    if caps_changed && !granted {
-        eprintln!(
-            "{id} updated but its capability set changed; it stays inactive until you re-approve with `aoe plugin update {id}`."
-        );
-    }
-
-    Ok(UpdateOutcome::Applied(InstallReport {
-        id: id.to_string(),
-        version: fetched.manifest.version.clone(),
-        capabilities,
-        granted,
-        validation: install_validation(featured_verified, &source_str),
-    }))
+    Ok(UpdateOutcome::Applied(apply_prepared(&prepared, grant)?))
 }
 
-/// Human-readable reason an auto-update was skipped, for the sweep log.
-fn skip_reason(caps_changed: bool, build_changed: bool, ui_changed: bool) -> String {
+/// Build the structured consent disclosure from a prepared update.
+fn consent_of(p: &Prepared) -> UpdateConsent {
+    UpdateConsent {
+        id: p.id.clone(),
+        from_version: p.from_version.clone(),
+        to_version: p.fetched.manifest.version.clone(),
+        prior_capabilities: p
+            .prior_grant
+            .as_ref()
+            .map(|g| g.capabilities.clone())
+            .unwrap_or_default(),
+        new_capabilities: p.capabilities.clone(),
+        added_capabilities: p.added_capabilities.clone(),
+        removed_capabilities: p.removed_capabilities.clone(),
+        ui: p
+            .fetched
+            .manifest
+            .ui
+            .iter()
+            .map(|u| UiView {
+                slot: u.slot.as_str().to_string(),
+                id: u.id.clone(),
+            })
+            .collect(),
+        build_steps: build_steps(&p.fetched.manifest)
+            .iter()
+            .map(|s| s.command.join(" "))
+            .collect(),
+        runtime_change: p.runtime_change.clone(),
+        trust_downgrade: p.trust_downgrade,
+        fingerprint: p.fingerprint.clone(),
+        stays_active_if_declined: true,
+    }
+}
+
+/// Classify an available update for one installed plugin without applying it:
+/// the in-app (web / TUI) "what would this update do" probe. Network-only.
+pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
+    let prepared = prepare_update(id).await?;
+    if prepared.prior_fingerprint.as_ref() == Some(&prepared.fingerprint) {
+        return Ok(UpdatePreview::NoUpdate);
+    }
+    if !prepared.needs_consent {
+        return Ok(UpdatePreview::SafeUpdate {
+            to_version: prepared.fetched.manifest.version.clone(),
+            fingerprint: prepared.fingerprint.clone(),
+        });
+    }
+    let dismissed = Config::load()
+        .ok()
+        .and_then(|c| c.plugins.get(id).and_then(|p| p.dismissed_update.clone()))
+        == Some(prepared.fingerprint.clone());
+    Ok(UpdatePreview::ConsentRequired {
+        consent: Box::new(consent_of(&prepared)),
+        dismissed,
+    })
+}
+
+/// Apply an update that was previewed in-app, granting whatever the fetched
+/// manifest declares. `expected_fingerprint` pins the exact content the user
+/// approved: if the remote moved since the preview, this refuses rather than
+/// silently granting something the user never saw. Clears any recorded
+/// dismissal for the plugin on success (via `persist_update`).
+pub async fn apply_update(id: &str, expected_fingerprint: Option<String>) -> Result<InstallReport> {
+    let prepared = prepare_update(id).await?;
+    if let Some(expected) = expected_fingerprint {
+        if expected != prepared.fingerprint {
+            bail!(
+                "the available update for {id} changed since it was shown; review it again before approving"
+            );
+        }
+    }
+    let grant = Some(CapabilityGrant {
+        manifest_hash: prepared.manifest_hash.clone(),
+        capabilities: prepared.capabilities.clone(),
+        granted_at: chrono::Utc::now(),
+    });
+    apply_prepared(&prepared, grant)
+}
+
+/// Record that the user declined an available update by its fingerprint, so the
+/// popup and the auto-update notification stop nagging until the next version.
+pub fn dismiss_update(id: &str, fingerprint: &str) -> Result<()> {
+    let mut config = Config::load()?;
+    let entry = config
+        .plugins
+        .entry(id.to_string())
+        .or_insert_with(PluginConfig::default);
+    if entry.source.is_none() {
+        bail!("{id} is not an installed external plugin");
+    }
+    entry.dismissed_update = Some(fingerprint.to_string());
+    save_config(&config)
+}
+
+/// Human-readable reason an auto-update was skipped, for the sweep log and the
+/// in-app notification.
+fn skip_reason(prepared: &Prepared) -> String {
     let mut parts = Vec::new();
-    if caps_changed {
+    if prepared.caps_changed {
         parts.push("capability change");
     }
-    if build_changed {
+    if prepared.build_changed {
         parts.push("build-step change");
     }
-    if ui_changed {
+    if prepared.ui_changed {
         parts.push("UI change");
+    }
+    if prepared.runtime_change.is_some() {
+        parts.push("runtime change");
+    }
+    if prepared.trust_downgrade {
+        parts.push("trust downgrade");
     }
     if parts.is_empty() {
         "needs approval".to_string()
@@ -793,6 +1104,9 @@ fn persist_update(id: &str, source: &str, grant: Option<CapabilityGrant>) -> Res
         .or_insert_with(PluginConfig::default);
     entry.source = Some(source.to_string());
     entry.grant = grant;
+    // The applied version is no longer "the update the user declined"; clear any
+    // stale dismissal so a later update is surfaced normally.
+    entry.dismissed_update = None;
     save_config(&config)
 }
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -37,8 +37,8 @@ pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
 pub use plugins::{
-    invoke_plugin_action, list_plugins, plugin_details, plugin_discover, plugin_ui_state,
-    plugin_updates, set_plugin_enabled,
+    apply_plugin_update, dismiss_plugin_update, invoke_plugin_action, list_plugins, plugin_details,
+    plugin_discover, plugin_ui_state, plugin_update_preview, plugin_updates, set_plugin_enabled,
 };
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -174,6 +174,96 @@ pub async fn invoke_plugin_action(
     }
 }
 
+/// `GET /api/plugins/{id}/update/preview`: classify the available update for one
+/// installed external plugin (no_update / safe_update / consent_required) and,
+/// when consent is required, return the structured disclosure the dashboard and
+/// TUI render. Gated on read-write mode: it does a full source fetch, which a
+/// read-only dashboard has no business driving, but it needs no elevation
+/// because it mutates no host state. Network failures (no release, dead remote)
+/// surface as a 502 for the UI to show.
+pub async fn plugin_update_preview(
+    State(state): State<std::sync::Arc<AppState>>,
+    session: Option<axum::Extension<AuthenticatedSession>>,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
+        return resp;
+    }
+    match plugin::install::preview_update(&id).await {
+        Ok(preview) => Json(preview).into_response(),
+        Err(e) => error_response(StatusCode::BAD_GATEWAY, "preview_failed", format!("{e:#}")),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ApplyUpdateBody {
+    /// The fingerprint the user approved, from the preview. Pins the apply to
+    /// exactly what was shown: if the remote moved since, the apply is refused.
+    #[serde(default)]
+    pub expected_fingerprint: Option<String>,
+}
+
+/// `POST /api/plugins/{id}/update/apply`: apply an update the user approved in
+/// the dashboard, granting whatever the fetched manifest declares. A privileged
+/// host mutation (it can expand the capability set and run build steps), so it
+/// is gated on read-write mode AND elevation, like enable/disable. Returns the
+/// refreshed plugin list on success. A fingerprint mismatch (the remote moved
+/// since the preview) is a 409 so the dashboard re-previews before re-approving.
+pub async fn apply_plugin_update(
+    State(state): State<std::sync::Arc<AppState>>,
+    session: Option<axum::Extension<AuthenticatedSession>>,
+    Path(id): Path<String>,
+    Json(body): Json<ApplyUpdateBody>,
+) -> Response {
+    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
+        return resp;
+    }
+    match plugin::install::apply_update(&id, body.expected_fingerprint).await {
+        Ok(_) => list_plugins().await.into_response(),
+        Err(e) => {
+            let message = format!("{e:#}");
+            // The TOCTOU guard's "changed since it was shown" is a conflict the
+            // client recovers from by re-previewing, not a bad request.
+            let status = if message.contains("changed since it was shown") {
+                StatusCode::CONFLICT
+            } else {
+                StatusCode::BAD_REQUEST
+            };
+            error_response(status, "apply_failed", message)
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DismissUpdateBody {
+    /// The fingerprint of the update the user declined, from the preview.
+    pub fingerprint: String,
+}
+
+/// `POST /api/plugins/{id}/update/dismiss`: record that the user declined an
+/// available update, so the popup and the auto-update notification stop nagging
+/// until the next version. Mutates host config and suppresses a security
+/// signal, so it is gated like apply (read-write + elevation).
+pub async fn dismiss_plugin_update(
+    State(state): State<std::sync::Arc<AppState>>,
+    session: Option<axum::Extension<AuthenticatedSession>>,
+    Path(id): Path<String>,
+    Json(body): Json<DismissUpdateBody>,
+) -> Response {
+    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
+        return resp;
+    }
+    let result = tokio::task::spawn_blocking(move || {
+        plugin::install::dismiss_update(&id, &body.fingerprint)
+    })
+    .await;
+    match result {
+        Ok(Ok(())) => (StatusCode::OK, Json(json!({ "ok": true }))).into_response(),
+        Ok(Err(e)) => error_response(StatusCode::BAD_REQUEST, "plugin_error", format!("{e:#}")),
+        Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", e.to_string()),
+    }
+}
+
 #[derive(Deserialize)]
 pub struct SetEnabledBody {
     pub enabled: bool,

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -177,17 +177,20 @@ pub async fn invoke_plugin_action(
 /// `GET /api/plugins/{id}/update/preview`: classify the available update for one
 /// installed external plugin (no_update / safe_update / consent_required) and,
 /// when consent is required, return the structured disclosure the dashboard and
-/// TUI render. Gated on read-write mode: it does a full source fetch, which a
-/// read-only dashboard has no business driving, but it needs no elevation
-/// because it mutates no host state. Network failures (no release, dead remote)
-/// surface as a 502 for the UI to show.
+/// TUI render. Gated on read-write mode only, NOT elevation: it mutates no host
+/// state and it powers the approval UI, so a non-elevated session must be able
+/// to fetch the capability diff before deciding (elevation is required on the
+/// actual apply). Network failures (no release, dead remote) surface as a 502.
 pub async fn plugin_update_preview(
     State(state): State<std::sync::Arc<AppState>>,
-    session: Option<axum::Extension<AuthenticatedSession>>,
     Path(id): Path<String>,
 ) -> Response {
-    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
-        return resp;
+    if state.read_only {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            "read_only",
+            "Server is in read-only mode".into(),
+        );
     }
     match plugin::install::preview_update(&id).await {
         Ok(preview) => Json(preview).into_response(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1522,6 +1522,18 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/plugins/{id}/enabled", post(api::set_plugin_enabled))
         .route("/api/plugins/{id}/action", post(api::invoke_plugin_action))
         .route(
+            "/api/plugins/{id}/update/preview",
+            get(api::plugin_update_preview),
+        )
+        .route(
+            "/api/plugins/{id}/update/apply",
+            post(api::apply_plugin_update),
+        )
+        .route(
+            "/api/plugins/{id}/update/dismiss",
+            post(api::dismiss_plugin_update),
+        )
+        .route(
             "/api/app-state/web-tour-seen",
             post(api::mark_web_tour_seen),
         )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1188,8 +1188,17 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 
     // Opt-in clean-only plugin auto-update sweep (off by default). Spawned
     // non-blocking so daemon startup never waits on git/network; freshly applied
-    // updates are picked up on the next daemon restart.
-    crate::plugin::auto_update::spawn_if_enabled(&crate::session::Config::load_or_warn());
+    // updates are picked up on the next daemon restart. The plugin host (when
+    // running) is passed as the notifier so a consent-needed skip surfaces as a
+    // dashboard notification, not just a log line.
+    let update_notifier = state
+        .plugin_host
+        .clone()
+        .map(|h| h as std::sync::Arc<dyn crate::plugin::auto_update::UpdateNotifier>);
+    crate::plugin::auto_update::spawn_if_enabled(
+        &crate::session::Config::load_or_warn(),
+        update_notifier,
+    );
 
     rate_limiter.spawn_cleanup_task(state.shutdown.clone());
     login_manager.spawn_cleanup_task(state.shutdown.clone());

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -125,6 +125,13 @@ pub struct PluginConfig {
     /// builtins are auto-granted and never store one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grant: Option<CapabilityGrant>,
+
+    /// An available update the user declined in-app, recorded by its content
+    /// fingerprint so the popup and auto-update notification stop nagging until
+    /// the next version. Cleared on any successful apply or uninstall. Absent
+    /// when no update has been dismissed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dismissed_update: Option<String>,
 }
 
 /// A user's approval of an external plugin's requested capabilities, pinned to
@@ -154,6 +161,7 @@ impl Default for PluginConfig {
             source: None,
             settings: toml::Table::new(),
             grant: None,
+            dismissed_update: None,
         }
     }
 }

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -205,7 +205,13 @@ impl PluginManagerDialog {
                 if let Some(consent) = self.consent.take() {
                     match crate::plugin::install::dismiss_update(&consent.id, &consent.fingerprint)
                     {
-                        Ok(()) => self.info = Some(format!("Declined update for {}.", consent.id)),
+                        Ok(()) => {
+                            // dismiss_update wrote plugin config; flag it so an
+                            // embedding settings surface resyncs and a later save
+                            // does not clobber the dismissal.
+                            self.mutated = true;
+                            self.info = Some(format!("Declined update for {}.", consent.id));
+                        }
                         Err(e) => self.error = Some(format!("{e:#}")),
                     }
                 }
@@ -398,8 +404,17 @@ impl PluginManagerDialog {
                                 self.start_apply(id, Some(fingerprint));
                             }
                         }
-                        Ok(UpdatePreview::ConsentRequired { consent, .. }) => {
-                            self.consent = Some(*consent);
+                        // An already-dismissed version must not re-prompt; it
+                        // surfaces again only when a new version appears.
+                        Ok(UpdatePreview::ConsentRequired { consent, dismissed }) => {
+                            if dismissed {
+                                self.info = Some(format!(
+                                    "Update for {} was already declined.",
+                                    consent.id
+                                ));
+                            } else {
+                                self.consent = Some(*consent);
+                            }
                         }
                         Err(message) => self.error = Some(message),
                     }
@@ -570,8 +585,13 @@ impl PluginManagerDialog {
             Style::default().fg(theme.dimmed),
         )));
 
-        let width = area.width.clamp(40, 72);
-        let height = (lines.len() as u16 + 2).clamp(8, area.height);
+        // A tiny terminal can be narrower/shorter than our preferred size;
+        // never pass clamp/centered_rect a max below the min (it panics).
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let width = area.width.clamp(1, 72);
+        let height = (lines.len() as u16).saturating_add(2).clamp(1, area.height);
         let rect = centered_rect(area, width, height);
         f.render_widget(Clear, rect);
         let block = Block::default()

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -1,8 +1,8 @@
 //! Plugin manager: list plugins (builtin and external) with their trust and
-//! enabled/approval state, and enable/disable them from the TUI. The TUI twin
-//! of `aoe plugin list` and the web Plugins tab. Installing, updating, and
-//! capability approval are CLI-driven (`aoe plugin install`); the TUI shows the
-//! resulting state but does not perform installs.
+//! enabled/approval state, enable/disable them, and update an external plugin
+//! with an in-TUI consent popup when the new version expands access. The TUI
+//! twin of `aoe plugin list` and the web Plugins tab. Installing a new plugin is
+//! still CLI-driven (`aoe plugin install`); the TUI shows the resulting state.
 
 use std::collections::HashMap;
 
@@ -13,6 +13,7 @@ use tokio::sync::oneshot;
 
 use super::{centered_rect, DialogResult};
 use crate::plugin::discover::DiscoveryResult;
+use crate::plugin::install::{UpdateConsent, UpdatePreview};
 use crate::plugin::update_check::UpdateStatus;
 use crate::tui::styles::Theme;
 
@@ -30,6 +31,10 @@ enum Mode {
 enum Pending {
     Updates(oneshot::Receiver<Vec<UpdateStatus>>),
     Discover(oneshot::Receiver<Result<Vec<DiscoveryResult>, String>>),
+    /// Classifying one plugin's available update (the `u` key).
+    Preview(oneshot::Receiver<Result<UpdatePreview, String>>),
+    /// Applying an approved update.
+    Apply(oneshot::Receiver<Result<(), String>>),
 }
 
 pub struct PluginManagerDialog {
@@ -59,6 +64,12 @@ pub struct PluginManagerDialog {
     /// Discovery results from the last `d` search, plus the cursor into them.
     discover_rows: Vec<DiscoveryResult>,
     discover_selected: usize,
+    /// The plugin id a preview/apply is running for, so `tick` knows which row
+    /// the result belongs to.
+    pending_plugin: Option<String>,
+    /// An open update-consent popup: the structured disclosure to render and
+    /// approve / decline.
+    consent: Option<UpdateConsent>,
 }
 
 impl Default for PluginManagerDialog {
@@ -83,6 +94,8 @@ impl PluginManagerDialog {
             updates: HashMap::new(),
             discover_rows: Vec::new(),
             discover_selected: 0,
+            pending_plugin: None,
+            consent: None,
         };
         dialog.reload();
         dialog.mutated = false; // Initial load is not a user mutation.
@@ -117,6 +130,10 @@ impl PluginManagerDialog {
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         self.info = None;
+        // An open consent popup owns the keyboard until the user decides.
+        if self.consent.is_some() {
+            return self.handle_consent_key(key);
+        }
         if self.mode == Mode::Discover {
             return self.handle_discover_key(key);
         }
@@ -157,6 +174,46 @@ impl PluginManagerDialog {
             }
             KeyCode::Char('d') => {
                 self.start_discover();
+                DialogResult::Continue
+            }
+            // Update the selected plugin, but only when the last `c` check found
+            // one available (the preview re-fetches and classifies it).
+            KeyCode::Char('u') => {
+                if let Some(row) = self.rows.get(self.selected) {
+                    if self.updates.get(&row.id).is_some_and(|u| u.needs_update) {
+                        self.start_preview(row.id.clone());
+                    }
+                }
+                DialogResult::Continue
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    /// Keys while the update-consent popup is open: approve, decline, or close.
+    fn handle_consent_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Enter => {
+                if let Some(consent) = self.consent.take() {
+                    self.start_apply(consent.id, Some(consent.fingerprint));
+                }
+                DialogResult::Continue
+            }
+            // Decline: record the dismissal so it stops nagging, keep the active
+            // version. `dismiss_update` is a quick local config write.
+            KeyCode::Char('n') => {
+                if let Some(consent) = self.consent.take() {
+                    match crate::plugin::install::dismiss_update(&consent.id, &consent.fingerprint)
+                    {
+                        Ok(()) => self.info = Some(format!("Declined update for {}.", consent.id)),
+                        Err(e) => self.error = Some(format!("{e:#}")),
+                    }
+                }
+                DialogResult::Continue
+            }
+            // Close without deciding.
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.consent = None;
                 DialogResult::Continue
             }
             _ => DialogResult::Continue,
@@ -207,6 +264,45 @@ impl PluginManagerDialog {
         });
         self.pending = Some(Pending::Updates(rx));
         self.loading = Some("Checking for updates…");
+        self.error = None;
+    }
+
+    fn start_preview(&mut self, id: String) {
+        if self.pending.is_some() {
+            return;
+        }
+        let (tx, rx) = oneshot::channel();
+        let preview_id = id.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(
+                crate::plugin::install::preview_update(&preview_id)
+                    .await
+                    .map_err(|e| format!("{e:#}")),
+            );
+        });
+        self.pending_plugin = Some(id);
+        self.pending = Some(Pending::Preview(rx));
+        self.loading = Some("Checking update…");
+        self.error = None;
+    }
+
+    fn start_apply(&mut self, id: String, fingerprint: Option<String>) {
+        if self.pending.is_some() {
+            return;
+        }
+        let (tx, rx) = oneshot::channel();
+        let apply_id = id.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(
+                crate::plugin::install::apply_update(&apply_id, fingerprint)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| format!("{e:#}")),
+            );
+        });
+        self.pending_plugin = Some(id);
+        self.pending = Some(Pending::Apply(rx));
+        self.loading = Some("Updating…");
         self.error = None;
     }
 
@@ -288,6 +384,59 @@ impl PluginManagerDialog {
                     true
                 }
             },
+            Pending::Preview(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    self.pending = None;
+                    self.loading = None;
+                    match result {
+                        Ok(UpdatePreview::NoUpdate) => {
+                            self.info = Some("Already up to date.".to_string());
+                        }
+                        // A safe update needs no consent: apply it straight away.
+                        Ok(UpdatePreview::SafeUpdate { fingerprint, .. }) => {
+                            if let Some(id) = self.pending_plugin.clone() {
+                                self.start_apply(id, Some(fingerprint));
+                            }
+                        }
+                        Ok(UpdatePreview::ConsentRequired { consent, .. }) => {
+                            self.consent = Some(*consent);
+                        }
+                        Err(message) => self.error = Some(message),
+                    }
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.error = Some("Update check failed.".to_string());
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+            },
+            Pending::Apply(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    self.pending = None;
+                    self.loading = None;
+                    match result {
+                        Ok(()) => {
+                            if let Some(id) = self.pending_plugin.take() {
+                                self.updates.remove(&id);
+                                self.info = Some(format!("Updated {id}."));
+                            }
+                            self.reload();
+                        }
+                        Err(message) => self.error = Some(message),
+                    }
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.error = Some("Update failed.".to_string());
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+            },
         }
     }
 
@@ -338,6 +487,102 @@ impl PluginManagerDialog {
         let inner = block.inner(rect);
         f.render_widget(block, rect);
         self.render_browse(f, inner, theme);
+        // The consent popup floats over the list, centered on the dialog rect.
+        if let Some(consent) = &self.consent {
+            self.render_consent(f, rect, theme, consent);
+        }
+    }
+
+    fn render_consent(&self, f: &mut Frame, area: Rect, theme: &Theme, consent: &UpdateConsent) {
+        let mut lines: Vec<Line> = vec![
+            Line::from(Span::styled(
+                format!(
+                    "Update {}? v{} -> v{}",
+                    consent.id, consent.from_version, consent.to_version
+                ),
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                "This update expands what the plugin can do.",
+                Style::default().fg(theme.dimmed),
+            )),
+            Line::from(""),
+        ];
+        if !consent.added_capabilities.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "New capabilities: {}",
+                    consent.added_capabilities.join(", ")
+                ),
+                Style::default().fg(theme.waiting),
+            )));
+        }
+        if !consent.removed_capabilities.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("Removed: {}", consent.removed_capabilities.join(", ")),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        if let Some(change) = &consent.runtime_change {
+            lines.push(Line::from(Span::styled(
+                format!("Runtime: {change}"),
+                Style::default().fg(theme.waiting),
+            )));
+        }
+        if consent.trust_downgrade {
+            lines.push(Line::from(Span::styled(
+                "No longer a verified featured plugin (community trust).",
+                Style::default().fg(theme.waiting),
+            )));
+        }
+        if !consent.build_steps.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "Build commands (run as you, unsandboxed):",
+                Style::default().fg(theme.waiting),
+            )));
+            for step in &consent.build_steps {
+                lines.push(Line::from(Span::styled(
+                    format!("  $ {step}"),
+                    Style::default().fg(theme.dimmed),
+                )));
+            }
+        }
+        if !consent.ui.is_empty() {
+            let mut slots: Vec<&str> = Vec::new();
+            for u in &consent.ui {
+                if !slots.contains(&u.slot.as_str()) {
+                    slots.push(u.slot.as_str());
+                }
+            }
+            lines.push(Line::from(Span::styled(
+                format!("UI slots: {}", slots.join(", ")),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Approving trusts this plugin; a worker and build steps run without OS sandboxing.",
+            Style::default().fg(theme.dimmed),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "y approve · n decline · esc close",
+            Style::default().fg(theme.dimmed),
+        )));
+
+        let width = area.width.clamp(40, 72);
+        let height = (lines.len() as u16 + 2).clamp(8, area.height);
+        let rect = centered_rect(area, width, height);
+        f.render_widget(Clear, rect);
+        let block = Block::default()
+            .title(" Approve update ")
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent));
+        let inner = block.inner(rect);
+        f.render_widget(block, rect);
+        let body = Paragraph::new(lines).wrap(Wrap { trim: true });
+        f.render_widget(body, inner);
     }
 
     fn render_browse(&self, f: &mut Frame, area: Rect, theme: &Theme) {
@@ -489,7 +734,7 @@ impl PluginManagerDialog {
                 "esc close"
             };
             (
-                format!("space toggle · c check updates · d discover · {back}"),
+                format!("space toggle · c check updates · u update · d discover · {back}"),
                 theme.dimmed,
             )
         };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -230,7 +230,8 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // Opt-in clean-only plugin auto-update sweep (off by default). Spawned
     // non-blocking so a slow remote or git never delays the TUI; applied updates
     // take effect on the next launch.
-    crate::plugin::auto_update::spawn_if_enabled(&crate::session::Config::load_or_warn());
+    // No notifier in the TUI: there is no plugin host / notification ring here.
+    crate::plugin::auto_update::spawn_if_enabled(&crate::session::Config::load_or_warn(), None);
 
     // Bail early if stdin is not a terminal. Running without a tty would
     // cause the event loop to busy-loop after the parent terminal dies.

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -1169,7 +1169,7 @@ async fn auto_update_applies_clean_github_update() {
 
     // A clean (no consent change) newer version on the remote.
     push_new_commit(base.path(), "acme", "upd", &[("aoe-plugin.toml", &v2)]);
-    let summary = auto_update::sweep().await;
+    let summary = auto_update::sweep(None).await;
     assert_eq!(summary.applied, vec!["acme.upd".to_string()], "{summary:?}");
     assert_eq!(
         Lockfile::load().unwrap().get("acme.upd").unwrap().version,

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use agent_of_empires::plugin::install::{self, UpdateOutcome};
+use agent_of_empires::plugin::install::{self, UpdateOutcome, UpdatePreview};
 use agent_of_empires::plugin::lockfile::Lockfile;
 use agent_of_empires::plugin::registry::PluginRegistry;
 use agent_of_empires::plugin::{auto_update, update_check};
@@ -1216,6 +1216,181 @@ async fn clean_update_skips_capability_change() {
         Lockfile::load().unwrap().get("acme.upd").unwrap().version,
         "1.0.0",
         "prior version kept",
+    );
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+/// The manifest a capability-expanding update fetches.
+fn with_net_cap_v2() -> String {
+    PLAIN_MANIFEST.replace("1.0.0", "2.0.0").replace(
+        "api_version = 2",
+        "api_version = 2\ncapabilities = [\"net\"]",
+    )
+}
+
+/// Install plain acme.upd from a local bare repo tracking `@main`, then push a
+/// v2 that adds the `net` capability. Returns the temp base so the caller keeps
+/// the repo alive.
+async fn install_then_push_cap_update() -> TempDir {
+    let base = tempfile::tempdir().unwrap();
+    make_bare_repo(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", PLAIN_MANIFEST)],
+    );
+    install::install("gh:acme/upd@main", true).await.unwrap();
+    push_new_commit(
+        base.path(),
+        "acme",
+        "upd",
+        &[("aoe-plugin.toml", &with_net_cap_v2())],
+    );
+    base
+}
+
+#[tokio::test]
+#[serial]
+async fn preview_reports_consent_required_for_capability_change() {
+    let _home = isolate();
+    let _base = install_then_push_cap_update().await;
+
+    match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, dismissed } => {
+            assert_eq!(consent.from_version, "1.0.0");
+            assert_eq!(consent.to_version, "2.0.0");
+            assert_eq!(consent.added_capabilities, vec!["net".to_string()]);
+            assert!(consent.removed_capabilities.is_empty());
+            assert!(!dismissed, "a fresh update is not pre-dismissed");
+            assert!(!consent.fingerprint.is_empty());
+        }
+        other => panic!("expected consent_required, got {other:?}"),
+    }
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn apply_update_grants_the_new_capability_set() {
+    let _home = isolate();
+    let _base = install_then_push_cap_update().await;
+
+    let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+
+    install::apply_update("acme.upd", Some(fingerprint))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "2.0.0",
+    );
+    let reg = load_registry();
+    let plugin = reg.get("acme.upd").expect("present");
+    assert!(plugin.active(), "the approved update is granted and active");
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn apply_update_rejects_a_stale_fingerprint() {
+    let _home = isolate();
+    let _base = install_then_push_cap_update().await;
+
+    // The user approved a different (stale) fingerprint than what is now fetched:
+    // the apply must refuse rather than grant something never disclosed.
+    let err = install::apply_update("acme.upd", Some("sha256:stale||community".to_string()))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("changed since it was shown"), "got: {err}");
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "1.0.0",
+        "a rejected apply keeps the prior version",
+    );
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[tokio::test]
+#[serial]
+async fn declining_keeps_the_prior_version_and_stops_nagging() {
+    let _home = isolate();
+    let _base = install_then_push_cap_update().await;
+
+    let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+
+    // Decline: record the dismissal. The new version is never applied.
+    install::dismiss_update("acme.upd", &fingerprint).unwrap();
+    assert_eq!(
+        Lockfile::load().unwrap().get("acme.upd").unwrap().version,
+        "1.0.0",
+        "the previously trusted version stays installed",
+    );
+    assert!(
+        load_registry().get("acme.upd").unwrap().active(),
+        "the prior version stays active",
+    );
+
+    // A re-preview now flags the dismissal so the surfaces stop re-prompting.
+    match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { dismissed, .. } => {
+            assert!(dismissed, "the declined fingerprint is remembered");
+        }
+        other => panic!("expected consent_required, got {other:?}"),
+    }
+
+    std::env::remove_var("AOE_GITHUB_CLONE_BASE");
+}
+
+#[derive(Default)]
+struct RecordingNotifier(std::sync::Mutex<Vec<String>>);
+
+impl auto_update::UpdateNotifier for RecordingNotifier {
+    fn needs_approval(&self, plugin_id: &str, _reason: &str) {
+        self.0.lock().unwrap().push(plugin_id.to_string());
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn sweep_notifies_then_respects_a_dismissal() {
+    let _home = isolate();
+    let _base = install_then_push_cap_update().await;
+
+    let fingerprint = match install::preview_update("acme.upd").await.unwrap() {
+        UpdatePreview::ConsentRequired { consent, .. } => consent.fingerprint,
+        other => panic!("expected consent_required, got {other:?}"),
+    };
+
+    // First sweep: not dismissed, so the consent-needed skip notifies.
+    let rec = std::sync::Arc::new(RecordingNotifier::default());
+    let notifier: std::sync::Arc<dyn auto_update::UpdateNotifier> = rec.clone();
+    auto_update::sweep(Some(&notifier)).await;
+    assert_eq!(
+        rec.0.lock().unwrap().as_slice(),
+        ["acme.upd".to_string()],
+        "an undismissed consent-needed skip notifies",
+    );
+
+    // After dismissing this exact version, a later sweep stays silent.
+    install::dismiss_update("acme.upd", &fingerprint).unwrap();
+    let rec2 = std::sync::Arc::new(RecordingNotifier::default());
+    let notifier2: std::sync::Arc<dyn auto_update::UpdateNotifier> = rec2.clone();
+    auto_update::sweep(Some(&notifier2)).await;
+    assert!(
+        rec2.0.lock().unwrap().is_empty(),
+        "a dismissed version does not re-notify",
     );
 
     std::env::remove_var("AOE_GITHUB_CLONE_BASE");

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -33,13 +33,19 @@ export function PluginUpdateConsentModal({
   onDecline,
   onClose,
 }: PluginUpdateConsentModalProps) {
+  // While an apply/dismiss is in flight, the modal must not close: dropping it
+  // would re-expose the Update button and let the same flow start concurrently.
+  const closeIfIdle = () => {
+    if (!busy) onClose();
+  };
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (!busy && e.key === "Escape") onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [busy, onClose]);
 
   return (
     <div
@@ -47,7 +53,7 @@ export function PluginUpdateConsentModal({
       role="dialog"
       aria-modal="true"
       aria-label={`Approve update for ${name}`}
-      onClick={onClose}
+      onClick={closeIfIdle}
       data-testid="plugin-update-consent-modal"
     >
       <div
@@ -63,8 +69,9 @@ export function PluginUpdateConsentModal({
           </div>
           <button
             type="button"
-            className="rounded border border-surface-700 px-2 py-0.5 text-xs hover:bg-surface-800"
-            onClick={onClose}
+            className="rounded border border-surface-700 px-2 py-0.5 text-xs hover:bg-surface-800 disabled:opacity-50"
+            disabled={busy}
+            onClick={closeIfIdle}
             data-testid="plugin-update-consent-close"
           >
             Close

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -149,7 +149,7 @@ export function PluginUpdateConsentModal({
           </button>
           <button
             type="button"
-            className="rounded bg-accent-500 px-3 py-1 text-xs font-medium text-surface-950 hover:bg-accent-400 disabled:opacity-50"
+            className="rounded bg-brand-600 px-3 py-1 text-xs font-medium text-white hover:bg-brand-500 disabled:opacity-50"
             disabled={busy}
             onClick={onApprove}
             data-testid="plugin-update-approve"

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -1,0 +1,163 @@
+import { useEffect } from "react";
+
+import type { PluginUpdateConsent } from "../../lib/api";
+
+interface PluginUpdateConsentModalProps {
+  /** The structured disclosure for the available update. */
+  consent: PluginUpdateConsent;
+  /** Plugin display name for the header. */
+  name: string;
+  /** True while an apply/dismiss request is in flight. */
+  busy: boolean;
+  /** Inline error from the last apply/dismiss attempt, if any. */
+  error: string | null;
+  /** Approve the expanded access and apply the update. */
+  onApprove: () => void;
+  /** Decline: keep the current version and stop nagging until the next version. */
+  onDecline: () => void;
+  /** Close without recording a decision (Esc / backdrop / Close button). */
+  onClose: () => void;
+}
+
+/// The in-app capability-consent popup for a plugin update that expands access.
+/// Renders the same disclosure the terminal prompt prints (capability diff, UI
+/// slots, build commands, runtime / trust changes) and gates the update behind
+/// an explicit Approve. Declining keeps the active version and records the
+/// dismissal; closing makes no decision.
+export function PluginUpdateConsentModal({
+  consent,
+  name,
+  busy,
+  error,
+  onApprove,
+  onDecline,
+  onClose,
+}: PluginUpdateConsentModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Approve update for ${name}`}
+      onClick={onClose}
+      data-testid="plugin-update-consent-modal"
+    >
+      <div
+        className="max-h-[80vh] w-full max-w-lg overflow-auto rounded border border-surface-700 bg-surface-900 p-4 text-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="font-semibold">Update {name}?</h2>
+            <p className="text-xs text-text-dim">
+              v{consent.from_version} → v{consent.to_version}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-2 py-0.5 text-xs hover:bg-surface-800"
+            onClick={onClose}
+            data-testid="plugin-update-consent-close"
+          >
+            Close
+          </button>
+        </div>
+
+        <p className="mb-3 text-xs text-text-dim">
+          This update expands what the plugin can do. Review the new access before approving.
+        </p>
+
+        {consent.added_capabilities.length > 0 && (
+          <div className="mb-3" data-testid="plugin-update-added-caps">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">
+              New capabilities
+            </p>
+            <p className="text-xs text-status-warning">{consent.added_capabilities.join(", ")}</p>
+          </div>
+        )}
+
+        {consent.removed_capabilities.length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Removed capabilities</p>
+            <p className="text-xs text-text-dim">{consent.removed_capabilities.join(", ")}</p>
+          </div>
+        )}
+
+        {consent.runtime_change && (
+          <p className="mb-3 text-xs text-status-warning" data-testid="plugin-update-runtime-change">
+            Runtime change: {consent.runtime_change}
+          </p>
+        )}
+
+        {consent.trust_downgrade && (
+          <p className="mb-3 text-xs text-status-warning" data-testid="plugin-update-trust-downgrade">
+            This version is no longer a verified featured plugin (community trust).
+          </p>
+        )}
+
+        {consent.build_steps.length > 0 && (
+          <div className="mb-3" data-testid="plugin-update-build-steps">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">
+              Build commands (run as you, unsandboxed)
+            </p>
+            <ul className="space-y-0.5">
+              {consent.build_steps.map((step, i) => (
+                <li key={i} className="font-mono text-[11px] text-text-dim">
+                  $ {step}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {consent.ui.length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Dashboard UI slots</p>
+            <p className="text-xs text-text-dim">{[...new Set(consent.ui.map((u) => u.slot))].join(", ")}</p>
+          </div>
+        )}
+
+        <p className="mb-3 text-[11px] text-text-dim">
+          Approving trusts this plugin. The host enforces capabilities at its API boundary, but a plugin worker (and any
+          build step) runs without OS-level sandboxing, so a malicious plugin is not contained. Only approve updates
+          from sources you trust.
+        </p>
+
+        {error && (
+          <p className="mb-3 text-xs text-status-error" data-testid="plugin-update-consent-error">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-3 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
+            disabled={busy}
+            onClick={onDecline}
+            data-testid="plugin-update-decline"
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            className="rounded bg-accent-500 px-3 py-1 text-xs font-medium text-surface-950 hover:bg-accent-400 disabled:opacity-50"
+            disabled={busy}
+            onClick={onApprove}
+            data-testid="plugin-update-approve"
+          >
+            {busy ? "Updating…" : "Approve and update"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -196,12 +196,18 @@ export function PluginsSettings() {
   const onDeclineUpdate = async () => {
     if (!consentModal) return;
     setConsentBusy(true);
+    setConsentError(null);
     try {
-      // Either way the current version stays active; record the decline so it
-      // stops nagging, then close.
-      await dismissPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
-      clearUpdateBadge(consentModal.plugin.id);
-      setConsentModal(null);
+      // The current version stays active either way, but only clear local state
+      // once the backend actually recorded the decline; otherwise a failed
+      // dismiss would look persisted and the prompt would return on reload.
+      const res = await dismissPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
+      if (res.kind === "ok") {
+        clearUpdateBadge(consentModal.plugin.id);
+        setConsentModal(null);
+      } else {
+        setConsentError(res.message);
+      }
     } finally {
       setConsentBusy(false);
     }

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -1,17 +1,22 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  applyPluginUpdate,
+  dismissPluginUpdate,
   discoverPlugins,
   fetchPluginUpdates,
   fetchPlugins,
+  previewPluginUpdate,
   setPluginEnabled,
   type PluginDiscoveryResult,
   type PluginListResponse,
+  type PluginUpdateConsent,
   type PluginUpdateStatus,
   type PluginView,
 } from "../../lib/api";
 import { reportInfo } from "../../lib/toastBus";
 import { PluginDetailModal } from "./PluginDetailModal";
+import { PluginUpdateConsentModal } from "./PluginUpdateConsentModal";
 
 interface DetailTarget {
   source: string;
@@ -51,6 +56,20 @@ export function PluginsSettings() {
 
   // The plugin whose detail modal is open (null = closed).
   const [detail, setDetail] = useState<DetailTarget | null>(null);
+
+  // The in-app update flow: which plugin's Update button is previewing, and the
+  // consent modal when a fetched update needs explicit approval.
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [consentModal, setConsentModal] = useState<{ plugin: PluginView; consent: PluginUpdateConsent } | null>(null);
+  const [consentBusy, setConsentBusy] = useState(false);
+  const [consentError, setConsentError] = useState<string | null>(null);
+
+  const clearUpdateBadge = (id: string) =>
+    setUpdates((u) => {
+      const next = { ...u };
+      delete next[id];
+      return next;
+    });
 
   // Two tabs, JetBrains-style: manage installed plugins vs browse the
   // marketplace (GitHub discovery).
@@ -117,6 +136,74 @@ export function PluginsSettings() {
       }
     } finally {
       setCheckingUpdates(false);
+    }
+  };
+
+  // Drive an in-app update: preview first, then apply a safe update directly or
+  // open the consent modal when the fetched version expands access.
+  const onUpdate = async (plugin: PluginView) => {
+    setUpdatingId(plugin.id);
+    setError(null);
+    try {
+      const res = await previewPluginUpdate(plugin.id);
+      if (res.kind !== "ok") {
+        setError(res.message);
+        return;
+      }
+      const preview = res.preview;
+      if (preview.kind === "no_update") {
+        reportInfo(`${plugin.name} is already up to date.`);
+        clearUpdateBadge(plugin.id);
+      } else if (preview.kind === "safe_update") {
+        const applied = await applyPluginUpdate(plugin.id, preview.fingerprint);
+        if (applied.kind === "ok") {
+          setData(applied.data);
+          clearUpdateBadge(plugin.id);
+          reportInfo(`${plugin.name} updated.`);
+        } else {
+          setError(applied.message);
+        }
+      } else {
+        setConsentError(null);
+        setConsentModal({ plugin, consent: preview.consent });
+      }
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const onApproveUpdate = async () => {
+    if (!consentModal) return;
+    setConsentBusy(true);
+    setConsentError(null);
+    try {
+      const res = await applyPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
+      if (res.kind === "ok") {
+        setData(res.data);
+        clearUpdateBadge(consentModal.plugin.id);
+        reportInfo(`${consentModal.plugin.name} updated.`);
+        setConsentModal(null);
+      } else {
+        // A moved-remote 409 (or any failure) keeps the modal open with the
+        // message; the user can close and re-Update to re-preview.
+        setConsentError(res.message);
+      }
+    } finally {
+      setConsentBusy(false);
+    }
+  };
+
+  const onDeclineUpdate = async () => {
+    if (!consentModal) return;
+    setConsentBusy(true);
+    try {
+      // Either way the current version stays active; record the decline so it
+      // stops nagging, then close.
+      await dismissPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
+      clearUpdateBadge(consentModal.plugin.id);
+      setConsentModal(null);
+    } finally {
+      setConsentBusy(false);
     }
   };
 
@@ -328,10 +415,20 @@ export function PluginsSettings() {
                       </p>
                     )}
                     {update?.needs_update && (
-                      <p className="mt-1 text-[11px] text-text-dim">
-                        Update available ({update.current} → {update.available ?? "modified"}). Update with{" "}
-                        <code>aoe plugin update {plugin.id}</code>.
-                      </p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <span className="text-[11px] text-text-dim">
+                          Update available ({update.current} → {update.available ?? "modified"}).
+                        </span>
+                        <button
+                          type="button"
+                          className="rounded border border-surface-700 px-2 py-0.5 text-[11px] hover:bg-surface-800 disabled:opacity-50"
+                          disabled={updatingId === plugin.id}
+                          onClick={() => void onUpdate(plugin)}
+                          data-testid={`plugin-update-${plugin.id}`}
+                        >
+                          {updatingId === plugin.id ? "Checking…" : "Update"}
+                        </button>
+                      </div>
                     )}
                     {update?.error && (
                       <p className="mt-1 text-[11px] text-status-error">Update check failed: {update.error}</p>
@@ -363,6 +460,19 @@ export function PluginsSettings() {
           fallback={detail.fallback}
           installCommand={detail.installCommand}
           onClose={() => setDetail(null)}
+        />
+      )}
+
+      {consentModal && (
+        <PluginUpdateConsentModal
+          key={consentModal.plugin.id}
+          consent={consentModal.consent}
+          name={consentModal.plugin.name}
+          busy={consentBusy}
+          error={consentError}
+          onApprove={() => void onApproveUpdate()}
+          onDecline={() => void onDeclineUpdate()}
+          onClose={() => setConsentModal(null)}
         />
       )}
     </div>

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -413,8 +413,6 @@ describe("PluginsSettings", () => {
     await waitFor(() => expect(queryByTestId("plugin-detail-modal")).toBeNull());
   });
 
-  // --- In-app update flow ---
-
   // Surface the per-row Update button by reporting an available update.
   function markOutdated() {
     fetchPluginUpdates.mockResolvedValue({

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -492,6 +492,22 @@ describe("PluginsSettings", () => {
     await waitFor(() => expect(queryByTestId("plugin-update-consent-modal")).toBeNull());
   });
 
+  it("a failed decline keeps the consent modal open and surfaces the error", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue(consentPreview);
+    dismissPluginUpdate.mockResolvedValue({ kind: "error", message: "Dashboard is read-only." });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-update-decline"));
+    const err = await findByTestId("plugin-update-consent-error");
+    expect(err.textContent).toContain("Dashboard is read-only.");
+    // The modal stays open and the update badge is not cleared, so the failed
+    // decline is not mistaken for a persisted one.
+    expect(queryByTestId("plugin-update-consent-modal")).not.toBeNull();
+    await findByTestId("plugin-update-available-example.plugin");
+  });
+
   it("a safe update applies directly without a consent modal", async () => {
     markOutdated();
     previewPluginUpdate.mockResolvedValue({

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -536,4 +536,83 @@ describe("PluginsSettings", () => {
     const err = await findByTestId("plugin-update-consent-error");
     expect(err.textContent).toContain("changed since it was shown");
   });
+
+  it("the consent modal renders removed caps, runtime, trust downgrade, and UI slots", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue({
+      kind: "ok",
+      preview: {
+        kind: "consent_required",
+        dismissed: false,
+        consent: {
+          id: "example.plugin",
+          from_version: "0.1.0",
+          to_version: "0.2.0",
+          prior_capabilities: ["net", "fs.read"],
+          new_capabilities: ["net"],
+          added_capabilities: [],
+          removed_capabilities: ["fs.read"],
+          ui: [{ slot: "status-bar", id: "s" }],
+          build_steps: [],
+          runtime_change: "the worker is now a downloaded release binary",
+          trust_downgrade: true,
+          fingerprint: "treeD||community",
+          stays_active_if_declined: true,
+        },
+      },
+    });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    await findByTestId("plugin-update-consent-modal");
+    expect((await findByTestId("plugin-update-runtime-change")).textContent).toContain("release binary");
+    await findByTestId("plugin-update-trust-downgrade");
+  });
+
+  it("Update reports up-to-date and clears the badge when preview finds no update", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue({ kind: "ok", preview: { kind: "no_update" } });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    await waitFor(() => expect(reportInfo).toHaveBeenCalled());
+    await waitFor(() => expect(queryByTestId("plugin-update-available-example.plugin")).toBeNull());
+  });
+
+  it("surfaces a preview error inline", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue({ kind: "error", message: "no published release" });
+    const { findByTestId, findByText } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    await findByText("no published release");
+  });
+
+  it("surfaces an error when a safe update fails to apply", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue({
+      kind: "ok",
+      preview: { kind: "safe_update", to_version: "0.2.0", fingerprint: "treeC||community" },
+    });
+    applyPluginUpdate.mockResolvedValue({ kind: "error", message: "apply boom" });
+    const { findByTestId, findByText } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    await findByText("apply boom");
+  });
+
+  it("does not close the consent modal while an apply is in flight", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue(consentPreview);
+    // A never-resolving apply keeps the modal in its busy state.
+    applyPluginUpdate.mockReturnValue(new Promise(() => {}));
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-update-approve"));
+    // Escape and the Close button must be no-ops while busy.
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.click(await findByTestId("plugin-update-consent-close"));
+    expect(queryByTestId("plugin-update-consent-modal")).not.toBeNull();
+  });
 });

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -12,8 +12,10 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import type {
   DiscoverResult,
   PluginDetailResult,
+  PluginDismissResult,
   PluginListResponse,
   PluginToggleResult,
+  PluginUpdatePreviewResult,
   PluginUpdatesResult,
 } from "../../../lib/api";
 
@@ -22,6 +24,9 @@ const setPluginEnabled = vi.fn<[string, boolean], Promise<PluginToggleResult>>()
 const fetchPluginUpdates = vi.fn<[], Promise<PluginUpdatesResult>>();
 const discoverPlugins = vi.fn<[string], Promise<DiscoverResult>>();
 const fetchPluginDetails = vi.fn<[string], Promise<PluginDetailResult>>();
+const previewPluginUpdate = vi.fn<[string], Promise<PluginUpdatePreviewResult>>();
+const applyPluginUpdate = vi.fn<[string, string | null], Promise<PluginToggleResult>>();
+const dismissPluginUpdate = vi.fn<[string, string], Promise<PluginDismissResult>>();
 const reportInfo = vi.fn<[string], void>();
 
 vi.mock("../../../lib/api", () => ({
@@ -30,6 +35,9 @@ vi.mock("../../../lib/api", () => ({
   fetchPluginUpdates: () => fetchPluginUpdates(),
   discoverPlugins: (q: string) => discoverPlugins(q),
   fetchPluginDetails: (source: string) => fetchPluginDetails(source),
+  previewPluginUpdate: (id: string) => previewPluginUpdate(id),
+  applyPluginUpdate: (id: string, fp: string | null) => applyPluginUpdate(id, fp),
+  dismissPluginUpdate: (id: string, fp: string) => dismissPluginUpdate(id, fp),
 }));
 
 vi.mock("../../../lib/toastBus", () => ({
@@ -85,6 +93,9 @@ beforeEach(() => {
   fetchPluginUpdates.mockReset();
   discoverPlugins.mockReset();
   fetchPluginDetails.mockReset();
+  previewPluginUpdate.mockReset();
+  applyPluginUpdate.mockReset();
+  dismissPluginUpdate.mockReset();
   reportInfo.mockReset();
   fetchPlugins.mockResolvedValue(listResponse());
   fetchPluginUpdates.mockResolvedValue({ kind: "ok", updates: [] });
@@ -400,5 +411,113 @@ describe("PluginsSettings", () => {
     expect(modal.textContent).toContain("v0.1.0");
     fireEvent.click(await findByTestId("plugin-detail-close"));
     await waitFor(() => expect(queryByTestId("plugin-detail-modal")).toBeNull());
+  });
+
+  // --- In-app update flow ---
+
+  // Surface the per-row Update button by reporting an available update.
+  function markOutdated() {
+    fetchPluginUpdates.mockResolvedValue({
+      kind: "ok",
+      updates: [
+        {
+          id: "example.plugin",
+          source: "gh:example/plugin",
+          current: "abc1234",
+          available: "def5678",
+          needs_update: true,
+          error: null,
+        },
+      ],
+    });
+  }
+
+  const consentPreview: PluginUpdatePreviewResult = {
+    kind: "ok",
+    preview: {
+      kind: "consent_required",
+      dismissed: false,
+      consent: {
+        id: "example.plugin",
+        from_version: "0.1.0",
+        to_version: "0.2.0",
+        prior_capabilities: ["net"],
+        new_capabilities: ["net", "fs.read"],
+        added_capabilities: ["fs.read"],
+        removed_capabilities: [],
+        ui: [],
+        build_steps: ["sh build.sh"],
+        runtime_change: null,
+        trust_downgrade: false,
+        fingerprint: "treeB||community",
+        stays_active_if_declined: true,
+      },
+    },
+  };
+
+  it("Update on a consent-required version opens the consent modal with the new access", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue(consentPreview);
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    await waitFor(() => expect(previewPluginUpdate).toHaveBeenCalledWith("example.plugin"));
+    await findByTestId("plugin-update-consent-modal");
+    expect((await findByTestId("plugin-update-added-caps")).textContent).toContain("fs.read");
+    expect((await findByTestId("plugin-update-build-steps")).textContent).toContain("sh build.sh");
+  });
+
+  it("Approving applies the update pinned to the previewed fingerprint and closes the modal", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue(consentPreview);
+    applyPluginUpdate.mockResolvedValue({ kind: "ok", data: listResponse() });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-update-approve"));
+    await waitFor(() => expect(applyPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeB||community"));
+    await waitFor(() => expect(queryByTestId("plugin-update-consent-modal")).toBeNull());
+  });
+
+  it("Declining records the dismissal and never applies (the version stays active)", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue(consentPreview);
+    dismissPluginUpdate.mockResolvedValue({ kind: "ok" });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-update-decline"));
+    await waitFor(() => expect(dismissPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeB||community"));
+    expect(applyPluginUpdate).not.toHaveBeenCalled();
+    await waitFor(() => expect(queryByTestId("plugin-update-consent-modal")).toBeNull());
+  });
+
+  it("a safe update applies directly without a consent modal", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue({
+      kind: "ok",
+      preview: { kind: "safe_update", to_version: "0.2.0", fingerprint: "treeC||community" },
+    });
+    applyPluginUpdate.mockResolvedValue({ kind: "ok", data: listResponse() });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    await waitFor(() => expect(applyPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeC||community"));
+    expect(queryByTestId("plugin-update-consent-modal")).toBeNull();
+  });
+
+  it("surfaces an apply error in the consent modal and keeps it open", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue(consentPreview);
+    applyPluginUpdate.mockResolvedValue({
+      kind: "error",
+      message: "the available update changed since it was shown; review it again before approving",
+    });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-update-approve"));
+    const err = await findByTestId("plugin-update-consent-error");
+    expect(err.textContent).toContain("changed since it was shown");
   });
 });

--- a/web/src/lib/__tests__/pluginsApi.test.ts
+++ b/web/src/lib/__tests__/pluginsApi.test.ts
@@ -130,6 +130,19 @@ describe("previewPluginUpdate", () => {
     fetchSpy.mockRejectedValue(new Error("offline"));
     expect(await previewPluginUpdate("acme.plugin")).toEqual({ kind: "error", message: "Network error." });
   });
+
+  it("rejects a malformed OK payload that drops the per-kind required fields", async () => {
+    // safe_update without a fingerprint, consent_required without a consent
+    // object, and an unknown kind must all be treated as errors, not passed on.
+    for (const bad of [
+      { kind: "safe_update", to_version: "2.0.0" },
+      { kind: "consent_required", dismissed: false },
+      { kind: "bogus" },
+    ]) {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(bad), { status: 200 }));
+      expect((await previewPluginUpdate("acme.plugin")).kind).toBe("error");
+    }
+  });
 });
 
 describe("applyPluginUpdate", () => {

--- a/web/src/lib/__tests__/pluginsApi.test.ts
+++ b/web/src/lib/__tests__/pluginsApi.test.ts
@@ -5,7 +5,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchPlugins, setPluginEnabled, updateSettings } from "../api";
+import {
+  applyPluginUpdate,
+  dismissPluginUpdate,
+  fetchPlugins,
+  previewPluginUpdate,
+  setPluginEnabled,
+  updateSettings,
+} from "../api";
 
 const fetchSpy = vi.fn<typeof fetch>();
 
@@ -83,6 +90,94 @@ describe("setPluginEnabled", () => {
     fetchSpy.mockRejectedValue(new Error("offline"));
     const result = await setPluginEnabled("aoe.web", true);
     expect(result).toEqual({ kind: "error", message: "Network error." });
+  });
+});
+
+const consentPreview = {
+  kind: "consent_required",
+  dismissed: false,
+  consent: {
+    id: "acme.plugin",
+    from_version: "1.0.0",
+    to_version: "2.0.0",
+    prior_capabilities: ["net"],
+    new_capabilities: ["net", "fs.read"],
+    added_capabilities: ["fs.read"],
+    removed_capabilities: [],
+    ui: [],
+    build_steps: [],
+    runtime_change: null,
+    trust_downgrade: false,
+    fingerprint: "treeB||community",
+    stays_active_if_declined: true,
+  },
+};
+
+describe("previewPluginUpdate", () => {
+  it("returns the parsed preview from GET .../update/preview", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(consentPreview), { status: 200 }));
+    const res = await previewPluginUpdate("acme.plugin");
+    expect(res).toEqual({ kind: "ok", preview: consentPreview });
+    expect(fetchSpy.mock.calls[0][0]).toBe("/api/plugins/acme.plugin/update/preview");
+  });
+
+  it("surfaces the server message on a non-OK response", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "no release" }), { status: 502 }));
+    expect(await previewPluginUpdate("acme.plugin")).toEqual({ kind: "error", message: "no release" });
+  });
+
+  it("returns a network error when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("offline"));
+    expect(await previewPluginUpdate("acme.plugin")).toEqual({ kind: "error", message: "Network error." });
+  });
+});
+
+describe("applyPluginUpdate", () => {
+  it("POSTs the fingerprint and returns the refreshed list on success", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(listPayload), { status: 200 }));
+    const res = await applyPluginUpdate("acme.plugin", "treeB||community");
+    expect(res).toEqual({ kind: "ok", data: listPayload });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/plugins/acme.plugin/update/apply");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ expected_fingerprint: "treeB||community" });
+  });
+
+  it("surfaces a conflict message (moved remote)", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "changed since shown" }), { status: 409 }));
+    expect(await applyPluginUpdate("acme.plugin", "x")).toEqual({ kind: "error", message: "changed since shown" });
+  });
+
+  it("reports an error when an OK response has a malformed shape", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ nope: true }), { status: 200 }));
+    expect((await applyPluginUpdate("acme.plugin", null)).kind).toBe("error");
+  });
+
+  it("returns a network error when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("offline"));
+    expect(await applyPluginUpdate("acme.plugin", null)).toEqual({ kind: "error", message: "Network error." });
+  });
+});
+
+describe("dismissPluginUpdate", () => {
+  it("POSTs the fingerprint and returns ok on success", async () => {
+    fetchSpy.mockResolvedValue(new Response("", { status: 200 }));
+    const res = await dismissPluginUpdate("acme.plugin", "treeB||community");
+    expect(res).toEqual({ kind: "ok" });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/plugins/acme.plugin/update/dismiss");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ fingerprint: "treeB||community" });
+  });
+
+  it("surfaces the server message on a non-OK response", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "read-only" }), { status: 403 }));
+    expect(await dismissPluginUpdate("acme.plugin", "x")).toEqual({ kind: "error", message: "read-only" });
+  });
+
+  it("returns a network error when the request throws", async () => {
+    fetchSpy.mockRejectedValue(new Error("offline"));
+    expect(await dismissPluginUpdate("acme.plugin", "x")).toEqual({ kind: "error", message: "Network error." });
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -383,6 +383,23 @@ export type PluginUpdatePreviewResult =
   | { kind: "ok"; preview: PluginUpdatePreview }
   | { kind: "error"; message: string };
 
+/** Validate a preview payload against the discriminated union, so a drifted
+ *  server response is rejected rather than passed on: a safe_update must carry a
+ *  string fingerprint (else the apply would send no pin) and a consent_required
+ *  must carry a consent object (else the modal path would blow up). */
+function isValidPreview(payload: Record<string, unknown>): payload is PluginUpdatePreview {
+  switch (payload.kind) {
+    case "no_update":
+      return true;
+    case "safe_update":
+      return typeof payload.fingerprint === "string";
+    case "consent_required":
+      return typeof payload.consent === "object" && payload.consent !== null;
+    default:
+      return false;
+  }
+}
+
 /** Classify the available update for one installed plugin (no install happens).
  *  When consent is required the payload carries the full disclosure. */
 export async function previewPluginUpdate(id: string): Promise<PluginUpdatePreviewResult> {
@@ -391,8 +408,8 @@ export async function previewPluginUpdate(id: string): Promise<PluginUpdatePrevi
       headers: { Accept: "application/json" },
     });
     const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-    if (res.ok && payload && typeof payload.kind === "string") {
-      return { kind: "ok", preview: payload as unknown as PluginUpdatePreview };
+    if (res.ok && payload && isValidPreview(payload)) {
+      return { kind: "ok", preview: payload };
     }
     const message =
       typeof payload?.message === "string"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -348,6 +348,107 @@ export async function fetchPluginDetails(source: string): Promise<PluginDetailRe
   }
 }
 
+/** One UI slot disclosed in an update consent (mirrors the engine `UiView`). */
+export interface PluginUpdateUiView {
+  slot: string;
+  id: string;
+}
+
+/** Structured disclosure for a capability-expanding plugin update, mirroring the
+ *  Rust `UpdateConsent`. Drives the consent modal. */
+export interface PluginUpdateConsent {
+  id: string;
+  from_version: string;
+  to_version: string;
+  prior_capabilities: string[];
+  new_capabilities: string[];
+  added_capabilities: string[];
+  removed_capabilities: string[];
+  ui: PluginUpdateUiView[];
+  build_steps: string[];
+  runtime_change: string | null;
+  trust_downgrade: boolean;
+  fingerprint: string;
+  stays_active_if_declined: boolean;
+}
+
+/** Result of `GET /api/plugins/{id}/update/preview`: a tagged union mirroring the
+ *  Rust `UpdatePreview`. */
+export type PluginUpdatePreview =
+  | { kind: "no_update" }
+  | { kind: "safe_update"; to_version: string; fingerprint: string }
+  | { kind: "consent_required"; consent: PluginUpdateConsent; dismissed: boolean };
+
+export type PluginUpdatePreviewResult =
+  | { kind: "ok"; preview: PluginUpdatePreview }
+  | { kind: "error"; message: string };
+
+/** Classify the available update for one installed plugin (no install happens).
+ *  When consent is required the payload carries the full disclosure. */
+export async function previewPluginUpdate(id: string): Promise<PluginUpdatePreviewResult> {
+  try {
+    const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/update/preview`, {
+      headers: { Accept: "application/json" },
+    });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && typeof payload.kind === "string") {
+      return { kind: "ok", preview: payload as unknown as PluginUpdatePreview };
+    }
+    const message =
+      typeof payload?.message === "string"
+        ? (payload.message as string)
+        : `Update preview failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
+/** Apply an approved update, pinned to the fingerprint the user saw. On success
+ *  the server returns the refreshed plugin list. A 409 means the remote moved
+ *  since the preview, so the caller should re-preview before re-approving. */
+export async function applyPluginUpdate(id: string, expectedFingerprint: string | null): Promise<PluginToggleResult> {
+  try {
+    const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/update/apply`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ expected_fingerprint: expectedFingerprint }),
+    });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && isValidPluginListResponse(payload)) {
+      return { kind: "ok", data: payload };
+    }
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Update failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
+export type PluginDismissResult = { kind: "ok" } | { kind: "error"; message: string };
+
+/** Record an in-app decline of an available update so it stops nagging until the
+ *  next version. */
+export async function dismissPluginUpdate(id: string, fingerprint: string): Promise<PluginDismissResult> {
+  try {
+    const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/update/dismiss`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fingerprint }),
+    });
+    if (res.ok) {
+      return { kind: "ok" };
+    }
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Dismiss failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
 // Plugin UI extension points (#2366).
 
 /** Display tone a plugin attaches to a slot entry or notification. The host

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2786,7 +2786,8 @@
       "specs": ["src/components/settings/__tests__/PluginsSettings.test.tsx"],
       "components": [
         "web/src/components/settings/PluginsSettings.tsx",
-        "web/src/components/settings/PluginDetailModal.tsx"
+        "web/src/components/settings/PluginDetailModal.tsx",
+        "web/src/components/settings/PluginUpdateConsentModal.tsx"
       ]
     },
     {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A plugin update that expands what a plugin can do should interrupt the user with an explicit approval before the new version becomes active. Until now that re-prompt only existed as a terminal `aoe plugin update <id>` stdin/stdout prompt: the web dashboard and TUI could show that a plugin "needs approval" but could only tell the user to drop to a terminal. This closes that gap with an in-app accept/decline popup on both surfaces.

The consent decision is lifted out of the terminal prompt into a structured payload that every surface renders. `update_with_consent` is refactored into a shared `prepare_update` (fetch + diff) and `apply_prepared` (replace + persist) pipeline; the CLI stays one frontend over it, and new `preview_update` / `apply_update` / `dismiss_update` entry points back the web and TUI. There is no second consent code path to drift.

Because accepting grants expanded access and build steps run unsandboxed, the approval pins on a content fingerprint (source tree hash + release-asset hash + trust class), not the manifest hash: a manifest hash alone misses a `build.sh` or worker script changing under an unchanged `aoe-plugin.toml`. `apply_update` refuses if the remote moved since the preview was shown, build-change detection now keys on the source tree, and the disclosure adds removed capabilities, runtime-kind switches, and featured-to-community trust downgrades as consent-worthy.

An in-app decline is persisted (`PluginConfig.dismissed_update`, the dismissed fingerprint, cleared on any apply) so the popup and the auto-update notification stop nagging until the next version. When the opt-in auto-update sweep skips a consent-needing update, it now surfaces a dashboard notification (via the plugin host's notification ring) instead of only logging a CLI instruction, unless that version was already dismissed.

The design was stress-tested with `/debate` (gpt-5.5 + gemini-3.1-pro), which is what moved the apply pin from the manifest hash to the tree-level fingerprint and added the runtime / trust disclosures.

Closes #2487

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Install an external plugin, publish an update that adds a capability, then in the dashboard plugin settings click "Check for updates" and "Update": a popup lists the new capability and the plugin does not change until you Approve.
- [ ] Approve the popup: the plugin updates to the new version and becomes active.
- [ ] Repeat but click Decline: the previously trusted version stays active and the popup does not reopen on the next Settings visit.
- [ ] Confirm a safe update (no new access) applies directly from the "Update" button with no popup.
- [ ] In the TUI plugin manager, press `c` then `u` on the outdated plugin: the same consent popup appears (`y` approve / `n` decline).
- [ ] With `updates.auto_update_plugins` enabled and a consent-needing update available, start `aoe serve`: a dashboard toast says the update needs approval.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated tests and updated `web/tests/coverage-matrix.json` (Vitest, the appropriate layer per `AGENTS.md` for this component flow: open, approve with fingerprint pin, decline-no-apply, safe-apply, and apply-error paths in `PluginsSettings.test.tsx`; `PluginUpdateConsentModal.tsx` mapped under `settings.plugins`).

**TUI / CLI (e2e test)**
- [ ] Skipped a test, because: the TUI consent popup reuses the same engine and `UpdateConsent` payload covered by the new `tests/plugin_install.rs` integration tests (preview / apply / stale-fingerprint guard / decline-keeps-old / dismissal-suppresses-notify); a tmux e2e exercising the popup keys is a reasonable follow-up.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a `/debate` design pass with gpt-5.5 and gemini-3.1-pro. I made the design calls (scope, tree-level fingerprint pin, persisted dismissal) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785188307&installation_id=139138837&pr_number=2499&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2499&signature=bf545e719e8f0fa49b997825df211be31d672d88a9fa33992f3ec0bd09f72543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds an in-product approval flow for plugin updates that expand or change what a plugin can do—so users no longer rely only on terminal prompts.

- Refactors plugin update consent into a shared “preview → approve/apply → decline/dismiss” flow that the web dashboard and TUI can render consistently.
- Adds a web approval modal and a matching TUI consent popup showing an itemized disclosure of what will change (including capabilities, runtime/trust changes, and relevant UI/build details).
- Extends the plugin update API with operations to preview an update, apply a specific approved preview, and dismiss a specific consent-required update.
- Makes approvals “content-pinned”: if the remote plugin content changes after preview, the update is rejected instead of being applied.
- Persists declines so users don’t get re-prompted for the same update version, while keeping the currently trusted plugin version active until the new one is explicitly approved.
- Improves auto-update UX: when auto-update requires approval, the plugin manager shows a visible in-product notification/badge instead of only logging CLI instructions.
- Updates plugin docs accordingly and adds/extends tests for the modal/popup behavior, stale-preview protection, skipped auto-update notifications, and decline behavior preserving the active version.

Benefit: a safer, clearer, and consistent plugin update experience across all interfaces, with stronger protection against unexpected capability/trust changes and better visibility when user approval is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->