### PR TITLE
fix(web): persist staged composer attachments in per-session drafts

### DIFF
--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -228,6 +228,12 @@ export function AcpRuntime({
       // Clear staged attachments only after the send resolves, so a
       // failed send keeps them staged for retry instead of dropping them.
       await acp.sendPrompt(text, attachments);
+      // Drop the persisted draft synchronously here, not only via the
+      // pendingAttachments effect: a send-then-immediately-navigate-away
+      // can unmount before the post-send render commits, which would
+      // otherwise leave an already-sent image behind to rehydrate later.
+      pendingAttachmentsRef.current = [];
+      setDraftAttachments(sessionId, []);
       setPendingAttachments([]);
     },
     onCancel,

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -40,6 +40,7 @@ import type {
   ToolCall,
 } from "../../lib/acpTypes";
 import { hasTodoArrayArgsText, parseJsonObject } from "../../lib/acpArgs";
+import { getDraftAttachments, setDraftAttachments } from "../../lib/acpDrafts";
 import { useHistoryWindow } from "../../hooks/useHistoryWindow";
 import { canOfferEarlier, earlierAction } from "../../lib/historyScroll";
 import { useAgentProfile } from "../../lib/agentProfileContext";
@@ -136,11 +137,31 @@ export function AcpRuntime({
   // Staged attachments for the next prompt. A ref mirror keeps `onNew`
   // (recreated each render by useExternalStoreRuntime) reading the
   // latest value without going stale. See #1000 / #965.
-  const [pendingAttachments, setPendingAttachments] = useState<PromptAttachmentInput[]>([]);
-  const pendingAttachmentsRef = useRef<PromptAttachmentInput[]>([]);
+  // Seed from the persisted draft so a staged image survives a session
+  // switch or reload like unsent text does. StructuredView remounts this
+  // runtime per session (`key={sessionId}`), so the initializer runs once
+  // with the right session's attachments and `sessionId` is stable for the
+  // instance lifetime, which keeps the persist effect below race-free.
+  const [pendingAttachments, setPendingAttachments] = useState<PromptAttachmentInput[]>(() =>
+    getDraftAttachments(sessionId),
+  );
+  const pendingAttachmentsRef = useRef<PromptAttachmentInput[]>(pendingAttachments);
   useEffect(() => {
     pendingAttachmentsRef.current = pendingAttachments;
   }, [pendingAttachments]);
+  // Mirror staged attachments into the per-session draft on every change.
+  // Skip the first run: the state was just initialized from storage, so
+  // re-serializing (potentially megabytes of base64) straight back would
+  // be wasted main-thread work on every session open. Post-send the
+  // composer clears pendingAttachments, which removes the key here.
+  const attachmentsHydratedRef = useRef(false);
+  useEffect(() => {
+    if (!attachmentsHydratedRef.current) {
+      attachmentsHydratedRef.current = true;
+      return;
+    }
+    setDraftAttachments(sessionId, pendingAttachments);
+  }, [sessionId, pendingAttachments]);
   // Stop-button escalation: a second press always force-ends, even when the
   // server never confirms the first cancel (no in-flight prompt on the
   // daemon). Owns its own reset-on-turn-end and reset-on-session-switch

--- a/web/src/lib/acpDrafts.test.ts
+++ b/web/src/lib/acpDrafts.test.ts
@@ -392,6 +392,13 @@ describe("hasDraft with attachment-only drafts (#2493)", () => {
     expect(hasDraft("s-1")).toBe(true);
   });
 
+  it("treats corrupt attachment storage as no draft", () => {
+    localStorage.setItem("acp:draft-attachments:s-1", "{not json");
+    expect(getDraftAttachments("s-1")).toEqual([]);
+    expect(hasDraftAttachments("s-1")).toBe(false);
+    expect(hasDraft("s-1")).toBe(false);
+  });
+
   it("sweepOrphanDrafts removes orphaned attachment keys", () => {
     setDraftAttachments("s-keep", [img("keep")]);
     setDraftAttachments("s-orphan", [img("gone")]);

--- a/web/src/lib/acpDrafts.test.ts
+++ b/web/src/lib/acpDrafts.test.ts
@@ -18,13 +18,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetDraftPersistFailureNotifications,
   clearDraft,
+  clearDraftAttachments,
   getDraft,
+  getDraftAttachments,
   hasDraft,
+  hasDraftAttachments,
   setDraft,
+  setDraftAttachments,
   subscribeDrafts,
   sweepOrphanDrafts,
 } from "./acpDrafts";
+import type { PromptAttachmentInput } from "./acpTypes";
 import { toastBus, type ToastApi } from "./toastBus";
+
+function img(dataB64 = "AAAA", name?: string): PromptAttachmentInput {
+  return { kind: "image", mimeType: "image/png", dataB64, ...(name ? { name } : {}) };
+}
 
 function makeQuotaError(): DOMException {
   return new DOMException("The quota has been exceeded.", "QuotaExceededError");
@@ -292,6 +301,113 @@ describe("sweepOrphanDrafts", () => {
     sweepOrphanDrafts(new Set());
     expect(hasDraft("s-a")).toBe(false);
     expect(hasDraft("s-b")).toBe(false);
+  });
+});
+
+describe("getDraftAttachments / setDraftAttachments (#2493)", () => {
+  it("returns an empty array when no attachment draft is persisted", () => {
+    expect(getDraftAttachments("s-1")).toEqual([]);
+  });
+
+  it("round-trips a staged attachment array", () => {
+    setDraftAttachments("s-1", [img("PNGBYTES", "shot.png")]);
+    const got = getDraftAttachments("s-1");
+    expect(got).toEqual([img("PNGBYTES", "shot.png")]);
+  });
+
+  it("scopes attachment drafts per session id", () => {
+    setDraftAttachments("s-1", [img("ONE")]);
+    setDraftAttachments("s-2", [img("TWO")]);
+    expect(getDraftAttachments("s-1")).toEqual([img("ONE")]);
+    expect(getDraftAttachments("s-2")).toEqual([img("TWO")]);
+  });
+
+  it("empty array removes the key entirely", () => {
+    setDraftAttachments("s-1", [img()]);
+    setDraftAttachments("s-1", []);
+    expect(getDraftAttachments("s-1")).toEqual([]);
+    expect(localStorage.getItem("acp:draft-attachments:s-1")).toBeNull();
+  });
+
+  it("clearDraftAttachments removes the key", () => {
+    setDraftAttachments("s-1", [img()]);
+    clearDraftAttachments("s-1");
+    expect(localStorage.getItem("acp:draft-attachments:s-1")).toBeNull();
+  });
+
+  it("drops malformed entries on read", () => {
+    localStorage.setItem("acp:draft-attachments:s-1", JSON.stringify([img("OK"), { kind: "image" }, "garbage", null]));
+    expect(getDraftAttachments("s-1")).toEqual([img("OK")]);
+  });
+
+  it("returns an empty array on corrupt JSON", () => {
+    localStorage.setItem("acp:draft-attachments:s-1", "{not json");
+    expect(getDraftAttachments("s-1")).toEqual([]);
+  });
+
+  it("removes the key on a failed write so a stale draft is never restored", () => {
+    setDraftAttachments("s-1", [img("OLD")]);
+    expect(getDraftAttachments("s-1")).toEqual([img("OLD")]);
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw makeQuotaError();
+    });
+    setDraftAttachments("s-1", [img("NEW-TOO-BIG")]);
+    spy.mockRestore();
+    expect(localStorage.getItem("acp:draft-attachments:s-1")).toBeNull();
+    expect(getDraftAttachments("s-1")).toEqual([]);
+  });
+
+  it("toasts once on a failed attachment write", () => {
+    const spy = attachToastSpy();
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw makeQuotaError();
+    });
+    setDraftAttachments("s-1", [img("BIG")]);
+    setDraftAttachments("s-1", [img("BIGGER")]);
+    expect(spy.errors).toHaveLength(1);
+    expect(spy.errors[0]).toMatch(/storage full/i);
+  });
+
+  it("notifies filtered subscribers on write", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    setDraftAttachments("s-1", [img()]);
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
+  });
+});
+
+describe("hasDraft with attachment-only drafts (#2493)", () => {
+  it("hasDraftAttachments is true for a non-empty staged array, false otherwise", () => {
+    expect(hasDraftAttachments("s-1")).toBe(false);
+    setDraftAttachments("s-1", [img()]);
+    expect(hasDraftAttachments("s-1")).toBe(true);
+    setDraftAttachments("s-1", []);
+    expect(hasDraftAttachments("s-1")).toBe(false);
+  });
+
+  it("hasDraft lights for an attachment-only draft (no text)", () => {
+    expect(hasDraft("s-1")).toBe(false);
+    setDraftAttachments("s-1", [img()]);
+    expect(hasDraft("s-1")).toBe(true);
+  });
+
+  it("sweepOrphanDrafts removes orphaned attachment keys", () => {
+    setDraftAttachments("s-keep", [img("keep")]);
+    setDraftAttachments("s-orphan", [img("gone")]);
+    setDraft("s-orphan", "text-too");
+    sweepOrphanDrafts(new Set(["s-keep"]));
+    expect(getDraftAttachments("s-keep")).toEqual([img("keep")]);
+    expect(localStorage.getItem("acp:draft-attachments:s-orphan")).toBeNull();
+    expect(localStorage.getItem("acp:draft:s-orphan")).toBeNull();
+  });
+
+  it("cross-tab storage event for an attachment key fires the listener", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    window.dispatchEvent(new StorageEvent("storage", { key: "acp:draft-attachments:s-1", newValue: "[]" }));
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
   });
 });
 

