### PR TITLE
feat(web): move sidebar Trash to footer icon, order Projects below Snoozed & archived

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2661,20 +2661,23 @@ export function WorkspaceSidebar({
 
   // Trashed workspaces, flattened across the active axis and deduped by id (the
   // same workspace can appear under more than one group). Feeds the footer
-  // Trash menu next to Settings (#2512), no longer an inline section.
+  // Trash menu next to Settings (#2512), no longer an inline section. Built
+  // from the unfiltered groups, not the filtered ones: trash is a global
+  // recovery affordance, so an active search or facet must not hide the footer
+  // icon and strand trashed sessions until the filter is cleared.
   const trashedWorkspaces = useMemo(() => {
     const raw = isNested
-      ? filteredNested.flatMap((ng) =>
+      ? nestedGroups.flatMap((ng) =>
           ng.subgroups.flatMap((sg) => sg.workspaces.filter((v) => workspaceIsTrashed(v.workspace))),
         )
-      : filteredGroups.flatMap((g) => g.workspaces.filter((v) => workspaceIsTrashed(v.workspace)));
+      : groups.flatMap((g) => g.workspaces.filter((v) => workspaceIsTrashed(v.workspace)));
     const seen = new Set<string>();
     return raw.filter((v) => {
       if (seen.has(v.workspace.id)) return false;
       seen.add(v.workspace.id);
       return true;
     });
-  }, [isNested, filteredNested, filteredGroups]);
+  }, [isNested, nestedGroups, groups]);
 
   // Sidebar multi-select. Selection is ephemeral sidebar UI state (not routed
   // or persisted); the anchor pivots Shift+click ranges. See #1724.

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -27,7 +27,10 @@ import {
   Pin,
   Play,
   Plus,
+  RotateCcw,
   Sparkles,
+  Trash2,
+  X,
 } from "lucide-react";
 import { usePluginUiEntries } from "../lib/pluginUiContext";
 import {
@@ -489,6 +492,115 @@ export function formatSnoozeRemainingShort(snoozedUntilIso: string): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h`;
   return `${Math.floor(hours / 24)}d`;
+}
+
+/** Trash control in the sidebar footer, next to Settings (#2512). Trash is a
+ *  terminal, rarely-touched state, so it lives as an icon with an upward
+ *  popover rather than a full scrolling section. Outside click and Escape
+ *  close it, mirroring SidebarSortPicker. Only rendered when something is
+ *  trashed. */
+function TrashMenu({
+  trashedWorkspaces,
+  readOnly,
+  onOpen,
+  onRestore,
+  onDelete,
+}: {
+  trashedWorkspaces: SidebarWorkspaceView[];
+  readOnly?: boolean;
+  onOpen: (workspaceId: string, e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean }) => void;
+  onRestore: (sessionIds: string[]) => void;
+  onDelete: (workspaceId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKeydown);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKeydown);
+    };
+  }, [open]);
+
+  const count = trashedWorkspaces.length;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="sidebar-trash-toggle"
+        className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
+        title={`Trash (${count})`}
+        aria-label={`Trash (${count})`}
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          data-testid="sidebar-trash-menu"
+          className="absolute bottom-full mb-1 left-0 min-w-[220px] max-h-[50vh] overflow-y-auto bg-surface-800 border border-surface-700/50 rounded-md shadow-xl py-1 z-50 animate-fade-in"
+        >
+          <div className="px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+            Trash ({count})
+          </div>
+          {trashedWorkspaces.map((v) => (
+            <div
+              key={v.key}
+              data-testid="sidebar-trash-row"
+              className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-text-secondary"
+            >
+              <button
+                type="button"
+                onClick={(e) => onOpen(v.workspace.id, e)}
+                title={v.workspace.displayName}
+                data-testid="sidebar-trash-open"
+                className="flex-1 truncate text-left hover:text-text-primary cursor-pointer"
+              >
+                {v.workspace.displayName}
+              </button>
+              {!readOnly && (
+                <>
+                  <button
+                    onClick={() => {
+                      const ids = v.workspace.sessions.map((s) => s.id);
+                      if (ids.length > 0) onRestore(ids);
+                    }}
+                    data-testid="sidebar-trash-restore"
+                    title="Restore"
+                    aria-label="Restore"
+                    className="text-accent-500 hover:text-accent-600 cursor-pointer"
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    onClick={() => onDelete(v.workspace.id)}
+                    data-testid="sidebar-trash-purge"
+                    title="Delete permanently"
+                    aria-label="Delete permanently"
+                    className="text-status-error/80 hover:text-status-error cursor-pointer"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 // Wraps a SessionRow with @dnd-kit sortable plumbing. The row itself
@@ -2393,9 +2505,6 @@ export function WorkspaceSidebar({
   const [filterQuery, setFilterQuery] = useState("");
   const [facetOpen, setFacetOpen] = useState(false);
   const [sunkExpanded, setSunkExpanded] = useState<boolean>(loadSunkExpanded);
-  // Trash section expand state: in-memory only, collapsed by default
-  // (recovery shelf, kept out of the way). See #2489.
-  const [trashExpanded, setTrashExpanded] = useState<boolean>(false);
   const toggleSunkExpanded = useCallback(() => {
     setSunkExpanded((prev) => {
       const next = !prev;
@@ -2549,6 +2658,23 @@ export function WorkspaceSidebar({
   const savedProjectsMatchQuery =
     !!q && savedProjects.some((p) => p.displayName.toLowerCase().includes(q) || p.repoPath.toLowerCase().includes(q));
   const hasResults = (isNested ? filteredNested.length > 0 : filteredGroups.length > 0) || savedProjectsMatchQuery;
+
+  // Trashed workspaces, flattened across the active axis and deduped by id (the
+  // same workspace can appear under more than one group). Feeds the footer
+  // Trash menu next to Settings (#2512), no longer an inline section.
+  const trashedWorkspaces = useMemo(() => {
+    const raw = isNested
+      ? filteredNested.flatMap((ng) =>
+          ng.subgroups.flatMap((sg) => sg.workspaces.filter((v) => workspaceIsTrashed(v.workspace))),
+        )
+      : filteredGroups.flatMap((g) => g.workspaces.filter((v) => workspaceIsTrashed(v.workspace)));
+    const seen = new Set<string>();
+    return raw.filter((v) => {
+      if (seen.has(v.workspace.id)) return false;
+      seen.add(v.workspace.id);
+      return true;
+    });
+  }, [isNested, filteredNested, filteredGroups]);
 
   // Sidebar multi-select. Selection is ephemeral sidebar UI state (not routed
   // or persisted); the anchor pivots Shift+click ranges. See #1724.
@@ -3180,16 +3306,6 @@ export function WorkspaceSidebar({
                 </div>
               );
             })}
-          <ProjectsSection
-            projects={savedProjects}
-            query={q}
-            readOnly={readOnly}
-            offline={offline}
-            onCreateSession={onCreateSession}
-            onAddProject={onAddProject}
-            onEditProject={onEditProject}
-            onRemoveProject={onRemoveProject}
-          />
           {(() => {
             // Single global "Snoozed & archived" section at the very
             // bottom of the sidebar. Aggregates sunk workspaces from
@@ -3262,93 +3378,16 @@ export function WorkspaceSidebar({
             );
           })()}
 
-          {(() => {
-            // Global "Trash" section, sibling of "Snoozed & archived" and
-            // pinned below it. Flat list of trashed workspaces with restore
-            // and permanent-delete actions. See #2489.
-            const trashedRaw = isNested
-              ? filteredNested.flatMap((ng) =>
-                  ng.subgroups.flatMap((sg) => sg.workspaces.filter((v) => workspaceIsTrashed(v.workspace))),
-                )
-              : filteredGroups.flatMap((g) => g.workspaces.filter((v) => workspaceIsTrashed(v.workspace)));
-            // The same workspace can appear under more than one group on the
-            // group axis; dedupe by workspace id so Trash doesn't double-count
-            // or double-render it. See #2489.
-            const seenTrashIds = new Set<string>();
-            const trashedWorkspaces = trashedRaw.filter((v) => {
-              if (seenTrashIds.has(v.workspace.id)) return false;
-              seenTrashIds.add(v.workspace.id);
-              return true;
-            });
-            if (trashedWorkspaces.length === 0) return null;
-            return (
-              <div data-testid="sidebar-trash-section">
-                <button
-                  onClick={() => setTrashExpanded((v) => !v)}
-                  data-testid="sidebar-trash-toggle"
-                  aria-expanded={trashExpanded}
-                  className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-secondary hover:bg-surface-800/40 cursor-pointer transition-colors border-t border-surface-800/60"
-                >
-                  <svg
-                    width="10"
-                    height="10"
-                    viewBox="0 0 10 10"
-                    fill="currentColor"
-                    className={`shrink-0 transition-transform duration-75 ${trashExpanded ? "" : "-rotate-90"}`}
-                  >
-                    <path
-                      d="M2 3 L5 6.5 L8 3"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  <span>Trash ({trashedWorkspaces.length})</span>
-                </button>
-                {trashExpanded &&
-                  trashedWorkspaces.map((v) => (
-                    <div
-                      key={v.key}
-                      data-testid="sidebar-trash-row"
-                      className="flex items-center gap-2 pl-7 pr-3 py-1.5 text-[13px] text-text-muted"
-                    >
-                      <button
-                        type="button"
-                        onClick={(e) => handleRowActivate(v.workspace.id, e)}
-                        title={v.workspace.displayName}
-                        data-testid="sidebar-trash-open"
-                        className="flex-1 truncate text-left hover:text-text-secondary cursor-pointer"
-                      >
-                        {v.workspace.displayName}
-                      </button>
-                      {!readOnly && (
-                        <>
-                          <button
-                            onClick={() => {
-                              const ids = v.workspace.sessions.map((s) => s.id);
-                              if (ids.length > 0) onRestoreSession?.(ids);
-                            }}
-                            data-testid="sidebar-trash-restore"
-                            className="text-[12px] text-accent-500 hover:text-accent-600 cursor-pointer"
-                          >
-                            Restore
-                          </button>
-                          <button
-                            onClick={() => onDeleteSession?.(v.workspace.id)}
-                            data-testid="sidebar-trash-purge"
-                            className="text-[12px] text-status-error/80 hover:text-status-error cursor-pointer"
-                          >
-                            Delete
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  ))}
-              </div>
-            );
-          })()}
+          <ProjectsSection
+            projects={savedProjects}
+            query={q}
+            readOnly={readOnly}
+            offline={offline}
+            onCreateSession={onCreateSession}
+            onAddProject={onAddProject}
+            onEditProject={onEditProject}
+            onRemoveProject={onRemoveProject}
+          />
 
           {!hasResults && hasFilter && (
             <div className="px-4 py-8 text-center">
@@ -3385,6 +3424,15 @@ export function WorkspaceSidebar({
         </div>
 
         <div className="border-t border-surface-700/20 p-2 flex items-center gap-1">
+          {trashedWorkspaces.length > 0 && (
+            <TrashMenu
+              trashedWorkspaces={trashedWorkspaces}
+              readOnly={readOnly}
+              onOpen={handleRowActivate}
+              onRestore={(ids) => onRestoreSession?.(ids)}
+              onDelete={(id) => onDeleteSession?.(id)}
+            />
+          )}
           <button
             onClick={onSettings}
             {...tourAnchor(TOUR_ANCHORS.sidebarSettings)}

--- a/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
+++ b/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
@@ -138,6 +138,25 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
     expect(screen.queryByTestId("sidebar-trash-menu")).toBeNull();
   });
 
+  it("closes the Trash popover on outside click", () => {
+    renderSidebar({ groups: trashedGroups() });
+    fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
+    expect(screen.getByTestId("sidebar-trash-menu")).toBeTruthy();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId("sidebar-trash-menu")).toBeNull();
+  });
+
+  it("keeps the Trash icon reachable while a filter hides every live row (#2512)", () => {
+    // Trash is a global recovery affordance: an active filter that matches no
+    // workspace must not strand trashed sessions by hiding the footer icon.
+    renderSidebar({ groups: trashedGroups() });
+    fireEvent.click(screen.getByLabelText("Filter sessions"));
+    fireEvent.change(screen.getByTestId("sidebar-filter-input"), { target: { value: "zzz-no-match" } });
+    expect(screen.getByTestId("sidebar-trash-toggle")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
+    expect(screen.getByTestId("sidebar-trash-row")).toBeTruthy();
+  });
+
   it("hides Restore/Delete actions in read-only mode", () => {
     renderSidebar({ groups: trashedGroups(), readOnly: true });
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));

--- a/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
+++ b/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 //
-// Coverage for the WorkspaceSidebar Trash section (#2489): a workspace whose
-// sessions are all trashed renders under a collapsible "Trash" group with
-// Open / Restore / Delete actions, separate from the live and sunk lists.
+// Coverage for the WorkspaceSidebar Trash control (#2489, reworked in #2512):
+// a workspace whose sessions are all trashed is reachable from a Trash icon in
+// the sidebar footer next to Settings, which opens a popover with Open /
+// Restore / Delete actions. Trash is no longer an inline scrolling section.
+// Also asserts the Projects section renders below "Snoozed & archived" (#2512).
 // Vitest (accurate per-file V8) rather than Playwright, whose bundle->source
 // remap is lossy for this large file.
 
@@ -99,21 +101,23 @@ function renderSidebar(over: Partial<React.ComponentProps<typeof WorkspaceSideba
 
 afterEach(cleanup);
 
-describe("WorkspaceSidebar Trash section (#2489)", () => {
+describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
   function trashedGroups() {
     const ws = workspace("trashed-ws", [session({ id: "s1", trashed_at: "2026-01-01T00:00:00Z" })]);
     return buildSessionGroups([ws], { idleDecayWindowMs: 60_000, sortMode: "lastActivity", isCollapsed: () => false });
   }
 
-  it("renders a trashed workspace under the Trash section and exposes its actions", () => {
+  it("reaches a trashed workspace via the footer Trash popover and exposes its actions", () => {
     const props = renderSidebar({ groups: trashedGroups() });
 
-    const section = screen.getByTestId("sidebar-trash-section");
-    expect(section).toBeTruthy();
-    // Collapsed by default: rows hidden until the toggle is clicked.
+    // No inline section in the scrolling list; only the footer toggle.
+    expect(screen.queryByTestId("sidebar-trash-section")).toBeNull();
+    // Closed by default: popover and rows hidden until the icon is clicked.
+    expect(screen.queryByTestId("sidebar-trash-menu")).toBeNull();
     expect(screen.queryByTestId("sidebar-trash-row")).toBeNull();
 
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
+    expect(screen.getByTestId("sidebar-trash-menu")).toBeTruthy();
     expect(screen.getByTestId("sidebar-trash-row")).toBeTruthy();
 
     fireEvent.click(screen.getByTestId("sidebar-trash-open"));
@@ -126,6 +130,14 @@ describe("WorkspaceSidebar Trash section (#2489)", () => {
     expect(props.onDeleteSession).toHaveBeenCalledWith("trashed-ws");
   });
 
+  it("closes the Trash popover on Escape", () => {
+    renderSidebar({ groups: trashedGroups() });
+    fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
+    expect(screen.getByTestId("sidebar-trash-menu")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("sidebar-trash-menu")).toBeNull();
+  });
+
   it("hides Restore/Delete actions in read-only mode", () => {
     renderSidebar({ groups: trashedGroups(), readOnly: true });
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
@@ -134,7 +146,7 @@ describe("WorkspaceSidebar Trash section (#2489)", () => {
     expect(screen.queryByTestId("sidebar-trash-purge")).toBeNull();
   });
 
-  it("omits the Trash section when nothing is trashed", () => {
+  it("omits the Trash icon when nothing is trashed", () => {
     renderSidebar({
       groups: buildSessionGroups([workspace("live-ws", [session({ id: "live", status: "Running" })])], {
         idleDecayWindowMs: 60_000,
@@ -142,6 +154,22 @@ describe("WorkspaceSidebar Trash section (#2489)", () => {
         isCollapsed: () => false,
       }),
     });
-    expect(screen.queryByTestId("sidebar-trash-section")).toBeNull();
+    expect(screen.queryByTestId("sidebar-trash-toggle")).toBeNull();
+  });
+
+  it("renders the Projects section below 'Snoozed & archived' (#2512)", () => {
+    // An archived (sunk) workspace surfaces the sunk section; the Projects
+    // section header always renders when CRUD is available. Assert DOM order.
+    const archivedWs = workspace("archived-ws", [session({ id: "a1", archived_at: "2026-01-01T00:00:00Z" })]);
+    renderSidebar({
+      groups: buildSessionGroups([archivedWs], {
+        idleDecayWindowMs: 60_000,
+        sortMode: "lastActivity",
+        isCollapsed: () => false,
+      }),
+    });
+    const sunk = screen.getByTestId("sidebar-sunk-section");
+    const projects = screen.getByTestId("sidebar-projects-section");
+    expect(sunk.compareDocumentPosition(projects) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/web/tests/live/session-trash.spec.ts
+++ b/web/tests/live/session-trash.spec.ts
@@ -59,9 +59,9 @@ base.describe("session trash + restore via sidebar (#2489)", () => {
         .toBe(true);
       await expect(row).toHaveCount(0, { timeout: 10_000 });
 
-      // Expand the Trash section and restore.
+      // Open the footer Trash popover and restore.
       const trashToggle = page.locator("[data-testid='sidebar-trash-toggle']");
-      await expect(trashToggle).toContainText("Trash (1)");
+      await expect(trashToggle).toHaveAttribute("aria-label", "Trash (1)");
       await trashToggle.click();
 
       const restorePromise = page.waitForResponse(

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -111,17 +111,18 @@ test.describe("Session trash flow", () => {
 
     await expect.poll(() => handle.trashCalls, { timeout: 10_000 }).toBe(1);
 
-    // Row leaves the active list and surfaces under the Trash section.
-    const trashSection = page.locator('[data-testid="sidebar-trash-section"]');
-    await expect(trashSection).toBeVisible({ timeout: 10_000 });
-    await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+    // Row leaves the active list; the footer Trash icon appears and its
+    // popover lists the trashed workspace.
+    const trashToggle = page.locator('[data-testid="sidebar-trash-toggle"]');
+    await expect(trashToggle).toBeVisible({ timeout: 10_000 });
+    await trashToggle.click();
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: "story-trash" });
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
 
     // Restore brings it back to the active list.
     await trashRow.locator('[data-testid="sidebar-trash-restore"]').click();
     await expect.poll(() => handle.restoreCalls, { timeout: 10_000 }).toBe(1);
-    await expect(trashSection).toHaveCount(0, { timeout: 10_000 });
+    await expect(trashToggle).toHaveCount(0, { timeout: 10_000 });
     await expect(row).toBeVisible({ timeout: 10_000 });
   });
 
@@ -142,11 +143,11 @@ test.describe("Session trash flow", () => {
       .click();
 
     await expect.poll(() => handle.trashCalls, { timeout: 10_000 }).toBe(1);
-    // The trash failed: no Trash section appears and the row stays put.
-    await expect(page.locator('[data-testid="sidebar-trash-section"]')).toHaveCount(0, { timeout: 5_000 });
+    // The trash failed: no Trash icon appears and the row stays put.
+    await expect(page.locator('[data-testid="sidebar-trash-toggle"]')).toHaveCount(0, { timeout: 5_000 });
   });
 
-  test("Delete from the Trash section opens the permanent-delete dialog", async ({ page }) => {
+  test("Delete from the Trash popover opens the permanent-delete dialog", async ({ page }) => {
     const handle = await mockApis(page);
     handle.trashed = true; // start already trashed
     await page.setViewportSize({ width: 1280, height: 720 });
@@ -156,7 +157,7 @@ test.describe("Session trash flow", () => {
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: "story-trash" });
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
 
-    // The Trash-section Delete re-opens the dialog; with the row already
+    // The Trash-popover Delete re-opens the dialog; with the row already
     // trashed it goes straight to permanent delete (no trash checkbox).
     await trashRow.locator('[data-testid="sidebar-trash-purge"]').click();
     const dialog = page.locator('[data-testid="delete-session-dialog"]');


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Reworks two pieces of the web dashboard sidebar layout (#2512).

Trash no longer gets a full collapsible section in the scrolling sidebar list. It is a terminal, rarely-touched state, so it now lives as an icon in the sidebar footer next to Settings. Clicking it opens an upward popover listing the trashed workspaces with the same Open / Restore / Delete actions the old section had; outside-click and Escape close it, mirroring `SidebarSortPicker`. The icon only renders when something is trashed, so the footer stays a single gear until there is trash to recover.

The Projects section now renders below the global "Snoozed & archived" bucket instead of above it. Top-to-bottom the sidebar scroll list reads: active groups, "Snoozed & archived", Projects, with Settings and the conditional Trash icon pinned in the footer.

The change is confined to `web/src/components/WorkspaceSidebar.tsx`: a new `TrashMenu` footer component, the `trashedWorkspaces` derivation lifted into the component body, the `<ProjectsSection>` block reordered after the sunk-section, and the old inline Trash section plus its `trashExpanded` state removed. No backend or trash-retention behavior changed.

Closes #2512

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard with no trashed sessions; confirm the footer shows only the Settings gear and the scroll list orders active groups, then "Snoozed & archived", then Projects.
- [ ] Trash a session (right-click row, Delete, confirm); confirm no "Trash" section appears in the scroll list and a Trash icon appears in the footer next to Settings.
- [ ] Click the Trash icon; confirm a popover lists the trashed workspace, Restore returns it to the active list, and Delete opens the permanent-delete dialog.
- [ ] With the popover open, press Escape and click outside; confirm both close it.
- [ ] In read-only mode, open the Trash popover; confirm the rows list but Restore/Delete are hidden.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Updated the vitest sidebar trash spec (footer icon, popover, Escape-close, read-only, and a DOM-order assertion that Projects follows "Snoozed & archived"), plus the mocked and live Playwright trash specs to drive the footer toggle. `WorkspaceSidebar.tsx` is already mapped by the existing `session.trash` and `session.trash.flow` coverage-matrix entries, so no new entry was needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (Trash as a footer popover, Projects below Snoozed & archived), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785245786&installation_id=139138837&pr_number=2516&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2516&signature=8988599f987cacc242863d8eccdc3296129f72afa342f066539d68b200fa1f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `WorkspaceSidebar` so “Trash” is no longer part of the scrolling sidebar sections. Instead, when there are trashed workspaces, a Trash icon appears in the footer next to Settings and opens an upward popover listing the trashed workspaces. The popover preserves the existing actions (Open/Restore and Delete permanently), and in read-only mode it still shows the trashed list while hiding the action buttons. The popover now closes on outside click and Escape.

The sidebar layout was also re-ordered so **Projects** appears below the **“Snoozed & archived”** bucket, and the old inline Trash UI (including its expanded state) was removed.

Tests were updated/added to cover the new footer popover behavior (open/close/dismissal), read-only behavior, correct access even when filters hide live rows, the icon’s absence when there’s nothing in Trash, and the new section ordering. Playwright end-to-end flows were adjusted to interact with the new Trash toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->