### PR TITLE
fix(web): scope Trash to whole workspaces and gate the trashed composer

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -859,15 +859,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       const primary = sessions[0];
       if (!primary) return;
       const ids = sessions.map((s) => s.id);
-      const wasActive = activeSessionId != null && ids.includes(activeSessionId);
+      const activeWorkspaceSessionId =
+        activeSessionId != null && ids.includes(activeSessionId) ? activeSessionId : null;
 
       // Close dialog and show "Deleting" status for every session immediately.
       setDeletingWorkspaceId(null);
       for (const id of ids) setSessionStatus(id, "Deleting");
-
-      if (wasActive) {
-        navigate("/");
-      }
 
       // Per-id local cleanup, run only after that id's server delete succeeds so
       // a failed delete never strands a stale acp cache (#1358), composer draft
@@ -884,12 +881,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       // If the primary delete fails (dirty worktree, server error) the shared
       // worktree is still present, so abort before destroying any sibling
       // record and leaving an orphaned workspace. See #2530.
+      let activeDeleted = false;
       const primaryResult = await deleteSession(primary.id, options);
       if (!primaryResult.ok) {
         for (const id of ids) setSessionStatus(id, "Error");
         toastBus.handler?.error(primaryResult.error || "Failed to delete session");
         return;
       }
+      if (activeWorkspaceSessionId === primary.id) activeDeleted = true;
       purgeLocal(primary.id);
 
       // Siblings keep the per-session cleanup (sandbox container, force) but
@@ -900,12 +899,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       for (const sibling of sessions.slice(1)) {
         const res = await deleteSession(sibling.id, siblingOptions);
         if (res.ok) {
+          if (activeWorkspaceSessionId === sibling.id) activeDeleted = true;
           purgeLocal(sibling.id);
         } else {
           anyFailed = true;
           setSessionStatus(sibling.id, "Error");
         }
       }
+
+      // Redirect only once the open session has actually been deleted, not
+      // merely because it belonged to the workspace: a failed primary (above)
+      // returns early with nothing removed, so navigating earlier would strand
+      // the user on `/` with the session still live. See #2539 review.
+      if (activeDeleted) navigate("/");
 
       if (anyFailed) {
         toastBus.handler?.error("Some sessions could not be deleted");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,11 +40,10 @@ import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab } from "./lib/
 import { isPluginPaneId, usePluginPanes, type PluginPane } from "./lib/pluginPanes";
 import { PluginPaneBody } from "./components/plugin/PluginSlots";
 import { TOUR_ANCHORS, tourAnchor } from "./lib/tourSteps";
-import { restoreSessions, trashSessions } from "./lib/trashActions";
+import { deleteWorkspaceSessions, restoreSessions, trashSessions } from "./lib/trashActions";
 import {
   loginStatus,
   logout,
-  deleteSession,
   stopSession,
   startSession,
   fetchAbout,
@@ -856,73 +855,22 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     async (options: DeleteSessionOptions) => {
       if (!deletingWorkspace) return;
       const sessions = deletingWorkspace.sessions;
-      const primary = sessions[0];
-      if (!primary) return;
-      const ids = sessions.map((s) => s.id);
-      const activeWorkspaceSessionId =
-        activeSessionId != null && ids.includes(activeSessionId) ? activeSessionId : null;
-
-      // Close dialog and show "Deleting" status for every session immediately.
+      // Close the dialog immediately; the loop, ordering, and toast logic live
+      // in deleteWorkspaceSessions so they are unit-testable without the bundle.
       setDeletingWorkspaceId(null);
-      for (const id of ids) setSessionStatus(id, "Deleting");
-
-      // Per-id local cleanup, run only after that id's server delete succeeds so
-      // a failed delete never strands a stale acp cache (#1358), composer draft
-      // (#1358), or diff-comments storage (#1842). Cross-tab / cross-device
-      // deletes still fall to the startup sweep.
-      const purgeLocal = (id: string) => {
-        clearAcpCache(id);
-        clearDraft(id);
-        clearStoredComments(id);
-      };
-
-      // Every session in a workspace shares one git worktree and branch, so the
-      // user-chosen worktree/branch cleanup runs exactly once, on the primary.
-      // If the primary delete fails (dirty worktree, server error) the shared
-      // worktree is still present, so abort before destroying any sibling
-      // record and leaving an orphaned workspace. See #2530.
-      let activeDeleted = false;
-      const primaryResult = await deleteSession(primary.id, options);
-      if (!primaryResult.ok) {
-        for (const id of ids) setSessionStatus(id, "Error");
-        toastBus.handler?.error(primaryResult.error || "Failed to delete session");
-        return;
-      }
-      if (activeWorkspaceSessionId === primary.id) activeDeleted = true;
-      purgeLocal(primary.id);
-
-      // Siblings keep the per-session cleanup (sandbox container, force) but
-      // never re-run the shared worktree/branch removal: it is already done, and
-      // remove_managed_worktree is not idempotent.
-      const siblingOptions: DeleteSessionOptions = { ...options, delete_worktree: false, delete_branch: false };
-      let anyFailed = false;
-      for (const sibling of sessions.slice(1)) {
-        const res = await deleteSession(sibling.id, siblingOptions);
-        if (res.ok) {
-          if (activeWorkspaceSessionId === sibling.id) activeDeleted = true;
-          purgeLocal(sibling.id);
-        } else {
-          anyFailed = true;
-          setSessionStatus(sibling.id, "Error");
-        }
-      }
-
-      // Redirect only once the open session has actually been deleted, not
-      // merely because it belonged to the workspace: a failed primary (above)
-      // returns early with nothing removed, so navigating earlier would strand
-      // the user on `/` with the session still live. See #2539 review.
-      if (activeDeleted) navigate("/");
-
-      if (anyFailed) {
-        toastBus.handler?.error("Some sessions could not be deleted");
-        return;
-      }
-
-      // Server returns `messages` from `perform_deletion` when there's something
-      // user-facing to report (e.g. "Scratch directory kept at: <path>" when
-      // `keep_scratch` is set). Surface the first one so the kept-path is visible.
-      const toast = primaryResult.messages?.[0] ?? (ids.length > 1 ? "Sessions deleted" : "Session deleted");
-      toastBus.handler?.info(toast);
+      await deleteWorkspaceSessions(sessions, options, activeSessionId, {
+        setStatus: setSessionStatus,
+        // Drop a deleted session's local-only state (#1358 acp cache + draft,
+        // #1842 diff comments). Cross-tab / cross-device deletes fall to the
+        // startup sweep.
+        purgeLocal: (id) => {
+          clearAcpCache(id);
+          clearDraft(id);
+          clearStoredComments(id);
+        },
+        navigateHome: () => navigate("/"),
+        notify: toastBus.handler,
+      });
     },
     [deletingWorkspace, activeSessionId, setSessionStatus, navigate],
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { useNestedSidebarGroups } from "./hooks/useNestedSidebarGroups";
 import { PluginUiProvider, usePluginUiEntries } from "./lib/pluginUiContext";
 import { buildSortValueMap, pluginSortSpecs } from "./lib/pluginUi";
 import type { PluginSortContext, SidebarSortMode } from "./lib/sidebarSort";
+import { workspaceIsTrashed } from "./lib/sidebarSort";
 import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
 import { useSidebarAxis } from "./hooks/useSidebarAxis";
 import { repoGroupToSidebarGroup, type SidebarGroup } from "./lib/sidebarGroups";
@@ -275,6 +276,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     applySession,
   } = useSessions();
   const workspaces = useWorkspaces(sessions);
+  // Trash is a whole-workspace concern, so it is derived here from the
+  // authoritative unsliced workspace list rather than reconstructed from the
+  // sidebar's per-`group_path` slice views. A workspace is in Trash only when
+  // every one of its sessions is trashed, and Restore/Delete then cover all of
+  // them. See #2533.
+  const trashedWorkspaces = useMemo(() => workspaces.filter(workspaceIsTrashed), [workspaces]);
 
   // Remember the active session and restore it on a PWA relaunch (#2103).
   useLastSessionRestore({ activeSessionId, sessions, sessionsLoaded });
