### PR TITLE
feat: 🗿🥚 (web + TUI)

### DIFF
--- a/src/tui/dialogs/cheats.rs
+++ b/src/tui/dialogs/cheats.rs
@@ -1,0 +1,137 @@
+//! Age of Empires cheat-code easter eggs for the TUI command palette.
+//!
+//! A wink at the "Agent of Empires" name. Mirrors the web registry
+//! (`web/src/lib/cheats.ts`); the two are hand-kept parallel since Rust and
+//! TypeScript can't share a literal. The TUI surfaces only the toast message
+//! (via `Action::SetTransientStatus`), not the web's visual flourishes.
+
+/// Cheat code (already normalized: lowercase, single-spaced) to the transient
+/// message shown when the user types it into the command palette.
+const CHEATS: &[(&str, &str)] = &[
+    // Age of Empires 1
+    (
+        "wololo",
+        "Wololo. The agent in the next worktree converts to your cause.",
+    ),
+    ("photon man", "A Photon Man vaporizes your merge conflicts."),
+    ("pow", "A baby on a tricycle with a gun. Don't ask."),
+    // Age of Empires 2
+    (
+        "how do you turn this on",
+        "🚗 A Cobra Car spawns in your sandbox and floors it.",
+    ),
+    (
+        "tuck tuck tuck",
+        "A monster truck flattens your flaky tests.",
+    ),
+    ("marco", "Marco! Every session revealed."),
+    (
+        "polo",
+        "Polo! Fog lifted. You see what every agent thinks. (No you don't.)",
+    ),
+    (
+        "aegis",
+        "AEGIS on. Worktrees build instantly. (cargo still takes 4 min.)",
+    ),
+    ("rock on", "+1000 stone. Spent it on rate limits."),
+    ("lumberjack", "+1000 wood. The daemon is cozy."),
+    ("robin hood", "+1000 tokens. Use them wisely."),
+    (
+        "cheese steak jimmy's",
+        "+1000 food. Agents refuse to stop coding.",
+    ),
+    (
+        "i love the monkey head",
+        "🐵 VDML. A furious monkey reviews your PR.",
+    ),
+    (
+        "black death",
+        "Black Death. All flaky tests eliminated. (They'll be back.)",
+    ),
+    // Age of Empires 3
+    (
+        "ya gotta make do with what ya got",
+        "The Tommynator rolls in and crushes your tech debt.",
+    ),
+    (
+        "nova & orion",
+        "+10000 XP. You leveled up to Staff Engineer.",
+    ),
+    ("medium rare please", "+10000 food. The grill never stops."),
+    (
+        "give me liberty or give me coin",
+        "+10000 coin. Still can't afford Opus.",
+    ),
+    ("this is too hard", "You win. PR merged. (It wasn't.)"),
+    ("speed always wins", "Research speed x100. CI still queued."),
+    (
+        "x marks the spot",
+        "Map revealed. The bug was in your code all along.",
+    ),
+];
+
+/// Normalize palette input the same way the web matcher does: lowercase, trim,
+/// and collapse internal whitespace runs to a single space.
+fn normalize(input: &str) -> String {
+    input
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Returns the cheat message for a full-string match, or `None`. Substrings
+/// never match, so ordinary palette searches ("settings", "new") pass through.
+pub fn match_cheat(input: &str) -> Option<&'static str> {
+    let normalized = normalize(input);
+    CHEATS
+        .iter()
+        .find(|(code, _)| *code == normalized)
+        .map(|(_, message)| *message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_every_registered_code() {
+        for (code, message) in CHEATS {
+            assert_eq!(match_cheat(code), Some(*message));
+        }
+    }
+
+    #[test]
+    fn all_codes_are_already_normalized() {
+        // If a key isn't normalized, match_cheat(key) would miss it.
+        for (code, _) in CHEATS {
+            assert_eq!(
+                normalize(code),
+                *code,
+                "cheat code is not normalized: {code:?}"
+            );
+        }
+        assert_eq!(CHEATS.len(), 21);
+    }
+
+    #[test]
+    fn case_insensitive_and_whitespace_tolerant() {
+        assert!(match_cheat("WOLOLO").is_some());
+        assert!(match_cheat("  Rock On  ").is_some());
+        assert!(match_cheat("how do  you   turn this on").is_some());
+    }
+
+    #[test]
+    fn ordinary_searches_do_not_match() {
+        assert_eq!(match_cheat("settings"), None);
+        assert_eq!(match_cheat("new session"), None);
+        assert_eq!(match_cheat(""), None);
+    }
+
+    #[test]
+    fn substrings_and_prefixes_do_not_match() {
+        assert_eq!(match_cheat("wolol"), None);
+        assert_eq!(match_cheat("wololo and more"), None);
+        assert_eq!(match_cheat("say marco"), None);
+    }
+}

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -68,6 +68,9 @@ pub enum PaletteAction {
     JumpToCursor(usize),
     /// Open a tool session by name (lazygit, yazi, etc.)
     ToolSession(String),
+    /// The query matched an Age of Empires cheat code; show its message as a
+    /// transient toast. The payload is the message to display.
+    Cheat(String),
 }
 
 /// One entry in the palette. `payload` is what gets returned when the user picks it.
@@ -249,6 +252,11 @@ impl CommandPaletteDialog {
             _ => {
                 self.input.handle_event(&crossterm::event::Event::Key(key));
                 self.recompute_matches();
+                // A full-string match on a known cheat code fires its toast and
+                // closes the palette, mirroring the web easter egg.
+                if let Some(message) = super::cheats::match_cheat(self.input.value()) {
+                    return DialogResult::Submit(PaletteAction::Cheat(message.to_string()));
+                }
                 DialogResult::Continue
             }
         }
@@ -672,6 +680,36 @@ mod tests {
         let attach_strict = strict.iter().find(|c| c.id == "attach").unwrap();
         assert_eq!(attach_normal.hotkey, "Enter");
         assert_eq!(attach_strict.hotkey, "Enter");
+    }
+
+    #[test]
+    fn typing_a_cheat_code_submits_a_cheat_payload() {
+        let mut dialog = make_dialog();
+        // Intermediate prefixes are not a full match and keep the palette open.
+        for c in "wolol".chars() {
+            assert!(matches!(
+                dialog.handle_key(ke(KeyCode::Char(c))),
+                DialogResult::Continue
+            ));
+        }
+        // Completing the code fires the cheat and closes the palette.
+        match dialog.handle_key(ke(KeyCode::Char('o'))) {
+            DialogResult::Submit(PaletteAction::Cheat(message)) => {
+                assert!(message.contains("converts to your cause"), "got: {message}");
+            }
+            _ => panic!("expected Submit(Cheat) after typing a full cheat code"),
+        }
+    }
+
+    #[test]
+    fn ordinary_query_does_not_trigger_a_cheat() {
+        let mut dialog = make_dialog();
+        for c in "settings".chars() {
+            assert!(matches!(
+                dialog.handle_key(ke(KeyCode::Char(c))),
+                DialogResult::Continue
+            ));
+        }
     }
 
     #[test]

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -1,6 +1,7 @@
 //! TUI dialog components
 
 mod changelog;
+mod cheats;
 mod command_palette;
 mod confirm;
 mod context_menu;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3042,6 +3042,7 @@ impl HomeView {
                 self.tool_preview_cache = super::PreviewCache::default();
                 None
             }
+            PaletteAction::Cheat(message) => Some(Action::SetTransientStatus(message)),
         }
     }
 

