### PR TITLE
chore(featured): vet plugin-github v1.3.0

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -32,4 +32,4 @@ source = "gh:agent-of-empires/plugin-github"
 # namespace gate skips it). Dropping the pin downgrades it to community so the
 # reserved-namespace install gate blocks it outright. Fixed in 1.2.0, which
 # builds under `.aoe-build/`.
-versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a" }
+versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a", "1.3.0" = "sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28" }


### PR DESCRIPTION
> **Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds the vetted source-tree hash for `agent-of-empires/plugin-github` **v1.3.0** to the curated index `plugins/featured.toml`. This is a maintainer attestation that the v1.3.0 source tree was reviewed.

Per the per-version map landed in #2392, this is **additive**: the existing `0.1.0` / `1.0.0` / `1.2.0` pins and the `source` are preserved; only `"1.3.0"` is appended to the `versions` map. Verification passes when a fetched tree hashes to any listed version.

### Verification

- Built `./target/debug/aoe` from this repo (`aoe plugin hash` uses the authoritative `integrity::tree_hash`).
- Clean LF checkout of tag `v1.3.0` -> commit `bca10210743f5a148196fb0f07afe2599fce3a9a`.
- `aoe plugin hash` run twice, deterministic:
  ```
  sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28
  ```
- Manifest at v1.3.0 has `runtime.kind = "command"` (release-binary plugins cannot be featured).
- `cargo fmt`, `cargo clippy` clean; `cargo test featured` passes (12 tests), so the index still parses.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: data-only change to a vetted-hash index; covered by `cargo test featured`

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude computed the hash, edited the index, and drafted this PR. Decision to vet v1.3.0 is the maintainer's.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785230652&installation_id=139138837&pr_number=2506&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2506&signature=25484cf9ed462ab5b393c05e469b44612bacb867b2fbc2e79c27f66949551225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added `agent-of-empires.github` v1.3.0 to the featured plugin allowlist in `plugins/featured.toml` by registering its vetted source-tree hash. Existing version pins and source metadata were kept intact. This expands the curated index to recognize the newer release while preserving prior vetted versions.

Benefit: keeps the featured list up to date with a verified release, making it easier to safely include the latest plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->