### PR TITLE
feat(tui): render the plugin pane slot in the structured view

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -644,10 +644,15 @@ The native **structured-view** TUI (`aoe acp attach`, the remote-home picker)
 polls the same endpoint on a 3-second cadence and renders the slots a terminal
 can show: global `status-bar` segments and the open session's `detail-badge`
 entries, tone-colored, in its status line, plus `notification`s as toasts
-(deduped by `seq`, queued so a burst shows one at a time). It renders text and
-tone only; `icon`, `tooltip`, and `href` are dropped, and `card`, `pane`,
-`row-badge`, `row-column`, `sort-key`, and `filter-facet` have no structured-view
-surface. The standalone home screen reads local session storage and has no
+(deduped by `seq`, queued so a burst shows one at a time). The open session's
+`pane` entries render in a read-only panel toggled with `p` from the transcript
+(#2467): a modal overlay drawing the known block kinds (`heading`, `row`,
+`note`, `divider`, `section`, `comment`) and the simple `{ title, body }` form,
+with `action` blocks shown as inert labels (firing them is a follow-up). It
+renders text and tone only; `icon`, `tooltip`, and `href` are dropped, and
+`card`, `row-badge`, `row-column`, `sort-key`, and `filter-facet` have no
+structured-view surface. The standalone home screen reads local session storage
+and has no
 daemon link, so it renders no plugin slots; rendering there is a follow-up
 (#2402).
 

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -344,7 +344,10 @@ fn indent_span(indent: usize) -> Vec<Span<'static>> {
 /// Skips the leading space when the line started with an indent span (the
 /// indent already separates it from the margin).
 fn push_sep(spans: &mut Vec<Span<'static>>, indent: usize) {
-    if !spans.is_empty() && !(spans.len() == 1 && indent > 0) {
+    // The line is empty, or holds only the leading indent span: no field has
+    // been pushed yet, so the next one needs no separator.
+    let only_indent = indent > 0 && spans.len() == 1;
+    if !spans.is_empty() && !only_indent {
         spans.push(Span::raw(" "));
     }
 }

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -10,7 +10,9 @@
 //! filtering / tone-mapping logic is unit-testable without a daemon.
 
 use aoe_plugin_api::UiSlot;
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use serde_json::Value;
 
 use crate::plugin::ui_state::{Notification, Tone, UiEntry, UiSnapshot};
 use crate::tui::styles::Theme;
@@ -106,6 +108,257 @@ pub fn new_notifications<'a>(
         .collect();
     out.sort_by_key(|n| n.seq);
     out
+}
+
+/// Width of a `divider` block's rule. The pane `Paragraph` wraps, so a fixed
+/// width is fine: a narrow pane just wraps the rule (harmless) and a wide one
+/// shows a partial rule rather than spanning the whole width. Not worth
+/// threading the render width down for a decorative line.
+const DIVIDER_WIDTH: usize = 32;
+
+/// Render the open session's `Pane` entries to terminal lines for the
+/// toggleable pane panel (#2467). Mirrors the web renderer's block vocabulary
+/// (`web/src/components/plugin/PluginSlots.tsx`), narrowed to what a terminal
+/// shows: text and tone only, with icons / hrefs / tooltips dropped and
+/// `action` blocks rendered as inert labels (interactive firing is a #2467
+/// follow-up). Forward-compatible: an unknown block `kind` renders nothing
+/// rather than failing, so a newer plugin can push kinds this host has not
+/// heard of. Entries are blank-line separated.
+pub fn pane_lines(snapshot: &UiSnapshot, session_id: &str, theme: &Theme) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+    for entry in session_entries(snapshot, UiSlot::Pane, session_id) {
+        if !out.is_empty() {
+            out.push(Line::default());
+        }
+        out.extend(pane_entry_lines(entry, theme));
+    }
+    out
+}
+
+/// One pane entry: an ordered `blocks` list when present, else the simple
+/// `{ title, body }` form (matching the web renderer's precedence).
+fn pane_entry_lines(entry: &UiEntry, theme: &Theme) -> Vec<Line<'static>> {
+    if let Some(blocks) = entry.payload.get("blocks").and_then(Value::as_array) {
+        return blocks
+            .iter()
+            .flat_map(|b| block_lines(b, 0, theme))
+            .collect();
+    }
+    let mut out: Vec<Line<'static>> = Vec::new();
+    if let Some(title) = block_str(&entry.payload, "title") {
+        out.push(indented_line(
+            0,
+            title.to_string(),
+            Style::default()
+                .fg(theme.title)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(body) = block_str(&entry.payload, "body") {
+        for l in body.lines() {
+            out.push(indented_line(
+                0,
+                l.to_string(),
+                Style::default().fg(theme.text),
+            ));
+        }
+    }
+    out
+}
+
+/// Render one block to lines, indented by `indent` spaces. `section` recurses
+/// with a deeper indent. An unknown kind, or a known kind missing its required
+/// field, yields no lines.
+fn block_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
+    match block.get("kind").and_then(Value::as_str) {
+        Some("heading") => match block_str(block, "text") {
+            Some(t) => vec![indented_line(
+                indent,
+                t.to_string(),
+                Style::default()
+                    .fg(theme.title)
+                    .add_modifier(Modifier::BOLD),
+            )],
+            None => vec![],
+        },
+        Some("note") => match block_str(block, "text") {
+            Some(t) => vec![indented_line(
+                indent,
+                t.to_string(),
+                tone_style(block_tone(block), theme),
+            )],
+            None => vec![],
+        },
+        Some("divider") => vec![indented_line(
+            indent,
+            "─".repeat(DIVIDER_WIDTH),
+            Style::default().fg(theme.dimmed),
+        )],
+        Some("action") => match block_str(block, "label") {
+            // Inert in this read-only pass: the label tells the user the plugin
+            // exposes an action the TUI cannot yet fire (#2467 follow-up).
+            Some(l) => vec![indented_line(
+                indent,
+                format!("[action] {l}"),
+                Style::default().fg(theme.dimmed),
+            )],
+            None => vec![],
+        },
+        Some("row") => row_lines(block, indent, theme),
+        Some("comment") => comment_lines(block, indent, theme),
+        Some("section") => section_lines(block, indent, theme),
+        _ => vec![],
+    }
+}
+
+/// `row`: `label value sublabel` on one line, the value tone-colored. Drops
+/// icon / href / color (no terminal surface). Renders nothing if all three
+/// text fields are absent.
+fn row_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
+    let label = block_str(block, "label");
+    let value = block_str(block, "value");
+    let sublabel = block_str(block, "sublabel");
+    if label.is_none() && value.is_none() && sublabel.is_none() {
+        return vec![];
+    }
+    let mut spans = indent_span(indent);
+    if let Some(l) = label {
+        spans.push(Span::styled(
+            l.to_string(),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(v) = value {
+        push_sep(&mut spans, indent);
+        spans.push(Span::styled(
+            v.to_string(),
+            tone_style(block_tone(block), theme),
+        ));
+    }
+    if let Some(s) = sublabel {
+        push_sep(&mut spans, indent);
+        spans.push(Span::styled(
+            s.to_string(),
+            Style::default().fg(theme.dimmed),
+        ));
+    }
+    vec![Line::from(spans)]
+}
+
+/// `comment`: a read-only PR review comment. A header line (author, optional
+/// `path:line`, resolved / unresolved marker) then the wrapped body. Drops the
+/// href. Renders nothing if both author and body are absent.
+fn comment_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
+    let author = block_str(block, "author");
+    let body = block_str(block, "body");
+    if author.is_none() && body.is_none() {
+        return vec![];
+    }
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let mut header = indent_span(indent);
+    if let Some(a) = author {
+        header.push(Span::styled(
+            a.to_string(),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(p) = block_str(block, "path") {
+        let where_ = match block.get("line").and_then(Value::as_i64) {
+            Some(n) => format!("  {p}:{n}"),
+            None => format!("  {p}"),
+        };
+        header.push(Span::styled(where_, Style::default().fg(theme.dimmed)));
+    }
+    let resolved = block
+        .get("resolved")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let (marker, color) = if resolved {
+        ("  resolved", theme.running)
+    } else {
+        ("  unresolved", theme.waiting)
+    };
+    header.push(Span::styled(marker.to_string(), Style::default().fg(color)));
+    out.push(Line::from(header));
+    if let Some(b) = body {
+        for l in b.lines() {
+            out.push(indented_line(
+                indent,
+                l.to_string(),
+                Style::default().fg(theme.text),
+            ));
+        }
+    }
+    out
+}
+
+/// `section`: an uppercase dim title then its children, recursively, indented
+/// one level deeper. Always expanded; the TUI has no fold affordance, so hiding
+/// the children would drop data with no way to reveal it.
+fn section_lines(block: &Value, indent: usize, theme: &Theme) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+    if let Some(title) = block_str(block, "title") {
+        out.push(indented_line(
+            indent,
+            title.to_uppercase(),
+            Style::default()
+                .fg(theme.dimmed)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(children) = block.get("children").and_then(Value::as_array) {
+        for c in children {
+            out.extend(block_lines(c, indent + 2, theme));
+        }
+    }
+    out
+}
+
+/// The block's tone, if it carries a valid one.
+fn block_tone(block: &Value) -> Option<Tone> {
+    block
+        .get("tone")
+        .and_then(|v| serde_json::from_value::<Tone>(v.clone()).ok())
+}
+
+/// A trimmed, non-empty string field, or `None`. Defensive against a malformed
+/// or schema-skewed block so the renderer never panics on plugin data.
+fn block_str<'a>(block: &'a Value, key: &str) -> Option<&'a str> {
+    block
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+/// Leading indent spans for a line, empty at indent 0.
+fn indent_span(indent: usize) -> Vec<Span<'static>> {
+    if indent == 0 {
+        Vec::new()
+    } else {
+        vec![Span::raw(" ".repeat(indent))]
+    }
+}
+
+/// Push a single-space separator before the next span on a multi-field line.
+/// Skips the leading space when the line started with an indent span (the
+/// indent already separates it from the margin).
+fn push_sep(spans: &mut Vec<Span<'static>>, indent: usize) {
+    if !spans.is_empty() && !(spans.len() == 1 && indent > 0) {
+        spans.push(Span::raw(" "));
+    }
+}
+
+/// A single styled line at `indent` spaces.
+fn indented_line(indent: usize, text: String, style: Style) -> Line<'static> {
+    if indent == 0 {
+        Line::from(Span::styled(text, style))
+    } else {
+        Line::from(vec![
+            Span::raw(" ".repeat(indent)),
+            Span::styled(text, style),
+        ])
+    }
 }
 
 #[cfg(test)]
@@ -226,5 +479,125 @@ mod tests {
     fn max_seq_handles_empty() {
         let snap = snapshot(json!([]), json!([]));
         assert_eq!(max_notification_seq(&snap), 0);
+    }
+
+    fn pane_snapshot(entries: serde_json::Value) -> UiSnapshot {
+        snapshot(entries, json!([]))
+    }
+
+    /// Flatten rendered lines to their plain text, one string per line, so a
+    /// test can assert on content without spelling out styles.
+    fn texts(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn pane_entry(payload: serde_json::Value) -> serde_json::Value {
+        json!([{"plugin_id": "p", "slot": "pane", "id": "gh", "session_id": "s1", "payload": payload}])
+    }
+
+    #[test]
+    fn pane_simple_title_body_form() {
+        let snap = pane_snapshot(pane_entry(json!({"title": "Checks", "body": "all\ngood"})));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        assert_eq!(texts(&lines), vec!["Checks", "all", "good"]);
+    }
+
+    #[test]
+    fn pane_filters_by_session_exactly() {
+        let snap = pane_snapshot(json!([
+            {"plugin_id": "p", "slot": "pane", "id": "a", "session_id": "s1", "payload": {"title": "mine"}},
+            {"plugin_id": "p", "slot": "pane", "id": "b", "session_id": "s2", "payload": {"title": "other"}},
+            {"plugin_id": "p", "slot": "pane", "id": "c", "payload": {"title": "global"}}
+        ]));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        assert_eq!(texts(&lines), vec!["mine"]);
+    }
+
+    #[test]
+    fn pane_separates_multiple_entries_with_blank_line() {
+        let snap = pane_snapshot(json!([
+            {"plugin_id": "p", "slot": "pane", "id": "a", "session_id": "s1", "payload": {"title": "one"}},
+            {"plugin_id": "p", "slot": "pane", "id": "b", "session_id": "s1", "payload": {"title": "two"}}
+        ]));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        assert_eq!(texts(&lines), vec!["one", "", "two"]);
+    }
+
+    #[test]
+    fn pane_renders_known_block_kinds() {
+        let snap = pane_snapshot(pane_entry(json!({"blocks": [
+            {"kind": "heading", "text": "GitHub"},
+            {"kind": "row", "label": "nexus", "value": "PR #12", "sublabel": "open"},
+            {"kind": "note", "text": "heads up", "tone": "warn"},
+            {"kind": "divider"},
+            {"kind": "action", "label": "Refresh", "method": "refresh"}
+        ]})));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        let t = texts(&lines);
+        assert_eq!(t[0], "GitHub");
+        assert_eq!(t[1], "nexus PR #12 open");
+        assert_eq!(t[2], "heads up");
+        assert_eq!(t[3], "─".repeat(DIVIDER_WIDTH));
+        // Action is inert: a label, not a fired button.
+        assert_eq!(t[4], "[action] Refresh");
+    }
+
+    #[test]
+    fn pane_renders_nested_section_indented() {
+        let snap = pane_snapshot(pane_entry(json!({"blocks": [
+            {"kind": "section", "title": "Reviews", "children": [
+                {"kind": "row", "label": "approved", "value": "2"}
+            ]}
+        ]})));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        let t = texts(&lines);
+        assert_eq!(t[0], "REVIEWS");
+        assert_eq!(t[1], "  approved 2");
+    }
+
+    #[test]
+    fn pane_renders_comment_header_and_body() {
+        let snap = pane_snapshot(pane_entry(json!({"blocks": [
+            {"kind": "comment", "author": "octocat", "path": "src/x.rs", "line": 9,
+             "resolved": false, "body": "needs a test"}
+        ]})));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        let t = texts(&lines);
+        assert_eq!(t[0], "octocat  src/x.rs:9  unresolved");
+        assert_eq!(t[1], "needs a test");
+    }
+
+    #[test]
+    fn pane_ignores_unknown_kinds_and_blocks_take_precedence() {
+        // Unknown kind drops out; blocks win over a stray title/body.
+        let snap = pane_snapshot(pane_entry(json!({
+            "title": "ignored",
+            "blocks": [
+                {"kind": "some-future-kind", "whatever": true},
+                {"kind": "heading", "text": "kept"}
+            ]
+        })));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        assert_eq!(texts(&lines), vec!["kept"]);
+    }
+
+    #[test]
+    fn pane_skips_blocks_missing_required_fields_without_panicking() {
+        let snap = pane_snapshot(pane_entry(json!({"blocks": [
+            {"kind": "heading"},
+            {"kind": "row"},
+            {"kind": "comment"},
+            {"kind": "note", "text": "  "}
+        ]})));
+        let lines = pane_lines(&snap, "s1", &Theme::default());
+        assert!(lines.is_empty());
     }
 }

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -16,6 +16,10 @@ pub enum Focus {
     Composer,
     Transcript,
     Approval,
+    /// The plugin pane panel is open (#2467). A modal read-only overlay: it
+    /// owns the keyboard while up, scrolls with the transcript keys, and
+    /// closes back to `Transcript`. Opened with `p` from the transcript.
+    Pane,
 }
 
 /// What the input dispatcher decided to do with this key. The view
@@ -128,6 +132,7 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
             transcript_keys(key, ctx.has_pending_approval, ctx.has_pending_elicitation)
         }
         Focus::Approval => approval_keys(key),
+        Focus::Pane => pane_keys(key),
     }
 }
 
@@ -260,6 +265,30 @@ fn transcript_keys(
         (m, KeyCode::Char('G')) if m.contains(KeyModifiers::SHIFT) => Intent::Scroll(i32::MAX),
         // Plain 'o' opens browser only when transcript is focused.
         (m, KeyCode::Char('o')) if m.is_empty() => Intent::OpenInBrowser,
+        // Plain 'p' opens the plugin pane panel. Transcript-only (like 'o'),
+        // so typing 'p' in the composer never opens it.
+        (m, KeyCode::Char('p')) if m.is_empty() => Intent::SetFocus(Focus::Pane),
+        _ => Intent::Ignore,
+    }
+}
+
+/// Keys while the plugin pane panel is open. Scrolls with the same vocabulary
+/// as the transcript (`Intent::Scroll`, routed to the pane by the view layer);
+/// `Esc` / `p` close it, `Tab` jumps to the composer. The universal
+/// `Ctrl-c/o/x` handled at the top of `dispatch` still apply.
+fn pane_keys(key: &KeyEvent) -> Intent {
+    match (key.modifiers, key.code) {
+        (m, KeyCode::Esc) if m.is_empty() => Intent::SetFocus(Focus::Transcript),
+        (m, KeyCode::Char('p')) if m.is_empty() => Intent::SetFocus(Focus::Transcript),
+        (m, KeyCode::Tab) if m.is_empty() => Intent::SetFocus(Focus::Composer),
+        (m, KeyCode::Char('j')) if m.is_empty() => Intent::Scroll(1),
+        (m, KeyCode::Char('k')) if m.is_empty() => Intent::Scroll(-1),
+        (m, KeyCode::Down) if m.is_empty() => Intent::Scroll(1),
+        (m, KeyCode::Up) if m.is_empty() => Intent::Scroll(-1),
+        (m, KeyCode::PageDown) if m.is_empty() => Intent::Scroll(10),
+        (m, KeyCode::PageUp) if m.is_empty() => Intent::Scroll(-10),
+        (m, KeyCode::Char('g')) if m.is_empty() => Intent::Scroll(i32::MIN),
+        (m, KeyCode::Char('G')) if m.contains(KeyModifiers::SHIFT) => Intent::Scroll(i32::MAX),
         _ => Intent::Ignore,
     }
 }
@@ -372,6 +401,65 @@ mod tests {
             dispatch(Focus::Approval, &key(KeyCode::Char('d')), ctx_pending()),
             Intent::ResolveApproval(ApprovalDecisionWire::Deny)
         ));