--- a/web/src/components/command-palette/CheatOverlay.tsx
+++ b/web/src/components/command-palette/CheatOverlay.tsx
@@ -4,7 +4,7 @@ import type { CheatEffect, CheatEffectKind } from "../../lib/cheats";
 
 // How long each effect lives before it self-cleans. Matches the CSS animation
 // durations in index.css; the overlay unmounts when the longest piece ends.
-export const CHEAT_DURATION_MS: Record<CheatEffectKind, number> = {
+const CHEAT_DURATION_MS: Record<CheatEffectKind, number> = {
   fly: 1600,
   confetti: 2200,
   flash: 600,

--- a/web/src/components/command-palette/CheatOverlay.tsx
+++ b/web/src/components/command-palette/CheatOverlay.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { CheatEffect, CheatEffectKind } from "../../lib/cheats";
+
+// How long each effect lives before it self-cleans. Matches the CSS animation
+// durations in index.css; the overlay unmounts when the longest piece ends.
+export const CHEAT_DURATION_MS: Record<CheatEffectKind, number> = {
+  fly: 1600,
+  confetti: 2200,
+  flash: 600,
+  pulse: 1000,
+};
+
+const CONFETTI_COUNT = 14;
+
+interface Props {
+  effect: CheatEffect;
+  // Bump to replay the same cheat; used as the React key by the caller.
+  onDone: () => void;
+}
+
+// Full-screen, pointer-events-none overlay so palette interaction is never
+// blocked. Rendered into a body portal so the sprite is not clipped by the
+// palette card. Self-cleans by calling onDone after the effect duration.
+export function CheatOverlay({ effect, onDone }: Props) {
+  useEffect(() => {
+    const t = setTimeout(onDone, CHEAT_DURATION_MS[effect.kind]);
+    return () => clearTimeout(t);
+  }, [effect, onDone]);
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-0 z-[100] overflow-hidden" data-testid="cheat-overlay" aria-hidden>
+      {renderEffect(effect)}
+    </div>,
+    document.body,
+  );
+}
+
+function renderEffect(effect: CheatEffect) {
+  switch (effect.kind) {
+    case "fly":
+      return (
+        <span
+          className={effect.dir === "rtl" ? "animate-cheat-fly-rtl" : "animate-cheat-fly-ltr"}
+          style={{ position: "absolute", top: "50%", left: 0, fontSize: "6rem", lineHeight: 1 }}
+        >
+          {effect.emoji}
+        </span>
+      );
+    case "confetti":
+      return (
+        <>
+          {Array.from({ length: CONFETTI_COUNT }, (_, i) => (
+            <span
+              key={i}
+              className="animate-cheat-confetti-fall"
+              style={{
+                position: "absolute",
+                top: 0,
+                left: `${(i / CONFETTI_COUNT) * 100}%`,
+                fontSize: "2rem",
+                animationDelay: `${(i % 5) * 0.12}s`,
+              }}
+            >
+              {effect.emoji}
+            </span>
+          ))}
+        </>
+      );
+    case "flash":
+      return (
+        <div className="animate-cheat-flash" style={{ position: "absolute", inset: 0, background: effect.color }} />
+      );
+    case "pulse":
+      return (
+        <span
+          className="animate-cheat-pulse"
+          style={{ position: "absolute", top: "50%", left: "50%", fontSize: "8rem", lineHeight: 1 }}
+        >
+          {effect.emoji}
+        </span>
+      );
+  }
+}

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Command } from "cmdk";
 import { StatusGlyph } from "../StatusGlyph";
