### PR TITLE
feat(worktree): relocate a session's worktree out of the active dir when trashed

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -124,6 +124,10 @@ init_submodules = true
 
 On the delete side, aoe runs `git submodule deinit -f --all` before `git worktree remove` for any worktree with `.gitmodules`, so the panic-button `Force` checkbox is not required just because the worktree has submodules. If git still refuses (e.g. a partially-broken submodule), aoe falls back to clearing `<main>/.git/worktrees/<name>/modules/` and pruning the stale entry manually.
 
+### Trashing relocates the worktree
+
+Moving a worktree session to the trash (rather than purging it) relocates its worktree out of the active worktree dir into a sibling `.aoe-trash/<session-id>` holding directory via `git worktree move`, so trashed sessions stop cluttering the active checkouts. The worktree stays a live checkout, so previewing a trashed session still works. Restoring the session moves the worktree back to its original path; if that path is now occupied, the restore is refused so nothing is overwritten. Purging a trashed session removes the worktree from the holding dir. Sessions trashed before this behavior existed are relocated the next time the daemon starts or the TUI loads.
+
 ### Template Variables
 
 | Variable | Description |

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -91,6 +91,31 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                 removed_title
             );
         }
+
+        // The session is durably trashed; now move its worktree out of the
+        // active dir into the holding area and persist the repointed
+        // project_path. A failure here never blocks the trash; the worktree
+        // just stays in place and a later reconcile pass can relocate it.
+        let mut inst = inst;
+        inst.trash();
+        match crate::session::trash::relocate_worktree_to_trash(&mut inst) {
+            crate::session::trash::RelocateOutcome::Relocated { .. } => {
+                let new_path = inst.project_path.clone();
+                let pre = inst.pre_trash_project_path.clone();
+                let _ = storage.update(|all_instances, _groups| {
+                    if let Some(stored) = all_instances.iter_mut().find(|i| i.id == removed_id) {
+                        stored.project_path = new_path.clone();
+                        stored.pre_trash_project_path = pre.clone();
+                    }
+                    Ok(())
+                });
+            }
+            crate::session::trash::RelocateOutcome::Failed { reason } => {
+                eprintln!("  Note: left worktree in place ({reason}).");
+            }
+            crate::session::trash::RelocateOutcome::Skipped => {}
+        }
+
         println!(
             "  Moved session to trash: {} (from profile '{}')",
             removed_title,

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -357,27 +357,44 @@ async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn restore_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new_unwatched(profile)?;
+
+    // Resolve within the trashed subset only. The CLI advertises the argument
+    // as an id OR title, and a live or archived session can share a title/path
+    // with a trashed one; resolving against the full list would let that row
+    // win and make `untrash()` a silent no-op on an already-live session.
+    // See #2489.
+    let (instances, _groups) = storage.load_with_groups()?;
+    let trashed: Vec<_> = instances
+        .iter()
+        .filter(|i| i.is_trashed())
+        .cloned()
+        .collect();
+    let mut inst = super::resolve_session(&args.identifier, &trashed)
+        .map_err(|_| anyhow::anyhow!("No trashed session matching '{}'", args.identifier))?
+        .clone();
+    let restore_id = inst.id.clone();
+
+    // Move the worktree back to its pre-trash location before flipping the
+    // marker. Strict: if the original path is occupied or git refuses, leave
+    // the session trashed and surface the error rather than restoring it to
+    // the holding-area path.
+    if let crate::session::trash::RestoreOutcome::Failed { reason } =
+        crate::session::trash::restore_worktree_location(&mut inst)
+    {
+        anyhow::bail!("Cannot restore worktree: {reason}");
+    }
+    let restored_path = inst.project_path.clone();
+    let restored_pre = inst.pre_trash_project_path.clone();
+
     let title = storage.update(|instances, _groups| {
-        // Resolve within the trashed subset only. The CLI advertises the
-        // argument as an id OR title, and a live or archived session can share
-        // a title/path with a trashed one; resolving against the full list
-        // would let that row win and make `untrash()` a silent no-op on an
-        // already-live session. See #2489.
-        let trashed: Vec<_> = instances
-            .iter()
-            .filter(|i| i.is_trashed())
-            .cloned()
-            .collect();
-        let id = super::resolve_session(&args.identifier, &trashed)
-            .map_err(|_| anyhow::anyhow!("No trashed session matching '{}'", args.identifier))?
-            .id
-            .clone();
-        let inst = instances
+        let stored = instances
             .iter_mut()
-            .find(|i| i.id == id)
-            .expect("resolve_session returned an id that is no longer in instances");
-        inst.untrash();
-        Ok(inst.title.clone())
+            .find(|i| i.id == restore_id)
+            .ok_or_else(|| anyhow::anyhow!("No trashed session matching '{}'", args.identifier))?;
+        stored.project_path = restored_path.clone();
+        stored.pre_trash_project_path = restored_pre.clone();
+        stored.untrash();
+        Ok(stored.title.clone())
     })?;
     println!("Restored: {}", title);
     Ok(())

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -57,6 +57,9 @@ pub(crate) use sessions::persist_session_update;
 // Trash retention sweep, driven by the daemon's hourly loop; not a route handler.
 #[cfg(feature = "serve")]
 pub(crate) use sessions::purge_expired_trash;
+// Startup backfill that relocates trashed worktrees; not a route handler.
+#[cfg(feature = "serve")]
+pub(crate) use sessions::reconcile_trashed_worktrees;
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, dismiss_update,
     docker_status, filesystem_home, get_about, get_current_theme, get_profile_settings,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2277,6 +2277,60 @@ pub async fn trash_session(
         }
     }
 
