### PR TITLE
feat(session): add GitHub Copilot CLI session resume

### DIFF
--- a/docs/guides/session-fork.md
+++ b/docs/guides/session-fork.md
@@ -50,7 +50,7 @@ Forking needs an agent that can branch a conversation:
 - **Terminal sessions**: claude, codex, and opencode.
 - **Structured (ACP) sessions**: the Claude adapter (`claude-agent-acp`).
 
-Resume-only agents (such as gemini, vibe, kiro, and qwen) and non-resuming agents (such as cursor, copilot, and droid) cannot fork. For those, the Fork option is hidden or refused.
+Resume-only agents (such as gemini, vibe, kiro, qwen, and copilot) and non-resuming agents (such as cursor and droid) cannot fork. For those, the Fork option is hidden or refused.
 
 ## Fork vs. resume
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -615,7 +615,7 @@ pub const AGENTS: &[AgentDef] = &[
     },
     AgentDef {
         name: "copilot",
-        oneshot_flag: None,
+        oneshot_flag: Some("-p"),
         binary: "copilot",
         launch_subcommand: None,
         aliases: &["github-copilot"],
@@ -627,7 +627,13 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[("COPILOT_CONFIG_DIR", "/root/.copilot")],
         hook_config: None,
         sidecar_hooks: None,
-        resume_strategy: ResumeStrategy::Unsupported,
+        // Copilot records its live session id (a UUID) in the `sessions` table
+        // of `~/.copilot/session-store.db`; the poller captures it and resumes
+        // with `copilot --session-id <id>`. `--session-id` takes a required
+        // value, so the space-separated form `build_resume_flags` emits parses
+        // unambiguously; `--resume[=<id>]` takes an optional value and would
+        // read a space-separated id as a positional prompt instead.
+        resume_strategy: ResumeStrategy::Flag("--session-id"),
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,
         send_keys_enter_delay_ms: 0,
@@ -855,6 +861,22 @@ impl AgentDef {
         }
     }
 
+    /// Static argv tokens appended *after* the prompt for a one-shot
+    /// (smart-rename) title call. Only meaningful for flag-value one-shots
+    /// (`oneshot_flag` is a `-p`-style option whose value is the prompt): the
+    /// CLI binds the prompt to the flag, so these trailing flags cannot be read
+    /// as the prompt, and the prompt cannot be read as one of them. Copilot
+    /// needs `-s` (print only the final answer, no stats) plus
+    /// `--allow-all-tools --no-ask-user` so the non-interactive title call
+    /// never blocks on a permission or follow-up question. These are static,
+    /// never user input, so the no-injection contract holds.
+    pub fn oneshot_trailing_args(&self) -> &'static [&'static str] {
+        match self.name {
+            "copilot" => &["-s", "--allow-all-tools", "--no-ask-user"],
+            _ => &[],
+        }
+    }
+
     /// The base launch token(s) for the default (non-overridden) command:
     /// the binary, plus any `launch_subcommand` (e.g. `"kiro-cli chat"`). All
     /// subsequent flags (extra args, yolo, resume) are appended after this, so
@@ -1030,6 +1052,27 @@ mod tests {
                 "agent '{}' one-shot flag must not interpolate the prompt",
                 agent.name
             );
+            // The same single-token, no-interpolation contract applies to the
+            // static args inserted before and after the prompt.
+            for extra in agent
+                .oneshot_extra_args()
+                .iter()
+                .chain(agent.oneshot_trailing_args())
+            {
+                assert!(
+                    !extra.contains("{}"),
+                    "agent '{}' one-shot arg '{}' must not interpolate the prompt",
+                    agent.name,
+                    extra
+                );
+                assert_eq!(
+                    extra.split_whitespace().count(),
+                    1,
+                    "agent '{}' one-shot arg '{}' must be exactly one argv token",
+                    agent.name,
+                    extra
+                );
+            }
         }
     }
 
