### PR TITLE
feat(plugins): install, uninstall, and update plugins from the dashboard

### DIFF
--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -145,7 +145,9 @@ pub enum SettingType {
     /// Free text, rendered as a text input.
     #[default]
     String,
-    /// On/off, rendered as a toggle.
+    /// On/off, rendered as a toggle. Accepts `boolean` too: it is the natural
+    /// spelling next to `integer`, and shipped plugins use it.
+    #[serde(alias = "boolean")]
     Bool,
     /// Integer, rendered as a number input (bounded by `min`/`max`).
     Integer,
@@ -638,6 +640,28 @@ impl PluginManifest {
             Ok(())
         } else {
             Err(ManifestError::Invalid(errors))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setting_type_accepts_boolean_and_bool() {
+        // `boolean` is the natural spelling next to `integer`, and shipped
+        // plugins (plugin-github) use it; both must parse to Bool.
+        for spelling in ["boolean", "bool"] {
+            let manifest = PluginManifest::from_toml_str(&format!(
+                "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"1.0.0\"\napi_version = 4\n\n[[settings]]\nkey = \"flag\"\ntype = \"{spelling}\"\n"
+            ))
+            .expect("manifest parses");
+            assert_eq!(
+                manifest.settings[0].value_type,
+                SettingType::Bool,
+                "{spelling}"
+            );
         }
     }
 }

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -182,7 +182,8 @@ Build steps are free to name bare PATH programs (`python3`, `node`, `uv`): they
 run in the user's interactive shell where PATH is reliable, which is exactly why
 the worker entrypoint, launched later by the daemon, is not. A step's optional `platforms` (`linux` / `macos` / `windows`)
 restricts it to matching hosts. Builds run with cwd set to the plugin dir, with
-stdin closed and stdout/stderr inherited so the user sees progress.
+stdin closed and stdout/stderr going to the operation log: the user's terminal
+for a CLI install, or a per-job log file for a dashboard install (see below).
 
 Why install time and the final dir, not launch or staging: `aoe plugin
 install` runs in the user's interactive shell, where `python3` / `node` / `uv`
@@ -192,6 +193,19 @@ absolute paths), so the build runs in the final `<plugins_dir>/<id>`, never in
 a staging tree that is then renamed. A failed build aborts the install with no
 trace; a failed update restores the prior version from a backup, and a leftover
 backup from an interrupted update is recovered on the next install/update.
+
+Web lifecycle jobs: the dashboard (Settings -> Plugins) installs, updates, and
+uninstalls a `gh:` plugin without a terminal. The same disclosure the CLI
+prompts for (capabilities, build commands, UI slots, unverified-source warning)
+is returned as structured data and approved in a modal; the host then runs the
+operation as a job whose progress and build output stream to a per-job log file
+under `<plugins_dir>/jobs/<job_id>.log`, which the dashboard tails. One
+lifecycle mutation runs at a time (config and lockfile writes are not
+concurrency-safe; a second start is rejected). One PATH caveat: a dashboard
+build runs with the daemon's environment, not the user's interactive shell, so a
+build step that names a bare PATH program present only in the interactive shell
+can succeed from `aoe plugin install` yet fail from a dashboard install. Local
+(non-`gh:`) installs stay CLI-only.
 
 The worker entrypoint (`command`'s `argv[0]`) must be plugin-relative: a path
 containing a separator (`.venv/bin/worker`), resolved inside the install

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -347,7 +347,7 @@ fn apply_prepared_install(p: &PreparedInstall, log: &OperationLog) -> Result<Ins
         version: p.fetched.manifest.version.clone(),
         capabilities: p.capabilities.clone(),
         granted: true,
-        validation: p.validation.clone(),
+        validation: p.validation,
     })
 }
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -1460,4 +1460,21 @@ mod tests {
             &[ui(UiSlot::StatusBar, "s")]
         ));
     }
+
+    #[tokio::test]
+    async fn web_install_rejects_non_gh_sources() {
+        // The web install path is gh: only, so a browser request can never make
+        // the daemon read an arbitrary local path. Both must bail before any
+        // network or filesystem work, with a message naming the gh: constraint.
+        let err = preview_install("/tmp/some/plugin")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("gh:"), "{err}");
+        let err = apply_install("./local/dir", "fp", &OperationLog::Inherit)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("gh:"), "{err}");
+    }
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -329,13 +329,23 @@ fn apply_prepared_install(p: &PreparedInstall, log: &OperationLog) -> Result<Ins
         return Err(e);
     }
 
