### PR TITLE
chore(plugins): pin agent-of-empires.github 1.4.0

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -32,4 +32,4 @@ source = "gh:agent-of-empires/plugin-github"
 # namespace gate skips it). Dropping the pin downgrades it to community so the
 # reserved-namespace install gate blocks it outright. Fixed in 1.2.0, which
 # builds under `.aoe-build/`.
-versions = { "0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a", "1.3.0" = "sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28" }
+versions = {"0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a", "1.3.0" = "sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28", "1.4.0" = "sha256:f2d231e8d0877a8092c75efaa06016359be8da30c2c4a9ffe88ee7c7f3dfac18"}


### PR DESCRIPTION
Manual featured-index pin (the release CI `featured-pr` job self-skips because `AOE_FEATURED_PR_TOKEN` is unset).

Pins `agent-of-empires.github` `1.4.0` in `plugins/featured.toml`.

- Version: 1.4.0
- Tree hash: `sha256:f2d231e8d0877a8092c75efaa06016359be8da30c2c4a9ffe88ee7c7f3dfac18`
- Hash algorithm: aoe-plugin-tree-hash-v1
- Source commit: 3d0c0be93ed774fa41ddff8a456a5581a8ff11fa
- Release: https://github.com/agent-of-empires/plugin-github/releases/tag/v1.4.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785235490&installation_id=139138837&pr_number=2509&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2509&signature=5614f56e93e57a10526f3c65c3be0ce7e3d2614f315c579ae4ab985b041a97e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Pinned `agent-of-empires.github` to version `1.4.0` in the featured plugin releases list. This adds a new verified release entry with its matching tree hash and source metadata, while leaving the rest of the plugin catalog unchanged.

Benefits:
- Keeps the featured plugin set aligned with the latest approved release
- Improves release reproducibility by locking in the exact published version
- Avoids relying on the skipped release automation path

<!-- end of auto-generated comment: release notes by coderabbit.ai -->