### PR TITLE
fix(plugins): hold the GitHub refresh spinner until the worker's state lands

### DIFF
--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -96,6 +96,13 @@ impl PluginHost {
         self.api.ui_snapshot()
     }
 
+    /// The plugin's current UI mutation counter. The action endpoint reads this
+    /// before forwarding an action so the dashboard can hold a spinner until the
+    /// worker's re-pushed state moves the counter off this baseline.
+    pub fn ui_revision(&self, plugin_id: &str) -> u64 {
+        self.api.ui_revision(plugin_id)
+    }
+
     /// Push a host-originated notification onto the ring (e.g. the auto-update
     /// sweep telling the user an update needs approval). Best-effort.
     pub fn notify_host(

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -96,11 +96,12 @@ impl PluginHost {
         self.api.ui_snapshot()
     }
 
-    /// The plugin's current UI mutation counter. The action endpoint reads this
-    /// before forwarding an action so the dashboard can hold a spinner until the
-    /// worker's re-pushed state moves the counter off this baseline.
-    pub fn ui_revision(&self, plugin_id: &str) -> u64 {
-        self.api.ui_revision(plugin_id)
+    /// The UI mutation counter for one `(plugin, session)` scope. The action
+    /// endpoint reads this for the clicked pane's session before forwarding, so
+    /// the dashboard can hold that pane's spinner until its re-pushed state
+    /// moves the counter off this baseline.
+    pub fn ui_revision(&self, plugin_id: &str, session_id: Option<&str>) -> u64 {
+        self.api.ui_revision(plugin_id, session_id)
     }
 
     /// Push a host-originated notification onto the ring (e.g. the auto-update

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -105,6 +105,11 @@ impl HostApiState {
         self.ui.snapshot()
     }
 
+    /// The plugin's current UI mutation counter (0 if none yet).
+    pub fn ui_revision(&self, plugin_id: &str) -> u64 {
+        self.ui.revision(plugin_id)
+    }
+
     /// Push a host-originated notification onto the ring. Unlike the `ui.notify`
     /// RPC this is the host itself speaking (e.g. the auto-update sweep telling
     /// the user an update needs approval), so it bypasses the per-worker

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -105,9 +105,9 @@ impl HostApiState {
         self.ui.snapshot()
     }
 
-    /// The plugin's current UI mutation counter (0 if none yet).
-    pub fn ui_revision(&self, plugin_id: &str) -> u64 {
-        self.ui.revision(plugin_id)
+    /// The UI mutation counter for one `(plugin, session)` scope (0 if none yet).
+    pub fn ui_revision(&self, plugin_id: &str, session_id: Option<&str>) -> u64 {
+        self.ui.revision(plugin_id, session_id)
     }
 
     /// Push a host-originated notification onto the ring. Unlike the `ui.notify`

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -15,7 +15,7 @@
 //! and immediately crashes should still reach the browser) and the client
 //! toasts each one once by tracking the monotonic `seq`.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 
@@ -282,14 +282,16 @@ pub struct UiEntry {
 pub struct UiSnapshot {
     pub entries: Vec<UiEntry>,
     pub notifications: Vec<Notification>,
-    /// Per-plugin monotonic mutation counter. The dashboard reads a baseline
-    /// from the action POST and holds a manual-action spinner until the
-    /// plugin's counter moves off it, so the spinner tracks the worker's
-    /// re-pushed state instead of the fire-and-forget POST. `BTreeMap` for a
-    /// deterministic serialized order; `serde(default)` so an older daemon's
-    /// snapshot still decodes.
+    /// Monotonic mutation counter per `(plugin_id, scope)`, where `scope` is a
+    /// session id, or `""` for a global (session-less) slot. The dashboard reads
+    /// a baseline from the action POST and holds a manual-action spinner until
+    /// the matching scope's counter moves off it, so the spinner tracks the
+    /// worker's re-pushed state for that pane instead of the fire-and-forget
+    /// POST, and an unrelated session's push never clears it. Outer key is the
+    /// plugin id, inner key the scope. `BTreeMap` for a deterministic serialized
+    /// order; `serde(default)` so an older daemon's snapshot still decodes.
     #[serde(default)]
-    pub revisions: BTreeMap<String, u64>,
+    pub revisions: BTreeMap<String, BTreeMap<String, u64>>,
 }
 
 #[derive(Default)]
@@ -301,17 +303,37 @@ struct Inner {
     active: HashMap<String, u64>,
     notifications: VecDeque<Notification>,
     notify_seq: u64,
-    /// Per-plugin mutation counter, bumped on every accepted entry change.
-    /// Daemon-local: it resets when the daemon restarts, so the client treats
-    /// any change off its baseline (including a reset to a lower value) as
-    /// "state moved".
-    revisions: HashMap<String, u64>,
+    /// Mutation counter keyed by `(plugin_id, scope)`, bumped on every accepted
+    /// entry change to that scope. `scope` is the entry's session id, or `""`
+    /// for a global slot. Daemon-local: it resets when the daemon restarts, so
+    /// the client treats any change off its baseline (including a reset to a
+    /// lower value) as "state moved".
+    revisions: HashMap<(String, String), u64>,
+}
+
+/// The revision scope an entry belongs to: its session id, or `""` for a global
+/// (session-less) slot. Shared by writes and the snapshot so they key alike.
+fn scope_of(session_id: Option<&str>) -> String {
+    session_id.unwrap_or("").to_string()
 }
 
 impl Inner {
-    fn bump_revision(&mut self, plugin_id: &str) {
-        let rev = self.revisions.entry(plugin_id.to_string()).or_insert(0);
+    fn bump_revision(&mut self, plugin_id: &str, scope: String) {
+        let rev = self
+            .revisions
+            .entry((plugin_id.to_string(), scope))
+            .or_insert(0);
         *rev = rev.saturating_add(1);
+    }
+
+    /// The distinct scopes a plugin currently has entries in. Used to bump every
+    /// affected pane's counter when a bulk clear drops a plugin's entries.
+    fn plugin_scopes(&self, plugin_id: &str) -> HashSet<String> {
+        self.entries
+            .keys()
+            .filter(|k| k.plugin_id == plugin_id)
+            .map(|k| scope_of(k.session_id.as_deref()))
+            .collect()
     }
 }
 
@@ -349,20 +371,25 @@ impl UiStore {
         // fast respawn (begin running before the exited worker's clear_plugin),
         // where clearing by the old generation would otherwise no-op and leave
         // its entries visible until the new worker happened to overwrite them.
-        let before = inner.entries.len();
+        let scopes = inner.plugin_scopes(plugin_id);
         inner.entries.retain(|k, _| k.plugin_id != plugin_id);
-        if before != inner.entries.len() {
-            inner.bump_revision(plugin_id);
+        for scope in scopes {
+            inner.bump_revision(plugin_id, scope);
         }
         inner.active.insert(plugin_id.to_string(), gen);
         gen
     }
 
-    /// The plugin's current mutation counter, or 0 if it has none yet. The
-    /// action endpoint reads this before forwarding an action so the client can
-    /// wait for the worker's re-pushed state to move it.
-    pub fn revision(&self, plugin_id: &str) -> u64 {
-        self.read().revisions.get(plugin_id).copied().unwrap_or(0)
+    /// The mutation counter for one `(plugin_id, session)` scope, or 0 if it has
+    /// none yet. The action endpoint reads this for the clicked pane's session
+    /// before forwarding, so the client waits only for that pane's re-pushed
+    /// state, not any update from the same plugin in another session.
+    pub fn revision(&self, plugin_id: &str, session_id: Option<&str>) -> u64 {
+        self.read()
+            .revisions
+            .get(&(plugin_id.to_string(), scope_of(session_id)))
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Validate and store one entry. Rejects a stale generation, a payload that
@@ -402,7 +429,7 @@ impl UiStore {
             return Err(UiError::QuotaExceeded);
         }
         inner.entries.insert(key, normalized);
-        inner.bump_revision(plugin_id);
+        inner.bump_revision(plugin_id, scope_of(session_id));
         Ok(())
     }
 
@@ -430,7 +457,7 @@ impl UiStore {
             return Err(UiError::StaleWorker);
         }
         if inner.entries.remove(&key).is_some() {
-            inner.bump_revision(plugin_id);
+            inner.bump_revision(plugin_id, scope_of(session_id));
         }
         Ok(())
     }
@@ -482,11 +509,11 @@ impl UiStore {
             return false;
         }
         inner.active.remove(plugin_id);
-        let before = inner.entries.len();
+        let scopes = inner.plugin_scopes(plugin_id);
         inner.entries.retain(|k, _| k.plugin_id != plugin_id);
-        let changed = before != inner.entries.len();
-        if changed {
-            inner.bump_revision(plugin_id);
+        let changed = !scopes.is_empty();
+        for scope in scopes {
+            inner.bump_revision(plugin_id, scope);
         }
         changed
     }
@@ -517,14 +544,17 @@ impl UiStore {
                 &b.session_id,
             ))
         });
+        let mut revisions: BTreeMap<String, BTreeMap<String, u64>> = BTreeMap::new();
+        for ((plugin_id, scope), rev) in &inner.revisions {
+            revisions
+                .entry(plugin_id.clone())
+                .or_default()
+                .insert(scope.clone(), *rev);
+        }
         UiSnapshot {
             entries,
             notifications: inner.notifications.iter().cloned().collect(),
-            revisions: inner
-                .revisions
-                .iter()
-                .map(|(k, v)| (k.clone(), *v))
-                .collect(),
+            revisions,
         }
     }
 
@@ -980,8 +1010,8 @@ mod tests {
     #[test]
     fn revision_bumps_on_mutation_and_surfaces_in_snapshot() {
         let s = store();
-        // Absent until the plugin first mutates state.
-        assert_eq!(s.revision("acme.kit"), 0);
+        // Absent until the plugin first mutates state (global scope here).
+        assert_eq!(s.revision("acme.kit", None), 0);
         let g = s.begin_generation("acme.kit");
 
         s.set(
@@ -993,7 +1023,7 @@ mod tests {
             &json!({"title": "x"}),
         )
         .unwrap();
-        assert_eq!(s.revision("acme.kit"), 1);
+        assert_eq!(s.revision("acme.kit", None), 1);
 
         // An identical re-push still bumps: a refresh that returns unchanged
         // data must still move the counter, or a waiting spinner would hang.
@@ -1006,17 +1036,57 @@ mod tests {
             &json!({"title": "x"}),
         )
         .unwrap();
-        assert_eq!(s.revision("acme.kit"), 2);
+        assert_eq!(s.revision("acme.kit", None), 2);
 
         // Removing a present entry bumps; removing an absent one does not.
         s.remove("acme.kit", g, UiSlot::Card, "c0", None).unwrap();
-        assert_eq!(s.revision("acme.kit"), 3);
+        assert_eq!(s.revision("acme.kit", None), 3);
         s.remove("acme.kit", g, UiSlot::Card, "gone", None).unwrap();
-        assert_eq!(s.revision("acme.kit"), 3);
+        assert_eq!(s.revision("acme.kit", None), 3);
 
-        // The counter is exposed in the polled snapshot, scoped per plugin.
+        // The counter is exposed in the polled snapshot, keyed plugin -> scope.
         let snap = s.snapshot();
-        assert_eq!(snap.revisions.get("acme.kit"), Some(&3));
+        assert_eq!(
+            snap.revisions.get("acme.kit").and_then(|m| m.get("")),
+            Some(&3)
+        );
         assert_eq!(snap.revisions.get("other.kit"), None);
+    }
+
+    #[test]
+    fn revision_is_scoped_per_session() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // A pane push for session s1 bumps only s1's scope.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Pane,
+            "p",
+            Some("s1"),
+            &json!({"title": "a"}),
+        )
+        .unwrap();
+        assert_eq!(s.revision("acme.kit", Some("s1")), 1);
+        assert_eq!(s.revision("acme.kit", Some("s2")), 0);
+
+        // A push for an unrelated session must not move s1's counter, so s1's
+        // refresh spinner cannot be cleared by s2's activity.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Pane,
+            "p",
+            Some("s2"),
+            &json!({"title": "b"}),
+        )
+        .unwrap();
+        assert_eq!(s.revision("acme.kit", Some("s1")), 1);
+        assert_eq!(s.revision("acme.kit", Some("s2")), 1);
+
+        // A bulk clear bumps every scope the plugin had entries in.
+        s.clear_plugin("acme.kit", g);
+        assert_eq!(s.revision("acme.kit", Some("s1")), 2);
+        assert_eq!(s.revision("acme.kit", Some("s2")), 2);
     }
 }

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -15,7 +15,7 @@
 //! and immediately crashes should still reach the browser) and the client
 //! toasts each one once by tracking the monotonic `seq`.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 
