### PR TITLE
feat(web): same-location pane splits in the right and bottom docks

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1184,10 +1184,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
     if (target === "paired") {
       // The paired shell only mounts when a terminal tab is the active tab of
-      // its dock.
-      const termTab =
-        (["right", "bottom"] as DockLocation[]).flatMap((d) => dockTabs(paneLayout, d)).find(isTerminalTabId) ??
-        terminalTabId(0);
+      // its group. Prefer a terminal that is already active (and thus mounted)
+      // over the first one, so multi-group layouts focus the live terminal
+      // instead of switching another group's tab.
+      const terminalTabs = (["right", "bottom"] as DockLocation[])
+        .flatMap((d) => dockTabs(paneLayout, d))
+        .filter(isTerminalTabId);
+      const termTab = terminalTabs.find((id) => isActiveTab(paneLayout, id)) ?? terminalTabs[0] ?? terminalTabId(0);
       const termDock = dockOf(paneLayout, termTab);
       if (termDock && isActiveTab(paneLayout, termTab)) {
         // Already the active tab (mounted): move focus synchronously so rapid

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,7 +34,7 @@ import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
 import { useIsWideViewport } from "./hooks/useIsWideViewport";
 import type { RightPanelView } from "./lib/rightPanelView";
-import { usePaneLayout, dockTabs, dockActive, dockOf } from "./lib/paneLayout";
+import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab } from "./lib/paneLayout";
 import { isPluginPaneId, usePluginPanes, type PluginPane } from "./lib/pluginPanes";
 import { PluginPaneBody } from "./components/plugin/PluginSlots";
 import { TOUR_ANCHORS, tourAnchor } from "./lib/tourSteps";
@@ -83,10 +83,11 @@ const StructuredView = lazy(() =>
     default: m.StructuredView,
   })),
 );
-import { Dock, type PaneDisplay } from "./components/Dock";
+import { type PaneDisplay } from "./components/Dock";
+import { DockGroups, type DockGroupView } from "./components/DockGroups";
 import { BottomDock } from "./components/BottomDock";
 import { PaneDndController } from "./components/PaneDndController";
-import { visibleToFullIndex } from "./components/paneDnd";
+import { visibleToFullIndex, type DropTarget } from "./components/paneDnd";
 import { BackgroundAgentsPanel } from "./components/acp/BackgroundAgentsPanel";
 import { DiffPane } from "./components/DiffPane";
 import { PairedShellPane } from "./components/PairedTerminal";
@@ -452,23 +453,31 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     (id: string) => !id.startsWith("plugin:") || pluginPaneById.has(id),
     [pluginPaneById],
   );
-  const visibleTabs = useCallback(
-    (dock: DockLocation) => dockTabs(paneLayout, dock).filter(tabAvailable),
+  // A dock's groups reduced to what's actually shown: each surviving group keeps
+  // its persisted index (so a drop addresses the right group) and a valid active
+  // tab. Groups with no visible tab (only unloaded plugins) are not rendered.
+  const renderGroups = useCallback(
+    (dock: DockLocation): DockGroupView[] =>
+      dockGroups(paneLayout, dock)
+        .map((g, group) => {
+          const tabs = g.tabs.filter(tabAvailable);
+          const active = g.active && tabs.includes(g.active) ? g.active : (tabs[0] ?? null);
+          return { group, tabs, active };
+        })
+        .filter((g) => g.tabs.length > 0),
     [paneLayout, tabAvailable],
   );
-  const visibleActive = useCallback(
-    (dock: DockLocation): string | null => {
-      const vis = visibleTabs(dock);
-      const a = dockActive(paneLayout, dock);
-      return a && vis.includes(a) ? a : (vis[0] ?? null);
-    },
-    [paneLayout, visibleTabs],
-  );
 
-  const rightTabs = visibleTabs("right");
-  const bottomTabs = visibleTabs("bottom");
-  const tabsByDock = useMemo(() => ({ right: rightTabs, bottom: bottomTabs }), [rightTabs, bottomTabs]);
-  const rightDockCollapsed = rightTabs.length === 0;
+  const rightGroups = renderGroups("right");
+  const bottomGroups = renderGroups("bottom");
+  const groupsByDock = useMemo(
+    () => ({
+      right: rightGroups.map((g) => ({ group: g.group, tabs: g.tabs })),
+      bottom: bottomGroups.map((g) => ({ group: g.group, tabs: g.tabs })),
+    }),
+    [rightGroups, bottomGroups],
+  );
+  const rightDockCollapsed = rightGroups.length === 0;
   const terminalOpen = (["right", "bottom"] as DockLocation[]).some((d) =>
     dockTabs(paneLayout, d).some(isTerminalTabId),
   );
@@ -519,13 +528,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     [closeTab, activeSessionId],
   );
   const movePaneAny = useCallback((id: string, dock: DockLocation) => moveTab(id, dock), [moveTab]);