--- a/web/src/lib/acpDrafts.ts
+++ b/web/src/lib/acpDrafts.ts
@@ -103,11 +103,15 @@ export function clearDraft(sessionId: string): void {
   setDraft(sessionId, "");
 }
 
+function isPromptAttachmentKind(kind: unknown): kind is PromptAttachmentInput["kind"] {
+  return kind === "image" || kind === "audio" || kind === "resource";
+}
+
 function isPromptAttachmentInput(v: unknown): v is PromptAttachmentInput {
   if (!v || typeof v !== "object" || Array.isArray(v)) return false;
   const r = v as Record<string, unknown>;
   return (
-    typeof r.kind === "string" &&
+    isPromptAttachmentKind(r.kind) &&
     typeof r.mimeType === "string" &&
     typeof r.dataB64 === "string" &&
     (r.name === undefined || typeof r.name === "string")
@@ -158,11 +162,13 @@ export function clearDraftAttachments(sessionId: string): void {
 }
 
 // Cheap presence check for the sidebar "unsent draft" dot: a non-empty
-// stored array serializes to more than "[]" (2 chars), so we avoid parsing
-// (potentially megabytes of base64) on the sidebar re-render hot path.
+// stored array serializes to more than "[]" (2 chars) and starts with "[",
+// so we avoid parsing (potentially megabytes of base64) on the sidebar
+// re-render hot path while still rejecting obviously-corrupt non-array
+// values (which would otherwise leave the dot stuck on).
 export function hasDraftAttachments(sessionId: string): boolean {
   const v = safeGetItem(attachmentKey(sessionId));
-  return v !== null && v.length > 2;
+  return v !== null && v.length > 2 && v.startsWith("[");
 }
 
 // Remove every `acp:draft:<id>` key whose session id is not in the

--- a/web/src/lib/acpDrafts.ts
+++ b/web/src/lib/acpDrafts.ts
@@ -5,10 +5,19 @@
 
 import { useMemo, useSyncExternalStore } from "react";
 
+import type { PromptAttachmentInput } from "./acpTypes";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "./safeStorage";
 import { toastBus } from "./toastBus";
 
 const DRAFT_KEY_PREFIX = "acp:draft:";
+// Staged composer attachments persist beside the text draft under their own
+// key (JSON array of PromptAttachmentInput) so an unsent multimodal prompt
+// survives session switches and reloads, matching the text-draft contract.
+// Kept parallel to the text key, not folded into one JSON blob: text writes
+// on a 250ms keystroke debounce while attachments write on stage/remove, and
+// a single blob would make the two write paths clobber each other. Parallel
+// keys also let text persist even when a large base64 image blows quota.
+const ATTACHMENT_KEY_PREFIX = "acp:draft-attachments:";
 
 // Sessions that have already surfaced a "storage full" toast this page
 // load. We dedupe so the composer does not toast on every keystroke once
@@ -32,9 +41,16 @@ function draftKey(sessionId: string): string {
   return `${DRAFT_KEY_PREFIX}${sessionId}`;
 }
 
+function attachmentKey(sessionId: string): string {
+  return `${ATTACHMENT_KEY_PREFIX}${sessionId}`;
+}
+
+// Recognizes both the text and attachment key prefixes so the orphan sweep
+// and the cross-tab storage listener cover attachment drafts for free.
 function sessionIdFromKey(key: string): string | null {
-  if (!key.startsWith(DRAFT_KEY_PREFIX)) return null;
-  return key.slice(DRAFT_KEY_PREFIX.length);
+  if (key.startsWith(DRAFT_KEY_PREFIX)) return key.slice(DRAFT_KEY_PREFIX.length);
+  if (key.startsWith(ATTACHMENT_KEY_PREFIX)) return key.slice(ATTACHMENT_KEY_PREFIX.length);
+  return null;
 }
 
 type Listener = () => void;
@@ -87,6 +103,68 @@ export function clearDraft(sessionId: string): void {
   setDraft(sessionId, "");
 }
 
+function isPromptAttachmentInput(v: unknown): v is PromptAttachmentInput {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.kind === "string" &&
+    typeof r.mimeType === "string" &&
+    typeof r.dataB64 === "string" &&
+    (r.name === undefined || typeof r.name === "string")
+  );
+}
+
+export function getDraftAttachments(sessionId: string): PromptAttachmentInput[] {
+  const raw = safeGetItem(attachmentKey(sessionId));
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isPromptAttachmentInput);
+  } catch {
+    return [];
+  }
+}
+
+export function setDraftAttachments(sessionId: string, attachments: readonly PromptAttachmentInput[]): void {
+  const key = attachmentKey(sessionId);
+  let ok = true;
+  if (attachments.length === 0) {
+    safeRemoveItem(key);
+  } else {
+    let json = "";
+    try {
+      json = JSON.stringify(attachments);
+    } catch {
+      ok = false;
+    }
+    if (ok) ok = safeSetItem(key, json);
+    // Exact-or-none: if the current set cannot be persisted (quota, serialize
+    // failure), drop the key so a stale older draft is never restored and
+    // silently re-sent. The in-memory staged attachments stay live for the
+    // current page lifetime; the user just loses them on reload.
+    if (!ok) safeRemoveItem(key);
+  }
+  if (!ok) {
+    notifyDraftPersistFailure(sessionId);
+  } else {
+    clearDraftPersistFailure(sessionId);
+  }
+  notify(sessionId);
+}
+
+export function clearDraftAttachments(sessionId: string): void {
+  setDraftAttachments(sessionId, []);
+}
+
+// Cheap presence check for the sidebar "unsent draft" dot: a non-empty
+// stored array serializes to more than "[]" (2 chars), so we avoid parsing
+// (potentially megabytes of base64) on the sidebar re-render hot path.
+export function hasDraftAttachments(sessionId: string): boolean {
+  const v = safeGetItem(attachmentKey(sessionId));
+  return v !== null && v.length > 2;
+}
+
 // Remove every `acp:draft:<id>` key whose session id is not in the
 // given active set. Run once on app mount to catch drafts left behind
 // by session deletions that happened in another tab or on another
