### PR TITLE
feat(web): Playwright showcase video pipeline

### DIFF
--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -2,6 +2,8 @@
 
 This document is the long-form reference for the web suite. The short version lives in `AGENTS.md` under "Web Dashboard Playwright Tests". Read the short version first.
 
+For the demo/highlight clip workflow that records every spec and stitches the videos into one mp4, see [showcase-video.md](showcase-video.md).
+
 ## The two suites
 
 | Suite | Config | Where | Speed | When to use |

--- a/docs/development/showcase-video.md
+++ b/docs/development/showcase-video.md
@@ -187,8 +187,8 @@ Playwright will recreate both on the next showcase run.
 
 ## Files
 
-- `web/playwright.showcase.config.ts` -- config used by step 1.
-- `web/scripts/combine-showcase-videos.sh` -- combiner used by step 2.
-- `web/package.json` -- `test:showcase` script.
-- `web/test-results/` -- per-test recordings (gitignored).
-- `web/playwright-showcase-report/` -- HTML report (gitignored).
+- `web/playwright.showcase.config.ts`: config used by step 1.
+- `web/scripts/combine-showcase-videos.sh`: combiner used by step 2.
+- `web/package.json`: `test:showcase` script.
+- `web/test-results/`: per-test recordings (gitignored).
+- `web/playwright-showcase-report/`: HTML report (gitignored).

--- a/docs/development/showcase-video.md
+++ b/docs/development/showcase-video.md
@@ -180,7 +180,7 @@ CRF=12 PRESET=veryslow GRID=2x2 ./scripts/combine-showcase-videos.sh ~/Desktop/a
 ### Reset between runs
 
 ```bash
-rm -rf web/test-results web/playwright-showcase-report
+rm -rf test-results playwright-showcase-report
 ```
 
 Playwright will recreate both on the next showcase run.