-  // The dnd controller works in visible-tab space; map its drop index back to
-  // the full persisted dock list, since a hidden (unloaded) plugin tab still
-  // holds a slot the visible index does not count.
+  // The dnd controller works in visible-tab space; map a drop index back to the
+  // target group's full persisted tab list, since a hidden (unloaded) plugin tab
+  // still holds a slot the visible index does not count. A split target carries
+  // no index (the new group starts with just the dragged tab).
   const placeVisibleTab = useCallback(
-    (id: string, toDock: DockLocation, visibleIndex: number) => {
-      const fullBase = dockTabs(paneLayout, toDock).filter((tab) => tab !== id);
-      placeTab(id, toDock, visibleToFullIndex(fullBase, visibleIndex, tabAvailable));
+    (id: string, target: DropTarget) => {
+      if (target.newGroup) {
+        placeTab(id, { dock: target.dock, group: target.group, newGroup: true });
+        return;
+      }
+      const fullBase = (dockGroups(paneLayout, target.dock)[target.group]?.tabs ?? []).filter((tab) => tab !== id);
+      const index = visibleToFullIndex(fullBase, target.index ?? fullBase.length, tabAvailable);
+      placeTab(id, { dock: target.dock, group: target.group, index });
     },
     [paneLayout, placeTab, tabAvailable],
   );
@@ -1174,7 +1189,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         (["right", "bottom"] as DockLocation[]).flatMap((d) => dockTabs(paneLayout, d)).find(isTerminalTabId) ??
         terminalTabId(0);
       const termDock = dockOf(paneLayout, termTab);
-      if (termDock && dockActive(paneLayout, termDock) === termTab) {
+      if (termDock && isActiveTab(paneLayout, termTab)) {
         // Already the active tab (mounted): move focus synchronously so rapid
         // agent<->paired toggles stay deterministic.
         dispatchFocusTerminal("paired");
@@ -1406,7 +1421,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     };
     return (
       <div className="flex-1 flex flex-col min-h-0">
-        <PaneDndController tabsByDock={tabsByDock} descriptorFor={paneDescriptor} onPlaceTab={placeVisibleTab}>
+        <PaneDndController groupsByDock={groupsByDock} descriptorFor={paneDescriptor} onPlaceTab={placeVisibleTab}>
           <ContentSplit
             collapsed={rightDockCollapsed}
             onToggleCollapse={toggleDiff}
@@ -1453,10 +1468,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             }
             right={
               <div {...tourAnchor(TOUR_ANCHORS.rightPanel)} className="flex min-h-0 min-w-0 flex-1">
-                <Dock
+                <DockGroups
                   location="right"
-                  tabs={rightTabs}
-                  active={visibleActive("right")}
+                  groups={rightGroups}
                   descriptorFor={paneDescriptor}
                   renderBody={renderPaneBody}
                   onActivate={(id) => activateTab("right", id)}
@@ -1467,10 +1481,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
               </div>
             }
           />
-          {bottomTabs.length > 0 && (
+          {bottomGroups.length > 0 && (
             <BottomDock
-              tabs={bottomTabs}
-              active={visibleActive("bottom")}
+              groups={bottomGroups}
               descriptorFor={paneDescriptor}
               renderBody={renderPaneBody}
               onActivate={(id) => activateTab("bottom", id)}

--- a/web/src/components/BottomDock.tsx
+++ b/web/src/components/BottomDock.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
-import { Dock, type PaneDisplay } from "./Dock";
+import { DockGroups, type DockGroupView } from "./DockGroups";
+import type { PaneDisplay } from "./Dock";
 import type { DockLocation } from "../lib/panes";
 
 const HEIGHT_KEY = "aoe-bottom-dock-height";
@@ -20,8 +21,7 @@ function loadHeight(): number {
 }
 
 interface Props {
-  tabs: string[];
-  active: string | null;
+  groups: DockGroupView[];
   descriptorFor: (id: string) => PaneDisplay;
   renderBody: (id: string) => ReactNode;
   onActivate: (id: string) => void;
@@ -31,18 +31,10 @@ interface Props {
 }
 
 /** Full-width bottom dock: a height-resizable strip below the main+right-dock
- *  row. Hidden by the parent when it has no open panes. Desktop only; mobile
- *  uses the single full-viewport view picker. */
-export function BottomDock({
-  tabs,
-  active,
-  descriptorFor,
-  renderBody,
-  onActivate,
-  onClose,
-  onMove,
-  onNewTerminal,
-}: Props) {
+ *  row. Hidden by the parent when it has no open panes. Holds one or more
+ *  stacked groups. Desktop only; mobile uses the single full-viewport view
+ *  picker. */
+export function BottomDock({ groups, descriptorFor, renderBody, onActivate, onClose, onMove, onNewTerminal }: Props) {
   const [height, setHeight] = useState(loadHeight);
   const ref = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
@@ -93,10 +85,9 @@ export function BottomDock({
         onMouseDown={handleMouseDown}
         className="h-1 cursor-row-resize shrink-0 hover:bg-brand-600/50 transition-colors duration-75"
       />
-      <Dock
+      <DockGroups
         location="bottom"
-        tabs={tabs}
-        active={active}
+        groups={groups}
         descriptorFor={descriptorFor}
         renderBody={renderBody}
         onActivate={onActivate}

--- a/web/src/components/Dock.tsx
+++ b/web/src/components/Dock.tsx
@@ -5,7 +5,7 @@ import { SortableContext, horizontalListSortingStrategy, useSortable } from "@dn
 import { CSS } from "@dnd-kit/utilities";
 
 import type { DockLocation } from "../lib/panes";
-import { usePaneDnd, type PaneTabData } from "./paneDnd";
+import { usePaneDnd, type PaneTabData, type SplitDropData } from "./paneDnd";
 
 export interface PaneDisplay {
   title: string;
@@ -14,6 +14,9 @@ export interface PaneDisplay {
 
 interface Props {
   location: DockLocation;
+  /** Persisted index of this group within its dock; carried on the drop
+   *  payloads so a drop addresses the right group. */
+  groupIndex: number;
   /** Visible tab ids in strip order (the parent pre-filters availability). */
   tabs: string[];
   /** Active tab id; falls back to the first tab if stale/missing. */
@@ -35,7 +38,7 @@ const btn =
   "w-5 h-5 flex items-center justify-center shrink-0 rounded text-text-dim hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors";
 
 /** A vertical bar marking where a dragged tab would land. Rendered inline
- *  between tabs (cross-dock drops only, see Dock), so it costs 2px of strip
+ *  between tabs (cross-group drops only, see Dock), so it costs 2px of strip
  *  width and no reflow of the tab bodies. */
 function InsertionMarker() {
   return <div data-testid="pane-insertion-marker" className="w-0.5 self-stretch bg-brand-500 shrink-0" />;
@@ -44,6 +47,7 @@ function InsertionMarker() {
 interface SortableTabProps {
   id: string;
   location: DockLocation;
+  groupIndex: number;
   isActive: boolean;
   desc: PaneDisplay;
   onActivate: (id: string) => void;
@@ -55,10 +59,10 @@ interface SortableTabProps {
  *  still activates rather than starting a drag. Only `listeners` are spread,
  *  not dnd-kit's `attributes`, which would inject a conflicting role/aria onto
  *  the role="tab" button. */
-function SortableTab({ id, location, isActive, desc, onActivate, onClose }: SortableTabProps) {
+function SortableTab({ id, location, groupIndex, isActive, desc, onActivate, onClose }: SortableTabProps) {
   const { setNodeRef, listeners, transform, transition, isDragging } = useSortable({
     id,
-    data: { type: "pane-tab", dock: location } satisfies PaneTabData,
+    data: { type: "pane-tab", dock: location, group: groupIndex } satisfies PaneTabData,
   });
   const name = desc.title.toLowerCase();
   const style = { transform: CSS.Transform.toString(transform), transition };
@@ -101,20 +105,55 @@ function SortableTab({ id, location, isActive, desc, onActivate, onClose }: Sort
   );
 }
 
-/** Renders one dock location as a tabbed group: a tab strip plus the active
- *  tab's body. Each tab carries its pane's icon, title, and a close control;
- *  the strip also offers move-to-other-dock and a new-terminal button. Only the
- *  active body is mounted; the terminal/diff state it shows is server-side
- *  (tmux session, diff API), so re-mounting on a tab switch is cheap. The
- *  parent hides the dock entirely when it has no tabs.
+/** A half of a group body that, while a tab is dragged, lifts the drop into a
+ *  fresh group before or after this one. Right docks split side-by-side (left /
+ *  right halves), bottom docks stack (top / bottom halves). Mounted only during
+ *  a drag, so it never intercepts ordinary clicks on the pane body (terminals,
+ *  iframes). */
+function SplitDropZone({
+  location,
+  groupIndex,
+  side,
+}: {
+  location: DockLocation;
+  groupIndex: number;
+  side: "before" | "after";
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `pane-split:${location}:${groupIndex}:${side}`,
+    data: { type: "pane-split", dock: location, group: groupIndex, side } satisfies SplitDropData,
+  });
+  const half =
+    location === "right"
+      ? side === "before"
+        ? "top-0 left-0 h-full w-1/2"
+        : "top-0 right-0 h-full w-1/2"
+      : side === "before"
+        ? "top-0 left-0 w-full h-1/2"
+        : "bottom-0 left-0 w-full h-1/2";
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`pane-split-${location}-${groupIndex}-${side}`}
+      className={`absolute z-20 ${half} ${isOver ? "bg-brand-600/25 ring-2 ring-inset ring-brand-500/70" : ""}`}
+    />
+  );
+}
+
+/** Renders one dock group: a tab strip plus the active tab's body. Each tab
+ *  carries its pane's icon, title, and a close control; the strip also offers
+ *  move-to-other-dock and a new-terminal button. Only the active body is
+ *  mounted; the terminal/diff state it shows is server-side (tmux session, diff
+ *  API), so re-mounting on a tab switch is cheap. The parent maps a dock's
+ *  groups to one Dock each and hides a dock with no groups.
  *
- *  Tabs reorder within the dock and move across docks via drag-and-drop (the
- *  shared DndContext lives in PaneDndController); the move button stays as the
- *  keyboard/click affordance. A within-dock reorder is shown by the tabs
- *  sliding apart; a cross-dock drop adds a destination ring plus an insertion
- *  marker, since the destination strip does not shift to preview the insert. */
+ *  Tabs reorder within a group and move across groups/docks via drag-and-drop
+ *  (the shared DndContext lives in PaneDndController); the move button stays as
+ *  the keyboard/click affordance. Dropping on the strip joins this group;
+ *  dropping on a body half splits into a new sibling group. */
 export function Dock({
   location,
+  groupIndex,
   tabs,
   active,
   descriptorFor,
@@ -124,30 +163,41 @@ export function Dock({
   onMove,
   onNewTerminal,
 }: Props) {
-  const { sourceDock, dropTarget } = usePaneDnd();
-  const { setNodeRef: setDockRef } = useDroppable({
-    id: `dock-body:${location}`,
-    data: { type: "pane-dock", dock: location },
+  const { activeTab, source, dropTarget } = usePaneDnd();
+  const { setNodeRef: setGroupRef } = useDroppable({
+    id: `pane-group:${location}:${groupIndex}`,
+    data: { type: "pane-group", dock: location, group: groupIndex },
   });
   if (tabs.length === 0) return null;
   const activeId = active && tabs.includes(active) ? active : tabs[0]!;
   const target: DockLocation = location === "right" ? "bottom" : "right";
   const MoveIcon = location === "right" ? PanelBottom : PanelRight;
   const activeName = descriptorFor(activeId).title.toLowerCase();
-  // Highlight + mark only a cross-dock drop: a within-dock reorder reads from
-  // the tabs sliding apart, so a marker there would double up with the gap.
-  const isDropTarget = dropTarget?.dock === location && sourceDock !== location;
-  const markerIndex = isDropTarget ? dropTarget!.index : null;
+  // Highlight + mark only a drop into a *different* group; a within-group
+  // reorder reads from the tabs sliding apart, so a marker there would double
+  // up with the gap.
+  const isSourceGroup = source?.dock === location && source.group === groupIndex;
+  const isDropTarget =
+    !!dropTarget &&
+    !dropTarget.newGroup &&
+    dropTarget.dock === location &&
+    dropTarget.group === groupIndex &&
+    !isSourceGroup;
+  const markerIndex = isDropTarget ? (dropTarget!.index ?? tabs.length) : null;
 
   return (
     <section
-      ref={setDockRef}
-      className={`flex flex-col min-h-0 flex-1 overflow-hidden ${
+      className={`flex flex-col min-h-0 min-w-0 flex-1 overflow-hidden ${
         isDropTarget ? "ring-2 ring-inset ring-brand-500/70" : ""
       }`}
       data-pane-dock={location}
+      data-pane-group={groupIndex}
     >
-      <div role="tablist" className="flex items-stretch h-7 shrink-0 bg-surface-900 border-b border-surface-700/20">
+      <div
+        ref={setGroupRef}
+        role="tablist"
+        className="flex items-stretch h-7 shrink-0 bg-surface-900 border-b border-surface-700/20"
+      >
         <div className="flex items-stretch min-w-0 overflow-x-auto">
           <SortableContext items={tabs} strategy={horizontalListSortingStrategy}>
             {tabs.map((id, i) => (
@@ -156,6 +206,7 @@ export function Dock({
                 <SortableTab
                   id={id}
                   location={location}
+                  groupIndex={groupIndex}
                   isActive={id === activeId}
                   desc={descriptorFor(id)}
                   onActivate={onActivate}
@@ -182,7 +233,15 @@ export function Dock({
           )}
         </div>
       </div>
-      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">{renderBody(activeId)}</div>
+      <div className="relative flex-1 flex flex-col min-h-0 overflow-hidden">
+        {renderBody(activeId)}
+        {activeTab && (
+          <>
+            <SplitDropZone location={location} groupIndex={groupIndex} side="before" />
+            <SplitDropZone location={location} groupIndex={groupIndex} side="after" />
+          </>
+        )}
+      </div>
     </section>
   );
 }

--- a/web/src/components/Dock.tsx
+++ b/web/src/components/Dock.tsx
@@ -106,10 +106,10 @@ function SortableTab({ id, location, groupIndex, isActive, desc, onActivate, onC
 }
 
 /** A half of a group body that, while a tab is dragged, lifts the drop into a
- *  fresh group before or after this one. Right docks split side-by-side (left /
- *  right halves), bottom docks stack (top / bottom halves). Mounted only during
- *  a drag, so it never intercepts ordinary clicks on the pane body (terminals,
- *  iframes). */
+ *  fresh group before or after this one. The tall right column stacks groups
+ *  (top / bottom halves), the wide bottom strip splits side by side (left /
+ *  right halves). Mounted only during a drag, so it never intercepts ordinary
+ *  clicks on the pane body (terminals, iframes). */
 function SplitDropZone({
   location,
   groupIndex,
@@ -126,11 +126,11 @@ function SplitDropZone({
   const half =
     location === "right"
       ? side === "before"
-        ? "top-0 left-0 h-full w-1/2"
-        : "top-0 right-0 h-full w-1/2"
-      : side === "before"
         ? "top-0 left-0 w-full h-1/2"
-        : "bottom-0 left-0 w-full h-1/2";
+        : "bottom-0 left-0 w-full h-1/2"
+      : side === "before"
+        ? "top-0 left-0 h-full w-1/2"
+        : "top-0 right-0 h-full w-1/2";
   return (
     <div
       ref={setNodeRef}

--- a/web/src/components/DockGroups.tsx
+++ b/web/src/components/DockGroups.tsx
@@ -26,8 +26,8 @@ interface Props {
 /** Lays a dock's groups out along its split axis: the tall right column stacks
  *  groups top to bottom (flex column), the wide bottom strip places groups
  *  side by side (flex row). Groups share space equally; a thin divider
- *  separates them.
- *  ponytail: equal flex, no per-group resize handles yet (#2486 follow-up). */
+ *  separates them. Equal flex sizing is intentional until per-group resize
+ *  handles are added (`#2486` follow-up). */
 export function DockGroups({
   location,
   groups,

--- a/web/src/components/DockGroups.tsx
+++ b/web/src/components/DockGroups.tsx
@@ -23,9 +23,10 @@ interface Props {
   onNewTerminal?: () => void;
 }
 
-/** Lays a dock's groups out along its split axis: the right dock splits into
- *  side-by-side columns (flex row), the bottom dock into stacked strips (flex
- *  column). Groups share space equally; a thin divider separates them.
+/** Lays a dock's groups out along its split axis: the tall right column stacks
+ *  groups top to bottom (flex column), the wide bottom strip places groups
+ *  side by side (flex row). Groups share space equally; a thin divider
+ *  separates them.
  *  ponytail: equal flex, no per-group resize handles yet (#2486 follow-up). */
 export function DockGroups({
   location,
@@ -38,8 +39,8 @@ export function DockGroups({
   onNewTerminal,
 }: Props) {
   if (groups.length === 0) return null;
-  const axis = location === "right" ? "flex-row" : "flex-col";
-  const divider = location === "right" ? "border-l" : "border-t";
+  const axis = location === "right" ? "flex-col" : "flex-row";
+  const divider = location === "right" ? "border-t" : "border-l";
   return (
     <div className={`flex ${axis} min-h-0 min-w-0 flex-1 overflow-hidden`}>
       {groups.map((g, i) => (

--- a/web/src/components/DockGroups.tsx
+++ b/web/src/components/DockGroups.tsx
@@ -1,0 +1,67 @@
+import { Fragment, type ReactNode } from "react";
+
+import type { DockLocation } from "../lib/panes";
+import { Dock, type PaneDisplay } from "./Dock";
+
+/** One rendered group: its persisted index, its visible tabs, and the active
+ *  one. The parent filters out groups with no visible tab but keeps each
+ *  surviving group's persisted index, so drops address the right group. */
+export interface DockGroupView {
+  group: number;
+  tabs: string[];
+  active: string | null;
+}
+
+interface Props {
+  location: DockLocation;
+  groups: DockGroupView[];
+  descriptorFor: (id: string) => PaneDisplay;
+  renderBody: (id: string) => ReactNode;
+  onActivate: (id: string) => void;
+  onClose: (id: string) => void;
+  onMove: (id: string, dock: DockLocation) => void;
+  onNewTerminal?: () => void;
+}
+
+/** Lays a dock's groups out along its split axis: the right dock splits into
+ *  side-by-side columns (flex row), the bottom dock into stacked strips (flex
+ *  column). Groups share space equally; a thin divider separates them.
+ *  ponytail: equal flex, no per-group resize handles yet (#2486 follow-up). */
+export function DockGroups({
+  location,
+  groups,
+  descriptorFor,
+  renderBody,
+  onActivate,
+  onClose,
+  onMove,
+  onNewTerminal,
+}: Props) {
+  if (groups.length === 0) return null;
+  const axis = location === "right" ? "flex-row" : "flex-col";
+  const divider = location === "right" ? "border-l" : "border-t";
+  return (
+    <div className={`flex ${axis} min-h-0 min-w-0 flex-1 overflow-hidden`}>
+      {groups.map((g, i) => (
+        <Fragment key={g.group}>
+          <div
+            className={`flex min-h-0 min-w-0 flex-1 overflow-hidden ${i > 0 ? `${divider} border-surface-700/40` : ""}`}
+          >
+            <Dock
+              location={location}
+              groupIndex={g.group}
+              tabs={g.tabs}
+              active={g.active}
+              descriptorFor={descriptorFor}
+              renderBody={renderBody}
+              onActivate={onActivate}
+              onClose={onClose}
+              onMove={onMove}
+              onNewTerminal={onNewTerminal}
+            />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/PaneDndController.tsx
+++ b/web/src/components/PaneDndController.tsx
@@ -23,33 +23,40 @@ import {
   resolvePlacement,
   shouldApplyPlacement,
   type DockDropData,
+  type DragSource,
   type DropTarget,
+  type EmptyDockDropData,
   type PaneDndState,
   type PaneTabData,
+  type RenderGroup,
 } from "./paneDnd";
 
 // Prefer the droppable the pointer is actually inside, and only among pane
-// droppables, so a drag in the right column never magnetically snaps to a tab
-// in the distant bottom strip the way a global closestCenter would. A tab hit
-// wins over a dock-body hit so dropping onto a sibling tab reorders rather than
-// appends. Mirrors the filtered-collision approach in WorkspaceSidebar (#1644).
+// droppables, so a drag in the right column never magnetically snaps to a
+// distant bottom target the way a global closestCenter would. A tab hit wins
+// over everything (reorder), then a split-half hit (split into a new group),
+// then group/empty-dock bodies. Mirrors the filtered-collision approach in
+// WorkspaceSidebar (#1644).
 const panesCollision: CollisionDetection = (args) => {
   const paneContainers = args.droppableContainers.filter((c) => {
     const t = c.data.current?.type;
-    return t === "pane-tab" || t === "pane-dock" || t === "pane-empty-dock";
+    return t === "pane-tab" || t === "pane-group" || t === "pane-split" || t === "pane-empty-dock";
   });
   const hits = pointerWithin({ ...args, droppableContainers: paneContainers });
-  const tabHits = hits.filter((h) => h.data?.droppableContainer?.data.current?.type === "pane-tab");
-  return tabHits.length > 0 ? tabHits : hits;
+  const typeOf = (h: (typeof hits)[number]) => h.data?.droppableContainer?.data.current?.type;
+  const tabHits = hits.filter((h) => typeOf(h) === "pane-tab");
+  if (tabHits.length > 0) return tabHits;
+  const splitHits = hits.filter((h) => typeOf(h) === "pane-split");
+  return splitHits.length > 0 ? splitHits : hits;
 };
 
 interface Props {
-  /** The rendered tab order per dock (already availability-filtered), so drop
-   *  indices line up with what the docks actually show. */
-  tabsByDock: Record<DockLocation, string[]>;
+  /** The rendered groups per dock (visible tabs, persisted group index), so
+   *  drop targets line up with what the docks actually show. */
+  groupsByDock: Record<DockLocation, RenderGroup[]>;
   descriptorFor: (id: string) => PaneDisplay;
-  /** Reorder within a dock or move across docks, landing at `toIndex`. */
-  onPlaceTab: (tabId: string, toDock: DockLocation, toIndex: number) => void;
+  /** Reorder, move across docks/groups, or split into a new group. */
+  onPlaceTab: (tabId: string, target: DropTarget) => void;
   children: ReactNode;
 }
 
@@ -57,9 +64,9 @@ interface Props {
  *  collision policy, the live drop target, a DragOverlay replica that follows
  *  the cursor across the distant docks, and the empty-dock landing zones. Docks
  *  stay presentational and read the drop state through usePaneDnd. */
-export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, children }: Props) {
+export function PaneDndController({ groupsByDock, descriptorFor, onPlaceTab, children }: Props) {
   const [activeTab, setActiveTab] = useState<string | null>(null);
-  const [sourceDock, setSourceDock] = useState<DockLocation | null>(null);
+  const [source, setSource] = useState<DragSource | null>(null);
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
 
   const sensors = useSensors(
@@ -67,30 +74,34 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
     useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
   );
 
-  // Resolve the destination dock + post-removal insertion index from the
-  // hovered droppable. Returns null when the pointer is not over a pane target.
+  // Resolve the destination dock + group + insertion index from the hovered
+  // droppable. Returns null when the pointer is not over a pane target.
   const resolveTarget = useCallback(
     (e: DragOverEvent | DragEndEvent): DropTarget | null => {
-      const overData = e.over?.data.current as PaneTabData | DockDropData | undefined;
-      if (!overData) return null;
+      const data = e.over?.data.current as PaneTabData | DockDropData | undefined;
+      if (!data) return null;
+      const group = "group" in data ? data.group : 0;
+      const side = data.type === "pane-split" ? data.side : undefined;
       return resolvePlacement(
         {
-          type: overData.type,
-          dock: overData.dock,
+          type: data.type,
+          dock: data.dock,
+          group,
+          side,
           tabId: String(e.over!.id),
           after: pointerInsertsAfter(e.active.rect.current.translated, e.over!.rect),
         },
         String(e.active.id),
-        tabsByDock,
+        groupsByDock,
       );
     },
-    [tabsByDock],
+    [groupsByDock],
   );
 
   const onDragStart = useCallback((e: DragStartEvent) => {
     const data = e.active.data.current as PaneTabData | undefined;
     setActiveTab(String(e.active.id));
-    setSourceDock(data?.dock ?? null);
+    setSource(data ? { dock: data.dock, group: data.group } : null);
     setDropTarget(null);
   }, []);
 
@@ -98,7 +109,7 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
 
   const reset = useCallback(() => {
     setActiveTab(null);
-    setSourceDock(null);
+    setSource(null);
     setDropTarget(null);
   }, []);
 
@@ -106,21 +117,15 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
     (e: DragEndEvent) => {
       const tabId = String(e.active.id);
       const target = resolveTarget(e);
-      // resolveTarget already gives the post-removal insertion index for both
-      // cases (before/after the hovered tab, or append on a dock-body drop);
-      // shouldApplyPlacement skips a within-dock drop onto the tab's own slot.
-      if (target && shouldApplyPlacement(tabsByDock, tabId, target, sourceDock)) {
-        onPlaceTab(tabId, target.dock, target.index);
+      if (target && shouldApplyPlacement(groupsByDock, tabId, target, source)) {
+        onPlaceTab(tabId, target);
       }
       reset();
     },
-    [resolveTarget, sourceDock, tabsByDock, onPlaceTab, reset],
+    [resolveTarget, source, groupsByDock, onPlaceTab, reset],
   );
 
-  const state = useMemo<PaneDndState>(
-    () => ({ activeTab, sourceDock, dropTarget }),
-    [activeTab, sourceDock, dropTarget],
-  );
+  const state = useMemo<PaneDndState>(() => ({ activeTab, source, dropTarget }), [activeTab, source, dropTarget]);
 
   const overlayDesc = activeTab ? descriptorFor(activeTab) : null;
 
@@ -139,7 +144,7 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
           {children}
           {activeTab &&
             (["right", "bottom"] as DockLocation[])
-              .filter((d) => tabsByDock[d].length === 0)
+              .filter((d) => groupsByDock[d].length === 0)
               .map((d) => <EmptyDockDropZone key={d} location={d} />)}
         </div>
         <DragOverlay dropAnimation={null}>
@@ -155,14 +160,14 @@ export function PaneDndController({ tabsByDock, descriptorFor, onPlaceTab, child
   );
 }
 
-/** A landing zone for a dock that currently has no tabs (so its Dock is not in
- *  the DOM to drop onto). Pinned to the dock's screen edge, shown only while a
- *  pane tab is dragged. MeasuringStrategy.Always on the context measures it
- *  even though it mounts on drag start. */
+/** A landing zone for a dock that currently has no groups (so no Dock is in the
+ *  DOM to drop onto). Pinned to the dock's screen edge, shown only while a pane
+ *  tab is dragged. MeasuringStrategy.Always on the context measures it even
+ *  though it mounts on drag start. */
 function EmptyDockDropZone({ location }: { location: DockLocation }) {
   const { setNodeRef, isOver } = useDroppable({
     id: `empty-dock:${location}`,
-    data: { type: "pane-empty-dock", dock: location } satisfies DockDropData,
+    data: { type: "pane-empty-dock", dock: location } satisfies EmptyDockDropData,
   });
   const edge = location === "right" ? "top-0 right-0 h-full w-24 border-l" : "bottom-0 left-0 w-full h-24 border-t";
   return (

--- a/web/src/components/__tests__/BottomDock.test.tsx
+++ b/web/src/components/__tests__/BottomDock.test.tsx
@@ -22,8 +22,7 @@ const descriptorFor = (id: string) => {
 function renderBottomDock(props = {}) {
   return render(
     <BottomDock
-      tabs={["terminal:0"]}
-      active="terminal:0"
+      groups={[{ group: 0, tabs: ["terminal:0"], active: "terminal:0" }]}
       descriptorFor={descriptorFor}
       renderBody={body}
       onActivate={vi.fn()}

--- a/web/src/components/__tests__/Dock.test.tsx
+++ b/web/src/components/__tests__/Dock.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { Dock } from "../Dock";
+import { PaneDndStateContext } from "../paneDnd";
 import { BUILTIN_PANES } from "../../lib/panes";
 
 afterEach(() => cleanup());
@@ -24,6 +25,7 @@ function renderDock(props: Partial<React.ComponentProps<typeof Dock>> = {}) {
   return render(
     <Dock
       location="right"
+      groupIndex={0}
       tabs={["diff", "terminal:0"]}
       active="terminal:0"
       descriptorFor={descriptorFor}
@@ -78,5 +80,30 @@ describe("Dock", () => {
     const { getByLabelText } = renderDock({ onNewTerminal });
     fireEvent.click(getByLabelText("New terminal"));
     expect(onNewTerminal).toHaveBeenCalled();
+  });
+
+  it("shows split drop zones only while a tab is being dragged", () => {
+    // No drag in progress (default context): no split zones mounted.
+    expect(document.querySelector('[data-testid="pane-split-right-0-before"]')).toBeNull();
+
+    render(
+      <PaneDndStateContext.Provider
+        value={{ activeTab: "diff", source: { dock: "right", group: 0 }, dropTarget: null }}
+      >
+        <Dock
+          location="right"
+          groupIndex={0}
+          tabs={["diff", "terminal:0"]}
+          active="terminal:0"
+          descriptorFor={descriptorFor}
+          renderBody={body}
+          onActivate={vi.fn()}
+          onClose={vi.fn()}
+          onMove={vi.fn()}
+        />
+      </PaneDndStateContext.Provider>,
+    );
+    expect(document.querySelector('[data-testid="pane-split-right-0-before"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="pane-split-right-0-after"]')).toBeTruthy();
   });
 });

--- a/web/src/components/__tests__/Dock.test.tsx
+++ b/web/src/components/__tests__/Dock.test.tsx
@@ -83,8 +83,12 @@ describe("Dock", () => {
   });
 
   it("shows split drop zones only while a tab is being dragged", () => {
-    // No drag in progress (default context): no split zones mounted.
+    // Baseline Dock with no drag in progress: no split zones mounted (assert
+    // after mounting so this catches unconditional rendering, not an empty DOM).
+    const { unmount } = renderDock();
     expect(document.querySelector('[data-testid="pane-split-right-0-before"]')).toBeNull();
+    expect(document.querySelector('[data-testid="pane-split-right-0-after"]')).toBeNull();
+    unmount();
 
     render(
       <PaneDndStateContext.Provider

--- a/web/src/components/__tests__/paneDnd.test.ts
+++ b/web/src/components/__tests__/paneDnd.test.ts
@@ -7,49 +7,80 @@ import {
   shouldApplyPlacement,
   visibleToFullIndex,
   type PlacementOver,
+  type RenderGroup,
 } from "../paneDnd";
 
-const tabsByDock = { right: ["diff", "terminal:0", "terminal:1"], bottom: ["plugin:p:a"] };
+const groupsByDock: Record<"right" | "bottom", RenderGroup[]> = {
+  right: [{ group: 0, tabs: ["diff", "terminal:0", "terminal:1"] }],
+  bottom: [{ group: 0, tabs: ["plugin:p:a"] }],
+};
 
 function over(partial: Partial<PlacementOver>): PlacementOver {
-  return { type: "pane-tab", dock: "right", tabId: "diff", after: false, ...partial };
+  return { type: "pane-tab", dock: "right", group: 0, tabId: "diff", after: false, ...partial };
 }
 
 describe("resolvePlacement", () => {
   it("inserts before the hovered tab when the pointer is on its leading half", () => {
     // Dragging terminal:1 onto diff's leading half; base (without the dragged
     // tab) is [diff, terminal:0], so before diff is index 0.
-    expect(resolvePlacement(over({ tabId: "diff", after: false }), "terminal:1", tabsByDock)).toEqual({
+    expect(resolvePlacement(over({ tabId: "diff", after: false }), "terminal:1", groupsByDock)).toEqual({
       dock: "right",
+      group: 0,
       index: 0,
     });
   });
 
   it("inserts after the hovered tab when the pointer is on its trailing half", () => {
-    expect(resolvePlacement(over({ tabId: "diff", after: true }), "terminal:1", tabsByDock)).toEqual({
+    expect(resolvePlacement(over({ tabId: "diff", after: true }), "terminal:1", groupsByDock)).toEqual({
       dock: "right",
+      group: 0,
       index: 1,
     });
   });
 
-  it("appends when dropping on a dock body rather than a tab", () => {
+  it("appends when dropping on a group strip rather than a tab", () => {
     // base without the dragged diff is [terminal:0, terminal:1], so append is 2.
-    expect(resolvePlacement(over({ type: "pane-dock", tabId: "" }), "diff", tabsByDock)).toEqual({
+    expect(resolvePlacement(over({ type: "pane-group", tabId: "" }), "diff", groupsByDock)).toEqual({
       dock: "right",
+      group: 0,
       index: 2,
     });
   });
 
-  it("appends to an empty-dock zone", () => {
-    expect(resolvePlacement(over({ type: "pane-empty-dock", dock: "bottom", tabId: "" }), "diff", tabsByDock)).toEqual({
-      dock: "bottom",
-      index: 1,
+  it("splits into a new group before the hovered group", () => {
+    expect(
+      resolvePlacement(over({ type: "pane-split", side: "before", group: 0, tabId: "" }), "diff", groupsByDock),
+    ).toEqual({
+      dock: "right",
+      group: 0,
+      newGroup: true,
     });
   });
 
-  it("appends when the hovered tab is not in the destination (cross-dock to a stale id)", () => {
-    expect(resolvePlacement(over({ dock: "bottom", tabId: "ghost" }), "diff", tabsByDock)).toEqual({
+  it("splits into a new group after the hovered group", () => {
+    expect(
+      resolvePlacement(over({ type: "pane-split", side: "after", group: 0, tabId: "" }), "diff", groupsByDock),
+    ).toEqual({
+      dock: "right",
+      group: 1,
+      newGroup: true,
+    });
+  });
+
+  it("seeds the first group on an empty-dock zone", () => {
+    expect(
+      resolvePlacement(over({ type: "pane-empty-dock", dock: "bottom", group: 0, tabId: "" }), "diff", groupsByDock),
+    ).toEqual({
       dock: "bottom",
+      group: 0,
+      newGroup: true,
+    });
+  });
+
+  it("appends when the hovered tab is not in the destination group (stale id)", () => {
+    expect(resolvePlacement(over({ dock: "bottom", group: 0, tabId: "ghost" }), "diff", groupsByDock)).toEqual({
+      dock: "bottom",
+      group: 0,
       index: 1,
     });
   });
@@ -78,18 +109,26 @@ describe("pointerInsertsAfter", () => {
 });
 
 describe("shouldApplyPlacement", () => {
+  const src = (group: number) => ({ dock: "right" as const, group });
+
   it("applies a cross-dock move", () => {
-    expect(shouldApplyPlacement(tabsByDock, "diff", { dock: "bottom", index: 0 }, "right")).toBe(true);
+    expect(shouldApplyPlacement(groupsByDock, "diff", { dock: "bottom", group: 0, index: 0 }, src(0))).toBe(true);
   });
-  it("applies a within-dock move to a different slot", () => {
-    expect(shouldApplyPlacement(tabsByDock, "diff", { dock: "right", index: 2 }, "right")).toBe(true);
+  it("applies a within-group move to a different slot", () => {
+    expect(shouldApplyPlacement(groupsByDock, "diff", { dock: "right", group: 0, index: 2 }, src(0))).toBe(true);
   });
-  it("skips a within-dock drop onto the tab's own slot", () => {
+  it("applies a cross-group move within the same dock", () => {
+    expect(shouldApplyPlacement(groupsByDock, "diff", { dock: "right", group: 1, index: 0 }, src(0))).toBe(true);
+  });
+  it("always applies a split into a new group", () => {
+    expect(shouldApplyPlacement(groupsByDock, "diff", { dock: "right", group: 0, newGroup: true }, src(0))).toBe(true);
+  });
+  it("skips a within-group drop onto the tab's own slot", () => {
     // diff is at index 0; a post-removal target index of 0 is a no-op.
-    expect(shouldApplyPlacement(tabsByDock, "diff", { dock: "right", index: 0 }, "right")).toBe(false);
+    expect(shouldApplyPlacement(groupsByDock, "diff", { dock: "right", group: 0, index: 0 }, src(0))).toBe(false);
   });
-  it("skips when the tab is not in the target dock", () => {
-    expect(shouldApplyPlacement(tabsByDock, "ghost", { dock: "right", index: 0 }, "right")).toBe(false);
+  it("skips when the tab is not in the target group", () => {
+    expect(shouldApplyPlacement(groupsByDock, "ghost", { dock: "right", group: 0, index: 0 }, src(0))).toBe(false);
   });
 });
 

--- a/web/src/components/__tests__/paneDnd.test.ts
+++ b/web/src/components/__tests__/paneDnd.test.ts
@@ -77,6 +77,15 @@ describe("resolvePlacement", () => {
     });
   });
 
+  it("treats a drop onto the dragged tab's own tab as a no-op, keeping its slot", () => {
+    // terminal:0 sits at index 1; dropping it on itself must not append it.
+    expect(resolvePlacement(over({ tabId: "terminal:0", after: true }), "terminal:0", groupsByDock)).toEqual({
+      dock: "right",
+      group: 0,
+      index: 1,
+    });
+  });
+
   it("appends when the hovered tab is not in the destination group (stale id)", () => {
     expect(resolvePlacement(over({ dock: "bottom", group: 0, tabId: "ghost" }), "diff", groupsByDock)).toEqual({
       dock: "bottom",

--- a/web/src/components/paneDnd.ts
+++ b/web/src/components/paneDnd.ts
@@ -105,8 +105,16 @@ export function resolvePlacement(
     return { dock: over.dock, group: 0, newGroup: true };
   }
   const grp = groupsByDock[over.dock].find((g) => g.group === over.group);
-  const base = (grp?.tabs ?? []).filter((id) => id !== draggedId);
+  const full = grp?.tabs ?? [];
+  const base = full.filter((id) => id !== draggedId);
   if (over.type !== "pane-tab") return { dock: over.dock, group: over.group, index: base.length };
+  // Dropping a tab onto its own tab is a no-op: keep its current slot rather
+  // than appending (base has the dragged tab filtered out, so its index would
+  // otherwise resolve to the end).
+  if (over.tabId === draggedId) {
+    const currentIndex = full.indexOf(draggedId);
+    return { dock: over.dock, group: over.group, index: currentIndex >= 0 ? currentIndex : base.length };
+  }
   const overIndex = base.indexOf(over.tabId);
   if (overIndex < 0) return { dock: over.dock, group: over.group, index: base.length };
   return { dock: over.dock, group: over.group, index: overIndex + (over.after ? 1 : 0) };

--- a/web/src/components/paneDnd.ts
+++ b/web/src/components/paneDnd.ts
@@ -2,69 +2,114 @@ import { createContext, useContext } from "react";
 
 import type { DockLocation } from "../lib/panes";
 
-/** Drag payloads. A tab carries the dock it currently lives in; the two dock
- *  droppables (the rendered dock body and the empty-dock landing zone) carry
- *  their location. onDragEnd branches on `type`, never on the id shape. */
+/** Drag payloads. A tab carries the dock + group it lives in. The drop
+ *  droppables carry their location and (for group/split targets) the group they
+ *  belong to; onDragEnd branches on `type`, never on the id shape. */
 export interface PaneTabData {
   type: "pane-tab";
   dock: DockLocation;
+  group: number;
 }
-export interface DockDropData {
-  type: "pane-dock" | "pane-empty-dock";
+export interface GroupDropData {
+  type: "pane-group";
+  dock: DockLocation;
+  group: number;
+}
+/** A split half over a group body: dropping here lifts the tab into a fresh
+ *  group before or after the hovered one. */
+export interface SplitDropData {
+  type: "pane-split";
+  dock: DockLocation;
+  group: number;
+  side: "before" | "after";
+}
+export interface EmptyDockDropData {
+  type: "pane-empty-dock";
   dock: DockLocation;
 }
+export type DockDropData = GroupDropData | SplitDropData | EmptyDockDropData;
 
-/** The live insertion point while a pane tab is dragged: which dock and the
- *  index it would land at within that dock (after the tab is removed from its
- *  source). Null when there is no valid target. */
+/** The live insertion point while a pane tab is dragged. Either an index inside
+ *  an existing group, or a fresh group spliced in at `group` (`newGroup`). The
+ *  `group` index and `index` are in the destination's *visible* coordinates;
+ *  the parent maps the index back to the full persisted list per group. Null
+ *  when there is no valid target. */
 export interface DropTarget {
   dock: DockLocation;
-  index: number;
+  group: number;
+  index?: number;
+  newGroup?: boolean;
+}
+
+/** Source address of the dragged tab (its dock + group), so a within-group
+ *  no-op reorder can be skipped. */
+export interface DragSource {
+  dock: DockLocation;
+  group: number;
 }
 
 export interface PaneDndState {
   activeTab: string | null;
-  sourceDock: DockLocation | null;
+  source: DragSource | null;
   dropTarget: DropTarget | null;
 }
 
 export const PaneDndStateContext = createContext<PaneDndState>({
   activeTab: null,
-  sourceDock: null,
+  source: null,
   dropTarget: null,
 });
 
-/** Dock reads this to show its destination ring and (cross-dock only) its
- *  insertion marker. Within-dock order is conveyed by the sortable shift, so
- *  the marker is suppressed when the target dock is the source dock. */
+/** Docks read this to show their destination ring, insertion marker, and the
+ *  split drop zones (mounted only while a tab is dragged). */
 export function usePaneDnd(): PaneDndState {
   return useContext(PaneDndStateContext);
 }
 
+/** One rendered group's visible tab ids, keyed by its persisted group index. A
+ *  group whose tabs are all hidden (unloaded plugins) is not rendered, so its
+ *  persisted index can be absent here; placement keys off the persisted index,
+ *  never a compressed render index. */
+export interface RenderGroup {
+  group: number;
+  tabs: string[];
+}
+
 /** The droppable the pointer is over, reduced to the bits placement needs. */
 export interface PlacementOver {
-  type: "pane-tab" | "pane-dock" | "pane-empty-dock";
+  type: "pane-tab" | "pane-group" | "pane-split" | "pane-empty-dock";
   dock: DockLocation;
+  /** Persisted group index of the hovered group (0 for an empty-dock zone). */
+  group: number;
+  /** Split side (only meaningful when `type` is "pane-split"). */
+  side?: "before" | "after";
   /** The hovered tab id (only meaningful when `type` is "pane-tab"). */
   tabId: string;
   /** Pointer is past the hovered tab's center, so insert after it. */
   after: boolean;
 }
 
-/** Where a dragged tab lands: the destination dock and the index in that dock's
- *  visible tab list *after* the dragged tab is removed. Dropping on a tab
- *  inserts before or after it; dropping on a dock body or empty-dock zone
- *  appends. Pure so the drag handler stays a thin adapter over the event. */
+/** Where a dragged tab lands. A split half lifts it into a new group; an
+ *  empty-dock zone seeds the dock's first group; a tab inserts before/after the
+ *  hovered tab in its group; a group body/strip appends into that group. Pure so
+ *  the drag handler stays a thin adapter over the event. */
 export function resolvePlacement(
   over: PlacementOver,
   draggedId: string,
-  tabsByDock: Record<DockLocation, string[]>,
+  groupsByDock: Record<DockLocation, RenderGroup[]>,
 ): DropTarget {
-  const base = tabsByDock[over.dock].filter((id) => id !== draggedId);
-  if (over.type !== "pane-tab") return { dock: over.dock, index: base.length };
+  if (over.type === "pane-split") {
+    return { dock: over.dock, group: over.side === "after" ? over.group + 1 : over.group, newGroup: true };
+  }
+  if (over.type === "pane-empty-dock") {
+    return { dock: over.dock, group: 0, newGroup: true };
+  }
+  const grp = groupsByDock[over.dock].find((g) => g.group === over.group);
+  const base = (grp?.tabs ?? []).filter((id) => id !== draggedId);
+  if (over.type !== "pane-tab") return { dock: over.dock, group: over.group, index: base.length };
   const overIndex = base.indexOf(over.tabId);
-  if (overIndex < 0) return { dock: over.dock, index: base.length };
-  return { dock: over.dock, index: overIndex + (over.after ? 1 : 0) };
+  if (overIndex < 0) return { dock: over.dock, group: over.group, index: base.length };
+  return { dock: over.dock, group: over.group, index: overIndex + (over.after ? 1 : 0) };
 }
 
 interface Rect {
@@ -87,24 +132,27 @@ export function pointerInsertsAfter(activeRect: Rect | null | undefined, overRec
   return a !== null && o !== null && a > o;
 }
 
-/** Whether a resolved drop is worth persisting: a cross-dock move always is, but
- *  a within-dock reorder onto the tab's own slot is a no-op to skip. */
+/** Whether a resolved drop is worth persisting: a split or a cross-group/dock
+ *  move always is, but a within-group reorder onto the tab's own slot is a
+ *  no-op to skip. */
 export function shouldApplyPlacement(
-  tabsByDock: Record<DockLocation, string[]>,
+  groupsByDock: Record<DockLocation, RenderGroup[]>,
   tabId: string,
   target: DropTarget,
-  sourceDock: DockLocation | null,
+  source: DragSource | null,
 ): boolean {
-  if (target.dock !== sourceDock) return true;
-  const from = tabsByDock[target.dock].indexOf(tabId);
+  if (target.newGroup) return true;
+  if (!source || target.dock !== source.dock || target.group !== source.group) return true;
+  const grp = groupsByDock[target.dock].find((g) => g.group === target.group);
+  const from = grp ? grp.tabs.indexOf(tabId) : -1;
   return from >= 0 && from !== target.index;
 }
 
-/** Translate an insertion index in a dock's *visible* tab list to the index in
- *  its *full* persisted list. They differ when the dock holds a tab that is
+/** Translate an insertion index in a group's *visible* tab list to the index in
+ *  its *full* persisted list. They differ when the group holds a tab that is
  *  currently hidden (an unloaded plugin pane), which still occupies a persisted
- *  slot. `fullBase` is the full dock list with the dragged tab already removed.
- *  An index at or past the visible end appends to the full list. */
+ *  slot. `fullBase` is the group's full tab list with the dragged tab already
+ *  removed. An index at or past the visible end appends to the full list. */
 export function visibleToFullIndex(
   fullBase: string[],
   visibleIndex: number,

--- a/web/src/lib/__tests__/paneLayout.test.ts
+++ b/web/src/lib/__tests__/paneLayout.test.ts
@@ -7,6 +7,7 @@ import {
   addTerminal,
   dockOf,
   dockTabs,
+  isActiveTab,
   moveTab,
   placeTab,
   removeAllTerminals,
@@ -64,8 +65,8 @@ describe("pane layout pure ops", () => {
     l = addTab(l, "right", "b");
     l = addTab(l, "right", "c");
     l = setActive(l, "right", "a");
-    // Drag "a" to the end. toIndex is the post-removal index, so end == 2.
-    l = placeTab(l, "a", "right", 2);
+    // Drag "a" to the end. index is the post-removal index, so end == 2.
+    l = placeTab(l, "a", { dock: "right", group: 0, index: 2 });
     expect(dockTabs(l, "right")).toEqual(["b", "c", "a"]);
     // Reordering the active tab keeps it active.
     expect(l.right[0]!.active).toBe("a");
@@ -76,7 +77,7 @@ describe("pane layout pure ops", () => {
     l = addTab(l, "right", "b");
     l = addTab(l, "right", "c");
     l = setActive(l, "right", "a");
-    l = placeTab(l, "c", "right", 0);
+    l = placeTab(l, "c", { dock: "right", group: 0, index: 0 });
     expect(dockTabs(l, "right")).toEqual(["c", "a", "b"]);
     expect(l.right[0]!.active).toBe("a");
   });
@@ -89,7 +90,7 @@ describe("pane layout pure ops", () => {
     l = setActive(l, "right", "a");
     l = setActive(l, "bottom", "x");
     // Move right's active "a" between x and y.
-    l = placeTab(l, "a", "bottom", 1);
+    l = placeTab(l, "a", { dock: "bottom", group: 0, index: 1 });
     expect(dockTabs(l, "right")).toEqual(["b"]);
     expect(dockTabs(l, "bottom")).toEqual(["x", "a", "y"]);
     // Moved tab activates in its destination.
@@ -98,18 +99,60 @@ describe("pane layout pure ops", () => {
     expect(l.right[0]!.active).toBe("b");
   });
 
-  it("placeTab clamps an out-of-range index and prunes an emptied source dock", () => {
-    let l = addTab(emptyLayout(), "right", "only");
-    l = placeTab(l, "only", "bottom", 99);
-    expect(l.right).toEqual([]);
-    expect(dockTabs(l, "bottom")).toEqual(["only"]);
+  it("placeTab clamps an out-of-range index within a group", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = placeTab(l, "a", { dock: "right", group: 0, index: 99 });
+    expect(dockTabs(l, "right")).toEqual(["b", "a"]);
   });
 
   it("placeTab does not mark a moved plugin tab as closed", () => {
     let l = addTab(emptyLayout(), "right", "plugin:p:a");
-    l = placeTab(l, "plugin:p:a", "bottom", 0);
+    l = placeTab(l, "plugin:p:a", { dock: "bottom", group: 0, newGroup: true });
     expect(dockOf(l, "plugin:p:a")).toBe("bottom");
     expect(l.closedPlugins).not.toContain("plugin:p:a");
+  });
+
+  it("placeTab split lifts a tab into a new sibling group in the same dock", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    // Split "b" into a fresh group after group 0.
+    l = placeTab(l, "b", { dock: "right", group: 1, newGroup: true });
+    expect(l.right.length).toBe(2);
+    expect(l.right[0]!.tabs).toEqual(["a"]);
+    expect(l.right[0]!.active).toBe("a");
+    expect(l.right[1]!.tabs).toEqual(["b"]);
+    expect(l.right[1]!.active).toBe("b");
+  });
+
+  it("removeTab prunes only the emptied group, leaving siblings intact", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = placeTab(l, "b", { dock: "right", group: 1, newGroup: true });
+    l = removeTab(l, "a"); // empties group 0 only
+    expect(l.right.length).toBe(1);
+    expect(l.right[0]!.tabs).toEqual(["b"]);
+  });
+
+  it("placeTab into another group activates it there and prunes the emptied source group", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = placeTab(l, "b", { dock: "right", group: 1, newGroup: true }); // groups [a], [b]
+    l = setActive(l, "right", "a");
+    // Move "a" (its group's only tab) into group 1; group 0 prunes and the
+    // target-group index shifts down by one.
+    l = placeTab(l, "a", { dock: "right", group: 1, index: 1 });
+    expect(l.right.length).toBe(1);
+    expect(l.right[0]!.tabs).toEqual(["b", "a"]);
+    expect(l.right[0]!.active).toBe("a");
+  });
+
+  it("isActiveTab reports each group's active tab independently", () => {
+    let l = addTab(emptyLayout(), "right", "a");
+    l = addTab(l, "right", "b");
+    l = placeTab(l, "b", { dock: "right", group: 1, newGroup: true });
+    expect(isActiveTab(l, "a")).toBe(true);
+    expect(isActiveTab(l, "b")).toBe(true);
   });
 
   it("moveTab appends to the destination and is a no-op within the same dock", () => {
@@ -213,6 +256,31 @@ describe("usePaneLayout migration + persistence", () => {
     );
     const { result } = renderHook(() => usePaneLayout("s1"));
     expect(dockTabs(result.current.layout, "right")).toEqual(["diff", "terminal:0"]);
+  });
+
+  it("loads multiple persisted groups per dock without merging them", () => {
+    localStorage.setItem(
+      "aoe-pane-layout-v2",
+      JSON.stringify({
+        version: 2,
+        template: { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [] },
+        sessions: {
+          s1: {
+            right: [
+              { tabs: ["diff"], active: "diff" },
+              { tabs: ["terminal:0"], active: "terminal:0" },
+            ],
+            bottom: [],
+            nextTerminalIndex: 1,
+            closedPlugins: [],
+          },
+        },
+      }),
+    );
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    expect(result.current.layout.right.length).toBe(2);
+    expect(result.current.layout.right[0]!.tabs).toEqual(["diff"]);
+    expect(result.current.layout.right[1]!.tabs).toEqual(["terminal:0"]);
   });
 
   it("toggleKind adds then removes the terminal tabs", () => {

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -49,25 +49,45 @@ function emptyDockLayout(): DockLayout {
   return { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [] };
 }
 
-/** First (and currently only) group of a dock, or undefined when empty. */
-function firstGroup(layout: DockLayout, dock: DockLocation): PaneGroup | undefined {
-  return layout[dock][0];
+/** All groups in a dock, in render order. */
+export function dockGroups(layout: DockLayout, dock: DockLocation): PaneGroup[] {
+  return layout[dock];
 }
 
+/** Every tab in a dock, flattened across its groups. Callers asking "is this
+ *  open / which dock holds it / close everything here" want the whole dock, not
+ *  a single group. */
 export function dockTabs(layout: DockLayout, dock: DockLocation): TabId[] {
-  return firstGroup(layout, dock)?.tabs ?? [];
+  return layout[dock].flatMap((g) => g.tabs);
 }
 
-export function dockActive(layout: DockLayout, dock: DockLocation): TabId | null {
-  return firstGroup(layout, dock)?.active ?? null;
+/** Address of a tab: its dock, its group's index, and its index in that group. */
+export interface TabAddress {
+  dock: DockLocation;
+  group: number;
+  index: number;
+}
+
+export function findTab(layout: DockLayout, tabId: TabId): TabAddress | null {
+  for (const dock of DOCKS) {
+    const groups = layout[dock];
+    for (let group = 0; group < groups.length; group++) {
+      const index = groups[group]!.tabs.indexOf(tabId);
+      if (index >= 0) return { dock, group, index };
+    }
+  }
+  return null;
+}
+
+/** True when `tabId` is the active tab of whichever group holds it. */
+export function isActiveTab(layout: DockLayout, tabId: TabId): boolean {
+  const at = findTab(layout, tabId);
+  return at ? layout[at.dock][at.group]!.active === tabId : false;
 }
 
 /** Which dock a tab currently lives in, or null if it is closed. */
 export function dockOf(layout: DockLayout, tabId: TabId): DockLocation | null {
-  for (const dock of DOCKS) {
-    if (dockTabs(layout, dock).includes(tabId)) return dock;
-  }
-  return null;
+  return findTab(layout, tabId)?.dock ?? null;
 }
 
 function clone(layout: DockLayout): DockLayout {
@@ -84,11 +104,12 @@ function ensureGroup(layout: DockLayout, dock: DockLocation): PaneGroup {
   return layout[dock][0]!;
 }
 
-/** Drop the dock's group entirely once its last tab closes, so the parent can
- *  hide an empty dock (it keys off a zero-length groups array). */
+/** Drop any group whose last tab just closed, leaving sibling groups intact. A
+ *  dock with no groups renders nothing (the parent keys off a zero-length
+ *  array). Prunes on real tab count, so a group holding only an unloaded plugin
+ *  tab survives. */
 function pruneEmpty(layout: DockLayout, dock: DockLocation): void {
-  const g = layout[dock][0];
-  if (g && g.tabs.length === 0) layout[dock] = [];
+  layout[dock] = layout[dock].filter((g) => g.tabs.length > 0);
 }
 
 export function addTab(layout: DockLayout, dock: DockLocation, tabId: TabId, activate = true): DockLayout {
@@ -102,28 +123,27 @@ export function addTab(layout: DockLayout, dock: DockLocation, tabId: TabId, act
 }
 
 export function removeTab(layout: DockLayout, tabId: TabId): DockLayout {
-  const dock = dockOf(layout, tabId);
-  if (!dock) return layout;
+  const at = findTab(layout, tabId);
+  if (!at) return layout;
   const next = clone(layout);
-  const group = next[dock][0]!;
-  const idx = group.tabs.indexOf(tabId);
-  group.tabs.splice(idx, 1);
+  const group = next[at.dock][at.group]!;
+  group.tabs.splice(at.index, 1);
   if (group.active === tabId) {
     // Prefer the tab that shifted into this slot, else the new last tab.
-    group.active = group.tabs[idx] ?? group.tabs[group.tabs.length - 1] ?? null;
+    group.active = group.tabs[at.index] ?? group.tabs[group.tabs.length - 1] ?? null;
   }
   if (tabId.startsWith("plugin:") && !next.closedPlugins.includes(tabId)) {
     next.closedPlugins.push(tabId);
   }
-  pruneEmpty(next, dock);
+  pruneEmpty(next, at.dock);
   return next;
 }
 
 export function setActive(layout: DockLayout, dock: DockLocation, tabId: TabId): DockLayout {
-  const group = firstGroup(layout, dock);
-  if (!group || !group.tabs.includes(tabId) || group.active === tabId) return layout;
+  const gi = layout[dock].findIndex((g) => g.tabs.includes(tabId));
+  if (gi < 0 || layout[dock][gi]!.active === tabId) return layout;
   const next = clone(layout);
-  next[dock][0]!.active = tabId;
+  next[dock][gi]!.active = tabId;
   return next;
 }
 
@@ -131,34 +151,57 @@ function clampIndex(index: number, max: number): number {
   return Math.max(0, Math.min(Math.floor(index), max));
 }
 
-/** Move `tabId` to position `toIndex` in `toDock`. Subsumes both within-dock
- *  reorder (toDock equals the source dock) and cross-dock move. `toIndex` is the
- *  index in the destination group *after* the tab is removed from its source.
+/** Where a tab should land: an existing group (`group` + `index`) or a fresh
+ *  group spliced into the dock at position `group` (when `newGroup`). */
+export interface PlaceTarget {
+  dock: DockLocation;
+  group: number;
+  index?: number;
+  newGroup?: boolean;
+}
+
+/** Move `tabId` to `target`. The single placement primitive: subsumes
+ *  within-group reorder, cross-group and cross-dock moves, and splitting a tab
+ *  into a new group. `index` is the position in the destination group *after*
+ *  the tab is removed from its source.
  *
- *  Active-tab rule: a within-dock reorder keeps whatever was active (including
- *  the dragged tab itself), so dragging a background tab never steals focus; a
- *  cross-dock move activates the tab in its destination, since it would
- *  otherwise land hidden behind the destination's active tab. Implemented
- *  directly rather than via removeTab so a move never marks a plugin tab as
- *  explicitly closed. */
-export function placeTab(layout: DockLayout, tabId: TabId, toDock: DockLocation, toIndex: number): DockLayout {
-  const fromDock = dockOf(layout, tabId);
-  if (!fromDock) return layout;
+ *  Active-tab rule: a within-group reorder keeps whatever was active (so
+ *  dragging a background tab never steals focus and dragging the active tab
+ *  keeps it active); any move into a different group activates the tab there,
+ *  since it would otherwise land hidden behind that group's active tab.
+ *  Implemented directly rather than via removeTab so a move never marks a plugin
+ *  tab as explicitly closed. */
+export function placeTab(layout: DockLayout, tabId: TabId, target: PlaceTarget): DockLayout {
+  const src = findTab(layout, tabId);
+  if (!src) return layout;
   const next = clone(layout);
-  const source = next[fromDock][0]!;
-  const fromIndex = source.tabs.indexOf(tabId);
-  if (fromIndex < 0) return layout;
-  const wasActive = source.active === tabId;
-  source.tabs.splice(fromIndex, 1);
-  if (wasActive) {
+  const srcGroup = next[src.dock][src.group]!;
+  const srcActive = srcGroup.active;
+  srcGroup.tabs.splice(src.index, 1);
+  if (srcActive === tabId) {
     // Source loses its active tab: prefer the tab that shifted into the slot,
-    // else the new last tab. (Overridden below for a within-dock reorder.)
-    source.active = source.tabs[fromIndex] ?? source.tabs[source.tabs.length - 1] ?? null;
+    // else the new last tab. (Restored below for a within-group reorder.)
+    srcGroup.active = srcGroup.tabs[src.index] ?? srcGroup.tabs[srcGroup.tabs.length - 1] ?? null;
   }
-  pruneEmpty(next, fromDock);
-  const dest = ensureGroup(next, toDock);
-  dest.tabs.splice(clampIndex(toIndex, dest.tabs.length), 0, tabId);
-  if (fromDock !== toDock || wasActive || dest.active === null) dest.active = tabId;
+  let srcPruned = false;
+  if (srcGroup.tabs.length === 0) {
+    next[src.dock].splice(src.group, 1);
+    srcPruned = true;
+  }
+  // Removing the source group renumbers later groups in the same dock; the
+  // caller's `target.group` was computed against the pre-removal layout.
+  let groupIdx = target.group;
+  if (srcPruned && src.dock === target.dock && src.group < groupIdx) groupIdx--;
+  const destGroups = next[target.dock];
+  if (target.newGroup) {
+    destGroups.splice(clampIndex(groupIdx, destGroups.length), 0, { tabs: [tabId], active: tabId });
+  } else {
+    const dest = destGroups[groupIdx];
+    if (!dest) return layout;
+    dest.tabs.splice(clampIndex(target.index ?? dest.tabs.length, dest.tabs.length), 0, tabId);
+    const sameGroup = !srcPruned && src.dock === target.dock && src.group === groupIdx;
+    dest.active = sameGroup ? srcActive : tabId;
+  }
   next.closedPlugins = next.closedPlugins.filter((id) => id !== tabId);
   return next;
 }
@@ -166,7 +209,10 @@ export function placeTab(layout: DockLayout, tabId: TabId, toDock: DockLocation,
 export function moveTab(layout: DockLayout, tabId: TabId, toDock: DockLocation): DockLayout {
   const from = dockOf(layout, tabId);
   if (!from || from === toDock) return layout;
-  return placeTab(layout, tabId, toDock, dockTabs(layout, toDock).length);
+  const groups = layout[toDock];
+  if (groups.length === 0) return placeTab(layout, tabId, { dock: toDock, group: 0, newGroup: true });
+  const last = groups.length - 1;
+  return placeTab(layout, tabId, { dock: toDock, group: last, index: groups[last]!.tabs.length });
 }
 
 /** Allocate a fresh terminal tab in `dock` and return its id + new layout. */
@@ -276,10 +322,7 @@ function normalizeGroups(v: unknown): PaneGroup[] {
     const active = typeof o.active === "string" && tabs.includes(o.active) ? o.active : tabs[0]!;
     groups.push({ tabs, active });
   }
-  // Collapse to a single group for now; DnD will lift this cap.
-  if (groups.length <= 1) return groups;
-  const merged: PaneGroup = { tabs: groups.flatMap((g) => g.tabs), active: groups[0]!.active };
-  return [merged];
+  return groups;
 }
 
 /** Drop from `group` any tab id already claimed by an earlier dock. A tab must
@@ -342,8 +385,8 @@ export interface PaneLayoutApi {
   closeTab: (tabId: TabId) => void;
   activateTab: (dock: DockLocation, tabId: TabId) => void;
   moveTab: (tabId: TabId, toDock: DockLocation) => void;
-  /** Reorder within a dock or move across docks, landing at `toIndex`. */
-  placeTab: (tabId: TabId, toDock: DockLocation, toIndex: number) => void;
+  /** Reorder, move across docks/groups, or split into a new group. */
+  placeTab: (tabId: TabId, target: PlaceTarget) => void;
   /** Activity-bar toggle for a built-in kind ("diff" or "terminal"). */
   toggleKind: (kind: "diff" | "terminal" | "agents", defaultDock: DockLocation) => void;
   /** Add/remove a plugin pane tab (activity-bar toggle). */
@@ -389,7 +432,7 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     [mutate],
   );
   const placeTabCb = useCallback(
-    (tabId: TabId, toDock: DockLocation, toIndex: number) => mutate((l) => placeTab(l, tabId, toDock, toIndex)),
+    (tabId: TabId, target: PlaceTarget) => mutate((l) => placeTab(l, tabId, target)),
     [mutate],
   );
   const toggleKind = useCallback(

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -31,6 +31,7 @@
       "components": [
         "web/src/components/ActivityBar.tsx",
         "web/src/components/Dock.tsx",
+        "web/src/components/DockGroups.tsx",
         "web/src/components/BottomDock.tsx",
         "web/src/components/PaneDndController.tsx",
         "web/src/components/paneDnd.ts",

--- a/web/tests/pane-docking.spec.ts
+++ b/web/tests/pane-docking.spec.ts
@@ -244,4 +244,39 @@ test.describe("Dockable pane system", () => {
     await expect.poll(() => dockGroupCount(page, "right")).toBe(1);
     await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
   });
+
+  test("dragging a tab onto a pane body splits the bottom dock into two groups that persist", async ({ page }) => {
+    await openSession(page);
+    await page.goto(`/session/${SESSION}`);
+
+    // Gather both panes into a single bottom-dock group.
+    await page.getByLabel("Move diff to bottom dock").click();
+    await page.getByLabel("Move terminal to bottom dock").click();
+    await expect.poll(() => dockTabOrder(page, "bottom")).toEqual(["diff", "terminal:0"]);
+    expect(await dockGroupCount(page, "bottom")).toBe(1);
+
+    // Drag terminal:0 onto the group body's trailing split half: the wide bottom
+    // strip splits side by side, so this lifts it into a second group.
+    await dragTab(page, "terminal:0", { x: 640, y: 650 }, async () => {
+      const zone = page.getByTestId("pane-split-bottom-0-after");
+      await expect(zone).toBeVisible();
+      const box = await zone.boundingBox();
+      if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 6 });
+    });
+
+    await expect.poll(() => dockGroupCount(page, "bottom")).toBe(2);
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    await expect(page.getByTestId("pane-tab-terminal:0")).toBeVisible();
+
+    // The split layout round-trips through localStorage.
+    await page.reload();
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    await expect.poll(() => dockGroupCount(page, "bottom")).toBe(2);
+
+    // Closing one group's pane prunes only that group; the other stays valid.
+    await page.getByLabel("Close terminal").click();
+    await expect(page.getByTestId("pane-tab-terminal:0")).toHaveCount(0);
+    await expect.poll(() => dockGroupCount(page, "bottom")).toBe(1);
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+  });
 });

--- a/web/tests/pane-docking.spec.ts
+++ b/web/tests/pane-docking.spec.ts
@@ -23,6 +23,12 @@ async function dockTabOrder(page: Page, dock: "right" | "bottom"): Promise<strin
   );
 }
 
+/** How many split groups a dock currently renders (one `[data-pane-dock]`
+ *  section per group). */
+async function dockGroupCount(page: Page, dock: "right" | "bottom"): Promise<number> {
+  return page.locator(`[data-pane-dock="${dock}"]`).count();
+}
+
 /** Press on a tab's activation button (where the drag listeners live), move past
  *  the 8px MouseSensor threshold, run `mid` while held, then drop on `target`.
  *  Playwright's mouse maps to dnd-kit's MouseSensor, so no press-hold delay. */
@@ -203,5 +209,39 @@ test.describe("Dockable pane system", () => {
     await page.getByLabel("Close terminal 2").click();
     await expect(page.getByTestId("pane-tab-terminal:1")).toHaveCount(0);
     await expect(page.getByTestId("pane-tab-terminal:0")).toBeVisible();
+  });
+
+  test("dragging a tab onto a pane body splits the right dock into two groups that persist", async ({ page }) => {
+    await openSession(page);
+    await page.goto(`/session/${SESSION}`);
+
+    // The right dock starts as one group holding diff + terminal:0.
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    expect(await dockGroupCount(page, "right")).toBe(1);
+
+    // Drag terminal:0 onto the group body's trailing split half: it lifts out
+    // into a second side-by-side group rather than just reordering tabs.
+    await dragTab(page, "terminal:0", { x: 1000, y: 400 }, async () => {
+      const zone = page.getByTestId("pane-split-right-0-after");
+      await expect(zone).toBeVisible();
+      const box = await zone.boundingBox();
+      if (box) await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 6 });
+    });
+
+    await expect.poll(() => dockGroupCount(page, "right")).toBe(2);
+    // Both panes stay open, now one per group.
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    await expect(page.getByTestId("pane-tab-terminal:0")).toBeVisible();
+
+    // The split layout round-trips through localStorage.
+    await page.reload();
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
+    await expect.poll(() => dockGroupCount(page, "right")).toBe(2);
+
+    // Closing one group's pane prunes only that group; the other stays valid.
+    await page.getByLabel("Close terminal").click();
+    await expect(page.getByTestId("pane-tab-terminal:0")).toHaveCount(0);
+    await expect.poll(() => dockGroupCount(page, "right")).toBe(1);
+    await expect(page.getByTestId("pane-tab-diff")).toBeVisible();
   });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Lets a user split panes within the same dock, the way tmux or iTerm split panes, instead of only tabbing them together or moving one to the opposite dock. Dragging a pane onto another pane's body in the same dock now lifts it into a second group: the tall right column stacks groups top to bottom, the wide bottom strip places them side by side. The split persists per session across reloads.

The persisted layout shape already stored `right`/`bottom` as `PaneGroup[]` (left ready by #2437 / PR #2446), so this is a render + interaction change, not a storage migration. The model was the blocker: every op used only `group[0]` and `normalizeGroups()` actively merged stored groups back into one on load.

What changed:
- **Model (`paneLayout.ts`)**: `dockTabs` now flattens across all groups (so "is this open / which dock / close everything here" stays correct); `dockGroups`, `findTab`, and `isActiveTab` are group-aware; `placeTab` takes one unified `PlaceTarget` covering reorder, cross-dock, cross-group, and split, repairing the source group's active tab and pruning only the emptied group (and adjusting the target index when the source group is removed). `normalizeGroups` no longer merges.
- **DnD**: drop targets carry a group index and a `newGroup` flag. Dropping on a group's tab strip joins it; dropping on a body half (shown only while dragging, so it never steals clicks from a terminal/iframe body) splits into a new group before/after by pointer position.
- **Render**: each dock maps its groups to one `Dock` each via a new `DockGroups` container. Groups share space equally; per-group resize handles are deliberately deferred (noted with a `ponytail:` comment for a follow-up).

The design was pressure-tested with a two-model debate (the unified `placeTab` vs a separate `splitTab`, flatten `dockTabs` vs migrate callers, edge split zones vs body-half split zones, and the hidden-plugin-slot index mapping going per-group).

Closes #2486

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary <!-- none: the split is a discoverable drag interaction, no docs surface -->
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How to test

- [ ] Open the dashboard on a desktop viewport with a session that has diff + terminal open in the right dock.
- [ ] Drag the terminal tab onto the lower half of the pane body; confirm it splits into a second group stacked below instead of just reordering the tab strip.
- [ ] Reload the page; confirm the two stacked groups are still there for that session.
- [ ] Drag a bottom-dock pane onto the side half of another bottom-dock pane's body; confirm it splits into a second group side by side.
- [ ] Close one group's last pane; confirm only that group disappears, the other keeps a valid active tab, and no tab is duplicated.
- [ ] Drag a tab from one group's strip onto another group's strip; confirm it merges (joins) rather than splitting.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the debate-driven design, implementation, and tests were drafted by Claude under my direction. I made the design calls (unified placement op, body-half split zones, deferring resizers) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enables tmux/iTerm-style “same-location” pane splits in the web dashboard: users can drag a terminal tab onto another pane’s body within the same dock to create a new pane group (rather than only tabbing together or switching docks). The right dock renders the resulting groups side-by-side, and the bottom dock renders them stacked. The layout now persists per session across reloads.

Key updates include making the pane layout and drag-and-drop flow group-aware (supporting multiple groups per dock), refactoring the UI to render dock groups separately, and updating drop targets so split joins vs tab-strip joins are distinguished correctly. Closing or moving panes is handled more safely so the active tab stays valid and unrelated groups aren’t accidentally collapsed.

Tests were added/updated (including Playwright) to cover group-based splitting, drag/drop placement behavior, and persistence across reloads.

Potential follow-ups: verify edge-case interactions when rapidly dragging between multiple groups (and across docks) and consider adding more accessibility/keyboard coverage for the new split targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->