### PR TITLE
feat(web): surface plugin row slots and panes on the mobile dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -671,6 +671,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setPairedMounted(true);
   }
 
+  // A plugin pane promoted into the mobile main pane can vanish (plugin
+  // unloaded, or the new session has no such pane). Fall back to the agent
+  // view so the user is never stranded on a blank pane. Mirrors the diff /
+  // paired guards above; render-phase derivation per the block at the top.
+  if (isPluginPaneId(rightPanelView) && !pluginPanes.some((p) => p.id === rightPanelView)) {
+    setRightPanelView("agent");
+  }
+
   // Refit the newly active terminal after a single-pane view switch: the
   // layers keep their geometry while hidden (visibility, not display:none),
   // but a resize nudge re-runs the xterm fit so the grid matches exactly.
@@ -1387,6 +1395,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       return (
         <MobileMainPane
           view={rightPanelView}
+          pluginPanes={pluginPanes}
           onBackToAgent={() => setRightPanelView("agent")}
           pairedMounted={pairedMounted}
           activeSession={activeSession ?? null}
@@ -1855,6 +1864,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           <MobileRightPanelPicker
             open={pickerOpen && singlePane}
             active={rightPanelView}
+            pluginPanes={pluginPanes}
             onSelect={handlePickView}
             onClose={() => setPickerOpen(false)}
           />

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -6,7 +6,9 @@ import { DiffFileList } from "./diff/DiffFileList";
 import { DiffFileViewer } from "./diff/DiffFileViewer";
 import { CommentsBanner } from "./diff/comments/CommentsBanner";
 import { SendCommentsDialog } from "./diff/comments/SendCommentsDialog";
+import { PluginPaneBody } from "./plugin/PluginSlots";
 import type { RightPanelView } from "../lib/rightPanelView";
+import { isPluginPaneId, type PluginPane } from "../lib/pluginPanes";
 import type { RepoBase, RichDiffFile, SessionResponse } from "../lib/types";
 import type { useDiffComments } from "../hooks/useDiffComments";
 import type { FileRef } from "../lib/fileRef";
@@ -15,6 +17,7 @@ const StructuredView = lazy(() => import("./acp/StructuredView").then((m) => ({ 
 
 interface Props {
   view: RightPanelView;
+  pluginPanes: PluginPane[];
   onBackToAgent: () => void;
   pairedMounted: boolean;
   activeSession: SessionResponse | null;
@@ -56,6 +59,7 @@ function layerClass(active: boolean): string {
  *  view switches; `display:none` would collapse xterm geometry to zero. */
 export function MobileMainPane({
   view,
+  pluginPanes,
   onBackToAgent,
   pairedMounted,
   activeSession,
@@ -84,7 +88,9 @@ export function MobileMainPane({
   onCloseSendDialog,
   onClearSelectedFile,
 }: Props) {
-  const viewLabel = view === "diff" ? "Diff" : "Paired terminal";
+  const activePluginPane = isPluginPaneId(view) ? (pluginPanes.find((p) => p.id === view) ?? null) : null;
+  const viewLabel =
+    view === "diff" ? "Diff" : view === "paired" ? "Paired terminal" : (activePluginPane?.title ?? "Plugin");
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -171,6 +177,12 @@ export function MobileMainPane({
                 />
               </div>
             )}
+          </div>
+        )}
+
+        {activePluginPane && (
+          <div className="absolute inset-0 z-10 flex flex-col min-h-0 overflow-hidden bg-surface-900">
+            <PluginPaneBody entry={activePluginPane.entry} />
           </div>
         )}
       </div>

--- a/web/src/components/MobileRightPanelPicker.tsx
+++ b/web/src/components/MobileRightPanelPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { RightPanelView } from "../lib/rightPanelView";
+import type { PluginPane } from "../lib/pluginPanes";
 
 interface Entry {
   view: RightPanelView;
@@ -16,6 +17,7 @@ const ENTRIES: Entry[] = [
 interface Props {
   open: boolean;
   active: RightPanelView;
+  pluginPanes: PluginPane[];
   onSelect: (view: RightPanelView) => void;
   onClose: () => void;
 }
@@ -24,7 +26,7 @@ interface Props {
  *  full-viewport main pane (#1452). Replaces the old slide-in right-panel
  *  overlay, which collapsed the paired terminal to zero height under the
  *  soft keyboard. */
-export function MobileRightPanelPicker({ open, active, onSelect, onClose }: Props) {
+export function MobileRightPanelPicker({ open, active, pluginPanes, onSelect, onClose }: Props) {
   // Close on Escape, matching the other dismissible overlays.
   useEffect(() => {
     if (!open) return;
@@ -68,6 +70,24 @@ export function MobileRightPanelPicker({ open, active, onSelect, onClose }: Prop
                 >
                   <span className="text-sm font-medium">{entry.label}</span>
                   <span className="text-xs text-text-dim">{entry.hint}</span>
+                </button>
+              </li>
+            );
+          })}
+          {pluginPanes.map((pane) => {
+            const isActive = pane.id === active;
+            return (
+              <li key={pane.id}>
+                <button
+                  onClick={() => onSelect(pane.id as RightPanelView)}
+                  aria-current={isActive ? "true" : undefined}
+                  data-testid={`mobile-right-panel-pick-${pane.id}`}
+                  className={`w-full flex flex-col items-start gap-0.5 px-3 py-2 rounded-lg text-left cursor-pointer transition-colors ${
+                    isActive ? "bg-brand-600/10 text-brand-500" : "text-text-secondary hover:bg-surface-800"
+                  }`}
+                >
+                  <span className="text-sm font-medium">{pane.title}</span>
+                  <span className="text-xs text-text-dim">Plugin</span>
                 </button>
               </li>
             );

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -110,7 +110,7 @@ import { OwnerAvatar } from "./OwnerAvatar";
 import { SessionGroupModal } from "./SessionGroupModal";
 import { SidebarSortPicker } from "./SidebarSortPicker";
 import { Tooltip } from "./Tooltip";
-import { PluginRowBadges, PluginRowColumn } from "./plugin/PluginSlots";
+import { PluginRowLine } from "./plugin/PluginSlots";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const SUNK_EXPANDED_KEY = "aoe-sidebar-sunk-expanded";
@@ -1213,9 +1213,8 @@ export const SessionRow = memo(function SessionRow({
                 <WakeupCountdown wakeAt={firstSession.next_wakeup_at} reason={firstSession.next_wakeup_reason} />
               )}
               {firstSession?.monitor_active && <MonitorBadge description={firstSession.monitor_description} />}
-              {firstSession && <PluginRowBadges sessionId={firstSession.id} />}
-              {firstSession && <PluginRowColumn sessionId={firstSession.id} />}
             </span>
+            {firstSession && <PluginRowLine sessionId={firstSession.id} />}
             {subtitle && (
               <span className="block text-[11px] font-mono text-text-dim truncate" title={subtitleTitle ?? subtitle}>
                 {subtitle}

--- a/web/src/components/__tests__/MobileMainPane.test.tsx
+++ b/web/src/components/__tests__/MobileMainPane.test.tsx
@@ -83,6 +83,7 @@ function setup(overrides: Partial<Parameters<typeof MobileMainPane>[0]> = {}) {
   const onBackToAgent = vi.fn();
   const props: Parameters<typeof MobileMainPane>[0] = {
     view: "agent",
+    pluginPanes: [],
     onBackToAgent,
     pairedMounted: false,
     activeSession: session(),
@@ -148,6 +149,26 @@ describe("MobileMainPane", () => {
     setup({ view: "diff" });
     expect(screen.getByTestId("diff-list")).toBeDefined();
     expect(screen.getByText("Diff")).toBeDefined();
+  });
+
+  it("renders the plugin pane body and its title for a plugin view", () => {
+    const pane = {
+      id: "plugin:acme.kit:gh" as const,
+      title: "GitHub",
+      defaultDock: "right" as const,
+      icon: undefined,
+      entry: {
+        plugin_id: "acme.kit",
+        slot: "pane" as const,
+        id: "gh",
+        session_id: "s1",
+        payload: { title: "GitHub", body: "PR #1 open" },
+      },
+    };
+    setup({ view: pane.id, pluginPanes: [pane] });
+    expect(screen.getByTestId("plugin-pane-body")).toBeDefined();
+    expect(screen.getByText("PR #1 open")).toBeDefined();
+    expect(screen.getByTestId("mobile-back-to-agent")).toBeDefined();
   });
 
   it("shows the diff viewer when a file is selected", () => {

--- a/web/src/components/__tests__/MobileRightPanelPicker.test.tsx
+++ b/web/src/components/__tests__/MobileRightPanelPicker.test.tsx
@@ -8,14 +8,23 @@ import { MobileRightPanelPicker } from "../MobileRightPanelPicker";
 function setup(overrides: Partial<Parameters<typeof MobileRightPanelPicker>[0]> = {}) {
   const onSelect = vi.fn();
   const onClose = vi.fn();
-  render(<MobileRightPanelPicker open active="agent" onSelect={onSelect} onClose={onClose} {...overrides} />);
+  render(
+    <MobileRightPanelPicker
+      open
+      active="agent"
+      pluginPanes={[]}
+      onSelect={onSelect}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
   return { onSelect, onClose };
 }
 
 describe("MobileRightPanelPicker", () => {
   it("renders nothing when closed", () => {
     const { container } = render(
-      <MobileRightPanelPicker open={false} active="agent" onSelect={vi.fn()} onClose={vi.fn()} />,
+      <MobileRightPanelPicker open={false} active="agent" pluginPanes={[]} onSelect={vi.fn()} onClose={vi.fn()} />,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -33,6 +42,22 @@ describe("MobileRightPanelPicker", () => {
     const { onSelect } = setup();
     fireEvent.click(screen.getByTestId("mobile-right-panel-pick-diff"));
     expect(onSelect).toHaveBeenCalledWith("diff");
+  });
+
+  it("lists plugin panes after the built-ins and selects them by id", () => {
+    const pane = {
+      id: "plugin:acme.kit:gh" as const,
+      title: "GitHub",
+      defaultDock: "right" as const,
+      icon: undefined,
+      entry: { plugin_id: "acme.kit", slot: "pane" as const, id: "gh", session_id: "s1", payload: {} },
+    };
+    const { onSelect } = setup({ pluginPanes: [pane], active: pane.id });
+    const option = screen.getByTestId("mobile-right-panel-pick-plugin:acme.kit:gh");
+    expect(option.textContent).toContain("GitHub");
+    expect(option.getAttribute("aria-current")).toBe("true");
+    fireEvent.click(option);
+    expect(onSelect).toHaveBeenCalledWith("plugin:acme.kit:gh");
   });
 
   it("closes on backdrop click", () => {

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -158,7 +158,8 @@ export function PluginRowBadges({ sessionId }: { sessionId: string }) {
   );
 }
 
-/** row-column: per-session text column, right-aligned on a session row. The
+/** row-column: per-session text column, anchored to the right of the plugin
+ *  row line (#2514) so it gives up no width to the badges beside it. The
  *  payload may also carry `sort_value` / `filter_values` scalars, which the
  *  sidebar's sort-key and filter-facet controls consume (#2401); this renders
  *  only the visible text. */
@@ -166,7 +167,7 @@ export function PluginRowColumn({ sessionId }: { sessionId: string }) {
   const entries = sessionEntries(usePluginUiEntries(), "row-column", sessionId);
   if (entries.length === 0) return null;
   return (
-    <span className="flex min-w-0 items-center gap-1.5">
+    <span className="ml-auto flex shrink-0 items-center gap-1.5">
       {entries.map((e) => {
         const text = entryText(e);
         if (!text) return null;
@@ -186,6 +187,27 @@ export function PluginRowColumn({ sessionId }: { sessionId: string }) {
           </span>
         );
       })}
+    </span>
+  );
+}
+
+/** The plugin row line: badges (wrapping, left) plus the right-anchored
+ *  status column, on their own line under the session name (#2514). Keeping
+ *  these off the name line stops the narrow mobile sidebar from squeezing the
+ *  column text to zero and pushing the badge icons past the drawer edge.
+ *  Renders nothing when the session has neither, so plugin-free rows keep their
+ *  original height. */
+export function PluginRowLine({ sessionId }: { sessionId: string }) {
+  const entries = usePluginUiEntries();
+  const hasBadges = sessionEntries(entries, "row-badge", sessionId).length > 0;
+  const hasColumn = sessionEntries(entries, "row-column", sessionId).length > 0;
+  if (!hasBadges && !hasColumn) return null;
+  return (
+    <span className="mt-0.5 flex items-center gap-1.5">
+      <span className="flex min-w-0 flex-wrap items-center gap-1.5">
+        <PluginRowBadges sessionId={sessionId} />
+      </span>
+      <PluginRowColumn sessionId={sessionId} />
     </span>
   );
 }

--- a/web/src/lib/rightPanelView.ts
+++ b/web/src/lib/rightPanelView.ts
@@ -1,4 +1,6 @@
 /** Which view occupies the single full-viewport main pane on mobile
  *  (below the `md` breakpoint). Desktop ignores this and renders the
- *  side-by-side ContentSplit. See #1452. */
-export type RightPanelView = "agent" | "diff" | "paired";
+ *  side-by-side ContentSplit. See #1452. A `plugin:<plugin>:<entry>` id
+ *  promotes a plugin pane into the mobile main pane (#2514); the prefix
+ *  matches `isPluginPaneId` in `pluginPanes.ts`. */
+export type RightPanelView = "agent" | "diff" | "paired" | `plugin:${string}`;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1039,6 +1039,13 @@
       ]
     },
     {
+      "id": "sidebar.plugin-row-slots",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/plugin-row-slots-mobile.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/components/plugin/PluginSlots.tsx"]
+    },
+    {
       "id": "sidebar.group-axis-pure",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1263,6 +1263,18 @@
       ]
     },
     {
+      "id": "right-panel.mobile-plugin-pane",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/mobile-plugin-pane.spec.ts"],
+      "components": [
+        "web/src/components/MobileRightPanelPicker.tsx",
+        "web/src/components/MobileMainPane.tsx",
+        "web/src/components/plugin/PluginSlots.tsx",
+        "web/src/lib/rightPanelView.ts"
+      ]
+    },
+    {
       "id": "right-panel.mobile-picker-units",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/live/file-watch-peer-propagation.spec.ts
+++ b/web/tests/live/file-watch-peer-propagation.spec.ts
@@ -47,10 +47,15 @@ test.describe.serial("file-watch peer propagation", () => {
         })
         .toBe(true);
 
-      // Once the watcher has updated daemon state, the dashboard can take a
-      // little longer to repaint.
+      // Once the watcher has updated daemon state, the dashboard still has to
+      // pick the change up on its own client poll (useSessions POLL_INTERVAL,
+      // 3s) and repaint. The watcher-beats-poll guarantee is already proven by
+      // the 1.5s daemon-state assertion above; this only confirms the UI
+      // eventually reflects it, so the budget must comfortably exceed one poll
+      // cycle. A 3s ceiling equalled the poll interval and raced (a rename
+      // landing right after a poll missed the window). Allow several cycles.
       await expect(page.getByText("peer-target")).toBeVisible({
-        timeout: 3_000,
+        timeout: 10_000,
       });
     } finally {
       await serve.stop();

--- a/web/tests/mobile-plugin-pane.spec.ts
+++ b/web/tests/mobile-plugin-pane.spec.ts
@@ -1,0 +1,74 @@
+// Mocked-Playwright coverage for plugin panes on mobile (#2514).
+//
+// Below the md breakpoint the layout collapses to a single full-viewport pane
+// chosen by the bottom-sheet picker, which used to hardcode agent / diff /
+// paired. A plugin "pane" slot (e.g. the github plugin's PR tool-window)
+// rendered as a dock tab on desktop but had no path on mobile at all. The
+// picker now lists plugin panes too, and selecting one promotes PluginPaneBody
+// into the main pane with the usual back-to-agent control.
+
+import { test, expect } from "./helpers/mockedTest";
+import { devices, type Page } from "@playwright/test";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
+import { mockTerminalApis } from "./helpers/terminal-mocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+// One plugin pane scoped to the seeded "pinch-test" session, shaped like the
+// github plugin's `github_pane`. Its id resolves to "plugin:acme.kit:gh".
+const PANE_ENTRY = {
+  plugin_id: "acme.kit",
+  slot: "pane",
+  id: "gh",
+  session_id: "pinch-test",
+  payload: {
+    title: "GitHub",
+    default_location: "right",
+    icon: "git-pull-request",
+    blocks: [
+      { kind: "heading", text: "GitHub" },
+      { kind: "note", text: "PR #1 open" },
+    ],
+  },
+};
+
+const PANE_ID = "plugin:acme.kit:gh";
+
+async function setupSession(page: Page) {
+  await mockTerminalApis(page);
+  // Registered after mockTerminalApis so this handler wins for ui-state.
+  await page.route("**/api/plugins/ui-state", (r) => r.fulfill({ json: { entries: [PANE_ENTRY], notifications: [] } }));
+  await page.goto("/");
+  await openMobileSidebar(page);
+  await clickSidebarSession(page, "pinch-test");
+  await page.locator("[data-live-terminal]").first().waitFor({ state: "visible", timeout: 10_000 });
+}
+
+async function openPicker(page: Page) {
+  await page.getByRole("button", { name: "Toggle panels" }).click();
+  await page.getByTestId("mobile-right-panel-picker").waitFor({ state: "visible", timeout: 5_000 });
+}
+
+test.describe("Mobile plugin pane picker (#2514)", () => {
+  test("picker lists the plugin pane and promotes it into the main pane", async ({ page }) => {
+    await setupSession(page);
+    await openPicker(page);
+
+    const option = page.getByTestId(`mobile-right-panel-pick-${PANE_ID}`);
+    await expect(option).toBeVisible();
+    await expect(option).toContainText("GitHub");
+
+    await option.click();
+    // Picker closes; the plugin pane body mounts full-viewport.
+    await expect(page.getByTestId("mobile-right-panel-picker")).toHaveCount(0);
+    await expect(page.getByTestId("plugin-pane-body")).toBeVisible();
+    await expect(page.getByTestId("plugin-pane-body")).toContainText("PR #1 open");
+
+    // The plugin view carries the persistent back-to-agent affordance.
+    const back = page.getByTestId("mobile-back-to-agent");
+    await expect(back).toBeVisible();
+    await back.click();
+    await expect(page.getByTestId("mobile-back-to-agent")).toHaveCount(0);
+    await expect(page.locator("[data-live-terminal]").first()).toBeVisible();
+  });
+});

--- a/web/tests/plugin-row-slots-mobile.spec.ts
+++ b/web/tests/plugin-row-slots-mobile.spec.ts
@@ -1,0 +1,115 @@
+// Mocked-Playwright coverage for the plugin row slots on a narrow mobile
+// sidebar (#2514).
+//
+// The github plugin's row-badge (icon chips) and row-column (status text) used
+// to render inline on the session-name line. On the narrow mobile drawer the
+// truncating name kept its width, so the column squeezed to zero and the
+// shrink-0 badges overflowed past the row's right edge. They now sit on their
+// own line (PluginRowLine), so both stay within the row regardless of how long
+// the session name is. This drives the real-CSS layout at a mobile viewport,
+// which jsdom cannot reproduce.
+
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+const LONG_TITLE = "this-is-a-deliberately-very-long-session-name-that-eats-the-whole-row-width-on-mobile";
+
+function sessionResponse() {
+  return {
+    id: "s1",
+    title: LONG_TITLE,
+    project_path: "/tmp/repo",
+    group_path: "/tmp/repo",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: "feature/x",
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    urgent: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+  };
+}
+
+// One icon chip per repo across a multi-repo workspace: enough shrink-0 badges
+// that the old inline layout overflowed the narrow row instead of wrapping.
+const BADGE_ITEMS = Array.from({ length: 12 }, (_, i) => ({
+  icon: "git-pull-request",
+  tone: "success",
+  tooltip: `PR #${i + 1}`,
+}));
+
+const UI_ENTRIES = [
+  {
+    plugin_id: "acme.kit",
+    slot: "row-badge",
+    id: "github_pr_badge",
+    session_id: "s1",
+    payload: { items: BADGE_ITEMS },
+  },
+  {
+    plugin_id: "acme.kit",
+    slot: "row-column",
+    id: "github_pr_status",
+    session_id: "s1",
+    payload: { text: "Changes requested", tone: "warning" },
+  },
+];
+
+async function mockApis(page: Page) {
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: { sessions: [sessionResponse()], workspace_ordering: ["/tmp/repo::feature/x"] },
+    });
+  });
+  await page.route("**/api/plugins/ui-state", (r) => r.fulfill({ json: { entries: UI_ENTRIES, notifications: [] } }));
+  for (const path of ["settings", "themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
+    await page.route(`**/api/${path}`, (r) => r.fulfill({ json: path === "docker/status" ? {} : [] }));
+  }
+}
+
+// A child element is "within" the row when its right edge does not spill past
+// the row's right edge (a couple of px of slack for sub-pixel rounding).
+async function allWithinRow(page: Page, selector: string): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const row = document.querySelector("[data-testid='sidebar-session-row']");
+    const els = Array.from(document.querySelectorAll(sel));
+    if (!row || els.length === 0) return false;
+    const r = row.getBoundingClientRect();
+    return els.every((el) => {
+      const e = el.getBoundingClientRect();
+      return e.width > 0 && e.right <= r.right + 2;
+    });
+  }, selector);
+}
+
+test.describe("Plugin row slots on a mobile sidebar (#2514)", () => {
+  test("row-column and badges stay within the row next to a long name", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockApis(page);
+    await page.goto("/");
+
+    // The drawer starts closed on mobile; open it.
+    await page.getByRole("button", { name: "Toggle sidebar" }).click();
+    await expect(page.locator("[data-testid='sidebar-session-row']")).toHaveCount(1, { timeout: 8000 });
+
+    const column = "[data-plugin-slot='row-column']";
+    const badge = "[data-plugin-slot='row-badge']";
+    await expect(page.locator(column)).toBeVisible();
+    await expect(page.locator(badge).first()).toBeVisible();
+
+    // The status text and every badge icon render inside the row, not squeezed
+    // to zero or clipped past its right edge.
+    expect(await allWithinRow(page, column)).toBe(true);
+    expect(await allWithinRow(page, badge)).toBe(true);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On a phone, the session-list sidebar did not show the github plugin's per-session content. The plugin's `row-badge` (icon chips) and `row-column` (PR status text) rendered inline on the session-name line, a single no-wrap flex row shared with the truncating name and the native badges. On the narrow fixed-width mobile drawer the name kept its min width, so the text column squeezed to zero (the element was effectively hidden) and the `shrink-0` icon badges overflowed past the row's right edge and clipped. The wider, resizable desktop sidebar had room, so the same content showed there, which is why this read as mobile-only.

This moves both slots onto their own line under the session name via a new `PluginRowLine` component: the badges wrap on the left and the status column anchors to the right (`ml-auto shrink-0`), which also makes `PluginRowColumn` the right-aligned cell its doc comment already described. `PluginRowLine` renders nothing when a session has neither slot, so plugin-free rows keep their original height. This implements both proposals from the issue: Proposal A (own line) and Proposal B (right-aligned reserved column plus wrapping badges).

This PR also closes the related gap that plugin **panes** had no path on mobile at all. Below the `md` breakpoint the layout collapses to one full-viewport pane chosen by a bottom-sheet picker that hardcoded agent / diff / paired, so a plugin pane (the github plugin's PR tool-window) rendered as a dock tab on desktop but was unreachable on a phone. The picker now lists the active session's plugin panes below the built-ins, and selecting one promotes `PluginPaneBody` into the main pane (mount-on-active, since the body is stateless) with the usual back-to-agent control. `RightPanelView` gains a `plugin:<plugin>:<entry>` id, and a render-phase guard falls back to the agent view when the active plugin pane disappears, mirroring the existing diff / paired guards.

Tested with two new mocked-Playwright specs. The row-slot spec runs at a 390px viewport with a long session name and a dozen icon badges; on the pre-fix tree it goes red (the row-column is hidden) and green after, with every slot's right edge inside the row. The mobile pane spec injects a plugin `pane` entry, opens the picker, selects the plugin pane, and asserts the pane body and back-to-agent control. Vitest unit suites for the two mobile components were extended for the plugin-pane path.

Closes #2514

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Run a github plugin (or any plugin pushing `row-badge` / `row-column`) so a session has PR status in the sidebar.
- [ ] On a phone (or a narrow browser window under 768px), open the sidebar drawer and find that session.
- [ ] Confirm the status text and the badge icons are both visible, on their own line under the session name, not clipped past the drawer edge or missing.
- [ ] Give the session a long name; confirm the name truncates on its own line and the plugin status still shows in full.
- [ ] On a wide desktop window, confirm the same session still shows the plugin badges and status (no regression).
- [ ] On a phone, open a session that has a plugin pane (e.g. the github pane), tap the panels button to open the bottom drawer, and confirm the plugin pane is listed below Agent terminal / Diff / Paired terminal.
- [ ] Tap the plugin pane entry; confirm its body fills the pane and the back arrow returns to the agent terminal.
- [ ] Switch to a session without that plugin pane (or disable the plugin); confirm the view falls back to the agent terminal instead of a blank pane.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (move to own line plus right-aligned column), reviewed each commit, and the reproduce-then-fix test was verified red on the pre-fix tree and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes the mobile session-list sidebar so GitHub plugin per-session row content (icon badges and the status text) renders correctly in narrow drawers without clipping.

- Introduced a `PluginRowLine` layout that moves the plugin badges and the `row-column` status onto their own line beneath the session name, instead of sharing a single no-wrap row with the session title.
- Allows badge content to wrap safely on the left, while right-aligning the status so it doesn’t collapse/overflow.
- When a session has no plugin row content, the new line renders nothing—preserving the original row height for plugin-free sessions.
- Added Playwright regression coverage for the narrow-sidebar layout to ensure badge/status stay within the session row boundary even with long session names.

It also improves mobile access to plugin panes:

- Below the `md` breakpoint, the panel picker now includes the active session’s plugin panes, and selecting one promotes the plugin content into the main panel with a back-to-agent control.
- Updated mobile right-panel view/pane rendering to support plugin pane ids, and added a render-phase fallback so the UI returns to the agent view if the active plugin pane disappears.
- Added Playwright + unit test coverage for the plugin-pane mobile flow and updated component coverage.

Benefit: mobile users can reliably see the GitHub plugin details in the session list and navigate into plugin panes without broken/overflowed UI or unreachable plugin content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->