+    // The session is durably trashed and its agent stopped; relocate its
+    // managed worktree out of the active dir into the holding area, then
+    // persist the repointed project_path. The git move is blocking, so it runs
+    // on a blocking thread. Best-effort: a failure leaves the worktree in
+    // place and the daemon's reconcile pass can move it later. Never blocks the
+    // trash itself, which already landed above.
+    {
+        let profile = inst_clone.source_profile.clone();
+        match tokio::task::spawn_blocking(move || {
+            let mut inst = inst_clone;
+            let outcome = crate::session::trash::relocate_worktree_to_trash(&mut inst);
+            (outcome, inst)
+        })
+        .await
+        {
+            Ok((crate::session::trash::RelocateOutcome::Relocated { .. }, moved)) => {
+                let new_path = moved.project_path.clone();
+                let pre = moved.pre_trash_project_path.clone();
+                let persist_id = id.clone();
+                let (np, pp) = (new_path.clone(), pre.clone());
+                let _ = persist_session_update(
+                    profile,
+                    "trash-relocate",
+                    state.file_watch.clone(),
+                    move |instances| {
+                        if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                            inst.project_path = np.clone();
+                            inst.pre_trash_project_path = pp.clone();
+                        }
+                    },
+                )
+                .await;
+                let mut instances = state.instances.write().await;
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                    inst.project_path = new_path;
+                    inst.pre_trash_project_path = pre;
+                }
+            }
+            Ok((crate::session::trash::RelocateOutcome::Failed { reason }, _)) => {
+                tracing::warn!(
+                    target: "http.api.sessions",
+                    session = %id,
+                    "trash worktree relocation skipped: {reason}"
+                );
+            }
+            Ok((crate::session::trash::RelocateOutcome::Skipped, _)) => {}
+            Err(e) => tracing::warn!(
+                target: "http.api.sessions",
+                session = %id,
+                "trash worktree relocation join failed: {e}"
+            ),
+        }
+    }
+
     let instances = state.instances.read().await;
     let response = match instances.iter().find(|i| i.id == id) {
         Some(inst) => {
@@ -2316,7 +2370,7 @@ pub async fn restore_session(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let profile = {
+    let (profile, snapshot) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
             return (
@@ -2325,16 +2379,50 @@ pub async fn restore_session(
             )
                 .into_response();
         };
-        inst.source_profile.clone()
+        (inst.source_profile.clone(), inst.clone())
     };
 
+    // Move the worktree back to its pre-trash location before clearing the
+    // marker. Strict: if the original path is occupied or git refuses, keep
+    // the session trashed and surface a conflict, rather than restoring it to
+    // the holding-area path. The git move is blocking, so it runs off the
+    // async runtime.
+    let restored = match tokio::task::spawn_blocking(move || {
+        let mut inst = snapshot;
+        let outcome = crate::session::trash::restore_worktree_location(&mut inst);
+        (outcome, inst)
+    })
+    .await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::warn!(target: "http.api.sessions", session = %id, "restore relocation join failed: {e}");
+            return persist_failed_response();
+        }
+    };
+    if let crate::session::trash::RestoreOutcome::Failed { reason } = &restored.0 {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "worktree_restore_failed",
+                "message": format!("Could not restore the worktree: {reason}")
+            })),
+        )
+            .into_response();
+    }
+    let restored_path = restored.1.project_path.clone();
+    let restored_pre = restored.1.pre_trash_project_path.clone();
+
     let persist_id = id.clone();
+    let (rp, pre) = (restored_path.clone(), restored_pre.clone());
     if persist_session_update(
         profile,
         "restore",
         state.file_watch.clone(),
         move |instances| {
             if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                inst.project_path = rp.clone();
+                inst.pre_trash_project_path = pre.clone();
                 inst.untrash();
             }
         },
@@ -2349,6 +2437,8 @@ pub async fn restore_session(
     let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
         return persist_failed_response();
     };
+    inst.project_path = restored_path;
+    inst.pre_trash_project_path = restored_pre;
     inst.untrash();
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
@@ -3218,6 +3308,74 @@ async fn purge_session_artifacts(
         }
     }
     Ok(messages)
+}
+
+/// Relocate any trashed managed worktree still sitting in the active dir into
+/// the holding area, and heal a pointer left stale by a crash between the move
+/// and its persist. Backfills rows trashed before relocation existed. Runs
+/// once on daemon startup, best-effort and per-session locked; a failure on one
+/// session logs and moves on. The git move is blocking, so it runs off the
+/// async runtime.
+pub(crate) async fn reconcile_trashed_worktrees(state: &Arc<AppState>) {
+    let candidates: Vec<(String, String)> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| i.is_trashed())
+            .map(|i| (i.id.clone(), i.source_profile.clone()))
+            .collect()
+    };
+    for (id, profile) in candidates {
+        let lock = state.instance_lock(&id).await;
+        let _guard = lock.lock().await;
+
+        let snapshot = {
+            let instances = state.instances.read().await;
+            match instances.iter().find(|i| i.id == id) {
+                Some(i) if i.is_trashed() => i.clone(),
+                _ => continue,
+            }
+        };
+        let reconciled = match tokio::task::spawn_blocking(move || {
+            let mut inst = snapshot;
+            let changed = crate::session::trash::reconcile_trashed_location(&mut inst);
+            (changed, inst)
+        })
+        .await
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::warn!(target: "http.api.sessions", session = %id, "trash reconcile join failed: {e}");
+                continue;
+            }
+        };
+        if !reconciled.0 {
+            continue;
+        }
+        let moved = reconciled.1;
+        let (np, pre) = (
+            moved.project_path.clone(),
+            moved.pre_trash_project_path.clone(),
+        );
+        let persist_id = id.clone();
+        let _ = persist_session_update(
+            profile,
+            "trash-reconcile",
+            state.file_watch.clone(),
+            move |instances| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                    inst.project_path = np.clone();
+                    inst.pre_trash_project_path = pre.clone();
+                }
+            },
+        )
+        .await;
+        let mut instances = state.instances.write().await;
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+            inst.project_path = moved.project_path;
+            inst.pre_trash_project_path = moved.pre_trash_project_path;
+        }
+    }
 }
 
 /// Auto-purge trashed sessions whose retention window has elapsed

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1101,6 +1101,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             "server.trash_retention_sweep",
             crate::task_util::PanicPolicy::Log,
             async move {
+                // One-shot startup backfill: relocate trashed worktrees still
+                // in the active dir (rows trashed before relocation existed)
+                // and heal any pointer a crash left stale. See #2522.
+                crate::server::api::reconcile_trashed_worktrees(&sweep_state).await;
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(60 * 60));
                 interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -501,6 +501,18 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trashed_at: Option<DateTime<Utc>>,
 