+    }
+
+    #[test]
+    fn transcript_p_opens_pane_but_composer_p_types() {
+        assert_eq!(
+            dispatch(Focus::Transcript, &key(KeyCode::Char('p')), ctx()),
+            Intent::SetFocus(Focus::Pane)
+        );
+        // In the composer, 'p' is ordinary text, never a pane toggle.
+        assert!(matches!(
+            dispatch(Focus::Composer, &key(KeyCode::Char('p')), ctx()),
+            Intent::Compose(_)
+        ));
+    }
+
+    #[test]
+    fn pane_keys_scroll_and_close() {
+        assert_eq!(
+            dispatch(Focus::Pane, &key(KeyCode::Char('j')), ctx()),
+            Intent::Scroll(1)
+        );
+        assert_eq!(
+            dispatch(Focus::Pane, &key(KeyCode::Up), ctx()),
+            Intent::Scroll(-1)
+        );
+        assert_eq!(
+            dispatch(
+                Focus::Pane,
+                &key_mod(KeyCode::Char('G'), KeyModifiers::SHIFT),
+                ctx()
+            ),
+            Intent::Scroll(i32::MAX)
+        );
+        // Esc and 'p' close back to the transcript; Tab jumps to the composer.
+        assert_eq!(
+            dispatch(Focus::Pane, &key(KeyCode::Esc), ctx()),
+            Intent::SetFocus(Focus::Transcript)
+        );
+        assert_eq!(
+            dispatch(Focus::Pane, &key(KeyCode::Char('p')), ctx()),
+            Intent::SetFocus(Focus::Transcript)
+        );
+        assert_eq!(
+            dispatch(Focus::Pane, &key(KeyCode::Tab), ctx()),
+            Intent::SetFocus(Focus::Composer)
+        );
+    }
+
+    #[test]
+    fn pane_focus_keeps_universal_cancel() {
+        // The pane is modal but must not trap the universal Ctrl-c interrupt.
+        assert_eq!(
+            dispatch(
+                Focus::Pane,
+                &key_mod(KeyCode::Char('c'), KeyModifiers::CONTROL),
+                ctx()
+            ),
+            Intent::CancelInFlight
+        );
     }
 
     fn ctx_pending_elicitation() -> InputContext {

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -451,6 +451,10 @@ async fn handle_terminal_event(
             } else {
                 focus
             };
+            // Opening the pane panel starts from the top each time.
+            if matches!(state.focus, Focus::Pane) {
+                state.pane_scroll = 0;
+            }
             // Leaving the composer ends any queue-recall browse; the
             // in-progress text stays put as a draft.
             if state.focus != Focus::Composer {
@@ -591,7 +595,13 @@ async fn handle_terminal_event(
             Ok(false)
         }
         Intent::Scroll(delta) => {
-            apply_scroll(state, delta);
+            // The pane panel and the transcript share the scroll keys; route by
+            // which one is focused.
+            if matches!(state.focus, Focus::Pane) {
+                apply_pane_scroll(state, delta);
+            } else {
+                apply_scroll(state, delta);
+            }
             Ok(false)
         }
         Intent::ResolveApproval(decision) => {
@@ -888,6 +898,21 @@ fn apply_scroll(state: &mut StructuredViewState, delta: i32) {
         state.scroll_offset = state.scroll_offset.saturating_sub((-delta) as u16);
     } else {
         state.scroll_offset = state.scroll_offset.saturating_add(delta as u16);
+    }
+}
+
+/// Scroll the plugin pane panel. `u16::MAX` is the bottom sentinel (the
+/// renderer clamps it to the content height), mirroring the transcript's
+/// stick-to-bottom convention.
+fn apply_pane_scroll(state: &mut StructuredViewState, delta: i32) {
+    if delta == i32::MIN {
+        state.pane_scroll = 0;
+    } else if delta == i32::MAX {
+        state.pane_scroll = u16::MAX;
+    } else if delta < 0 {
+        state.pane_scroll = state.pane_scroll.saturating_sub((-delta) as u16);
+    } else {
+        state.pane_scroll = state.pane_scroll.saturating_add(delta as u16);
     }
 }
 

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -52,6 +52,64 @@ pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredVi
     } else if state.mention.is_some() {
         render_mention_picker(frame, chunks[3], theme, state);
     }
+    // The plugin pane panel is a modal overlay drawn over everything when open
+    // (#2467); it owns the keyboard while up, so nothing else needs to coexist.
+    if matches!(state.focus, Focus::Pane) {
+        render_pane_panel(frame, area, theme, state);
+    }
+}
+
+/// The plugin pane panel (#2467): a read-only overlay showing the open session's
+/// `pane` entries. Anchored to the right half on a wide terminal, full width on
+/// a narrow one. Scrolls by logical line; the scroll offset is clamped here to
+/// the content height so `G` (bottom) and overscroll land on the last screen.
+fn render_pane_panel(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
+    let panel = if area.width >= 100 {
+        let half = area.width / 2;
+        Rect {
+            x: area.x + (area.width - half),
+            y: area.y,
+            width: half,
+            height: area.height,
+        }
+    } else {
+        area
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .title(" Plugin pane (j/k=scroll · Esc=close) ")
+        .border_style(Style::default().fg(theme.title));
+    let inner = block.inner(panel);
+    frame.render_widget(Clear, panel);
+    frame.render_widget(block, panel);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    let lines = plugin_ui::pane_lines(&state.plugin_ui, &state.session_id, theme);
+    if lines.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "No plugin pane for this session.",
+                Style::default().fg(theme.dimmed),
+            ))),
+            inner,
+        );
+        return;
+    }
+    // Logical-line scroll: a single long block that wraps past the viewport
+    // scrolls as one unit. Acceptable for a read-only first pass; visual-line
+    // scroll can come later if it bites.
+    let height = visual_line_count(&lines, inner.width);
+    let max_scroll = height.saturating_sub(inner.height);
+    let offset = state.pane_scroll.min(max_scroll);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .scroll((offset, 0)),
+        inner,
+    );
 }
 
 /// Up to this many queued prompts are previewed in the strip; the rest