@@ -282,6 +282,14 @@ pub struct UiEntry {
 pub struct UiSnapshot {
     pub entries: Vec<UiEntry>,
     pub notifications: Vec<Notification>,
+    /// Per-plugin monotonic mutation counter. The dashboard reads a baseline
+    /// from the action POST and holds a manual-action spinner until the
+    /// plugin's counter moves off it, so the spinner tracks the worker's
+    /// re-pushed state instead of the fire-and-forget POST. `BTreeMap` for a
+    /// deterministic serialized order; `serde(default)` so an older daemon's
+    /// snapshot still decodes.
+    #[serde(default)]
+    pub revisions: BTreeMap<String, u64>,
 }
 
 #[derive(Default)]
@@ -293,6 +301,18 @@ struct Inner {
     active: HashMap<String, u64>,
     notifications: VecDeque<Notification>,
     notify_seq: u64,
+    /// Per-plugin mutation counter, bumped on every accepted entry change.
+    /// Daemon-local: it resets when the daemon restarts, so the client treats
+    /// any change off its baseline (including a reset to a lower value) as
+    /// "state moved".
+    revisions: HashMap<String, u64>,
+}
+
+impl Inner {
+    fn bump_revision(&mut self, plugin_id: &str) {
+        let rev = self.revisions.entry(plugin_id.to_string()).or_insert(0);
+        *rev = rev.saturating_add(1);
+    }
 }
 
 /// The shared store. A `std::sync::RwLock` (not `tokio::Mutex`): writes happen
@@ -329,9 +349,20 @@ impl UiStore {
         // fast respawn (begin running before the exited worker's clear_plugin),
         // where clearing by the old generation would otherwise no-op and leave
         // its entries visible until the new worker happened to overwrite them.
+        let before = inner.entries.len();
         inner.entries.retain(|k, _| k.plugin_id != plugin_id);
+        if before != inner.entries.len() {
+            inner.bump_revision(plugin_id);
+        }
         inner.active.insert(plugin_id.to_string(), gen);
         gen
+    }
+
+    /// The plugin's current mutation counter, or 0 if it has none yet. The
+    /// action endpoint reads this before forwarding an action so the client can
+    /// wait for the worker's re-pushed state to move it.
+    pub fn revision(&self, plugin_id: &str) -> u64 {
+        self.read().revisions.get(plugin_id).copied().unwrap_or(0)
     }
 
     /// Validate and store one entry. Rejects a stale generation, a payload that
@@ -371,6 +402,7 @@ impl UiStore {
             return Err(UiError::QuotaExceeded);
         }
         inner.entries.insert(key, normalized);
+        inner.bump_revision(plugin_id);
         Ok(())
     }
 