@@ -847,45 +854,71 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const handleConfirmDelete = useCallback(
     async (options: DeleteSessionOptions) => {
-      if (!deletingSession) return;
-      const sessionId = deletingSession.id;
-      const wasActive = sessionId === activeSessionId;
+      if (!deletingWorkspace) return;
+      const sessions = deletingWorkspace.sessions;
+      const primary = sessions[0];
+      if (!primary) return;
+      const ids = sessions.map((s) => s.id);
+      const wasActive = activeSessionId != null && ids.includes(activeSessionId);
 
-      // Close dialog and show "Deleting" status immediately
+      // Close dialog and show "Deleting" status for every session immediately.
       setDeletingWorkspaceId(null);
-      setSessionStatus(sessionId, "Deleting");
+      for (const id of ids) setSessionStatus(id, "Deleting");
 
       if (wasActive) {
         navigate("/");
       }
 
-      const result = await deleteSession(sessionId, options);
-      if (!result.ok) {
-        // Revert status on failure
-        setSessionStatus(sessionId, "Error");
-        toastBus.handler?.error(result.error || "Failed to delete session");
+      // Per-id local cleanup, run only after that id's server delete succeeds so
+      // a failed delete never strands a stale acp cache (#1358), composer draft
+      // (#1358), or diff-comments storage (#1842). Cross-tab / cross-device
+      // deletes still fall to the startup sweep.
+      const purgeLocal = (id: string) => {
+        clearAcpCache(id);
+        clearDraft(id);
+        clearStoredComments(id);
+      };
+
+      // Every session in a workspace shares one git worktree and branch, so the
+      // user-chosen worktree/branch cleanup runs exactly once, on the primary.
+      // If the primary delete fails (dirty worktree, server error) the shared
+      // worktree is still present, so abort before destroying any sibling
+      // record and leaving an orphaned workspace. See #2530.
+      const primaryResult = await deleteSession(primary.id, options);
+      if (!primaryResult.ok) {
+        for (const id of ids) setSessionStatus(id, "Error");
+        toastBus.handler?.error(primaryResult.error || "Failed to delete session");
         return;
       }
+      purgeLocal(primary.id);
 
-      // Drop the per-session acp cache so a recreated session with
-      // the same id doesn't briefly show the prior transcript on
-      // remount before fetchReplay clears it.
-      clearAcpCache(sessionId);
-      // Drop the persisted composer draft for the deleted session so its
-      // localStorage key doesn't linger (#1358). Cross-tab / cross-device
-      // deletes go through the startup sweep instead.
-      clearDraft(sessionId);
-      // Same hygiene for persisted diff-comments storage (#1842); cross-tab /
-      // cross-device deletes still fall to the startup sweep.
-      clearStoredComments(sessionId);
+      // Siblings keep the per-session cleanup (sandbox container, force) but
+      // never re-run the shared worktree/branch removal: it is already done, and
+      // remove_managed_worktree is not idempotent.
+      const siblingOptions: DeleteSessionOptions = { ...options, delete_worktree: false, delete_branch: false };
+      let anyFailed = false;
+      for (const sibling of sessions.slice(1)) {
+        const res = await deleteSession(sibling.id, siblingOptions);
+        if (res.ok) {
+          purgeLocal(sibling.id);
+        } else {
+          anyFailed = true;
+          setSessionStatus(sibling.id, "Error");
+        }
+      }
+
+      if (anyFailed) {
+        toastBus.handler?.error("Some sessions could not be deleted");
+        return;
+      }
 
       // Server returns `messages` from `perform_deletion` when there's something
       // user-facing to report (e.g. "Scratch directory kept at: <path>" when
       // `keep_scratch` is set). Surface the first one so the kept-path is visible.
-      const toast = result.messages?.[0] ?? "Session deleted";
+      const toast = primaryResult.messages?.[0] ?? (ids.length > 1 ? "Sessions deleted" : "Session deleted");
       toastBus.handler?.info(toast);
     },
-    [deletingSession, activeSessionId, setSessionStatus, navigate],
+    [deletingWorkspace, activeSessionId, setSessionStatus, navigate],
   );
 
   // Move-to-trash path (#2489): the safe default. Unlike permanent delete it
@@ -1770,6 +1803,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             <WorkspaceSidebar
               groups={sidebarGroups}
               nestedGroups={nestedGroups}
+              trashedWorkspaces={trashedWorkspaces}
               onToggleSubgroup={toggleSubgroupCollapsed}
               onReorderWorkspaces={handleReorderWorkspaces}
               onReorderGroups={reorderRepoGroups}
@@ -1864,6 +1898,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             isScratch={deletingSession.scratch}
             cleanupDefaults={deletingSession.cleanup_defaults}
             defaultToTrash={!deletingSession.trashed_at && deletingSession.cleanup_defaults.delete_to_trash}
+            extraSessionCount={deletingWorkspace ? deletingWorkspace.sessions.length - 1 : 0}
             onConfirm={handleConfirmDelete}
             onTrash={handleConfirmTrash}
             onCancel={() => setDeletingWorkspaceId(null)}

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -13,6 +13,11 @@ interface Props {
    *  Trash" with a "Delete permanently" disclosure; when false it goes
    *  straight to the permanent-delete options. See #2489. */
   defaultToTrash: boolean;
+  /** Number of sibling sessions in the workspace beyond the one named above.
+   *  A workspace shares one worktree across all its sessions, and delete acts
+   *  on the whole workspace, so when this is >0 the dialog discloses that more
+   *  than the named session will be removed. See #2530. */
+  extraSessionCount?: number;
   onConfirm: (options: DeleteSessionOptions) => Promise<void>;
   onTrash: () => Promise<void>;
   onCancel: () => void;
@@ -26,6 +31,7 @@ export function DeleteSessionDialog({
   isScratch,
   cleanupDefaults,
   defaultToTrash,
+  extraSessionCount = 0,
   onConfirm,
   onTrash,
   onCancel,
@@ -129,6 +135,12 @@ export function DeleteSessionDialog({
           <p className="text-[13px] text-text-secondary">
             Delete <span className="font-mono text-text-primary">{sessionTitle}</span>?
           </p>
+
+          {extraSessionCount > 0 && (
+            <p className="text-[12px] text-text-dim" data-testid="delete-session-extra-count">
+              This removes all {extraSessionCount + 1} sessions on this branch.
+            </p>
+          )}
 
           {/* When trash is the default, deleting moves the session to the
               Trash (restore later); this checkbox opts into erasing it now.

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -138,7 +138,9 @@ export function DeleteSessionDialog({
 
           {extraSessionCount > 0 && (
             <p className="text-[12px] text-text-dim" data-testid="delete-session-extra-count">
-              This removes all {extraSessionCount + 1} sessions on this branch.
+              {permanent
+                ? `This permanently deletes all ${extraSessionCount + 1} sessions in this workspace.`
+                : `This moves all ${extraSessionCount + 1} sessions in this workspace to Trash.`}
             </p>
           )}
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -272,6 +272,15 @@ interface Props {
   // The nested `repo+group` axis model (#1720). Only consumed when
   // `axis === "repo+group"`; the flat `groups` list drives the other axes.
   nestedGroups: NestedSidebarGroup[];
+  // Fully-trashed workspaces, computed by the parent from the authoritative
+  // unsliced workspace list (`workspaces.filter(workspaceIsTrashed)`), NOT from
+  // the per-`group_path` slice views in `groups`/`nestedGroups`. Trash
+  // membership and Restore scope are a whole-workspace concern: a workspace
+  // split across groups is in Trash only when every one of its sessions is
+  // trashed, and Restore must cover all of them. See #2533. Optional with an
+  // empty default so callers that never trash (and render-only tests) need not
+  // thread it.
+  trashedWorkspaces?: Workspace[];
   onToggleSubgroup: (repoId: string, groupPath: string) => void;
   onReorderWorkspaces: (newOrder: string[]) => void;
   onReorderGroups: (orderedGroupIds: string[]) => void;
@@ -506,7 +515,7 @@ function TrashMenu({
   onRestore,
   onDelete,
 }: {
-  trashedWorkspaces: SidebarWorkspaceView[];
+  trashedWorkspaces: Workspace[];
   readOnly?: boolean;
   onOpen: (workspaceId: string, e: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean }) => void;
   onRestore: (sessionIds: string[]) => void;
@@ -555,26 +564,26 @@ function TrashMenu({
           <div className="px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted">
             Trash ({count})
           </div>
-          {trashedWorkspaces.map((v) => (
+          {trashedWorkspaces.map((ws) => (
             <div
-              key={v.key}
+              key={ws.id}
               data-testid="sidebar-trash-row"
               className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-text-secondary"
             >
               <button
                 type="button"
-                onClick={(e) => onOpen(v.workspace.id, e)}
-                title={v.workspace.displayName}
+                onClick={(e) => onOpen(ws.id, e)}
+                title={ws.displayName}
                 data-testid="sidebar-trash-open"
                 className="flex-1 truncate text-left hover:text-text-primary cursor-pointer"
               >
-                {v.workspace.displayName}
+                {ws.displayName}
               </button>
               {!readOnly && (
                 <>
                   <button
                     onClick={() => {
-                      const ids = v.workspace.sessions.map((s) => s.id);
+                      const ids = ws.sessions.map((s) => s.id);
                       if (ids.length > 0) onRestore(ids);
                     }}
                     data-testid="sidebar-trash-restore"
@@ -585,7 +594,7 @@ function TrashMenu({
                     <RotateCcw className="h-3.5 w-3.5" />
                   </button>
                   <button
-                    onClick={() => onDelete(v.workspace.id)}
+                    onClick={() => onDelete(ws.id)}
                     data-testid="sidebar-trash-purge"
                     title="Delete permanently"
                     aria-label="Delete permanently"
@@ -2409,6 +2418,7 @@ const AXIS_ARIA: Record<SidebarAxis, string> = {
 export function WorkspaceSidebar({
   groups,
   nestedGroups,
+  trashedWorkspaces = [],
   onToggleSubgroup,
   onReorderWorkspaces,
   onReorderGroups,
@@ -2657,26 +2667,6 @@ export function WorkspaceSidebar({
   const savedProjectsMatchQuery =
     !!q && savedProjects.some((p) => p.displayName.toLowerCase().includes(q) || p.repoPath.toLowerCase().includes(q));
   const hasResults = (isNested ? filteredNested.length > 0 : filteredGroups.length > 0) || savedProjectsMatchQuery;
-
-  // Trashed workspaces, flattened across the active axis and deduped by id (the
-  // same workspace can appear under more than one group). Feeds the footer
-  // Trash menu next to Settings (#2512), no longer an inline section. Built
-  // from the unfiltered groups, not the filtered ones: trash is a global
-  // recovery affordance, so an active search or facet must not hide the footer
-  // icon and strand trashed sessions until the filter is cleared.
-  const trashedWorkspaces = useMemo(() => {
-    const raw = isNested
-      ? nestedGroups.flatMap((ng) =>
-          ng.subgroups.flatMap((sg) => sg.workspaces.filter((v) => workspaceIsTrashed(v.workspace))),
-        )
-      : groups.flatMap((g) => g.workspaces.filter((v) => workspaceIsTrashed(v.workspace)));
-    const seen = new Set<string>();
-    return raw.filter((v) => {
-      if (seen.has(v.workspace.id)) return false;
-      seen.add(v.workspace.id);
-      return true;
-    });
-  }, [isNested, nestedGroups, groups]);
 
   // Sidebar multi-select. Selection is ephemeral sidebar UI state (not routed
   // or persisted); the anchor pivots Shift+click ranges. See #1724.

--- a/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
+++ b/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
@@ -102,13 +102,27 @@ function renderSidebar(over: Partial<React.ComponentProps<typeof WorkspaceSideba
 afterEach(cleanup);
 
 describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
+  // The Trash list is owned by the parent (App computes it from the full,
+  // unsliced workspace set) and passed in as `trashedWorkspaces`; the sidebar
+  // no longer derives it from `groups`. See #2533. Tests pass both: `groups`
+  // so the workspace exists for navigation, `trashedWorkspaces` to populate
+  // the footer popover.
+  function trashedWorkspace(): Workspace {
+    return workspace("trashed-ws", [session({ id: "s1", trashed_at: "2026-01-01T00:00:00Z" })]);
+  }
   function trashedGroups() {
-    const ws = workspace("trashed-ws", [session({ id: "s1", trashed_at: "2026-01-01T00:00:00Z" })]);
-    return buildSessionGroups([ws], { idleDecayWindowMs: 60_000, sortMode: "lastActivity", isCollapsed: () => false });
+    return buildSessionGroups([trashedWorkspace()], {
+      idleDecayWindowMs: 60_000,
+      sortMode: "lastActivity",
+      isCollapsed: () => false,
+    });
+  }
+  function renderWithTrash(over: Partial<React.ComponentProps<typeof WorkspaceSidebar>> = {}) {
+    return renderSidebar({ groups: trashedGroups(), trashedWorkspaces: [trashedWorkspace()], ...over });
   }
 
   it("reaches a trashed workspace via the footer Trash popover and exposes its actions", () => {
-    const props = renderSidebar({ groups: trashedGroups() });
+    const props = renderWithTrash();
 
     // No inline section in the scrolling list; only the footer toggle.
     expect(screen.queryByTestId("sidebar-trash-section")).toBeNull();
@@ -131,7 +145,7 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
   });
 
   it("closes the Trash popover on Escape", () => {
-    renderSidebar({ groups: trashedGroups() });
+    renderWithTrash();
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
     expect(screen.getByTestId("sidebar-trash-menu")).toBeTruthy();
     fireEvent.keyDown(document, { key: "Escape" });
@@ -139,7 +153,7 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
   });
 
   it("closes the Trash popover on outside click", () => {
-    renderSidebar({ groups: trashedGroups() });
+    renderWithTrash();
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
     expect(screen.getByTestId("sidebar-trash-menu")).toBeTruthy();
     fireEvent.mouseDown(document.body);
@@ -149,7 +163,7 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
   it("keeps the Trash icon reachable while a filter hides every live row (#2512)", () => {
     // Trash is a global recovery affordance: an active filter that matches no
     // workspace must not strand trashed sessions by hiding the footer icon.
-    renderSidebar({ groups: trashedGroups() });
+    renderWithTrash();
     fireEvent.click(screen.getByLabelText("Filter sessions"));
     fireEvent.change(screen.getByTestId("sidebar-filter-input"), { target: { value: "zzz-no-match" } });
     expect(screen.getByTestId("sidebar-trash-toggle")).toBeTruthy();
@@ -158,7 +172,7 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
   });
 
   it("hides Restore/Delete actions in read-only mode", () => {
-    renderSidebar({ groups: trashedGroups(), readOnly: true });
+    renderWithTrash({ readOnly: true });
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
     expect(screen.getByTestId("sidebar-trash-open")).toBeTruthy();
     expect(screen.queryByTestId("sidebar-trash-restore")).toBeNull();

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -604,67 +604,74 @@ function AcpChrome({
           </div>
         </ThreadPrimitive.Viewport>
 
-        <div ref={belowViewportRef}>
-          <QueuedPromptsStrip
-            queued={state.queuedPrompts}
-            onRemove={removeQueuedPrompt}
-            onEdit={editQueuedPrompt}
-            onClear={clearQueue}
-            pendingResume={
-              status !== "open" || acpWorkerState !== "running" || state.workerStopped || state.workerRestarting
-            }
-          />
+        {/* A trashed session is read-only until restored: the reconciler will
+            never resume it, so the queue strips and composer (which would only
+            stash input into a queue that never drains) are not rendered. The
+            transcript above stays visible. Archived / snoozed sessions are
+            resumable, so they keep their composer. See #2529. */}
+        {!trashedAt && (
+          <div ref={belowViewportRef}>
+            <QueuedPromptsStrip
+              queued={state.queuedPrompts}
+              onRemove={removeQueuedPrompt}
+              onEdit={editQueuedPrompt}
+              onClear={clearQueue}
+              pendingResume={
+                status !== "open" || acpWorkerState !== "running" || state.workerStopped || state.workerRestarting
+              }
+            />
 
-          <RejectedPromptsStrip
-            rejected={state.rejectedPrompts}
-            onRetry={sendPrompt}
-            onDismiss={dismissRejectedPrompt}
-            disabled={state.workerRestarting || state.workerStopped || Boolean(state.startupError)}
-          />
+            <RejectedPromptsStrip
+              rejected={state.rejectedPrompts}
+              onRetry={sendPrompt}
+              onDismiss={dismissRejectedPrompt}
+              disabled={state.workerRestarting || state.workerStopped || Boolean(state.startupError)}
+            />
 
-          <ModeSwitchFailedNotice failure={state.modeSwitchFailed} onDismiss={dismissModeSwitchFailed} />
+            <ModeSwitchFailedNotice failure={state.modeSwitchFailed} onDismiss={dismissModeSwitchFailed} />
 
-          <ConfigOptionSwitchFailedNotice
-            failure={state.configOptionSwitchFailed}
-            configOptions={state.configOptions}
-            onDismiss={dismissConfigOptionSwitchFailed}
-          />
+            <ConfigOptionSwitchFailedNotice
+              failure={state.configOptionSwitchFailed}
+              configOptions={state.configOptions}
+              onDismiss={dismissConfigOptionSwitchFailed}
+            />
 
-          <ContextPrimerBanner
-            sessionId={sessionId}
-            available={state.contextPrimerAvailable}
-            onInsertPrimer={(text) =>
-              setPrimerPrefill({
-                id: `primer-${state.contextPrimerAvailable?.resetSeq ?? 0}-${Date.now()}`,
-                text,
-              })
-            }
-            onDismiss={dismissPrimer}
-          />
+            <ContextPrimerBanner
+              sessionId={sessionId}
+              available={state.contextPrimerAvailable}
+              onInsertPrimer={(text) =>
+                setPrimerPrefill({
+                  id: `primer-${state.contextPrimerAvailable?.resetSeq ?? 0}-${Date.now()}`,
+                  text,
+                })
+              }
+              onDismiss={dismissPrimer}
+            />
 
-          <Composer
-            sessionId={sessionId}
-            currentAgent={state.agent}
-            availableModes={state.availableModes}
-            currentModeId={state.currentModeId}
-            legacyMode={state.mode}
-            configOptions={state.configOptions}
-            pendingConfigOption={state.pendingConfigOption}
-            setConfigOption={setConfigOption}
-            sessionUsage={state.sessionUsage}
-            availableCommands={state.availableCommands}
-            connected={status === "open" && !state.workerStopped && !state.workerRestarting}
-            turnActive={state.turnActive}
-            queuedCount={state.queuedPrompts.length}
-            enqueuePrompt={sendPrompt}
-            promptCapabilities={state.promptCapabilities}
-            pendingAttachments={pendingAttachments}
-            setPendingAttachments={setPendingAttachments}
-            primerPrefill={primerPrefill}
-            queuedPrompts={state.queuedPrompts}
-            editQueuedPrompt={editQueuedPrompt}
-          />
-        </div>
+            <Composer
+              sessionId={sessionId}
+              currentAgent={state.agent}
+              availableModes={state.availableModes}
+              currentModeId={state.currentModeId}
+              legacyMode={state.mode}
+              configOptions={state.configOptions}
+              pendingConfigOption={state.pendingConfigOption}
+              setConfigOption={setConfigOption}
+              sessionUsage={state.sessionUsage}
+              availableCommands={state.availableCommands}
+              connected={status === "open" && !state.workerStopped && !state.workerRestarting}
+              turnActive={state.turnActive}
+              queuedCount={state.queuedPrompts.length}
+              enqueuePrompt={sendPrompt}
+              promptCapabilities={state.promptCapabilities}
+              pendingAttachments={pendingAttachments}
+              setPendingAttachments={setPendingAttachments}
+              primerPrefill={primerPrefill}
+              queuedPrompts={state.queuedPrompts}
+              editQueuedPrompt={editQueuedPrompt}
+            />
+          </div>
+        )}
       </ThreadPrimitive.Root>
     </StructuredViewRoot>
   );

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -604,74 +604,80 @@ function AcpChrome({
           </div>
         </ThreadPrimitive.Viewport>
 
-        {/* A trashed session is read-only until restored: the reconciler will
-            never resume it, so the queue strips and composer (which would only
-            stash input into a queue that never drains) are not rendered. The
-            transcript above stays visible. Archived / snoozed sessions are
-            resumable, so they keep their composer. See #2529. */}
-        {!trashedAt && (
-          <div ref={belowViewportRef}>
-            <QueuedPromptsStrip
-              queued={state.queuedPrompts}
-              onRemove={removeQueuedPrompt}
-              onEdit={editQueuedPrompt}
-              onClear={clearQueue}
-              pendingResume={
-                status !== "open" || acpWorkerState !== "running" || state.workerStopped || state.workerRestarting
-              }
-            />
+        {/* The ref host stays mounted always: the transcript's pinned-bottom
+            sampling and earlier-history resize anchoring (the useLayoutEffect
+            above) depend on `belowViewportRef.current` being present, and a
+            trashed session still scrolls its read-only transcript. Only the
+            interactive controls are gated. A trashed session is read-only until
+            restored (the reconciler will never resume it), so the queue strips
+            and composer, which would only stash input into a queue that never
+            drains, are not rendered. Archived / snoozed sessions are resumable,
+            so they keep their composer. See #2529. */}
+        <div ref={belowViewportRef}>
+          {!trashedAt && (
+            <>
+              <QueuedPromptsStrip
+                queued={state.queuedPrompts}
+                onRemove={removeQueuedPrompt}
+                onEdit={editQueuedPrompt}
+                onClear={clearQueue}
+                pendingResume={
+                  status !== "open" || acpWorkerState !== "running" || state.workerStopped || state.workerRestarting
+                }
+              />
 
-            <RejectedPromptsStrip
-              rejected={state.rejectedPrompts}
-              onRetry={sendPrompt}
-              onDismiss={dismissRejectedPrompt}
-              disabled={state.workerRestarting || state.workerStopped || Boolean(state.startupError)}
-            />
+              <RejectedPromptsStrip
+                rejected={state.rejectedPrompts}
+                onRetry={sendPrompt}
+                onDismiss={dismissRejectedPrompt}
+                disabled={state.workerRestarting || state.workerStopped || Boolean(state.startupError)}
+              />
 
-            <ModeSwitchFailedNotice failure={state.modeSwitchFailed} onDismiss={dismissModeSwitchFailed} />
+              <ModeSwitchFailedNotice failure={state.modeSwitchFailed} onDismiss={dismissModeSwitchFailed} />
 
-            <ConfigOptionSwitchFailedNotice
-              failure={state.configOptionSwitchFailed}
-              configOptions={state.configOptions}
-              onDismiss={dismissConfigOptionSwitchFailed}
-            />
+              <ConfigOptionSwitchFailedNotice
+                failure={state.configOptionSwitchFailed}
+                configOptions={state.configOptions}
+                onDismiss={dismissConfigOptionSwitchFailed}
+              />
 
-            <ContextPrimerBanner
-              sessionId={sessionId}
-              available={state.contextPrimerAvailable}
-              onInsertPrimer={(text) =>
-                setPrimerPrefill({
-                  id: `primer-${state.contextPrimerAvailable?.resetSeq ?? 0}-${Date.now()}`,
-                  text,
-                })
-              }
-              onDismiss={dismissPrimer}
-            />
+              <ContextPrimerBanner
+                sessionId={sessionId}
+                available={state.contextPrimerAvailable}
+                onInsertPrimer={(text) =>
+                  setPrimerPrefill({
+                    id: `primer-${state.contextPrimerAvailable?.resetSeq ?? 0}-${Date.now()}`,
+                    text,
+                  })
+                }
+                onDismiss={dismissPrimer}
+              />
 
-            <Composer
-              sessionId={sessionId}
-              currentAgent={state.agent}
-              availableModes={state.availableModes}
-              currentModeId={state.currentModeId}
-              legacyMode={state.mode}
-              configOptions={state.configOptions}
-              pendingConfigOption={state.pendingConfigOption}
-              setConfigOption={setConfigOption}
-              sessionUsage={state.sessionUsage}
-              availableCommands={state.availableCommands}
-              connected={status === "open" && !state.workerStopped && !state.workerRestarting}
-              turnActive={state.turnActive}
-              queuedCount={state.queuedPrompts.length}
-              enqueuePrompt={sendPrompt}
-              promptCapabilities={state.promptCapabilities}
-              pendingAttachments={pendingAttachments}
-              setPendingAttachments={setPendingAttachments}
-              primerPrefill={primerPrefill}
-              queuedPrompts={state.queuedPrompts}
-              editQueuedPrompt={editQueuedPrompt}
-            />
-          </div>
-        )}
+              <Composer
+                sessionId={sessionId}
+                currentAgent={state.agent}
+                availableModes={state.availableModes}
+                currentModeId={state.currentModeId}
+                legacyMode={state.mode}
+                configOptions={state.configOptions}
+                pendingConfigOption={state.pendingConfigOption}
+                setConfigOption={setConfigOption}
+                sessionUsage={state.sessionUsage}
+                availableCommands={state.availableCommands}
+                connected={status === "open" && !state.workerStopped && !state.workerRestarting}
+                turnActive={state.turnActive}
+                queuedCount={state.queuedPrompts.length}
+                enqueuePrompt={sendPrompt}
+                promptCapabilities={state.promptCapabilities}
+                pendingAttachments={pendingAttachments}
+                setPendingAttachments={setPendingAttachments}
+                primerPrefill={primerPrefill}
+                queuedPrompts={state.queuedPrompts}
+                editQueuedPrompt={editQueuedPrompt}
+              />
+            </>
+          )}
+        </div>
       </ThreadPrimitive.Root>
     </StructuredViewRoot>
   );

--- a/web/src/lib/__tests__/trashActions.test.ts
+++ b/web/src/lib/__tests__/trashActions.test.ts
@@ -7,19 +7,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../api", () => ({
   trashSession: vi.fn(),
   restoreSession: vi.fn(),
+  deleteSession: vi.fn(),
 }));
 
-import { restoreSession, trashSession } from "../api";
-import { restoreSessions, trashSessions } from "../trashActions";
+import { deleteSession, restoreSession, trashSession } from "../api";
+import { deleteWorkspaceSessions, restoreSessions, trashSessions } from "../trashActions";
 import type { SessionResponse } from "../types";
 
 const snap = (id: string) => ({ id, title: id }) as unknown as SessionResponse;
 const trashMock = vi.mocked(trashSession);
 const restoreMock = vi.mocked(restoreSession);
+const deleteMock = vi.mocked(deleteSession);
 
 beforeEach(() => {
   trashMock.mockReset();
   restoreMock.mockReset();
+  deleteMock.mockReset();
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -86,5 +89,91 @@ describe("restoreSessions (#2489)", () => {
   it("tolerates a null notifier", async () => {
     restoreMock.mockResolvedValue(snap("a"));
     await expect(restoreSessions(["a"], { applySession: vi.fn(), notify: null })).resolves.toBe(true);
+  });
+});
+
+describe("deleteWorkspaceSessions (#2530, #2539)", () => {
+  const ok = (messages?: string[]) => ({ ok: true as const, messages });
+  const sessions = (...ids: string[]) => ids.map((id) => ({ id }) as unknown as SessionResponse);
+  const deps = () => ({
+    setStatus: vi.fn(),
+    purgeLocal: vi.fn(),
+    navigateHome: vi.fn(),
+    notify: { info: vi.fn(), error: vi.fn() },
+  });
+
+  it("deletes every session; the primary carries the chosen cleanup, siblings strip worktree/branch", async () => {
+    deleteMock.mockResolvedValue(ok());
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b", "c"), { delete_worktree: true, delete_branch: true }, null, d);
+
+    expect(deleteMock).toHaveBeenCalledTimes(3);
+    expect(deleteMock).toHaveBeenNthCalledWith(1, "a", { delete_worktree: true, delete_branch: true });
+    expect(deleteMock).toHaveBeenNthCalledWith(2, "b", { delete_worktree: false, delete_branch: false });
+    expect(deleteMock).toHaveBeenNthCalledWith(3, "c", { delete_worktree: false, delete_branch: false });
+    expect(d.purgeLocal).toHaveBeenCalledTimes(3);
+    expect(d.notify.info).toHaveBeenCalledWith("Sessions deleted");
+    expect(d.navigateHome).not.toHaveBeenCalled();
+  });
+
+  it("aborts the siblings and does not navigate when the primary delete fails", async () => {
+    deleteMock.mockResolvedValueOnce({ ok: false, error: "dirty" });
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b"), {}, "b", d);
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(d.purgeLocal).not.toHaveBeenCalled();
+    expect(d.navigateHome).not.toHaveBeenCalled();
+    expect(d.setStatus).toHaveBeenCalledWith("a", "Error");
+    expect(d.setStatus).toHaveBeenCalledWith("b", "Error");
+    expect(d.notify.error).toHaveBeenCalledWith("dirty");
+  });
+
+  it("navigates home only after the open session is actually deleted (primary)", async () => {
+    deleteMock.mockResolvedValue(ok());
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b"), {}, "a", d);
+
+    expect(d.navigateHome).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates home when the open session is a deleted sibling", async () => {
+    deleteMock.mockResolvedValue(ok());
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b"), {}, "b", d);
+
+    expect(d.navigateHome).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a partial failure and skips purge for the failed sibling", async () => {
+    deleteMock.mockResolvedValueOnce(ok()).mockResolvedValueOnce({ ok: false, error: "boom" });
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b"), {}, null, d);
+
+    expect(d.purgeLocal).toHaveBeenCalledTimes(1);
+    expect(d.purgeLocal).toHaveBeenCalledWith("a");
+    expect(d.setStatus).toHaveBeenCalledWith("b", "Error");
+    expect(d.notify.error).toHaveBeenCalledWith("Some sessions could not be deleted");
+  });
+
+  it("surfaces a server message and handles a single-session workspace", async () => {
+    deleteMock.mockResolvedValue(ok(["Scratch directory kept at: /tmp/x"]));
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("solo"), {}, null, d);
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(d.notify.info).toHaveBeenCalledWith("Scratch directory kept at: /tmp/x");
+  });
+
+  it("no-ops on an empty workspace", async () => {
+    const d = deps();
+    await deleteWorkspaceSessions([], {}, null, d);
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/trashActions.ts
+++ b/web/src/lib/trashActions.ts
@@ -2,8 +2,9 @@
 // per-session apply + aggregate toast logic is unit-testable rather than
 // reachable only through the structured-view bundle.
 
-import { restoreSession, trashSession } from "./api";
-import type { SessionResponse } from "./types";
+import { deleteSession, restoreSession, trashSession } from "./api";
+import type { DeleteSessionOptions } from "./api";
+import type { SessionResponse, SessionStatus } from "./types";
 
 /** A toast sink; both methods are optional so callers can pass the bus
  *  handler before it is wired without a guard. */
@@ -42,6 +43,73 @@ export async function trashSessions(
     deps.notify?.info?.("Moved to trash");
   }
   return !anyFailed;
+}
+
+interface DeleteWorkspaceDeps {
+  /** Reflect a per-session lifecycle status optimistically (Deleting / Error). */
+  setStatus: (id: string, status: SessionStatus) => void;
+  /** Drop a deleted session's local-only state (acp cache, draft, comments).
+   *  Run only after the server delete for that id succeeds. */
+  purgeLocal: (id: string) => void;
+  /** Navigate away from the deleted session (to the dashboard root). */
+  navigateHome: () => void;
+  notify: Notifier | null;
+}
+
+/** Permanently delete every session in a workspace (#2530). All sessions share
+ *  one git worktree and branch, so the caller's worktree/branch cleanup options
+ *  run exactly once, on the primary (`sessions[0]`); a failed primary aborts
+ *  before any sibling record is destroyed (the shared worktree is still
+ *  present, so removing siblings would orphan the workspace), and siblings
+ *  never re-run the non-idempotent worktree removal. Redirects home only once
+ *  the currently-open session has actually been deleted, not merely because it
+ *  belonged to the workspace (#2539). Local cleanup runs per id only after that
+ *  id's delete succeeds, so a failure never strands a draft or cache. */
+export async function deleteWorkspaceSessions(
+  sessions: SessionResponse[],
+  options: DeleteSessionOptions,
+  activeSessionId: string | null,
+  deps: DeleteWorkspaceDeps,
+): Promise<void> {
+  const primary = sessions[0];
+  if (!primary) return;
+  const ids = sessions.map((s) => s.id);
+  const activeWorkspaceSessionId = activeSessionId != null && ids.includes(activeSessionId) ? activeSessionId : null;
+
+  for (const id of ids) deps.setStatus(id, "Deleting");
+
+  let activeDeleted = false;
+  const primaryResult = await deleteSession(primary.id, options);
+  if (!primaryResult.ok) {
+    for (const id of ids) deps.setStatus(id, "Error");
+    deps.notify?.error?.(primaryResult.error || "Failed to delete session");
+    return;
+  }
+  if (activeWorkspaceSessionId === primary.id) activeDeleted = true;
+  deps.purgeLocal(primary.id);
+
+  const siblingOptions: DeleteSessionOptions = { ...options, delete_worktree: false, delete_branch: false };
+  let anyFailed = false;
+  for (const sibling of sessions.slice(1)) {
+    const res = await deleteSession(sibling.id, siblingOptions);
+    if (res.ok) {
+      if (activeWorkspaceSessionId === sibling.id) activeDeleted = true;
+      deps.purgeLocal(sibling.id);
+    } else {
+      anyFailed = true;
+      deps.setStatus(sibling.id, "Error");
+    }
+  }
+
+  if (activeDeleted) deps.navigateHome();
+
+  if (anyFailed) {
+    deps.notify?.error?.("Some sessions could not be deleted");
+    return;
+  }
+  // `messages` carries any user-facing note from `perform_deletion` (e.g. a
+  // kept scratch path); surface the first.
+  deps.notify?.info?.(primaryResult.messages?.[0] ?? (ids.length > 1 ? "Sessions deleted" : "Session deleted"));
 }
 
 /** Restore every id, applying each returned snapshot. Returns true iff all

--- a/web/tests/acp-trashed-composer.spec.ts
+++ b/web/tests/acp-trashed-composer.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "./helpers/mockedTest";
+import { mockAcpSession, openStructuredSession, stopped, agentMessageChunk } from "./helpers/acpMock";
+
+// User story (#2529): a trashed structured-view session is read-only until
+// restored. The transcript stays visible under the trashed banner, but the
+// queue strips and composer are gone: the reconciler will never resume a
+// trashed session, so any input would only stash into a queue that never
+// drains.
+
+test.describe("trashed structured session is read-only", () => {
+  test("renders the trashed banner and no composer", async ({ page }) => {
+    const mock = await mockAcpSession(page, {
+      title: "story-trashed",
+      trashedAt: new Date().toISOString(),
+      // A transcript line plus a user_stopped worker so the trashed banner
+      // (which gates on workerStopped) shows, matching a real trashed session.
+      initialEvents: [agentMessageChunk("earlier reply"), stopped("user_stopped")],
+    });
+    await openStructuredSession(page, mock);
+
+    await expect(page.getByTestId(`acp-trashed-banner-${mock.sessionId}`)).toBeVisible({ timeout: 10_000 });
+    // The transcript is still shown read-only.
+    await expect(page.getByText("earlier reply")).toBeVisible();
+    // No composer / send affordance for a session that cannot be resumed.
+    await expect(page.getByTestId("composer-footer")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Send message" })).toHaveCount(0);
+  });
+
+  test("a live (non-trashed) session still renders the composer", async ({ page }) => {
+    const mock = await mockAcpSession(page, {
+      title: "story-live",
+      initialEvents: [agentMessageChunk("hello")],
+    });
+    await openStructuredSession(page, mock);
+
+    await expect(page.getByTestId("composer-footer")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1124,7 +1124,19 @@
       "kind": "mocked-playwright",
       "risk": "high",
       "specs": ["tests/session-trash-flow.spec.ts"],
-      "components": ["web/src/App.tsx", "web/src/components/WorkspaceSidebar.tsx", "web/src/hooks/useSessions.ts"]
+      "components": [
+        "web/src/App.tsx",
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/components/DeleteSessionDialog.tsx",
+        "web/src/hooks/useSessions.ts"
+      ]
+    },
+    {
+      "id": "session.trash.read-only-composer",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/acp-trashed-composer.spec.ts"],
+      "components": ["web/src/components/acp/StructuredView.tsx"]
     },
     {
       "id": "session.group-edit",

--- a/web/tests/helpers/acpMock.ts
+++ b/web/tests/helpers/acpMock.ts
@@ -27,6 +27,9 @@ export interface AcpSessionMockOptions {
   onConfigOption?: (body: { config_id: string; value: string }) => unknown[];
   /** Override the `/api/about` payload (e.g. `{ read_only: true }`). */
   about?: Record<string, unknown>;
+  /** When set, the session is reported trashed (`trashed_at`) with a stopped
+   *  worker, so the trashed read-only banner shows. See #2529. */
+  trashedAt?: string;
 }
 
 export interface AcpSessionMock {
@@ -107,7 +110,7 @@ export async function mockAcpSession(page: Page, opts: AcpSessionMockOptions = {
             project_path: `/tmp/${title}`,
             group_path: "/tmp",
             tool: "claude",
-            status: "Running",
+            status: opts.trashedAt ? "Stopped" : "Running",
             yolo_mode: false,
             created_at: new Date().toISOString(),
             last_accessed_at: null,
@@ -117,9 +120,10 @@ export async function mockAcpSession(page: Page, opts: AcpSessionMockOptions = {
             is_sandboxed: false,
             has_terminal: true,
             profile: "default",
+            trashed_at: opts.trashedAt ?? null,
             workspace_repos: [],
             view: "structured",
-            acp_worker_state: "running",
+            acp_worker_state: opts.trashedAt ? "stopped" : "running",
             claude_fullscreen: false,
           },
         ],

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -215,6 +215,18 @@ async function mockMultiApis(
   const handle: MultiHandle = { deletedIds: [], deleteOptions: {}, restoredIds: [] };
   const trashedState = new Map(sessions.map((s) => [s.id, s.trashed]));
 
+  // Force the user-group axis so `buildSessionGroups` actually slices the
+  // workspace by `group_path`. The slicing bug (#2533) cannot reproduce on the
+  // default repo axis, where rows already carry the full unsliced workspace.
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem("aoe-sidebar-axis", "group");
+    } catch {
+      // jsdom-less / storage-disabled contexts fall back to the default axis.
+    }
+  });
+  await page.route("**/api/app-state/web-ui-state", (r) => r.fulfill({ json: { "aoe-sidebar-axis": "group" } }));
+
   await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
   await page.route("**/api/sessions", (r) => {
     if (r.request().method() !== "GET") return r.fulfill({ status: 400 });

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -167,3 +167,144 @@ test.describe("Session trash flow", () => {
     await expect.poll(() => handle.deletes, { timeout: 10_000 }).toBe(1);
   });
 });
+
+// Multi-session workspace coverage (#2530, #2533). A "workspace" is keyed by
+// `repoPath::branch`, so two sessions on the same branch but different
+// `group_path` belong to ONE workspace that the sidebar splits into two
+// per-group slices. Trash membership, Restore, and permanent Delete must all
+// act on the whole workspace, not on whichever slice survives dedupe.
+
+interface MultiHandle {
+  /** Session ids that received a DELETE, in call order. */
+  deletedIds: string[];
+  /** Last DELETE option body keyed by session id. */
+  deleteOptions: Record<string, Record<string, unknown>>;
+  /** Session ids that received a restore POST, in call order. */
+  restoredIds: string[];
+}
+
+function multiPayload(id: string, groupPath: string, trashed: boolean) {
+  return {
+    id,
+    title: id,
+    project_path: "/tmp/repo",
+    group_path: groupPath,
+    tool: "claude",
+    status: trashed ? "Stopped" : "Running",
+    yolo_mode: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: "feat/x",
+    main_repo_path: "/tmp/repo",
+    is_sandboxed: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    trashed_at: trashed ? new Date().toISOString() : null,
+    cleanup_defaults: { delete_to_trash: true },
+    workspace_repos: [],
+  };
+}
+
+async function mockMultiApis(
+  page: Page,
+  sessions: Array<{ id: string; groupPath: string; trashed: boolean }>,
+): Promise<MultiHandle> {
+  const handle: MultiHandle = { deletedIds: [], deleteOptions: {}, restoredIds: [] };
+  const trashedState = new Map(sessions.map((s) => [s.id, s.trashed]));
+
+  await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    const live = sessions
+      .filter((s) => !handle.deletedIds.includes(s.id))
+      .map((s) => multiPayload(s.id, s.groupPath, trashedState.get(s.id) ?? false));
+    return r.fulfill({ json: { sessions: live, workspace_ordering: [] } });
+  });
+  for (const s of sessions) {
+    await page.route(`**/api/sessions/${s.id}/restore`, (r) => {
+      if (r.request().method() !== "POST") return r.fulfill({ status: 400 });
+      handle.restoredIds.push(s.id);
+      trashedState.set(s.id, false);
+      return r.fulfill({ json: multiPayload(s.id, s.groupPath, false) });
+    });
+    await page.route(`**/api/sessions/${s.id}`, (r) => {
+      if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
+      handle.deletedIds.push(s.id);
+      const body = r.request().postData();
+      handle.deleteOptions[s.id] = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+      return r.fulfill({ json: {} });
+    });
+  }
+  await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
+  await page.route("**/api/sessions/*/terminal", (r) => r.fulfill({ status: 200, body: "" }));
+  await page.route("**/api/sessions/*/diff/files", (r) =>
+    r.fulfill({ json: { files: [], per_repo_bases: [], warning: null } }),
+  );
+  for (const path of ["settings", "themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
+    await page.route(`**/api/${path}`, (r) => r.fulfill({ json: path === "docker/status" ? {} : [] }));
+  }
+  await page.routeWebSocket(/\/sessions\/.*\/(ws|acp-ws|container-ws)$/, () => {});
+  return handle;
+}
+
+test.describe("Multi-session workspace trash", () => {
+  test("a workspace trashed in only one group slice does not appear in Trash (#2533)", async ({ page }) => {
+    await mockMultiApis(page, [
+      { id: "sess-a", groupPath: "alpha", trashed: true },
+      { id: "sess-b", groupPath: "beta", trashed: false },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    // The still-live sibling keeps the workspace out of Trash entirely: no
+    // Trash footer icon, even though the "alpha" slice is fully trashed.
+    await expect(page.locator('[data-testid="sidebar-session-row"]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-testid="sidebar-trash-toggle"]')).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test("Restore from Trash restores every session of a split workspace (#2533)", async ({ page }) => {
+    const handle = await mockMultiApis(page, [
+      { id: "sess-a", groupPath: "alpha", trashed: true },
+      { id: "sess-b", groupPath: "beta", trashed: true },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+    // The two slices dedupe to a single Trash row for the workspace.
+    const trashRows = page.locator('[data-testid="sidebar-trash-row"]');
+    await expect(trashRows).toHaveCount(1, { timeout: 10_000 });
+
+    await trashRows.first().locator('[data-testid="sidebar-trash-restore"]').click();
+    await expect.poll(() => [...handle.restoredIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
+  });
+
+  test("permanent Delete purges every session of a trashed workspace (#2530)", async ({ page }) => {
+    const handle = await mockMultiApis(page, [
+      { id: "sess-a", groupPath: "alpha", trashed: true },
+      { id: "sess-b", groupPath: "beta", trashed: true },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+    const trashRow = page.locator('[data-testid="sidebar-trash-row"]').first();
+    await expect(trashRow).toBeVisible({ timeout: 10_000 });
+
+    await trashRow.locator('[data-testid="sidebar-trash-purge"]').click();
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    // The dialog discloses the workspace-wide scope (#2530).
+    await expect(dialog.locator('[data-testid="delete-session-extra-count"]')).toContainText("all 2 sessions");
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+
+    await expect.poll(() => [...handle.deletedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
+    // Whichever id is the workspace primary, the sibling never re-runs the
+    // shared worktree/branch removal.
+    const siblingId = handle.deletedIds[1]!;
+    expect(handle.deleteOptions[siblingId]).toMatchObject({ delete_worktree: false, delete_branch: false });
+  });
+});

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -323,6 +323,35 @@ test.describe("Multi-session workspace trash", () => {
     expect(handle.deleteOptions[siblingId]).toMatchObject({ delete_worktree: false, delete_branch: false });
   });
 
+  test("a sibling delete failure leaves that session in Trash and reports it (#2530)", async ({ page }) => {
+    // Primary (sess-a) and one sibling (sess-b) purge, but sess-c fails. The
+    // workspace stays in Trash holding the surviving session, surfacing the
+    // partial-failure path of the delete loop.
+    const handle = await mockMultiApis(
+      page,
+      [
+        { id: "sess-a", groupPath: "alpha", trashed: true },
+        { id: "sess-b", groupPath: "beta", trashed: true },
+        { id: "sess-c", groupPath: "gamma", trashed: true },
+      ],
+      { failDeleteIds: ["sess-c"] },
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    const toggle = page.locator('[data-testid="sidebar-trash-toggle"]');
+    await toggle.click();
+    await page.locator('[data-testid="sidebar-trash-purge"]').first().click();
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+
+    // The two that succeeded are gone; the failed one is still attempted.
+    await expect.poll(() => [...handle.deletedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
+    // The workspace remains in Trash because sess-c is still trashed.
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+  });
+
   test("a failed primary delete does not redirect away from an open sibling (#2539 review)", async ({ page }) => {
     // Open session is the sibling (sess-b); the primary (sess-a) delete fails,
     // so nothing is removed. The user must stay on the still-live session

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -352,4 +352,26 @@ test.describe("Multi-session workspace trash", () => {
     await expect.poll(() => handle.deletedIds, { timeout: 5_000 }).toEqual([]);
     await expect(page).toHaveURL(/\/session\/sess-b/);
   });
+
+  for (const open of ["sess-a", "sess-b"] as const) {
+    test(`redirects to / after the open ${open === "sess-a" ? "primary" : "sibling"} is purged`, async ({ page }) => {
+      await mockMultiApis(page, [
+        { id: "sess-a", groupPath: "alpha", trashed: true },
+        { id: "sess-b", groupPath: "beta", trashed: true },
+      ]);
+      await page.setViewportSize({ width: 1280, height: 720 });
+
+      await page.goto(`/session/${open}`);
+      await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+      const trashRow = page.locator('[data-testid="sidebar-trash-row"]').first();
+      await expect(trashRow).toBeVisible({ timeout: 10_000 });
+      await trashRow.locator('[data-testid="sidebar-trash-purge"]').click();
+      const dialog = page.locator('[data-testid="delete-session-dialog"]');
+      await expect(dialog).toBeVisible({ timeout: 5_000 });
+      await dialog.getByRole("button", { name: /^Delete$/ }).click();
+
+      // The open session was deleted, so the handler navigates home.
+      await expect(page).toHaveURL(/\/$/, { timeout: 10_000 });
+    });
+  }
 });

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -211,9 +211,11 @@ function multiPayload(id: string, groupPath: string, trashed: boolean) {
 async function mockMultiApis(
   page: Page,
   sessions: Array<{ id: string; groupPath: string; trashed: boolean }>,
+  opts: { failDeleteIds?: string[] } = {},
 ): Promise<MultiHandle> {
   const handle: MultiHandle = { deletedIds: [], deleteOptions: {}, restoredIds: [] };
   const trashedState = new Map(sessions.map((s) => [s.id, s.trashed]));
+  const failDelete = new Set(opts.failDeleteIds ?? []);
 
   // Force the user-group axis so `buildSessionGroups` actually slices the
   // workspace by `group_path`. The slicing bug (#2533) cannot reproduce on the
@@ -244,6 +246,7 @@ async function mockMultiApis(
     });
     await page.route(`**/api/sessions/${s.id}`, (r) => {
       if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
+      if (failDelete.has(s.id)) return r.fulfill({ status: 500, json: { message: "boom" } });
       handle.deletedIds.push(s.id);
       const body = r.request().postData();
       handle.deleteOptions[s.id] = body ? (JSON.parse(body) as Record<string, unknown>) : {};
@@ -318,5 +321,35 @@ test.describe("Multi-session workspace trash", () => {
     // shared worktree/branch removal.
     const siblingId = handle.deletedIds[1]!;
     expect(handle.deleteOptions[siblingId]).toMatchObject({ delete_worktree: false, delete_branch: false });
+  });
+
+  test("a failed primary delete does not redirect away from an open sibling (#2539 review)", async ({ page }) => {
+    // Open session is the sibling (sess-b); the primary (sess-a) delete fails,
+    // so nothing is removed. The user must stay on the still-live session
+    // instead of being kicked back to "/".
+    const handle = await mockMultiApis(
+      page,
+      [
+        { id: "sess-a", groupPath: "alpha", trashed: true },
+        { id: "sess-b", groupPath: "beta", trashed: true },
+      ],
+      { failDeleteIds: ["sess-a"] },
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/session/sess-b");
+    await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+    const trashRow = page.locator('[data-testid="sidebar-trash-row"]').first();
+    await expect(trashRow).toBeVisible({ timeout: 10_000 });
+    await trashRow.locator('[data-testid="sidebar-trash-purge"]').click();
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+
+    // Dialog closes (the handler ran), the primary delete failed so no session
+    // was removed, and the route still points at the open sibling.
+    await expect(dialog).toHaveCount(0, { timeout: 10_000 });
+    await expect.poll(() => handle.deletedIds, { timeout: 5_000 }).toEqual([]);
+    await expect(page).toHaveURL(/\/session\/sess-b/);
   });
 });


### PR DESCRIPTION
> **Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Three linked bugs in the web Trash UI, all rooted in the sidebar treating a workspace as its per-`group_path` slices rather than as a whole.

A workspace (`repoPath::branch`) can host several agent sessions sharing one git worktree, and the sidebar splits it into one row per `group_path`. The Trash UI was built on those slices:

- **#2533:** Trash membership and Restore were computed from slices. A workspace live in one group but trashed in another showed up in Trash (the slice looked fully trashed), and Restore only covered the surviving slice's session ids. Fixed by deriving Trash in `App` from the authoritative unsliced workspace list (`workspaces.filter(workspaceIsTrashed)`) and passing it down. A workspace is in Trash only when every one of its sessions is trashed, and Restore now covers all of them. This is also axis-independent, so the repo / group / repo+group views agree.
- **#2530:** Permanent delete purged only `sessions[0]`, leaving the rest of a multi-session workspace behind. `handleConfirmDelete` now deletes every session. They share one worktree and branch, so the chosen worktree/branch cleanup runs once on the primary; if the primary delete fails the siblings are left untouched (no orphaned workspace), and siblings never re-run the non-idempotent worktree removal. The delete dialog discloses the workspace-wide scope when more than the named session will be removed.
- **#2529:** A trashed structured-view session showed the read-only banner but still rendered the queue strips and composer, accepting input into a queue the reconciler never drains. The footer is now gated on `!trashedAt`; the transcript stays visible read-only. Archived and snoozed sessions are resumable, so they keep their composer.

Backend-only and broader-UX work surfaced during design review is deferred to #2536 (atomic workspace-delete endpoint), #2537 (composer gating for archived/snoozed), and #2538 (fully workspace-shaped delete dialog).

Closes #2529
Closes #2530
Closes #2533

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Put a workspace's sessions in two different user groups (set distinct `group_path`s), trash one group's session(s) only, switch the sidebar to the "group" or "repo + group" axis: the workspace stays in the live list and does **not** appear in the footer Trash popover.
- [ ] Trash every session of that split workspace, open the Trash popover, click Restore: all of its sessions return to the live list (not just one group's).
- [ ] With a multi-session workspace fully trashed, open the Trash popover and click Delete permanently: the dialog notes it removes all N sessions on the branch, and confirming purges every session (none linger in Trash).
- [ ] Open a trashed structured-view session: the read-only banner shows, the transcript is visible, and there is no composer or queue strip below it.
- [ ] Open an archived or snoozed structured-view session: the composer is still present (unchanged).

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added multi-session and split-workspace cases to `web/tests/session-trash-flow.spec.ts` (purge-all #2530, restore-all + visibility #2533, forced onto the group axis where the slicing bug reproduces) and a new `web/tests/acp-trashed-composer.spec.ts` (#2529). Updated the `WorkspaceSidebarTrash` vitest for the new prop-driven contract. Each new test was confirmed red on the pre-fix tree (ephemeral worktree at the base commit) and green after.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a two-model design debate, implementation, and prose drafted by Claude under my direction. I made the design calls (App-owned trash selector, primary-first delete ordering, scope of the trashed-session gate), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785267047&installation_id=139138837&pr_number=2539&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2539&signature=d1cd80b6da3efebf3d98dff89859fcc5cbda0b9201208c36272056987864e535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes Trash behavior in the web UI so it operates on whole workspaces instead of only within a single `group_path` slice.

- **Trash membership + Restore:** Trash now considers a workspace trashed only when **all** of its sessions are trashed, and **Restore** brings back **every** trashed session in that workspace.
- **Permanent delete:** Permanent delete from a trashed workspace now removes **all** trashed sessions in the workspace (not just the first one). The delete dialog also communicates when the action will affect multiple sessions.
- **Structured-view trashed sessions UI:** When a structured-view session is trashed, the UI becomes **transcript-only/read-only** by hiding composer-related controls (while keeping the transcript visible). Archived and snoozed sessions keep their composer.

To support this, the code was refactored around an authoritative workspace-level session list, with a new helper for workspace-wide delete operations, plus updated/added tests and mocks (including new Playwright coverage for read-only trashed structured-view composer behavior) and coverage-matrix updates.

Overall benefit: the Trash/Restore/delete experience is now consistent and predictable for multi-session workspaces, and trashed structured-view sessions no longer expose actions that shouldn’t be available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->