+import { CheatOverlay } from "./CheatOverlay";
 import { GROUP_ORDER } from "./groups";
 import type { CommandAction, CommandActionGroup } from "./types";
+import { matchCheat, type CheatEffect } from "../../lib/cheats";
+import { reportInfo } from "../../lib/toastBus";
 
 interface Props {
   open: boolean;
@@ -13,6 +16,23 @@ interface Props {
 export function CommandPalette({ open, onClose, actions }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [search, setSearch] = useState("");
+  // Active easter-egg effect plus a monotonic id so retyping the same cheat
+  // replays the animation (the id is the overlay's React key).
+  const [cheat, setCheat] = useState<{ effect: CheatEffect; id: number } | null>(null);
+
+  // A full-string match on a known Age of Empires cheat code fires a toast and
+  // a one-off visual, then clears the input. Anything else is a normal search.
+  const onSearchChange = (value: string) => {
+    const hit = matchCheat(value);
+    if (hit) {
+      reportInfo(hit.toast);
+      setCheat((prev) => ({ effect: hit.effect, id: (prev?.id ?? 0) + 1 }));
+      setSearch("");
+      return;
+    }
+    setSearch(value);
+  };
 
   // Capture the launcher before moving focus into the palette, then restore
   // it on close so Esc / backdrop-close return keyboard users to where they
@@ -27,6 +47,11 @@ export function CommandPalette({ open, onClose, actions }: Props) {
       const prev = previousFocusRef.current;
       if (prev?.isConnected) prev.focus();
     };
+  }, [open]);
+
+  // Controlled input keeps its value across open/close, so clear it on close.
+  useEffect(() => {
+    if (!open) setSearch("");
   }, [open]);
 
   const grouped = useMemo(() => {
@@ -78,6 +103,8 @@ export function CommandPalette({ open, onClose, actions }: Props) {
           </svg>
           <Command.Input
             ref={inputRef}
+            value={search}
+            onValueChange={onSearchChange}
             placeholder="Search actions, sessions, settings…"
             className="flex-1 bg-transparent outline-none text-[15px] text-text-primary placeholder:text-text-muted"
           />
@@ -136,6 +163,7 @@ export function CommandPalette({ open, onClose, actions }: Props) {
           </span>
         </div>
       </Command>
+      {cheat && <CheatOverlay key={cheat.id} effect={cheat.effect} onDone={() => setCheat(null)} />}
     </div>
   );
 }

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Command } from "cmdk";
 import { StatusGlyph } from "../StatusGlyph";
 import { CheatOverlay } from "./CheatOverlay";
@@ -49,10 +49,18 @@ export function CommandPalette({ open, onClose, actions }: Props) {
     };
   }, [open]);
 
