### PR TITLE
feat(plugins): client-executed command actions, with open-ui-link in the cmd+k palette and keymap

### DIFF
--- a/aoe-plugin-api/src/capability.rs
+++ b/aoe-plugin-api/src/capability.rs
@@ -82,6 +82,10 @@ pub const KNOWN_CAPABILITIES: &[&str] = &[
     "clipboard.write",
     // Posting desktop / TUI notifications.
     "notifications",
+    // Opening an external URL in the user's browser, driven by a command's
+    // `action` (or a future host RPC). Distinct from a rendered `href` anchor
+    // the user clicks, which needs no grant.
+    "browser_open",
 ];
 
 /// How far a plugin is trusted. Host-assigned at load time, never declared in

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -18,9 +18,9 @@ mod manifest;
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
-    screenshot_path_ok, BuildStep, CommandContribution, KeybindContribution, ManifestError,
-    PluginManifest, RuntimeSpec, Screenshot, SettingContribution, SettingType, StatusContribution,
-    ThemeContribution, UiContribution, UiSlot, MAX_SCREENSHOTS,
+    screenshot_path_ok, BuildStep, ClientAction, CommandContribution, KeybindContribution,
+    ManifestError, PluginManifest, RuntimeSpec, Screenshot, SettingContribution, SettingType,
+    StatusContribution, ThemeContribution, UiContribution, UiSlot, MAX_SCREENSHOTS,
 };
 
 /// Version of the manifest schema and host API this crate describes.
@@ -31,5 +31,6 @@ pub use manifest::{
 /// the `detail-panel` slot became the dockable `pane` slot (with
 /// `default_location`); 4 when the `status` contribution section and the
 /// `aoe_version` host-compatibility field were added; 5 when the `screenshots`
-/// presentation metadata was added.
-pub const API_VERSION: u32 = 5;
+/// presentation metadata was added; 6 when a command could declare a
+/// client-executed `action` (`ClientAction`).
+pub const API_VERSION: u32 = 6;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -615,9 +615,13 @@ impl PluginManifest {
                     format!("commands[{i}].action open-ui-link slot must be per-session"),
                 );
                 check(
-                    self.ui.iter().any(|u| u.slot == *slot && &u.id == id),
+                    self.ui
+                        .iter()
+                        .filter(|u| u.slot == *slot && &u.id == id)
+                        .count()
+                        == 1,
                     format!(
-                        "commands[{i}].action references undeclared ui slot ({}, {id})",
+                        "commands[{i}].action must reference exactly one ui slot ({}, {id})",
                         slot.as_str()
                     ),
                 );
@@ -858,7 +862,21 @@ mod tests {
         ))
         .unwrap_err()
         .to_string();
-        assert!(err.contains("undeclared ui slot"), "{err}");
+        assert!(err.contains("exactly one ui slot"), "{err}");
+    }
+
+    #[test]
+    fn open_ui_link_rejects_duplicate_slot() {
+        // Two ui contributions declare the same per-session (slot, id), so the
+        // action's target is ambiguous and must be rejected.
+        let err = PluginManifest::from_toml_str(
+            "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"1.0.0\"\napi_version = 6\ncapabilities = [\"browser_open\"]\n\n\
+             [[ui]]\nslot = \"row-column\"\nid = \"link\"\n\n[[ui]]\nslot = \"row-column\"\nid = \"link\"\n\n\
+             [[commands]]\nid = \"open\"\n[commands.action]\nkind = \"open-ui-link\"\nslot = \"row-column\"\nid = \"link\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("exactly one ui slot"), "{err}");
     }
 
     #[test]

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -101,6 +101,26 @@ pub struct CommandContribution {
     pub title: String,
     #[serde(default)]
     pub description: String,
+    /// How invoking the command behaves. Absent means a fire-and-forget worker
+    /// notification (deferred). When present, the host surface executes the
+    /// action directly, synchronously inside the user's gesture, so it works on
+    /// a remote web dashboard where an async round-trip would be popup-blocked.
+    /// Requires `api_version >= 6` and the `browser_open` capability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<ClientAction>,
+}
+
+/// A client-executed command action: the host surface (web dashboard, TUI) runs
+/// it directly rather than forwarding to the worker. Tagged by `kind` so future
+/// action shapes extend the set without breaking existing manifests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ClientAction {
+    /// Open the `href` carried by this plugin's own `(slot, id)` UI-state entry
+    /// for the active session, in the user's browser. The href is read from the
+    /// snapshot the surface already holds, so no worker call is made; the slot
+    /// must be per-session.
+    OpenUiLink { slot: UiSlot, id: String },
 }
 
 /// A keybind the plugin contributes, binding a key chord to a command.