@@ -113,7 +191,10 @@ export function sweepOrphanDrafts(activeSessionIds: ReadonlySet<string>): void {
 
 export function hasDraft(sessionId: string): boolean {
   const v = safeGetItem(draftKey(sessionId));
-  return v !== null && v.length > 0;
+  if (v !== null && v.length > 0) return true;
+  // An attachment-only draft (no text) is still unsent work, so the sidebar
+  // dot must light for it too. useHasDraftForSessions reads through here.
+  return hasDraftAttachments(sessionId);
 }
 
 // Subscribe to draft changes. `filter` scopes the listener to a specific

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1377,6 +1377,17 @@
       ]
     },
     {
+      "id": "acp.attachment-drafts",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/acp-attachment-draft.spec.ts"],
+      "components": [
+        "web/src/components/acp/AcpRuntime.tsx",
+        "web/src/components/acp/Composer.tsx",
+        "web/src/lib/acpDrafts.ts"
+      ]
+    },
+    {
       "id": "acp.approval",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/acp-attachment-draft.spec.ts
+++ b/web/tests/live/acp-attachment-draft.spec.ts
@@ -1,0 +1,124 @@
+// Structured view composer attachment-draft persistence (#2493).
+//
+// Staged composer images must survive a session switch and a page reload
+// the same way unsent text drafts already do. Before the fix, switching
+// sessions remounted AcpRuntime (`<StructuredView key={sessionId}>`),
+// dropping the in-memory `pendingAttachments`, so a pasted/picked image
+// vanished even though its text draft came back.
+//
+// This drives the real composer: stage an image via the file picker,
+// switch sessions through the command palette (client-side remount),
+// switch back, and assert the chip is restored; then reload and assert it
+// survives that too. It also asserts session B does not inherit A's draft.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, resolveAoeBinary } from "../helpers/aoeServe";
+import { enableStructuredViewAndWait, waitForStructuredView } from "../helpers/acp";
+
+const MOD = process.platform === "darwin" ? "Meta" : "Control";
+
+// A valid 1x1 PNG (same fixture as acp-attachment.spec.ts).
+const PNG_1X1_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function seedTwoSessions(): (seedEnv: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => void {
+  return ({ home, env }) => {
+    for (const [title, subdir] of [
+      ["draft-source", "project-a"],
+      ["draft-target", "project-b"],
+    ] as const) {
+      const projectDir = join(home, subdir);
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+      const res = spawnSync(resolveAoeBinary(), ["add", projectDir, "-t", title, "-c", "claude"], { env });
+      if (res.status !== 0) {
+        throw new Error(`aoe add ${title} failed: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`);
+      }
+    }
+  };
+}
+
+base("staged composer image survives session switch and reload", async ({ page }, testInfo) => {
+  // Advertise the image prompt capability so the composer enables attachments.
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-acp-draft-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify({ promptCapabilities: { image: true } }));
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedTwoSessions(),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const source = sessions.find((s) => s.title === "draft-source")!;
+    const target = sessions.find((s) => s.title === "draft-target")!;
+
+    await enableStructuredViewAndWait(serve.baseUrl, source.id, 30_000, serve.home);
+    await enableStructuredViewAndWait(serve.baseUrl, target.id, 30_000, serve.home);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(source.id)}`);
+    await waitForStructuredView(page);
+
+    // Attachments only stage once the agent's image capability has arrived,
+    // which flips the attach button out of its "Waiting for agent
+    // capabilities" disabled state.
+    const attachButton = page.getByRole("button", { name: /Attach files/ });
+    await expect(attachButton).toBeEnabled({ timeout: 30_000 });
+
+    // Stage an image through the composer's hidden file input.
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "shot.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(PNG_1X1_B64, "base64"),
+    });
+
+    const chip = page.getByRole("img", { name: "shot.png" });
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+
+    // Switch to session B via the command palette (client-side remount).
+    await page.keyboard.press(`${MOD}+K`);
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible({ timeout: 5_000 });
+    await palette.getByPlaceholder("Search actions, sessions, settings…").fill("draft-target");
+    await palette.getByText("draft-target").first().click();
+    await expect(page).toHaveURL(new RegExp(`/session/${target.id}`), { timeout: 10_000 });
+    await waitForStructuredView(page);
+
+    // B must not inherit A's staged attachment.
+    await expect(page.getByRole("img", { name: "shot.png" })).toHaveCount(0);
+
+    // Switch back to A: its staged image must be restored.
+    await page.keyboard.press(`${MOD}+K`);
+    await expect(palette).toBeVisible({ timeout: 5_000 });
+    await palette.getByPlaceholder("Search actions, sessions, settings…").fill("draft-source");
+    await palette.getByText("draft-source").first().click();
+    await expect(page).toHaveURL(new RegExp(`/session/${source.id}`), { timeout: 10_000 });
+    await waitForStructuredView(page);
+    await expect(page.getByRole("img", { name: "shot.png" })).toBeVisible({ timeout: 10_000 });
+
+    // And it survives a full page reload.
+    await page.reload();
+    await waitForStructuredView(page);
+    await expect(page.getByRole("img", { name: "shot.png" })).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the investigation, prose, and implementation via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web dashboard structured-view composer, staged image attachments (pasted, dropped, or picker-selected) were silently dropped when switching sessions or reloading the page, even though unsent text drafts for the same session were restored. A user could paste a screenshot, navigate away to inspect another session, and return to find it gone.

Root cause: `<StructuredView key={sessionId}>` fully remounts `AcpRuntime` on every session switch, so its `pendingAttachments` state reset to empty and was never persisted. Text drafts survive only because the composer mirrors its text into `localStorage` via `lib/acpDrafts.ts`; attachments had no equivalent persistence path.

This extends the existing per-session draft model to staged attachments. A parallel `localStorage` key `acp:draft-attachments:<sessionId>` holds the staged `PromptAttachmentInput[]` beside the text draft. `AcpRuntime` seeds its state from storage in the `useState` initializer (the only point synchronously correct on remount) and persists on change, skipping the redundant mount write. On a failed or quota-exhausted write the key is removed, so a stale older draft can never be silently restored and re-sent. The sidebar "unsent draft" dot now also lights for attachment-only drafts, and the orphan sweep drops attachment keys for deleted sessions.

Parallel key over a widened JSON blob is deliberate: text writes on a keystroke debounce while attachments write on stage/remove, so a single blob would let the two paths clobber each other, and base64 images are large enough that coupling them would make text drafts fail to persist under quota pressure.

Longer term, base64 images in `localStorage` will hit the ~5MB origin quota; moving draft attachment storage to IndexedDB is the real fix but is out of scope here.

Closes #2493

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the structured-view composer, paste or pick an image, type some text, switch to another session, then switch back. Both the text and the image chip are restored.
- [ ] Stage an image, then reload the page. The chip is restored and the prompt is still sendable.
- [ ] With a staged image in session A, switch to session B. B shows no attachment. Switch back to A. A's image is back.
- [ ] Stage an image in a session with no text. The sidebar shows the "unsent draft" dot for that session.
- [ ] Send a prompt with a staged image, then reload. No stale attachment reappears (the draft is cleared after send).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult between two models on the storage shape and failure modes. I made the design calls and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785195779&installation_id=139138837&pr_number=2500&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2500&signature=042053164cf7f0a0a454f74eb4d6d225b1e02e1d117fac0c394bdc553f4927c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update makes staged composer image attachments behave like existing text drafts in the structured-view composer: they’re now saved and restored per session. As a result, pasted/dropped/picker-selected images no longer disappear when switching sessions or reloading the page, and they don’t leak into other sessions. The sidebar “unsent draft” indicator now also shows attachment-only drafts, and any orphaned attachment draft data is cleaned up when sessions are removed.

The change adds unit coverage and a new end-to-end Playwright test to verify attachment persistence across session remounts and full reloads, including handling for malformed stored data, failed/quota-limited writes, and orphan cleanup/notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->