@@ -1031,8 +1089,11 @@ fn help_hint(focus: Focus) -> &'static str {
         Focus::Composer => {
             " Enter=send · Shift+Enter=newline · /=commands · Esc=back · Ctrl-C=cancel "
         }
-        Focus::Transcript => " j/k=scroll · i=compose · Tab=approvals · o=browser · Esc=exit ",
+        Focus::Transcript => {
+            " j/k=scroll · i=compose · Tab=approvals · p=plugin pane · o=browser · Esc=exit "
+        }
         Focus::Approval => " a=allow · A=always · d=deny · Esc=back ",
+        Focus::Pane => " j/k=scroll · g/G=top/bottom · Tab=compose · Esc/p=close ",
     }
 }
 

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -86,6 +86,10 @@ pub struct StructuredViewState {
     /// Notification bookkeeping so each `ui.notify` toasts once. See
     /// [`PluginNotifyState`].
     pub plugin_notify: PluginNotifyState,
+    /// Vertical scroll of the plugin pane panel (#2467), in logical lines.
+    /// `u16::MAX` sticks to the bottom; the renderer clamps it to the content
+    /// height. Reset to 0 each time the panel is opened.
+    pub pane_scroll: u16,
 }
 
 /// Tracks which plugin notifications have been shown and buffers any awaiting