-  // Controlled input keeps its value across open/close, so clear it on close.
+  // Controlled input keeps its value across open/close, so reset it on close;
+  // also drop any in-flight cheat so reopening does not replay the last one.
   useEffect(() => {
-    if (!open) setSearch("");
+    if (!open) {
+      setSearch("");
+      setCheat(null);
+    }
   }, [open]);
+
+  // Stable so the overlay's cleanup timer is not reset by unrelated re-renders
+  // (e.g. the user typing again while an effect is still on screen).
+  const clearCheat = useCallback(() => setCheat(null), []);
 
   const grouped = useMemo(() => {
     const map = new Map<CommandActionGroup, CommandAction[]>();
@@ -163,7 +171,7 @@ export function CommandPalette({ open, onClose, actions }: Props) {
           </span>
         </div>
       </Command>
-      {cheat && <CheatOverlay key={cheat.id} effect={cheat.effect} onDone={() => setCheat(null)} />}
+      {cheat && <CheatOverlay key={cheat.id} effect={cheat.effect} onDone={clearCheat} />}
     </div>
   );
 }

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -49,14 +49,18 @@ export function CommandPalette({ open, onClose, actions }: Props) {
     };
   }, [open]);
 
-  // Controlled input keeps its value across open/close, so reset it on close;
-  // also drop any in-flight cheat so reopening does not replay the last one.
-  useEffect(() => {
+  // Controlled input keeps its value across open/close, so reset it when the
+  // palette closes; also drop any in-flight cheat so reopening does not replay
+  // the last one. Adjusting during render on the open->closed edge is the
+  // React-recommended pattern, no effect needed.
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
     if (!open) {
       setSearch("");
       setCheat(null);
     }
-  }, [open]);
+  }
 
   // Stable so the overlay's cleanup timer is not reset by unrelated re-renders
   // (e.g. the user typing again while an effect is still on screen).

