### PR TITLE
feat(web): search session conversations from the command palette

### DIFF
--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -564,6 +564,15 @@ impl EventStore {
             match hits.get_mut(&session_id) {
                 Some(hit) => hit.match_count += 1,
                 None => {
+                    // Stop once we have enough distinct sessions: rows are
+                    // newest-first, so any further new session ranks below
+                    // these and would be dropped anyway. Counting the cap on
+                    // distinct sessions (not raw rows) keeps one chatty
+                    // session from hiding others. match_count past this point
+                    // is left approximate on purpose.
+                    if order.len() >= limit {
+                        break;
+                    }
                     order.push(session_id.clone());
                     hits.insert(
                         session_id.clone(),
@@ -581,7 +590,6 @@ impl EventStore {
 
         order
             .into_iter()
-            .take(limit)
             .filter_map(|id| hits.remove(&id))
             .collect()
     }
@@ -1376,10 +1384,13 @@ const MIN_SEARCH_CHARS: usize = 2;
 const MAX_SEARCH_CHARS: usize = 128;
 /// Most sessions returned from a single search.
 const MAX_SEARCH_RESULTS: usize = 20;
-/// Upper bound on rows the LIKE prefilter scans before grouping. Bounds
-/// the cost of a search on a large DB; older matches past this are not
-/// surfaced (newest-first), an acceptable MVP ceiling.
-const SEARCH_ROW_SCAN_CAP: usize = 300;
+/// Hard ceiling on rows the LIKE prefilter scans, so a no-match query on a
+/// huge DB can't scan the whole table. The scan also stops early as soon as
+/// `limit` distinct sessions are collected, so the common case reads far
+/// fewer rows; this ceiling only bites when matches are sparse. Set well
+/// above `limit` so a single chatty session's run of newest events does not
+/// crowd other matching sessions out of the window.
+const SEARCH_ROW_SCAN_CAP: usize = 2000;
 /// Characters of context kept on each side of the match in a snippet.
 const SNIPPET_RADIUS_CHARS: usize = 60;
 
@@ -1601,6 +1612,32 @@ mod tests {
             hits.is_empty(),
             "% must be matched literally, not as a wildcard"
         );
+    }
+
+    #[test]
+    fn search_content_caps_distinct_sessions_not_raw_rows() {
+        let (_tmp, store) = open_store(1000);
+        // A chatty session (s_busy) with many matching events recorded first
+        // (older), then a single newer match in s_quiet. The cap is on
+        // distinct sessions, so s_busy must not crowd s_quiet out.
+        for seq in 1..=20 {
+            store
+                .record("s_busy", seq, &agent_chunk("needle again"))
+                .unwrap();
+        }
+        store.record("s_quiet", 1, &agent_chunk("needle")).unwrap();
+
+        let all = store.search_content("needle", 10);
+        let ids: Vec<&str> = all.iter().map(|h| h.session_id.as_str()).collect();
+        assert!(ids.contains(&"s_busy"), "chatty session present");
+        assert!(
+            ids.contains(&"s_quiet"),
+            "quiet session not hidden by chatty one"
+        );
+
+        // limit caps the number of distinct sessions, not raw matched rows.
+        let one = store.search_content("needle", 1);
+        assert_eq!(one.len(), 1, "limit bounds distinct sessions");
     }
 
     fn img_blob(id: &str) -> AttachmentBlob {

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -119,6 +119,15 @@ fn is_user_turn_boundary(ev: &Event) -> bool {
 /// acp -> events.
 pub struct EventStore {
     conn: Mutex<Connection>,
+    /// Read-only connection used exclusively by `search_content`. A
+    /// content search scans many rows; routing it through the writer
+    /// `conn` would hold that mutex for the whole scan and stall the
+    /// live `record()` path (WAL gives no concurrency while one Rust
+    /// mutex serializes every access). A separate read-only connection
+    /// lets WAL serve the scan concurrently with writes. Searches still
+    /// serialize against each other behind this mutex, which is fine:
+    /// one in-flight search at a time is plenty for the palette.
+    search_conn: Mutex<Connection>,
     schema: events::Schema,
     /// Per-session retention cap. Older events are pruned on insert
     /// once the count exceeds this value. Bytes are not enforced here
@@ -137,6 +146,22 @@ impl EventStore {
         // tables, so an established database opens unchanged (no migration).
         let schema = events::Schema::new("acp")?;
         let conn = events::open(db_path, &schema)?;
+        // Separate read-only handle for content search; the writer above
+        // already created the file and tables, so opening read-only here
+        // always succeeds. query_only is belt-and-suspenders on top of the
+        // READ_ONLY flag; busy_timeout keeps a scan from erroring out if it
+        // briefly contends with a checkpoint.
+        let search_conn = Connection::open_with_flags(
+            db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        )
+        .with_context(|| format!("open read-only search handle at {}", db_path.display()))?;
+        search_conn
+            .pragma_update(None, "query_only", "ON")
+            .context("set query_only=ON on search handle")?;
+        search_conn
+            .busy_timeout(std::time::Duration::from_millis(1000))
+            .context("set busy_timeout on search handle")?;
         debug!(
             target: "acp.event_store",
             path = %db_path.display(),
@@ -145,6 +170,7 @@ impl EventStore {
         );
         Ok(Self {
             conn: Mutex::new(conn),
+            search_conn: Mutex::new(search_conn),
             schema,
             max_events_per_session,
         })
@@ -454,6 +480,110 @@ impl EventStore {
         } else {
             None
         }
+    }
+
+    /// Full-text search over conversation content (agent messages, user
+    /// prompts, tool output) across every session, newest match first,
+    /// grouped to one hit per session. Backs the web command palette's
+    /// "Conversations" group (#2515).
+    ///
+    /// Runs on the dedicated read-only `search_conn` so a scan never
+    /// blocks the live `record()` path. Returns an empty vec for a query
+    /// below the minimum length or on any DB error: search is best-effort
+    /// chrome, not a correctness path.
+    ///
+    // ponytail: raw event_json LIKE prefilter, then decode + verify in
+    // Rust. No FTS5 and no plaintext sidecar table, so zero write-path
+    // cost and no migration. The SQL LIKE can over-match on JSON keys
+    // (e.g. "text"), but the post-decode check that the extracted prose
+    // actually contains the query drops those before they reach results.
+    // Ceiling: a full scan bounded by SEARCH_ROW_SCAN_CAP. Upgrade path
+    // if the corpus outgrows it: a plaintext sidecar table or an FTS5
+    // virtual table populated on record().
+    pub fn search_content(&self, query: &str, limit: usize) -> Vec<ContentHit> {
+        let trimmed = query.trim();
+        if trimmed.chars().count() < MIN_SEARCH_CHARS {
+            return Vec::new();
+        }
+        let needle: String = trimmed
+            .chars()
+            .take(MAX_SEARCH_CHARS)
+            .collect::<String>()
+            .to_lowercase();
+        let limit = limit.clamp(1, MAX_SEARCH_RESULTS);
+        let pattern = format!("%{}%", escape_like(&needle));
+
+        let conn = match self.search_conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut stmt = match conn.prepare(
+            "SELECT session_id, seq, event_json FROM acp_events
+             WHERE event_json LIKE ?1 ESCAPE '\\'
+             ORDER BY created_at DESC LIMIT ?2",
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(target: "acp.event_store", "prepare search query: {e}");
+                return Vec::new();
+            }
+        };
+        let rows = match stmt.query_map(params![pattern, SEARCH_ROW_SCAN_CAP as i64], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        }) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(target: "acp.event_store", "run search query: {e}");
+                return Vec::new();
+            }
+        };
+
+        // Preserve newest-first row order; the first row seen for a
+        // session is its representative (newest) hit, later rows only
+        // bump match_count.
+        let mut order: Vec<String> = Vec::new();
+        let mut hits: std::collections::HashMap<String, ContentHit> =
+            std::collections::HashMap::new();
+        for row in rows.flatten() {
+            let (session_id, seq, json) = row;
+            let Ok(event) = serde_json::from_str::<Event>(&json) else {
+                continue;
+            };
+            let Some((kind, text)) = event_search_text(&event) else {
+                continue;
+            };
+            // The SQL LIKE matched the raw JSON; confirm the query is in
+            // the extracted prose, not a field name or escape sequence.
+            if !text.to_lowercase().contains(&needle) {
+                continue;
+            }
+            match hits.get_mut(&session_id) {
+                Some(hit) => hit.match_count += 1,
+                None => {
+                    order.push(session_id.clone());
+                    hits.insert(
+                        session_id.clone(),
+                        ContentHit {
+                            session_id,
+                            seq: seq.max(0) as u64,
+                            kind,
+                            snippet: make_snippet(&text, &needle),
+                            match_count: 1,
+                        },
+                    );
+                }
+            }
+        }
+
+        order
+            .into_iter()
+            .take(limit)
+            .filter_map(|id| hits.remove(&id))
+            .collect()
     }
 
     /// Return the most recent `Event::RateLimit` stored for `session_id`
@@ -1238,6 +1368,100 @@ pub struct AttachmentBlob {
 /// full payload (assistant chunks can be a few KB each). Unknown
 /// variants fall back to "other"; `event_kind` only exists for log
 /// breadcrumbs and doesn't need to stay in lockstep with the enum.
+/// Shortest query `search_content` will run; below this every session
+/// matches and the result is noise.
+const MIN_SEARCH_CHARS: usize = 2;
+/// Cap on query length so a pathological input can't build a huge LIKE
+/// pattern.
+const MAX_SEARCH_CHARS: usize = 128;
+/// Most sessions returned from a single search.
+const MAX_SEARCH_RESULTS: usize = 20;
+/// Upper bound on rows the LIKE prefilter scans before grouping. Bounds
+/// the cost of a search on a large DB; older matches past this are not
+/// surfaced (newest-first), an acceptable MVP ceiling.
+const SEARCH_ROW_SCAN_CAP: usize = 300;
+/// Characters of context kept on each side of the match in a snippet.
+const SNIPPET_RADIUS_CHARS: usize = 60;
+
+/// One session's content-search hit: the newest matching event plus a
+/// count of how many of its events matched within the scanned window.
+#[derive(Debug, Clone)]
+pub struct ContentHit {
+    pub session_id: String,
+    pub seq: u64,
+    pub kind: &'static str,
+    pub snippet: String,
+    pub match_count: usize,
+}
+
+/// Escape the LIKE metacharacters so user input is matched literally
+/// rather than as wildcard syntax (a bare `%` would otherwise match
+/// every row). Paired with `ESCAPE '\'` in the query.
+fn escape_like(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if matches!(ch, '\\' | '%' | '_') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Extract the user-facing prose from an event for content search, with
+/// a short kind label. Returns `None` for structural / metadata events
+/// that carry no conversation text. Only the high-signal prose sources
+/// are indexed; status and error strings are deliberately excluded so a
+/// search stays scoped to the conversation.
+fn event_search_text(event: &Event) -> Option<(&'static str, String)> {
+    let pick = |s: &str, kind: &'static str| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some((kind, s.to_string()))
+        }
+    };
+    match event {
+        Event::AgentMessageChunk { text, .. } => pick(text, "agent"),
+        Event::UserPromptSent { text, .. } => pick(text, "user"),
+        Event::UserDiffCommentsPrompt {
+            assembled_markdown, ..
+        } => pick(assembled_markdown, "user"),
+        Event::ToolCallContent { content, .. } => pick(content, "tool"),
+        Event::ToolCallCompleted { content, .. } => pick(content, "tool"),
+        _ => None,
+    }
+}
+
+/// Build a display snippet: a window of `SNIPPET_RADIUS_CHARS` on each
+/// side of the first case-insensitive match of `needle` (already
+/// lowercased) in `text`, whitespace-collapsed, with ellipses where
+/// trimmed. Falls back to the head of the text when the needle is not
+/// found (callers only pass text that matched, so this is rare). UTF-8
+/// safe: windows on char boundaries, never byte offsets.
+fn make_snippet(text: &str, needle: &str) -> String {
+    let collapsed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let chars: Vec<char> = collapsed.chars().collect();
+    let lower = collapsed.to_lowercase();
+    // Map the byte index of the match to a char index over `chars`.
+    let match_char = lower
+        .find(needle)
+        .map(|byte_idx| lower[..byte_idx].chars().count())
+        .unwrap_or(0);
+    let start = match_char.saturating_sub(SNIPPET_RADIUS_CHARS);
+    let end = (match_char + needle.chars().count() + SNIPPET_RADIUS_CHARS).min(chars.len());
+    let mut snippet = String::new();
+    if start > 0 {
+        snippet.push('…');
+    }
+    snippet.extend(&chars[start..end]);
+    if end < chars.len() {
+        snippet.push('…');
+    }
+    snippet
+}
+
 fn event_kind(event: &Event) -> &'static str {
     match event {
         Event::PlanUpdated { .. } => "plan_updated",
@@ -1298,6 +1522,85 @@ mod tests {
         let path = tmp.path().join("acp.db");
         let store = EventStore::open(&path, max).unwrap();
         (tmp, store)
+    }
+
+    fn agent_chunk(text: &str) -> Event {
+        Event::AgentMessageChunk { text: text.into() }
+    }
+
+    fn user_prompt(text: &str) -> Event {
+        Event::UserPromptSent {
+            text: text.into(),
+            attachments: vec![],
+        }
+    }
+
+    #[test]
+    fn search_content_finds_prompt_agent_and_tool_text() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s1", 1, &user_prompt("please refactor the reconciler"))
+            .unwrap();
+        store
+            .record("s2", 1, &agent_chunk("I updated the supervisor"))
+            .unwrap();
+        store
+            .record(
+                "s3",
+                1,
+                &Event::ToolCallContent {
+                    tool_call_id: "t1".into(),
+                    content: "grep matched reconciler in supervisor.rs".into(),
+                },
+            )
+            .unwrap();
+
+        let hits = store.search_content("reconciler", 10);
+        let ids: Vec<&str> = hits.iter().map(|h| h.session_id.as_str()).collect();
+        assert!(ids.contains(&"s1"), "prompt text should match");
+        assert!(ids.contains(&"s3"), "tool content should match");
+        assert!(!ids.contains(&"s2"), "non-matching session excluded");
+    }
+
+    #[test]
+    fn search_content_ignores_json_keys() {
+        let (_tmp, store) = open_store(1000);
+        // The substring "text" is a JSON key in every UserPromptSent row,
+        // so a raw LIKE would match; the decode-and-verify step must drop
+        // it because the prose does not contain "text".
+        store.record("s1", 1, &user_prompt("hello world")).unwrap();
+        let hits = store.search_content("text", 10);
+        assert!(hits.is_empty(), "JSON key 'text' must not match prose");
+    }
+
+    #[test]
+    fn search_content_is_case_insensitive_and_groups_by_session() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s1", 1, &agent_chunk("The Quick Brown Fox"))
+            .unwrap();
+        store.record("s1", 2, &agent_chunk("quick again")).unwrap();
+        let hits = store.search_content("QUICK", 10);
+        assert_eq!(hits.len(), 1, "two matching events collapse to one session");
+        assert_eq!(hits[0].session_id, "s1");
+        assert_eq!(hits[0].match_count, 2);
+    }
+
+    #[test]
+    fn search_content_escapes_like_wildcards() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s1", 1, &agent_chunk("plain message"))
+            .unwrap();
+        // Unescaped, "e%" becomes LIKE pattern %e%% which matches any text
+        // containing "e" (the prose has several). Escaped, it matches only
+        // the literal substring "e%", which the prose lacks, so the result
+        // is empty. This fails if wildcard escaping regresses.
+        let hits = store.search_content("e%", 10);
+        assert!(
+            hits.is_empty(),
+            "% must be matched literally, not as a wildcard"
+        );
     }
 
     fn img_blob(id: &str) -> AttachmentBlob {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -45,11 +45,12 @@ pub use projects::{create_project, delete_project, list_projects, update_project
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
     force_smart_rename, get_recent_projects, kill_terminal, list_sessions,
-    preview_volume_ignores_globs, read_output, rename_session, restore_session, send_message,
-    session_diff_file, session_diff_files, set_worktree_name, start_session, stop_session,
-    trash_session, update_session_archive, update_session_diff_base, update_session_group,
-    update_session_notifications, update_session_pin, update_session_snooze, update_session_unread,
-    update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
+    preview_volume_ignores_globs, read_output, rename_session, restore_session, search_sessions,
+    send_message, session_diff_file, session_diff_files, set_worktree_name, start_session,
+    stop_session, trash_session, update_session_archive, update_session_diff_base,
+    update_session_group, update_session_notifications, update_session_pin, update_session_snooze,
+    update_session_unread, update_workspace_ordering, CleanupDefaults, OutputQuery,
+    SendMessageRequest, SessionResponse,
 };
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -5557,6 +5557,52 @@ pub async fn preview_volume_ignores_globs(
     }
 }
 
+#[derive(Deserialize)]
+pub struct SearchQuery {
+    pub q: String,
+    pub limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+pub struct SearchHit {
+    pub session_id: String,
+    pub seq: u64,
+    pub kind: String,
+    pub snippet: String,
+    pub match_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct SearchResponse {
+    pub results: Vec<SearchHit>,
+}
+
+/// Full-text search over session conversation content (#2515). Scans the
+/// structured-view event store on its read-only connection and returns
+/// one hit per matching session, newest first. The response carries only
+/// the session id; the web client already holds the session list and
+/// resolves the title and state from it. Read-only; allowed in
+/// `--read-only` mode.
+pub async fn search_sessions(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(q): axum::extract::Query<SearchQuery>,
+) -> Json<SearchResponse> {
+    let limit = q.limit.unwrap_or(10);
+    let results = state
+        .acp_event_store
+        .search_content(&q.q, limit)
+        .into_iter()
+        .map(|h| SearchHit {
+            session_id: h.session_id,
+            seq: h.seq,
+            kind: h.kind.to_string(),
+            snippet: h.snippet,
+            match_count: h.match_count,
+        })
+        .collect();
+    Json(SearchResponse { results })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -5588,18 +5588,26 @@ pub async fn search_sessions(
     axum::extract::Query(q): axum::extract::Query<SearchQuery>,
 ) -> Json<SearchResponse> {
     let limit = q.limit.unwrap_or(10);
-    let results = state
-        .acp_event_store
-        .search_content(&q.q, limit)
-        .into_iter()
-        .map(|h| SearchHit {
-            session_id: h.session_id,
-            seq: h.seq,
-            kind: h.kind.to_string(),
-            snippet: h.snippet,
-            match_count: h.match_count,
-        })
-        .collect();
+    // search_content does synchronous SQLite I/O plus JSON decoding; the
+    // palette fires it repeatedly as the user types, so run it on the
+    // blocking pool to keep slow scans off the Tokio worker threads.
+    let store = Arc::clone(&state.acp_event_store);
+    let query = q.q.clone();
+    let results = tokio::task::spawn_blocking(move || {
+        store
+            .search_content(&query, limit)
+            .into_iter()
+            .map(|h| SearchHit {
+                session_id: h.session_id,
+                seq: h.seq,
+                kind: h.kind.to_string(),
+                snippet: h.snippet,
+                match_count: h.match_count,
+            })
+            .collect()
+    })
+    .await
+    .unwrap_or_default();
     Json(SearchResponse { results })
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1443,6 +1443,9 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/sessions",
             get(api::list_sessions).post(api::create_session),
         )
+        // Static segment; registered before /api/sessions/{id} so the
+        // literal "search" never resolves as a session id. See #2515.
+        .route("/api/sessions/search", get(api::search_sessions))
         .route("/api/recent-projects", get(api::get_recent_projects))
         .route(
             "/api/workspace-ordering",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -115,6 +115,8 @@ import { TelemetryConsentModal } from "./components/TelemetryConsentModal";
 import { TipsModal } from "./components/TipsModal";
 import { useTips, shouldAutoPopTips } from "./hooks/useTips";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
+import { useConversationSearch } from "./hooks/useConversationSearch";
+import type { CommandAction } from "./components/command-palette/types";
 import { DisconnectBanner } from "./components/DisconnectBanner";
 import { ElevationPrompt } from "./components/ElevationPrompt";
 import { UpdateBanner } from "./components/UpdateBanner";
@@ -571,6 +573,10 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // unit-tested directly.
   const tips = useTips();
   const [showPalette, setShowPalette] = useState(false);
+  // Palette content-search query (#2515); declared here so the keyboard
+  // handlers below can clear it on close/toggle. Consumed lower down by
+  // useConversationSearch.
+  const [paletteQuery, setPaletteQuery] = useState("");
   const [showAbout, setShowAbout] = useState(false);
   const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
   // Whether the telemetry status fetch has settled. `telemetryConsentNeeded`
@@ -1274,6 +1280,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           }
           if (showPalette) {
             setShowPalette(false);
+            setPaletteQuery("");
             return;
           }
           setShowSessionWizard(false);
@@ -1284,7 +1291,10 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         },
         onHelp: () => setShowHelp((h) => !h),
         onSettings: () => (showSettings ? handleCloseSettings() : navigate("/settings")),
-        onPalette: () => setShowPalette((p) => !p),
+        onPalette: () => {
+          setPaletteQuery("");
+          setShowPalette((p) => !p);
+        },
         onToggleSidebar: () => setSidebarOpen((o) => !o),
         onToggleRightPanel: () => toggleRightDock(),
         onToggleTerminalFocus: handleToggleTerminalFocus,
@@ -1329,6 +1339,37 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     readOnly: !!serverAbout?.read_only,
     onOpenSettingsTab: openSettingsTab,
   });
+
+  // Conversation-content search for the palette (#2515). paletteQuery is
+  // declared above (near showPalette) so the keyboard handlers can clear it
+  // on close/toggle; consumed here.
+  const { results: conversationHits, loading: conversationSearching } = useConversationSearch(paletteQuery);
+  const conversationActions = useMemo<CommandAction[]>(() => {
+    return conversationHits.flatMap((hit) => {
+      const session = sessions.find((s) => s.id === hit.session_id);
+      if (!session || session.id === activeSessionId) return [];
+      const state = session.trashed_at
+        ? "trashed"
+        : session.archived_at
+          ? "archived"
+          : session.snoozed_until
+            ? "snoozed"
+            : null;
+      const title = session.title || session.branch || "(untitled)";
+      const count = hit.match_count > 1 ? ` (${hit.match_count} matches)` : "";
+      return [
+        {
+          id: `conversation:${session.id}`,
+          title: state ? `${title} · ${state}` : title,
+          subtitle: `${hit.snippet}${count}`,
+          group: "Conversations" as const,
+          status: session.status,
+          statusCreatedAt: session.created_at,
+          perform: () => handleSelectSession(session.id),
+        },
+      ];
+    });
+  }, [conversationHits, sessions, activeSessionId, handleSelectSession]);
 
   const renderContent = () => {
     if (showSettings) {
@@ -1847,8 +1888,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
         <CommandPalette
           open={showPalette}
-          onClose={() => setShowPalette(false)}
-          actions={[...commandActions, ...settingsCommands]}
+          onClose={() => {
+            setShowPalette(false);
+            setPaletteQuery("");
+          }}
+          actions={[...commandActions, ...conversationActions, ...settingsCommands]}
+          onSearchChange={setPaletteQuery}
+          searching={conversationSearching}
         />
 
         {activeWorkspace && activeSession && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,7 +28,7 @@ import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useDiffComments } from "./hooks/useDiffComments";
 import { clearStoredComments, sweepOrphanComments } from "./components/diff/comments/storage";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
-import { useCommandActions } from "./hooks/useCommandActions";
+import { useCommandActions, buildConversationActions } from "./hooks/useCommandActions";
 import { useSettingsCommands } from "./hooks/useSettingsCommands";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
@@ -116,7 +116,6 @@ import { TipsModal } from "./components/TipsModal";
 import { useTips, shouldAutoPopTips } from "./hooks/useTips";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
 import { useConversationSearch } from "./hooks/useConversationSearch";
-import type { CommandAction } from "./components/command-palette/types";
 import { DisconnectBanner } from "./components/DisconnectBanner";
 import { ElevationPrompt } from "./components/ElevationPrompt";
 import { UpdateBanner } from "./components/UpdateBanner";
@@ -1344,32 +1343,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // declared above (near showPalette) so the keyboard handlers can clear it
   // on close/toggle; consumed here.
   const { results: conversationHits, loading: conversationSearching } = useConversationSearch(paletteQuery);
-  const conversationActions = useMemo<CommandAction[]>(() => {
-    return conversationHits.flatMap((hit) => {
-      const session = sessions.find((s) => s.id === hit.session_id);
-      if (!session || session.id === activeSessionId) return [];
-      const state = session.trashed_at
-        ? "trashed"
-        : session.archived_at
-          ? "archived"
-          : session.snoozed_until
-            ? "snoozed"
-            : null;
-      const title = session.title || session.branch || "(untitled)";
-      const count = hit.match_count > 1 ? ` (${hit.match_count} matches)` : "";
-      return [
-        {
-          id: `conversation:${session.id}`,
-          title: state ? `${title} · ${state}` : title,
-          subtitle: `${hit.snippet}${count}`,
-          group: "Conversations" as const,
-          status: session.status,
-          statusCreatedAt: session.created_at,
-          perform: () => handleSelectSession(session.id),
-        },
-      ];
-    });
-  }, [conversationHits, sessions, activeSessionId, handleSelectSession]);
+  const conversationActions = useMemo(
+    () =>
+      buildConversationActions(conversationHits, sessions, activeSessionId).map(({ sessionId, ...rest }) => ({
+        ...rest,
+        perform: () => handleSelectSession(sessionId),
+      })),
+    [conversationHits, sessions, activeSessionId, handleSelectSession],
+  );
 
   const renderContent = () => {
     if (showSettings) {

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Command } from "cmdk";
+import { Command, defaultFilter } from "cmdk";
 import { StatusGlyph } from "../StatusGlyph";
 import { CheatOverlay } from "./CheatOverlay";
 import { GROUP_ORDER } from "./groups";
@@ -11,9 +11,15 @@ interface Props {
   open: boolean;
   onClose: () => void;
   actions: CommandAction[];
+  /** Called with the current search text (debounced upstream) so the host
+   *  can run an async conversation-content search. */
+  onSearchChange?: (query: string) => void;
+  /** True while a conversation-content search is in flight; renders a
+   *  spinner row in the Conversations group. */
+  searching?: boolean;
 }
 
-export function CommandPalette({ open, onClose, actions }: Props) {
+export function CommandPalette({ open, onClose, actions, onSearchChange, searching }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [search, setSearch] = useState("");
@@ -23,15 +29,17 @@ export function CommandPalette({ open, onClose, actions }: Props) {
 
   // A full-string match on a known Age of Empires cheat code fires a toast and
   // a one-off visual, then clears the input. Anything else is a normal search.
-  const onSearchChange = (value: string) => {
+  const handleSearchChange = (value: string) => {
     const hit = matchCheat(value);
     if (hit) {
       reportInfo(hit.toast);
       setCheat((prev) => ({ effect: hit.effect, id: (prev?.id ?? 0) + 1 }));
       setSearch("");
+      onSearchChange?.("");
       return;
     }
     setSearch(value);
+    onSearchChange?.(value);
   };
 
   // Capture the launcher before moving focus into the palette, then restore
@@ -95,6 +103,12 @@ export function CommandPalette({ open, onClose, actions }: Props) {
       <Command
         label="Command palette"
         loop
+        filter={(value, searchText, keywords) =>
+          // Conversation hits are already filtered server-side by content
+          // (which the client text does not contain), so force-keep them;
+          // everything else uses cmdk's default fuzzy scoring.
+          value.startsWith("conversation:") ? 1 : defaultFilter!(value, searchText, keywords)
+        }
         className="w-full max-w-[600px] bg-surface-800 border border-surface-700/50 rounded-lg shadow-2xl overflow-hidden animate-slide-up"
         onClick={(e) => e.stopPropagation()}
       >
@@ -116,7 +130,7 @@ export function CommandPalette({ open, onClose, actions }: Props) {
           <Command.Input
             ref={inputRef}
             value={search}
-            onValueChange={onSearchChange}
+            onValueChange={handleSearchChange}
             placeholder="Search actions, sessions, settings…"
             className="flex-1 bg-transparent outline-none text-[15px] text-text-primary placeholder:text-text-muted"
           />
@@ -130,13 +144,26 @@ export function CommandPalette({ open, onClose, actions }: Props) {
 
           {GROUP_ORDER.map((groupName) => {
             const items = grouped.get(groupName) ?? [];
-            if (items.length === 0) return null;
+            // The Conversations group still renders while a content search
+            // is in flight, so the spinner replaces a premature "No matches".
+            const showSpinner = groupName === "Conversations" && !!searching;
+            if (items.length === 0 && !showSpinner) return null;
             return (
               <Command.Group
                 key={groupName}
                 heading={groupName}
                 className="mb-1 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-2 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-mono [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-text-muted"
               >
+                {showSpinner && (
+                  <Command.Item
+                    value="conversation:__loading__"
+                    disabled
+                    className="flex items-center gap-2 px-3 h-9 rounded-md text-sm text-text-muted"
+                  >
+                    <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-text-muted border-t-transparent" />
+                    <span>Searching conversations…</span>
+                  </Command.Item>
+                )}
                 {items.map((action) => {
                   const searchValue = [action.title, action.subtitle ?? "", ...(action.keywords ?? [])].join(" ");
                   return (

--- a/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
+++ b/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
@@ -61,4 +61,39 @@ describe("CommandPalette", () => {
     fireEvent.click(screen.getByTestId("command-palette-backdrop"));
     expect(onClose).toHaveBeenCalledOnce();
   });
+
+  it("shows a spinner row in Conversations while a content search runs", () => {
+    render(<CommandPalette open onClose={() => {}} actions={[action()]} searching />);
+    expect(screen.getByText("Searching conversations…")).toBeTruthy();
+  });
+
+  it("keeps conversation hits even when the query does not match their text", () => {
+    render(
+      <CommandPalette
+        open
+        onClose={() => {}}
+        actions={[
+          action({ id: "session:s1", title: "Some Title", group: "Sessions" }),
+          action({ id: "conversation:s2", title: "Hit session", group: "Conversations" }),
+        ]}
+      />,
+    );
+    // Type a query that matches neither title; the conversation hit is
+    // force-kept (server already matched it by content), the metadata
+    // session row is filtered out.
+    fireEvent.change(screen.getByPlaceholderText("Search actions, sessions, settings…"), {
+      target: { value: "zzzznomatch" },
+    });
+    expect(screen.getByText("Hit session")).toBeTruthy();
+    expect(screen.queryByText("Some Title")).toBeNull();
+  });
+
+  it("reports the typed query through onSearchChange", () => {
+    const onSearchChange = vi.fn();
+    render(<CommandPalette open onClose={() => {}} actions={[action()]} onSearchChange={onSearchChange} />);
+    fireEvent.change(screen.getByPlaceholderText("Search actions, sessions, settings…"), {
+      target: { value: "reconciler" },
+    });
+    expect(onSearchChange).toHaveBeenCalledWith("reconciler");
+  });
 });

--- a/web/src/components/command-palette/groups.ts
+++ b/web/src/components/command-palette/groups.ts
@@ -1,3 +1,3 @@
 import type { CommandActionGroup } from "./types";
 
-export const GROUP_ORDER: CommandActionGroup[] = ["Actions", "Sessions", "Settings"];
+export const GROUP_ORDER: CommandActionGroup[] = ["Actions", "Sessions", "Conversations", "Settings"];

--- a/web/src/components/command-palette/types.ts
+++ b/web/src/components/command-palette/types.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import type { SessionStatus } from "../../lib/types";
 
-export type CommandActionGroup = "Actions" | "Sessions" | "Settings";
+export type CommandActionGroup = "Actions" | "Sessions" | "Conversations" | "Settings";
 
 export interface CommandAction {
   id: string;

--- a/web/src/hooks/__tests__/useCommandActions.test.tsx
+++ b/web/src/hooks/__tests__/useCommandActions.test.tsx
@@ -8,7 +8,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useCommandActions } from "../useCommandActions";
+import { useCommandActions, buildConversationActions } from "../useCommandActions";
 import type { SessionResponse } from "../../lib/types";
 
 type Args = Parameters<typeof useCommandActions>[0];
@@ -67,5 +67,47 @@ describe("useCommandActions: scratch command", () => {
     const ids = result.current.map((a) => a.id);
     expect(ids).not.toContain("action:new-session");
     expect(ids).not.toContain("action:new-scratch-session");
+  });
+});
+
+describe("buildConversationActions", () => {
+  const hit = (over: Partial<import("../../lib/api").ConversationSearchHit> = {}) => ({
+    session_id: "s1",
+    seq: 1,
+    kind: "agent",
+    snippet: "matched text",
+    match_count: 1,
+    ...over,
+  });
+  const session = (over: Partial<SessionResponse> = {}) =>
+    ({ id: "s1", title: "My Session", status: "idle", created_at: "2026-01-01T00:00:00Z", ...over }) as SessionResponse;
+
+  it("maps a hit to Conversations row data carrying its session id", () => {
+    const actions = buildConversationActions([hit()], [session()], null);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      id: "conversation:s1",
+      sessionId: "s1",
+      title: "My Session",
+      group: "Conversations",
+      subtitle: "matched text",
+    });
+  });
+
+  it("skips the active session and hits whose session is gone", () => {
+    expect(buildConversationActions([hit()], [session()], "s1")).toHaveLength(0);
+    expect(buildConversationActions([hit({ session_id: "ghost" })], [session()], null)).toHaveLength(0);
+  });
+
+  it("labels sunk state and a multi-match count", () => {
+    const trashed = buildConversationActions(
+      [hit({ match_count: 3 })],
+      [session({ trashed_at: "2026-01-02T00:00:00Z" })],
+      null,
+    );
+    expect(trashed[0]!.title).toBe("My Session · trashed");
+    expect(trashed[0]!.subtitle).toBe("matched text (3 matches)");
+    const snoozed = buildConversationActions([hit()], [session({ snoozed_until: "2099-01-01T00:00:00Z" })], null);
+    expect(snoozed[0]!.title).toBe("My Session · snoozed");
   });
 });

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -2,7 +2,51 @@ import { useMemo } from "react";
 
 const IS_MAC = typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
 import type { SessionResponse } from "../lib/types";
+import type { ConversationSearchHit } from "../lib/api";
 import type { CommandAction } from "../components/command-palette/types";
+
+// A conversation-search palette row minus its `perform` handler. The caller
+// attaches `perform` in a closure (so the select callback is never passed
+// into this render-time builder, which the react-hooks lint reads as a
+// possible ref access during render).
+export type ConversationActionData = Omit<CommandAction, "perform"> & { sessionId: string };
+
+// Map conversation-content search hits (#2515) to palette row data. The hit
+// carries only the session id; title and state come from the client's
+// session list. Skips the active session (already in view) and any hit whose
+// session is no longer in the list. A sunk-state label and a match-count
+// suffix annotate the row so an archived/trashed hit is not mistaken for a
+// live one.
+export function buildConversationActions(
+  hits: ConversationSearchHit[],
+  sessions: SessionResponse[],
+  activeSessionId: string | null,
+): ConversationActionData[] {
+  return hits.flatMap((hit) => {
+    const session = sessions.find((s) => s.id === hit.session_id);
+    if (!session || session.id === activeSessionId) return [];
+    const state = session.trashed_at
+      ? "trashed"
+      : session.archived_at
+        ? "archived"
+        : session.snoozed_until
+          ? "snoozed"
+          : null;
+    const title = session.title || session.branch || "(untitled)";
+    const count = hit.match_count > 1 ? ` (${hit.match_count} matches)` : "";
+    return [
+      {
+        id: `conversation:${session.id}`,
+        sessionId: session.id,
+        title: state ? `${title} · ${state}` : title,
+        subtitle: `${hit.snippet}${count}`,
+        group: "Conversations" as const,
+        status: session.status,
+        statusCreatedAt: session.created_at,
+      },
+    ];
+  });
+}
 
 interface Args {
   sessions: SessionResponse[];

--- a/web/src/hooks/useConversationSearch.test.ts
+++ b/web/src/hooks/useConversationSearch.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+//
+// Coverage for useConversationSearch: debounces, skips queries below the
+// minimum length, and drops a stale in-flight response when the query
+// changes so out-of-order resolution never shows old results.
+
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useConversationSearch } from "./useConversationSearch";
+import * as api from "../lib/api";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useConversationSearch", () => {
+  it("does not search below the minimum length", () => {
+    const spy = vi.spyOn(api, "searchConversations").mockResolvedValue([]);
+    renderHook(() => useConversationSearch("a"));
+    act(() => vi.advanceTimersByTime(500));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("debounces then returns results", async () => {
+    const spy = vi
+      .spyOn(api, "searchConversations")
+      .mockResolvedValue([{ session_id: "s1", seq: 3, kind: "agent", snippet: "hit", match_count: 1 }]);
+    const { result } = renderHook(() => useConversationSearch("reconciler"));
+    expect(spy).not.toHaveBeenCalled(); // still inside the debounce window
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(result.current.results).toHaveLength(1);
+  });
+
+  it("drops a stale response when the query changes", async () => {
+    // First query resolves slowly; second resolves immediately. The hook
+    // must show only the second query's results.
+    let resolveFirst: (v: api.ConversationSearchHit[]) => void = () => {};
+    const spy = vi
+      .spyOn(api, "searchConversations")
+      .mockImplementationOnce(() => new Promise((res) => (resolveFirst = res)))
+      .mockResolvedValueOnce([{ session_id: "s2", seq: 1, kind: "user", snippet: "second", match_count: 1 }]);
+
+    const { result, rerender } = renderHook(({ q }) => useConversationSearch(q), {
+      initialProps: { q: "first" },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+      await Promise.resolve();
+    });
+
+    rerender({ q: "second" });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+      await Promise.resolve();
+    });
+
+    // Late first response arrives after the query changed; it was aborted,
+    // so applying it must be a no-op.
+    await act(async () => {
+      resolveFirst([{ session_id: "s1", seq: 9, kind: "agent", snippet: "first", match_count: 1 }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(result.current.results).toEqual([
+      { session_id: "s2", seq: 1, kind: "user", snippet: "second", match_count: 1 },
+    ]);
+  });
+});

--- a/web/src/hooks/useConversationSearch.ts
+++ b/web/src/hooks/useConversationSearch.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { searchConversations, type ConversationSearchHit } from "../lib/api";
+
+const DEBOUNCE_MS = 200;
+const MIN_CHARS = 2;
+
+interface SearchState {
+  results: ConversationSearchHit[];
+  loading: boolean;
+}
+
+// Debounced full-text search over session conversation content (#2515).
+// Returns `loading` while a request is in flight so the palette can show a
+// spinner instead of a premature "No matches". An AbortController drops a
+// stale response when the query changes, so out-of-order resolution never
+// shows results for an old query.
+export function useConversationSearch(query: string): SearchState {
+  const [state, setState] = useState<SearchState>({ results: [], loading: false });
+  const normalized = query.trim();
+  const enabled = normalized.length >= MIN_CHARS;
+
+  // All setState happens inside async callbacks (the debounce timer and the
+  // fetch resolution), never synchronously in the effect body, mirroring the
+  // async-only discipline in useSessions so this stays a real external-sync
+  // effect rather than a render-cascade. The too-short case is derived at
+  // return time, so no effect run is needed to clear results.
+  useEffect(() => {
+    if (!enabled) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      setState((prev) => ({ ...prev, loading: true }));
+      void searchConversations(normalized, controller.signal).then((results) => {
+        if (controller.signal.aborted) return;
+        setState({ results, loading: false });
+      });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [normalized, enabled]);
+
+  return enabled ? state : { results: [], loading: false };
+}

--- a/web/src/hooks/useConversationSearch.ts
+++ b/web/src/hooks/useConversationSearch.ts
@@ -5,6 +5,14 @@ const DEBOUNCE_MS = 200;
 const MIN_CHARS = 2;
 
 interface SearchState {
+  // The query these results belong to, so a result that resolves after the
+  // query changed is suppressed rather than shown under the new query.
+  query: string;
+  results: ConversationSearchHit[];
+  loading: boolean;
+}
+
+interface SearchResult {
   results: ConversationSearchHit[];
   loading: boolean;
 }
@@ -14,8 +22,8 @@ interface SearchState {
 // spinner instead of a premature "No matches". An AbortController drops a
 // stale response when the query changes, so out-of-order resolution never
 // shows results for an old query.
-export function useConversationSearch(query: string): SearchState {
-  const [state, setState] = useState<SearchState>({ results: [], loading: false });
+export function useConversationSearch(query: string): SearchResult {
+  const [state, setState] = useState<SearchState>({ query: "", results: [], loading: false });
   const normalized = query.trim();
   const enabled = normalized.length >= MIN_CHARS;
 
@@ -28,10 +36,10 @@ export function useConversationSearch(query: string): SearchState {
     if (!enabled) return;
     const controller = new AbortController();
     const timer = setTimeout(() => {
-      setState((prev) => ({ ...prev, loading: true }));
+      setState({ query: normalized, results: [], loading: true });
       void searchConversations(normalized, controller.signal).then((results) => {
         if (controller.signal.aborted) return;
-        setState({ results, loading: false });
+        setState({ query: normalized, results, loading: false });
       });
     }, DEBOUNCE_MS);
 
@@ -41,5 +49,10 @@ export function useConversationSearch(query: string): SearchState {
     };
   }, [normalized, enabled]);
 
-  return enabled ? state : { results: [], loading: false };
+  // Suppress results that belong to a previous query (the new query's fetch
+  // has not settled yet), so stale hits never stay selectable in the palette.
+  if (!enabled) return { results: [], loading: false };
+  return state.query === normalized
+    ? { results: state.results, loading: state.loading }
+    : { results: [], loading: state.loading };
 }

--- a/web/src/lib/__tests__/searchConversationsApi.test.ts
+++ b/web/src/lib/__tests__/searchConversationsApi.test.ts
@@ -1,0 +1,43 @@
+// Vitest coverage for the conversation-search API client (#2515). The palette
+// hook GETs /api/sessions/search and folds the results into a Conversations
+// group. Like the other read helpers it degrades to an empty list on a
+// non-OK or failed request rather than throwing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { searchConversations } from "../api";
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("searchConversations (#2515)", () => {
+  it("GETs the search endpoint with the encoded query and returns results", async () => {
+    const results = [{ session_id: "s1", seq: 3, kind: "agent", snippet: "hit", match_count: 2 }];
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ results }), { status: 200 }));
+
+    const out = await searchConversations("foo bar");
+
+    expect(out).toEqual(results);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/api/sessions/search?q=foo%20bar");
+  });
+
+  it("forwards an abort signal to fetch", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+    const controller = new AbortController();
+    await searchConversations("q", controller.signal);
+    expect((fetchSpy.mock.calls[0][1] as RequestInit).signal).toBe(controller.signal);
+  });
+
+  it("returns an empty list on a non-OK response", async () => {
+    fetchSpy.mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await searchConversations("q")).toEqual([]);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,8 +38,6 @@ export function fetchSessions(): Promise<SessionsEnvelope | null> {
   return fetchJson<SessionsEnvelope>("/api/sessions");
 }
 
-// --- Conversation content search (#2515) ---
-
 export interface ConversationSearchHit {
   session_id: string;
   seq: number;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,6 +38,30 @@ export function fetchSessions(): Promise<SessionsEnvelope | null> {
   return fetchJson<SessionsEnvelope>("/api/sessions");
 }
 
+// --- Conversation content search (#2515) ---
+
+export interface ConversationSearchHit {
+  session_id: string;
+  seq: number;
+  kind: string;
+  snippet: string;
+  match_count: number;
+}
+
+interface ConversationSearchResponse {
+  results: ConversationSearchHit[];
+}
+
+// Full-text search over session conversation content. Returns one hit per
+// matching session, newest first. `signal` lets the caller abort a stale
+// in-flight search when the query changes.
+export async function searchConversations(query: string, signal?: AbortSignal): Promise<ConversationSearchHit[]> {
+  const res = await fetchJson<ConversationSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(query)}`, {
+    signal,
+  });
+  return res?.results ?? [];
+}
+
 // --- Recent projects ---
 
 export interface RecentProjectEntry {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -817,6 +817,20 @@
       ]
     },
     {
+      "id": "palette.content-search",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/palette-content-search.spec.ts",
+        "src/components/command-palette/__tests__/CommandPalette.test.tsx",
+        "src/hooks/useConversationSearch.test.ts"
+      ],
+      "components": [
+        "web/src/App.tsx",
+        "web/src/components/command-palette/CommandPalette.tsx"
+      ]
+    },
+    {
       "id": "sidebar.scratch-group",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -823,12 +823,11 @@
       "specs": [
         "tests/live/palette-content-search.spec.ts",
         "src/components/command-palette/__tests__/CommandPalette.test.tsx",
-        "src/hooks/useConversationSearch.test.ts"
+        "src/hooks/useConversationSearch.test.ts",
+        "src/hooks/__tests__/useCommandActions.test.tsx",
+        "src/lib/__tests__/searchConversationsApi.test.ts"
       ],
-      "components": [
-        "web/src/App.tsx",
-        "web/src/components/command-palette/CommandPalette.tsx"
-      ]
+      "components": ["web/src/App.tsx", "web/src/components/command-palette/CommandPalette.tsx"]
     },
     {
       "id": "sidebar.scratch-group",

--- a/web/tests/live/palette-content-search.spec.ts
+++ b/web/tests/live/palette-content-search.spec.ts
@@ -1,0 +1,62 @@
+// Conversation content search round-trip (#2515).
+//
+// Seeds a structured session, sends a prompt carrying a unique token, then
+// asserts GET /api/sessions/search surfaces that session by its conversation
+// content (the user prompt text), not by any title/metadata. The token is
+// chosen so it cannot appear in the session title, branch, or path, so a hit
+// proves the search reached the stored event content.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
+import { enableStructuredViewAndWait, waitForReplayContains } from "../helpers/acp";
+
+const NEEDLE = "xyzzycontentneedle";
+
+base("search surfaces a session by its conversation content", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "content-search" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    expect(sessions.length).toBeGreaterThan(0);
+    const sessionId: string = sessions[0]!.id;
+
+    await enableStructuredViewAndWait(serve.baseUrl, sessionId);
+
+    const promptRes = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: `please remember ${NEEDLE} for later` }),
+    });
+    expect(promptRes.status).toBeGreaterThanOrEqual(200);
+    expect(promptRes.status).toBeLessThan(300);
+
+    // The prompt is recorded as a UserPromptSent event; wait until it lands.
+    await waitForReplayContains(serve.baseUrl, sessionId, ["user_prompt_sent", "UserPromptSent"]);
+
+    // Searching the unique token must return exactly this session.
+    await expect
+      .poll(
+        async () => {
+          const res = await fetch(`${serve.baseUrl}/api/sessions/search?q=${NEEDLE}`);
+          if (!res.ok) return [];
+          const body = await res.json();
+          return (body.results ?? []).map((h: { session_id: string }) => h.session_id);
+        },
+        { timeout: 10_000 },
+      )
+      .toContain(sessionId);
+
+    // A token that appears nowhere in the conversation returns no hit.
+    const miss = await fetch(`${serve.baseUrl}/api/sessions/search?q=zzznevertypedthis`);
+    const missBody = await miss.json();
+    expect(missBody.results ?? []).toHaveLength(0);
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web command palette (Cmd/Ctrl+K) could only find sessions by metadata: title, branch, repo, agent. It could not find a session by what was said inside it. This adds full-text search over conversation content (agent messages, your prompts, tool output) for structured sessions, surfacing matching sessions in a new "Conversations" group with a snippet, and a spinner while the search runs.

Backend: a new `EventStore::search_content` runs on a dedicated read-only SQLite connection, so a content scan never blocks the live `record()` path (a single shared writer mutex would otherwise stall live agent streaming, since WAL gives no concurrency while one Rust mutex serializes every access). It uses a wildcard-escaped `event_json LIKE` prefilter feeding a Rust decode-and-verify step: each candidate event is deserialized, its conversation prose extracted, and the query reconfirmed against that prose, so JSON-key false positives (matching the key `text`, etc.) never reach results. Exposed as `GET /api/sessions/search`.

Frontend: a debounced, abortable `useConversationSearch` hook drives the new group; a custom cmdk `filter` force-keeps server-matched rows while preserving fuzzy scoring for everything else; a spinner row shows while a search is in flight; selecting a hit opens that session.

Scope: structured (ACP) sessions only (plain tmux sessions persist no transcript), and bounded by the existing per-session event retention cap. FTS5 and a plaintext sidecar table were considered and deferred behind a `LIKE`-prefilter MVP; the read-only-connection split (the part that protects live recording) is in now.

Closes #2515

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve --features serve`, open the dashboard, start a structured (ACP) session and send a prompt containing a distinctive word.
- [ ] Press Cmd/Ctrl+K and type that word (not in the session title): a "Conversations" entry for the session appears with a snippet, and selecting it opens the session.
- [ ] While the search is resolving, confirm a "Searching conversations…" spinner row shows instead of "No matches".
- [ ] Type a word that matches only a session title: the instant "Sessions" group still works with no regression.
- [ ] Type a word that appears nowhere: no Conversations hit (and no JSON-key false positives like `text` or `content`).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/palette-content-search.spec.ts` (live round-trip: prompt with a unique token, then `GET /api/sessions/search` surfaces the session by content and returns nothing for an absent token), Vitest for the palette (spinner row, force-kept conversation hits, `onSearchChange`) and the `useConversationSearch` hook (debounce, min-length, stale-response drop), and a Rust unit test for `search_content` (finds prompt/agent/tool text, ignores JSON keys, escapes `%`, case-insensitive grouping). New matrix entry `palette.content-search`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a `/debate` pass between two models on the storage and connection design. I made the design calls (read-only connection, defer FTS5, decode-and-verify over raw JSON), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785245790&installation_id=139138837&pr_number=2517&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2517&signature=68f4833a9030eaff3bcf326ceedb980165072db59e0208a5fe45f00d5bef9081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### What changed
- Added full-text search over **structured session transcripts** to Cmd/Ctrl+K command palette by introducing a new **“Conversations”** group.
- Implemented a backend endpoint (**GET `/api/sessions/search`**) that scans conversation content (agent messages, user prompts, tool output) and returns matching sessions with a **snippet** (plus match counts).
- Updated the frontend with a **debounced, abortable** `useConversationSearch` hook and palette wiring to display **“Searching conversations…”** while results load.
- Ensured conversation results are preserved in the palette filtering flow, and selecting a hit now **opens the matching session**.
- Added/extended tests, including backend unit coverage, frontend hook + palette behavior, and a live end-to-end Playwright scenario.

### Benefits
- Lets users find sessions by **what was said**, not just by metadata like title or branch.
- Keeps the existing instant metadata search behavior intact while adding content search.
- Limits results to **structured/ACP sessions** and respects existing retention constraints.

### Technical notes
- Server-side search uses a dedicated read-only SQLite connection and avoids JSON-key false positives by verifying matches after a `LIKE` prefilter, then returns grouped hits per session with snippets.
- Frontend search requires a minimum query length, debounces requests, aborts in-flight calls, and guards against stale responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->