@@ -186,6 +190,7 @@ impl StructuredViewState {
                 notifications: Vec::new(),
             },
             plugin_notify: PluginNotifyState::default(),
+            pane_scroll: 0,
         }
     }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured-view TUI did not render the `pane` plugin UI slot, so a plugin whose only surface is a pane (the GitHub plugin's PR panel today) showed nothing in the native TUI even when attached to a daemon, while it rendered fully on the web dashboard. The host backend and the `GET /api/plugins/ui-state` snapshot already carry pane entries, and the structured view already polls that snapshot, so this is rendering only.

This adds a read-only pane panel, toggled with `p` from the transcript. It is a modal overlay (`Focus::Pane`) anchored to the right half on a wide terminal, full width on a narrow one. It renders the known block kinds (`heading`, `row`, `note`, `divider`, `section`, `comment`) and the simple `{ title, body }` form via a new pure `pane_lines` renderer that mirrors the web `PluginSlots` renderer, narrowed to what a terminal shows (text and tone only; icons, hrefs, and tooltips are dropped, matching the existing #2402 slots). `action` blocks render as inert labels; firing them is the #2467 scope-2 follow-up. Unknown block kinds and malformed blocks render nothing rather than failing, so a newer plugin can push kinds this host has not heard of.

While the panel is open it reuses the transcript scroll keys (routed by focus), `g`/`G` jump to top and bottom, `Esc`/`p` close back to the transcript, and `Tab` jumps to the composer. The universal `Ctrl-c`/`Ctrl-o`/`Ctrl-x` interrupts still apply. Composer typing is unaffected: `p` is intercepted only in transcript and pane focus. Out of scope (per the issue): interactive action firing, the standalone non-daemon home screen, and dock/move/activity-bar affordances.

Closes #2467

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Attach the native structured view to a daemon running a plugin that pushes a `pane` (e.g. the GitHub plugin's PR panel) for the open session.
- [ ] From the transcript, press `p`: a "Plugin pane" panel opens on the right, showing the pane's blocks (headings, rows, comments, dividers, sections).
- [ ] Scroll the panel with `j`/`k` or the arrow keys; `g` jumps to the top, `G` to the bottom.
- [ ] Press `Esc` (or `p` again) to close it; press `Tab` from the panel to jump to the composer.
- [ ] With no plugin pane for the session, press `p`: the panel shows "No plugin pane for this session."
- [ ] Confirm an `action` block renders as an inert `[action] <label>` line (not yet fireable).
- [ ] Confirm typing `p` in the composer inserts the letter and never opens the panel.
- [ ] While the panel is open, press `Ctrl-c`: an in-flight prompt still cancels.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Skipped a full e2e, because: the new logic is the pure `pane_lines` block-to-lines renderer and the input dispatch, both unit-tested directly (block kinds, nested sections, comments, unknown/malformed blocks skipped, session-exact filtering, plus `p` toggle, pane scroll keys, and the universal-cancel guarantee). A live-daemon e2e for a read-only toggle overlay would be high cost for low marginal coverage over those unit tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. A `/debate` between two models settled the design (modal `Focus::Pane` over a separate open flag, transcript `p` over a universal `Ctrl-p`, rendering `comment` blocks since the GitHub PR panel relies on them). I reviewed each commit, made the design calls, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785196333&installation_id=139138837&pr_number=2503&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2503&signature=310eb4e988be52bb6f75b8456d23b0e6667c4d60761b3d50ed0f1bf84da4469d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds native TUI support for plugin pane content in the structured view. Pane-only plugins can now appear in a read-only overlay panel opened with `p`, instead of showing up empty in the terminal UI.

It also updates the pane rendering rules so the TUI can display the same core content types as the web view, including headings, rows, notes, dividers, sections, comments, and simple title/body content. Action items are shown as non-clickable labels, and unknown content is safely ignored.

The new panel behaves like a modal: it can be scrolled, opened and closed from the transcript, and moved to the composer with `Tab`. Supporting state, focus handling, rendering, and documentation were updated, and tests were added for the pane-to-lines rendering behavior.

Benefits:
- Makes pane-based plugins visible in the native TUI
- Keeps behavior read-only and safe
- Matches web dashboard content more closely
- Preserves existing transcript and composer flows

Technical:
- Added a pure `pane_lines()` renderer
- Introduced `Focus::Pane` and pane-specific key handling
- Added pane scroll state and overlay rendering
- Expanded unit coverage for pane block rendering and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->