### PR TITLE
feat(plugin): screenshots and GIFs in the marketplace detail modal

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -18,8 +18,8 @@ mod manifest;
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
-    BuildStep, CommandContribution, KeybindContribution, ManifestError, PluginManifest,
-    RuntimeSpec, Screenshot, SettingContribution, SettingType, StatusContribution,
+    screenshot_path_ok, BuildStep, CommandContribution, KeybindContribution, ManifestError,
+    PluginManifest, RuntimeSpec, Screenshot, SettingContribution, SettingType, StatusContribution,
     ThemeContribution, UiContribution, UiSlot, MAX_SCREENSHOTS,
 };
 

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -19,8 +19,8 @@ pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
     BuildStep, CommandContribution, KeybindContribution, ManifestError, PluginManifest,
-    RuntimeSpec, SettingContribution, SettingType, StatusContribution, ThemeContribution,
-    UiContribution, UiSlot,
+    RuntimeSpec, Screenshot, SettingContribution, SettingType, StatusContribution,
+    ThemeContribution, UiContribution, UiSlot, MAX_SCREENSHOTS,
 };
 
 /// Version of the manifest schema and host API this crate describes.
@@ -30,5 +30,6 @@ pub use manifest::{
 /// 2 when the contribution sections and capability taxonomy were added; 3 when
 /// the `detail-panel` slot became the dockable `pane` slot (with
 /// `default_location`); 4 when the `status` contribution section and the
-/// `aoe_version` host-compatibility field were added.
-pub const API_VERSION: u32 = 4;
+/// `aoe_version` host-compatibility field were added; 5 when the `screenshots`
+/// presentation metadata was added.
+pub const API_VERSION: u32 = 5;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -218,17 +218,17 @@ pub fn screenshot_path_ok(path: &str) -> bool {
         return false;
     }
     // A colon rejects both URL schemes (`https:`) and Windows drive letters
-    // (`C:`); a leading separator rejects absolute paths.
-    if path.starts_with('/') || path.starts_with('\\') || path.contains(':') {
+    // (`C:`); a leading slash rejects absolute paths. Screenshot paths are
+    // repository paths, so they must use `/`, never `\`: a backslash would
+    // survive into the resolved raw URL percent-encoded and 404, so reject it
+    // here to fail fast for the author rather than render a broken image.
+    if path.starts_with('/') || path.contains(':') || path.contains('\\') {
         return false;
     }
     if path.chars().any(char::is_control) {
         return false;
     }
-    if path
-        .split(['/', '\\'])
-        .any(|seg| seg == ".." || seg.is_empty())
-    {
+    if path.split('/').any(|seg| seg == ".." || seg.is_empty()) {
         return false;
     }
     match path.rsplit('.').next() {

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -25,6 +25,12 @@ pub struct PluginManifest {
     #[serde(default)]
     pub description: String,
 
+    /// Screenshots / animated GIFs the plugin ships to illustrate itself in the
+    /// marketplace and detail views. Each `path` is repository-relative;
+    /// presentation only, granting nothing. Requires `api_version >= 5`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub screenshots: Vec<Screenshot>,
+
     /// Resource/effect capabilities the plugin requests. Static contributions
     /// below are NOT listed here; only runtime resource access is. The user
     /// grants these once at install (community plugins); builtins are
@@ -172,6 +178,66 @@ pub struct StatusContribution {
     /// Human-readable text shown in the status surface.
     #[serde(default)]
     pub label: String,
+}
+
+/// Maximum screenshots a manifest may declare. A cap keeps the detail modal
+/// usable and the manifest from ballooning; the lenient detail parser truncates
+/// to the same bound.
+pub const MAX_SCREENSHOTS: usize = 8;
+
+/// Image extensions a screenshot `path` may use. The host renders each in an
+/// `<img>`, so this is the raster/animated set a browser shows inline; SVG is
+/// deliberately excluded (it can embed external references).
+const SCREENSHOT_EXTENSIONS: [&str; 5] = ["png", "jpg", "jpeg", "gif", "webp"];
+
+/// A screenshot or animated GIF a plugin ships to illustrate itself. `path` is
+/// repository-relative (resolved against the plugin's source repo by the detail
+/// endpoint); absolute URLs are rejected so opening a detail modal cannot issue
+/// author-chosen third-party requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Screenshot {
+    /// Repository-relative path to a PNG/JPEG/GIF/WebP asset in the plugin's
+    /// source repo. Not a URL: no scheme, no leading separator, no `..`.
+    pub path: String,
+    /// Accessible description of the image. Required; screenshots are content,
+    /// not decoration.
+    pub alt: String,
+    /// Optional human-visible caption shown beneath the image.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub caption: String,
+}
+
+/// Whether `path` is a clean repository-relative image path usable as a
+/// screenshot: relative (no URL scheme, no drive letter, no leading separator),
+/// no `..` traversal, no empty components, no control characters, bounded
+/// length, and an allowed image extension. Shared by the strict validator and
+/// the lenient detail parser so both agree on what resolves.
+pub fn screenshot_path_ok(path: &str) -> bool {
+    if path.is_empty() || path.len() > 512 {
+        return false;
+    }
+    // A colon rejects both URL schemes (`https:`) and Windows drive letters
+    // (`C:`); a leading separator rejects absolute paths.
+    if path.starts_with('/') || path.starts_with('\\') || path.contains(':') {
+        return false;
+    }
+    if path.chars().any(char::is_control) {
+        return false;
+    }
+    if path
+        .split(['/', '\\'])
+        .any(|seg| seg == ".." || seg.is_empty())
+    {
+        return false;
+    }
+    match path.rsplit('.').next() {
+        Some(ext) if ext != path => {
+            SCREENSHOT_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
+        }
+        // No extension (or a leading-dot dotfile with no extension).
+        _ => false,
+    }
 }
 
 /// A host-rendered UI slot a plugin may push state into (#2366). A closed set,
@@ -596,6 +662,27 @@ impl PluginManifest {
                 format!("status[{i}].id must not be empty"),
             );
         }
+        check(
+            self.screenshots.len() <= MAX_SCREENSHOTS,
+            format!(
+                "at most {MAX_SCREENSHOTS} screenshots are allowed (got {})",
+                self.screenshots.len()
+            ),
+        );
+        for (i, s) in self.screenshots.iter().enumerate() {
+            check(
+                screenshot_path_ok(&s.path),
+                format!(
+                    "screenshots[{i}].path {:?} must be a repository-relative image path \
+                     (png/jpg/jpeg/gif/webp), not a URL or an absolute/traversing path",
+                    s.path
+                ),
+            );
+            check(
+                !s.alt.trim().is_empty(),
+                format!("screenshots[{i}].alt must not be empty"),
+            );
+        }
         // `aoe_version` is the host-app compatibility range, gated by the host
         // at install and load; reject a malformed requirement at parse so the
         // author learns of it before publishing rather than at a user's install.
@@ -618,6 +705,15 @@ impl PluginManifest {
             check(
                 self.aoe_version.is_none(),
                 "aoe_version requires api_version >= 4".into(),
+            );
+        }
+        // `screenshots` is an api_version 5 field; force the bump for the same
+        // reason as the api_version 4 fields above, so a pre-5 host emits the
+        // "upgrade aoe" path rather than a confusing "unknown field" error.
+        if self.api_version < 5 {
+            check(
+                self.screenshots.is_empty(),
+                "screenshots require api_version >= 5".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -770,3 +770,118 @@ fn manifest_hash_is_stable_and_prefixed() {
     assert!(a.starts_with("sha256:"));
     assert_ne!(a, PluginManifest::hash_bytes(b"different"));
 }
+
+#[test]
+fn screenshots_parse_and_round_trip() {
+    let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 5
+
+[[screenshots]]
+path = "docs/screenshots/dashboard.png"
+alt = "Dashboard card"
+caption = "The plugin's dashboard card."
+
+[[screenshots]]
+path = "media/demo.gif"
+alt = "Animated demo"
+"#;
+    let manifest = PluginManifest::from_toml_str(toml).expect("screenshots parse");
+    assert_eq!(manifest.screenshots.len(), 2);
+    assert_eq!(
+        manifest.screenshots[0].path,
+        "docs/screenshots/dashboard.png"
+    );
+    assert_eq!(
+        manifest.screenshots[0].caption,
+        "The plugin's dashboard card."
+    );
+    assert_eq!(manifest.screenshots[1].alt, "Animated demo");
+    assert_eq!(manifest.screenshots[1].caption, "");
+}
+
+#[test]
+fn screenshots_require_api_version_5() {
+    let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 4
+
+[[screenshots]]
+path = "a.png"
+alt = "a"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("screenshots require api_version >= 5"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn screenshots_reject_absolute_url_and_traversal_paths() {
+    for bad in [
+        "https://tracker.example.com/x.png",
+        "/etc/passwd.png",
+        "../secrets.png",
+        "a/../../b.png",
+        "C:/Windows/x.png",
+        "no-extension",
+        "evil.svg",
+    ] {
+        let toml = format!(
+            r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 5
+
+[[screenshots]]
+path = "{bad}"
+alt = "x"
+"#
+        );
+        let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+        assert!(
+            matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("must be a repository-relative image path"))),
+            "path {bad:?} should be rejected, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn screenshots_reject_empty_alt() {
+    let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 5
+
+[[screenshots]]
+path = "a.png"
+alt = "   "
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("alt must not be empty"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn screenshots_reject_too_many() {
+    let entries = (0..9)
+        .map(|i| format!("[[screenshots]]\npath = \"s{i}.png\"\nalt = \"s{i}\"\n"))
+        .collect::<String>();
+    let toml = format!(
+        "id = \"acme.widget\"\nname = \"Widget\"\nversion = \"0.1.0\"\napi_version = 5\n\n{entries}"
+    );
+    let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("at most 8 screenshots"))),
+        "got {err:?}"
+    );
+}

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -885,3 +885,23 @@ fn screenshots_reject_too_many() {
         "got {err:?}"
     );
 }
+
+#[test]
+fn screenshot_path_ok_rejects_backslash_and_bad_shapes() {
+    use aoe_plugin_api::screenshot_path_ok;
+    assert!(screenshot_path_ok("docs/shot.png"));
+    assert!(screenshot_path_ok("a/b/c.gif"));
+    for bad in [
+        "docs\\shot.png",
+        "..\\x.png",
+        "C:\\x.png",
+        "/abs.png",
+        "https://x/y.png",
+        "a/../b.png",
+        "noext",
+        "evil.svg",
+        "",
+    ] {
+        assert!(!screenshot_path_ok(bad), "{bad:?} should be rejected");
+    }
+}

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -23,6 +23,26 @@ contribution section from a future schema is a hard error today) and validates
 (`api_version` in range, non-empty `name`/`version`). `API_VERSION` is the
 schema/host version this crate understands.
 
+### Screenshots
+
+A plugin may declare up to eight `[[screenshots]]` to illustrate itself in the
+dashboard marketplace and detail modal (requires `api_version >= 5`):
+
+```toml
+[[screenshots]]
+path = "docs/screenshots/dashboard.png"  # repository-relative; not a URL
+alt = "Dashboard card the plugin contributes"  # required, for accessibility
+caption = "Live status card."  # optional, shown beneath the image
+```
+
+`path` must be a repository-relative image (`png`/`jpg`/`jpeg`/`gif`/`webp`):
+absolute URLs, absolute or `..`-traversing paths, and other extensions are
+rejected. The plugin detail endpoint resolves each path against the source
+repo's `raw.githubusercontent.com` (honoring the installed ref, else `HEAD`),
+so the browser fetches the asset directly; AoE never proxies image bytes. The
+assets must be committed and pushed to the source repo before they render; a
+local plugin's screenshots are not served (a follow-up, see #2484).
+
 ## Registry
 
 `src/plugin/registry.rs` owns the in-process registry.

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -40,8 +40,11 @@ absolute URLs, absolute or `..`-traversing paths, and other extensions are
 rejected. The plugin detail endpoint resolves each path against the source
 repo's `raw.githubusercontent.com` (honoring the installed ref, else `HEAD`),
 so the browser fetches the asset directly; AoE never proxies image bytes. The
-assets must be committed and pushed to the source repo before they render; a
-local plugin's screenshots are not served (a follow-up, see #2484).
+endpoint silently drops any screenshot whose path or alt text fails validation
+rather than failing the whole detail response, so one bad entry omits only that
+image. The assets must be committed and pushed to the source repo before they
+render; local plugins do not support screenshots yet (future work beyond
+#2484).
 
 ## Registry
 

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -13,9 +13,32 @@
 use std::time::Duration;
 
 use anyhow::{bail, Result};
+use aoe_plugin_api::{screenshot_path_ok, MAX_SCREENSHOTS};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use serde::{Deserialize, Serialize};
 
 use crate::github::{GitHubClient, GitHubClientConfig, GitHubRepo, DEFAULT_USER_AGENT};
+
+/// Characters to percent-encode in a `raw.githubusercontent.com` path while
+/// keeping `/` (segment separators) and the unreserved set intact. The path is
+/// already structurally validated by [`screenshot_path_ok`]; this guards the
+/// remaining URL-unsafe bytes (spaces, `?`, `#`, `%`, ...).
+const RAW_PATH: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}')
+    .add(b'|')
+    .add(b'^')
+    .add(b'\\')
+    .add(b'[')
+    .add(b']');
 
 use super::featured::FeaturedIndex;
 use super::source::PluginSource;
@@ -175,12 +198,40 @@ pub struct DetailManifest {
     pub api_version: u32,
     pub capabilities: Vec<String>,
     pub ui_contributions: Vec<UiSlotView>,
+    /// Screenshot/GIF previews, each resolved to a browser-fetchable URL on
+    /// `raw.githubusercontent.com`. Author-declared paths that fail validation
+    /// are dropped here rather than failing the whole detail.
+    pub screenshots: Vec<ScreenshotView>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct UiSlotView {
     pub slot: String,
     pub id: String,
+}
+
+/// A screenshot resolved for the detail modal: `src` is a fully-qualified
+/// `raw.githubusercontent.com` URL the browser fetches directly.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScreenshotView {
+    pub src: String,
+    pub alt: String,
+    pub caption: String,
+}
+
+/// Build the `raw.githubusercontent.com` URL for a repository-relative path.
+/// `reference` defaults to `HEAD` (the repo's default branch) when the source
+/// is unpinned. The path is already validated by [`screenshot_path_ok`]; this
+/// only percent-encodes the remaining URL-unsafe bytes per segment.
+fn raw_url(owner: &str, repo: &str, reference: Option<&str>, path: &str) -> String {
+    let reference = reference.unwrap_or("HEAD");
+    format!(
+        "https://raw.githubusercontent.com/{}/{}/{}/{}",
+        utf8_percent_encode(owner, RAW_PATH),
+        utf8_percent_encode(repo, RAW_PATH),
+        utf8_percent_encode(reference, RAW_PATH),
+        utf8_percent_encode(path, RAW_PATH),
+    )
 }
 
 /// The on-demand detail for one plugin source: its manifest fields plus the
@@ -210,12 +261,24 @@ struct RawManifest {
     capabilities: Vec<String>,
     #[serde(default)]
     ui: Vec<RawUi>,
+    #[serde(default)]
+    screenshots: Vec<RawScreenshot>,
 }
 
 #[derive(Deserialize)]
 struct RawUi {
     slot: String,
     id: String,
+}
+
+#[derive(Deserialize)]
+struct RawScreenshot {
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    alt: String,
+    #[serde(default)]
+    caption: String,
 }
 
 /// Fetch the detail for a `gh:owner/repo` source: its `aoe-plugin.toml` (read
@@ -250,6 +313,20 @@ pub async fn details(source: &str) -> Result<PluginDetail> {
                     .map(|u| UiSlotView {
                         slot: u.slot,
                         id: u.id,
+                    })
+                    .collect(),
+                screenshots: m
+                    .screenshots
+                    .into_iter()
+                    // Drop entries the strict schema would reject (URLs,
+                    // traversing/absolute paths, empty alt) so one bad entry
+                    // never poisons the whole detail; cap at the manifest bound.
+                    .filter(|s| screenshot_path_ok(&s.path) && !s.alt.trim().is_empty())
+                    .take(MAX_SCREENSHOTS)
+                    .map(|s| ScreenshotView {
+                        src: raw_url(owner, repo, reference, &s.path),
+                        alt: s.alt,
+                        caption: s.caption,
                     })
                     .collect(),
             })
@@ -375,6 +452,53 @@ id = "s"
         assert_eq!(m.capabilities, vec!["net"]);
         assert_eq!(m.ui.len(), 1);
         assert_eq!(m.ui[0].slot, "status-bar");
+    }
+
+    #[test]
+    fn raw_url_defaults_to_head_and_encodes_path() {
+        assert_eq!(
+            raw_url("acme", "widget", None, "docs/shots/a.png"),
+            "https://raw.githubusercontent.com/acme/widget/HEAD/docs/shots/a.png"
+        );
+        // A pinned ref is honored; spaces in a path are percent-encoded while
+        // the `/` separators survive.
+        assert_eq!(
+            raw_url("acme", "widget", Some("v1.2.0"), "media/cool demo.gif"),
+            "https://raw.githubusercontent.com/acme/widget/v1.2.0/media/cool%20demo.gif"
+        );
+    }
+
+    #[test]
+    fn detail_manifest_parses_screenshots_and_drops_bad_entries() {
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 5
+
+[[screenshots]]
+path = "docs/a.png"
+alt = "good"
+
+[[screenshots]]
+path = "https://tracker.example.com/x.png"
+alt = "bad url"
+
+[[screenshots]]
+path = "docs/b.png"
+alt = "   "
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        let kept: Vec<_> = m
+            .screenshots
+            .into_iter()
+            .filter(|s| screenshot_path_ok(&s.path) && !s.alt.trim().is_empty())
+            .map(|s| raw_url("acme", "widget", None, &s.path))
+            .collect();
+        assert_eq!(
+            kept,
+            vec!["https://raw.githubusercontent.com/acme/widget/HEAD/docs/a.png".to_string()]
+        );
     }
 
     #[test]

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -219,6 +219,33 @@ pub struct ScreenshotView {
     pub caption: String,
 }
 
+/// Resolve a manifest's raw screenshots into browser-fetchable views. Gated on
+/// `api_version >= 5` to mirror [`aoe_plugin_api::PluginManifest::validate`], so
+/// the detail modal never shows media for a manifest the install path would
+/// reject; entries that fail [`screenshot_path_ok`] or have empty alt text are
+/// dropped (one bad entry never poisons the whole detail), capped at
+/// [`MAX_SCREENSHOTS`].
+fn resolve_screenshots(
+    api_version: u32,
+    raws: Vec<RawScreenshot>,
+    owner: &str,
+    repo: &str,
+    reference: Option<&str>,
+) -> Vec<ScreenshotView> {
+    if api_version < 5 {
+        return Vec::new();
+    }
+    raws.into_iter()
+        .filter(|s| screenshot_path_ok(&s.path) && !s.alt.trim().is_empty())
+        .take(MAX_SCREENSHOTS)
+        .map(|s| ScreenshotView {
+            src: raw_url(owner, repo, reference, &s.path),
+            alt: s.alt,
+            caption: s.caption,
+        })
+        .collect()
+}
+
 /// Build the `raw.githubusercontent.com` URL for a repository-relative path.
 /// `reference` defaults to `HEAD` (the repo's default branch) when the source
 /// is unpinned. The path is already validated by [`screenshot_path_ok`]; this
@@ -315,20 +342,13 @@ pub async fn details(source: &str) -> Result<PluginDetail> {
                         id: u.id,
                     })
                     .collect(),
-                screenshots: m
-                    .screenshots
-                    .into_iter()
-                    // Drop entries the strict schema would reject (URLs,
-                    // traversing/absolute paths, empty alt) so one bad entry
-                    // never poisons the whole detail; cap at the manifest bound.
-                    .filter(|s| screenshot_path_ok(&s.path) && !s.alt.trim().is_empty())
-                    .take(MAX_SCREENSHOTS)
-                    .map(|s| ScreenshotView {
-                        src: raw_url(owner, repo, reference, &s.path),
-                        alt: s.alt,
-                        caption: s.caption,
-                    })
-                    .collect(),
+                screenshots: resolve_screenshots(
+                    m.api_version,
+                    m.screenshots,
+                    owner,
+                    repo,
+                    reference,
+                ),
             })
             .map_err(|e| format!("aoe-plugin.toml is invalid: {e}")),
         Err(e) => Err(format!("{e}")),