--- a/docs/development/showcase-video.md
+++ b/docs/development/showcase-video.md
@@ -1,0 +1,194 @@
+# Showcase video generation
+
+A two-step pipeline that turns the existing Playwright suites into a single highlight clip:
+
+1. **Record** every spec under a special Playwright config that always captures video.
+2. **Combine** all the recorded `video.webm` files into one mp4 (concat or paginated grid, with optional title overlays).
+
+Both steps reuse the existing mocked and live test suites; no showcase-specific spec is required. New tests added to the suite show up in the next showcase render automatically.
+
+## When to use this
+
+- Cutting a demo clip for a release post, a PR, or a Slack share.
+- Spot-checking a refactor visually across the whole UI surface in one pass.
+- Stress-running both mocked and live suites under deterministic single-worker conditions (failures during showcase are real test failures; the videos are emitted regardless).
+
+It is **not** a replacement for normal CI. The showcase config disables parallelism and adds per-action slow-motion, so a full run is multiple times slower than the regular suites.
+
+## Step 1: record the videos
+
+### Config
+
+`web/playwright.showcase.config.ts` defines a single Playwright project pair (mocked + live) under `tests/` and `tests/live/`. It extends nothing implicitly: the file is self-contained so it does not drift if `playwright.live.config.ts` changes shape later.
+
+Key knobs (all in the file):
+
+| Setting | Value | Why |
+|---|---|---|
+| `fullyParallel` | `false` | Recordings must be deterministic; parallel workers would also fight the encoder for CPU. |
+| `workers` | `1` | Same reason. |
+| `retries` | `0` | A retried test would produce a second video and pollute the combined output. |
+| `timeout` | `180_000` | `slowMo` + video encoding stretches per-test wall clock well past the live default of 60s. |
+| `use.video` | `{ mode: "on", size: { width: 1440, height: 900 } }` | Every test gets a full-viewport recording, pass or fail. |
+| `use.trace` | `"on"` | Trace Viewer companion alongside the video; useful when a showcase run also surfaces a failure. |
+| `use.launchOptions.slowMo` | `250` | Visible pacing between Playwright actions. The combine step speeds the result up. |
+| `webServer` | `vite preview` on 4173 | Required for the `mocked` project. The `live` project ignores it. |
+| `globalSetup` | live's `liveGlobalSetup.ts` | No-op when the `aoe` binary is already on disk; otherwise builds release. |
+
+### Run
+
+```bash
+# Use the debug binary so the live specs don't touch the release namespace.
+cargo build --features serve
+cd web
+npm run build
+
+export AOE_E2E_BINARY="$(pwd)/../target/debug/aoe"
+npm run test:showcase
+```
+
+`test:showcase` is wired in `web/package.json` and just runs `playwright test --config=playwright.showcase.config.ts`.
+
+Filter to a subset:
+
+```bash
+# One project.
+npx playwright test --config=playwright.showcase.config.ts --project=mocked
+npx playwright test --config=playwright.showcase.config.ts --project=live
+
+# One spec.
+npx playwright test --config=playwright.showcase.config.ts tests/live/golden-path.spec.ts
+```
+
+Recordings land under `web/test-results/<spec-name>/video.webm`. The HTML report at `web/playwright-showcase-report/` embeds each video. A failed test still produces a usable `video.webm`, which is by design: showcase runs prioritize footage over passing CI.
+
+## Step 2: combine into one clip
+
+`web/scripts/combine-showcase-videos.sh` walks `web/test-results/`, finds every `video.webm`, and produces a single mp4 with a configurable layout, speed, and quality.
+
+### Quick reference
+
+```bash
+cd web
+
+# Simplest case: concat all videos, cap at 2 minutes.
+./scripts/combine-showcase-videos.sh
+
+# Custom output path.
+./scripts/combine-showcase-videos.sh ~/Desktop/aoe-showcase.mp4
+
+# 2x2 streaming-lane grid with per-cell titles.
+GRID=2x2 SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh
+
+# Higher quality (lower CRF), slower encode.
+CRF=12 PRESET=veryslow GRID=2x2 SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh
+
+# Different cap, different resolution.
+MAX_SECONDS=60 TARGET_W=1440 TARGET_H=900 ./scripts/combine-showcase-videos.sh
+```
+
+### How the layouts work
+
+**Concat (default; no `GRID` set).** Videos play back-to-back in filesystem-sorted order. The total duration of the run is the sum of input durations; the script speeds playback by `factor = max(1, total / MAX_SECONDS)` so the output is always at most `MAX_SECONDS` long.
+
+**Grid (`GRID=COLSxROWS`, e.g. `2x2`).** Cells are arranged in a `COLS by ROWS` grid. Within the grid, each cell is an **independent streaming lane**: when a lane's current video finishes, the next one starts immediately. Cells do not wait on each other.
+
+Distribution across lanes is round-robin: with 9 videos in a 2x2 grid, lane 0 plays inputs 0/4/8, lane 1 plays 1/5, lane 2 plays 2/6, lane 3 plays 3/7. Round-robin keeps lane lengths balanced so no lane runs out long before the others, which avoids a static dead panel at the end of the clip.
+
+A lane that finishes before the longest lane freezes on its last frame until xstack runs out of input. Speed factor in grid mode is `max(1, longest_lane / MAX_SECONDS)`.
+
+### Titles (`SHOW_TITLES=1`)
+
+When set, a translucent bottom-left text box is overlaid on each cell (grid mode) or each segment (concat mode). Title text is derived from the spec's `test-results` directory name:
+
+```
+test-results/tests-live-golden-path-create-view-delete.../video.webm
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                  -> "golden path: create view delete..."
+```
+
+The `tests-` and `live-` prefixes are stripped, dashes are turned into spaces, and the result is capped at 80 characters.
+
+Drawtext requires an ffmpeg build that links libfreetype. The default Homebrew ffmpeg 8.x does not include it; install the `homebrew-ffmpeg/ffmpeg` tap version instead:
+
+```bash
+brew uninstall ffmpeg
+brew tap homebrew-ffmpeg/ffmpeg
+brew install homebrew-ffmpeg/ffmpeg/ffmpeg
+ffmpeg -filters 2>/dev/null | grep drawtext  # must list it
+```
+
+Without that build, run without `SHOW_TITLES=1`.
+
+### All environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `MAX_SECONDS` | `120` | Hard cap on output duration. Speed factor scales to fit. |
+| `CRF` | `14` | libx264 constant rate factor. 0 = lossless, 14 ~= near-lossless, 18 ~= visually lossless, 23 = libx264 default, 28+ = visibly lossy. Lower is better but file size grows fast. |
+| `PRESET` | `slow` | libx264 preset. `veryslow` = best compression at same quality, `medium`/`fast` cheaper. |
+| `GRID` | unset | `COLSxROWS` enables grid mode (e.g. `2x2`, `3x3`, `4x2`). Must total >= 2 cells. |
+| `SHOW_TITLES` | `0` | `1` overlays the spec name on each cell/segment. Requires drawtext. |
+| `TARGET_W` | `1440` | Output canvas width. Matches Playwright viewport. |
+| `TARGET_H` | `900` | Output canvas height. Matches Playwright viewport. |
+| `FONT` | auto-detect | Path to a TTF/TTC. Tries common macOS and Linux fonts if unset. |
+
+The script auto-rounds cell width/height to even numbers (libx264 requirement).
+
+### Quality vs file size
+
+The defaults (`CRF=14`, `PRESET=slow`) are tuned for screen-recording content: lots of crisp text, sharp UI edges, low motion. Typical output for a 2-minute clip at 1440x900 grid: ~50-150 MB.
+
+| CRF | Look | Size (rough, 2-min 1440x900 4-panel) |
+|---|---|---|
+| 0 | Mathematically lossless | 500 MB - 2 GB |
+| 12 | Near-lossless | ~150-300 MB |
+| 14 (default) | Visually lossless on text/UI | ~50-150 MB |
+| 18 | Visually lossless on natural video; can soften text | ~25-60 MB |
+| 23 | libx264 default; text edges visibly softer | ~10-25 MB |
+
+If a future showcase clip needs uploading to a tool with a size cap (Slack 1 GB, GitHub upload 25 MB), use `CRF=20-23` with `PRESET=veryslow`. The slower preset reclaims a lot of quality at higher CRF.
+
+### Performance notes
+
+- Concat mode without titles uses the cheap path (concat demuxer + a single `setpts` re-encode pass). One ffmpeg pass, modest CPU.
+- Concat mode with titles, and any grid mode, build a `filter_complex` graph with one input per video. With 200+ recordings this graph is large; ffmpeg parses it fine but encode time scales with input count.
+- On macOS, `ARG_MAX` is ~262 kB. With several hundred inputs and absolute paths, the command line can approach that. If you hit it, render in batches and concat the batch outputs as a second pass.
+- `slowMo: 250` in the Playwright config is the main multiplier on step-1 wall clock. Dropping to `slowMo: 100` (or removing it) speeds the recording stage substantially, at the cost of some footage looking jumpy on fast UI transitions.
+
+## Common workflows
+
+### Just give me the demo clip
+
+```bash
+cd web
+AOE_E2E_BINARY="$(pwd)/../target/debug/aoe" npm run test:showcase
+SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh
+open test-results/showcase-combined.mp4
+```
+
+### Re-render combine without re-running tests
+
+The recordings persist in `test-results/` until Playwright cleans them up (it doesn't clean by default). Iterate on the combine command without re-recording:
+
+```bash
+GRID=2x2 SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh
+GRID=3x3 SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh
+CRF=12 PRESET=veryslow GRID=2x2 ./scripts/combine-showcase-videos.sh ~/Desktop/aoe-highlight.mp4
+```
+
+### Reset between runs
+
+```bash
+rm -rf web/test-results web/playwright-showcase-report
+```
+
+Playwright will recreate both on the next showcase run.
+
+## Files
+
+- `web/playwright.showcase.config.ts` -- config used by step 1.
+- `web/scripts/combine-showcase-videos.sh` -- combiner used by step 2.
+- `web/package.json` -- `test:showcase` script.
+- `web/test-results/` -- per-test recordings (gitignored).
+- `web/playwright-showcase-report/` -- HTML report (gitignored).

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -3,4 +3,5 @@ dist/
 test-results/
 playwright-report/
 playwright-live-report/
+playwright-showcase-report/
 test-report.junit.xml

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
+    "test:showcase": "playwright test --config=playwright.showcase.config.ts",
     "test:unit": "vitest run",
     "coverage:merge": "node scripts/merge-coverage.mjs",
     "coverage:all": "rm -rf coverage && AOE_COVERAGE=1 npm run test:unit -- --coverage && AOE_COVERAGE=1 npx playwright test && npm run coverage:merge"

--- a/web/playwright.showcase.config.ts
+++ b/web/playwright.showcase.config.ts
@@ -1,27 +1,9 @@
-// Showcase Playwright config.
+// Showcase Playwright config: records every mocked AND live spec in one run
+// for demo videos, trading throughput for cinematic footage (full-resolution
+// video, slow per-action delay, single worker so the encoder owns the CPU).
 //
-// Reuses the existing mocked specs (`tests/*.spec.ts`) AND live-backend
-// specs (`tests/live/**/*.spec.ts`) under a single run, trading throughput
-// for cinematic, deterministic video recordings. Each test gets a full
-// resolution video, a slow per-action delay, and a single worker so the
-// encoder never fights another browser for CPU.
-//
-// Run:
-//   cd web
-//   npx playwright test --config=playwright.showcase.config.ts
-//
-// Filter to a single project or spec:
-//   npx playwright test --config=playwright.showcase.config.ts --project=mocked
-//   npx playwright test --config=playwright.showcase.config.ts tests/live/golden-path.spec.ts
-//
-// The aoe binary is resolved the same way as the live config
-// (AOE_E2E_BINARY env or ../target/release/aoe). Build it first with
-// `cargo build --features serve --release` (globalSetup will do that
-// for you on first run too).
-//
-// Videos land under `test-results/**/video.webm`. The HTML report at
-// `playwright-showcase-report/` embeds them. Post-process with ffmpeg
-// (e.g. `-filter:v "setpts=0.4*PTS" -an`) to speed the final clip up.
+// Usage, build steps, and the ffmpeg post-processing live in
+// docs/development/showcase-video.md.
 
 import { defineConfig } from "@playwright/test";
 
@@ -56,8 +38,10 @@ export default defineConfig({
   // globalSetup and is a no-op when the binary is already on disk.
   globalSetup: "./tests/helpers/liveGlobalSetup.ts",
 
-  // Mocked specs need a vite preview server on 4173. Live specs ignore
-  // it (they spawn their own backend per test).
+  // webServer is config-wide, so it boots for every project: mocked specs
+  // hit it on 4173, and a live-only run (--project=live) still starts vite
+  // preview here and therefore needs a built bundle, even though live specs
+  // spawn their own backend per test.
   webServer: {
     command: "npx vite preview --port 4173",
     port: 4173,

--- a/web/playwright.showcase.config.ts
+++ b/web/playwright.showcase.config.ts
@@ -64,10 +64,7 @@ export default defineConfig({
     reuseExistingServer: true,
   },
 
-  reporter: [
-    ["html", { open: "never", outputFolder: "playwright-showcase-report" }],
-    ["list"],
-  ],
+  reporter: [["html", { open: "never", outputFolder: "playwright-showcase-report" }], ["list"]],
 
   projects: [
     {

--- a/web/playwright.showcase.config.ts
+++ b/web/playwright.showcase.config.ts
@@ -1,0 +1,92 @@
+// Showcase Playwright config.
+//
+// Reuses the existing mocked specs (`tests/*.spec.ts`) AND live-backend
+// specs (`tests/live/**/*.spec.ts`) under a single run, trading throughput
+// for cinematic, deterministic video recordings. Each test gets a full
+// resolution video, a slow per-action delay, and a single worker so the
+// encoder never fights another browser for CPU.
+//
+// Run:
+//   cd web
+//   npx playwright test --config=playwright.showcase.config.ts
+//
+// Filter to a single project or spec:
+//   npx playwright test --config=playwright.showcase.config.ts --project=mocked
+//   npx playwright test --config=playwright.showcase.config.ts tests/live/golden-path.spec.ts
+//
+// The aoe binary is resolved the same way as the live config
+// (AOE_E2E_BINARY env or ../target/release/aoe). Build it first with
+// `cargo build --features serve --release` (globalSetup will do that
+// for you on first run too).
+//
+// Videos land under `test-results/**/video.webm`. The HTML report at
+// `playwright-showcase-report/` embeds them. Post-process with ffmpeg
+// (e.g. `-filter:v "setpts=0.4*PTS" -an`) to speed the final clip up.
+
+import { defineConfig } from "@playwright/test";
+
+const sharedUse = {
+  headless: true,
+  viewport: { width: 1440, height: 900 },
+  video: {
+    mode: "on" as const,
+    size: { width: 1440, height: 900 },
+  },
+  trace: "on" as const,
+  screenshot: "only-on-failure" as const,
+  // Visible pacing. Each Playwright action waits this many ms before
+  // executing. ffmpeg speed-up pass compresses the result later.
+  launchOptions: {
+    slowMo: 250,
+  },
+};
+
+export default defineConfig({
+  // Single worker keeps the recording deterministic and prevents the
+  // video encoder from contending with parallel browser instances.
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+
+  // slowMo + video encoding stretches wall-clock per test well past the
+  // 30s mocked / 60s live defaults.
+  timeout: 180_000,
+
+  // Live specs need the aoe binary built; this is the live config's
+  // globalSetup and is a no-op when the binary is already on disk.
+  globalSetup: "./tests/helpers/liveGlobalSetup.ts",
+
+  // Mocked specs need a vite preview server on 4173. Live specs ignore
+  // it (they spawn their own backend per test).
+  webServer: {
+    command: "npx vite preview --port 4173",
+    port: 4173,
+    reuseExistingServer: true,
+  },
+
+  reporter: [
+    ["html", { open: "never", outputFolder: "playwright-showcase-report" }],
+    ["list"],
+  ],
+
+  projects: [
+    {
+      name: "mocked",
+      testDir: "./tests",
+      testIgnore: ["**/live/**"],
+      use: {
+        ...sharedUse,
+        browserName: "chromium",
+        baseURL: "http://localhost:4173",
+      },
+    },
+    {
+      name: "live",
+      testDir: "./tests/live",
+      use: {
+        ...sharedUse,
+        browserName: "chromium",
+      },
+    },
+  ],
+});

--- a/web/scripts/combine-showcase-videos.sh
+++ b/web/scripts/combine-showcase-videos.sh
@@ -200,21 +200,23 @@ if [[ -n "${GRID}" ]]; then
   # lane_count[k]: how many videos in lane k.
   # lane_total[k]: sum of their durations.
   lane_indices_lookup=""  # space-separated "lane_k:idx_in_videos" pairs, ordered.
+  lane_count=()
+  lane_total=()
   for (( k=0; k<cells; k++ )); do
-    eval "lane_count_${k}=0"
-    eval "lane_total_${k}=0"
+    lane_count[k]=0
+    lane_total[k]=0
   done
   for (( i=0; i<count; i++ )); do
     k=$(( i % cells ))
-    eval "lane_count_${k}=\$(( lane_count_${k} + 1 ))"
-    eval "lane_total_${k}=\$(awk -v a=\"\$lane_total_${k}\" -v b=\"${durations[$i]}\" 'BEGIN { printf \"%.6f\", a + b }')"
+    lane_count[k]=$(( lane_count[k] + 1 ))
+    lane_total[k]="$(awk -v a="${lane_total[k]}" -v b="${durations[$i]}" 'BEGIN { printf "%.6f", a + b }')"
   done
 
   # Lane max = max over lane totals. xstack needs every lane to reach
   # that timestamp, so shorter lanes tail-pad to lane_max.
   lane_max=0
   for (( k=0; k<cells; k++ )); do
-    eval "lt=\$lane_total_${k}"
+    lt="${lane_total[k]}"
     lane_max="$(awk -v a="${lane_max}" -v b="${lt}" 'BEGIN { print (b > a) ? b : a }')"
   done
 
@@ -233,8 +235,8 @@ if [[ -n "${GRID}" ]]; then
   filter=""
   stack_inputs=""
   for (( k=0; k<cells; k++ )); do
-    eval "lc=\$lane_count_${k}"
-    eval "lt=\$lane_total_${k}"
+    lc="${lane_count[k]}"
+    lt="${lane_total[k]}"
 
     # Per-video chain: scale+pad to cell dims, optional title overlay.
     # Emits labels [v_k_0], [v_k_1], ... that the concat filter ties together.

--- a/web/scripts/combine-showcase-videos.sh
+++ b/web/scripts/combine-showcase-videos.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Combine every Playwright showcase video.webm under test-results/ into a
+# single mp4 capped at MAX_SECONDS (default 120s). Speed-up is computed
+# so the final clip is always ~MAX_SECONDS regardless of input count.
+#
+# Two layouts:
+#
+#   - concat (default): videos play back-to-back. factor = max(1, sum / cap).
+#   - grid (GRID=COLSxROWS): videos play in parallel in a fixed grid.
+#     Shorter cells are tail-padded with their last frame so every cell
+#     ends at the same time. factor = max(1, longest / cap).
+#     If video count > COLS*ROWS, the extras are dropped (warn).
+#     If video count < COLS*ROWS, empty cells are filled with black.
+#
+# Optional per-cell / per-segment title overlay (SHOW_TITLES=1). Title
+# text is derived from the video's parent directory name (Playwright
+# names it after the spec + test title).
+#
+# Output is H.264 mp4 (libx264, crf 18, slow preset). Re-encode is
+# unavoidable because we apply a setpts filter; stream-copy is not
+# compatible with filter graphs.
+#
+# Usage:
+#   ./scripts/combine-showcase-videos.sh                                  # concat, 120s cap, no titles
+#   ./scripts/combine-showcase-videos.sh out.mp4                          # custom output
+#   MAX_SECONDS=60 ./scripts/combine-showcase-videos.sh
+#   GRID=2x2 ./scripts/combine-showcase-videos.sh                         # 2x2 grid
+#   GRID=3x3 SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh           # 3x3 grid + per-cell titles
+#   SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh                    # concat + per-segment titles
+#   CRF=23 PRESET=fast ./scripts/combine-showcase-videos.sh               # cheaper / lower-quality encode
+#   TARGET_W=1920 TARGET_H=1080 ./scripts/combine-showcase-videos.sh      # output canvas size
+#   FONT=/path/to/font.ttf ./scripts/combine-showcase-videos.sh           # override drawtext font
+#
+# Order is filesystem-sorted (Playwright's per-test dir prefix sorts
+# stably enough for a deterministic playback order across runs).
+
+set -euo pipefail
+
+# ffmpeg opens one fd per input. Grid/concat-with-titles modes pass every
+# recording as its own -i, so a ~250-spec showcase blows past macOS's
+# default 256 soft fd limit ("Too many open files"). Raise to the lesser
+# of 8192 and the current hard limit. macOS hard limit is typically
+# 10240+ (`ulimit -Hn`).
+hard="$(ulimit -Hn 2>/dev/null || echo 8192)"
+if [[ "${hard}" == "unlimited" ]]; then
+  ulimit -n 8192 || true
+elif [[ "${hard}" -gt 8192 ]]; then
+  ulimit -n 8192 || true
+else
+  ulimit -n "${hard}" || true
+fi
+
+MAX_SECONDS="${MAX_SECONDS:-120}"
+CRF="${CRF:-14}"
+PRESET="${PRESET:-slow}"
+GRID="${GRID:-}"
+SHOW_TITLES="${SHOW_TITLES:-0}"
+# Playwright videos are captured at 1440x900 (see playwright.showcase.config.ts).
+# Keep the target at native resolution: upscaling adds no detail and just
+# bloats encode time.
+TARGET_W="${TARGET_W:-1440}"
+TARGET_H="${TARGET_H:-900}"
+FONT="${FONT:-}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS="${ROOT}/test-results"
+OUT="${1:-${RESULTS}/showcase-combined.mp4}"
+
+if [[ ! -d "${RESULTS}" ]]; then
+  echo "no test-results/ directory at ${RESULTS}" >&2
+  exit 1
+fi
+
+for bin in ffmpeg ffprobe awk; do
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    echo "${bin} not found on PATH" >&2
+    exit 1
+  fi
+done
+
+# Default fonts per platform if drawtext is requested but FONT not set.
+if [[ "${SHOW_TITLES}" == "1" && -z "${FONT}" ]]; then
+  for candidate in \
+    "/System/Library/Fonts/Supplemental/Arial.ttf" \
+    "/System/Library/Fonts/Helvetica.ttc" \
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf" \
+    "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf"; do
+    if [[ -f "${candidate}" ]]; then
+      FONT="${candidate}"
+      break
+    fi
+  done
+  if [[ -z "${FONT}" ]]; then
+    echo "SHOW_TITLES=1 but no usable font found; set FONT=/path/to/font.ttf" >&2
+    exit 1
+  fi
+fi
+
+# Escape a string for drawtext: backslash, colon, percent, single quote.
+escape_drawtext() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//:/\\:}"
+  s="${s//\'/\\\\\'}"
+  s="${s//%/\\%}"
+  printf '%s' "${s}"
+}
+
+# Turn "test-results/tests-live-golden-path-create-view-delete.../video.webm"
+# into "golden path: create view delete...". Truncated for overlay sanity.
+derive_title() {
+  local video="$1"
+  local dir
+  dir="$(basename "$(dirname "${video}")")"
+  # Drop common Playwright prefix.
+  dir="${dir#tests-}"
+  dir="${dir#live-}"
+  # Dashes -> spaces. Cap to 80 chars.
+  dir="${dir//-/ }"
+  if [[ "${#dir}" -gt 80 ]]; then
+    dir="${dir:0:77}..."
+  fi
+  printf '%s' "${dir}"
+}
+
+# Collect videos + per-file metadata.
+videos=()
+titles=()
+durations=()
+while IFS= read -r -d '' video; do
+  videos+=("${video}")
+  titles+=("$(derive_title "${video}")")
+  dur="$(ffprobe -v error -show_entries format=duration -of default=nokey=1:noprint_wrappers=1 "${video}" || echo 0)"
+  durations+=("${dur}")
+done < <(find "${RESULTS}" -type f -name 'video.webm' -print0 | sort -z)
+
+count="${#videos[@]}"
+if [[ "${count}" -eq 0 ]]; then
+  echo "no video.webm files found under ${RESULTS}" >&2
+  exit 1
+fi
+
+# Common drawtext fragment (omit text= so we can plug in per-call).
+drawtext_style() {
+  printf "fontfile='%s':fontcolor=white:fontsize=22:box=1:boxcolor=black@0.55:boxborderw=10:x=24:y=h-th-24" "${FONT}"
+}
+
+if [[ -n "${GRID}" ]]; then
+  # ---- grid mode (streaming lanes) ------------------------------------
+  # Each cell is an independent lane. Videos are distributed round-robin
+  # across lanes so cell 0 plays inputs 0,N,2N,...; cell 1 plays 1,N+1,...
+  # When a lane's current video ends, the next one starts immediately:
+  # cells don't wait for each other. The overall clip ends when every
+  # lane has exhausted its queue; shorter lanes are tail-padded with
+  # their last frame so xstack can run to that final tick.
+  #
+  # Round-robin (vs chunked) keeps all lanes lively at once and avoids
+  # the "one lane finished 30s ago" dead-air effect you'd get if cell 0
+  # got the first N/cells videos.
+  if [[ ! "${GRID}" =~ ^([0-9]+)x([0-9]+)$ ]]; then
+    echo "GRID must be COLSxROWS (e.g. 2x2), got '${GRID}'" >&2
+    exit 1
+  fi
+  cols="${BASH_REMATCH[1]}"
+  rows="${BASH_REMATCH[2]}"
+  cells=$((cols * rows))
+  if (( cells < 2 )); then
+    echo "GRID must total at least 2 cells; use concat mode (no GRID) for single-cell" >&2
+    exit 1
+  fi
+
+  # Cell dimensions; force even numbers (libx264 requires even).
+  cell_w=$(( TARGET_W / cols ))
+  cell_h=$(( TARGET_H / rows ))
+  (( cell_w % 2 == 1 )) && cell_w=$(( cell_w - 1 ))
+  (( cell_h % 2 == 1 )) && cell_h=$(( cell_h - 1 ))
+
+  # xstack layout: cells are uniform, compute once.
+  layout=""
+  for (( r=0; r<rows; r++ )); do
+    for (( c=0; c<cols; c++ )); do
+      xexpr=""
+      yexpr=""
+      for (( k=0; k<c; k++ )); do
+        xexpr+="+w${k}"
+      done
+      for (( k=0; k<r; k++ )); do
+        yexpr+="+h$(( k * cols ))"
+      done
+      xexpr="${xexpr#+}"
+      yexpr="${yexpr#+}"
+      [[ -z "${xexpr}" ]] && xexpr="0"
+      [[ -z "${yexpr}" ]] && yexpr="0"
+      [[ -n "${layout}" ]] && layout+="|"
+      layout+="${xexpr}_${yexpr}"
+    done
+  done
+
+  # Round-robin lane assignment + per-lane duration sum.
+  # lane_count[k]: how many videos in lane k.
+  # lane_total[k]: sum of their durations.
+  lane_indices_lookup=""  # space-separated "lane_k:idx_in_videos" pairs, ordered.
+  for (( k=0; k<cells; k++ )); do
+    eval "lane_count_${k}=0"
+    eval "lane_total_${k}=0"
+  done
+  for (( i=0; i<count; i++ )); do
+    k=$(( i % cells ))
+    eval "lane_count_${k}=\$(( lane_count_${k} + 1 ))"
+    eval "lane_total_${k}=\$(awk -v a=\"\$lane_total_${k}\" -v b=\"${durations[$i]}\" 'BEGIN { printf \"%.6f\", a + b }')"
+  done
+
+  # Lane max = max over lane totals. xstack needs every lane to reach
+  # that timestamp, so shorter lanes tail-pad to lane_max.
+  lane_max=0
+  for (( k=0; k<cells; k++ )); do
+    eval "lt=\$lane_total_${k}"
+    lane_max="$(awk -v a="${lane_max}" -v b="${lt}" 'BEGIN { print (b > a) ? b : a }')"
+  done
+
+  factor="$(awk -v t="${lane_max}" -v m="${MAX_SECONDS}" 'BEGIN { f = t / m; if (f < 1) f = 1; printf "%.6f", f }')"
+
+  echo "grid ${cols}x${rows} streaming lanes, ${count} video(s) across ${cells} lane(s), longest lane=${lane_max}s, cap=${MAX_SECONDS}s, speed=${factor}x -> ${OUT}"
+
+  # Build inputs list (ffmpeg input order = videos[] order; lane access
+  # uses [${i}:v] for the i-th video).
+  inputs=()
+  for i in "${!videos[@]}"; do
+    inputs+=("-i" "${videos[$i]}")
+  done
+
+  # Build filter graph.
+  filter=""
+  stack_inputs=""
+  for (( k=0; k<cells; k++ )); do
+    eval "lc=\$lane_count_${k}"
+    eval "lt=\$lane_total_${k}"
+
+    # Per-video chain: scale+pad to cell dims, optional title overlay.
+    # Emits labels [v_k_0], [v_k_1], ... that the concat filter ties together.
+    member_inputs=""
+    member_idx=0
+    for (( i=k; i<count; i+=cells )); do
+      chain="[${i}:v]scale=${cell_w}:${cell_h}:force_original_aspect_ratio=decrease,pad=${cell_w}:${cell_h}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1"
+      if [[ "${SHOW_TITLES}" == "1" ]]; then
+        title_escaped="$(escape_drawtext "${titles[$i]}")"
+        chain+=",drawtext=$(drawtext_style):text='${title_escaped}'"
+      fi
+      chain+="[v_${k}_${member_idx}];"
+      filter+="${chain}"
+      member_inputs+="[v_${k}_${member_idx}]"
+      member_idx=$(( member_idx + 1 ))
+    done
+
+    if (( lc == 0 )); then
+      # Empty lane (only when cells > count). Pure black for lane_max.
+      filter+="color=c=black:s=${cell_w}x${cell_h}:d=${lane_max}[lane${k}];"
+    else
+      # Concat the lane's members, then tail-pad to lane_max.
+      pad_delta="$(awk -v m="${lane_max}" -v t="${lt}" 'BEGIN { x = m - t; if (x < 0) x = 0; printf "%.6f", x }')"
+      if (( lc == 1 )); then
+        # concat=n=1 is illegal; just relabel.
+        filter+="${member_inputs}null,tpad=stop_mode=clone:stop_duration=${pad_delta}[lane${k}];"
+      else
+        filter+="${member_inputs}concat=n=${lc}:v=1:a=0,tpad=stop_mode=clone:stop_duration=${pad_delta}[lane${k}];"
+      fi
+    fi
+
+    stack_inputs+="[lane${k}]"
+  done
+
+  filter+="${stack_inputs}xstack=inputs=${cells}:layout=${layout}[stacked];"
+  filter+="[stacked]setpts=PTS/${factor},format=yuv420p[out]"
+
+  ffmpeg -y "${inputs[@]}" \
+    -filter_complex "${filter}" \
+    -map "[out]" \
+    -an \
+    -c:v libx264 -preset "${PRESET}" -crf "${CRF}" \
+    -movflags +faststart \
+    "${OUT}"
+
+else
+  # ---- concat mode ------------------------------------------------------
+  total=0
+  for d in "${durations[@]}"; do
+    total="$(awk -v a="${total}" -v b="${d}" 'BEGIN { printf "%.6f", a + b }')"
+  done
+  factor="$(awk -v t="${total}" -v m="${MAX_SECONDS}" 'BEGIN { f = t / m; if (f < 1) f = 1; printf "%.6f", f }')"
+
+  echo "concat ${count} video(s), total=${total}s, cap=${MAX_SECONDS}s, speed=${factor}x -> ${OUT}"
+
+  if [[ "${SHOW_TITLES}" == "1" ]]; then
+    # Use filter_complex concat=, drawtext per input before concat so
+    # each segment carries its own title for its own duration.
+    inputs=()
+    filter=""
+    for i in "${!videos[@]}"; do
+      inputs+=("-i" "${videos[$i]}")
+      title_escaped="$(escape_drawtext "${titles[$i]}")"
+      filter+="[${i}:v]scale=${TARGET_W}:${TARGET_H}:force_original_aspect_ratio=decrease,pad=${TARGET_W}:${TARGET_H}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1,drawtext=$(drawtext_style):text='${title_escaped}'[s${i}];"
+    done
+    concat_inputs=""
+    for (( i=0; i<count; i++ )); do
+      concat_inputs+="[s${i}]"
+    done
+    filter+="${concat_inputs}concat=n=${count}:v=1:a=0[joined];"
+    filter+="[joined]setpts=PTS/${factor},format=yuv420p[out]"
+
+    ffmpeg -y "${inputs[@]}" \
+      -filter_complex "${filter}" \
+      -map "[out]" \
+      -an \
+      -c:v libx264 -preset "${PRESET}" -crf "${CRF}" \
+      -movflags +faststart \
+      "${OUT}"
+  else
+    # Cheap path: concat demuxer + setpts filter. One re-encode, no
+    # per-input scaling so input resolution must match across files
+    # (the showcase config pins it).
+    LIST="$(mktemp -t showcase-concat.XXXXXX)"
+    trap 'rm -f "${LIST}"' EXIT
+    for video in "${videos[@]}"; do
+      escaped="${video//\'/\'\\\'\'}"
+      printf "file '%s'\n" "${escaped}" >>"${LIST}"
+    done
+
+    ffmpeg -y -f concat -safe 0 -i "${LIST}" \
+      -filter:v "setpts=PTS/${factor},format=yuv420p" \
+      -an \
+      -c:v libx264 -preset "${PRESET}" -crf "${CRF}" \
+      -movflags +faststart \
+      "${OUT}"
+  fi
+fi
+
+echo "done -> ${OUT}"

--- a/web/scripts/combine-showcase-videos.sh
+++ b/web/scripts/combine-showcase-videos.sh
@@ -1,38 +1,15 @@
 #!/usr/bin/env bash
-# Combine every Playwright showcase video.webm under test-results/ into a
-# single mp4 capped at MAX_SECONDS (default 120s). Speed-up is computed
-# so the final clip is always ~MAX_SECONDS regardless of input count.
+# Combine every Playwright showcase video.webm under test-results/ into one
+# mp4. Speed-up is computed so the result is always ~MAX_SECONDS regardless
+# of input count. Re-encode is unavoidable (we apply a setpts filter, which
+# stream-copy can't do). Usage and env knobs: docs/development/showcase-video.md.
 #
-# Two layouts:
-#
-#   - concat (default): videos play back-to-back. factor = max(1, sum / cap).
-#   - grid (GRID=COLSxROWS): videos play in parallel in a fixed grid.
-#     Shorter cells are tail-padded with their last frame so every cell
-#     ends at the same time. factor = max(1, longest / cap).
-#     If video count > COLS*ROWS, the extras are dropped (warn).
-#     If video count < COLS*ROWS, empty cells are filled with black.
-#
-# Optional per-cell / per-segment title overlay (SHOW_TITLES=1). Title
-# text is derived from the video's parent directory name (Playwright
-# names it after the spec + test title).
-#
-# Output is H.264 mp4 (libx264, crf 18, slow preset). Re-encode is
-# unavoidable because we apply a setpts filter; stream-copy is not
-# compatible with filter graphs.
-#
-# Usage:
-#   ./scripts/combine-showcase-videos.sh                                  # concat, 120s cap, no titles
-#   ./scripts/combine-showcase-videos.sh out.mp4                          # custom output
-#   MAX_SECONDS=60 ./scripts/combine-showcase-videos.sh
-#   GRID=2x2 ./scripts/combine-showcase-videos.sh                         # 2x2 grid
-#   GRID=3x3 SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh           # 3x3 grid + per-cell titles
-#   SHOW_TITLES=1 ./scripts/combine-showcase-videos.sh                    # concat + per-segment titles
-#   CRF=23 PRESET=fast ./scripts/combine-showcase-videos.sh               # cheaper / lower-quality encode
-#   TARGET_W=1920 TARGET_H=1080 ./scripts/combine-showcase-videos.sh      # output canvas size
-#   FONT=/path/to/font.ttf ./scripts/combine-showcase-videos.sh           # override drawtext font
-#
-# Order is filesystem-sorted (Playwright's per-test dir prefix sorts
-# stably enough for a deterministic playback order across runs).
+# Two layouts, both deterministic (inputs are filesystem-sorted):
+#   - concat (default): videos play back-to-back; factor = max(1, sum / cap).
+#   - grid (GRID=COLSxROWS): videos stream into COLS*ROWS lanes round-robin,
+#     concatenated within each lane and played in parallel. Shorter lanes
+#     tail-pad with their last frame; empty lanes (fewer videos than cells)
+#     are black. factor = max(1, longest-lane / cap).
 
 set -euo pipefail
 

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -210,6 +210,13 @@ const PAGES = [
       "Long-form reference for the web dashboard test pipeline: mocked vs live Playwright, Vitest contract tests, fake ACP agent, coverage matrix, coverage reports.",
   },
   {
+    source: "docs/development/showcase-video.md",
+    dest: "docs/development/showcase-video.md",
+    title: "Showcase video pipeline",
+    description:
+      "Record every Playwright spec as video and stitch the clips into one demo/highlight mp4: showcase config, the combine script, and its layout/speed/quality knobs.",
+  },
+  {
     source: "docs/development/releases.md",
     dest: "docs/development/releases.md",
     title: "Releases",
@@ -374,6 +381,7 @@ const URL_MAP = {
   "docs/development/adding-settings.md": "/docs/development/adding-settings/",
   "docs/development/logging.md": "/docs/development/logging/",
   "docs/development/playwright.md": "/docs/development/playwright/",
+  "docs/development/showcase-video.md": "/docs/development/showcase-video/",
   "docs/development/releases.md": "/docs/development/releases/",
   "docs/development/web-dashboard.md": "/docs/development/web-dashboard/",
   "docs/development/internals/structured-view.md": "/docs/development/internals/structured-view/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -81,6 +81,7 @@ export const docsNav: NavSection[] = [
       { title: "Adding a Setting", href: "/docs/development/adding-settings/" },
       { title: "Logging", href: "/docs/development/logging/" },
       { title: "Playwright + Vitest testing", href: "/docs/development/playwright/" },
+      { title: "Showcase video pipeline", href: "/docs/development/showcase-video/" },
       { title: "Releases", href: "/docs/development/releases/" },
       {
         title: "Web Dashboard Development",


### PR DESCRIPTION
> AI disclosure: this PR was authored with AI assistance (Claude Opus 4.8).

## Description

Adds a dev-only pipeline to record every Playwright spec as video and stitch the clips into one demo/highlight mp4.

- `web/playwright.showcase.config.ts`: self-contained config running both mocked + live projects with visible `slowMo` pacing, retries off (a retry would emit a duplicate video), HTML report into `playwright-showcase-report/`.
- `web/scripts/combine-showcase-videos.sh`: walks `web/test-results/`, finds every `video.webm`, produces one mp4 with configurable grid layout, speed, and quality (env knobs: `GRID`, `SHOW_TITLES`, `CRF`, `PRESET`, `MAX_SECONDS`, `TARGET_W/H`).
- `web/package.json`: `test:showcase` script.
- `docs/development/showcase-video.md`: full recipe, plus a cross-link from `playwright.md`.
- Registered the new doc page on the website (sync-docs PAGES + URL_MAP, docsNav) so the cross-link does not 404 publicly.
- Gitignored `web/playwright-showcase-report/`.

## PR Type

- [x] New Feature
- [x] Documentation

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No app UI changed; this is test/dev tooling. Verified locally: `oxfmt --check`, `eslint`, `tsc -b` all clean. No Rust touched.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This adds a config that runs the existing specs to capture footage; it changes no dashboard flow, so `coverage-matrix.json` does not apply.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785236411&installation_id=139138837&pr_number=2510&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2510&signature=d9a82572f9ea5a1871c66344ba304443b1a44712d8df6485fad3623dfe304b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new dev-only “showcase video” pipeline for the `web` app so developers can generate polished demo clips directly from real Playwright test runs.

It introduces:
- **A dedicated Playwright showcase configuration** (`web/playwright.showcase.config.ts`) that runs **both mocked and live** specs in one go, with deterministic, demo-friendly pacing and disabled retries.
- **A new npm script** (`web/package.json`: `test:showcase`) to run the showcase config.
- **Video post-processing** (`web/scripts/combine-showcase-videos.sh`) that scans `web/test-results/**/video.webm` and stitches everything into a single MP4, supporting **concat** (default) and **grid layouts** plus options for titles, speed, quality, and canvas sizing.
- **Documentation** (`docs/development/showcase-video.md`) and an update to the existing Playwright guide to point to the new workflow.
- **Website wiring** so the new doc page appears in navigation and links correctly (updates to `website/scripts/sync-docs.mjs` and `website/src/data/docsNav.ts`).
- **Git hygiene** by ignoring generated output (`web/.gitignore`: `playwright-showcase-report/`).

Benefits:
- Makes it easy to create consistent, shareable demo/highlight videos from the full test suite.
- Keeps the recording + stitching workflow repeatable and self-contained for contributors.
- Improves discoverability by adding clear doc entry points and navigation.

Potential areas for further enhancement:
- The combined-video workflow depends on local tooling/fonts for title overlays; documenting required system dependencies (or auto-falling back) could make it smoother across environments.
- Consider adding a “one-command” end-to-end script (record + combine + clean) to reduce friction for first-time users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->