@@ -1071,6 +1114,31 @@ mod tests {
     #[test]
     fn test_get_agent_unknown() {
         assert!(get_agent("unknown").is_none());
+    }
+
+    #[test]
+    fn test_copilot_agent_definition() {
+        let copilot = get_agent("copilot").unwrap();
+        assert_eq!(copilot.binary, "copilot");
+        assert!(matches!(
+            &copilot.detection,
+            DetectionMethod::Which("copilot")
+        ));
+        assert!(matches!(&copilot.yolo, Some(YoloMode::CliFlag("--yolo"))));
+        // Copilot resumes a prior conversation with `copilot --session-id <id>`,
+        // where the id is captured from `~/.copilot/session-store.db`.
+        assert!(matches!(
+            &copilot.resume_strategy,
+            ResumeStrategy::Flag("--session-id")
+        ));
+        // One-shot title generation runs `copilot -p <prompt> -s
+        // --allow-all-tools --no-ask-user`.
+        assert_eq!(copilot.oneshot_flag, Some("-p"));
+        assert_eq!(
+            copilot.oneshot_trailing_args(),
+            &["-s", "--allow-all-tools", "--no-ask-user"]
+        );
+        assert!(!copilot.host_only);
     }
 
     #[test]

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -1993,15 +1993,15 @@ fn extract_gemini_fields(path: &std::path::Path) -> Option<(Option<String>, Opti
 ///
 /// Copilot records every session in the `sessions` table of `session-store.db`
 /// under its config dir (`$COPILOT_CONFIG_DIR`, default `~/.copilot`). Each row
-/// carries the session UUID (`id`), the working directory (`cwd`), and an ISO
-/// 8601 `updated_at` timestamp.
+/// carries the session UUID (`id`), the working directory (`cwd`), and an RFC
+/// 3339 `updated_at` timestamp.
 fn copilot_db_path() -> Result<PathBuf> {
     Ok(resolve_agent_home(Some("COPILOT_CONFIG_DIR"), ".copilot")?.join("session-store.db"))
 }
 
 /// Load Copilot's session rows from its SQLite store at `db_path`, newest
 /// first. Each row is `(id, cwd)`; rows without a `cwd` are skipped since they
-/// cannot be matched to a project. ISO 8601 `updated_at` strings sort
+/// cannot be matched to a project. RFC 3339 `updated_at` strings sort
 /// chronologically as text, so `ORDER BY updated_at DESC` yields most-recent
 /// first.
 fn read_copilot_sessions_from_sqlite_at(db_path: &Path) -> Result<Vec<(String, String)>> {
@@ -4088,7 +4088,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_capture_copilot_basic() {
+    fn test_copilot_capture_basic() {
         let tmp = create_copilot_test_db(&[
             (
                 "11111111-1111-4111-8111-111111111111",
@@ -4110,7 +4110,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_capture_copilot_filters_by_project_path() {
+    fn test_copilot_capture_filters_by_project_path() {
         let tmp = create_copilot_test_db(&[
             (
                 "33333333-3333-4333-8333-333333333333",
@@ -4131,7 +4131,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_capture_copilot_no_db() {
+    fn test_copilot_capture_no_db() {
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("COPILOT_CONFIG_DIR", tmp.path()) };
         let result = capture_copilot_session_id("/work/proj", &HashSet::new());

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -1987,6 +1987,113 @@ fn extract_gemini_fields(path: &std::path::Path) -> Option<(Option<String>, Opti
     Some((session_id, project_hash))
 }
 
+// ─── Copilot CLI session capture ──────────────────────────────────────────────
+
+/// Resolve the path to Copilot's local SQLite session store.
+///
+/// Copilot records every session in the `sessions` table of `session-store.db`
+/// under its config dir (`$COPILOT_CONFIG_DIR`, default `~/.copilot`). Each row
+/// carries the session UUID (`id`), the working directory (`cwd`), and an ISO
+/// 8601 `updated_at` timestamp.
+fn copilot_db_path() -> Result<PathBuf> {
+    Ok(resolve_agent_home(Some("COPILOT_CONFIG_DIR"), ".copilot")?.join("session-store.db"))
+}
+
+/// Load Copilot's session rows from its SQLite store at `db_path`, newest
+/// first. Each row is `(id, cwd)`; rows without a `cwd` are skipped since they
+/// cannot be matched to a project. ISO 8601 `updated_at` strings sort
+/// chronologically as text, so `ORDER BY updated_at DESC` yields most-recent
+/// first.
+fn read_copilot_sessions_from_sqlite_at(db_path: &Path) -> Result<Vec<(String, String)>> {
+    use rusqlite::{Connection, OpenFlags};
+
+    if !db_path.exists() {
+        anyhow::bail!("Copilot session store not found at {}", db_path.display());
+    }
+
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to open Copilot session store at {}",
+            db_path.display()
+        )
+    })?;
+    conn.busy_timeout(Duration::from_millis(100))
+        .context("Failed to set Copilot session store busy timeout")?;
+
+    let mut stmt = conn
+        .prepare("SELECT id, cwd FROM sessions WHERE cwd IS NOT NULL ORDER BY updated_at DESC")
+        .context("Copilot sessions table schema mismatch")?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            let id: String = row.get(0)?;
+            let cwd: String = row.get(1)?;
+            Ok((id, cwd))
+        })
+        .context("Failed to query Copilot sessions table")?;
+
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for row in rows {
+        entries.push(row.context("Failed to read Copilot session row")?);
+    }
+    Ok(entries)
+}
+
+/// Pick the newest unexcluded Copilot session whose `cwd` matches `match_path`.
+///
+/// `entries` are `(id, cwd)` pairs in newest-first order. Paths are compared
+/// after canonicalization so a symlinked or `/tmp` -> `/private/tmp` cwd still
+/// matches; a now-deleted cwd falls back to a raw string compare.
+fn select_copilot_session(
+    entries: &[(String, String)],
+    match_path: &str,
+    exclusion: &HashSet<String>,
+) -> Result<String> {
+    let canonical_match = canonicalize_or_raw(match_path);
+    entries
+        .iter()
+        .find(|(id, cwd)| !exclusion.contains(id) && canonicalize_or_raw(cwd) == canonical_match)
+        .map(|(id, _)| id.clone())
+        .ok_or_else(|| anyhow::anyhow!("No Copilot session found matching project path"))
+}
+
+/// Capture a Copilot session ID for `project_path`.
+///
+/// Reads the `sessions` table of `~/.copilot/session-store.db` (or
+/// `$COPILOT_CONFIG_DIR/session-store.db`) newest-first and returns the UUID of
+/// the most recently updated session whose recorded `cwd` matches
+/// `project_path`, skipping any IDs in `exclusion`. Copilot resumes that UUID
+/// with `copilot --session-id <id>`.
+pub(crate) fn capture_copilot_session_id(
+    project_path: &str,
+    exclusion: &HashSet<String>,
+) -> Result<String> {
+    let db_path = copilot_db_path()?;
+    let entries = read_copilot_sessions_from_sqlite_at(&db_path)?;
+    select_copilot_session(&entries, project_path, exclusion)
+}
+
+/// Polling closure for Copilot CLI session tracking.
+pub(crate) fn copilot_poll_fn(
+    project_path: String,
+    instance_id: String,
+    extra_excludes: HashSet<String>,
+) -> impl Fn() -> Option<String> + Send + 'static {
+    move || {
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
+        capture_copilot_session_id(&project_path, &exclusion)
+            .map_err(
+                |e| tracing::debug!(target: "session.capture", "Copilot poll capture failed: {}", e),
+            )
+            .ok()
+            .and_then(validated_session_id)
+    }
+}
+
 // ─── Hermes session capture ───────────────────────────────────────────────────
 
 const HERMES_COMMAND_TIMEOUT_SECS: u64 = 5;
@@ -3924,6 +4031,112 @@ mod tests {
     #[test]
     fn test_hermes_session_id_format_valid() {
         assert!(is_valid_session_id("20260429_193246_adcddd"));
+    }
+
+    fn create_copilot_test_db(rows: &[(&str, &str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("session-store.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                cwd TEXT,
+                updated_at TEXT
+            );",
+        )
+        .unwrap();
+        for (id, cwd, updated_at) in rows {
+            conn.execute(
+                "INSERT INTO sessions (id, cwd, updated_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![id, cwd, updated_at],
+            )
+            .unwrap();
+        }
+        drop(conn);
+        dir
+    }
+
+    #[test]
+    fn test_select_copilot_session_matches_cwd_newest_first() {
+        let entries = vec![
+            ("newer".to_string(), "/work/proj".to_string()),
+            ("older".to_string(), "/work/proj".to_string()),
+            ("other".to_string(), "/work/elsewhere".to_string()),
+        ];
+        // ORDER BY updated_at DESC already put the newest match first.
+        let result = select_copilot_session(&entries, "/work/proj", &HashSet::new()).unwrap();
+        assert_eq!(result, "newer");
+    }
+
+    #[test]
+    fn test_select_copilot_session_skips_excluded() {
+        let entries = vec![
+            ("newer".to_string(), "/work/proj".to_string()),
+            ("older".to_string(), "/work/proj".to_string()),
+        ];
+        let exclusion: HashSet<String> = ["newer".to_string()].into_iter().collect();
+        let result = select_copilot_session(&entries, "/work/proj", &exclusion).unwrap();
+        assert_eq!(result, "older");
+    }
+
+    #[test]
+    fn test_select_copilot_session_no_cwd_match_errs() {
+        let entries = vec![("a".to_string(), "/work/elsewhere".to_string())];
+        let result = select_copilot_session(&entries, "/work/proj", &HashSet::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn test_capture_copilot_basic() {
+        let tmp = create_copilot_test_db(&[
+            (
+                "11111111-1111-4111-8111-111111111111",
+                "/work/proj",
+                "2026-06-28T10:00:00.000Z",
+            ),
+            (
+                "22222222-2222-4222-8222-222222222222",
+                "/work/proj",
+                "2026-06-28T12:00:00.000Z",
+            ),
+        ]);
+        unsafe { std::env::set_var("COPILOT_CONFIG_DIR", tmp.path()) };
+        let result = capture_copilot_session_id("/work/proj", &HashSet::new()).unwrap();
+        unsafe { std::env::remove_var("COPILOT_CONFIG_DIR") };
+        // Newest updated_at wins.
+        assert_eq!(result, "22222222-2222-4222-8222-222222222222");
+    }
+
+    #[test]
+    #[serial]
+    fn test_capture_copilot_filters_by_project_path() {
+        let tmp = create_copilot_test_db(&[
+            (
+                "33333333-3333-4333-8333-333333333333",
+                "/work/other",
+                "2026-06-28T12:00:00.000Z",
+            ),
+            (
+                "44444444-4444-4444-8444-444444444444",
+                "/work/proj",
+                "2026-06-28T10:00:00.000Z",
+            ),
+        ]);
+        unsafe { std::env::set_var("COPILOT_CONFIG_DIR", tmp.path()) };
+        let result = capture_copilot_session_id("/work/proj", &HashSet::new()).unwrap();
+        unsafe { std::env::remove_var("COPILOT_CONFIG_DIR") };
+        assert_eq!(result, "44444444-4444-4444-8444-444444444444");
+    }
+
+    #[test]
+    #[serial]
+    fn test_capture_copilot_no_db() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("COPILOT_CONFIG_DIR", tmp.path()) };
+        let result = capture_copilot_session_id("/work/proj", &HashSet::new());
+        unsafe { std::env::remove_var("COPILOT_CONFIG_DIR") };
+        assert!(result.is_err());
     }
 
     fn create_opencode_test_db(rows: &[(&str, &str, i64)]) -> (tempfile::TempDir, PathBuf) {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1973,7 +1973,14 @@ impl Instance {
             // A fork is a fresh session, not an in-place resume.
             return false;
         }
-        let (session_id, is_existing) = self.acquire_session_id();
+        let (mut session_id, is_existing) = self.acquire_session_id();
+        // Sandboxed Copilot starts fresh: the session db lives inside the
+        // container, so a host-captured or manually pinned sid would launch
+        // `--session-id <id>` against a UUID that does not resolve there.
+        // Capture is already host-only above; drop the sid to gate emission too.
+        if self.tool == "copilot" && self.is_sandboxed() {
+            session_id = None;
+        }
         let emitted =
             append_resume_flags(&self.tool, session_id.as_deref(), is_existing, cmd, context);
         is_existing && emitted

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -19,16 +19,16 @@ use super::poller::SessionPoller;
 
 use crate::session::capture::{
     capture_claude_session_id, capture_claude_session_id_in_container, capture_codex_session_id,
-    capture_gemini_session_id, capture_hermes_session_id, capture_pi_session_id,
-    capture_vibe_session_id, claude_poll_fn, claude_poll_fn_sandboxed, codex_poll_fn,
-    codex_poll_fn_sandboxed, gemini_poll_fn, gemini_poll_fn_sandboxed, generate_claude_session_id,
-    hermes_poll_fn, hermes_poll_fn_sandboxed, is_valid_session_id, opencode_poll_fn,
-    opencode_poll_fn_sandboxed, pi_poll_fn, pi_poll_fn_sandboxed,
-    try_capture_codex_session_id_in_container, try_capture_gemini_session_id_in_container,
-    try_capture_hermes_session_id_in_container, try_capture_opencode_session_id,
-    try_capture_opencode_session_id_in_container, try_capture_pi_session_id_in_container,
-    try_capture_vibe_session_id_in_container, validated_session_id, vibe_poll_fn,
-    vibe_poll_fn_sandboxed,
+    capture_copilot_session_id, capture_gemini_session_id, capture_hermes_session_id,
+    capture_pi_session_id, capture_vibe_session_id, claude_poll_fn, claude_poll_fn_sandboxed,
+    codex_poll_fn, codex_poll_fn_sandboxed, copilot_poll_fn, gemini_poll_fn,
+    gemini_poll_fn_sandboxed, generate_claude_session_id, hermes_poll_fn, hermes_poll_fn_sandboxed,
+    is_valid_session_id, opencode_poll_fn, opencode_poll_fn_sandboxed, pi_poll_fn,
+    pi_poll_fn_sandboxed, try_capture_codex_session_id_in_container,
+    try_capture_gemini_session_id_in_container, try_capture_hermes_session_id_in_container,
+    try_capture_opencode_session_id, try_capture_opencode_session_id_in_container,
+    try_capture_pi_session_id_in_container, try_capture_vibe_session_id_in_container,
+    validated_session_id, vibe_poll_fn, vibe_poll_fn_sandboxed,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1894,6 +1894,18 @@ impl Instance {
                     capture_hermes_session_id(&self.project_path, &exclusion).ok()
                 }
             }
+            "copilot" => {
+                // Copilot stores sessions in a SQLite db. Host capture reads it
+                // directly; sandbox resume is a follow-up (the container's db is
+                // not read over `docker exec`), so a sandboxed Copilot session
+                // simply starts fresh on restart.
+                if self.is_sandboxed() {
+                    None
+                } else {
+                    let exclusion = self.retroactive_capture_exclusion_set();
+                    capture_copilot_session_id(&self.project_path, &exclusion).ok()
+                }
+            }
             _ => None,
         };
         result.and_then(validated_session_id)
@@ -3387,6 +3399,20 @@ impl Instance {
                         extra_excludes,
                     ))
                 }
+            }
+            "copilot" => {
+                // Host-only: the Copilot session-store SQLite db is read
+                // directly on the host. Sandboxed sessions have no poller, so
+                // their session id is never captured and they start fresh on
+                // restart (sandbox resume is a follow-up).
+                if self.is_sandboxed() {
+                    return;
+                }
+                Box::new(copilot_poll_fn(
+                    self.project_path.clone(),
+                    self.id.clone(),
+                    extra_excludes,
+                ))
             }
             _ => return,
         };
@@ -7105,6 +7131,7 @@ mod tests {
             assert!(should_attempt_resume(Some("session_abc.123"), "opencode"));
             assert!(should_attempt_resume(Some("uuid-abc-123"), "codex"));
             assert!(should_attempt_resume(Some("uuid-abc-123"), "gemini"));
+            assert!(should_attempt_resume(Some("uuid-abc-123"), "copilot"));
         }
 
         #[test]
@@ -7112,10 +7139,6 @@ mod tests {
             assert!(!should_attempt_resume(
                 Some("11111111-1111-1111-1111-111111111111"),
                 "cursor"
-            ));
-            assert!(!should_attempt_resume(
-                Some("11111111-1111-1111-1111-111111111111"),
-                "copilot"
             ));
         }
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -2,8 +2,8 @@
 //!
 //! After a system reboot, tmux loses all its sessions. AoE sessions whose
 //! agent supports `--resume <sid>` (claude, opencode, codex, gemini, vibe,
-//! pi, hermes, kiro, qwen) can be transparently recreated by replaying the
-//! resume cascade in `start_with_resume_fallback`. This module centralises
+//! pi, hermes, kiro, qwen, copilot) can be transparently recreated by replaying
+//! the resume cascade in `start_with_resume_fallback`. This module centralises
 //! the candidate selection and the cross-process exclusion needed to make
 //! that safe when both the TUI (`aoe`) and the daemon (`aoe serve`) are
 //! running.

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -206,17 +206,24 @@ pub fn build_prompt(user_message: &str) -> String {
 }
 
 /// Build the argv for a one-shot title call, or `None` when the agent has no
-/// known one-shot mode. Always `[binary, oneshot_token, prompt]`: the prompt is
-/// a single argv element passed straight to the process, never interpolated
-/// into a shell string, so untrusted user text cannot inject arguments.
+/// known one-shot mode. Shape is `[binary, oneshot_token, extra.., prompt,
+/// trailing..]`: the prompt is a single argv element passed straight to the
+/// process, never interpolated into a shell string, so untrusted user text
+/// cannot inject arguments. `oneshot_trailing_args` is only populated for
+/// flag-value one-shots (e.g. copilot `-p`), where the CLI binds the prompt to
+/// the flag, so trailing flags after it stay unambiguous.
 pub fn build_oneshot_argv(agent: &agents::AgentDef, prompt: &str) -> Option<Vec<String>> {
     let token = agent.oneshot_flag?;
     let mut argv = vec![agent.binary.to_string(), token.to_string()];
     // Static per-agent flags (e.g. codex `--skip-git-repo-check`) go between the
-    // one-shot token and the prompt; the prompt stays the final argv element so
+    // one-shot token and the prompt; the prompt stays directly after them so
     // untrusted user text can never be read as an argument.
     argv.extend(agent.oneshot_extra_args().iter().map(|s| s.to_string()));
     argv.push(prompt.to_string());
+    // Static trailing flags (e.g. copilot `-s --allow-all-tools --no-ask-user`)
+    // follow the prompt for flag-value one-shots; the CLI has already bound the
+    // prompt to the one-shot flag, so these parse as options, not the prompt.
+    argv.extend(agent.oneshot_trailing_args().iter().map(|s| s.to_string()));
     Some(argv)
 }
 
@@ -709,6 +716,27 @@ mod tests {
         assert_eq!(
             build_oneshot_argv(claude(), "name this").unwrap(),
             vec!["claude", "-p", "name this"]
+        );
+    }
+
+    #[test]
+    fn argv_copilot_appends_silent_autoapprove_flags_after_prompt() {
+        // Copilot's `-p` binds the prompt as its value, so the auto-approve and
+        // silent flags follow the prompt. Without them a non-interactive title
+        // call can block on a permission prompt or print stats that pollute the
+        // title; with them stdout is just the final answer.
+        let argv = build_oneshot_argv(agents::get_agent("copilot").unwrap(), "name this")
+            .expect("copilot one-shot");
+        assert_eq!(
+            argv,
+            vec![
+                "copilot",
+                "-p",
+                "name this",
+                "-s",
+                "--allow-all-tools",
+                "--no-ask-user"
+            ]
         );
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1059,11 +1059,13 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
     }
 
     // Empty ready prompt: Copilot's idle footer is `/ commands · ? help · tab
-    // next tab`. `tab next tab` and `? help` only render at the ready prompt
-    // (Working and approval footers differ), so they mark the turn as done and
-    // waiting for the user. `copilot>` is kept for custom wrappers/older builds.
-    if last_lines_lower.contains("tab next tab")
-        || last_lines_lower.contains("? help")
+    // next tab`. Require all three tokens together so ordinary prose mentioning
+    // `? help` or `tab next tab` mid-turn does not falsely read as Waiting; the
+    // full footer only renders at the ready prompt (Working and approval footers
+    // differ). `copilot>` is kept for custom wrappers/older builds.
+    if (last_lines_lower.contains("/ commands")
+        && last_lines_lower.contains("? help")
+        && last_lines_lower.contains("tab next tab"))
         || matches_input_prompt(&non_empty_lines, 10, &["copilot>"])
     {
         return Status::Waiting;
@@ -2831,6 +2833,13 @@ run this command? (y/n)
     fn test_detect_copilot_status_idle() {
         assert_eq!(detect_copilot_status("file saved"), Status::Idle);
         assert_eq!(detect_copilot_status("random output text"), Status::Idle);
+        // Prose mentioning footer phrases without the full footer must not read
+        // as Waiting: only the complete `/ commands · ? help · tab next tab`
+        // shape (or `copilot>`) marks the turn done.
+        assert_eq!(
+            detect_copilot_status("need more? help is available; use tab next tab to switch"),
+            Status::Idle
+        );
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1001,8 +1001,15 @@ fn cursor_is_follow_up_prompt(line: &str) -> bool {
 }
 
 /// Copilot CLI status detection via tmux pane parsing.
-/// Copilot CLI is a full-screen TUI. It shows "Thinking" while the model is
-/// processing and displays tool approval prompts when actions need confirmation.
+///
+/// Copilot CLI (v1.0.65) is a full-screen TUI rendered inside a bordered input
+/// box. The bottom status line is the reliable signal:
+///   - `◎ Working ... esc cancel` while the model is generating (Running).
+///   - `/ commands · ? help · tab next tab` when parked at an empty prompt,
+///     ready for the next message (Waiting).
+///   - a numbered choice list with `enter to select` / `esc to cancel` for a
+///     tool/folder-trust approval (Waiting). `--yolo` (allow-all-paths +
+///     allow-all-tools) suppresses most of these.
 pub fn detect_copilot_status(raw_content: &str) -> Status {
     let content = raw_content.to_lowercase();
     let lines: Vec<&str> = content.lines().collect();
@@ -1030,6 +1037,9 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
         || last_lines_lower.contains("working")
         || last_lines_lower.contains("esc to interrupt")
         || last_lines_lower.contains("ctrl+c to interrupt")
+        // Copilot's live footer reads `◎ Working ... esc cancel`; key on the
+        // interrupt hint too so a verb change doesn't drop the Running signal.
+        || last_lines_lower.contains("esc cancel")
     {
         return Status::Running;
     }
@@ -1048,7 +1058,14 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
         return Status::Waiting;
     }
 
-    if matches_input_prompt(&non_empty_lines, 10, &["copilot>"]) {
+    // Empty ready prompt: Copilot's idle footer is `/ commands · ? help · tab
+    // next tab`. `tab next tab` and `? help` only render at the ready prompt
+    // (Working and approval footers differ), so they mark the turn as done and
+    // waiting for the user. `copilot>` is kept for custom wrappers/older builds.
+    if last_lines_lower.contains("tab next tab")
+        || last_lines_lower.contains("? help")
+        || matches_input_prompt(&non_empty_lines, 10, &["copilot>"])
+    {
         return Status::Waiting;
     }
 
@@ -2783,6 +2800,11 @@ run this command? (y/n)
         );
         assert_eq!(detect_copilot_status("working ⠋"), Status::Running);
         assert_eq!(detect_copilot_status("loading ⠹"), Status::Running);
+        // Real v1.0.65 working footer.
+        assert_eq!(
+            detect_copilot_status("┃\n◎ Working esc cancel    MAI-Code-1-Flash"),
+            Status::Running
+        );
     }
 
     #[test]
@@ -2798,6 +2820,11 @@ run this command? (y/n)
         );
         assert_eq!(detect_copilot_status("done\n>"), Status::Waiting);
         assert_eq!(detect_copilot_status("done\ncopilot>"), Status::Waiting);
+        // Real v1.0.65 idle/ready footer: turn done, waiting for the next message.
+        assert_eq!(
+            detect_copilot_status("answer text\n┃\n/ commands · ? help · tab next tab"),
+            Status::Waiting
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Promotes GitHub Copilot CLI from a second-class agent (`ResumeStrategy::Unsupported`, no one-shot, brittle pane scraping) to a first-class resumable agent, mirroring the session-resume series for OpenCode (#850), Codex (#853), and Gemini CLI (#854).

- Resume: Copilot's `resume_strategy` is now `Flag("--session-id")`. The session-id poller reads Copilot's live session UUID from the `sessions` table of `~/.copilot/session-store.db` (newest-first, matched by project path), mirroring the OpenCode SQLite reader. Each relaunch resumes with `copilot --session-id <id>`, and startup auto-recovery revives Copilot sessions after a reboot.
- Why `--session-id` and not `--resume`: against copilot v1.0.65, `--resume[=value]` takes an optional value (only binds with the `=` form), while `--session-id <id>` takes a required value and parses with the space-separated form `build_resume_flags` emits.
- One-shot and smart rename: Copilot now exposes `-p` print mode. The non-interactive title call runs `copilot -p <prompt> -s --allow-all-tools --no-ask-user`; the silent and auto-approve flags follow the prompt because `-p` binds the prompt as its value.
- Status detection now keys on the real v1.0.65 TUI footers (the working footer for Running, the ready footer for Waiting) instead of a `copilot>` prompt the TUI never renders.

Scope note: host resume is fully implemented. Sandboxed (Docker) Copilot resume is a documented follow-up (the container's SQLite store is not read over `docker exec`).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated tests: unit tests for Copilot session-id capture/selection (`capture.rs`), the resume strategy and one-shot argv (`agents.rs`, `smart_rename.rs`), `should_attempt_resume`, and the new TUI status markers (`status_detection.rs`), mirroring the Codex/Gemini resume tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** opencode (AI-assisted)

**Any Additional AI Details you'd like to share:** Resume, one-shot, and status markers were verified hands-on against the real copilot CLI v1.0.65 on this machine: creating a session and then relaunching with `copilot --session-id <id>` retained context, and one-shot `-p` exits cleanly with only the final answer.

- [ ] I am an AI Agent filling out this form (check box if true)

## Testing (on this machine)

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all --check`, and `cargo test --lib` (3526 passed) are clean. The resume command was verified against the live CLI as described above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785254575&installation_id=139138837&pr_number=2521&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2521&signature=8bbe5a3e7827ad61dd9cd8a13ccb733b29bee63a51e445fc70e93c978ba6d68e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds first-class session resume support for GitHub Copilot CLI and improves how Copilot is launched, monitored, and used for non-interactive flows.

In short:
- **Copilot can now resume on relaunch** from a previously captured **host** session via `copilot --session-id <id>`, instead of always starting fresh.
- The app **discovers the best matching session** by reading `~/.copilot/session-store.db` and selecting the newest unexcluded entry whose stored working directory matches the current project.
- **Docker/sandboxed Copilot resume remains blocked**; additionally, sandboxed runs no longer reuse persisted Copilot session IDs.
- **Non-interactive one-shot “title generation”** is updated so the prompt is passed as the value to `-p`, and Copilot’s required one-shot flags are appended **after** the prompt.
- **Copilot status detection** was refreshed for Copilot v1.0.65 by switching to **footer-marker based cues** (with stricter “ready/footer” matching to avoid false positives).
- Tests were added/updated to cover **session capture/selection**, **resume attempts**, **one-shot argv handling**, and **new status markers**.

Benefits:
- More reliable recovery of Copilot work after interruptions or reboots (host session auto-recovery).
- Safer, more predictable automation (correct argv/flag ordering for non-interactive title generation).
- More trustworthy Copilot terminal status (accurate Running vs Waiting detection using v1.0.65 footer signals).

Potential areas to improve:
- CI still appears **not fully clean**, despite local test/lint passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->