@@ -397,7 +429,9 @@ impl UiStore {
         if inner.active.get(plugin_id) != Some(&generation) {
             return Err(UiError::StaleWorker);
         }
-        inner.entries.remove(&key);
+        if inner.entries.remove(&key).is_some() {
+            inner.bump_revision(plugin_id);
+        }
         Ok(())
     }
 
@@ -450,7 +484,11 @@ impl UiStore {
         inner.active.remove(plugin_id);
         let before = inner.entries.len();
         inner.entries.retain(|k, _| k.plugin_id != plugin_id);
-        before != inner.entries.len()
+        let changed = before != inner.entries.len();
+        if changed {
+            inner.bump_revision(plugin_id);
+        }
+        changed
     }
 
     /// Clone the full state for the web to render.
@@ -482,6 +520,11 @@ impl UiStore {
         UiSnapshot {
             entries,
             notifications: inner.notifications.iter().cloned().collect(),
+            revisions: inner
+                .revisions
+                .iter()
+                .map(|(k, v)| (k.clone(), *v))
+                .collect(),
         }
     }
 
@@ -932,5 +975,48 @@ mod tests {
             &json!({"title": "y"}),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn revision_bumps_on_mutation_and_surfaces_in_snapshot() {
+        let s = store();
+        // Absent until the plugin first mutates state.
+        assert_eq!(s.revision("acme.kit"), 0);
+        let g = s.begin_generation("acme.kit");
+
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Card,
+            "c0",
+            None,
+            &json!({"title": "x"}),
+        )
+        .unwrap();
+        assert_eq!(s.revision("acme.kit"), 1);
+
+        // An identical re-push still bumps: a refresh that returns unchanged
+        // data must still move the counter, or a waiting spinner would hang.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::Card,
+            "c0",
+            None,
+            &json!({"title": "x"}),
+        )
+        .unwrap();
+        assert_eq!(s.revision("acme.kit"), 2);
+
+        // Removing a present entry bumps; removing an absent one does not.
+        s.remove("acme.kit", g, UiSlot::Card, "c0", None).unwrap();
+        assert_eq!(s.revision("acme.kit"), 3);
+        s.remove("acme.kit", g, UiSlot::Card, "gone", None).unwrap();
+        assert_eq!(s.revision("acme.kit"), 3);
+
+        // The counter is exposed in the polled snapshot, scoped per plugin.
+        let snap = s.snapshot();
+        assert_eq!(snap.revisions.get("acme.kit"), Some(&3));
+        assert_eq!(snap.revisions.get("other.kit"), None);
     }
 }

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -181,7 +181,21 @@ pub async fn invoke_plugin_action(
     // session's activity cannot move it. The dashboard holds the spinner until
     // this scope's revision moves off the baseline.
     let baseline_revision = host.ui_revision(&id, body.session_id.as_deref());
-    if host.notify_worker(&id, &body.method, body.params).await {
+    // Forward the firing pane's session to the worker so a per-session action
+    // (e.g. github.refresh) can scope its work to that session instead of every
+    // one. Merged into the params object; a worker that does not use it ignores
+    // it (the honest-plugin model).
+    let mut params = body.params;
+    if let Some(sid) = &body.session_id {
+        match &mut params {
+            serde_json::Value::Object(map) => {
+                map.insert("session_id".into(), serde_json::Value::String(sid.clone()));
+            }
+            serde_json::Value::Null => params = json!({ "session_id": sid }),
+            _ => {}
+        }
+    }
+    if host.notify_worker(&id, &body.method, params).await {
         (
             StatusCode::ACCEPTED,
             Json(json!({ "ok": true, "baseline_revision": baseline_revision })),

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -137,6 +137,12 @@ pub struct PluginActionBody {
     pub method: String,
     #[serde(default)]
     pub params: serde_json::Value,
+    /// The session whose pane fired the action, if any. The host reads the
+    /// baseline revision for this `(plugin, session)` scope so the dashboard
+    /// waits only for that pane's re-pushed state; it is not forwarded to the
+    /// worker.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// `POST /api/plugins/{id}/action`: forward a dashboard UI action (a pane
@@ -168,12 +174,13 @@ pub async fn invoke_plugin_action(
             "Plugin host is not running".into(),
         );
     };
-    // Read the plugin's UI revision before forwarding, not the value the
-    // dashboard last polled: that one is stale, so an unrelated push between
-    // the last poll and this click would already exceed it and clear the
-    // spinner before the worker has done anything. The dashboard holds the
-    // spinner until the plugin's revision moves off this baseline.
-    let baseline_revision = host.ui_revision(&id);
+    // Read the pane's UI revision before forwarding, not the value the dashboard
+    // last polled: that one is stale, so an unrelated push between the last poll
+    // and this click would already exceed it and clear the spinner before the
+    // worker has done anything. Scoped to the firing pane's session so another
+    // session's activity cannot move it. The dashboard holds the spinner until
+    // this scope's revision moves off the baseline.
+    let baseline_revision = host.ui_revision(&id, body.session_id.as_deref());
     if host.notify_worker(&id, &body.method, body.params).await {
         (
             StatusCode::ACCEPTED,

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -168,8 +168,18 @@ pub async fn invoke_plugin_action(
             "Plugin host is not running".into(),
         );
     };
+    // Read the plugin's UI revision before forwarding, not the value the
+    // dashboard last polled: that one is stale, so an unrelated push between
+    // the last poll and this click would already exceed it and clear the
+    // spinner before the worker has done anything. The dashboard holds the
+    // spinner until the plugin's revision moves off this baseline.
+    let baseline_revision = host.ui_revision(&id);
     if host.notify_worker(&id, &body.method, body.params).await {
-        (StatusCode::ACCEPTED, Json(json!({ "ok": true }))).into_response()
+        (
+            StatusCode::ACCEPTED,
+            Json(json!({ "ok": true, "baseline_revision": baseline_revision })),
+        )
+            .into_response()
     } else {
         error_response(
             StatusCode::NOT_FOUND,

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -184,6 +184,7 @@ impl StructuredViewState {
             plugin_ui: UiSnapshot {
                 entries: Vec::new(),
                 notifications: Vec::new(),
+                revisions: Default::default(),
             },
             plugin_notify: PluginNotifyState::default(),
         }

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -307,11 +307,19 @@ const ACTION_TIMEOUT_MS = 15000;
  *  worker's re-pushed state has landed), not merely until the POST is accepted,
  *  with a hard timeout fallback so it can never hang. A failed POST clears the
  *  spinner at once. An icon is optional. */
-function BlockAction({ block, pluginId }: { block: Record<string, unknown>; pluginId: string }) {
+function BlockAction({
+  block,
+  pluginId,
+  sessionId,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+}) {
   const label = str(block, "label");
   const method = str(block, "method");
   const iconComp = lucideIcon(str(block, "icon"));
-  const revision = usePluginUiRevision(pluginId);
+  const revision = usePluginUiRevision(pluginId, sessionId);
   const poke = usePluginUiPoke();
   // `posting`: the POST is in flight. `waitBaseline`: the revision the host had
   // when it accepted the action; the button keeps spinning until the polled
@@ -345,11 +353,14 @@ function BlockAction({ block, pluginId }: { block: Record<string, unknown>; plug
     postingRef.current = true;
     setPosting(true);
     try {
-      const accepted = await invokePluginAction(pluginId, method);
+      const accepted = await invokePluginAction(pluginId, method, sessionId);
       if (!accepted) return; // 403/404/network: nothing re-pushes, stop spinning
+      poke();
+      // No baseline (older daemon): can't track completion, so degrade to
+      // clearing when the POST settles rather than spinning to the timeout.
+      if (accepted.baselineRevision === null) return;
       // Hold the spinner until the revision moves off this baseline (see above).
       setWaitBaseline(accepted.baselineRevision);
-      poke();
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
         setWaitBaseline(null);
@@ -454,7 +465,15 @@ function BlockComment({ block }: { block: Record<string, unknown> }) {
  *  an unknown `kind` (or a known kind missing its required field) renders
  *  nothing rather than throwing, so a newer plugin can push kinds an older host
  *  has never heard of. */
-function DetailBlock({ block, pluginId }: { block: Record<string, unknown>; pluginId: string }) {
+function DetailBlock({
+  block,
+  pluginId,
+  sessionId,
+}: {
+  block: Record<string, unknown>;
+  pluginId: string;
+  sessionId?: string;
+}) {
   switch (str(block, "kind")) {
     case "heading": {
       const text = str(block, "text");
@@ -471,11 +490,11 @@ function DetailBlock({ block, pluginId }: { block: Record<string, unknown>; plug
     case "divider":
       return <hr className="border-surface-700/60" />;
     case "action":
-      return <BlockAction block={block} pluginId={pluginId} />;
+      return <BlockAction block={block} pluginId={pluginId} sessionId={sessionId} />;
     case "section": {
       const title = str(block, "title");
       const children = Array.isArray(block.children) ? block.children.filter(isObject) : [];
-      const body = children.map((c, i) => <DetailBlock key={i} block={c} pluginId={pluginId} />);
+      const body = children.map((c, i) => <DetailBlock key={i} block={c} pluginId={pluginId} sessionId={sessionId} />);
       // An optional tone-tinted icon on the title gives an at-a-glance status
       // even when the section is folded (e.g. a green check vs a red x).
       const tone = validTone(block.tone);
@@ -540,7 +559,7 @@ export function PluginPaneBody({ entry }: { entry: PluginUiEntry }) {
       {blocks ? (
         <div className="flex flex-col gap-1.5">
           {blocks.map((b, i) => (
-            <DetailBlock key={i} block={b} pluginId={entry.plugin_id} />
+            <DetailBlock key={i} block={b} pluginId={entry.plugin_id} sessionId={entry.session_id} />
           ))}
         </div>
       ) : (

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -6,11 +6,16 @@
 // sort-key and filter-facet slots render as sidebar sort options and a facet
 // filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
-import { createElement, useId, useRef, useState } from "react";
+import { createElement, useEffect, useId, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { invokePluginAction } from "../../lib/api";
-import { usePluginUiEntries, usePluginUiRefreshing } from "../../lib/pluginUiContext";
+import {
+  usePluginUiEntries,
+  usePluginUiPoke,
+  usePluginUiRefreshing,
+  usePluginUiRevision,
+} from "../../lib/pluginUiContext";
 import {
   accentStyle,
   entryText,
@@ -290,32 +295,69 @@ function Spinner({ className }: { className: string }) {
   );
 }
 
+// A pane action's spinner clears after this even if no fresh state arrives, so
+// a worker that processes the action without re-pushing (no sessions, ignored
+// method, mid-refresh crash) can never leave the button spinning forever.
+const ACTION_TIMEOUT_MS = 15000;
+
 /** An `action` pane block: a button that forwards a worker method (named by the
- *  plugin) to that plugin's worker. Fire-and-forget; the worker re-pushes its
- *  UI state, which the next poll renders. While the POST is in flight the button
- *  disables and swaps its icon for a spinner, so a refresh shows it is underway;
- *  `invokePluginAction` never rejects (it returns false on failure), so the
- *  `finally` always restores the button to an actionable state. An icon is
- *  optional. */
+ *  plugin) to that plugin's worker. The worker runs the method and re-pushes its
+ *  UI state, which a later poll renders. The button spins from the click until
+ *  the plugin's UI revision moves off the baseline the action POST returned (the
+ *  worker's re-pushed state has landed), not merely until the POST is accepted,
+ *  with a hard timeout fallback so it can never hang. A failed POST clears the
+ *  spinner at once. An icon is optional. */
 function BlockAction({ block, pluginId }: { block: Record<string, unknown>; pluginId: string }) {
   const label = str(block, "label");
   const method = str(block, "method");
   const iconComp = lucideIcon(str(block, "icon"));
-  const [busy, setBusy] = useState(false);
-  // A ref guard, not just `busy`: two clicks in the same tick both see the old
-  // `busy` state before React commits the update, so the boolean alone would
-  // double-fire. The ref flips synchronously.
-  const busyRef = useRef(false);
+  const revision = usePluginUiRevision(pluginId);
+  const poke = usePluginUiPoke();
+  // `posting`: the POST is in flight. `waitBaseline`: the revision the host had
+  // when it accepted the action; the button keeps spinning until the polled
+  // revision moves off it (the worker's re-pushed state landed) or the timeout
+  // fires. Stored as state so a polled revision change re-renders the button.
+  const [posting, setPosting] = useState(false);
+  const [waitBaseline, setWaitBaseline] = useState<number | null>(null);
+  // Guards a same-tick double-fire of the POST, before `posting` commits and
+  // `disabled` takes effect; the wait phase is guarded by `busy`/`disabled`.
+  const postingRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Derived in render, so nothing has to chase the revision in an effect: still
+  // waiting only while the polled revision has not moved off the baseline. `!==`
+  // so a daemon restart that resets the counter to a lower value also clears.
+  const waiting = waitBaseline !== null && revision === waitBaseline;
+  const busy = posting || waiting;
+
+  // Only an unmount guard: stop the fallback timer so it cannot fire setState on
+  // an unmounted block. No state writes here, so no effect-chases-event lint.
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
   if (!label || !method) return null;
   const onClick = async () => {
-    if (busyRef.current) return;
-    busyRef.current = true;
-    setBusy(true);
+    if (postingRef.current || busy) return;
+    postingRef.current = true;
+    setPosting(true);
     try {
-      await invokePluginAction(pluginId, method);
+      const accepted = await invokePluginAction(pluginId, method);
+      if (!accepted) return; // 403/404/network: nothing re-pushes, stop spinning
+      // Hold the spinner until the revision moves off this baseline (see above).
+      setWaitBaseline(accepted.baselineRevision);
+      poke();
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setWaitBaseline(null);
+        timerRef.current = null;
+      }, ACTION_TIMEOUT_MS);
     } finally {
-      busyRef.current = false;
-      setBusy(false);
+      postingRef.current = false;
+      setPosting(false);
     }
   };
   return (

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -110,7 +110,7 @@ describe("plugin slot renderers", () => {
     const btn = screen.getByTestId("plugin-pane-action");
     expect(btn.textContent).toContain("Refresh");
     fireEvent.click(btn);
-    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh"));
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh", "s1"));
   });
 
   it("holds the spinner until the plugin revision advances, not just until the POST resolves", async () => {
@@ -174,6 +174,28 @@ describe("plugin slot renderers", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("skips the wait and clears on POST settle when the daemon omits a baseline", async () => {
+    // Older daemon: no baseline_revision, so the API returns null. The button
+    // must not spin to the 15s timeout; it clears once the POST settles.
+    revisionRef.current = 0;
+    invokeMock.mockImplementationOnce(async () => ({ baselineRevision: null }));
+    const entry: PluginUiEntry = {
+      plugin_id: "acme.kit",
+      slot: "pane",
+      id: "p",
+      session_id: "s1",
+      payload: { blocks: [{ kind: "action", label: "Refresh", method: "github.refresh" }] },
+    };
+    const { container } = render(<PluginPaneBody entry={entry} />);
+    const btn = screen.getByTestId("plugin-pane-action") as HTMLButtonElement;
+    fireEvent.click(btn);
+    await waitFor(() => expect(pokeMock).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(container.querySelector("svg.animate-spin")).toBeNull();
+      expect(btn.disabled).toBe(false);
+    });
   });
 
   it("pane action stops the spinner and stays actionable when the POST fails", async () => {

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -5,19 +5,27 @@ import { describe, expect, it, vi } from "vitest";
 import type { PluginUiEntry } from "../../../lib/api";
 import { PluginCards, PluginPaneBody, PluginRowBadges, PluginStatusBarSegments } from "../PluginSlots";
 
-// The slot components read entries (and the refresh flag) from context; mock
-// those hooks so each test drives a fixed snapshot.
-const { entriesRef, refreshingRef } = vi.hoisted(() => ({
+// The slot components read entries, the refresh flag, the per-plugin revision,
+// and the poke fn from context; mock those hooks so each test drives a fixed
+// snapshot and can advance the revision to simulate the poll seeing fresh state.
+const { entriesRef, refreshingRef, revisionRef, pokeMock } = vi.hoisted(() => ({
   entriesRef: { current: [] as PluginUiEntry[] },
   refreshingRef: { current: false },
+  revisionRef: { current: 0 },
+  pokeMock: vi.fn(),
 }));
 vi.mock("../../../lib/pluginUiContext", () => ({
   usePluginUiEntries: () => entriesRef.current,
   usePluginUiRefreshing: () => refreshingRef.current,
+  usePluginUiRevision: () => revisionRef.current,
+  usePluginUiPoke: () => pokeMock,
 }));
 
-// The action block forwards to the worker via this; stub it.
-const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn(async () => true) }));
+// The action block forwards to the worker via this; stub it. The default
+// returns an accepted baseline of 0 (matching the initial revision).
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(async () => ({ baselineRevision: 0 })),
+}));
 vi.mock("../../../lib/api", () => ({ invokePluginAction: invokeMock }));
 
 function set(entries: PluginUiEntry[]) {
@@ -105,10 +113,11 @@ describe("plugin slot renderers", () => {
     await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh"));
   });
 
-  it("pane action shows a spinner while the request is in flight, then clears it", async () => {
-    // Defer the action so the in-flight state is observable.
-    let resolve!: (v: boolean) => void;
-    invokeMock.mockImplementationOnce(() => new Promise<boolean>((r) => (resolve = r)));
+  it("holds the spinner until the plugin revision advances, not just until the POST resolves", async () => {
+    // The host had revision 7 when it accepted the action; the worker re-pushes
+    // its state asynchronously, bumping the revision to 8 on a later poll.
+    revisionRef.current = 7;
+    invokeMock.mockImplementationOnce(async () => ({ baselineRevision: 7 }));
     const entry: PluginUiEntry = {
       plugin_id: "acme.kit",
       slot: "pane",
@@ -116,23 +125,59 @@ describe("plugin slot renderers", () => {
       session_id: "s1",
       payload: { blocks: [{ kind: "action", label: "Refresh", method: "github.refresh" }] },
     };
-    const { container } = render(<PluginPaneBody entry={entry} />);
+    const { container, rerender } = render(<PluginPaneBody entry={entry} />);
     const btn = screen.getByTestId("plugin-pane-action") as HTMLButtonElement;
-    expect(container.querySelector("svg.animate-spin")).toBeNull();
 
     fireEvent.click(btn);
-    await waitFor(() => expect(container.querySelector("svg.animate-spin")).toBeTruthy());
+    // POST has resolved, but the revision has not moved yet: the spinner must
+    // stay (the old behavior cleared it here, which is the bug).
+    await waitFor(() => expect(pokeMock).toHaveBeenCalled());
+    expect(container.querySelector("svg.animate-spin")).toBeTruthy();
     expect(btn.getAttribute("aria-busy")).toBe("true");
     expect(btn.disabled).toBe(true);
 
-    await act(async () => resolve(true));
+    // The poll delivers the worker's re-pushed state: revision moves off the
+    // baseline and the spinner clears.
+    revisionRef.current = 8;
+    rerender(<PluginPaneBody entry={entry} />);
     await waitFor(() => expect(container.querySelector("svg.animate-spin")).toBeNull());
     expect(btn.getAttribute("aria-busy")).toBeNull();
     expect(btn.disabled).toBe(false);
   });
 
-  it("pane action stops the spinner and stays actionable when the request fails", async () => {
-    invokeMock.mockImplementationOnce(async () => false);
+  it("clears a stuck spinner after the timeout when no fresh state arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      revisionRef.current = 3;
+      invokeMock.mockImplementationOnce(async () => ({ baselineRevision: 3 }));
+      const entry: PluginUiEntry = {
+        plugin_id: "acme.kit",
+        slot: "pane",
+        id: "p",
+        session_id: "s1",
+        payload: { blocks: [{ kind: "action", label: "Refresh", method: "github.refresh" }] },
+      };
+      const { container } = render(<PluginPaneBody entry={entry} />);
+      const btn = screen.getByTestId("plugin-pane-action") as HTMLButtonElement;
+
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+      expect(container.querySelector("svg.animate-spin")).toBeTruthy();
+
+      // Revision never moves; the hard timeout restores the button.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000);
+      });
+      expect(container.querySelector("svg.animate-spin")).toBeNull();
+      expect(btn.disabled).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("pane action stops the spinner and stays actionable when the POST fails", async () => {
+    invokeMock.mockImplementationOnce(async () => null);
     const entry: PluginUiEntry = {
       plugin_id: "acme.kit",
       slot: "pane",

--- a/web/src/hooks/usePluginUiState.ts
+++ b/web/src/hooks/usePluginUiState.ts
@@ -36,7 +36,7 @@ const REFRESH_INDICATOR_DELAY = 250;
 
 export function usePluginUiState() {
   const [entries, setEntries] = useState<PluginUiEntry[]>([]);
-  const [revisions, setRevisions] = useState<Record<string, number>>({});
+  const [revisions, setRevisions] = useState<Record<string, Record<string, number>>>({});
   const [isRefreshing, setIsRefreshing] = useState(false);
   // Highest notification seq already toasted. Seeded from the first snapshot so
   // a page load does not replay the whole backlog as fresh toasts.

--- a/web/src/hooks/usePluginUiState.ts
+++ b/web/src/hooks/usePluginUiState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchPluginUiState, type PluginUiEntry, type PluginUiNotification } from "../lib/api";
 import { reportError, reportInfo } from "../lib/toastBus";
 
@@ -7,6 +7,14 @@ import { reportError, reportInfo } from "../lib/toastBus";
 // (no separate, tearing-prone clock). Notifications are point-in-time: each
 // arrives once, tracked by its monotonic seq, and is pushed to the toast bus.
 const POLL_INTERVAL = 3000;
+// While a manual pane action is settling, `poke()` drops the cadence to this so
+// the worker's re-pushed state (and the revision bump that clears the action's
+// spinner) shows up in well under a second instead of waiting a full 3s tick.
+const BOOST_INTERVAL = 500;
+// How long a single `poke()` keeps the boosted cadence before reverting. Sized
+// to outlast a slow (network / rate-limited) GitHub refresh; the action spinner
+// has its own hard timeout, so an over-long boost is bounded regardless.
+const BOOST_MS = 15000;
 
 /** Map a plugin notification onto the toast bus. The bus only distinguishes
  *  error vs info, so danger/warn tones surface as errors and the rest as info;
@@ -28,15 +36,22 @@ const REFRESH_INDICATOR_DELAY = 250;
 
 export function usePluginUiState() {
   const [entries, setEntries] = useState<PluginUiEntry[]>([]);
+  const [revisions, setRevisions] = useState<Record<string, number>>({});
   const [isRefreshing, setIsRefreshing] = useState(false);
   // Highest notification seq already toasted. Seeded from the first snapshot so
   // a page load does not replay the whole backlog as fresh toasts.
   const lastNotifySeqRef = useRef<number | null>(null);
+  // `poke()` reaches into the running poll loop to run a tick now and boost the
+  // cadence. The loop publishes its trigger here; poke is otherwise a no-op
+  // (e.g. called before the effect mounts).
+  const pokeRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let slowTimer: ReturnType<typeof setTimeout> | null = null;
+    let inFlight = false;
+    let boostUntil = 0;
 
     const apply = (notifications: PluginUiNotification[]) => {
       const maxSeq = notifications.reduce((m, n) => Math.max(m, n.seq), 0);
@@ -55,11 +70,19 @@ export function usePluginUiState() {
       lastNotifySeqRef.current = Math.max(seen, maxSeq);
     };
 
+    const scheduleNext = () => {
+      if (cancelled) return;
+      const delay = Date.now() < boostUntil ? BOOST_INTERVAL : POLL_INTERVAL;
+      timer = setTimeout(() => void tick(), delay);
+    };
+
     // Recursive setTimeout, not setInterval: the next poll is scheduled only
     // after the current one settles, so requests never overlap and a slow
     // response cannot land after a newer one and roll the dashboard back to
     // stale plugin UI. A failed fetch (null) just skips this round.
     const tick = async () => {
+      if (inFlight) return; // a poke during an in-flight fetch; scheduleNext re-fires
+      inFlight = true;
       // Flip the indicator on only once the poll outlasts the threshold, so a
       // fast fetch never shows it. Cleared in finally whether the fetch
       // succeeds, returns null, or the threshold never fires.
@@ -70,22 +93,35 @@ export function usePluginUiState() {
         const state = await fetchPluginUiState();
         if (cancelled || state === null) return;
         setEntries(state.entries);
+        setRevisions(state.revisions ?? {});
         apply(state.notifications);
       } finally {
         if (slowTimer) clearTimeout(slowTimer);
+        inFlight = false;
         if (!cancelled) {
           setIsRefreshing(false);
-          timer = setTimeout(() => void tick(), POLL_INTERVAL);
+          scheduleNext();
         }
       }
     };
+
+    pokeRef.current = () => {
+      boostUntil = Date.now() + BOOST_MS;
+      if (inFlight) return; // the in-flight fetch's scheduleNext picks up the boost
+      if (timer) clearTimeout(timer);
+      void tick();
+    };
+
     void tick();
     return () => {
       cancelled = true;
+      pokeRef.current = () => {};
       if (timer) clearTimeout(timer);
       if (slowTimer) clearTimeout(slowTimer);
     };
   }, []);
 
-  return { entries, isRefreshing };
+  const poke = useCallback(() => pokeRef.current(), []);
+
+  return { entries, revisions, isRefreshing, poke };
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -645,10 +645,11 @@ export interface PluginUiNotification {
 export interface PluginUiState {
   entries: PluginUiEntry[];
   notifications: PluginUiNotification[];
-  /** Per-plugin monotonic mutation counter. A manual pane action records the
-   *  baseline returned by the action POST and holds its spinner until the
-   *  plugin's counter here moves off it. Absent on an older daemon. */
-  revisions?: Record<string, number>;
+  /** Mutation counter per plugin, then per scope (a session id, or `""` for a
+   *  global slot). A manual pane action records the baseline the action POST
+   *  returns and holds its spinner until its own scope's counter moves off it,
+   *  so another session's push never clears it. Absent on an older daemon. */
+  revisions?: Record<string, Record<string, number>>;
 }
 
 /** The host's aggregated UI-state snapshot. Returns an empty state (not null)
@@ -678,34 +679,40 @@ export async function setPluginEnabled(id: string, enabled: boolean): Promise<Pl
   }
 }
 
-/** A worker accepted an action. `baselineRevision` is the plugin's UI mutation
+/** A worker accepted an action. `baselineRevision` is the scope's UI mutation
  *  counter the host read before forwarding; the pane holds its spinner until
- *  the polled counter moves off this value. */
+ *  the polled counter moves off this value. `null` means the daemon did not
+ *  report a baseline (older daemon), so the caller skips the wait and just
+ *  clears when the POST settles. */
 export interface PluginActionAccepted {
-  baselineRevision: number;
+  baselineRevision: number | null;
 }
 
 /**
  * Forward a plugin pane's UI action (e.g. a "Refresh" button) to the plugin's
  * worker. Fire-and-forget at the worker: the worker runs the named method and
- * re-pushes its UI state, which a later ui-state poll renders. Returns the
- * accepted baseline revision, or null on read-only (403), no running worker
- * (404), or network failure.
+ * re-pushes its UI state, which a later ui-state poll renders. `sessionId`
+ * scopes the baseline revision to the firing pane's session. Returns the
+ * accepted baseline (or null if the daemon omitted one), or null on read-only
+ * (403), no running worker (404), or network failure.
  */
 export async function invokePluginAction(
   pluginId: string,
   method: string,
+  sessionId?: string,
   params: Record<string, unknown> = {},
 ): Promise<PluginActionAccepted | null> {
   try {
     const res = await fetch(`/api/plugins/${encodeURIComponent(pluginId)}/action`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ method, params }),
+      body: JSON.stringify({ method, params, session_id: sessionId ?? null }),
     });
     if (!res.ok) return null;
     const body = (await res.json().catch(() => null)) as { baseline_revision?: unknown } | null;
-    const rev = typeof body?.baseline_revision === "number" ? body.baseline_revision : 0;
+    // A missing baseline (older daemon) is a sentinel, not revision 0: 0 would
+    // wedge the spinner until timeout since the polled revision is also 0.
+    const rev = typeof body?.baseline_revision === "number" ? body.baseline_revision : null;
     return { baselineRevision: rev };
   } catch {
     return null;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -645,6 +645,10 @@ export interface PluginUiNotification {
 export interface PluginUiState {
   entries: PluginUiEntry[];
   notifications: PluginUiNotification[];
+  /** Per-plugin monotonic mutation counter. A manual pane action records the
+   *  baseline returned by the action POST and holds its spinner until the
+   *  plugin's counter here moves off it. Absent on an older daemon. */
+  revisions?: Record<string, number>;
 }
 
 /** The host's aggregated UI-state snapshot. Returns an empty state (not null)
@@ -674,26 +678,37 @@ export async function setPluginEnabled(id: string, enabled: boolean): Promise<Pl
   }
 }
 
+/** A worker accepted an action. `baselineRevision` is the plugin's UI mutation
+ *  counter the host read before forwarding; the pane holds its spinner until
+ *  the polled counter moves off this value. */
+export interface PluginActionAccepted {
+  baselineRevision: number;
+}
+
 /**
  * Forward a plugin pane's UI action (e.g. a "Refresh" button) to the plugin's
- * worker. Fire-and-forget: the worker runs the named method and re-pushes its
- * UI state, which the next ui-state poll renders. Returns false on read-only
- * (403), no running worker (404), or network failure.
+ * worker. Fire-and-forget at the worker: the worker runs the named method and
+ * re-pushes its UI state, which a later ui-state poll renders. Returns the
+ * accepted baseline revision, or null on read-only (403), no running worker
+ * (404), or network failure.
  */
 export async function invokePluginAction(
   pluginId: string,
   method: string,
   params: Record<string, unknown> = {},
-): Promise<boolean> {
+): Promise<PluginActionAccepted | null> {
   try {
     const res = await fetch(`/api/plugins/${encodeURIComponent(pluginId)}/action`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ method, params }),
     });
-    return res.ok;
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as { baseline_revision?: unknown } | null;
+    const rev = typeof body?.baseline_revision === "number" ? body.baseline_revision : 0;
+    return { baselineRevision: rev };
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/web/src/lib/pluginUiContext.tsx
+++ b/web/src/lib/pluginUiContext.tsx
@@ -15,7 +15,7 @@ import type { PluginUiEntry } from "./api";
 // change even though they never read them.
 const PluginUiEntriesContext = createContext<PluginUiEntry[]>([]);
 const PluginUiRefreshingContext = createContext(false);
-const PluginUiRevisionsContext = createContext<Record<string, number>>({});
+const PluginUiRevisionsContext = createContext<Record<string, Record<string, number>>>({});
 const PluginUiPokeContext = createContext<() => void>(() => {});
 
 export function PluginUiProvider({ children }: { children: ReactNode }) {
@@ -42,10 +42,12 @@ export function usePluginUiRefreshing(): boolean {
   return useContext(PluginUiRefreshingContext);
 }
 
-/** The plugin's current UI mutation counter (0 if none seen yet). A pane action
- *  holds its spinner until this moves off the baseline the action POST returned. */
-export function usePluginUiRevision(pluginId: string): number {
-  return useContext(PluginUiRevisionsContext)[pluginId] ?? 0;
+/** The UI mutation counter for one plugin pane's scope (a session id, or the
+ *  global `""` scope), 0 if none seen yet. A pane action holds its spinner until
+ *  this moves off the baseline the action POST returned, so a different
+ *  session's push for the same plugin cannot clear it. */
+export function usePluginUiRevision(pluginId: string, sessionId?: string): number {
+  return useContext(PluginUiRevisionsContext)[pluginId]?.[sessionId ?? ""] ?? 0;
 }
 
 /** Run a ui-state poll now and briefly boost the cadence, so a just-fired pane

--- a/web/src/lib/pluginUiContext.tsx
+++ b/web/src/lib/pluginUiContext.tsx
@@ -9,18 +9,24 @@ import { createContext, useContext, type ReactNode } from "react";
 import { usePluginUiState } from "../hooks/usePluginUiState";
 import type { PluginUiEntry } from "./api";
 
-// Entries and the refresh flag live in separate contexts: the flag toggles on
-// every slow poll, and folding it into the entries context would re-render all
-// entry consumers (rows, badges, cards, top bar) on each toggle even though
-// they never read it.
+// Entries, revisions, the refresh flag, and poke live in separate contexts: the
+// flag and revisions toggle on polls, and folding them into the entries context
+// would re-render all entry consumers (rows, badges, cards, top bar) on each
+// change even though they never read them.
 const PluginUiEntriesContext = createContext<PluginUiEntry[]>([]);
 const PluginUiRefreshingContext = createContext(false);
+const PluginUiRevisionsContext = createContext<Record<string, number>>({});
+const PluginUiPokeContext = createContext<() => void>(() => {});
 
 export function PluginUiProvider({ children }: { children: ReactNode }) {
-  const { entries, isRefreshing } = usePluginUiState();
+  const { entries, revisions, isRefreshing, poke } = usePluginUiState();
   return (
     <PluginUiEntriesContext.Provider value={entries}>
-      <PluginUiRefreshingContext.Provider value={isRefreshing}>{children}</PluginUiRefreshingContext.Provider>
+      <PluginUiRevisionsContext.Provider value={revisions}>
+        <PluginUiPokeContext.Provider value={poke}>
+          <PluginUiRefreshingContext.Provider value={isRefreshing}>{children}</PluginUiRefreshingContext.Provider>
+        </PluginUiPokeContext.Provider>
+      </PluginUiRevisionsContext.Provider>
     </PluginUiEntriesContext.Provider>
   );
 }
@@ -34,4 +40,16 @@ export function usePluginUiEntries(): PluginUiEntry[] {
  *  delay. Lets a pane renderer show a refresh-in-progress affordance. */
 export function usePluginUiRefreshing(): boolean {
   return useContext(PluginUiRefreshingContext);
+}
+
+/** The plugin's current UI mutation counter (0 if none seen yet). A pane action
+ *  holds its spinner until this moves off the baseline the action POST returned. */
+export function usePluginUiRevision(pluginId: string): number {
+  return useContext(PluginUiRevisionsContext)[pluginId] ?? 0;
+}
+
+/** Run a ui-state poll now and briefly boost the cadence, so a just-fired pane
+ *  action's result (and its revision bump) shows up without waiting a full tick. */
+export function usePluginUiPoke(): () => void {
+  return useContext(PluginUiPokeContext);
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The GitHub plugin pane's `Refresh` button had a spinner that never worked and a refresh that felt slow, both from the same root cause: the action was acknowledged at dispatch, never at completion. Clicking the button POSTs to `/api/plugins/{id}/action`, which the host forwards to the worker as a fire-and-forget notification and answers with `202` in milliseconds. The button's `busy` state was tied to that POST, so the spinner blinked once and cleared while the actual refresh was still running in the worker; the refreshed data then only appeared on the next 3s ui-state poll.

This adds an in-repo completion signal without touching the plugin worker. The host's UI store now keeps a per-plugin monotonic revision counter, bumped on every accepted `ui.state.set` (even an identical re-push) and on removals/clears that change state, and exposes it in the polled snapshot. The action endpoint reads the plugin's baseline revision before forwarding and returns it in the `202` body. The dashboard records that baseline and keeps the button spinning until the polled revision moves off it, which is when the worker's re-pushed state has actually landed, with a 15s timeout fallback so it can never hang and an immediate clear on a failed POST. Reading the baseline on the host (not from the poll-stale client value) avoids an unrelated earlier push clearing the spinner before the refresh did anything.

To cut the perceived tail, a manual action now also triggers an immediate ui-state poll and briefly boosts the poll cadence to 500ms for a short window, so the fresh data shows up in well under a second instead of waiting a full 3s tick.

Worker-side slowness (a manual refresh re-fetching every session and bypassing the cache) is out of scope here and tracked separately in the `plugin-github` repo.

Closes #2513

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Run `aoe serve` with the GitHub plugin enabled and open the dashboard.
- [ ] Open a GitHub plugin pane and click `Refresh`. Confirm the spinner stays visible until the refreshed PR/CI data actually updates in the pane, not just for a brief flash.
- [ ] Click `Refresh` and watch timing: the refreshed data should appear noticeably faster than the old fixed 3s cadence.
- [ ] With no active sessions (nothing for the worker to push), click `Refresh` and confirm the spinner stops on its own within ~15s and the button becomes clickable again.
- [ ] Stop the daemon while a pane spinner is up (or trigger a 403/404 by toggling read-only), and confirm the button returns to an actionable state rather than spinning forever.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a Playwright spec, because: the change is client-side timing logic (spinner held by a revision compare, not backend round-trip state), which `AGENTS.md` routes to Vitest + RTL. Covered by new cases in `web/src/components/plugin/__tests__/PluginSlots.test.tsx` (spinner holds until the revision advances, timeout fallback, clears on failed POST) plus a Rust unit test for the host revision counter in `src/plugin/ui_state.rs`. `PluginSlots.tsx` is already mapped in `web/tests/coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the design debate, and implementation were drafted by Claude under my direction. I made the design calls (in-repo revision signal, baseline read on the host, boosted poll), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785245808&installation_id=139138837&pr_number=2519&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2519&signature=10db77ed07c20a7c5d3d018c9e0f4c959668aaef8c14c4e5b4aff44bb3a8389a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change makes the GitHub plugin Refresh action feel accurate and reliable.

- The refresh spinner now stays active until the refreshed UI state is actually shown (not just when the server accepts the request).
- The system adds an in-repo “completion” signal by tracking a per-plugin UI revision counter (scoped to a pane/session when available) and returning a baseline revision from the refresh endpoint; the client keeps waiting until the polled revision advances.
- Manual refresh is scoped to the focused pane/session, triggers an immediate UI-state poll, and temporarily increases polling frequency to reduce the perceived delay.
- A hard timeout and failure handling ensure the spinner can’t hang indefinitely, and the button becomes usable again.
- UI and API plumbing were extended to carry/consume session scope, and React state now includes revision + a “poke” mechanism to drive faster updates.
- Tests were updated/added to verify spinner lifecycle (waits for new data, stops after timeout, and clears on failure) and that refresh is correctly scoped.

Benefit: users get trustworthy refresh feedback, quicker visible updates after refresh, and no stuck “loading” state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->