@@ -489,16 +509,32 @@ path = "docs/b.png"
 alt = "   "
 "#;
         let m: RawManifest = toml::from_str(toml).expect("lenient parse");
-        let kept: Vec<_> = m
-            .screenshots
-            .into_iter()
-            .filter(|s| screenshot_path_ok(&s.path) && !s.alt.trim().is_empty())
-            .map(|s| raw_url("acme", "widget", None, &s.path))
-            .collect();
+        let kept = resolve_screenshots(m.api_version, m.screenshots, "acme", "widget", None);
+        assert_eq!(kept.len(), 1);
         assert_eq!(
-            kept,
-            vec!["https://raw.githubusercontent.com/acme/widget/HEAD/docs/a.png".to_string()]
+            kept[0].src,
+            "https://raw.githubusercontent.com/acme/widget/HEAD/docs/a.png"
         );
+    }
+
+    #[test]
+    fn screenshots_gated_out_below_api_version_5() {
+        // A v4 manifest must not surface screenshots in the detail modal, since
+        // the strict install validator rejects them; the lenient detail path
+        // mirrors that gate.
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 4
+
+[[screenshots]]
+path = "docs/a.png"
+alt = "good"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        let kept = resolve_screenshots(m.api_version, m.screenshots, "acme", "widget", None);
+        assert!(kept.is_empty(), "v4 must not expose screenshots");
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1789,10 +1789,12 @@ async fn http_request_span(
 ///   runtime (terminal font-size updates) and Tailwind v4 emits inline
 ///   `<style>` blocks in dev. Blocking inline styles breaks xterm.js's
 ///   rendered viewport.
-/// - `img-src 'self' data: https://github.com https://avatars.githubusercontent.com`:
+/// - `img-src 'self' data: https://github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com`:
 ///   repo-owner avatars are loaded from `github.com/{user}.png` which 302s
 ///   to `avatars.githubusercontent.com`; CSP checks both URLs across the
 ///   redirect, so both hosts must be allowed. `data:` covers inline icons.
+///   `raw.githubusercontent.com` serves plugin screenshots resolved by the
+///   plugin detail endpoint (#2484).
 /// - `font-src 'self'`: Geist fonts are bundled under /fonts/.
 /// - `connect-src 'self' ws: wss:`: REST + PTY WebSocket to same origin.
 /// - `frame-ancestors 'none'`: CSP-native equivalent of X-Frame-Options.
@@ -1801,7 +1803,7 @@ async fn http_request_span(
 const CSP: &str = "default-src 'self'; \
     script-src 'self' 'wasm-unsafe-eval'; \
     style-src 'self' 'unsafe-inline'; \
-    img-src 'self' data: https://github.com https://avatars.githubusercontent.com; \
+    img-src 'self' data: https://github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com; \
     font-src 'self'; \
     connect-src 'self' ws: wss:; \
     frame-ancestors 'none'; \
@@ -5151,7 +5153,7 @@ mod tests {
         for needle in [
             "default-src 'self'",
             "script-src 'self' 'wasm-unsafe-eval'",
-            "img-src 'self' data: https://github.com https://avatars.githubusercontent.com",
+            "img-src 'self' data: https://github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com",
             "connect-src 'self' ws: wss:",
             "frame-ancestors 'none'",
         ] {

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -200,9 +200,11 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
           aria-label={`${zoomed.alt || "Screenshot"} full size`}
           onClick={(e) => {
             // Don't bubble to the modal backdrop (which would close the whole
-            // modal); the lightbox owns this click.
+            // modal); the lightbox owns this click. Dismiss only on a backdrop
+            // click, not when the image itself is clicked, so inspecting the
+            // full-size image does not make it vanish.
             e.stopPropagation();
-            setZoomed(null);
+            if (e.target === e.currentTarget) setZoomed(null);
           }}
           data-testid="plugin-detail-lightbox"
         >

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -33,17 +33,22 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
   const isGithub = source.startsWith("gh:");
   const [detail, setDetail] = useState<PluginDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // The screenshot opened full-size in the lightbox, or null when none is.
+  const [zoomed, setZoomed] = useState<{ src: string; alt: string } | null>(null);
   // Derived, not stored: avoids a synchronous setState in the effect. The modal
   // is remounted per source (keyed at the call site), so this resets each open.
   const loading = isGithub && !detail && !error;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      // Escape closes the lightbox first if it is open, the modal otherwise.
+      if (zoomed) setZoomed(null);
+      else onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [onClose, zoomed]);
 
   useEffect(() => {
     if (!isGithub) return;
@@ -110,18 +115,25 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
           <div className="mb-3 grid gap-3" data-testid="plugin-detail-screenshots">
             {screenshots.map((shot) => (
               <figure key={shot.src} className="overflow-hidden rounded border border-surface-700 bg-surface-950">
-                <img
-                  src={shot.src}
-                  alt={shot.alt}
-                  loading="lazy"
-                  decoding="async"
-                  className="max-h-72 w-full object-contain"
-                  // A moved branch/tag or deleted asset 404s; hide the figure
-                  // rather than leave a broken-image icon.
-                  onError={(e) => {
-                    e.currentTarget.closest("figure")?.classList.add("hidden");
-                  }}
-                />
+                <button
+                  type="button"
+                  className="block w-full cursor-zoom-in"
+                  onClick={() => setZoomed({ src: shot.src, alt: shot.alt })}
+                  aria-label={`View ${shot.alt || "screenshot"} full size`}
+                >
+                  <img
+                    src={shot.src}
+                    alt={shot.alt}
+                    loading="lazy"
+                    decoding="async"
+                    className="max-h-72 w-full object-contain"
+                    // A moved branch/tag or deleted asset 404s; hide the figure
+                    // rather than leave a broken-image icon.
+                    onError={(e) => {
+                      e.currentTarget.closest("figure")?.classList.add("hidden");
+                    }}
+                  />
+                </button>
                 {shot.caption && (
                   <figcaption className="px-2 py-1 text-[11px] text-text-dim">{shot.caption}</figcaption>
                 )}
@@ -179,6 +191,24 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
           </p>
         )}
       </div>
+
+      {zoomed && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${zoomed.alt || "Screenshot"} full size`}
+          onClick={(e) => {
+            // Don't bubble to the modal backdrop (which would close the whole
+            // modal); the lightbox owns this click.
+            e.stopPropagation();
+            setZoomed(null);
+          }}
+          data-testid="plugin-detail-lightbox"
+        >
+          <img src={zoomed.src} alt={zoomed.alt} className="max-h-full max-w-full object-contain" />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -23,11 +23,12 @@ interface PluginDetailModalProps {
   onClose: () => void;
 }
 
-/// A modal showing one plugin's detail: version, description, capabilities, UI
-/// slots, and the available release versions. Opened from a discovery result or
-/// an installed-plugin row. For a gh source it fetches the live manifest +
-/// release tags; for a local source it renders the passed-in fallback fields.
-/// Screenshots and richer metadata are a future addition.
+/// A modal showing one plugin's detail: screenshots, version, description,
+/// capabilities, UI slots, and the available release versions. Opened from a
+/// discovery result or an installed-plugin row. For a gh source it fetches the
+/// live manifest + release tags; for a local source it renders the passed-in
+/// fallback fields. Screenshots come only from the fetched gh manifest (the
+/// server resolves their paths to raw.githubusercontent.com URLs).
 export function PluginDetailModal({ source, title, fallback, installCommand, onClose }: PluginDetailModalProps) {
   const isGithub = source.startsWith("gh:");
   const [detail, setDetail] = useState<PluginDetail | null>(null);
@@ -65,6 +66,9 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
   const description = manifest?.description ?? fallback?.description ?? null;
   const capabilities = manifest?.capabilities ?? fallback?.capabilities ?? [];
   const ui = manifest?.ui_contributions ?? fallback?.ui_contributions ?? [];
+  // Screenshots come only from the fetched gh manifest; a no-media plugin
+  // yields an empty list and renders no gallery chrome.
+  const screenshots = manifest?.screenshots ?? [];
 
   return (
     <div
@@ -100,6 +104,30 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
           <p className="text-xs text-status-error" data-testid="plugin-detail-error">
             {error}
           </p>
+        )}
+
+        {screenshots.length > 0 && (
+          <div className="mb-3 grid gap-3" data-testid="plugin-detail-screenshots">
+            {screenshots.map((shot) => (
+              <figure key={shot.src} className="overflow-hidden rounded border border-surface-700 bg-surface-950">
+                <img
+                  src={shot.src}
+                  alt={shot.alt}
+                  loading="lazy"
+                  decoding="async"
+                  className="max-h-72 w-full object-contain"
+                  // A moved branch/tag or deleted asset 404s; hide the figure
+                  // rather than leave a broken-image icon.
+                  onError={(e) => {
+                    e.currentTarget.closest("figure")?.classList.add("hidden");
+                  }}
+                />
+                {shot.caption && (
+                  <figcaption className="px-2 py-1 text-[11px] text-text-dim">{shot.caption}</figcaption>
+                )}
+              </figure>
+            ))}
+          </div>
         )}
 
         {description && <p className="mb-3 text-text-dim">{description}</p>}

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -419,14 +419,22 @@ describe("PluginsSettings", () => {
     expect(imgs[0].getAttribute("alt")).toBe("Dashboard card");
     expect(imgs[0].getAttribute("loading")).toBe("lazy");
     expect(gallery.textContent).toContain("Live card.");
-    // Clicking a screenshot opens the full-size lightbox; clicking it closes.
+    // Clicking a screenshot opens the full-size lightbox.
     const { findByTestId: findInModal, queryByTestId } = within(document.body);
     fireEvent.click(imgs[0]!);
     const lightbox = await findInModal("plugin-detail-lightbox");
-    expect(lightbox.querySelector("img")?.getAttribute("src")).toBe(
-      "https://raw.githubusercontent.com/acme/widget/HEAD/a.png",
-    );
-    fireEvent.click(lightbox);
+    const bigImg = lightbox.querySelector("img")!;
+    expect(bigImg.getAttribute("src")).toBe("https://raw.githubusercontent.com/acme/widget/HEAD/a.png");
+    // Clicking the image itself does not dismiss; only the backdrop does.
+    fireEvent.click(bigImg);
+    expect(queryByTestId("plugin-detail-lightbox")).not.toBeNull();
+    // Escape closes the lightbox first, leaving the detail modal open.
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => expect(queryByTestId("plugin-detail-lightbox")).toBeNull());
+    expect(queryByTestId("plugin-detail-modal")).not.toBeNull();
+    // Backdrop click also dismisses.
+    fireEvent.click(imgs[0]!);
+    fireEvent.click(await findInModal("plugin-detail-lightbox"));
     await waitFor(() => expect(queryByTestId("plugin-detail-lightbox")).toBeNull());
     // A 404 (moved ref / deleted asset) hides the figure rather than leaving a
     // broken-image icon.
@@ -463,6 +471,14 @@ describe("PluginsSettings", () => {
     // Falls back to the installed view's fields immediately.
     expect(modal.textContent).toContain("v0.1.0");
     fireEvent.click(await findByTestId("plugin-detail-close"));
+    await waitFor(() => expect(queryByTestId("plugin-detail-modal")).toBeNull());
+  });
+
+  it("Escape closes the detail modal when no lightbox is open", async () => {
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-open-example.plugin"));
+    await findByTestId("plugin-detail-modal");
+    fireEvent.keyDown(window, { key: "Escape" });
     await waitFor(() => expect(queryByTestId("plugin-detail-modal")).toBeNull());
   });
 

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -7,7 +7,7 @@
 // shown rather than swallowed.
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor, within } from "@testing-library/react";
 
 import type {
   DiscoverResult,
@@ -419,6 +419,15 @@ describe("PluginsSettings", () => {
     expect(imgs[0].getAttribute("alt")).toBe("Dashboard card");
     expect(imgs[0].getAttribute("loading")).toBe("lazy");
     expect(gallery.textContent).toContain("Live card.");
+    // Clicking a screenshot opens the full-size lightbox; clicking it closes.
+    const { findByTestId: findInModal, queryByTestId } = within(document.body);
+    fireEvent.click(imgs[0]!);
+    const lightbox = await findInModal("plugin-detail-lightbox");
+    expect(lightbox.querySelector("img")?.getAttribute("src")).toBe(
+      "https://raw.githubusercontent.com/acme/widget/HEAD/a.png",
+    );
+    fireEvent.click(lightbox);
+    await waitFor(() => expect(queryByTestId("plugin-detail-lightbox")).toBeNull());
     // A 404 (moved ref / deleted asset) hides the figure rather than leaving a
     // broken-image icon.
     fireEvent.error(imgs[0]!);

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -419,6 +419,10 @@ describe("PluginsSettings", () => {
     expect(imgs[0].getAttribute("alt")).toBe("Dashboard card");
     expect(imgs[0].getAttribute("loading")).toBe("lazy");
     expect(gallery.textContent).toContain("Live card.");
+    // A 404 (moved ref / deleted asset) hides the figure rather than leaving a
+    // broken-image icon.
+    fireEvent.error(imgs[0]!);
+    expect(imgs[0]!.closest("figure")!.className).toContain("hidden");
   });
 
   it("separates installed management from the marketplace into tabs", async () => {

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -364,6 +364,7 @@ describe("PluginsSettings", () => {
           api_version: 4,
           capabilities: ["net"],
           ui_contributions: [{ slot: "status-bar", id: "s" }],
+          screenshots: [],
         },
         manifest_error: null,
         release_tags: ["v2.3.0", "v2.2.0"],
@@ -379,6 +380,45 @@ describe("PluginsSettings", () => {
     expect(modal.textContent).toContain("net");
     const versions = await findByTestId("plugin-detail-versions");
     expect(versions.textContent).toContain("v2.2.0");
+    // No screenshots in the manifest: no gallery chrome.
+    expect(modal.querySelector("[data-testid='plugin-detail-screenshots']")).toBeNull();
+  });
+
+  it("renders a screenshot gallery when the manifest declares screenshots", async () => {
+    fetchPluginDetails.mockResolvedValue({
+      kind: "ok",
+      detail: {
+        source: "gh:acme/widget",
+        manifest: {
+          id: "acme.widget",
+          name: "Widget",
+          version: "2.3.0",
+          description: "A widget plugin.",
+          api_version: 5,
+          capabilities: [],
+          ui_contributions: [],
+          screenshots: [
+            {
+              src: "https://raw.githubusercontent.com/acme/widget/HEAD/a.png",
+              alt: "Dashboard card",
+              caption: "Live card.",
+            },
+            { src: "https://raw.githubusercontent.com/acme/widget/HEAD/b.gif", alt: "Demo", caption: "" },
+          ],
+        },
+        manifest_error: null,
+        release_tags: [],
+      },
+    });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-open-example.plugin"));
+    const gallery = await findByTestId("plugin-detail-screenshots");
+    const imgs = gallery.querySelectorAll("img");
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0].getAttribute("src")).toBe("https://raw.githubusercontent.com/acme/widget/HEAD/a.png");
+    expect(imgs[0].getAttribute("alt")).toBe("Dashboard card");
+    expect(imgs[0].getAttribute("loading")).toBe("lazy");
+    expect(gallery.textContent).toContain("Live card.");
   });
 
   it("separates installed management from the marketplace into tabs", async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -316,6 +316,8 @@ export interface PluginDetailManifest {
   api_version: number;
   capabilities: string[];
   ui_contributions: { slot: string; id: string }[];
+  /** Screenshot/GIF previews, each resolved server-side to a raw.githubusercontent.com URL. */
+  screenshots: { src: string; alt: string; caption: string }[];
 }
 
 /** On-demand detail for one plugin source (`GET /api/plugins/details`): manifest


### PR DESCRIPTION
> **Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Plugin authors can now declare screenshots / GIFs in `aoe-plugin.toml`, and the web dashboard renders them in the plugin detail modal, so a UI-heavy plugin is no longer reduced to plain text while browsing the marketplace.

A new `[[screenshots]]` list (`path`, `alt`, optional `caption`) is added to the manifest, gated behind a new `api_version 5`. `path` is repository-relative and validated: absolute URLs, absolute or `..`-traversing paths, non-image extensions, empty `alt`, and more than eight entries are rejected. Rejecting URLs is deliberate; allowing an author-supplied absolute URL would let opening the modal harvest a viewer's IP from an arbitrary third party. Presentation metadata only, it grants nothing.

`GET /api/plugins/details` parses the screenshots and resolves each repository-relative path to a `raw.githubusercontent.com` URL (honoring the installed ref, else `HEAD`), dropping any entry the strict schema would reject so one bad path never poisons the whole detail. The browser fetches the assets directly; AoE never proxies image bytes. `raw.githubusercontent.com` is added to the dashboard CSP `img-src`.

The detail modal shows the gallery above the description; images lazy-load and hide themselves on a 404 (moved ref / deleted asset), so a plugin with no screenshots renders exactly as before with no broken chrome. This is a modal-only first cut: marketplace card thumbnails, local (non-gh) installed-plugin asset serving, and video are deferred. Local-plugin screenshots are not served yet, so authors must push assets to the source repo before they render.

Closes #2484

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Add `screenshots = [{ path, alt, caption }]` (with `api_version = 5`) to a plugin's `aoe-plugin.toml`, commit a PNG/GIF at that path, and push to a public GitHub repo.
- [ ] In the dashboard Plugins settings, open the marketplace, search for that repo, open its detail modal, and confirm the images render above the description.
- [ ] Open a plugin that declares no screenshots and confirm the modal looks exactly as before (no empty gallery, no broken-image icon).
- [ ] Point a screenshot `path` at a file that does not exist, reopen the modal, and confirm the broken image hides itself rather than showing a broken-image icon.
- [ ] Try to install / load a manifest that declares `screenshots` under `api_version = 4` and confirm it is rejected with "screenshots require api_version >= 5".

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test under `web/` (extended the Vitest spec `src/components/settings/__tests__/PluginsSettings.test.tsx`, which the existing `settings.plugins` coverage-matrix entry maps to `PluginDetailModal.tsx`): the modal renders the resolved `<img>` gallery when the manifest has screenshots and shows no gallery chrome when it does not.
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult between two models on the design (which is where rejecting absolute URLs came from). I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785231292&installation_id=139138837&pr_number=2507&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2507&signature=65aa494c50bd8d83ed7a4f7be91e104338cf757395a11a16399664c333b74d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added screenshot/GIF support for plugins across the manifest, server, and dashboard.

- Plugin authors can declare up to 8 `[[screenshots]]` entries (`path`, required `alt`, optional `caption`) in `aoe-plugin.toml`, gated behind `api_version >= 5`.
- The server resolves repository-relative screenshot paths into `raw.githubusercontent.com` URLs in `GET /api/plugins/details`, and filters out invalid screenshot entries (so the rest of the plugin details still load).
- The dashboard’s plugin detail modal now shows a screenshot gallery (above the description) with lazy-loading, a zoomable lightbox, and automatic removal of images that fail to load (e.g., 404).
- Plugins without screenshots continue to render as before.
- Manifests, server behavior, and UI behavior are covered with added validation and contract/unit tests, and internal docs were updated with the new manifest rules.

Benefits:
- Makes marketplace browsing and plugin detail pages more engaging with visual previews.
- Prevents broken configuration from breaking the entire details page by safely skipping invalid media.
- Keeps discovery lightweight by only resolving screenshot media for the on-demand detail view (not during search).

Technical (optional):
- Introduced screenshot types and strict validation in the plugin manifest (`MAX_SCREENSHOTS`, repository-relative path + extension rules, non-empty `alt`, and `api_version` gating) with tests.
- Extended the details response model with server-resolved screenshot URLs.
- Updated dashboard rendering logic (CSP `img-src` allowance for `raw.githubusercontent.com`, lightbox/open/close + error-hiding behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->