@@ -572,11 +592,36 @@ impl PluginManifest {
         // Contribution sections declare required identifiers; an empty one would
         // install and persist a malformed manifest, so reject it here rather
         // than push the cleanup onto the later consumers (#2094 / #2095 / #2366).
+        let has_browser_open = self
+            .capabilities
+            .iter()
+            .any(|c| c.as_str() == "browser_open");
         for (i, c) in self.commands.iter().enumerate() {
             check(
                 !c.id.is_empty(),
                 format!("commands[{i}].id must not be empty"),
             );
+            if let Some(ClientAction::OpenUiLink { slot, id }) = &c.action {
+                check(
+                    self.api_version >= 6,
+                    format!("commands[{i}].action requires api_version >= 6"),
+                );
+                check(
+                    has_browser_open,
+                    format!("commands[{i}].action needs the `browser_open` capability"),
+                );
+                check(
+                    slot.is_per_session(),
+                    format!("commands[{i}].action open-ui-link slot must be per-session"),
+                );
+                check(
+                    self.ui.iter().any(|u| u.slot == *slot && &u.id == id),
+                    format!(
+                        "commands[{i}].action references undeclared ui slot ({}, {id})",
+                        slot.as_str()
+                    ),
+                );
+            }
         }
         for (i, k) in self.keybinds.iter().enumerate() {
             check(
@@ -743,6 +788,78 @@ impl PluginManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn open_ui_link_toml(api_version: u32, caps: &str, ui_slot: &str, action_slot: &str) -> String {
+        format!(
+            "id = \"acme.thing\"\nname = \"Thing\"\nversion = \"1.0.0\"\napi_version = {api_version}\ncapabilities = [{caps}]\n\n\
+             [[ui]]\nslot = \"{ui_slot}\"\nid = \"link\"\n\n\
+             [[commands]]\nid = \"open\"\ntitle = \"Open\"\n[commands.action]\nkind = \"open-ui-link\"\nslot = \"{action_slot}\"\nid = \"link\"\n"
+        )
+    }
+
+    #[test]
+    fn open_ui_link_action_valid() {
+        let m = PluginManifest::from_toml_str(&open_ui_link_toml(
+            6,
+            "\"browser_open\"",
+            "row-column",
+            "row-column",
+        ))
+        .expect("manifest parses");
+        assert!(matches!(
+            m.commands[0].action,
+            Some(ClientAction::OpenUiLink { .. })
+        ));
+    }
+
+    #[test]
+    fn open_ui_link_requires_capability() {
+        let err =
+            PluginManifest::from_toml_str(&open_ui_link_toml(6, "", "row-column", "row-column"))
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("browser_open"), "{err}");
+    }
+
+    #[test]
+    fn open_ui_link_requires_api_version_6() {
+        let err = PluginManifest::from_toml_str(&open_ui_link_toml(
+            5,
+            "\"browser_open\"",
+            "row-column",
+            "row-column",
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("api_version"), "{err}");
+    }
+
+    #[test]
+    fn open_ui_link_rejects_global_slot() {
+        let err = PluginManifest::from_toml_str(&open_ui_link_toml(
+            6,
+            "\"browser_open\"",
+            "status-bar",
+            "status-bar",
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("per-session"), "{err}");
+    }
+
+    #[test]
+    fn open_ui_link_requires_declared_slot() {
+        // Declares a row-badge ui slot but the action points at row-column.
+        let err = PluginManifest::from_toml_str(&open_ui_link_toml(
+            6,
+            "\"browser_open\"",
+            "row-badge",
+            "row-column",
+        ))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("undeclared ui slot"), "{err}");
+    }
 
     #[test]
     fn setting_type_accepts_boolean_and_bool() {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -37,9 +37,10 @@ pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
 pub use plugins::{
-    apply_plugin_update, dismiss_plugin_update, invoke_plugin_action, list_plugins, plugin_details,
-    plugin_discover, plugin_job_status, plugin_ui_state, plugin_update_preview, plugin_updates,
-    preview_plugin_install, set_plugin_enabled, start_plugin_install, start_plugin_uninstall,
+    apply_plugin_update, dismiss_plugin_update, invoke_plugin_action, list_plugins,
+    plugin_commands, plugin_details, plugin_discover, plugin_job_status, plugin_ui_state,
+    plugin_update_preview, plugin_updates, preview_plugin_install, set_plugin_enabled,
+    start_plugin_install, start_plugin_uninstall,
 };
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -64,6 +64,52 @@ pub async fn list_plugins() -> Json<serde_json::Value> {
     }))
 }
 
+/// One active plugin command, normalized for the dashboard command palette and
+/// keymap: the namespaced `fqid`, its declared keybind chords, and its optional
+/// client-executed `action`. The web binds and renders these without parsing
+/// raw manifests.
+#[derive(Serialize)]
+struct PluginCommandView {
+    fqid: String,
+    plugin_id: String,
+    id: String,
+    title: String,
+    description: String,
+    keybinds: Vec<String>,
+    action: Option<aoe_plugin_api::ClientAction>,
+}
+
+/// `GET /api/plugins/commands`: active plugins' contributed commands, each with
+/// the chords bound to it and its client action. Reads the registry (manifests),
+/// not workers, so it is safe in read-only mode.
+pub async fn plugin_commands() -> Json<serde_json::Value> {
+    let registry = plugin::registry();
+    let mut commands = Vec::new();
+    for p in registry.active() {
+        let plugin_id = p.id().to_string();
+        for c in &p.manifest.commands {
+            let fqid = format!("plugin.{plugin_id}.{}", c.id);
+            let keybinds = p
+                .manifest
+                .keybinds
+                .iter()
+                .filter(|kb| kb.command == c.id || kb.command == fqid)
+                .map(|kb| kb.key.clone())
+                .collect();
+            commands.push(PluginCommandView {
+                fqid: fqid.clone(),
+                plugin_id: plugin_id.clone(),
+                id: c.id.clone(),
+                title: c.title.clone(),
+                description: c.description.clone(),
+                keybinds,
+                action: c.action.clone(),
+            });
+        }
+    }
+    Json(json!({ "commands": commands }))
+}
+
 /// `GET /api/plugins/ui-state`: the plugin host's aggregated UI-state snapshot
 /// (the slots workers have pushed, plus the notification ring). Empty when no
 /// host is running (read-only mode, or a TUI-only build with no daemon). The

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1554,6 +1554,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Plugin management. The enable/disable toggle gates on read-only +
         // elevation inside the handler.
         .route("/api/plugins", get(api::list_plugins))
+        .route("/api/plugins/commands", get(api::plugin_commands))
         .route("/api/plugins/ui-state", get(api::plugin_ui_state))
         .route("/api/plugins/updates", get(api::plugin_updates))
         .route("/api/plugins/discover", get(api::plugin_discover))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import { useDiffComments } from "./hooks/useDiffComments";
 import { clearStoredComments, sweepOrphanComments } from "./components/diff/comments/storage";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
 import { useCommandActions, buildConversationActions } from "./hooks/useCommandActions";
+import { usePluginCommands } from "./hooks/usePluginCommands";
 import { useSettingsCommands } from "./hooks/useSettingsCommands";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
@@ -1346,6 +1347,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     readOnly: !!serverAbout?.read_only,
     onOpenSettingsTab: openSettingsTab,
   });