+    /// The `project_path` a managed-worktree session had before it was
+    /// trashed, captured when the trash flow relocates the worktree into the
+    /// `.aoe-trash` holding area (see `src/session/trash.rs`). `project_path`
+    /// is repointed to the trash location while trashed so the structured-view
+    /// preview, diff, and purge keep reading the worktree at its real spot;
+    /// restore moves the worktree back here and clears this field. `None` for
+    /// sessions that were never relocated (plain / non-managed worktrees, or
+    /// rows trashed before relocation existed). Additive: absent in older
+    /// `sessions.json` rows, so no migration is needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pre_trash_project_path: Option<String>,
+
     /// Namespaced per-session plugin data, keyed by plugin id. Each plugin
     /// owns only its own slot (`plugin_meta["<id>"]`), an opaque JSON value it
     /// reads and writes through the host API that lands with the Tier 1 host
@@ -924,6 +936,7 @@ impl Instance {
             idle_dormant_since: None,
             pinned_at: None,
             trashed_at: None,
+            pre_trash_project_path: None,
             plugin_meta: std::collections::BTreeMap::new(),
             scratch: false,
             worktree_info: None,
@@ -1229,6 +1242,9 @@ impl Instance {
         }
         if pre.trashed_at != post.trashed_at {
             self.trashed_at = post.trashed_at;
+        }
+        if pre.pre_trash_project_path != post.pre_trash_project_path {
+            self.pre_trash_project_path = post.pre_trash_project_path.clone();
         }
         if pre.unread != post.unread {
             self.unread = post.unread;

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -556,4 +556,65 @@ mod tests {
             Some(original.as_str())
         );
     }
+
+    #[test]
+    fn relocated_worktree_is_a_working_checkout() {
+        // The structured-view preview and diff read the worktree at
+        // project_path; after relocation that must still be a live git
+        // worktree, not a detached directory.
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        let status = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&inst.project_path)
+            .output()
+            .unwrap();
+        assert!(
+            status.status.success(),
+            "git status must work in the relocated worktree: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+    }
+
+    #[test]
+    fn purge_removes_relocated_worktree() {
+        // Acceptance criterion: purging a trashed session deletes the worktree
+        // at its relocated holding path, leaving nothing behind.
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        let holding = PathBuf::from(&inst.project_path);
+        assert!(holding.exists());
+
+        let result = crate::session::deletion::perform_deletion(
+            &crate::session::deletion::DeletionRequest {
+                session_id: inst.id.clone(),
+                instance: inst.clone(),
+                delete_worktree: true,
+                delete_branch: true,
+                delete_sandbox: false,
+                force_delete: true,
+                detach_hooks: true,
+                keep_scratch: false,
+            },
+        );
+        assert!(result.success, "purge failed: {:?}", result.errors);
+        assert!(
+            !holding.exists(),
+            "relocated worktree should be gone after purge"
+        );
+    }
 }

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -268,6 +268,23 @@ pub fn reconcile_trashed_location(inst: &mut Instance) -> bool {
             && current != target
             && !is_holding_path(&current, &inst.id)
         {
+            // Crash case: the worktree was already moved to `target` but the
+            // marker/pointer persist was lost and something was recreated at
+            // the original path. Retrying the move would fail (target exists)
+            // and leave project_path on the wrong dir, so heal to the existing
+            // holding path and record the marker. Restore can then fail
+            // cleanly if the original stays occupied.
+            if target.exists() {
+                inst.project_path = target.to_string_lossy().into_owned();
+                inst.pre_trash_project_path = Some(original.to_string_lossy().into_owned());
+                tracing::info!(
+                    target: "session.trash",
+                    session = %inst.id,
+                    to = %target.display(),
+                    "reconciled trashed worktree pointer to existing holding area"
+                );
+                return true;
+            }
             return match relocate_worktree_to_trash(inst) {
                 RelocateOutcome::Relocated { .. } => true,
                 RelocateOutcome::Failed { reason } => {
@@ -579,6 +596,41 @@ mod tests {
         );
         assert_eq!(inst.project_path, holding);
         assert!(!PathBuf::from(&holding).join(".aoe-trash").exists());
+    }
+
+    #[test]
+    fn reconcile_heals_to_holding_when_original_recreated() {
+        // Crash case: worktree already moved to the holding path, but the
+        // marker was lost and the original path was recreated. Reconcile must
+        // point at the existing holding worktree and record the marker, not
+        // retry the (now-failing) move and leave project_path on the recreated
+        // original.
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        let original = inst.project_path.clone();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        let holding = inst.project_path.clone();
+
+        // Lost persist + recreated original.
+        inst.project_path = original.clone();
+        inst.pre_trash_project_path = None;
+        std::fs::create_dir_all(&original).unwrap();
+
+        assert!(
+            reconcile_trashed_location(&mut inst),
+            "reconcile should heal to the existing holding path"
+        );
+        assert_eq!(inst.project_path, holding);
+        assert_eq!(
+            inst.pre_trash_project_path.as_deref(),
+            Some(original.as_str())
+        );
     }
 
     #[test]

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -35,6 +35,19 @@ pub fn trash_holding_path(original: &Path, session_id: &str) -> Option<PathBuf> 
     Some(original.parent()?.join(TRASH_DIR_NAME).join(session_id))
 }
 
+/// True when `path` is already a holding path for this session, i.e. its leaf
+/// is the session id sitting directly under a `.aoe-trash` dir. Guards the
+/// backfill branch of reconciliation from nesting an already-relocated (but
+/// markerless) worktree under `.aoe-trash/.aoe-trash/<id>`.
+fn is_holding_path(path: &Path, session_id: &str) -> bool {
+    path.file_name()
+        .is_some_and(|leaf| leaf == std::ffi::OsStr::new(session_id))
+        && path
+            .parent()
+            .and_then(|p| p.file_name())
+            .is_some_and(|name| name == std::ffi::OsStr::new(TRASH_DIR_NAME))
+}
+
 /// Result of attempting to relocate a trashed session's worktree.
 #[derive(Debug)]
 pub enum RelocateOutcome {
@@ -248,12 +261,25 @@ pub fn reconcile_trashed_location(inst: &mut Instance) -> bool {
     if current.exists() {
         // Legacy backfill: a trashed managed worktree still sitting in the
         // active dir with no marker gets relocated now. An already-relocated
-        // row (marker set, current == holding) is left alone.
-        if inst.pre_trash_project_path.is_none() && current != target {
-            return matches!(
-                relocate_worktree_to_trash(inst),
-                RelocateOutcome::Relocated { .. }
-            );
+        // row (marker set, current == holding) is left alone, as is a
+        // markerless row that already sits in the holding area (relocating it
+        // again would nest it under .aoe-trash/.aoe-trash/<id>).
+        if inst.pre_trash_project_path.is_none()
+            && current != target
+            && !is_holding_path(&current, &inst.id)
+        {
+            return match relocate_worktree_to_trash(inst) {
+                RelocateOutcome::Relocated { .. } => true,
+                RelocateOutcome::Failed { reason } => {
+                    tracing::warn!(
+                        target: "session.trash",
+                        session = %inst.id,
+                        "trash worktree reconcile relocation failed: {reason}"
+                    );
+                    false
+                }
+                RelocateOutcome::Skipped => false,
+            };
         }
         return false;
     }
@@ -451,8 +477,9 @@ mod tests {
             "expected relocation, got {out:?}"
         );
         // Worktree moved into the holding area, original dir gone.
-        assert!(inst.project_path.contains("/.aoe-trash/"));
-        assert!(PathBuf::from(&inst.project_path).exists());
+        let holding = trash_holding_path(Path::new(&original), &inst.id).unwrap();
+        assert_eq!(PathBuf::from(&inst.project_path), holding);
+        assert!(holding.exists());
         assert!(!PathBuf::from(&original).exists());
         assert_eq!(
             inst.pre_trash_project_path.as_deref(),
@@ -516,7 +543,8 @@ mod tests {
             reconcile_trashed_location(&mut inst),
             "reconcile should relocate a legacy trashed worktree"
         );
-        assert!(inst.project_path.contains("/.aoe-trash/"));
+        let holding = trash_holding_path(Path::new(&original), &inst.id).unwrap();
+        assert_eq!(PathBuf::from(&inst.project_path), holding);
         assert_eq!(
             inst.pre_trash_project_path.as_deref(),
             Some(original.as_str())
@@ -525,6 +553,32 @@ mod tests {
 
         // Second pass changes nothing.
         assert!(!reconcile_trashed_location(&mut inst));
+    }
+
+    #[test]
+    fn reconcile_skips_markerless_row_already_in_holding() {
+        // A trashed worktree that already lives in the holding area but lost
+        // its marker must not be relocated again (which would nest it under
+        // .aoe-trash/.aoe-trash/<id>).
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        let holding = inst.project_path.clone();
+        // Drop the marker: the row now points at the holding path with no record.
+        inst.pre_trash_project_path = None;
+
+        assert!(
+            !reconcile_trashed_location(&mut inst),
+            "a markerless row already in holding must be left alone"
+        );
+        assert_eq!(inst.project_path, holding);
+        assert!(!PathBuf::from(&holding).join(".aoe-trash").exists());
     }
 
     #[test]

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -11,9 +11,281 @@
 //! manual purge / empty-trash. This module owns the pure "which rows are
 //! expired" decision so it can be unit-tested in isolation.
 
+use std::path::{Path, PathBuf};
+
 use chrono::{DateTime, Utc};
 
+use crate::git::GitWorktree;
+use crate::session::worktree_edit::{
+    discard_sandbox_container_after_move, sandbox_container_holds_worktree,
+};
 use crate::session::Instance;
+
+/// Hidden, product-owned holding directory for trashed worktrees. A relocated
+/// worktree lands at `<original-worktree-parent>/.aoe-trash/<session-id>`. The
+/// name is namespaced (not a generic `.trash`) so it cannot collide with a
+/// user's own tooling, and keeping it a sibling of the active worktree leaf
+/// means `git worktree move` stays a same-filesystem rename rather than a
+/// cross-device copy that git refuses.
+const TRASH_DIR_NAME: &str = ".aoe-trash";
+
+/// Where a trashed session's worktree is parked. `None` when `original` has no
+/// parent (a filesystem root), in which case relocation is skipped.
+pub fn trash_holding_path(original: &Path, session_id: &str) -> Option<PathBuf> {
+    Some(original.parent()?.join(TRASH_DIR_NAME).join(session_id))
+}
+
+/// Result of attempting to relocate a trashed session's worktree.
+#[derive(Debug)]
+pub enum RelocateOutcome {
+    /// The worktree was moved into the holding area and `project_path` was
+    /// repointed; `pre_trash_project_path` now holds the original location.
+    Relocated { from: PathBuf, to: PathBuf },
+    /// Nothing to do: not a managed single-repo worktree, or already
+    /// relocated. `project_path` is untouched.
+    Skipped,
+    /// The move could not run safely (sandbox container still mounting the
+    /// dir, locked, cross-device, git error). `project_path` is untouched;
+    /// the caller trashes in place and surfaces `reason`. Never blocks trash.
+    Failed { reason: String },
+}
+
+/// Result of attempting to move a worktree back out of the holding area.
+#[derive(Debug)]
+pub enum RestoreOutcome {
+    /// The worktree was moved back to its pre-trash location.
+    Restored { from: PathBuf, to: PathBuf },
+    /// No relocation had happened (plain/non-managed session, or a row trashed
+    /// before relocation existed), so there is nothing to move. The caller
+    /// still clears `trashed_at`.
+    NoChange,
+    /// The worktree could not be moved back (its original path is now occupied
+    /// by something else, or git refused). The session stays trashed and the
+    /// caller surfaces `reason`. Restore is strict: it never lands the
+    /// worktree somewhere other than where it came from.
+    Failed { reason: String },
+}
+
+fn is_managed_single_worktree(inst: &Instance) -> bool {
+    !inst.scratch
+        && inst
+            .worktree_info
+            .as_ref()
+            .is_some_and(|w| w.managed_by_aoe)
+}
+
+fn is_sandboxed(inst: &Instance) -> bool {
+    inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
+}
+
+/// Move a freshly-trashed session's managed worktree into the holding area and
+/// repoint `project_path`, capturing the original location in
+/// `pre_trash_project_path`. The caller MUST have stopped the live agent first
+/// (a running sandbox container holds the dir and the move fails EBUSY); this
+/// checks that gate and returns [`RelocateOutcome::Failed`] rather than
+/// blocking. Idempotent: a session that already carries
+/// `pre_trash_project_path` is [`RelocateOutcome::Skipped`].
+pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
+    if !inst.is_trashed() || !is_managed_single_worktree(inst) {
+        return RelocateOutcome::Skipped;
+    }
+    if inst.pre_trash_project_path.is_some() {
+        return RelocateOutcome::Skipped;
+    }
+
+    let current = PathBuf::from(&inst.project_path);
+    let Some(target) = trash_holding_path(&current, &inst.id) else {
+        return RelocateOutcome::Failed {
+            reason: format!("worktree path {} has no parent dir", current.display()),
+        };
+    };
+    if target.exists() {
+        return RelocateOutcome::Failed {
+            reason: format!("trash holding path {} already exists", target.display()),
+        };
+    }
+    if sandbox_container_holds_worktree(&inst.id, is_sandboxed(inst)) {
+        return RelocateOutcome::Failed {
+            reason: "sandbox container is still running and holds the worktree".to_string(),
+        };
+    }
+
+    let main_repo = inst
+        .worktree_info
+        .as_ref()
+        .map(|w| w.main_repo_path.clone())
+        .unwrap_or_default();
+    let git = match GitWorktree::new(PathBuf::from(&main_repo)) {
+        Ok(g) => g,
+        Err(e) => {
+            return RelocateOutcome::Failed {
+                reason: format!("open main repo {main_repo}: {e}"),
+            }
+        }
+    };
+    if let Some(parent) = target.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return RelocateOutcome::Failed {
+                reason: format!("create {}: {e}", parent.display()),
+            };
+        }
+    }
+    if let Err(e) = git.move_worktree(&current, &target) {
+        return RelocateOutcome::Failed {
+            reason: format!("git worktree move: {e}"),
+        };
+    }
+
+    discard_sandbox_container_after_move(&inst.id, is_sandboxed(inst));
+    inst.pre_trash_project_path = Some(inst.project_path.clone());
+    inst.project_path = target.to_string_lossy().into_owned();
+    tracing::info!(
+        target: "session.trash",
+        session = %inst.id,
+        from = %current.display(),
+        to = %target.display(),
+        "relocated trashed worktree into holding area"
+    );
+    RelocateOutcome::Relocated {
+        from: current,
+        to: target,
+    }
+}
+
+/// Move a trashed session's worktree back to its pre-trash location and clear
+/// `pre_trash_project_path`. Strict: if the original path is now occupied, the
+/// session stays trashed and the caller surfaces the failure, rather than
+/// silently restoring it to a different path.
+pub fn restore_worktree_location(inst: &mut Instance) -> RestoreOutcome {
+    let Some(original) = inst.pre_trash_project_path.clone() else {
+        return RestoreOutcome::NoChange;
+    };
+    let original = PathBuf::from(original);
+    let current = PathBuf::from(&inst.project_path);
+    if current == original {
+        // Never actually moved (relocation failed at trash time), or already
+        // back. Drop the marker so the row looks un-relocated again.
+        inst.pre_trash_project_path = None;
+        return RestoreOutcome::NoChange;
+    }
+    if sandbox_container_holds_worktree(&inst.id, is_sandboxed(inst)) {
+        return RestoreOutcome::Failed {
+            reason: "sandbox container is still running and holds the worktree".to_string(),
+        };
+    }
+    if original.exists() {
+        return RestoreOutcome::Failed {
+            reason: format!(
+                "original worktree path {} is occupied; move or remove it first",
+                original.display()
+            ),
+        };
+    }
+    let main_repo = inst
+        .worktree_info
+        .as_ref()
+        .map(|w| w.main_repo_path.clone())
+        .unwrap_or_default();
+    let git = match GitWorktree::new(PathBuf::from(&main_repo)) {
+        Ok(g) => g,
+        Err(e) => {
+            return RestoreOutcome::Failed {
+                reason: format!("open main repo {main_repo}: {e}"),
+            }
+        }
+    };
+    if let Err(e) = git.move_worktree(&current, &original) {
+        return RestoreOutcome::Failed {
+            reason: format!("git worktree move: {e}"),
+        };
+    }
+    discard_sandbox_container_after_move(&inst.id, is_sandboxed(inst));
+    inst.project_path = original.to_string_lossy().into_owned();
+    inst.pre_trash_project_path = None;
+    tracing::info!(
+        target: "session.trash",
+        session = %inst.id,
+        from = %current.display(),
+        to = %original.display(),
+        "restored worktree from holding area"
+    );
+    RestoreOutcome::Restored {
+        from: current,
+        to: original,
+    }
+}
+
+/// Load-time reconciliation for a single trashed session. Returns `true` when
+/// it mutated the instance (the caller must then persist).
+///
+/// Three jobs, all idempotent:
+///   - Backfill: a managed worktree trashed before relocation existed (no
+///     `pre_trash_project_path`, worktree still in the active dir) is relocated
+///     into the holding area now.
+///   - Heal-after-crash: if `project_path` no longer exists on disk but the
+///     deterministic holding path does, the move landed but the second persist
+///     was lost; repoint `project_path` and set `pre_trash_project_path`.
+///   - Heal-back: if `project_path` is gone and only the original survives, the
+///     move never took (or was undone); point back at the original.
+///
+/// Best-effort and non-fatal: a git failure logs and leaves the row as-is.
+pub fn reconcile_trashed_location(inst: &mut Instance) -> bool {
+    if !inst.is_trashed() || !is_managed_single_worktree(inst) {
+        return false;
+    }
+    let current = PathBuf::from(&inst.project_path);
+    // The pre-trash location: the recorded marker if we have one, else the
+    // current path (an un-relocated legacy row points at its own original).
+    let original = inst
+        .pre_trash_project_path
+        .clone()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| current.clone());
+    let Some(target) = trash_holding_path(&original, &inst.id) else {
+        return false;
+    };
+
+    if current.exists() {
+        // Legacy backfill: a trashed managed worktree still sitting in the
+        // active dir with no marker gets relocated now. An already-relocated
+        // row (marker set, current == holding) is left alone.
+        if inst.pre_trash_project_path.is_none() && current != target {
+            return matches!(
+                relocate_worktree_to_trash(inst),
+                RelocateOutcome::Relocated { .. }
+            );
+        }
+        return false;
+    }
+
+    // The recorded path is gone. Heal the pointer toward wherever the worktree
+    // actually landed.
+    if target.exists() {
+        inst.project_path = target.to_string_lossy().into_owned();
+        if inst.pre_trash_project_path.is_none() {
+            inst.pre_trash_project_path = Some(original.to_string_lossy().into_owned());
+        }
+        tracing::info!(
+            target: "session.trash",
+            session = %inst.id,
+            to = %target.display(),
+            "reconciled trashed worktree pointer to holding area"
+        );
+        return true;
+    }
+    if original.exists() && original != current {
+        inst.project_path = original.to_string_lossy().into_owned();
+        inst.pre_trash_project_path = None;
+        tracing::info!(
+            target: "session.trash",
+            session = %inst.id,
+            to = %original.display(),
+            "reconciled trashed worktree pointer back to original (holding move never landed)"
+        );
+        return true;
+    }
+    false
+}
 
 /// True when a trashed session is past its retention window and should be
 /// auto-purged. `retention_days == 0` means "keep forever" (manual purge
@@ -89,5 +361,199 @@ mod tests {
 
         let ids = expired_trashed_ids(&instances, 30, Utc::now());
         assert_eq!(ids, vec![old_a.id, old_b.id]);
+    }
+
+    #[test]
+    fn holding_path_is_namespaced_sibling() {
+        let p = trash_holding_path(Path::new("/repo-worktrees/feature"), "abc123").unwrap();
+        assert_eq!(p, PathBuf::from("/repo-worktrees/.aoe-trash/abc123"));
+        assert!(trash_holding_path(Path::new("/"), "abc123").is_none());
+    }
+
+    #[test]
+    fn relocate_skips_plain_session() {
+        let mut inst = Instance::new("plain", "/tmp/plain");
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Skipped
+        ));
+        assert_eq!(inst.project_path, "/tmp/plain");
+        assert!(inst.pre_trash_project_path.is_none());
+    }
+
+    /// Build a real aoe-managed worktree on disk and return (tmp, instance).
+    /// Mirrors the harness in `src/session/deletion.rs` tests.
+    fn real_worktree_instance() -> (tempfile::TempDir, Instance) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let main_repo = tmp.path().join("main");
+        let worktree_path = tmp.path().join("wt").join("feature");
+        std::fs::create_dir_all(&main_repo).unwrap();
+        std::fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+
+        let repo = git2::Repository::init(&main_repo).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let mut index = repo.index().unwrap();
+            index.write_tree().unwrap()
+        };
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        let status = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "feature/relocate-me",
+                worktree_path.to_str().unwrap(),
+            ])
+            .current_dir(&main_repo)
+            .output()
+            .unwrap();
+        assert!(
+            status.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+
+        let mut inst = Instance::new("WT", worktree_path.to_str().unwrap());
+        inst.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "feature/relocate-me".to_string(),
+            main_repo_path: main_repo.to_string_lossy().to_string(),
+            managed_by_aoe: true,
+            created_at: Utc::now(),
+            base_branch: None,
+        });
+        (tmp, inst)
+    }
+
+    fn git_available() -> bool {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_ok()
+    }
+
+    #[test]
+    fn relocate_then_restore_round_trip() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        let original = inst.project_path.clone();
+        inst.trash();
+
+        let out = relocate_worktree_to_trash(&mut inst);
+        assert!(
+            matches!(out, RelocateOutcome::Relocated { .. }),
+            "expected relocation, got {out:?}"
+        );
+        // Worktree moved into the holding area, original dir gone.
+        assert!(inst.project_path.contains("/.aoe-trash/"));
+        assert!(PathBuf::from(&inst.project_path).exists());
+        assert!(!PathBuf::from(&original).exists());
+        assert_eq!(
+            inst.pre_trash_project_path.as_deref(),
+            Some(original.as_str())
+        );
+
+        // Relocate again is a no-op (idempotent).
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Skipped
+        ));
+
+        // Restore moves it back and clears the marker.
+        let back = restore_worktree_location(&mut inst);
+        assert!(
+            matches!(back, RestoreOutcome::Restored { .. }),
+            "expected restore, got {back:?}"
+        );
+        assert_eq!(inst.project_path, original);
+        assert!(inst.pre_trash_project_path.is_none());
+        assert!(PathBuf::from(&original).exists());
+    }
+
+    #[test]
+    fn restore_fails_when_original_occupied() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        let original = inst.project_path.clone();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        // Something now occupies the original path.
+        std::fs::create_dir_all(&original).unwrap();
+
+        let out = restore_worktree_location(&mut inst);
+        assert!(
+            matches!(out, RestoreOutcome::Failed { .. }),
+            "restore should refuse an occupied original, got {out:?}"
+        );
+        // Still relocated, still recoverable later.
+        assert!(inst.pre_trash_project_path.is_some());
+        assert_ne!(inst.project_path, original);
+    }
+
+    #[test]
+    fn reconcile_backfills_legacy_then_is_idempotent() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        let original = inst.project_path.clone();
+        // Legacy trashed row: trashed, worktree still in the active dir, no marker.
+        inst.trash();
+        assert!(inst.pre_trash_project_path.is_none());
+
+        assert!(
+            reconcile_trashed_location(&mut inst),
+            "reconcile should relocate a legacy trashed worktree"
+        );
+        assert!(inst.project_path.contains("/.aoe-trash/"));
+        assert_eq!(
+            inst.pre_trash_project_path.as_deref(),
+            Some(original.as_str())
+        );
+        assert!(!PathBuf::from(&original).exists());
+
+        // Second pass changes nothing.
+        assert!(!reconcile_trashed_location(&mut inst));
+    }
+
+    #[test]
+    fn reconcile_heals_pointer_after_lost_persist() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        let original = inst.project_path.clone();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        let holding = inst.project_path.clone();
+
+        // Simulate the crash-after-move window: the durable row still points at
+        // the (now-missing) original and never recorded the marker.
+        inst.project_path = original.clone();
+        inst.pre_trash_project_path = None;
+
+        assert!(
+            reconcile_trashed_location(&mut inst),
+            "reconcile should heal the pointer to the holding area"
+        );
+        assert_eq!(inst.project_path, holding);
+        assert_eq!(
+            inst.pre_trash_project_path.as_deref(),
+            Some(original.as_str())
+        );
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1850,6 +1850,24 @@ impl HomeView {
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
             }