--- a/web/src/components/command-palette/__tests__/CheatOverlay.test.tsx
+++ b/web/src/components/command-palette/__tests__/CheatOverlay.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { CheatOverlay } from "../CheatOverlay";
+import type { CheatEffect } from "../../../lib/cheats";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("CheatOverlay", () => {
+  it("renders a fly sprite with the direction-specific animation", () => {
+    const effect: CheatEffect = { kind: "fly", emoji: "🚗", dir: "ltr" };
+    render(<CheatOverlay effect={effect} onDone={() => {}} />);
+    const overlay = screen.getByTestId("cheat-overlay");
+    expect(overlay.querySelector(".animate-cheat-fly-ltr")?.textContent).toBe("🚗");
+  });
+
+  it("uses the rtl animation when dir is rtl", () => {
+    render(<CheatOverlay effect={{ kind: "fly", emoji: "🚚", dir: "rtl" }} onDone={() => {}} />);
+    expect(screen.getByTestId("cheat-overlay").querySelector(".animate-cheat-fly-rtl")).not.toBeNull();
+  });
+
+  it("rains a full set of confetti sprites", () => {
+    render(<CheatOverlay effect={{ kind: "confetti", emoji: "🪨" }} onDone={() => {}} />);
+    const pieces = screen.getByTestId("cheat-overlay").querySelectorAll(".animate-cheat-confetti-fall");
+    expect(pieces.length).toBe(14);
+    expect(pieces[0].textContent).toBe("🪨");
+  });
+
+  it("renders a flash tinted with the effect color", () => {
+    render(<CheatOverlay effect={{ kind: "flash", color: "#3b82f6" }} onDone={() => {}} />);
+    const flash = screen.getByTestId("cheat-overlay").querySelector<HTMLElement>(".animate-cheat-flash");
+    expect(flash).not.toBeNull();
+    expect(flash?.style.background).toBe("rgb(59, 130, 246)");
+  });
+
+  it("renders a pulse sprite", () => {
+    render(<CheatOverlay effect={{ kind: "pulse", emoji: "🗺️" }} onDone={() => {}} />);
+    expect(screen.getByTestId("cheat-overlay").querySelector(".animate-cheat-pulse")?.textContent).toBe("🗺️");
+  });
+
+  it("never intercepts clicks so the palette stays interactive", () => {
+    render(<CheatOverlay effect={{ kind: "flash", color: "#000" }} onDone={() => {}} />);
+    expect(screen.getByTestId("cheat-overlay").className).toContain("pointer-events-none");
+  });
+
+  it("self-cleans after the effect duration and not before", () => {
+    vi.useFakeTimers();
+    const onDone = vi.fn();
+    render(<CheatOverlay effect={{ kind: "flash", color: "#000" }} onDone={onDone} />);
+    vi.advanceTimersByTime(599);
+    expect(onDone).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits the longer confetti duration before cleaning", () => {
+    vi.useFakeTimers();
+    const onDone = vi.fn();
+    render(<CheatOverlay effect={{ kind: "confetti", emoji: "🎉" }} onDone={onDone} />);
+    vi.advanceTimersByTime(2199);
+    expect(onDone).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -492,6 +492,14 @@ body {
 .animate-cheat-pulse {
   animation: cheat-pulse 1s ease-out forwards;
 }
+/* Respect reduced-motion: drop the visual flourish entirely (the toast still
+   fires as the functional signal). Hiding the overlay avoids a static
+   full-screen flash that animation:none would otherwise leave behind. */
+@media (prefers-reduced-motion: reduce) {
+  [data-testid="cheat-overlay"] {
+    display: none;
+  }
+}
 
 /* Focus indicators for keyboard navigation */
 button:focus-visible,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -449,7 +449,7 @@ body {
   }
   to {
     transform: translateY(110vh) rotate(540deg);
-    opacity: 0.9;
+    opacity: 0;
   }
 }
 @keyframes cheat-flash {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -425,6 +425,73 @@ body {
     animation: none;
   }
 }
+/* Cheat-code easter egg effects (command palette). One-off, non-blocking. */
+@keyframes cheat-fly-ltr {
+  from {
+    transform: translateX(-20vw) translateY(-50%) rotate(-8deg);
+  }
+  to {
+    transform: translateX(120vw) translateY(-50%) rotate(8deg);
+  }
+}
+@keyframes cheat-fly-rtl {
+  from {
+    transform: translateX(120vw) translateY(-50%) rotate(8deg);
+  }
+  to {
+    transform: translateX(-20vw) translateY(-50%) rotate(-8deg);
+  }
+}
+@keyframes cheat-confetti-fall {
+  from {
+    transform: translateY(-10vh) rotate(0deg);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(110vh) rotate(540deg);
+    opacity: 0.9;
+  }
+}
+@keyframes cheat-flash {
+  0% {
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.55;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes cheat-pulse {
+  0% {
+    transform: translate(-50%, -50%) scale(0.4);
+    opacity: 0;
+  }
+  40% {
+    transform: translate(-50%, -50%) scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.2);
+    opacity: 0;
+  }
+}
+.animate-cheat-fly-ltr {
+  animation: cheat-fly-ltr 1.6s ease-in forwards;
+}
+.animate-cheat-fly-rtl {
+  animation: cheat-fly-rtl 1.6s ease-in forwards;
+}
+.animate-cheat-confetti-fall {
+  animation: cheat-confetti-fall 2s ease-in forwards;
+}
+.animate-cheat-flash {
+  animation: cheat-flash 0.6s ease-out forwards;
+}
+.animate-cheat-pulse {
+  animation: cheat-pulse 1s ease-out forwards;
+}
 
 /* Focus indicators for keyboard navigation */
 button:focus-visible,

--- a/web/src/lib/__tests__/cheats.test.ts
+++ b/web/src/lib/__tests__/cheats.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { CHEATS, matchCheat } from "../cheats";
+
+describe("matchCheat", () => {
+  it("matches every registered code exactly", () => {
+    for (const code of Object.keys(CHEATS)) {
+      expect(matchCheat(code)).toBe(CHEATS[code]);
+    }
+  });
+
+  it("is case-insensitive and whitespace-tolerant", () => {
+    expect(matchCheat("WOLOLO")).toBe(CHEATS["wololo"]);
+    expect(matchCheat("  Rock On  ")).toBe(CHEATS["rock on"]);
+    expect(matchCheat("how do  you   turn this on")).toBe(CHEATS["how do you turn this on"]);
+  });
+
+  it("returns null for ordinary palette searches", () => {
+    expect(matchCheat("settings")).toBeNull();
+    expect(matchCheat("new session")).toBeNull();
+    expect(matchCheat("")).toBeNull();
+  });
+
+  it("does not match substrings or prefixes", () => {
+    expect(matchCheat("wolol")).toBeNull();
+    expect(matchCheat("wololo and more")).toBeNull();
+    expect(matchCheat("say marco")).toBeNull();
+  });
+});

--- a/web/src/lib/cheats.ts
+++ b/web/src/lib/cheats.ts
@@ -1,0 +1,123 @@
+// Age of Empires cheat-code easter eggs for the command palette. Type a full
+// code into the cmd+k search and a themed toast plus a one-off visual flourish
+// fires. A wink at the "Agent of Empires" name; not documented on purpose.
+
+export type CheatEffectKind = "fly" | "confetti" | "flash" | "pulse";
+
+export interface CheatEffect {
+  kind: CheatEffectKind;
+  // Sprite for fly / confetti / pulse. Unused by flash.
+  emoji?: string;
+  // Tint for flash. Unused by the others.
+  color?: string;
+  // Travel direction for fly.
+  dir?: "ltr" | "rtl";
+}
+
+export interface Cheat {
+  toast: string;
+  effect: CheatEffect;
+}
+
+// Keys are already normalized (see normalize): lowercase, single-spaced, trimmed.
+export const CHEATS: Record<string, Cheat> = {
+  // Age of Empires 1
+  wololo: {
+    toast: "Wololo. The agent in the next worktree converts to your cause.",
+    effect: { kind: "flash", color: "#3b82f6" },
+  },
+  "photon man": {
+    toast: "A Photon Man vaporizes your merge conflicts.",
+    effect: { kind: "fly", emoji: "⚡", dir: "ltr" },
+  },
+  pow: {
+    toast: "A baby on a tricycle with a gun. Don't ask.",
+    effect: { kind: "fly", emoji: "👶", dir: "rtl" },
+  },
+
+  // Age of Empires 2
+  "how do you turn this on": {
+    toast: "🚗 A Cobra Car spawns in your sandbox and floors it.",
+    effect: { kind: "fly", emoji: "🚗", dir: "ltr" },
+  },
+  "tuck tuck tuck": {
+    toast: "A monster truck flattens your flaky tests.",
+    effect: { kind: "fly", emoji: "🚚", dir: "rtl" },
+  },
+  marco: {
+    toast: "Marco! Every session revealed.",
+    effect: { kind: "pulse", emoji: "🗺️" },
+  },
+  polo: {
+    toast: "Polo! Fog lifted. You see what every agent thinks. (No you don't.)",
+    effect: { kind: "pulse", emoji: "🌫️" },
+  },
+  aegis: {
+    toast: "AEGIS on. Worktrees build instantly. (cargo still takes 4 min.)",
+    effect: { kind: "flash", color: "#eab308" },
+  },
+  "rock on": {
+    toast: "+1000 stone. Spent it on rate limits.",
+    effect: { kind: "confetti", emoji: "🪨" },
+  },
+  lumberjack: {
+    toast: "+1000 wood. The daemon is cozy.",
+    effect: { kind: "confetti", emoji: "🪵" },
+  },
+  "robin hood": {
+    toast: "+1000 tokens. Use them wisely.",
+    effect: { kind: "confetti", emoji: "🪙" },
+  },
+  "cheese steak jimmy's": {
+    toast: "+1000 food. Agents refuse to stop coding.",
+    effect: { kind: "confetti", emoji: "🍔" },
+  },
+  "i love the monkey head": {
+    toast: "🐵 VDML. A furious monkey reviews your PR.",
+    effect: { kind: "fly", emoji: "🐵", dir: "ltr" },
+  },
+  "black death": {
+    toast: "Black Death. All flaky tests eliminated. (They'll be back.)",
+    effect: { kind: "flash", color: "#1f2937" },
+  },
+
+  // Age of Empires 3
+  "ya gotta make do with what ya got": {
+    toast: "The Tommynator rolls in and crushes your tech debt.",
+    effect: { kind: "fly", emoji: "🚛", dir: "rtl" },
+  },
+  "nova & orion": {
+    toast: "+10000 XP. You leveled up to Staff Engineer.",
+    effect: { kind: "confetti", emoji: "⭐" },
+  },
+  "medium rare please": {
+    toast: "+10000 food. The grill never stops.",
+    effect: { kind: "confetti", emoji: "🍖" },
+  },
+  "give me liberty or give me coin": {
+    toast: "+10000 coin. Still can't afford Opus.",
+    effect: { kind: "confetti", emoji: "🪙" },
+  },
+  "this is too hard": {
+    toast: "You win. PR merged. (It wasn't.)",
+    effect: { kind: "confetti", emoji: "🎉" },
+  },
+  "speed always wins": {
+    toast: "Research speed x100. CI still queued.",
+    effect: { kind: "flash", color: "#22c55e" },
+  },
+  "x marks the spot": {
+    toast: "Map revealed. The bug was in your code all along.",
+    effect: { kind: "pulse", emoji: "❌" },
+  },
+};
+
+function normalize(input: string): string {
+  return input.toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+// Returns the cheat for a full-string match, or null. Substrings never match,
+// so normal palette searches ("settings", "new") pass straight through.
+export function matchCheat(input: string): Cheat | null {
+  return CHEATS[normalize(input)] ?? null;
+}

--- a/web/src/lib/cheats.ts
+++ b/web/src/lib/cheats.ts
@@ -24,7 +24,7 @@ export const CHEATS: Record<string, Cheat> = {
   // Age of Empires 1
   wololo: {
     toast: "Wololo. The agent in the next worktree converts to your cause.",
-    effect: { kind: "flash", color: "#3b82f6" },
+    effect: { kind: "flash", color: "var(--color-terminal-active)" },
   },
   "photon man": {
     toast: "A Photon Man vaporizes your merge conflicts.",
@@ -54,7 +54,7 @@ export const CHEATS: Record<string, Cheat> = {
   },
   aegis: {
     toast: "AEGIS on. Worktrees build instantly. (cargo still takes 4 min.)",
-    effect: { kind: "flash", color: "#eab308" },
+    effect: { kind: "flash", color: "var(--color-status-waiting)" },
   },
   "rock on": {
     toast: "+1000 stone. Spent it on rate limits.",
@@ -78,7 +78,7 @@ export const CHEATS: Record<string, Cheat> = {
   },
   "black death": {
     toast: "Black Death. All flaky tests eliminated. (They'll be back.)",
-    effect: { kind: "flash", color: "#1f2937" },
+    effect: { kind: "flash", color: "var(--color-surface-800)" },
   },
 
   // Age of Empires 3
@@ -104,7 +104,7 @@ export const CHEATS: Record<string, Cheat> = {
   },
   "speed always wins": {
     toast: "Research speed x100. CI still queued.",
-    effect: { kind: "flash", color: "#22c55e" },
+    effect: { kind: "flash", color: "var(--color-status-running)" },
   },
   "x marks the spot": {
     toast: "Map revealed. The bug was in your code all along.",

--- a/web/tests/command-palette.spec.ts
+++ b/web/tests/command-palette.spec.ts
@@ -123,4 +123,42 @@ test.describe("Command palette", () => {
     await page.getByRole("button", { name: "Open command palette" }).first().click();
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();
   });
+
+  test("cheat code fires a toast and clears the input", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await page.locator("body").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    const search = page.getByPlaceholder("Search actions, sessions, settings…");
+    await search.fill("wololo");
+    await expect(page.getByText(/converts to your cause/i)).toBeVisible();
+    await expect(search).toHaveValue("");
+  });
+
+  test("cheat visual overlay auto-cleans and never blocks the palette", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await page.locator("body").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    const search = page.getByPlaceholder("Search actions, sessions, settings…");
+    await search.fill("rock on");
+    await expect(page.locator('[data-testid="cheat-overlay"]')).toBeVisible();
+    // Confetti lives ~2.2s; it must remove itself afterwards.
+    await expect(page.locator('[data-testid="cheat-overlay"]')).toHaveCount(0, { timeout: 4000 });
+    // Palette is still interactive: a normal search still filters.
+    await search.fill("settings");
+    await expect(page.getByRole("option", { name: /Open settings/i })).toBeVisible();
+  });
+
+  test("non-cheat search does not fire an easter egg", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await page.locator("body").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    const search = page.getByPlaceholder("Search actions, sessions, settings…");
+    await search.fill("settings");
+    await expect(page.locator('[data-testid="cheat-overlay"]')).toHaveCount(0);
+    await expect(search).toHaveValue("settings");
+    await expect(page.getByRole("option", { name: /Open settings/i })).toBeVisible();
+  });
 });

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1925,7 +1925,10 @@
       "kind": "mocked-playwright",
       "risk": "low",
       "specs": ["tests/command-palette.spec.ts"],
-      "components": ["web/src/components/command-palette/CommandPalette.tsx", "web/src/components/command-palette/CheatOverlay.tsx"]
+      "components": [
+        "web/src/components/command-palette/CommandPalette.tsx",
+        "web/src/components/command-palette/CheatOverlay.tsx"
+      ]
     },
     {
       "id": "story.shortcut-toggle-sidebar",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1921,6 +1921,13 @@
       "components": ["web/src/hooks/useSettingsCommands.ts", "web/src/App.tsx"]
     },
     {
+      "id": "story.cmdk-cheat-codes",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": ["tests/command-palette.spec.ts"],
+      "components": ["web/src/components/command-palette/CommandPalette.tsx", "web/src/components/command-palette/CheatOverlay.tsx"]
+    },
+    {
       "id": "story.shortcut-toggle-sidebar",
       "kind": "mocked-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A small delight feature: Age of Empires cheat codes hidden in the command palette, a wink at the "Agent of Empires" name. Type a full classic cheat code into the palette search (for example `wololo`, `how do you turn this on`, `tuck tuck tuck`, `nova & orion`) and an easter egg fires, then the input clears.

**Web dashboard (cmd+k):** a themed toast plus a one-off visual flourish. 21 codes span Age of Empires 1, 2, and 3, mapped to four reusable CSS keyframe primitives so every cheat composes an existing effect rather than a bespoke animation: `fly` (a sprite whooshes across the screen), `confetti` (emoji rains down), `flash` (brief full-screen tint, theme-colored), `pulse` (centered emoji scales out). The overlay is a full-screen, pointer-events-none body portal that self-cleans after its duration, so it never blocks palette interaction, and it is hidden under `prefers-reduced-motion`.

**TUI (Ctrl+K):** the same 21 codes surface their message as a transient bottom-banner toast via the existing `Action::SetTransientStatus` path. A parallel Rust cheat registry holds the codes (Rust and TypeScript can't share a literal); the TUI shows the message only, not the web's visual effects, since those don't translate cleanly to a terminal.

The match is case-insensitive, whitespace-tolerant, and full-string only on both surfaces, so substrings and normal palette queries never trigger it. Delivery reuses existing toast infrastructure, so no new dependency.

There is intentionally no documentation for this; it is an easter egg and documenting it would spoil the surprise.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Web: open the dashboard, press cmd+k (or ctrl+k), type `wololo`; a blue flash plays, a "converts to your cause" toast appears, and the input clears.
- [ ] Web: type `how do you turn this on`; a car sprite drives across the screen.
- [ ] Web: type `rock on`; confetti falls and the toast reads "+1000 stone."
- [ ] Web: with an effect on screen, keep typing a normal query like `settings`; the palette stays interactive and filters as usual.
- [ ] Web: enable OS "reduce motion"; cheat toasts still fire but the visual overlay is suppressed.
- [ ] TUI: run `aoe`, press Ctrl+K, type `tuck tuck tuck`; the message shows as a transient banner at the bottom and the palette closes.
- [ ] Both: type a partial code like `wolol` or a normal query like `settings`; nothing fires (full-string match only) and normal filtering is unchanged.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated tests: Rust unit tests for the cheat matcher and the palette `Cheat` dispatch (`src/tui/dialogs/cheats.rs`, `command_palette.rs`)
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. I designed the cheat list, the effect mapping, and the web-vs-TUI scope split, made the design calls, reviewed each commit, and ran the test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785237068&installation_id=139138837&pr_number=2511&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2511&signature=c7d5c1a6a572c8f8372c8b987f9fd8a684646e5c7cfd6f9f987eff44278ba233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a classic Age of Empires cheat-code easter egg to the command palette in both the web dashboard and TUI.

The web version now recognizes a set of cheat phrases, shows a themed toast, clears the input, and plays a full-screen visual overlay for matching codes. The overlay includes several animation styles, cleans itself up automatically, and is disabled for users who prefer reduced motion.

The TUI now supports the same cheat-code matching and turns a match into a transient status message instead of a visual effect. Matching is case-insensitive, ignores extra whitespace, and only triggers on full exact phrases so normal searches still behave as expected.

Tests were added on both sides to cover matching, overlay behavior, cleanup, and end-to-end command-palette flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->