-    persist_install(
-        &p.persisted_source,
-        &p.id,
-        &p.capabilities,
-        &p.manifest_hash,
-    )?;
-    write_lock(&p.id, &p.fetched, &p.manifest_hash, p.featured_verified)?;
+    // Persist config and lockfile together; if either fails, roll the install
+    // back so a half-written config/lock and an untracked tree do not block
+    // retries with "already installed" or leave the two out of sync.
+    let persisted = (|| -> Result<()> {
+        persist_install(
+            &p.persisted_source,
+            &p.id,
+            &p.capabilities,
+            &p.manifest_hash,
+        )?;
+        write_lock(&p.id, &p.fetched, &p.manifest_hash, p.featured_verified)
+    })();
+    if let Err(e) = persisted {
+        let _ = uninstall(&p.id);
+        let _ = std::fs::remove_dir_all(&final_dir);
+        return Err(e);
+    }
     super::reload_registry();
     log.line(&format!(
         "installed {} {}",

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -17,6 +17,61 @@ use super::lockfile::{LockedPlugin, Lockfile};
 use super::registry::ValidationState;
 use super::source::PluginSource;
 
+/// Where install / update / uninstall progress and child build output are
+/// written. The CLI uses `Inherit` so the user watches build output on their
+/// terminal; the dashboard's host-side job path uses `File`, so a dashboard
+/// user with no terminal attached can tail the same output.
+pub enum OperationLog {
+    Inherit,
+    File(std::fs::File),
+}
+
+impl OperationLog {
+    /// Open a job log file in append mode, owner-only (0600 on Unix). Build
+    /// output is not secret, but the log lives beside other 0600 daemon state,
+    /// so keep the convention.
+    pub fn file(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating plugin job log dir {}", parent.display()))?;
+        }
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let file = opts
+            .open(path)
+            .with_context(|| format!("opening plugin job log {}", path.display()))?;
+        Ok(OperationLog::File(file))
+    }
+
+    /// Write one host-side progress line.
+    fn line(&self, msg: &str) {
+        match self {
+            OperationLog::Inherit => eprintln!("{msg}"),
+            OperationLog::File(file) => {
+                let _ = writeln!(&mut &*file, "{msg}");
+            }
+        }
+    }
+
+    /// stdout and stderr for a child build step: inherited for the CLI, or two
+    /// clones of the job log handle so the child's output lands in the tail.
+    fn child_stdio(&self) -> Result<(Stdio, Stdio)> {
+        match self {
+            OperationLog::Inherit => Ok((Stdio::inherit(), Stdio::inherit())),
+            OperationLog::File(file) => {
+                let out = file.try_clone().context("cloning plugin job log handle")?;
+                let err = file.try_clone().context("cloning plugin job log handle")?;
+                Ok((Stdio::from(out), Stdio::from(err)))
+            }
+        }
+    }
+}
+
 /// Set the enabled flag for a known plugin id in the global config, then reload
 /// the registry so the change takes effect.
 pub fn set_enabled(plugin_id: &str, enabled: bool) -> Result<()> {
@@ -157,15 +212,61 @@ pub enum UpdatePreview {
     },
 }
 
-/// Install an external plugin from `input` (`gh:owner/repo[@ref]` or a local
-/// dir). Prompts once for the manifest's capabilities unless `assume_yes`.
-pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
+/// Everything an install needs after fetching and validating, before any
+/// consent decision or filesystem mutation. Computing this in one place is what
+/// lets the CLI prompt and the in-app preview/apply flow stay in lockstep, the
+/// same split `Prepared` gives the update path.
+struct PreparedInstall {
+    /// Persisted source string for a later `update`.
+    persisted_source: String,
+    /// The install is off the audited-release default path (an explicit `@ref`
+    /// or a no-release default-branch fallback).
+    unverified: bool,
+    /// One line stating what is being installed.
+    notice: String,
+    fetched: FetchedPlugin,
+    featured_verified: bool,
+    id: String,
+    capabilities: Vec<String>,
+    manifest_hash: String,
+    /// Content fingerprint of the fetched version (tree + release asset + trust).
+    fingerprint: String,
+    validation: ValidationState,
+}
+
+/// The structured disclosure an in-app (web / TUI) install approval renders, the
+/// same data the terminal prompt prints. `fingerprint` pins the exact content
+/// being approved so `apply_install` refuses if the remote moved since this was
+/// shown.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallConsent {
+    pub id: String,
+    pub version: String,
+    /// Persisted source slug (`gh:owner/repo[@ref]`).
+    pub source: String,
+    /// One line stating what is being installed (resolved release, ref, etc).
+    pub notice: String,
+    /// The source is off the audited-release default path (explicit ref or a
+    /// no-release default-branch fallback); the dashboard warns on it.
+    pub unverified: bool,
+    /// Resolved trust class (featured / community / local).
+    pub validation: String,
+    /// Capabilities the manifest declares (each needs a grant).
+    pub capabilities: Vec<String>,
+    /// Dashboard UI slots the plugin contributes to.
+    pub ui: Vec<UiView>,
+    /// Build commands the plugin will run, unsandboxed, at install time.
+    pub build_steps: Vec<String>,
+    /// Content fingerprint of the version being approved.
+    pub fingerprint: String,
+}
+
+/// Resolve, fetch, and validate an install candidate without touching the
+/// installed tree. Network-only. The caller decides consent (CLI prompt or web
+/// preview/apply) and then calls [`apply_prepared_install`].
+async fn prepare_install(input: &str) -> Result<PreparedInstall> {
     let source = PluginSource::parse(input)?;
     let resolved = resolve_source(source, true).await?;
-    eprintln!("{}", resolved.notice);
-    if resolved.unverified && !assume_yes && !confirm_unverified()? {
-        bail!("install cancelled; the unverified source was not approved");
-    }
     let fetched = fetch::fetch(&resolved.source).await?;
 
     let id = fetched.manifest.id.as_str().to_string();
@@ -173,25 +274,54 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
     reject_reserved_or_builtin(&fetched.manifest, featured_verified)?;
     reject_incompatible_host(&fetched.manifest)?;
 
-    let final_dir = super::plugins_dir()?.join(&id);
-    if final_dir.exists() {
+    if super::plugins_dir()?.join(&id).exists() {
         bail!("{id} is already installed; run `aoe plugin update {id}` or uninstall it first");
     }
 
     let capabilities = capability_strings(&fetched)?;
-    let build = build_steps(&fetched.manifest);
-    let granted =
-        if assume_yes || !install_needs_consent(&capabilities, build, &fetched.manifest.ui) {
-            true
-        } else {
-            confirm_capabilities(&id, &capabilities, &fetched.manifest.ui, build)?
-        };
-    if !granted {
-        bail!("install cancelled; no capabilities were granted");
+    let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
+    let trust = if featured_verified {
+        "featured"
+    } else {
+        "community"
+    };
+    let fingerprint = fingerprint(&fetched.tree_hash, fetched.asset_sha256.as_deref(), trust);
+    let persisted_source = persisted_source(&resolved.source, input);
+    let validation = install_validation(featured_verified, &persisted_source);
+
+    Ok(PreparedInstall {
+        persisted_source,
+        unverified: resolved.unverified,
+        notice: resolved.notice,
+        fetched,
+        featured_verified,
+        id,
+        capabilities,
+        manifest_hash,
+        fingerprint,
+        validation,
+    })
+}
+
+/// Move the fetched tree into place, build it, and persist the grant, config,
+/// and lockfile. Consent is already decided by the caller; build output goes to
+/// `log`. A failed build leaves nothing behind.
+fn apply_prepared_install(p: &PreparedInstall, log: &OperationLog) -> Result<InstallReport> {
+    let final_dir = super::plugins_dir()?.join(&p.id);
+    if final_dir.exists() {
+        bail!(
+            "{} is already installed; run `aoe plugin update {}` or uninstall it first",
+            p.id,
+            p.id
+        );
     }
 
-    move_into_place(&fetched, &final_dir)?;
-    if let Err(e) = build_in_place(&id, &final_dir, &fetched.manifest) {
+    log.line(&format!(
+        "installing {} {}",
+        p.id, p.fetched.manifest.version
+    ));
+    move_into_place(&p.fetched, &final_dir)?;
+    if let Err(e) = build_in_place(&p.id, &final_dir, &p.fetched.manifest, log) {
         // A failed build must not leave a half-installed tree behind; nothing
         // is persisted to config or the lockfile, so removing the directory
         // returns the host to its pre-install state.
@@ -199,19 +329,110 @@ pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
         return Err(e);
     }
 
-    let manifest_hash = PluginManifest::hash_bytes(&fetched.manifest_bytes);
-    let persisted = persisted_source(&resolved.source, input);
-    persist_install(&persisted, &id, &capabilities, &manifest_hash)?;
-    write_lock(&id, &fetched, &manifest_hash, featured_verified)?;
+    persist_install(
+        &p.persisted_source,
+        &p.id,
+        &p.capabilities,
+        &p.manifest_hash,
+    )?;
+    write_lock(&p.id, &p.fetched, &p.manifest_hash, p.featured_verified)?;
     super::reload_registry();
+    log.line(&format!(
+        "installed {} {}",
+        p.id, p.fetched.manifest.version
+    ));
 
     Ok(InstallReport {
-        id,
-        version: fetched.manifest.version.clone(),
-        capabilities,
+        id: p.id.clone(),
+        version: p.fetched.manifest.version.clone(),
+        capabilities: p.capabilities.clone(),
         granted: true,
-        validation: install_validation(featured_verified, &persisted),
+        validation: p.validation.clone(),
     })
+}
+
+/// Install an external plugin from `input` (`gh:owner/repo[@ref]` or a local
+/// dir). Prompts once for the manifest's capabilities unless `assume_yes`.
+pub async fn install(input: &str, assume_yes: bool) -> Result<InstallReport> {
+    let prepared = prepare_install(input).await?;
+    eprintln!("{}", prepared.notice);
+    if prepared.unverified && !assume_yes && !confirm_unverified()? {
+        bail!("install cancelled; the unverified source was not approved");
+    }
+    let build = build_steps(&prepared.fetched.manifest);
+    let granted = if assume_yes
+        || !install_needs_consent(&prepared.capabilities, build, &prepared.fetched.manifest.ui)
+    {
+        true
+    } else {
+        confirm_capabilities(
+            &prepared.id,
+            &prepared.capabilities,
+            &prepared.fetched.manifest.ui,
+            build,
+        )?
+    };
+    if !granted {
+        bail!("install cancelled; no capabilities were granted");
+    }
+    apply_prepared_install(&prepared, &OperationLog::Inherit)
+}
+
+/// Classify an install candidate for an in-app approval without installing it:
+/// the dashboard "what would this install do" probe. Network-only. Restricted
+/// to `gh:` sources so a browser request never makes the daemon read an
+/// arbitrary local path; local installs stay on the CLI.
+pub async fn preview_install(input: &str) -> Result<InstallConsent> {
+    if !input.starts_with("gh:") {
+        bail!("web install supports gh: sources only; use `aoe plugin install` for a local path");
+    }
+    let p = prepare_install(input).await?;
+    Ok(InstallConsent {
+        id: p.id.clone(),
+        version: p.fetched.manifest.version.clone(),
+        source: p.persisted_source.clone(),
+        notice: p.notice.clone(),
+        unverified: p.unverified,
+        validation: p.validation.as_str().to_string(),
+        capabilities: p.capabilities.clone(),
+        ui: p
+            .fetched
+            .manifest
+            .ui
+            .iter()
+            .map(|u| UiView {
+                slot: u.slot.as_str().to_string(),
+                id: u.id.clone(),
+            })
+            .collect(),
+        build_steps: build_steps(&p.fetched.manifest)
+            .iter()
+            .map(|s| s.command.join(" "))
+            .collect(),
+        fingerprint: p.fingerprint.clone(),
+    })
+}
+
+/// Apply an install previewed in-app, granting whatever the fetched manifest
+/// declares. `expected_fingerprint` pins the exact content the user approved: if
+/// the remote moved since the preview, this refuses rather than installing
+/// something the user never saw. Build output goes to `log`. `gh:` only, like
+/// [`preview_install`].
+pub async fn apply_install(
+    input: &str,
+    expected_fingerprint: &str,
+    log: &OperationLog,
+) -> Result<InstallReport> {
+    if !input.starts_with("gh:") {
+        bail!("web install supports gh: sources only; use `aoe plugin install` for a local path");
+    }
+    let prepared = prepare_install(input).await?;
+    if prepared.fingerprint != expected_fingerprint {
+        bail!(
+            "the plugin at {input} changed since it was shown; review it again before installing"
+        );
+    }
+    apply_prepared_install(&prepared, log)
 }
 
 /// Re-fetch an installed external plugin from its recorded source, prompting on
@@ -424,13 +645,21 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
 /// version active without rewriting the tree or lockfile, matching the in-app
 /// decline. (Arbitrary build steps the user just refused must never run, and a
 /// declined capability expansion must not silently replace the install.)
-fn apply_prepared(prepared: &Prepared, grant: Option<CapabilityGrant>) -> Result<InstallReport> {
+fn apply_prepared(
+    prepared: &Prepared,
+    grant: Option<CapabilityGrant>,
+    log: &OperationLog,
+) -> Result<InstallReport> {
     let id = prepared.id.as_str();
     let final_dir = super::plugins_dir()?.join(id);
     if prepared.needs_consent && grant.is_none() {
         bail!("update cancelled for {id}; the previously trusted version was kept");
     }
-    replace_and_build(id, &prepared.fetched, &final_dir)?;
+    log.line(&format!(
+        "updating {id} to {}",
+        prepared.fetched.manifest.version
+    ));
+    replace_and_build(id, &prepared.fetched, &final_dir, log)?;
 
     let granted = grant.is_some();
     persist_update(id, &prepared.source_str, grant)?;
@@ -504,7 +733,11 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
         })
     };
 
-    Ok(UpdateOutcome::Applied(apply_prepared(&prepared, grant)?))
+    Ok(UpdateOutcome::Applied(apply_prepared(
+        &prepared,
+        grant,
+        &OperationLog::Inherit,
+    )?))
 }
 
 /// Build the structured consent disclosure from a prepared update.
@@ -572,7 +805,11 @@ pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
 /// MUST carry a fingerprint, so approval cannot bypass the stale-preview guard;
 /// a safe update may omit it. Clears any recorded dismissal on success (via
 /// `persist_update`).
-pub async fn apply_update(id: &str, expected_fingerprint: Option<String>) -> Result<InstallReport> {
+pub async fn apply_update(
+    id: &str,
+    expected_fingerprint: Option<String>,
+    log: &OperationLog,
+) -> Result<InstallReport> {
     let prepared = prepare_update(id).await?;
     match &expected_fingerprint {
         Some(expected) if *expected != prepared.fingerprint => {
@@ -592,7 +829,7 @@ pub async fn apply_update(id: &str, expected_fingerprint: Option<String>) -> Res
         capabilities: prepared.capabilities.clone(),
         granted_at: chrono::Utc::now(),
     });
-    apply_prepared(&prepared, grant)
+    apply_prepared(&prepared, grant, log)
 }
 
 /// Record that the user declined an available update by its fingerprint, so the
@@ -661,6 +898,15 @@ pub fn uninstall(id: &str) -> Result<()> {
         lock.save()?;
     }
     super::reload_registry();
+    Ok(())
+}
+
+/// [`uninstall`] with progress written to `log`, for the dashboard job path so a
+/// terminal-less user gets a readable tail that ends in success or failure.
+pub fn uninstall_logged(id: &str, log: &OperationLog) -> Result<()> {
+    log.line(&format!("uninstalling {id}"));
+    uninstall(id)?;
+    log.line(&format!("uninstalled {id}"));
     Ok(())
 }
 
@@ -949,8 +1195,13 @@ fn build_steps(manifest: &PluginManifest) -> &[BuildStep] {
 /// worker entrypoint is runnable. Builds run in the final directory (not the
 /// staging tree) because tools like Python venvs embed absolute paths and are
 /// not relocatable, so a build followed by a rename would break the worker.
-fn build_in_place(plugin_id: &str, dir: &Path, manifest: &PluginManifest) -> Result<()> {
-    run_build(plugin_id, dir, build_steps(manifest))?;
+fn build_in_place(
+    plugin_id: &str,
+    dir: &Path,
+    manifest: &PluginManifest,
+    log: &OperationLog,
+) -> Result<()> {
+    run_build(plugin_id, dir, build_steps(manifest), log)?;
     // A build can succeed by exit code yet not produce the entrypoint (every
     // step skipped on this platform, or a no-op build against a broken
     // project). Resolve the launch command now, while the user is watching, so
@@ -983,8 +1234,9 @@ fn build_in_place(plugin_id: &str, dir: &Path, manifest: &PluginManifest) -> Res
 /// the same policy as the launch command, immediately before it runs, so a step
 /// like `.venv/bin/pip` resolves once the prior step created it. Build stdin is
 /// `/dev/null` so an interactive prompt cannot hang a `--yes` install; stdout
-/// and stderr inherit the terminal so the user sees build progress.
-fn run_build(plugin_id: &str, dir: &Path, steps: &[BuildStep]) -> Result<()> {
+/// and stderr go to `log` (the terminal for the CLI, or the job log file for a
+/// dashboard install) so the user sees build progress either way.
+fn run_build(plugin_id: &str, dir: &Path, steps: &[BuildStep], log: &OperationLog) -> Result<()> {
     let os = std::env::consts::OS;
     for (i, step) in steps.iter().enumerate() {
         if !step.platforms.is_empty() && !step.platforms.iter().any(|p| p == os) {
@@ -998,12 +1250,15 @@ fn run_build(plugin_id: &str, dir: &Path, steps: &[BuildStep]) -> Result<()> {
             &super::launch::OsLaunchResolver,
         )
         .with_context(|| format!("resolving build step {} ({pretty})", i + 1))?;
-        eprintln!("  building {plugin_id}: {pretty}");
+        log.line(&format!("  building {plugin_id}: {pretty}"));
+        let (stdout, stderr) = log.child_stdio()?;
         let status = std::process::Command::new(&program)
             .args(&args)
             .current_dir(dir)
             .env("AOE_PLUGIN_ID", plugin_id)
             .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr)
             .status()
             .with_context(|| format!("spawning build step {} ({pretty})", i + 1))?;
         if !status.success() {
@@ -1022,7 +1277,12 @@ fn run_build(plugin_id: &str, dir: &Path, steps: &[BuildStep]) -> Result<()> {
 /// Then move the current install aside, place the new tree, and build: on
 /// success drop the backup, on failure restore it so the user is never left
 /// worse off than before the update.
-fn replace_and_build(plugin_id: &str, fetched: &FetchedPlugin, final_dir: &Path) -> Result<()> {
+fn replace_and_build(
+    plugin_id: &str,
+    fetched: &FetchedPlugin,
+    final_dir: &Path,
+    log: &OperationLog,
+) -> Result<()> {
     // `with_file_name`, not `with_extension`: a plugin id like `acme.worker`
     // has a dot, and `with_extension("bak")` would replace `.worker`, yielding
     // `acme.bak` and colliding with every other `acme.*` plugin's backup.
@@ -1049,7 +1309,7 @@ fn replace_and_build(plugin_id: &str, fetched: &FetchedPlugin, final_dir: &Path)
                 final_dir.display()
             )
         })?;
-        build_in_place(plugin_id, final_dir, &fetched.manifest)
+        build_in_place(plugin_id, final_dir, &fetched.manifest, log)
     })();
 
     match place_and_build {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -17,7 +17,7 @@ mod client_log;
 mod git;
 mod log_level;
 mod mcp;
-mod plugins;
+pub mod plugins;
 mod projects;
 mod sessions;
 pub(crate) mod system;
@@ -38,7 +38,8 @@ pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
 pub use plugins::{
     apply_plugin_update, dismiss_plugin_update, invoke_plugin_action, list_plugins, plugin_details,
-    plugin_discover, plugin_ui_state, plugin_update_preview, plugin_updates, set_plugin_enabled,
+    plugin_discover, plugin_job_status, plugin_ui_state, plugin_update_preview, plugin_updates,
+    preview_plugin_install, set_plugin_enabled, start_plugin_install, start_plugin_uninstall,
 };
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -291,7 +291,7 @@ pub async fn set_plugin_enabled(
     }
 }
 
-// ---- Plugin lifecycle jobs (install / update / uninstall) -----------------
+// Plugin lifecycle jobs: install, update, and uninstall.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -5,15 +5,20 @@
 //! requires read-write mode AND an elevated session when login is enabled,
 //! mirroring the requires-elevation settings fields.
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use super::AppState;
 use crate::plugin;
+use crate::plugin::install::OperationLog;
 use crate::server::auth::AuthenticatedSession;
 
 fn error_response(status: StatusCode, code: &str, message: String) -> Response {
@@ -209,9 +214,11 @@ pub struct ApplyUpdateBody {
 /// `POST /api/plugins/{id}/update/apply`: apply an update the user approved in
 /// the dashboard, granting whatever the fetched manifest declares. A privileged
 /// host mutation (it can expand the capability set and run build steps), so it
-/// is gated on read-write mode AND elevation, like enable/disable. Returns the
-/// refreshed plugin list on success. A fingerprint mismatch (the remote moved
-/// since the preview) is a 409 so the dashboard re-previews before re-approving.
+/// is gated on read-write mode AND elevation, like enable/disable. Runs as a
+/// host-side job so the build is observable; returns a `job_id` the dashboard
+/// polls for the live log. A fingerprint mismatch (the remote moved since the
+/// preview) surfaces as a failed job, which the UI recovers from by
+/// re-previewing.
 pub async fn apply_plugin_update(
     State(state): State<std::sync::Arc<AppState>>,
     session: Option<axum::Extension<AuthenticatedSession>>,
@@ -221,20 +228,13 @@ pub async fn apply_plugin_update(
     if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
         return resp;
     }
-    match plugin::install::apply_update(&id, body.expected_fingerprint).await {
-        Ok(_) => list_plugins().await.into_response(),
-        Err(e) => {
-            let message = format!("{e:#}");
-            // The TOCTOU guard's "changed since it was shown" is a conflict the
-            // client recovers from by re-previewing, not a bad request.
-            let status = if message.contains("changed since it was shown") {
-                StatusCode::CONFLICT
-            } else {
-                StatusCode::BAD_REQUEST
-            };
-            error_response(status, "apply_failed", message)
-        }
-    }
+    let plugin_id = id.clone();
+    let fingerprint = body.expected_fingerprint;
+    start_job(state, PluginJobKind::Update, id, move |log| async move {
+        plugin::install::apply_update(&plugin_id, fingerprint, &log)
+            .await
+            .map(|_| ())
+    })
 }
 
 #[derive(Deserialize)]
@@ -287,6 +287,312 @@ pub async fn set_plugin_enabled(
     match result {
         Ok(Ok(())) => list_plugins().await.into_response(),
         Ok(Err(e)) => error_response(StatusCode::BAD_REQUEST, "plugin_error", format!("{e:#}")),
+        Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", e.to_string()),
+    }
+}
+
+// ---- Plugin lifecycle jobs (install / update / uninstall) -----------------
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A host-side plugin lifecycle operation the dashboard started and tails. The
+/// daemon owns the work; the browser polls `GET /api/plugins/jobs/{id}` for
+/// status plus the live log tail.
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginJobKind {
+    Install,
+    Update,
+    Uninstall,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum PluginJobStatus {
+    Running,
+    Succeeded,
+    Failed { error: String },
+}
+
+#[derive(Clone, Serialize)]
+pub struct PluginJob {
+    pub id: String,
+    pub kind: PluginJobKind,
+    /// What is being operated on: a source slug for install, a plugin id else.
+    pub target: String,
+    pub status: PluginJobStatus,
+    pub started_at: i64,
+    pub finished_at: Option<i64>,
+    /// On-disk log file; never serialized (read via the tail endpoint instead).
+    #[serde(skip)]
+    log_path: PathBuf,
+}
+
+/// Drop finished jobs and their log files older than this when a new job
+/// starts. A dashboard polls a job for seconds to minutes; an hour is a wide
+/// margin that bounds the in-memory map and the on-disk logs over a long-lived
+/// daemon.
+const FINISHED_JOB_TTL_SECS: i64 = 3600;
+
+/// In-memory registry of plugin lifecycle jobs. Dies with the daemon: a job
+/// running at shutdown is gone, but its on-disk log survives so a tail after a
+/// restart still shows what happened, just without live status.
+// ponytail: in-memory only; a persisted job table would need process
+// supervision and orphaned-build recovery to mean anything. Add that only if
+// restart-survival of in-flight jobs is ever required.
+pub struct PluginJobRegistry {
+    jobs: Mutex<HashMap<String, PluginJob>>,
+    /// At most one lifecycle mutation runs at a time. Config + lockfile writes
+    /// and in-place tree mutations are not concurrency-safe, so a second start
+    /// is rejected with 409 rather than queued (a queued mutation can go stale
+    /// before it runs).
+    active: AtomicBool,
+}
+
+impl Default for PluginJobRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PluginJobRegistry {
+    pub fn new() -> Self {
+        Self {
+            jobs: Mutex::new(HashMap::new()),
+            active: AtomicBool::new(false),
+        }
+    }
+
+    /// Begin a job if no other lifecycle mutation is active. Returns the job id
+    /// and its log path, or `None` if one is already running.
+    fn begin(&self, kind: PluginJobKind, target: String) -> Option<(String, PathBuf)> {
+        if self
+            .active
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return None;
+        }
+        let log_path = match plugin::plugins_dir() {
+            Ok(dir) => dir
+                .join("jobs")
+                .join(format!("{}.log", uuid::Uuid::new_v4())),
+            Err(_) => {
+                self.active.store(false, Ordering::SeqCst);
+                return None;
+            }
+        };
+        let id = uuid::Uuid::new_v4().to_string();
+        self.prune();
+        let job = PluginJob {
+            id: id.clone(),
+            kind,
+            target,
+            status: PluginJobStatus::Running,
+            started_at: chrono::Utc::now().timestamp(),
+            finished_at: None,
+            log_path: log_path.clone(),
+        };
+        self.jobs.lock().unwrap().insert(id.clone(), job);
+        Some((id, log_path))
+    }
+
+    /// Mark a job done and release the single-active guard.
+    fn finish(&self, id: &str, result: anyhow::Result<()>) {
+        if let Some(job) = self.jobs.lock().unwrap().get_mut(id) {
+            job.finished_at = Some(chrono::Utc::now().timestamp());
+            job.status = match result {
+                Ok(()) => PluginJobStatus::Succeeded,
+                Err(e) => PluginJobStatus::Failed {
+                    error: format!("{e:#}"),
+                },
+            };
+        }
+        self.active.store(false, Ordering::SeqCst);
+    }
+
+    pub fn get(&self, id: &str) -> Option<PluginJob> {
+        self.jobs.lock().unwrap().get(id).cloned()
+    }
+
+    /// Drop finished jobs older than the TTL and remove their log files.
+    fn prune(&self) {
+        let cutoff = chrono::Utc::now().timestamp() - FINISHED_JOB_TTL_SECS;
+        self.jobs.lock().unwrap().retain(|_, job| {
+            let stale = job.finished_at.is_some_and(|t| t < cutoff);
+            if stale {
+                let _ = std::fs::remove_file(&job.log_path);
+            }
+            !stale
+        });
+    }
+}
+
+/// Begin a lifecycle job, spawn its work, and return `202 { job_id }`. Returns
+/// `409` when another lifecycle mutation is already running. The work runs in a
+/// detached task; its build output and host-side progress lines land in the job
+/// log file, which the dashboard tails via `plugin_job_status`.
+// ponytail: install/update run their (synchronous) build inside this async
+// task, parking one runtime worker for the build's duration. The single-active
+// guard caps that at one parked worker; switch to a dedicated blocking thread
+// only if that ever matters.
+fn start_job<F, Fut>(
+    state: std::sync::Arc<AppState>,
+    kind: PluginJobKind,
+    target: String,
+    run: F,
+) -> Response
+where
+    F: FnOnce(OperationLog) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let Some((job_id, log_path)) = state.plugin_jobs.begin(kind, target) else {
+        return error_response(
+            StatusCode::CONFLICT,
+            "plugin_job_active",
+            "Another plugin operation is already running".into(),
+        );
+    };
+    let jobs = state.plugin_jobs.clone();
+    let id = job_id.clone();
+    tokio::spawn(async move {
+        let result = match OperationLog::file(&log_path) {
+            Ok(log) => run(log).await,
+            Err(e) => Err(e),
+        };
+        jobs.finish(&id, result);
+    });
+    (StatusCode::ACCEPTED, Json(json!({ "job_id": job_id }))).into_response()
+}
+
+#[derive(Deserialize)]
+pub struct InstallPreviewBody {
+    pub source: String,
+}
+
+/// `POST /api/plugins/install/preview`: classify a `gh:` install candidate and
+/// return the capability / build / UI disclosure the dashboard renders before
+/// the user approves. Read-write only, NOT elevation: it mutates nothing and
+/// powers the approval UI (elevation is required on the actual install).
+pub async fn preview_plugin_install(
+    State(state): State<std::sync::Arc<AppState>>,
+    Json(body): Json<InstallPreviewBody>,
+) -> Response {
+    if state.read_only {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            "read_only",
+            "Server is in read-only mode".into(),
+        );
+    }
+    match plugin::install::preview_install(&body.source).await {
+        Ok(consent) => Json(consent).into_response(),
+        Err(e) => error_response(StatusCode::BAD_GATEWAY, "preview_failed", format!("{e:#}")),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct StartInstallBody {
+    pub source: String,
+    /// The fingerprint the user approved, from the preview. Pins the install to
+    /// exactly what was shown.
+    pub expected_fingerprint: String,
+}
+
+/// `POST /api/plugins/install`: start a host-side install job for a `gh:` source
+/// the user approved in the dashboard. Read-write + elevation, like update
+/// apply. Returns a `job_id` to poll; `409` if another lifecycle job is running.
+pub async fn start_plugin_install(
+    State(state): State<std::sync::Arc<AppState>>,
+    session: Option<axum::Extension<AuthenticatedSession>>,
+    Json(body): Json<StartInstallBody>,
+) -> Response {
+    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
+        return resp;
+    }
+    let source = body.source.clone();
+    let fingerprint = body.expected_fingerprint;
+    start_job(
+        state,
+        PluginJobKind::Install,
+        source.clone(),
+        move |log| async move {
+            plugin::install::apply_install(&source, &fingerprint, &log)
+                .await
+                .map(|_| ())
+        },
+    )
+}
+
+/// `POST /api/plugins/{id}/uninstall`: start a host-side uninstall job. Removes
+/// the plugin's tree, config entry, and lockfile entry. Read-write + elevation;
+/// returns a `job_id` to poll; `409` if another lifecycle job is running.
+pub async fn start_plugin_uninstall(
+    State(state): State<std::sync::Arc<AppState>>,
+    session: Option<axum::Extension<AuthenticatedSession>>,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(resp) = mutation_gate(&state, session.as_deref()).await {
+        return resp;
+    }
+    let plugin_id = id.clone();
+    start_job(state, PluginJobKind::Uninstall, id, move |log| async move {
+        // Uninstall is synchronous filesystem work; run it off the async task so
+        // it never parks a runtime worker.
+        match tokio::task::spawn_blocking(move || {
+            plugin::install::uninstall_logged(&plugin_id, &log)
+        })
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => Err(anyhow::anyhow!("uninstall task failed: {e}")),
+        }
+    })
+}
+
+#[derive(Deserialize)]
+pub struct JobLogQuery {
+    /// Trailing lines to return; clamped to [1, 2000], default 200.
+    pub tail: Option<usize>,
+}
+
+/// `GET /api/plugins/jobs/{job_id}`: a lifecycle job's status plus a bounded
+/// tail of its host-side log. Polled by the dashboard progress modal. Reads job
+/// state only, so no elevation; the global auth middleware still applies.
+pub async fn plugin_job_status(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path(job_id): Path<String>,
+    Query(q): Query<JobLogQuery>,
+) -> Response {
+    let Some(job) = state.plugin_jobs.get(&job_id) else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "job_not_found",
+            format!("No plugin job {job_id}"),
+        );
+    };
+    let tail = q.tail.unwrap_or(200).clamp(1, 2000);
+    let log_path = job.log_path.clone();
+    let read = tokio::task::spawn_blocking(move || {
+        crate::server::api::acp::read_log_tail(&log_path, tail)
+    })
+    .await;
+    match read {
+        Ok(Ok((lines, truncated, exists))) => Json(json!({
+            "job": job,
+            "log": {
+                "exists": exists,
+                "tail": lines.join("\n"),
+                "lines_returned": lines.len(),
+                "truncated": truncated,
+            }
+        }))
+        .into_response(),
+        Ok(Err(e)) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "log_read_failed",
+            format!("{e}"),
+        ),
         Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", e.to_string()),
     }
 }

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -306,7 +306,7 @@ pub enum PluginJobKind {
     Uninstall,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum PluginJobStatus {
     Running,
@@ -594,5 +594,45 @@ pub async fn plugin_job_status(
             format!("{e}"),
         ),
         Err(e) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal", e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_allows_one_active_job_then_releases_on_finish() {
+        let reg = PluginJobRegistry::new();
+        let (id1, _) = reg
+            .begin(PluginJobKind::Install, "gh:a/b".into())
+            .expect("first job begins");
+        // A second lifecycle mutation is rejected while one is active: config
+        // and lockfile writes are not concurrency-safe.
+        assert!(
+            reg.begin(PluginJobKind::Uninstall, "x".into()).is_none(),
+            "second job rejected while one is active"
+        );
+        assert!(matches!(
+            reg.get(&id1).unwrap().status,
+            PluginJobStatus::Running
+        ));
+
+        reg.finish(&id1, Ok(()));
+        assert!(matches!(
+            reg.get(&id1).unwrap().status,
+            PluginJobStatus::Succeeded
+        ));
+
+        // The guard is released, so a new job can begin and a failure records
+        // its message.
+        let (id2, _) = reg
+            .begin(PluginJobKind::Update, "gh:c/d".into())
+            .expect("job begins after the prior one finished");
+        reg.finish(&id2, Err(anyhow::anyhow!("boom")));
+        match reg.get(&id2).unwrap().status {
+            PluginJobStatus::Failed { error } => assert!(error.contains("boom"), "{error}"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -372,6 +372,10 @@ pub struct AppState {
     /// stand up a host; `Some` in a live daemon.
     #[cfg(feature = "serve")]
     pub plugin_host: Option<Arc<crate::plugin::host::PluginHost>>,
+    /// Tracks in-flight web plugin install / update / uninstall jobs so the
+    /// dashboard can tail their host-side log. In-memory; see
+    /// `api::plugins::PluginJobRegistry`.
+    pub plugin_jobs: Arc<crate::server::api::plugins::PluginJobRegistry>,
     /// Epoch-millis timestamp of the most recent authenticated API request.
     /// Updated by auth middleware on every successful auth. The push consumer
     /// checks this to suppress notifications when someone is actively using
@@ -1008,6 +1012,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         acp_supervisor: acp_supervisor.clone(),
         #[cfg(feature = "serve")]
         plugin_host: plugin_host.clone(),
+        plugin_jobs: Arc::new(api::plugins::PluginJobRegistry::new()),
         push: push_state,
         push_enabled,
         web_config: config.web.clone(),
@@ -1552,6 +1557,16 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/plugins/details", get(api::plugin_details))
         .route("/api/plugins/{id}/enabled", post(api::set_plugin_enabled))
         .route("/api/plugins/{id}/action", post(api::invoke_plugin_action))
+        .route(
+            "/api/plugins/install/preview",
+            post(api::preview_plugin_install),
+        )
+        .route("/api/plugins/install", post(api::start_plugin_install))
+        .route(
+            "/api/plugins/{id}/uninstall",
+            post(api::start_plugin_uninstall),
+        )
+        .route("/api/plugins/jobs/{job_id}", get(api::plugin_job_status))
         .route(
             "/api/plugins/{id}/update/preview",
             get(api::plugin_update_preview),
@@ -4121,6 +4136,7 @@ pub mod test_support {
             acp_event_store: event_store,
             acp_supervisor: supervisor,
             plugin_host: None,
+            plugin_jobs: Arc::new(api::plugins::PluginJobRegistry::new()),
             push: None,
             push_enabled: false,
             web_config: crate::session::config::WebConfig::default(),

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -300,10 +300,14 @@ impl PluginManagerDialog {
         let apply_id = id.clone();
         tokio::spawn(async move {
             let _ = tx.send(
-                crate::plugin::install::apply_update(&apply_id, fingerprint)
-                    .await
-                    .map(|_| ())
-                    .map_err(|e| format!("{e:#}")),
+                crate::plugin::install::apply_update(
+                    &apply_id,
+                    fingerprint,
+                    &crate::plugin::install::OperationLog::Inherit,
+                )
+                .await
+                .map(|_| ())
+                .map_err(|e| format!("{e:#}")),
             );
         });
         self.pending_plugin = Some(id);

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -1282,9 +1282,13 @@ async fn apply_update_grants_the_new_capability_set() {
         other => panic!("expected consent_required, got {other:?}"),
     };
 
-    install::apply_update("acme.upd", Some(fingerprint))
-        .await
-        .unwrap();
+    install::apply_update(
+        "acme.upd",
+        Some(fingerprint),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         Lockfile::load().unwrap().get("acme.upd").unwrap().version,
@@ -1305,10 +1309,14 @@ async fn apply_update_rejects_a_stale_fingerprint() {
 
     // The user approved a different (stale) fingerprint than what is now fetched:
     // the apply must refuse rather than grant something never disclosed.
-    let err = install::apply_update("acme.upd", Some("sha256:stale||community".to_string()))
-        .await
-        .unwrap_err()
-        .to_string();
+    let err = install::apply_update(
+        "acme.upd",
+        Some("sha256:stale||community".to_string()),
+        &install::OperationLog::Inherit,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
     assert!(err.contains("changed since it was shown"), "got: {err}");
     assert_eq!(
         Lockfile::load().unwrap().get("acme.upd").unwrap().version,

--- a/web/src/components/settings/PluginInstallConsentModal.tsx
+++ b/web/src/components/settings/PluginInstallConsentModal.tsx
@@ -55,7 +55,11 @@ export function PluginInstallConsentModal({
           <div>
             <h2 className="font-semibold">Install {consent.id}?</h2>
             <p className="text-xs text-text-dim">
-              v{consent.version} · {consent.validation} · {consent.source}
+              v{consent.version} ·{" "}
+              <span className={consent.validation === "featured" ? "font-medium text-accent-500" : undefined}>
+                {consent.validation}
+              </span>{" "}
+              · {consent.source}
             </p>
           </div>
           <button

--- a/web/src/components/settings/PluginInstallConsentModal.tsx
+++ b/web/src/components/settings/PluginInstallConsentModal.tsx
@@ -1,0 +1,145 @@
+import { useEffect } from "react";
+
+import type { PluginInstallConsent } from "../../lib/api";
+
+interface PluginInstallConsentModalProps {
+  /** The structured disclosure for the install candidate. */
+  consent: PluginInstallConsent;
+  /** True while the install request is being started. */
+  busy: boolean;
+  /** Inline error from the last start attempt, if any. */
+  error: string | null;
+  /** Approve the disclosed access and start the install. */
+  onApprove: () => void;
+  /** Close without installing (Esc / backdrop / Cancel button). */
+  onClose: () => void;
+}
+
+/// The in-app capability-consent popup for a web plugin install. Renders the
+/// same disclosure the terminal prompt prints (capabilities, build commands, UI
+/// slots, unverified-source warning) and gates the install behind an explicit
+/// Approve, so the web path never silently grants what the CLI prompts for.
+export function PluginInstallConsentModal({
+  consent,
+  busy,
+  error,
+  onApprove,
+  onClose,
+}: PluginInstallConsentModalProps) {
+  const closeIfIdle = () => {
+    if (!busy) onClose();
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!busy && e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [busy, onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Install ${consent.id}`}
+      onClick={closeIfIdle}
+      data-testid="plugin-install-consent-modal"
+    >
+      <div
+        className="max-h-[80vh] w-full max-w-lg overflow-auto rounded border border-surface-700 bg-surface-900 p-4 text-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="font-semibold">Install {consent.id}?</h2>
+            <p className="text-xs text-text-dim">
+              v{consent.version} · {consent.validation} · {consent.source}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-2 py-0.5 text-xs hover:bg-surface-800 disabled:opacity-50"
+            disabled={busy}
+            onClick={closeIfIdle}
+            data-testid="plugin-install-consent-close"
+          >
+            Close
+          </button>
+        </div>
+
+        <p className="mb-3 text-xs text-text-dim">{consent.notice}</p>
+
+        {consent.unverified && (
+          <p className="mb-3 text-xs text-status-warning" data-testid="plugin-install-unverified">
+            This is unverified, un-audited code: it does not come from a vetted release and is not covered by the
+            featured index. Install it only if you trust the source.
+          </p>
+        )}
+
+        {consent.capabilities.length > 0 && (
+          <div className="mb-3" data-testid="plugin-install-caps">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">Capabilities</p>
+            <p className="text-xs text-status-warning">{consent.capabilities.join(", ")}</p>
+          </div>
+        )}
+
+        {consent.build_steps.length > 0 && (
+          <div className="mb-3" data-testid="plugin-install-build-steps">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">
+              Build commands (run as you, unsandboxed)
+            </p>
+            <ul className="space-y-0.5">
+              {consent.build_steps.map((step, i) => (
+                <li key={i} className="font-mono text-[11px] text-text-dim">
+                  $ {step}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {consent.ui.length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Dashboard UI slots</p>
+            <p className="text-xs text-text-dim">{[...new Set(consent.ui.map((u) => u.slot))].join(", ")}</p>
+          </div>
+        )}
+
+        <p className="mb-3 text-[11px] text-text-dim">
+          Installing trusts this plugin. The host enforces capabilities at its API boundary, but a plugin worker (and
+          any build step) runs without OS-level sandboxing, so a malicious plugin is not contained. Build steps run as
+          you before any capability gate. Only install plugins you trust.
+        </p>
+
+        {error && (
+          <p className="mb-3 text-xs text-status-error" data-testid="plugin-install-consent-error">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-3 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
+            disabled={busy}
+            onClick={closeIfIdle}
+            data-testid="plugin-install-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded bg-brand-600 px-3 py-1 text-xs font-medium text-white hover:bg-brand-500 disabled:opacity-50"
+            disabled={busy}
+            onClick={onApprove}
+            data-testid="plugin-install-approve"
+          >
+            {busy ? "Starting…" : "Approve and install"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/PluginJobProgressModal.tsx
+++ b/web/src/components/settings/PluginJobProgressModal.tsx
@@ -107,6 +107,19 @@ export function PluginJobProgressModal({ jobId, title, onClose }: PluginJobProgr
         >
           {job?.log.tail || (state === "running" ? "Starting…" : "")}
         </pre>
+
+        {done && (
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              className="rounded bg-brand-600 px-3 py-1 text-xs font-medium text-white hover:bg-brand-500"
+              onClick={onClose}
+              data-testid="plugin-job-done"
+            >
+              Close
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/settings/PluginJobProgressModal.tsx
+++ b/web/src/components/settings/PluginJobProgressModal.tsx
@@ -20,6 +20,9 @@ interface PluginJobProgressModalProps {
 export function PluginJobProgressModal({ jobId, title, onClose }: PluginJobProgressModalProps) {
   const [job, setJob] = useState<PluginJob | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // The job is gone (404), e.g. the daemon restarted mid-run. Terminal: stop
+  // polling and let the user close, rather than spinning forever.
+  const [gone, setGone] = useState(false);
   const logRef = useRef<HTMLPreElement>(null);
 
   useEffect(() => {
@@ -34,6 +37,10 @@ export function PluginJobProgressModal({ jobId, title, onClose }: PluginJobProgr
         if (res.job.job.status.state === "running") {
           timer = setTimeout(() => void poll(), 1000);
         }
+      } else if (res.status === 404) {
+        // The job no longer exists; treat it as terminal instead of retrying.
+        setGone(true);
+        setError(res.message);
       } else {
         // A transient read failure should not kill the follow; retry slower.
         setError(res.message);
@@ -54,7 +61,7 @@ export function PluginJobProgressModal({ jobId, title, onClose }: PluginJobProgr
   }, [job?.log.tail]);
 
   const state = job?.job.status.state ?? "running";
-  const done = state === "succeeded" || state === "failed";
+  const done = state === "succeeded" || state === "failed" || gone;
   const failedError = job?.job.status.state === "failed" ? job.job.status.error : null;
 
   return (
@@ -70,9 +77,9 @@ export function PluginJobProgressModal({ jobId, title, onClose }: PluginJobProgr
           <div>
             <h2 className="font-semibold">{title}</h2>
             <p className="text-xs text-text-dim" data-testid="plugin-job-status">
-              {state === "running" && "Running…"}
-              {state === "succeeded" && "Done."}
-              {state === "failed" && "Failed."}
+              {gone ? "Job no longer available." : state === "running" && "Running…"}
+              {!gone && state === "succeeded" && "Done."}
+              {!gone && state === "failed" && "Failed."}
             </p>
           </div>
           <button

--- a/web/src/components/settings/PluginJobProgressModal.tsx
+++ b/web/src/components/settings/PluginJobProgressModal.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from "react";
+
+import { fetchPluginJob, type PluginJob } from "../../lib/api";
+
+interface PluginJobProgressModalProps {
+  /** The lifecycle job to follow. */
+  jobId: string;
+  /** Header line, e.g. "Installing acme.widget". */
+  title: string;
+  /** Close the modal. The caller refreshes the plugin list. Closing mid-run
+   *  only stops polling; the host-side job keeps running. */
+  onClose: () => void;
+}
+
+/// Live progress for a host-side plugin lifecycle job (install / update /
+/// uninstall). Polls the job status + log tail once a second until the job
+/// reaches a terminal state, rendering the verbatim host output so a
+/// dashboard-only user can watch fetch / build / remove work and see the final
+/// success or failure without a terminal.
+export function PluginJobProgressModal({ jobId, title, onClose }: PluginJobProgressModalProps) {
+  const [job, setJob] = useState<PluginJob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const logRef = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const poll = async () => {
+      const res = await fetchPluginJob(jobId);
+      if (cancelled) return;
+      if (res.kind === "ok") {
+        setJob(res.job);
+        setError(null);
+        if (res.job.job.status.state === "running") {
+          timer = setTimeout(() => void poll(), 1000);
+        }
+      } else {
+        // A transient read failure should not kill the follow; retry slower.
+        setError(res.message);
+        timer = setTimeout(() => void poll(), 2000);
+      }
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [jobId]);
+
+  // Keep the newest output in view as the tail grows.
+  useEffect(() => {
+    const el = logRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [job?.log.tail]);
+
+  const state = job?.job.status.state ?? "running";
+  const done = state === "succeeded" || state === "failed";
+  const failedError = job?.job.status.state === "failed" ? job.job.status.error : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      data-testid="plugin-job-modal"
+    >
+      <div className="max-h-[80vh] w-full max-w-2xl overflow-auto rounded border border-surface-700 bg-surface-900 p-4 text-sm">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="font-semibold">{title}</h2>
+            <p className="text-xs text-text-dim" data-testid="plugin-job-status">
+              {state === "running" && "Running…"}
+              {state === "succeeded" && "Done."}
+              {state === "failed" && "Failed."}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded border border-surface-700 px-2 py-0.5 text-xs hover:bg-surface-800 disabled:opacity-50"
+            disabled={!done}
+            onClick={onClose}
+            data-testid="plugin-job-close"
+          >
+            {done ? "Close" : "Running…"}
+          </button>
+        </div>
+
+        {failedError && (
+          <p className="mb-2 text-xs text-status-error" data-testid="plugin-job-error">
+            {failedError}
+          </p>
+        )}
+        {error && !done && <p className="mb-2 text-xs text-text-dim">Reconnecting… ({error})</p>}
+
+        <pre
+          ref={logRef}
+          className="max-h-[50vh] overflow-auto whitespace-pre-wrap break-words rounded border border-surface-700 bg-surface-950 p-2 font-mono text-[11px] text-text-dim"
+          data-testid="plugin-job-log"
+        >
+          {job?.log.tail || (state === "running" ? "Starting…" : "")}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -392,7 +392,8 @@ export function PluginsSettings() {
                     </div>
                     {r.description && <p className="mt-1 text-text-dim">{r.description}</p>}
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      {r.badge === "installed" ? (
+                      {r.badge === "installed" ||
+                      data?.plugins.some((p) => p.source === sourceFromCommand(r.install_command)) ? (
                         <span className="text-text-dim">Installed.</span>
                       ) : (
                         <button

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -6,9 +6,13 @@ import {
   discoverPlugins,
   fetchPluginUpdates,
   fetchPlugins,
+  previewPluginInstall,
   previewPluginUpdate,
   setPluginEnabled,
+  startPluginInstall,
+  startPluginUninstall,
   type PluginDiscoveryResult,
+  type PluginInstallConsent,
   type PluginListResponse,
   type PluginUpdateConsent,
   type PluginUpdateStatus,
@@ -16,6 +20,8 @@ import {
 } from "../../lib/api";
 import { reportInfo } from "../../lib/toastBus";
 import { PluginDetailModal } from "./PluginDetailModal";
+import { PluginInstallConsentModal } from "./PluginInstallConsentModal";
+import { PluginJobProgressModal } from "./PluginJobProgressModal";
 import { PluginUpdateConsentModal } from "./PluginUpdateConsentModal";
 
 interface DetailTarget {
@@ -31,14 +37,15 @@ interface DetailTarget {
 }
 
 /// Plugin management: list every known plugin (name, version, description,
-/// validation provenance, capabilities, and enabled / approval state) and
-/// toggle it on or off. Installing and capability approval are CLI-driven (`aoe plugin
-/// install`); this panel shows the resulting state. The toggle POSTs to
-/// `/api/plugins/{id}/enabled`; it is a host mutation, so it needs read-write
-/// mode and (when login is enabled) an elevated session. A `403
-/// elevation_required` response pops the global passphrase prompt via the
-/// fetch interceptor, the same as any other elevated setting; other failures
-/// surface their message inline. `load_errors` are shown as a warning line.
+/// validation provenance, capabilities, and enabled / approval state), toggle
+/// it on or off, and run the lifecycle actions (install from the marketplace,
+/// update, uninstall) as host-side jobs with a live log tail. Install and
+/// uninstall still show the same capability disclosure the CLI prompts for. The
+/// mutations are host operations, so they need read-write mode and (when login
+/// is enabled) an elevated session. A `403 elevation_required` response pops the
+/// global passphrase prompt via the fetch interceptor, the same as any other
+/// elevated setting; other failures surface their message inline. `load_errors`
+/// are shown as a warning line.
 export function PluginsSettings() {
   const [data, setData] = useState<PluginListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +55,7 @@ export function PluginsSettings() {
   const [updates, setUpdates] = useState<Record<string, PluginUpdateStatus>>({});
   const [checkingUpdates, setCheckingUpdates] = useState(false);
 
-  // GitHub discovery (browse-only; install is CLI).
+  // GitHub discovery (the marketplace tab; each result can install in-app).
   const [discoverQuery, setDiscoverQuery] = useState("");
   const [discoverResults, setDiscoverResults] = useState<PluginDiscoveryResult[] | null>(null);
   const [discoverError, setDiscoverError] = useState<string | null>(null);
@@ -63,6 +70,21 @@ export function PluginsSettings() {
   const [consentModal, setConsentModal] = useState<{ plugin: PluginView; consent: PluginUpdateConsent } | null>(null);
   const [consentBusy, setConsentBusy] = useState(false);
   const [consentError, setConsentError] = useState<string | null>(null);
+
+  // The in-app install flow: which marketplace source is previewing, the
+  // consent modal once its disclosure is fetched, and busy/error while the
+  // install job is started.
+  const [previewingSource, setPreviewingSource] = useState<string | null>(null);
+  const [installConsent, setInstallConsent] = useState<PluginInstallConsent | null>(null);
+  const [installBusy, setInstallBusy] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  // An installed external plugin awaiting uninstall confirmation.
+  const [confirmUninstall, setConfirmUninstall] = useState<PluginView | null>(null);
+
+  // The active lifecycle job (install / update / uninstall) the progress modal
+  // is following; null when none is running.
+  const [job, setJob] = useState<{ id: string; title: string } | null>(null);
 
   const clearUpdateBadge = (id: string) =>
     setUpdates((u) => {
@@ -155,13 +177,12 @@ export function PluginsSettings() {
         reportInfo(`${plugin.name} is already up to date.`);
         clearUpdateBadge(plugin.id);
       } else if (preview.kind === "safe_update") {
-        const applied = await applyPluginUpdate(plugin.id, preview.fingerprint);
-        if (applied.kind === "ok") {
-          setData(applied.data);
+        const started = await applyPluginUpdate(plugin.id, preview.fingerprint);
+        if (started.kind === "ok") {
           clearUpdateBadge(plugin.id);
-          reportInfo(`${plugin.name} updated.`);
+          setJob({ id: started.jobId, title: `Updating ${plugin.name}` });
         } else {
-          setError(applied.message);
+          setError(started.message);
         }
       } else {
         setConsentError(null);
@@ -179,13 +200,13 @@ export function PluginsSettings() {
     try {
       const res = await applyPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
       if (res.kind === "ok") {
-        setData(res.data);
         clearUpdateBadge(consentModal.plugin.id);
-        reportInfo(`${consentModal.plugin.name} updated.`);
+        const name = consentModal.plugin.name;
         setConsentModal(null);
+        setJob({ id: res.jobId, title: `Updating ${name}` });
       } else {
-        // A moved-remote 409 (or any failure) keeps the modal open with the
-        // message; the user can close and re-Update to re-preview.
+        // Any failure keeps the modal open with the message; the user can close
+        // and re-Update to re-preview.
         setConsentError(res.message);
       }
     } finally {
@@ -211,6 +232,66 @@ export function PluginsSettings() {
     } finally {
       setConsentBusy(false);
     }
+  };
+
+  // The `gh:owner/repo` source to install, taken from the discovery row's copy
+  // command (`aoe plugin install gh:owner/repo`) so it always carries the `gh:`
+  // prefix the web install path requires.
+  const sourceFromCommand = (command: string) => command.replace(/^.*\binstall\s+/, "").trim();
+
+  // Marketplace install: preview the disclosure first, then open the consent
+  // modal. Nothing is installed until the user approves.
+  const onInstall = async (source: string) => {
+    setPreviewingSource(source);
+    setDiscoverError(null);
+    setInstallError(null);
+    try {
+      const res = await previewPluginInstall(source);
+      if (res.kind === "ok") {
+        setInstallConsent(res.consent);
+      } else {
+        setDiscoverError(res.message);
+      }
+    } finally {
+      setPreviewingSource(null);
+    }
+  };
+
+  const onApproveInstall = async () => {
+    if (!installConsent) return;
+    setInstallBusy(true);
+    setInstallError(null);
+    try {
+      const res = await startPluginInstall(installConsent.source, installConsent.fingerprint);
+      if (res.kind === "ok") {
+        const title = `Installing ${installConsent.id}`;
+        setInstallConsent(null);
+        setJob({ id: res.jobId, title });
+      } else {
+        setInstallError(res.message);
+      }
+    } finally {
+      setInstallBusy(false);
+    }
+  };
+
+  const onConfirmUninstall = async () => {
+    if (!confirmUninstall) return;
+    const plugin = confirmUninstall;
+    setConfirmUninstall(null);
+    const res = await startPluginUninstall(plugin.id);
+    if (res.kind === "ok") {
+      setJob({ id: res.jobId, title: `Uninstalling ${plugin.name}` });
+    } else {
+      setError(res.message);
+    }
+  };
+
+  // When a job modal closes (terminal state), refresh the list so the installed
+  // set, versions, and approval state reflect what the job did.
+  const onJobClose = async () => {
+    setJob(null);
+    await reload();
   };
 
   const onDiscover = async () => {
@@ -310,9 +391,24 @@ export function PluginsSettings() {
                       </a>
                     </div>
                     {r.description && <p className="mt-1 text-text-dim">{r.description}</p>}
-                    <p className="mt-1 text-text-dim">
-                      Install in a terminal: <code>{r.install_command}</code>
-                    </p>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      {r.badge === "installed" ? (
+                        <span className="text-text-dim">Installed.</span>
+                      ) : (
+                        <button
+                          type="button"
+                          className="rounded bg-brand-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-brand-500 disabled:opacity-50"
+                          disabled={previewingSource !== null}
+                          onClick={() => void onInstall(sourceFromCommand(r.install_command))}
+                          data-testid={`plugins-install-${r.slug}`}
+                        >
+                          {previewingSource === sourceFromCommand(r.install_command) ? "Checking…" : "Install"}
+                        </button>
+                      )}
+                      <span className="text-text-dim">
+                        or in a terminal: <code>{r.install_command}</code>
+                      </span>
+                    </div>
                   </div>
                 ))
               )}
@@ -440,17 +536,29 @@ export function PluginsSettings() {
                       <p className="mt-1 text-[11px] text-status-error">Update check failed: {update.error}</p>
                     )}
                   </div>
-                  <label className="flex shrink-0 items-center gap-1 text-xs">
-                    <input
-                      type="checkbox"
-                      role="switch"
-                      aria-label={`Enable ${plugin.name}`}
-                      checked={plugin.enabled}
-                      disabled={busy}
-                      onChange={(e) => void onToggle(plugin, e.target.checked)}
-                    />
-                    Enabled
-                  </label>
+                  <div className="flex shrink-0 flex-col items-end gap-2">
+                    <label className="flex items-center gap-1 text-xs">
+                      <input
+                        type="checkbox"
+                        role="switch"
+                        aria-label={`Enable ${plugin.name}`}
+                        checked={plugin.enabled}
+                        disabled={busy}
+                        onChange={(e) => void onToggle(plugin, e.target.checked)}
+                      />
+                      Enabled
+                    </label>
+                    {!plugin.builtin && plugin.source && (
+                      <button
+                        type="button"
+                        className="rounded border border-status-error/50 px-2 py-0.5 text-[11px] text-status-error hover:bg-status-error/10 disabled:opacity-50"
+                        onClick={() => setConfirmUninstall(plugin)}
+                        data-testid={`plugin-uninstall-${plugin.id}`}
+                      >
+                        Uninstall
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             );
@@ -481,6 +589,59 @@ export function PluginsSettings() {
           onClose={() => setConsentModal(null)}
         />
       )}
+
+      {installConsent && (
+        <PluginInstallConsentModal
+          key={installConsent.fingerprint}
+          consent={installConsent}
+          busy={installBusy}
+          error={installError}
+          onApprove={() => void onApproveInstall()}
+          onClose={() => setInstallConsent(null)}
+        />
+      )}
+
+      {confirmUninstall && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Uninstall ${confirmUninstall.name}`}
+          onClick={() => setConfirmUninstall(null)}
+          data-testid="plugin-uninstall-confirm"
+        >
+          <div
+            className="w-full max-w-sm rounded border border-surface-700 bg-surface-900 p-4 text-sm"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-2 font-semibold">Uninstall {confirmUninstall.name}?</h2>
+            <p className="mb-4 text-xs text-text-dim">
+              This removes the plugin's files, config entry, and lockfile entry from the host. You can reinstall it
+              later from the marketplace.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded border border-surface-700 px-3 py-1 text-xs hover:bg-surface-800"
+                onClick={() => setConfirmUninstall(null)}
+                data-testid="plugin-uninstall-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded bg-status-error px-3 py-1 text-xs font-medium text-white hover:opacity-90"
+                onClick={() => void onConfirmUninstall()}
+                data-testid="plugin-uninstall-confirm-button"
+              >
+                Uninstall
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {job && <PluginJobProgressModal jobId={job.id} title={job.title} onClose={() => void onJobClose()} />}
     </div>
   );
 }

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -825,6 +825,20 @@ describe("PluginsSettings", () => {
     expect(err.textContent).toContain("removing tree failed");
   });
 
+  it("the job modal treats a 404 (job gone) as terminal, not an endless reconnect", async () => {
+    startPluginUninstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+    // The daemon restarted mid-run: the job entry is gone. The modal must stop
+    // polling and let the user close, not spin forever with Close disabled.
+    fetchPluginJob.mockResolvedValue({ kind: "error", status: 404, message: "No plugin job job1" });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-uninstall-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-uninstall-confirm-button"));
+    const status = await findByTestId("plugin-job-status");
+    await waitFor(() => expect(status.textContent).toContain("no longer available"));
+    const close = (await findByTestId("plugin-job-close")) as HTMLButtonElement;
+    expect(close.disabled).toBe(false);
+  });
+
   it("a rejected install start (e.g. another job active) surfaces the error in the consent modal", async () => {
     discoverWidget();
     previewPluginInstall.mockResolvedValue(installConsent);

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -13,6 +13,9 @@ import type {
   DiscoverResult,
   PluginDetailResult,
   PluginDismissResult,
+  PluginInstallPreviewResult,
+  PluginJobResult,
+  PluginJobStartResult,
   PluginListResponse,
   PluginToggleResult,
   PluginUpdatePreviewResult,
@@ -25,8 +28,12 @@ const fetchPluginUpdates = vi.fn<[], Promise<PluginUpdatesResult>>();
 const discoverPlugins = vi.fn<[string], Promise<DiscoverResult>>();
 const fetchPluginDetails = vi.fn<[string], Promise<PluginDetailResult>>();
 const previewPluginUpdate = vi.fn<[string], Promise<PluginUpdatePreviewResult>>();
-const applyPluginUpdate = vi.fn<[string, string | null], Promise<PluginToggleResult>>();
+const applyPluginUpdate = vi.fn<[string, string | null], Promise<PluginJobStartResult>>();
 const dismissPluginUpdate = vi.fn<[string, string], Promise<PluginDismissResult>>();
+const previewPluginInstall = vi.fn<[string], Promise<PluginInstallPreviewResult>>();
+const startPluginInstall = vi.fn<[string, string], Promise<PluginJobStartResult>>();
+const startPluginUninstall = vi.fn<[string], Promise<PluginJobStartResult>>();
+const fetchPluginJob = vi.fn<[string, number?], Promise<PluginJobResult>>();
 const reportInfo = vi.fn<[string], void>();
 
 vi.mock("../../../lib/api", () => ({
@@ -38,6 +45,10 @@ vi.mock("../../../lib/api", () => ({
   previewPluginUpdate: (id: string) => previewPluginUpdate(id),
   applyPluginUpdate: (id: string, fp: string | null) => applyPluginUpdate(id, fp),
   dismissPluginUpdate: (id: string, fp: string) => dismissPluginUpdate(id, fp),
+  previewPluginInstall: (source: string) => previewPluginInstall(source),
+  startPluginInstall: (source: string, fp: string) => startPluginInstall(source, fp),
+  startPluginUninstall: (id: string) => startPluginUninstall(id),
+  fetchPluginJob: (jobId: string, tail?: number) => fetchPluginJob(jobId, tail),
 }));
 
 vi.mock("../../../lib/toastBus", () => ({
@@ -96,6 +107,10 @@ beforeEach(() => {
   previewPluginUpdate.mockReset();
   applyPluginUpdate.mockReset();
   dismissPluginUpdate.mockReset();
+  previewPluginInstall.mockReset();
+  startPluginInstall.mockReset();
+  startPluginUninstall.mockReset();
+  fetchPluginJob.mockReset();
   reportInfo.mockReset();
   fetchPlugins.mockResolvedValue(listResponse());
   fetchPluginUpdates.mockResolvedValue({ kind: "ok", updates: [] });
@@ -103,6 +118,25 @@ beforeEach(() => {
   fetchPluginDetails.mockResolvedValue({
     kind: "ok",
     detail: { source: "gh:example/plugin", manifest: null, manifest_error: null, release_tags: [] },
+  });
+  // Lifecycle jobs default to "started" + a terminal succeeded poll, so a
+  // progress modal that opens resolves to Done without hanging.
+  applyPluginUpdate.mockResolvedValue({ kind: "ok", jobId: "job1" });
+  startPluginInstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+  startPluginUninstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+  fetchPluginJob.mockResolvedValue({
+    kind: "ok",
+    job: {
+      job: {
+        id: "job1",
+        kind: "install",
+        target: "gh:acme/widget",
+        status: { state: "succeeded" },
+        started_at: 0,
+        finished_at: 1,
+      },
+      log: { exists: true, tail: "installed acme.widget 1.0.0", lines_returned: 1, truncated: false },
+    },
   });
 });
 
@@ -465,16 +499,18 @@ describe("PluginsSettings", () => {
     expect((await findByTestId("plugin-update-build-steps")).textContent).toContain("sh build.sh");
   });
 
-  it("Approving applies the update pinned to the previewed fingerprint and closes the modal", async () => {
+  it("Approving applies the update pinned to the previewed fingerprint and opens the job modal", async () => {
     markOutdated();
     previewPluginUpdate.mockResolvedValue(consentPreview);
-    applyPluginUpdate.mockResolvedValue({ kind: "ok", data: listResponse() });
+    applyPluginUpdate.mockResolvedValue({ kind: "ok", jobId: "job1" });
     const { findByTestId, queryByTestId } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugins-check-updates"));
     fireEvent.click(await findByTestId("plugin-update-example.plugin"));
     fireEvent.click(await findByTestId("plugin-update-approve"));
     await waitFor(() => expect(applyPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeB||community"));
+    // The consent modal closes and the update runs as a job with a live log.
     await waitFor(() => expect(queryByTestId("plugin-update-consent-modal")).toBeNull());
+    await findByTestId("plugin-job-modal");
   });
 
   it("Declining records the dismissal and never applies (the version stays active)", async () => {
@@ -506,18 +542,19 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-update-available-example.plugin");
   });
 
-  it("a safe update applies directly without a consent modal", async () => {
+  it("a safe update applies directly without a consent modal and follows the job", async () => {
     markOutdated();
     previewPluginUpdate.mockResolvedValue({
       kind: "ok",
       preview: { kind: "safe_update", to_version: "0.2.0", fingerprint: "treeC||community" },
     });
-    applyPluginUpdate.mockResolvedValue({ kind: "ok", data: listResponse() });
+    applyPluginUpdate.mockResolvedValue({ kind: "ok", jobId: "job1" });
     const { findByTestId, queryByTestId } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugins-check-updates"));
     fireEvent.click(await findByTestId("plugin-update-example.plugin"));
     await waitFor(() => expect(applyPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeC||community"));
     expect(queryByTestId("plugin-update-consent-modal")).toBeNull();
+    await findByTestId("plugin-job-modal");
   });
 
   it("surfaces an apply error in the consent modal and keeps it open", async () => {
@@ -612,5 +649,192 @@ describe("PluginsSettings", () => {
     fireEvent.keyDown(window, { key: "Escape" });
     fireEvent.click(await findByTestId("plugin-update-consent-close"));
     expect(queryByTestId("plugin-update-consent-modal")).not.toBeNull();
+  });
+
+  // --- Install (marketplace) ---
+
+  function discoverWidget() {
+    discoverPlugins.mockResolvedValue({
+      kind: "ok",
+      results: [
+        {
+          slug: "gh:acme/widget",
+          html_url: "https://github.com/acme/widget",
+          description: "A widget plugin.",
+          stars: 42,
+          badge: "unvetted",
+          install_command: "aoe plugin install gh:acme/widget",
+        },
+      ],
+    });
+  }
+
+  const installConsent: PluginInstallPreviewResult = {
+    kind: "ok",
+    consent: {
+      id: "acme.widget",
+      version: "1.0.0",
+      source: "gh:acme/widget",
+      notice: "installing the latest release v1.0.0",
+      unverified: false,
+      validation: "community",
+      capabilities: ["net"],
+      ui: [],
+      build_steps: ["sh build.sh"],
+      fingerprint: "treeA||community",
+    },
+  };
+
+  it("Install on a marketplace result previews the gh: source and shows the disclosure", async () => {
+    discoverWidget();
+    previewPluginInstall.mockResolvedValue(installConsent);
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
+    fireEvent.click(await findByTestId("plugins-discover"));
+    fireEvent.click(await findByTestId("plugins-install-gh:acme/widget"));
+    // The gh: source is taken from the copy command, prefix intact.
+    await waitFor(() => expect(previewPluginInstall).toHaveBeenCalledWith("gh:acme/widget"));
+    await findByTestId("plugin-install-consent-modal");
+    expect((await findByTestId("plugin-install-caps")).textContent).toContain("net");
+    expect((await findByTestId("plugin-install-build-steps")).textContent).toContain("sh build.sh");
+  });
+
+  it("Approving an install starts the job pinned to the previewed fingerprint", async () => {
+    discoverWidget();
+    previewPluginInstall.mockResolvedValue(installConsent);
+    startPluginInstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
+    fireEvent.click(await findByTestId("plugins-discover"));
+    fireEvent.click(await findByTestId("plugins-install-gh:acme/widget"));
+    fireEvent.click(await findByTestId("plugin-install-approve"));
+    await waitFor(() => expect(startPluginInstall).toHaveBeenCalledWith("gh:acme/widget", "treeA||community"));
+    await waitFor(() => expect(queryByTestId("plugin-install-consent-modal")).toBeNull());
+    await findByTestId("plugin-job-modal");
+  });
+
+  it("surfaces an install preview error without opening the consent modal", async () => {
+    discoverWidget();
+    previewPluginInstall.mockResolvedValue({ kind: "error", message: "no published release" });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
+    fireEvent.click(await findByTestId("plugins-discover"));
+    fireEvent.click(await findByTestId("plugins-install-gh:acme/widget"));
+    const err = await findByTestId("plugins-discover-error");
+    expect(err.textContent).toContain("no published release");
+    expect(queryByTestId("plugin-install-consent-modal")).toBeNull();
+  });
+
+  it("an installed marketplace result shows no Install button", async () => {
+    discoverPlugins.mockResolvedValue({
+      kind: "ok",
+      results: [
+        {
+          slug: "gh:acme/widget",
+          html_url: "https://github.com/acme/widget",
+          description: "A widget plugin.",
+          stars: 42,
+          badge: "installed",
+          install_command: "aoe plugin install gh:acme/widget",
+        },
+      ],
+    });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
+    fireEvent.click(await findByTestId("plugins-discover"));
+    await findByTestId("plugins-discover-result-gh:acme/widget");
+    expect(queryByTestId("plugins-install-gh:acme/widget")).toBeNull();
+  });
+
+  // --- Uninstall ---
+
+  it("Uninstall on an external plugin confirms, then starts the job", async () => {
+    startPluginUninstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-uninstall-example.plugin"));
+    await findByTestId("plugin-uninstall-confirm");
+    fireEvent.click(await findByTestId("plugin-uninstall-confirm-button"));
+    await waitFor(() => expect(startPluginUninstall).toHaveBeenCalledWith("example.plugin"));
+    await findByTestId("plugin-job-modal");
+  });
+
+  it("Cancelling the uninstall confirm starts no job", async () => {
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-uninstall-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-uninstall-cancel"));
+    await waitFor(() => expect(queryByTestId("plugin-uninstall-confirm")).toBeNull());
+    expect(startPluginUninstall).not.toHaveBeenCalled();
+  });
+
+  it("a builtin plugin has no Uninstall button", async () => {
+    const { findByText, queryByTestId } = render(<PluginsSettings />);
+    await findByText("Agent Status Detection");
+    expect(queryByTestId("plugin-uninstall-aoe.status")).toBeNull();
+  });
+
+  // --- Job progress modal ---
+
+  it("the job modal renders the live log tail and closes to a refreshed list when done", async () => {
+    startPluginUninstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+    fetchPluginJob.mockResolvedValue({
+      kind: "ok",
+      job: {
+        job: {
+          id: "job1",
+          kind: "uninstall",
+          target: "example.plugin",
+          status: { state: "succeeded" },
+          started_at: 0,
+          finished_at: 1,
+        },
+        log: { exists: true, tail: "uninstalled example.plugin", lines_returned: 1, truncated: false },
+      },
+    });
+    const { findByTestId, queryByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-uninstall-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-uninstall-confirm-button"));
+    const log = await findByTestId("plugin-job-log");
+    await waitFor(() => expect(log.textContent).toContain("uninstalled example.plugin"));
+    const fetchCountBefore = fetchPlugins.mock.calls.length;
+    fireEvent.click(await findByTestId("plugin-job-close"));
+    await waitFor(() => expect(queryByTestId("plugin-job-modal")).toBeNull());
+    // Closing refreshes the list so the removed plugin disappears.
+    await waitFor(() => expect(fetchPlugins.mock.calls.length).toBeGreaterThan(fetchCountBefore));
+  });
+
+  it("the job modal shows the failure error from a failed job", async () => {
+    startPluginUninstall.mockResolvedValue({ kind: "ok", jobId: "job1" });
+    fetchPluginJob.mockResolvedValue({
+      kind: "ok",
+      job: {
+        job: {
+          id: "job1",
+          kind: "uninstall",
+          target: "example.plugin",
+          status: { state: "failed", error: "removing tree failed" },
+          started_at: 0,
+          finished_at: 1,
+        },
+        log: { exists: true, tail: "uninstalling example.plugin", lines_returned: 1, truncated: false },
+      },
+    });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-uninstall-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-uninstall-confirm-button"));
+    const err = await findByTestId("plugin-job-error");
+    expect(err.textContent).toContain("removing tree failed");
+  });
+
+  it("a rejected install start (e.g. another job active) surfaces the error in the consent modal", async () => {
+    discoverWidget();
+    previewPluginInstall.mockResolvedValue(installConsent);
+    startPluginInstall.mockResolvedValue({ kind: "error", message: "Another plugin operation is already running" });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-tab-marketplace"));
+    fireEvent.click(await findByTestId("plugins-discover"));
+    fireEvent.click(await findByTestId("plugins-install-gh:acme/widget"));
+    fireEvent.click(await findByTestId("plugin-install-approve"));
+    const err = await findByTestId("plugin-install-consent-error");
+    expect(err.textContent).toContain("already running");
   });
 });

--- a/web/src/lib/__tests__/pluginsApi.test.ts
+++ b/web/src/lib/__tests__/pluginsApi.test.ts
@@ -146,10 +146,10 @@ describe("previewPluginUpdate", () => {
 });
 
 describe("applyPluginUpdate", () => {
-  it("POSTs the fingerprint and returns the refreshed list on success", async () => {
-    fetchSpy.mockResolvedValue(new Response(JSON.stringify(listPayload), { status: 200 }));
+  it("POSTs the fingerprint and returns a job id on success", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ job_id: "job1" }), { status: 202 }));
     const res = await applyPluginUpdate("acme.plugin", "treeB||community");
-    expect(res).toEqual({ kind: "ok", data: listPayload });
+    expect(res).toEqual({ kind: "ok", jobId: "job1" });
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe("/api/plugins/acme.plugin/update/apply");
     expect(init?.method).toBe("POST");
@@ -161,7 +161,7 @@ describe("applyPluginUpdate", () => {
     expect(await applyPluginUpdate("acme.plugin", "x")).toEqual({ kind: "error", message: "changed since shown" });
   });
 
-  it("reports an error when an OK response has a malformed shape", async () => {
+  it("reports an error when an OK response carries no job id", async () => {
     fetchSpy.mockResolvedValue(new Response(JSON.stringify({ nope: true }), { status: 200 }));
     expect((await applyPluginUpdate("acme.plugin", null)).kind).toBe("error");
   });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -533,10 +533,12 @@ export interface PluginJob {
   };
 }
 
-export type PluginJobResult = { kind: "ok"; job: PluginJob } | { kind: "error"; message: string };
+export type PluginJobResult = { kind: "ok"; job: PluginJob } | { kind: "error"; status: number; message: string };
 
 /** Fetch a lifecycle job's status plus a tail of its log. Polled by the
- *  progress modal until the job reaches a terminal state. */
+ *  progress modal until the job reaches a terminal state. The HTTP `status` is
+ *  preserved so the caller can tell a terminal 404 (the job is gone, e.g. after
+ *  a daemon restart) from a transient failure worth retrying. */
 export async function fetchPluginJob(jobId: string, tail = 200): Promise<PluginJobResult> {
   try {
     const res = await fetch(`/api/plugins/jobs/${encodeURIComponent(jobId)}?tail=${tail}`, {
@@ -548,9 +550,9 @@ export async function fetchPluginJob(jobId: string, tail = 200): Promise<PluginJ
     }
     const message =
       typeof payload?.message === "string" ? (payload.message as string) : `Job status failed (HTTP ${res.status}).`;
-    return { kind: "error", message };
+    return { kind: "error", status: res.status, message };
   } catch {
-    return { kind: "error", message: "Network error." };
+    return { kind: "error", status: 0, message: "Network error." };
   }
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -421,22 +421,133 @@ export async function previewPluginUpdate(id: string): Promise<PluginUpdatePrevi
   }
 }
 
-/** Apply an approved update, pinned to the fingerprint the user saw. On success
- *  the server returns the refreshed plugin list. A 409 means the remote moved
- *  since the preview, so the caller should re-preview before re-approving. */
-export async function applyPluginUpdate(id: string, expectedFingerprint: string | null): Promise<PluginToggleResult> {
+/** Start a host-side update job, pinned to the fingerprint the user saw. The
+ *  update runs as a job (like install/uninstall) so its build is observable;
+ *  poll the returned job id with `fetchPluginJob`. A fingerprint mismatch (the
+ *  remote moved since the preview) surfaces as a failed job, which the UI
+ *  recovers from by re-previewing. */
+export async function applyPluginUpdate(id: string, expectedFingerprint: string | null): Promise<PluginJobStartResult> {
+  return startPluginJob(`/api/plugins/${encodeURIComponent(id)}/update/apply`, {
+    expected_fingerprint: expectedFingerprint,
+  });
+}
+
+/** Structured install disclosure (`POST /api/plugins/install/preview`),
+ *  mirroring the Rust `InstallConsent`. Drives the install consent modal. */
+export interface PluginInstallConsent {
+  id: string;
+  version: string;
+  source: string;
+  /** One line stating what is being installed (resolved release, ref, etc). */
+  notice: string;
+  /** The source is off the audited-release default path; warn on it. */
+  unverified: boolean;
+  /** Trust class: "featured" | "community" | "local". */
+  validation: string;
+  capabilities: string[];
+  ui: PluginUpdateUiView[];
+  build_steps: string[];
+  fingerprint: string;
+}
+
+export type PluginInstallPreviewResult =
+  | { kind: "ok"; consent: PluginInstallConsent }
+  | { kind: "error"; message: string };
+
+/** Classify a gh: install candidate and return its disclosure, without
+ *  installing. Backs the install consent modal. */
+export async function previewPluginInstall(source: string): Promise<PluginInstallPreviewResult> {
   try {
-    const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/update/apply`, {
+    const res = await fetch("/api/plugins/install/preview", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ expected_fingerprint: expectedFingerprint }),
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ source }),
     });
     const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-    if (res.ok && payload && isValidPluginListResponse(payload)) {
-      return { kind: "ok", data: payload };
+    if (res.ok && payload && typeof payload.fingerprint === "string") {
+      return { kind: "ok", consent: payload as unknown as PluginInstallConsent };
     }
     const message =
-      typeof payload?.message === "string" ? (payload.message as string) : `Update failed (HTTP ${res.status}).`;
+      typeof payload?.message === "string"
+        ? (payload.message as string)
+        : `Install preview failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
+/** Outcome of starting a lifecycle job: a job id to poll, or an error (403
+ *  read_only / elevation_required is handled by the fetch interceptor). */
+export type PluginJobStartResult = { kind: "ok"; jobId: string } | { kind: "error"; message: string };
+
+async function startPluginJob(url: string, body: unknown): Promise<PluginJobStartResult> {
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && typeof payload.job_id === "string") {
+      return { kind: "ok", jobId: payload.job_id as string };
+    }
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Request failed (HTTP ${res.status}).`;
+    return { kind: "error", message };
+  } catch {
+    return { kind: "error", message: "Network error." };
+  }
+}
+
+/** Start a host-side install job for an approved gh: source. Poll the returned
+ *  job id with `fetchPluginJob`. */
+export async function startPluginInstall(source: string, expectedFingerprint: string): Promise<PluginJobStartResult> {
+  return startPluginJob("/api/plugins/install", { source, expected_fingerprint: expectedFingerprint });
+}
+
+/** Start a host-side uninstall job for an installed external plugin. */
+export async function startPluginUninstall(id: string): Promise<PluginJobStartResult> {
+  return startPluginJob(`/api/plugins/${encodeURIComponent(id)}/uninstall`, {});
+}
+
+/** A lifecycle job's status, mirroring the Rust `PluginJobStatus` tag. */
+export type PluginJobState = { state: "running" } | { state: "succeeded" } | { state: "failed"; error: string };
+
+/** A lifecycle job plus a bounded tail of its host-side log
+ *  (`GET /api/plugins/jobs/{id}`). */
+export interface PluginJob {
+  job: {
+    id: string;
+    kind: "install" | "update" | "uninstall";
+    target: string;
+    status: PluginJobState;
+    started_at: number;
+    finished_at: number | null;
+  };
+  log: {
+    exists: boolean;
+    tail: string;
+    lines_returned: number;
+    truncated: boolean;
+  };
+}
+
+export type PluginJobResult = { kind: "ok"; job: PluginJob } | { kind: "error"; message: string };
+
+/** Fetch a lifecycle job's status plus a tail of its log. Polled by the
+ *  progress modal until the job reaches a terminal state. */
+export async function fetchPluginJob(jobId: string, tail = 200): Promise<PluginJobResult> {
+  try {
+    const res = await fetch(`/api/plugins/jobs/${encodeURIComponent(jobId)}?tail=${tail}`, {
+      headers: { Accept: "application/json" },
+    });
+    const payload = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (res.ok && payload && typeof payload.job === "object" && payload.job !== null) {
+      return { kind: "ok", job: payload as unknown as PluginJob };
+    }
+    const message =
+      typeof payload?.message === "string" ? (payload.message as string) : `Job status failed (HTTP ${res.status}).`;
     return { kind: "error", message };
   } catch {
     return { kind: "error", message: "Network error." };

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2817,7 +2817,9 @@
       "components": [
         "web/src/components/settings/PluginsSettings.tsx",
         "web/src/components/settings/PluginDetailModal.tsx",
-        "web/src/components/settings/PluginUpdateConsentModal.tsx"
+        "web/src/components/settings/PluginUpdateConsentModal.tsx",
+        "web/src/components/settings/PluginInstallConsentModal.tsx",
+        "web/src/components/settings/PluginJobProgressModal.tsx"
       ]
     },
     {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a web-native plugin lifecycle surface to Settings -> Plugins. The dashboard previously stopped at discovery, details, update checks, and enable/disable; install and uninstall forced a host terminal, and there was no way to watch the host-side build of any lifecycle operation. This wires install, uninstall, and update into the dashboard as host-side jobs with a live log tail.

**Trust boundary preserved.** Install splits into a network-only `preview_install` (mirroring the existing `preview_update`) that returns the same structured disclosure the CLI prompts for (capabilities, build commands, UI slots, unverified-source warning) plus a content fingerprint, and a non-interactive, fingerprint-pinned `apply_install`. The web flow shows that disclosure in a consent modal and requires an explicit approval before any host work runs; nothing is auto-granted. Web install is restricted to `gh:` sources so a browser request can never make the daemon read an arbitrary local path; local installs stay on the CLI.

**Live log tail.** A typed `OperationLog` sink is threaded through the build chain: the CLI keeps inherited stdio, while a dashboard operation writes progress and child build output to a per-job log file under `<plugins_dir>/jobs/<job_id>.log`. The new endpoints start each operation as a job and return a `job_id`; `GET /api/plugins/jobs/{job_id}` returns the job status plus a bounded tail (reusing the proven ACP `read_log_tail`), which a progress modal polls once a second until success or failure. Jobs run through an in-memory registry that allows one lifecycle mutation at a time (config and lockfile writes are not concurrency-safe; a second start is rejected with 409).

**Update from Settings.** Update already existed in the web UI but applied synchronously with no observable build. It now runs through the same job surface, so its build is observable too; `POST /api/plugins/{id}/update/apply` returns a `job_id` instead of the refreshed list.

Mutations stay gated on read-write mode plus elevation, matching enable/disable.

Closes #2494

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In Settings -> Plugins -> Marketplace, search GitHub, click Install on a result, confirm the consent modal lists the plugin's capabilities, build commands, and UI slots (and an unverified-source warning for an `@ref` / no-release source) before anything installs.
- [ ] Approve the install and confirm a progress modal shows the live host-side log streaming until it ends in success or failure, then the installed list refreshes.
- [ ] On an installed external plugin, click Uninstall, confirm the dialog, and confirm the plugin is removed with a live status/log ending in a clear result.
- [ ] Run "Check for updates", then Update an outdated plugin, and confirm the update now runs through the same live-log progress modal.
- [ ] Start one lifecycle operation, then try to start another before it finishes, and confirm the second is rejected (one mutation at a time).
- [ ] Confirm a local (non-`gh:`) install is still CLI-only (the marketplace only offers `gh:` sources).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

<!--
The user-facing flow (install preview -> consent -> job, uninstall confirm ->
job, update -> job, and the progress modal's poll / log / terminal states) is
covered by the extended Vitest contract test, which the existing
`settings.plugins` coverage-matrix entry maps (now listing the two new modals).
The hermetic plugin-install harness exists at the Rust integration level
(`tests/plugin_install.rs`, local git + local release fixture, never network);
the install/update/uninstall core is exercised there, so a live Playwright
install (which would need a hermetic gh source in the live harness) is deferred.
-->

**TUI / CLI (e2e test)**
- [x] N/A: this PR changes no TUI rendering, CLI subcommand, or session lifecycle (the CLI install/update/uninstall behavior is unchanged and still covered by `tests/plugin_install.rs`).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a multi-model `/debate`), and implementation were drafted by Claude under my direction. I made the design calls (job-backed lifecycle, polling log tail, gh:-only web install, one-mutation-at-a-time) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785232360&installation_id=139138837&pr_number=2508&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2508&signature=77254ed208fc67dc453e37c524761854970f15f067c43f899f5db6d831cba3a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a web-based plugin lifecycle flow in **Settings → Plugins** so **install, update, and uninstall** can run from the dashboard with **live host-side logs**, instead of being terminal-only for most operations.

Key changes:
- Added a **web install preview** step plus an **explicit “Approve and install” consent boundary** that shows the same trust/disclosure information as the CLI and returns a **fingerprint-pinned** approval payload.
- Switched lifecycle mutations (**install, update, uninstall**) to run as **host-side background jobs**; the UI starts the job and then tracks it instead of waiting for inline completion.
- Introduced a **job progress modal** that **polls job status** and displays a **bounded live tail** of the job log until the job **succeeds or fails**. If the job disappears (404), the modal treats it as a **terminal state** and stops polling.
- Added a server-side **plugin job registry** with **single-operation-at-a-time** enforcement to prevent unsafe concurrent config/lockfile writes, plus log/job cleanup (TTL).
- Updated backend/TUI/web wiring to thread structured progress output through the build/apply pipeline via a typed **`OperationLog`**, writing **stdout/stderr** into per-job log files and surfacing build progress in the UI.
- Web installs are supported **only for `gh:` sources**; **local installs remain CLI-only**.
- Updated the dashboard marketplace flow to drive install/uninstall through the new preview/start/job polling endpoints, including UI gating and inline error handling.
- Updated build/internals documentation to reflect how web job builds run under the daemon environment (including a **PATH/environment caveat**) and where log output is routed.

Benefits:
- Clearer and safer lifecycle operations via **explicit approval** and **fingerprint pinning**.
- Much better transparency and troubleshooting with **live host-side log tails** directly in the dashboard.
- Improved reliability by running lifecycle changes as **serialized jobs** and standardizing build/output handling across install/update/uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->