+            // Backfill / heal trashed worktrees: relocate any still sitting in
+            // the active dir (rows trashed before relocation existed) and fix a
+            // pointer a crash left stale. Best-effort and only touches trashed
+            // rows, which are typically few. See #2522.
+            for inst in &mut instances {
+                if crate::session::trash::reconcile_trashed_location(inst) {
+                    let new_path = inst.project_path.clone();
+                    let pre = inst.pre_trash_project_path.clone();
+                    let target_id = inst.id.clone();
+                    let _ = storage.update(|disk, _groups| {
+                        if let Some(d) = disk.iter_mut().find(|i| i.id == target_id) {
+                            d.project_path = new_path.clone();
+                            d.pre_trash_project_path = pre.clone();
+                        }
+                        Ok(())
+                    });
+                }
+            }
             let tree = GroupTree::new_with_groups(&instances, &groups);
             group_trees.insert(profile_name.clone(), tree);
             all_instances.extend(instances);

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1455,6 +1455,21 @@ impl HomeView {
         if let Some(inst) = self.instances.iter().find(|i| i.id == id) {
             inst.kill_all_tmux_sessions();
         }
+        // The session is durably trashed and its agent stopped; relocate its
+        // worktree out of the active dir. The move + repointed project_path
+        // persist through the same diff path. Best-effort: a failure leaves the
+        // worktree in place and a later reconcile pass can move it.
+        let mut relocate_warning: Option<String> = None;
+        let _ = self.apply_user_action(id, |inst| {
+            if let crate::session::trash::RelocateOutcome::Failed { reason } =
+                crate::session::trash::relocate_worktree_to_trash(inst)
+            {
+                relocate_warning = Some(reason);
+            }
+        });
+        if let Some(reason) = relocate_warning {
+            tracing::warn!(target: "tui.session", session = %id, "trash worktree relocation skipped: {reason}");
+        }
         self.reveal_trashed_section();
         self.flat_items = self.build_flat_items();
         self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
@@ -1476,8 +1491,25 @@ impl HomeView {
         if !is_trashed {
             return;
         }
-        if let Err(e) = self.apply_user_action(&id, |inst| inst.untrash()) {
-            tracing::warn!(target: "tui.session", session = %id, "restore failed: {e}");
+        // Move the worktree back to its pre-trash location before clearing the
+        // marker. Strict: if the original path is occupied, keep the session
+        // trashed and tell the user, rather than restoring it to the holding
+        // path.
+        let mut restore_error: Option<String> = None;
+        let _ = self.apply_user_action(&id, |inst| {
+            if let crate::session::trash::RestoreOutcome::Failed { reason } =
+                crate::session::trash::restore_worktree_location(inst)
+            {
+                restore_error = Some(reason);
+            } else {
+                inst.untrash();
+            }
+        });
+        if let Some(reason) = restore_error {
+            self.info_dialog = Some(crate::tui::dialogs::InfoDialog::new(
+                "Restore Failed",
+                &format!("Could not restore the worktree: {reason}"),
+            ));
             return;
         }
         self.flat_items = self.build_flat_items();


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Trashing a session used to leave its git worktree exactly where it was created, so trashed sessions kept cluttering the active worktree dir until they were purged (sometimes for the full retention window, or forever when retention is `0`). This makes trash actually get the worktree out of the way.

When a managed-worktree session is trashed, after its agent is stopped, aoe now moves the worktree into a sibling `.aoe-trash/<session-id>` holding directory via `git worktree move` and repoints the session's `project_path` at the new location. Because the structured-view preview, diff base, and purge all read `project_path`, they keep working with no extra plumbing: previewing a trashed session reads the relocated (still-live) worktree, and purging it removes the worktree from the holding dir. Restoring a session moves the worktree back to its original path; if that path is now occupied, the restore is refused (web returns 409, TUI shows a dialog, CLI errors) so nothing is overwritten. Plain and non-managed sessions are untouched, only the trash marker flips.

A new `pre_trash_project_path` marker on `Instance` records the original location for a faithful restore (it cannot be recomputed: the creation-time path seed is unrecoverable and the template may have drifted). The move is two-phase and crash-tolerant: the session is durably trashed before the move, and a `reconcile_trashed_location` pass on daemon startup and TUI load heals a pointer left stale by a crash between the move and its persist. That same pass backfills sessions that were already in the trash before this change shipped, relocating their worktrees on the next daemon start or TUI load.

Implemented per a `/debate` between two models. One notable deviation from the issue: the issue proposed a `src/migrations/v019` for the backfill, but the field is `#[serde(default)]` (no schema migration needed) and shelling out to git from a blocking startup migration is the wrong vehicle, so the backfill runs as the best-effort reconcile pass instead. This was agreed at plan time.

Closes #2522

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a worktree-backed session, note its worktree dir under the active worktree base, then trash it. Confirm the worktree dir moves to a sibling `.aoe-trash/<session-id>` and the active base no longer holds it.
- [ ] With the session trashed, open it in the structured view and confirm the preview still shows its files (cwd is not broken).
- [ ] Restore the trashed session and confirm the worktree moves back to its original path and the session is live again.
- [ ] Trash a session, recreate a directory at its original worktree path, then try to restore: confirm the restore is refused (web 409 / TUI "Restore Failed" dialog / CLI error) rather than restoring to the holding path.
- [ ] Trash a worktree session, then purge it (`aoe rm --purge`, web "Delete permanently", or let retention expire): confirm the relocated worktree under `.aoe-trash` is removed with no leftover dir.
- [ ] Trash a plain (non-worktree) session and confirm nothing on disk moves.
- [ ] With a session already in the trash from before this change, restart the daemon (`aoe serve`) or relaunch the TUI and confirm its worktree gets relocated into `.aoe-trash`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the change is backend-only (no `web/src` or dashboard UI changed; the existing trash/restore buttons call the same endpoints). The new behavior is covered by deterministic Rust integration tests in `src/session/trash.rs` (relocate, restore, reconcile, purge round-trips against a real temp git repo + worktree) plus the existing session-handler tests. A structured-view-preview-after-trash live spec is a reasonable follow-up.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the relocation, restore, and reconcile logic is covered by deterministic Rust integration tests against a real temp git worktree, including the "relocated worktree is still a working checkout" and "purge removes the relocated worktree" cases. A full tmux e2e would add flakiness without exercising logic the unit tests miss.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a two-model `/debate` on the design, and implementation were drafted by Claude under my direction. I made the design calls (two-phase ordering, dropping the migration in favor of a reconcile pass, the strict-restore behavior) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785260702&installation_id=139138837&pr_number=2531&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2531&signature=2e2146d00031e0ee120e03a0ae77805ce294ffe0e38a5e682d218c69f3dbe1b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added worktree “trash relocation” for trashed managed sessions and safe round-trip restore.

- When a **managed single-repo** session is trashed (via CLI/server/TUI), the agent stops it and **moves its git worktree out of the active directory** into a sibling holding folder: **`.aoe-trash/<session-id>`**, then **repoints `project_path`** so previews/diffs continue to work.
- A new **`pre_trash_project_path` marker** records the original worktree location so restore can move it back precisely.
- On **restore**, the worktree is moved back to the recorded original path and the session’s paths are restored; **restore is refused if the original destination is already occupied** (surfaced to UI/API/CLI appropriately).
- Added **crash-tolerant reconciliation/backfill** so older/partially-updated trashed sessions are healed:
  - during **daemon startup** and
  - when the **TUI home view** loads.
- **Non-managed/plain sessions** keep the old behavior (just marked trashed; no filesystem move).
- **Failure handling:** if relocation can’t be performed (e.g., environment/locking/container constraints), trash still completes, but relocation is skipped with a warning; purge later removes from the holding directory.

Benefits: cleaner active workspaces (trashed repos no longer clutter active checkouts), previews stay functional while trashed, and restore becomes more reliable—especially after crashes or upgrades—with automatic repair of legacy trashed worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->