### PR TITLE
fix(tui): persist trash before tmux teardown

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1227,6 +1227,9 @@ impl Instance {
         if pre.pinned_at != post.pinned_at {
             self.pinned_at = post.pinned_at;
         }
+        if pre.trashed_at != post.trashed_at {
+            self.trashed_at = post.trashed_at;
+        }
         if pre.unread != post.unread {
             self.unread = post.unread;
         }
@@ -4622,6 +4625,27 @@ mod tests {
         let mut disk2 = pre2.clone();
         disk2.merge_user_action_diff(&pre2, &post2);
         assert!(!disk2.unread);
+    }
+
+    #[test]
+    fn test_merge_user_action_diff_propagates_trash_marker() {
+        let pre = Instance::new("t", "/tmp");
+        let mut post = pre.clone();
+        post.trash();
+        let mut disk = pre.clone();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.is_trashed());
+
+        let pre2 = post.clone();
+        let mut post2 = pre2.clone();
+        post2.untrash();
+        let mut disk2 = pre2.clone();
+
+        disk2.merge_user_action_diff(&pre2, &post2);
+
+        assert!(!disk2.is_trashed());
     }
 
     #[test]

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1448,12 +1448,12 @@ impl HomeView {
     /// restored. The Trash section is revealed so the user sees where the row
     /// went. See #2489.
     pub(super) fn trash_session_by_id(&mut self, id: &str) {
-        if let Some(inst) = self.instances.iter().find(|i| i.id == id) {
-            inst.kill_all_tmux_sessions();
-        }
         if let Err(e) = self.apply_user_action(id, |inst| inst.trash()) {
             tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
             return;
+        }
+        if let Some(inst) = self.instances.iter().find(|i| i.id == id) {
+            inst.kill_all_tmux_sessions();
         }
         self.reveal_trashed_section();
         self.flat_items = self.build_flat_items();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6674,6 +6674,35 @@ fn trash_then_restore_round_trip() {
     );
 }
 
+#[test]
+#[serial]
+fn d_on_session_with_default_trash_persists_trash_marker() {
+    let mut env = create_test_env_with_sessions(2);
+    let id = env.view.selected_session.clone().unwrap();
+
+    env.view.handle_key(key(KeyCode::Char('d')), None);
+
+    assert!(
+        env.view.get_instance(&id).unwrap().is_trashed(),
+        "pressing d with default trash-first config must mark the row trashed in memory"
+    );
+    assert!(
+        env.view.unified_delete_dialog.is_none(),
+        "trash-first d must not open the permanent-delete dialog"
+    );
+    let disk_row = Storage::new_unwatched("test")
+        .unwrap()
+        .load()
+        .unwrap()
+        .into_iter()
+        .find(|inst| inst.id == id)
+        .expect("disk row present");
+    assert!(
+        disk_row.is_trashed(),
+        "pressing d must persist trashed_at so a storage refresh cannot resurrect a killed session"
+    );
+}
+
 /// When no session is selected, the toggle is a silent no-op.
 #[test]
 #[serial]


### PR DESCRIPTION
## Description
Fixes the TUI trash-first delete path so pressing `d` does not leave a killed tmux session visible as active after a storage refresh.

The fix persists `trashed_at` through `merge_user_action_diff` and only tears down tmux after the trash state is successfully applied. It also adds regression coverage for the default `d` trash path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot/recording: this is a TUI session-lifecycle persistence fix with focused Rust regression coverage.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the bug is covered by focused Rust tests for `merge_user_action_diff` and the TUI `d` key path without creating real tmux sessions.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Sisyphus / GPT-5.5 via OhMyOpenCode.

**Any Additional AI Details you'd like to share:**
Used parallel code/history investigation, targeted Rust tests, and a five-lane review pass for goal fit, QA, code quality, security, and missed context.

Validation:
- `nix develop -c cargo test --lib trash_marker`
- `nix develop -c cargo test --lib trash_then_restore_round_trip`
- `nix develop -c cargo test --lib test_d_on_session_opens_delete_dialog`
- `nix develop -c cargo fmt --check`
- `cargo clippy -- -D warnings` via pre-commit hook inside `nix develop`
- `GIT_MASTER=1 git diff --check main..HEAD`

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785248276&installation_id=139138837&pr_number=2520&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2520&signature=091067fcc8affcf3dc67f45580bbc782928d8311b5e7e650d24838f9c9e03331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change makes the trash-first delete flow behave correctly in the TUI.

It now keeps the trash state when session data is merged, and it delays tmux cleanup until after the trash action succeeds. A regression test was also added to cover the default `d` key behavior and confirm the trashed state stays saved after a refresh.

Benefits:
- Prevents trashed sessions from reappearing as active after refresh
- Avoids tearing down tmux before the delete state is safely recorded
- Adds coverage for the main delete shortcut path

<!-- end of auto-generated comment: release notes by coderabbit.ai -->