+  const pluginCommandActions = usePluginCommands(pluginUiEntries, activeSessionId);
 
   // Conversation-content search for the palette (#2515). paletteQuery is
   // declared above (near showPalette) so the keyboard handlers can clear it
@@ -1882,7 +1884,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             setShowPalette(false);
             setPaletteQuery("");
           }}
-          actions={[...commandActions, ...conversationActions, ...settingsCommands]}
+          actions={[...commandActions, ...conversationActions, ...settingsCommands, ...pluginCommandActions]}
           onSearchChange={setPaletteQuery}
           searching={conversationSearching}
         />

--- a/web/src/hooks/usePluginCommands.ts
+++ b/web/src/hooks/usePluginCommands.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { fetchPluginCommands, type PluginCommand, type PluginUiEntry } from "../lib/api";
+import type { CommandAction } from "../components/command-palette/types";
+import {
+  buildPluginCommandActions,
+  matchPluginChord,
+  openExternal,
+  parsePluginChord,
+  resolveCommandHref,
+} from "../lib/pluginCommands";
+
+/** Surfaces active plugin commands as palette actions and binds their declared
+ *  keybinds. `open-ui-link` commands open the active session's PR href from the
+ *  UI-state snapshot, synchronously in the key/click handler so a remote
+ *  dashboard is not popup-blocked. The keybind fires whenever the href resolves,
+ *  independent of whether the (href-gated) palette entry is shown. */
+export function usePluginCommands(entries: PluginUiEntry[], activeSessionId: string | null): CommandAction[] {
+  const [commands, setCommands] = useState<PluginCommand[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    void fetchPluginCommands().then((res) => {
+      if (alive && res) setCommands(res.commands);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const actions = useMemo(
+    () => buildPluginCommandActions(commands, entries, activeSessionId),
+    [commands, entries, activeSessionId],
+  );
+
+  // The listener reads live state through a ref so it registers once rather than
+  // re-binding on every ui-state poll.
+  const live = useRef({ commands, entries, activeSessionId });
+  useEffect(() => {
+    live.current = { commands, entries, activeSessionId };
+  });
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
+      const { commands, entries, activeSessionId } = live.current;
+      for (const cmd of commands) {
+        if (cmd.action?.kind !== "open-ui-link") continue;
+        for (const key of cmd.keybinds) {
+          const chord = parsePluginChord(key);
+          if (!chord || !matchPluginChord(chord, e)) continue;
+          const href = resolveCommandHref(cmd, entries, activeSessionId);
+          if (href) {
+            e.preventDefault();
+            openExternal(href);
+          }
+          return;
+        }
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  return actions;
+}

--- a/web/src/hooks/usePluginCommands.ts
+++ b/web/src/hooks/usePluginCommands.ts
@@ -2,13 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { fetchPluginCommands, type PluginCommand, type PluginUiEntry } from "../lib/api";
 import type { CommandAction } from "../components/command-palette/types";
-import {
-  buildPluginCommandActions,
-  matchPluginChord,
-  openExternal,
-  parsePluginChord,
-  resolveCommandHref,
-} from "../lib/pluginCommands";
+import { buildPluginCommandActions, openExternal, pickKeybindHref } from "../lib/pluginCommands";
 
 /** Surfaces active plugin commands as palette actions and binds their declared
  *  keybinds. `open-ui-link` commands open the active session's PR href from the
@@ -45,18 +39,10 @@ export function usePluginCommands(entries: PluginUiEntry[], activeSessionId: str
       const t = e.target as HTMLElement | null;
       if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
       const { commands, entries, activeSessionId } = live.current;
-      for (const cmd of commands) {
-        if (cmd.action?.kind !== "open-ui-link") continue;
-        for (const key of cmd.keybinds) {
-          const chord = parsePluginChord(key);
-          if (!chord || !matchPluginChord(chord, e)) continue;
-          const href = resolveCommandHref(cmd, entries, activeSessionId);
-          if (href) {
-            e.preventDefault();
-            openExternal(href);
-          }
-          return;
-        }
+      const href = pickKeybindHref(commands, entries, activeSessionId, e);
+      if (href) {
+        e.preventDefault();
+        openExternal(href);
       }
     };
     document.addEventListener("keydown", handler);

--- a/web/src/lib/__tests__/pluginCommands.test.ts
+++ b/web/src/lib/__tests__/pluginCommands.test.ts
@@ -146,6 +146,12 @@ describe("multi-repo workspaces", () => {
     expect(resolveCommandLinks(badge, [badgeEntry(dup)], "s1")).toHaveLength(1);
   });
 
+  it("skips malformed (null/primitive) item entries without throwing", () => {
+    const mixed = [null, "nope", 42, items[0]];
+    const links = resolveCommandLinks(badge, [badgeEntry(mixed)], "s1");
+    expect(links).toEqual([{ href: "https://github.com/o/a/pull/1", label: "a: PR #1" }]);
+  });
+
   it("falls back to the top-level href when there are no item hrefs", () => {
     const links = resolveCommandLinks(badge, [badgeEntry([], "https://github.com/o/a/pull/9")], "s1");
     expect(links).toEqual([{ href: "https://github.com/o/a/pull/9", label: "https://github.com/o/a/pull/9" }]);

--- a/web/src/lib/__tests__/pluginCommands.test.ts
+++ b/web/src/lib/__tests__/pluginCommands.test.ts
@@ -7,7 +7,28 @@ import {
   matchPluginChord,
   parsePluginChord,
   resolveCommandHref,
+  resolveCommandLinks,
 } from "../pluginCommands";
+
+const badge: PluginCommand = {
+  fqid: "plugin.acme.github.open_pr",
+  plugin_id: "acme.github",
+  id: "open_pr",
+  title: "Open GitHub PR",
+  description: "",
+  keybinds: ["Ctrl+Shift+G"],
+  action: { kind: "open-ui-link", slot: "row-badge", id: "github_pr_badge" },
+};
+
+function badgeEntry(items: unknown[], href?: string): PluginUiEntry {
+  return {
+    plugin_id: "acme.github",
+    slot: "row-badge",
+    id: "github_pr_badge",
+    session_id: "s1",
+    payload: href ? { items, href } : { items },
+  };
+}
 
 const openPr: PluginCommand = {
   fqid: "plugin.acme.github.open_pr",
@@ -101,5 +122,55 @@ describe("matchPluginChord", () => {
   it("does not match when a modifier differs", () => {
     const e = { ctrlKey: true, shiftKey: false, altKey: false, metaKey: false, key: "g" } as KeyboardEvent;
     expect(matchPluginChord(chord, e)).toBe(false);
+  });
+});
+
+describe("multi-repo workspaces", () => {
+  const items = [
+    { href: "https://github.com/o/a/pull/1", tooltip: "a: PR #1" },
+    { href: "https://github.com/o/b/pull/2", tooltip: "b: PR #2" },
+    { tooltip: "c: no PR" }, // no href -> skipped
+  ];
+
+  it("resolveCommandLinks returns one link per open PR from items", () => {
+    const links = resolveCommandLinks(badge, [badgeEntry(items)], "s1");
+    expect(links).toEqual([
+      { href: "https://github.com/o/a/pull/1", label: "a: PR #1" },
+      { href: "https://github.com/o/b/pull/2", label: "b: PR #2" },
+    ]);
+  });
+
+  it("dedupes repeated hrefs", () => {
+    const dup = [items[0], items[0]];
+    expect(resolveCommandLinks(badge, [badgeEntry(dup)], "s1")).toHaveLength(1);
+  });
+
+  it("falls back to the top-level href when there are no item hrefs", () => {
+    const links = resolveCommandLinks(badge, [badgeEntry([], "https://github.com/o/a/pull/9")], "s1");
+    expect(links).toEqual([{ href: "https://github.com/o/a/pull/9", label: "https://github.com/o/a/pull/9" }]);
+  });
+
+  it("builds one palette entry per PR, titled by item label", () => {
+    const actions = buildPluginCommandActions([badge], [badgeEntry(items)], "s1");
+    expect(actions.map((a) => a.title)).toEqual(["Open GitHub PR: a: PR #1", "Open GitHub PR: b: PR #2"]);
+    expect(actions.map((a) => a.id)).toEqual([
+      "plugin:plugin.acme.github.open_pr:0",
+      "plugin:plugin.acme.github.open_pr:1",
+    ]);
+    // No single-entry shortcut hint when the command fans out.
+    expect(actions[0].shortcut).toBeUndefined();
+  });
+
+  it("builds a single titled entry when only one PR is open", () => {
+    const actions = buildPluginCommandActions([badge], [badgeEntry([items[0]])], "s1");
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({ id: "plugin:plugin.acme.github.open_pr", title: "Open GitHub PR" });
+    expect(actions[0].shortcut).toBe("Ctrl+Shift+G");
+  });
+
+  it("resolveCommandHref returns the top-level primary for the keybind", () => {
+    expect(resolveCommandHref(badge, [badgeEntry(items, "https://github.com/o/b/pull/2")], "s1")).toBe(
+      "https://github.com/o/b/pull/2",
+    );
   });
 });

--- a/web/src/lib/__tests__/pluginCommands.test.ts
+++ b/web/src/lib/__tests__/pluginCommands.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import type { PluginCommand, PluginUiEntry } from "../api";
+import {
+  buildPluginCommandActions,
+  isExternalHttpUrl,
+  matchPluginChord,
+  parsePluginChord,
+  resolveCommandHref,
+} from "../pluginCommands";
+
+const openPr: PluginCommand = {
+  fqid: "plugin.acme.github.open_pr",
+  plugin_id: "acme.github",
+  id: "open_pr",
+  title: "Open GitHub PR",
+  description: "Open the active session's PR",
+  keybinds: ["Ctrl+Shift+G"],
+  action: { kind: "open-ui-link", slot: "row-column", id: "pr" },
+};
+
+function entry(over: Partial<PluginUiEntry>): PluginUiEntry {
+  return {
+    plugin_id: "acme.github",
+    slot: "row-column",
+    id: "pr",
+    session_id: "s1",
+    payload: { href: "https://github.com/o/r/pull/12" },
+    ...over,
+  };
+}
+
+describe("isExternalHttpUrl", () => {
+  it("accepts http/https and rejects everything else", () => {
+    expect(isExternalHttpUrl("https://x.test")).toBe(true);
+    expect(isExternalHttpUrl("http://x.test")).toBe(true);
+    expect(isExternalHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(isExternalHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isExternalHttpUrl("")).toBe(false);
+    expect(isExternalHttpUrl(undefined)).toBe(false);
+  });
+});
+
+describe("resolveCommandHref", () => {
+  it("returns the href for the matching active-session entry", () => {
+    expect(resolveCommandHref(openPr, [entry({})], "s1")).toBe("https://github.com/o/r/pull/12");
+  });
+  it("returns null with no active session", () => {
+    expect(resolveCommandHref(openPr, [entry({})], null)).toBeNull();
+  });
+  it("ignores entries for another session", () => {
+    expect(resolveCommandHref(openPr, [entry({ session_id: "other" })], "s1")).toBeNull();
+  });
+  it("ignores another plugin's entry at the same slot/id", () => {
+    expect(resolveCommandHref(openPr, [entry({ plugin_id: "evil" })], "s1")).toBeNull();
+  });
+  it("rejects an unsafe href", () => {
+    expect(resolveCommandHref(openPr, [entry({ payload: { href: "javascript:1" } })], "s1")).toBeNull();
+  });
+});
+
+describe("buildPluginCommandActions", () => {
+  it("includes an open-ui-link command when its href resolves", () => {
+    const actions = buildPluginCommandActions([openPr], [entry({})], "s1");
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({ id: "plugin:plugin.acme.github.open_pr", group: "Actions" });
+  });
+  it("hides the command when no href resolves", () => {
+    expect(buildPluginCommandActions([openPr], [], "s1")).toHaveLength(0);
+  });
+  it("skips commands without a client action", () => {
+    const noAction: PluginCommand = { ...openPr, action: null };
+    expect(buildPluginCommandActions([noAction], [entry({})], "s1")).toHaveLength(0);
+  });
+});
+
+describe("parsePluginChord", () => {
+  it("parses modifiers plus a base key", () => {
+    expect(parsePluginChord("Ctrl+Shift+G")).toEqual({
+      ctrl: true,
+      shift: true,
+      alt: false,
+      meta: false,
+      base: "g",
+    });
+  });
+  it("returns null for two base keys", () => {
+    expect(parsePluginChord("g+h")).toBeNull();
+  });
+  it("returns null with no base key", () => {
+    expect(parsePluginChord("Ctrl+Shift")).toBeNull();
+  });
+});
+
+describe("matchPluginChord", () => {
+  const chord = parsePluginChord("Ctrl+Shift+G")!;
+  it("matches an exact event", () => {
+    const e = { ctrlKey: true, shiftKey: true, altKey: false, metaKey: false, key: "G" } as KeyboardEvent;
+    expect(matchPluginChord(chord, e)).toBe(true);
+  });
+  it("does not match when a modifier differs", () => {
+    const e = { ctrlKey: true, shiftKey: false, altKey: false, metaKey: false, key: "g" } as KeyboardEvent;
+    expect(matchPluginChord(chord, e)).toBe(false);
+  });
+});

--- a/web/src/lib/__tests__/pluginCommands.test.ts
+++ b/web/src/lib/__tests__/pluginCommands.test.ts
@@ -6,6 +6,7 @@ import {
   isExternalHttpUrl,
   matchPluginChord,
   parsePluginChord,
+  pickKeybindHref,
   resolveCommandHref,
   resolveCommandLinks,
 } from "../pluginCommands";
@@ -172,5 +173,43 @@ describe("multi-repo workspaces", () => {
     expect(resolveCommandHref(badge, [badgeEntry(items, "https://github.com/o/b/pull/2")], "s1")).toBe(
       "https://github.com/o/b/pull/2",
     );
+  });
+});
+
+describe("pickKeybindHref", () => {
+  const ev = { ctrlKey: true, shiftKey: true, altKey: false, metaKey: false, key: "g" } as KeyboardEvent;
+  const cmdA: PluginCommand = {
+    fqid: "plugin.acme.a.open",
+    plugin_id: "acme.a",
+    id: "open",
+    title: "A",
+    description: "",
+    keybinds: ["Ctrl+Shift+G"],
+    action: { kind: "open-ui-link", slot: "row-column", id: "pr" },
+  };
+  const cmdB: PluginCommand = { ...cmdA, fqid: "plugin.acme.b.open", plugin_id: "acme.b" };
+
+  function entryFor(pluginId: string, href: string): PluginUiEntry {
+    return { plugin_id: pluginId, slot: "row-column", id: "pr", session_id: "s1", payload: { href } };
+  }
+
+  it("opens the matching command's href", () => {
+    expect(pickKeybindHref([cmdA], [entryFor("acme.a", "https://x.test/1")], "s1", ev)).toBe("https://x.test/1");
+  });
+
+  it("falls through to a later command sharing the chord when the first is inactive", () => {
+    // cmdA matches the chord but has no entry (inactive for this session); cmdB
+    // shares the chord and resolves, so it must still fire.
+    const href = pickKeybindHref([cmdA, cmdB], [entryFor("acme.b", "https://x.test/2")], "s1", ev);
+    expect(href).toBe("https://x.test/2");
+  });
+
+  it("returns null when no matching command can execute", () => {
+    expect(pickKeybindHref([cmdA, cmdB], [], "s1", ev)).toBeNull();
+  });
+
+  it("ignores commands whose chord does not match", () => {
+    const other = { ctrlKey: false, shiftKey: false, altKey: false, metaKey: false, key: "x" } as KeyboardEvent;
+    expect(pickKeybindHref([cmdA], [entryFor("acme.a", "https://x.test/1")], "s1", other)).toBeNull();
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -252,6 +252,30 @@ export function fetchPlugins(): Promise<PluginListResponse | null> {
   return fetchJson<PluginListResponse>("/api/plugins");
 }
 
+/** A command's client-executed action (`api_version >= 6`). `open-ui-link` opens
+ *  the `href` from the plugin's own per-session UI-state entry at `(slot, id)`. */
+export type PluginClientAction = { kind: "open-ui-link"; slot: PluginUiSlot; id: string };
+
+/** One active plugin command (`GET /api/plugins/commands`), normalized for the
+ *  command palette and keymap. */
+export interface PluginCommand {
+  fqid: string;
+  plugin_id: string;
+  id: string;
+  title: string;
+  description: string;
+  keybinds: string[];
+  action: PluginClientAction | null;
+}
+
+export interface PluginCommandsResponse {
+  commands: PluginCommand[];
+}
+
+export function fetchPluginCommands(): Promise<PluginCommandsResponse | null> {
+  return fetchJson<PluginCommandsResponse>("/api/plugins/commands");
+}
+
 function isValidPluginListResponse(payload: unknown): payload is PluginListResponse {
   return (
     typeof payload === "object" &&

--- a/web/src/lib/pluginCommands.ts
+++ b/web/src/lib/pluginCommands.ts
@@ -168,3 +168,25 @@ export function matchPluginChord(chord: ParsedChord, e: KeyboardEvent): boolean 
     e.key.toLowerCase() === chord.base
   );
 }
+
+/** The href to open for a keydown event: the first command whose chord matches
+ *  AND whose primary href resolves. A chord match that can't execute (no PR for
+ *  this session) is skipped, so a second command sharing the chord still fires.
+ *  `null` when nothing matches or nothing resolves. */
+export function pickKeybindHref(
+  commands: PluginCommand[],
+  entries: PluginUiEntry[],
+  activeSessionId: string | null,
+  e: KeyboardEvent,
+): string | null {
+  for (const cmd of commands) {
+    if (cmd.action?.kind !== "open-ui-link") continue;
+    for (const key of cmd.keybinds) {
+      const chord = parsePluginChord(key);
+      if (!chord || !matchPluginChord(chord, e)) continue;
+      const href = resolveCommandHref(cmd, entries, activeSessionId);
+      if (href) return href;
+    }
+  }
+  return null;
+}

--- a/web/src/lib/pluginCommands.ts
+++ b/web/src/lib/pluginCommands.ts
@@ -16,27 +16,74 @@ export function openExternal(url: string): void {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
-/** The href an `open-ui-link` command would open for the active session: the
- *  `href` on the plugin's own `(slot, id)` UI-state entry, validated. `null`
- *  when there is no active session, no matching entry, or no safe href (e.g. the
- *  session has no open PR). */
+/** One openable link an `open-ui-link` command exposes: a validated href plus a
+ *  human label (from the badge item's tooltip/text). */
+export interface CommandLink {
+  href: string;
+  label: string;
+}
+
+function entryFor(
+  cmd: PluginCommand,
+  entries: PluginUiEntry[],
+  activeSessionId: string | null,
+): PluginUiEntry | undefined {
+  if (!activeSessionId || cmd.action?.kind !== "open-ui-link") return undefined;
+  const { slot, id } = cmd.action;
+  return entries.find(
+    (e) => e.plugin_id === cmd.plugin_id && e.slot === slot && e.id === id && e.session_id === activeSessionId,
+  );
+}
+
+/** Every link an `open-ui-link` command can open for the active session, deduped
+ *  by href. A multi-repo workspace exposes one link per open PR via the entry's
+ *  `items`; a single-link slot falls back to the entry's top-level `href`. Empty
+ *  when there is no active session, no matching entry, or no safe href. */
+export function resolveCommandLinks(
+  cmd: PluginCommand,
+  entries: PluginUiEntry[],
+  activeSessionId: string | null,
+): CommandLink[] {
+  const entry = entryFor(cmd, entries, activeSessionId);
+  if (!entry) return [];
+  const links: CommandLink[] = [];
+  const seen = new Set<string>();
+  const push = (href: unknown, label: unknown) => {
+    if (!isExternalHttpUrl(href) || seen.has(href)) return;
+    seen.add(href);
+    links.push({ href, label: typeof label === "string" && label ? label : href });
+  };
+  const items = entry.payload.items;
+  if (Array.isArray(items)) {
+    for (const raw of items) {
+      const item = raw as Record<string, unknown>;
+      push(item.href, item.tooltip ?? item.text);
+    }
+  }
+  // Fall back to the entry's top-level href (e.g. a single-link slot, or a badge
+  // with no per-item hrefs).
+  if (links.length === 0) push(entry.payload.href, entry.payload.tooltip ?? entry.payload.text);
+  return links;
+}
+
+/** The primary href an `open-ui-link` command opens (for the keybind, which
+ *  cannot disambiguate): the entry's top-level `href` if valid, else the first
+ *  resolved link. `null` when nothing safe resolves. */
 export function resolveCommandHref(
   cmd: PluginCommand,
   entries: PluginUiEntry[],
   activeSessionId: string | null,
 ): string | null {
-  if (!activeSessionId || cmd.action?.kind !== "open-ui-link") return null;
-  const { slot, id } = cmd.action;
-  const entry = entries.find(
-    (e) => e.plugin_id === cmd.plugin_id && e.slot === slot && e.id === id && e.session_id === activeSessionId,
-  );
-  const href = entry?.payload.href;
-  return isExternalHttpUrl(href) ? href : null;
+  const entry = entryFor(cmd, entries, activeSessionId);
+  const top = entry?.payload.href;
+  if (isExternalHttpUrl(top)) return top;
+  return resolveCommandLinks(cmd, entries, activeSessionId)[0]?.href ?? null;
 }
 
 /** Palette entries for the active session's client-executable plugin commands.
- *  An `open-ui-link` command is shown only when its href resolves, so the
- *  palette never offers a dead "open" with nothing to open. */
+ *  A command with a single link becomes one entry; a multi-repo workspace with
+ *  several open PRs becomes one entry per PR so the palette is the picker. A
+ *  command whose links do not resolve is omitted, so no dead "open" is shown. */
 export function buildPluginCommandActions(
   commands: PluginCommand[],
   entries: PluginUiEntry[],
@@ -45,16 +92,18 @@ export function buildPluginCommandActions(
   const actions: CommandAction[] = [];
   for (const cmd of commands) {
     if (cmd.action?.kind !== "open-ui-link") continue;
-    const href = resolveCommandHref(cmd, entries, activeSessionId);
-    if (!href) continue;
-    actions.push({
-      id: `plugin:${cmd.fqid}`,
-      title: cmd.title || cmd.id,
-      subtitle: cmd.description || undefined,
-      group: "Actions",
-      keywords: ["plugin", cmd.plugin_id, cmd.id],
-      shortcut: cmd.keybinds[0],
-      perform: () => openExternal(href),
+    const links = resolveCommandLinks(cmd, entries, activeSessionId);
+    const multiple = links.length > 1;
+    links.forEach((link, i) => {
+      actions.push({
+        id: multiple ? `plugin:${cmd.fqid}:${i}` : `plugin:${cmd.fqid}`,
+        title: multiple ? `${cmd.title || cmd.id}: ${link.label}` : cmd.title || cmd.id,
+        subtitle: multiple ? undefined : cmd.description || undefined,
+        group: "Actions",
+        keywords: ["plugin", cmd.plugin_id, cmd.id],
+        shortcut: !multiple ? cmd.keybinds[0] : undefined,
+        perform: () => openExternal(link.href),
+      });
     });
   }
   return actions;

--- a/web/src/lib/pluginCommands.ts
+++ b/web/src/lib/pluginCommands.ts
@@ -56,6 +56,9 @@ export function resolveCommandLinks(
   const items = entry.payload.items;
   if (Array.isArray(items)) {
     for (const raw of items) {
+      // payload is untyped plugin JSON; a primitive or null item must not crash
+      // resolution for the whole session.
+      if (!raw || typeof raw !== "object") continue;
       const item = raw as Record<string, unknown>;
       push(item.href, item.tooltip ?? item.text);
     }

--- a/web/src/lib/pluginCommands.ts
+++ b/web/src/lib/pluginCommands.ts
@@ -1,0 +1,121 @@
+// Pure helpers for turning active plugin commands into command-palette actions
+// and keybind handlers. Kept side-effect free (except `openExternal`) so the
+// resolution and chord-matching rules are unit-tested in one place.
+
+import type { CommandAction } from "../components/command-palette/types";
+import type { PluginCommand, PluginUiEntry } from "./api";
+
+/** Only `http`/`https` URLs may be opened; reject `javascript:`, `file:`,
+ *  `data:`, and anything else a plugin might smuggle into an href. */
+export function isExternalHttpUrl(u: unknown): u is string {
+  return typeof u === "string" && /^https?:\/\//i.test(u);
+}
+
+/** Open an external URL in a new tab with the opener relationship severed. */
+export function openExternal(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+/** The href an `open-ui-link` command would open for the active session: the
+ *  `href` on the plugin's own `(slot, id)` UI-state entry, validated. `null`
+ *  when there is no active session, no matching entry, or no safe href (e.g. the
+ *  session has no open PR). */
+export function resolveCommandHref(
+  cmd: PluginCommand,
+  entries: PluginUiEntry[],
+  activeSessionId: string | null,
+): string | null {
+  if (!activeSessionId || cmd.action?.kind !== "open-ui-link") return null;
+  const { slot, id } = cmd.action;
+  const entry = entries.find(
+    (e) => e.plugin_id === cmd.plugin_id && e.slot === slot && e.id === id && e.session_id === activeSessionId,
+  );
+  const href = entry?.payload.href;
+  return isExternalHttpUrl(href) ? href : null;
+}
+
+/** Palette entries for the active session's client-executable plugin commands.
+ *  An `open-ui-link` command is shown only when its href resolves, so the
+ *  palette never offers a dead "open" with nothing to open. */
+export function buildPluginCommandActions(
+  commands: PluginCommand[],
+  entries: PluginUiEntry[],
+  activeSessionId: string | null,
+): CommandAction[] {
+  const actions: CommandAction[] = [];
+  for (const cmd of commands) {
+    if (cmd.action?.kind !== "open-ui-link") continue;
+    const href = resolveCommandHref(cmd, entries, activeSessionId);
+    if (!href) continue;
+    actions.push({
+      id: `plugin:${cmd.fqid}`,
+      title: cmd.title || cmd.id,
+      subtitle: cmd.description || undefined,
+      group: "Actions",
+      keywords: ["plugin", cmd.plugin_id, cmd.id],
+      shortcut: cmd.keybinds[0],
+      perform: () => openExternal(href),
+    });
+  }
+  return actions;
+}
+
+/** A parsed key chord. Mirrors the host's `parse_chord` set (`Ctrl`/`Shift`
+ *  plus a base key); `Alt`/`Meta` are tolerated here for forward compatibility
+ *  even though the TUI rejects them. */
+export interface ParsedChord {
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+  base: string;
+}
+
+/** Parse a chord string like `Ctrl+Shift+G` into modifiers plus a lowercased
+ *  base key, or `null` when it has no base key or two base keys. */
+export function parsePluginChord(key: string): ParsedChord | null {
+  let ctrl = false;
+  let shift = false;
+  let alt = false;
+  let meta = false;
+  let base: string | null = null;
+  for (const tok of key
+    .split("+")
+    .map((t) => t.trim())
+    .filter(Boolean)) {
+    switch (tok.toLowerCase()) {
+      case "ctrl":
+      case "control":
+        ctrl = true;
+        break;
+      case "shift":
+        shift = true;
+        break;
+      case "alt":
+      case "option":
+        alt = true;
+        break;
+      case "meta":
+      case "cmd":
+      case "super":
+        meta = true;
+        break;
+      default:
+        if (base !== null) return null;
+        base = tok.toLowerCase();
+    }
+  }
+  return base ? { ctrl, shift, alt, meta, base } : null;
+}
+
+/** Whether a keydown event matches a parsed chord exactly (every modifier and
+ *  the base key). */
+export function matchPluginChord(chord: ParsedChord, e: KeyboardEvent): boolean {
+  return (
+    e.ctrlKey === chord.ctrl &&
+    e.shiftKey === chord.shift &&
+    e.altKey === chord.alt &&
+    e.metaKey === chord.meta &&
+    e.key.toLowerCase() === chord.base
+  );
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Makes plugin-contributed commands and keybinds first-class on the web dashboard, and adds a client-executed command action so a plugin command can open a URL without a worker round-trip.

A command may now declare an optional `action` (`api_version >= 6`). The first kind, `open-ui-link { slot, id }`, tells the host surface to open the `href` from that plugin's own per-session UI-state entry. The surface runs it synchronously inside the user's gesture (web `window.open`, validated to http/https with `noopener`), so it is not popup-blocked on a remote dashboard, and no host->worker request/response primitive is needed (the href is already in the snapshot the surface holds). A new `browser_open` capability gates it; manifest validation requires the referenced `(slot, id)` to be a declared per-session UI contribution.

The web dashboard now fetches `GET /api/plugins/commands` (normalized: fqid, bound chords, action) and surfaces each active plugin command in the cmd+k palette plus a global keybind listener. The first consumer is the GitHub plugin's `open_pr` command (companion PR in `agent-of-empires/plugin-github`, which closes #46 there): `Ctrl+Shift+G` or the palette opens the active session's PR.

This is the host half. The companion plugin PR declares the command, keybind, and `browser_open` capability and publishes the PR href on its row-badge slot.

Cross-reference: agent-of-empires/plugin-github#46.

Deferred to a follow-up: executing the keybind in the native TUI (the structured-view input pipeline needs wiring plus a live-daemon e2e), and the fire-and-forget worker-command path for commands without a client action. Both are out of scope here.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec (`web/src/lib/__tests__/pluginCommands.test.ts`) covering href resolution, URL-scheme validation, palette-entry gating, and chord parsing/matching. No new component file under `web/src/components/**`, so the coverage matrix needs no new entry (validator passes); the new logic lives in `web/src/lib` and `web/src/hooks`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle (the TUI executor is deferred).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design (two model debates on the protocol and the popup-blocker constraint), and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

## How to test

- [ ] With the GitHub plugin (companion PR) installed and a session on a branch with an open PR, open the web command palette (Cmd+K) and confirm a "GitHub: open PR" entry appears.
- [ ] Invoke it and confirm the PR opens in a new tab.
- [ ] Press `Ctrl+Shift+G` with that session active and confirm the PR opens.
- [ ] Switch to a session with no open PR and confirm the entry is absent and the chord is a no-op.
- [ ] Confirm `GET /api/plugins/commands` returns the command with its `action` and `keybinds`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785260330&installation_id=139138837&pr_number=2526&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2526&signature=3ac2c0e195217f06b191c465790f0ebf96dc22dba2e0cdc927397a040b37f931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added first-class support for plugin-contributed commands in the web dashboard.

- Plugins can now contribute commands that show up in the cmd+k command palette and can be triggered via keyboard keybinds.
- Introduced an optional client-executed command action (`open-ui-link`) so qualifying plugin commands can open a session-scoped UI link directly in the browser (no worker round-trip). This is gated by a new `browser_open` capability and validated so the `(slot, id)` target maps to exactly one existing per-session UI contribution.
- The server now exposes `GET /api/plugins/commands`, returning normalized active plugin commands (fully qualified IDs, resolved keybind chords, and optional client action details). The web UI fetches these commands, adds them to the palette, and listens globally for matching key chords (with safe `http/https` URL handling).
- Wired the GitHub plugin’s “open PR” as the first end-to-end consumer (accessible from the palette and via `Ctrl+Shift+G`).

UX improvement for cold-start sandboxes:
- When a session is being ensured (including cases where the sandbox/container needs to come up), the web terminal view immediately shows a “Starting session...” placeholder instead of appearing stuck.

Benefits:
- Easier discovery and faster execution of plugin commands in the web UI.
- Safer, session-aware navigation for plugin-provided links.
- Clear loading feedback during the initial sandbox/container pull.

Technical notes:
- Plugin API version bumped to support the client action model; `open-ui-link` includes host capability checks plus `(slot,id)` validation.
- Added server/client types and unit tests around command normalization, link resolution, chord parsing/matching, and keybind-to-action execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->