### PR TITLE
feat(plugin): expose archived/snoozed flags on sessions.list

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -490,6 +490,13 @@ that loses returns the current value rather than clobbering it. Writes go
 through `Storage`'s cross-process lock, so the daemon picks them up on its next
 session reload (eventual consistency, not a live push).
 
+`sessions.list` returns one entry per session with `id`, `title`,
+`project_path`, `tool`, `status` (the run-state), and two inactivity flags:
+`archived` (the session is archived) and `snoozed` (it has a snooze deadline
+still in the future; a past deadline reports `false`). The call never filters
+server-side, so a worker that should ignore dormant sessions, for example to
+avoid spending API quota on them, checks these flags itself.
+
 `config.get { key }` returns the value at `plugins.<plugin-id>.settings.<key>`
 for the calling plugin's own id, so a worker reads back the settings the user
 edited on the TUI/web surfaces, falling back to its own default when the key is

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -438,6 +438,8 @@ fn sessions_list(state: &HostApiState) -> Result<Value, DispatchError> {
                 "project_path": i.project_path,
                 "tool": i.tool,
                 "status": format!("{:?}", i.status),
+                "archived": i.is_archived(),
+                "snoozed": i.is_snoozed(),
             })
         })
         .collect();
@@ -766,10 +768,79 @@ mod tests {
         .unwrap();
         assert_eq!(other["value"], json!(null));
 
-        // sessions.list surfaces the seeded session.
+        // sessions.list surfaces the seeded session; an active session reports
+        // neither archived nor snoozed.
         let list = dispatch(&state, &a, "sessions.list", &json!({})).unwrap();
         let sessions = list["sessions"].as_array().unwrap();
-        assert!(sessions.iter().any(|s| s["id"] == json!(session_id)));
+        let seeded = sessions
+            .iter()
+            .find(|s| s["id"] == json!(session_id))
+            .unwrap();
+        assert_eq!(seeded["archived"], json!(false));
+        assert_eq!(seeded["snoozed"], json!(false));
+    }
+
+    /// `sessions.list` exposes the archive/snooze state per entry so a worker can
+    /// skip inactive sessions. A past snooze deadline reports `snoozed: false`
+    /// (snooze is deadline-based; only a future deadline counts as active).
+    #[test]
+    #[serial_test::serial]
+    fn sessions_list_exposes_archived_and_snoozed_flags() {
+        use crate::session::{Instance, Storage};
+
+        struct XdgGuard(Option<std::ffi::OsString>);
+        impl Drop for XdgGuard {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let _xdg = XdgGuard(std::env::var_os("XDG_CONFIG_HOME"));
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+
+        let storage = Storage::new_unwatched("default").unwrap();
+        let (archived_id, future_id, past_id) = storage
+            .update(|instances, _groups| {
+                let mut archived = Instance::new("archived", "/tmp/plugin-host-test");
+                archived.archived_at = Some(chrono::Utc::now());
+                let archived_id = archived.id.clone();
+
+                let mut future = Instance::new("future-snooze", "/tmp/plugin-host-test");
+                future.snoozed_until = Some(chrono::Utc::now() + chrono::Duration::hours(1));
+                let future_id = future.id.clone();
+
+                let mut past = Instance::new("past-snooze", "/tmp/plugin-host-test");
+                past.snoozed_until = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+                let past_id = past.id.clone();
+
+                instances.push(archived);
+                instances.push(future);
+                instances.push(past);
+                Ok((archived_id, future_id, past_id))
+            })
+            .unwrap();
+
+        let state =
+            HostApiState::open(&tmp.path().join("plugin_events.db"), "default", 100).unwrap();
+        let a = ctx(&[CAP_SESSION_READ]);
+
+        let list = dispatch(&state, &a, "sessions.list", &json!({})).unwrap();
+        let sessions = list["sessions"].as_array().unwrap();
+        let by_id = |id: &str| sessions.iter().find(|s| s["id"] == json!(id)).unwrap();
+
+        assert_eq!(by_id(&archived_id)["archived"], json!(true));
+        assert_eq!(by_id(&archived_id)["snoozed"], json!(false));
+
+        assert_eq!(by_id(&future_id)["snoozed"], json!(true));
+        assert_eq!(by_id(&future_id)["archived"], json!(false));
+
+        // A snooze deadline in the past is inactive.
+        assert_eq!(by_id(&past_id)["snoozed"], json!(false));
+        assert_eq!(by_id(&past_id)["archived"], json!(false));
     }
 
     /// `config.get` reads the calling plugin's own persisted settings, gated by


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`sessions.list` (the plugin host API) returned only `id`, `title`, `project_path`, `tool`, and `status` per session, where `status` is the run-state. The archive and snooze state (`Instance.archived_at`, `Instance.snoozed_until`) was never exposed, so a worker enumerating sessions could not tell which were dormant and ended up polling them (for example plugin-github spending GitHub rate-limit quota on archived/snoozed sessions).

This adds two additive boolean flags per entry, reusing the existing `Instance::is_archived()` and `is_snoozed()` helpers so the semantics match the rest of the codebase:

- `archived`: `archived_at.is_some()`
- `snoozed`: the snooze deadline is still in the future; a past deadline reports `false`.

The call still never filters server-side, since `sessions.list` is a general API and other consumers may want all sessions; each worker decides what to skip. The host-API doc gains one paragraph describing the entry shape and flags.

Closes #2504

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Archive a session, have a plugin worker call `sessions.list`, confirm that session's entry reports `"archived": true`.
- [ ] Snooze a session into the future, confirm its entry reports `"snoozed": true`.
- [ ] Let a snooze deadline pass (or seed one in the past), confirm the entry reports `"snoozed": false`.
- [ ] Confirm an active session reports both flags `false` and the existing fields (`id`, `title`, `project_path`, `tool`, `status`) are unchanged.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This change is to the plugin host API (`src/plugin/host_api.rs`); it is covered by a new unit test in that module's test mod (`sessions_list_exposes_archived_and_snoozed_flags`) that seeds an archived, a future-snoozed, and a past-snoozed instance and asserts the flags, including a past snooze reporting `false`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed the commit, made the design calls, and ran the test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785200395&installation_id=139138837&pr_number=2505&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2505&signature=d0420e5e2eb491b607ce1c6b2a9659ad90d4b750cdba3c385028e58988dc62d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change makes session listings more informative by adding two new flags that show whether a session is archived or snoozed. The host API now returns these alongside the existing session details, and the documentation was updated to explain the new behavior. The response still includes all sessions, so workers can decide which ones to ignore on their side.

A test update and a new test were added to confirm the new flags work correctly for archived sessions, active future-snoozed sessions, and sessions whose snooze period has already passed.

Benefits: plugins can now avoid wasting effort on dormant sessions, reducing unnecessary polling and quota usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->