### PR TITLE
fix(cli): correct trash and purge path bugs (#2524, #2525, #2527, #2534)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -119,15 +119,24 @@ pub(crate) fn purge_acp_transcript(inst: &Instance) -> Result<()> {
 /// A missing table means the store predates it: nothing to purge. Kept
 /// feature-independent so non-`serve` CLI builds can clean transcripts too.
 fn purge_acp_transcript_rows(db_path: &std::path::Path, session_id: &str) -> Result<()> {
-    let conn = rusqlite::Connection::open(db_path)
+    let mut conn = rusqlite::Connection::open(db_path)
         .map_err(|e| anyhow::anyhow!("acp transcript purge: open event store: {e}"))?;
     // A running daemon may hold the store open; wait briefly rather than fail.
     conn.busy_timeout(std::time::Duration::from_secs(5))
         .map_err(|e| anyhow::anyhow!("acp transcript purge: set busy_timeout: {e}"))?;
+    // Both deletes run in one transaction so the purge is all-or-nothing: if the
+    // attachments delete fails after the events delete, the dropped `tx` rolls
+    // both back and the caller keeps the session row for retry rather than
+    // leaving the transcript half removed.
+    let tx = conn
+        .transaction()
+        .map_err(|e| anyhow::anyhow!("acp transcript purge: begin transaction: {e}"))?;
     // The source of truth for these names is `crate::events::Schema` (prefix
-    // "acp"), which is serve-gated and so cannot be referenced from here.
+    // "acp"), which is serve-gated and so cannot be referenced from here. They
+    // are fixed literals, not user input, and `session_id` is bound, so the
+    // `format!` only interpolates a constant.
     for table in ["acp_events", "acp_attachments"] {
-        match conn.execute(
+        match tx.execute(
             &format!("DELETE FROM {table} WHERE session_id = ?1"),
             rusqlite::params![session_id],
         ) {
@@ -140,6 +149,8 @@ fn purge_acp_transcript_rows(db_path: &std::path::Path, session_id: &str) -> Res
             }
         }
     }
+    tx.commit()
+        .map_err(|e| anyhow::anyhow!("acp transcript purge: commit: {e}"))?;
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,34 +93,91 @@ pub fn resolve_session<'a>(identifier: &str, instances: &'a [Instance]) -> Resul
 /// daemon does this through its supervisor; the CLI has no live worker, so it
 /// opens the event store directly. It cannot send the adapter `session/delete`
 /// RPC the daemon sends (that needs a running worker), but deleting the local
-/// UI transcript stops purged rows from orphaning. No-op for non-structured
-/// sessions or when the store does not exist. See #2489.
+/// UI transcript stops purged rows from orphaning. No-op when the store does
+/// not exist; a failure to open or write it returns `Err` so callers keep the
+/// session row rather than orphan its transcript. See #2489, #2524.
+///
+/// The delete is idempotent and feature-independent: `rusqlite` is a
+/// non-optional dependency, so a default (non-`serve`) build can reach the
+/// store too. It deliberately does NOT gate on `Instance::is_structured()`,
+/// which always returns `false` in a non-`serve` build (the `view` field is
+/// serve-gated), so the old guard left the non-serve bail unreachable and
+/// orphaned transcripts. Deleting zero rows for a terminal session is harmless.
 pub(crate) fn purge_acp_transcript(inst: &Instance) -> Result<()> {
-    if !inst.is_structured() {
+    let app_dir = crate::session::get_app_dir()
+        .map_err(|e| anyhow::anyhow!("acp transcript purge: resolve app dir: {e}"))?;
+    let db_path = app_dir.join("acp_events.db");
+    if !db_path.exists() {
         return Ok(());
     }
-    // The durable transcript only exists under the `serve` feature (the `acp`
-    // module is gated on it). A default build cannot reach the event store, so
-    // it must NOT report success: callers (`rm --purge`, `empty-trash`) read
-    // `Ok(())` as "safe to drop the session row", which would delete the row
-    // while orphaning its transcript in `acp_events.db`. Bail instead.
-    #[cfg(not(feature = "serve"))]
-    {
-        anyhow::bail!("acp transcript purge requires a build with the `serve` feature")
-    }
-    #[cfg(feature = "serve")]
-    {
-        let app_dir = crate::session::get_app_dir()
-            .map_err(|e| anyhow::anyhow!("acp transcript purge: resolve app dir: {e}"))?;
-        let db_path = app_dir.join("acp_events.db");
-        if !db_path.exists() {
-            return Ok(());
+    purge_acp_transcript_rows(&db_path, &inst.id)
+}
+
+/// Delete a session's rows from the ACP event store at `db_path`, removing both
+/// the event rows and their attachment blobs (mirrors
+/// `crate::events::delete_topic`'s cascade so no orphaned bytes are left).
+/// A missing table means the store predates it: nothing to purge. Kept
+/// feature-independent so non-`serve` CLI builds can clean transcripts too.
+fn purge_acp_transcript_rows(db_path: &std::path::Path, session_id: &str) -> Result<()> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| anyhow::anyhow!("acp transcript purge: open event store: {e}"))?;
+    // A running daemon may hold the store open; wait briefly rather than fail.
+    conn.busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(|e| anyhow::anyhow!("acp transcript purge: set busy_timeout: {e}"))?;
+    // The source of truth for these names is `crate::events::Schema` (prefix
+    // "acp"), which is serve-gated and so cannot be referenced from here.
+    for table in ["acp_events", "acp_attachments"] {
+        match conn.execute(
+            &format!("DELETE FROM {table} WHERE session_id = ?1"),
+            rusqlite::params![session_id],
+        ) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg))) if msg.contains("no such table") => {}
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "acp transcript purge: delete from {table}: {e}"
+                ))
+            }
         }
-        let store = crate::acp::event_store::EventStore::open(&db_path, 100)
-            .map_err(|e| anyhow::anyhow!("acp transcript purge: open event store: {e}"))?;
-        store.delete_session(&inst.id);
-        Ok(())
     }
+    Ok(())
+}
+
+/// Decides whether a CLI permanent purge must KEEP a row it had targeted,
+/// because the row was restored after the purge snapshot was taken. A purge
+/// runs its destructive teardown on an unlocked snapshot and only removes the
+/// row from storage under the lock; if it targeted a trashed session and a
+/// concurrent restore untrashed it in between, the restore wins and the row is
+/// kept rather than silently deleted. A purge of a row that was not trashed at
+/// snapshot time (a direct `rm --purge` of a live session) has no restore to
+/// lose to, so it is never kept on this basis. See #2534.
+pub(crate) fn purge_restored_row_must_be_kept(targeted_trashed: bool, still_trashed: bool) -> bool {
+    targeted_trashed && !still_trashed
+}
+
+/// Apply a completed `empty-trash` purge to the latest storage snapshot under
+/// the lock: drop every successfully-purged row that is still trashed, and keep
+/// any that a concurrent restore brought back (its teardown already ran, so the
+/// caller should warn). Returns `(removed, restored_kept)`. The `removed` count
+/// is what callers must report instead of the candidate count. See #2527, #2534.
+pub(crate) fn apply_empty_trash_purge(
+    instances: &mut Vec<Instance>,
+    purged: &std::collections::HashSet<String>,
+) -> (usize, usize) {
+    let before = instances.len();
+    let mut restored = 0usize;
+    instances.retain(|i| {
+        if !purged.contains(&i.id) {
+            return true;
+        }
+        if purge_restored_row_must_be_kept(true, i.is_trashed()) {
+            restored += 1;
+            true
+        } else {
+            false
+        }
+    });
+    (before - instances.len(), restored)
 }
 
 pub fn truncate(s: &str, max: usize) -> String {
@@ -235,5 +292,106 @@ mod tests {
         })
         .unwrap();
         assert_eq!(v[1].title, "renamed");
+    }
+
+    // #2534: a purge keeps a targeted row only when it was trashed at snapshot
+    // time but is no longer trashed (restored mid-purge); every other case
+    // drops it (still trashed, or a direct live purge with no restore to lose).
+    #[test]
+    fn purge_keeps_only_rows_restored_after_a_trashed_snapshot() {
+        assert!(purge_restored_row_must_be_kept(true, false));
+        assert!(!purge_restored_row_must_be_kept(true, true));
+        assert!(!purge_restored_row_must_be_kept(false, false));
+        assert!(!purge_restored_row_must_be_kept(false, true));
+    }
+
+    // #2527 + #2534: empty-trash must report the count actually removed (not
+    // the candidate count), drop only rows still trashed, and keep rows a
+    // concurrent restore brought back.
+    #[test]
+    fn apply_empty_trash_purge_counts_removed_and_keeps_restored() {
+        use std::collections::HashSet;
+
+        let mut still_trashed = Instance::new("gone", "/tmp/a");
+        still_trashed.trash();
+        let restored = Instance::new("restored", "/tmp/b"); // purged but no longer trashed
+        let mut untargeted = Instance::new("other", "/tmp/c");
+        untargeted.trash();
+
+        let purged: HashSet<String> = [still_trashed.id.clone(), restored.id.clone()]
+            .into_iter()
+            .collect();
+        let restored_id = restored.id.clone();
+        let untargeted_id = untargeted.id.clone();
+        let mut instances = vec![still_trashed, restored, untargeted];
+
+        let (removed, kept_restored) = apply_empty_trash_purge(&mut instances, &purged);
+
+        assert_eq!(removed, 1, "only the still-trashed candidate is removed");
+        assert_eq!(
+            kept_restored, 1,
+            "the restored candidate is kept and counted"
+        );
+        let surviving: Vec<&str> = instances.iter().map(|i| i.id.as_str()).collect();
+        assert!(surviving.contains(&restored_id.as_str()));
+        assert!(surviving.contains(&untargeted_id.as_str()));
+        assert_eq!(instances.len(), 2);
+    }
+
+    // #2524: the non-serve purge path used to be unreachable, orphaning
+    // transcripts. The feature-independent row delete must drop both the
+    // event rows and their attachment blobs for the target session only.
+    #[test]
+    fn purge_acp_transcript_rows_deletes_only_target_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("acp_events.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE acp_events (session_id TEXT, seq INTEGER, event_json TEXT);
+             CREATE TABLE acp_attachments (session_id TEXT, attachment_id TEXT, data BLOB);
+             INSERT INTO acp_events VALUES ('keep', 0, '{}'), ('drop', 0, '{}'), ('drop', 1, '{}');
+             INSERT INTO acp_attachments VALUES ('keep', 'a0', x'00'), ('drop', 'a1', x'01');",
+        )
+        .unwrap();
+        drop(conn);
+
+        purge_acp_transcript_rows(&db_path, "drop").unwrap();
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM acp_events WHERE session_id = 'drop'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let attachments: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM acp_attachments WHERE session_id = 'drop'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let kept_events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM acp_events WHERE session_id = 'keep'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(events, 0, "target event rows should be deleted");
+        assert_eq!(attachments, 0, "target attachment blobs should be deleted");
+        assert_eq!(kept_events, 1, "other session must be untouched");
+    }
+
+    // A store that predates a table (or any expected table missing) is not an
+    // error: there is simply nothing to purge.
+    #[test]
+    fn purge_acp_transcript_rows_tolerates_missing_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("acp_events.db");
+        // Open creates an empty db with neither acp_events nor acp_attachments.
+        rusqlite::Connection::open(&db_path).unwrap();
+        purge_acp_transcript_rows(&db_path, "whatever").unwrap();
     }
 }

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -46,6 +46,21 @@ fn needs_worktree_cleanup(inst: &Instance, args: &RemoveArgs) -> bool {
     args.delete_worktree && inst.has_managed_worktree_or_workspace()
 }
 
+/// Whether a `--purge` should delete the session's git branch(es). #2525: gated
+/// on the shape-agnostic predicate so it fires for multi-repo workspace sessions
+/// (only `workspace_info`, no `worktree_info`) as well as worktree sessions;
+/// `perform_deletion` keys both worktree and workspace-repo branch cleanup off
+/// this flag. The old `worktree_info`-only gate skipped workspace branches.
+fn should_delete_branch(
+    inst: &Instance,
+    args: &RemoveArgs,
+    delete_worktree: bool,
+    delete_branch_on_cleanup: bool,
+) -> bool {
+    inst.has_managed_worktree_or_workspace()
+        && (args.delete_branch || (delete_worktree && delete_branch_on_cleanup))
+}
+
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     let storage = Storage::new_unwatched(profile)?;
@@ -128,11 +143,12 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     }
 
     let delete_worktree = needs_worktree_cleanup(&inst, &args);
-    let delete_branch = inst
-        .worktree_info
-        .as_ref()
-        .is_some_and(|wt| wt.managed_by_aoe)
-        && (args.delete_branch || (delete_worktree && config.worktree.delete_branch_on_cleanup));
+    let delete_branch = should_delete_branch(
+        &inst,
+        &args,
+        delete_worktree,
+        config.worktree.delete_branch_on_cleanup,
+    );
     let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
         && !args.keep_container
         && config.sandbox.auto_cleanup;
@@ -204,18 +220,50 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     }
 
     // Phase 2 (locked): drop the entry by id from the latest disk state.
-    // No-op if a peer already removed it; that is the correct semantics.
-    storage.update(|all_instances, _groups| {
-        all_instances.retain(|i| i.id != removed_id);
-        Ok(())
+    // #2534: revalidate under the lock. The destructive teardown above ran on
+    // an unlocked snapshot; if this purge targeted a trashed session and a
+    // concurrent restore untrashed it in the meantime, the restore must win, so
+    // keep the row instead of deleting a session the user just brought back.
+    // A no-op when a peer already removed it; that is the correct semantics.
+    let was_trashed = inst.is_trashed();
+    let outcome = storage.update(|all_instances, _groups| {
+        Ok(
+            match all_instances.iter().position(|i| i.id == removed_id) {
+                None => RowRemoval::AlreadyGone,
+                Some(idx)
+                    if super::purge_restored_row_must_be_kept(
+                        was_trashed,
+                        all_instances[idx].is_trashed(),
+                    ) =>
+                {
+                    RowRemoval::KeptRestored
+                }
+                Some(idx) => {
+                    all_instances.remove(idx);
+                    RowRemoval::Removed
+                }
+            },
+        )
     })?;
+
+    if matches!(outcome, RowRemoval::KeptRestored) {
+        eprintln!(
+            "Warning: session {} was restored while its purge was running; kept the \
+             restored record, but its worktree, branch, container, or transcript may \
+             already have been removed by the purge. Inspect and repair it.",
+            removed_title
+        );
+        return Ok(());
+    }
 
     // Keep the project in the new-session wizard's Recent tab after its last
     // session is gone (#2141). Best-effort; a failure must not fail the remove.
-    if let Some(entry) = crate::session::recent_project_entry_for(&inst) {
-        if let Err(e) = crate::session::record_recent_project(entry) {
-            tracing::warn!(target: "session.delete",
-                "recording recent project after remove failed: {e}");
+    if matches!(outcome, RowRemoval::Removed) {
+        if let Some(entry) = crate::session::recent_project_entry_for(&inst) {
+            if let Err(e) = crate::session::record_recent_project(entry) {
+                tracing::warn!(target: "session.delete",
+                    "recording recent project after remove failed: {e}");
+            }
         }
     }
 
@@ -226,6 +274,16 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Outcome of the final locked row-removal step in a `--purge`. See #2534.
+enum RowRemoval {
+    /// The row was dropped from storage.
+    Removed,
+    /// A concurrent restore won; the (now untrashed) row was kept.
+    KeptRestored,
+    /// A peer already removed the row before this purge reached the lock.
+    AlreadyGone,
 }
 
 #[cfg(test)]
@@ -269,5 +327,38 @@ mod tests {
 
         assert!(needs_worktree_cleanup(&inst, &args(true)));
         assert!(!needs_worktree_cleanup(&inst, &args(false)));
+    }
+
+    // Regression for #2525: a multi-repo workspace session has no
+    // `worktree_info`, so the old `worktree_info`-only gate returned false and
+    // `--purge --delete-worktree --delete-branch` left the AoE-created branches
+    // behind. The shape-agnostic gate must enable branch deletion for it.
+    #[test]
+    fn should_delete_branch_true_for_workspace_session() {
+        let mut inst = Instance::new("WS", "/tmp/ws/repo-a");
+        inst.workspace_info = Some(WorkspaceInfo {
+            branch: "feature/abc".to_string(),
+            workspace_dir: "/tmp/ws".to_string(),
+            repos: vec![WorkspaceRepo {
+                name: "repo-a".to_string(),
+                source_path: "/tmp/src/repo-a".to_string(),
+                branch: "feature/abc".to_string(),
+                worktree_path: "/tmp/ws/repo-a".to_string(),
+                main_repo_path: "/tmp/src/repo-a".to_string(),
+                managed_by_aoe: true,
+            }],
+            created_at: Utc::now(),
+            cleanup_on_delete: true,
+        });
+
+        let mut with_flag = args(true);
+        with_flag.delete_branch = true;
+        // Explicit --delete-branch fires regardless of the config default.
+        assert!(should_delete_branch(&inst, &with_flag, true, false));
+        // And via the config default when deleting the worktree.
+        assert!(should_delete_branch(&inst, &args(true), true, true));
+        // Not without any managed worktree/workspace.
+        let plain = Instance::new("plain", "/tmp/plain");
+        assert!(!should_delete_branch(&plain, &with_flag, true, true));
     }
 }

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -172,19 +172,28 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
         eprintln!("Warning: {}", err);
     }
 
+    // A failed teardown (worktree/branch/container cleanup) must keep the
+    // session row so the leftover artifacts can be retried, not abandoned by
+    // dropping the record below. Mirrors `empty-trash`, which only purges rows
+    // whose teardown succeeded. See #2489.
+    if !result.success {
+        anyhow::bail!(
+            "Session teardown failed, so the session record was kept (retry, or fix the \
+             underlying cause and remove it again)"
+        );
+    }
+
     // Permanent purge of a structured-view session must also drop its durable
     // transcript so it does not orphan in the event store; the CLI opens the
     // store directly since it has no live worker. Only after a successful
     // teardown so a failed purge stays restorable. If the transcript can't be
     // dropped, keep the session row (skip the removal below) rather than
     // orphan the transcript. See #2489.
-    if result.success {
-        if let Err(e) = super::purge_acp_transcript(&inst) {
-            anyhow::bail!(
-                "Session teardown succeeded but its transcript could not be purged, so the session \
-                 record was kept (retry, or remove it once the event store is reachable): {e}"
-            );
-        }
+    if let Err(e) = super::purge_acp_transcript(&inst) {
+        anyhow::bail!(
+            "Session teardown succeeded but its transcript could not be purged, so the session \
+             record was kept (retry, or remove it once the event store is reachable): {e}"
+        );
     }
 
     if !delete_worktree {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -485,18 +485,36 @@ async fn empty_trash(profile: &str) -> Result<()> {
         }
     }
 
-    // Phase 2 (locked): drop every purged id from the latest disk state.
+    // Phase 2 (locked): drop every successfully-purged id from the latest disk
+    // state. #2534: revalidate under the lock; a candidate restored mid-purge
+    // (no longer trashed) must survive even though its teardown already ran on
+    // the snapshot. #2527: report the count actually removed, not the candidate
+    // count, plus how many were kept (teardown/transcript failed, or restored).
     let purged_set: HashSet<String> = purged_ids.into_iter().collect();
-    storage.update(|all_instances, _groups| {
-        all_instances.retain(|i| !purged_set.contains(&i.id));
-        Ok(())
+    let candidates = trashed.len();
+    let (removed, restored) = storage.update(|all_instances, _groups| {
+        Ok(super::apply_empty_trash_purge(all_instances, &purged_set))
     })?;
 
-    println!(
-        "Emptied trash: purged {} session(s) from profile '{}'.",
-        trashed.len(),
-        storage.profile()
-    );
+    let kept = candidates.saturating_sub(removed);
+    if restored > 0 {
+        eprintln!(
+            "Warning: {restored} session(s) were restored while the trash was being \
+             emptied; kept the restored records, but their worktree, branch, container, \
+             or transcript may already have been removed. Inspect and repair them."
+        );
+    }
+    if kept > 0 {
+        println!(
+            "Emptied trash: purged {removed} session(s), kept {kept} for retry, from profile '{}'.",
+            storage.profile()
+        );
+    } else {
+        println!(
+            "Emptied trash: purged {removed} session(s) from profile '{}'.",
+            storage.profile()
+        );
+    }
     Ok(())
 }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -491,12 +491,19 @@ async fn empty_trash(profile: &str) -> Result<()> {
     // the snapshot. #2527: report the count actually removed, not the candidate
     // count, plus how many were kept (teardown/transcript failed, or restored).
     let purged_set: HashSet<String> = purged_ids.into_iter().collect();
-    let candidates = trashed.len();
-    let (removed, restored) = storage.update(|all_instances, _groups| {
-        Ok(super::apply_empty_trash_purge(all_instances, &purged_set))
+    let candidate_ids: HashSet<String> = trashed.iter().map(|i| i.id.clone()).collect();
+    // Compute `kept` from candidate rows that are STILL present after the purge,
+    // not `candidates - removed`: a candidate a peer already removed before this
+    // lock is neither removed by us nor still around, so subtracting would
+    // wrongly report it as kept for retry.
+    let (removed, restored, kept) = storage.update(|all_instances, _groups| {
+        let (removed, restored) = super::apply_empty_trash_purge(all_instances, &purged_set);
+        let kept = all_instances
+            .iter()
+            .filter(|i| candidate_ids.contains(&i.id))
+            .count();
+        Ok((removed, restored, kept))
     })?;
-
-    let kept = candidates.saturating_sub(removed);
     if restored > 0 {
         eprintln!(
             "Warning: {restored} session(s) were restored while the trash was being \


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Four related correctness bugs in the CLI permanent-purge paths (`aoe rm --purge`, `aoe session empty-trash`). They overlap in the same three functions, so they are fixed together; the shared helpers live in `src/cli/mod.rs`.

- **#2524 (transcript orphaning):** `purge_acp_transcript` returned `Ok(())` for any non-structured session before its non-serve `bail!` could run. In a default (non-`serve`) build `is_structured()` is always `false` (its backing `view` field is serve-gated), so the bail was dead code and a non-serve purge dropped the session row while orphaning its ACP transcript in `acp_events.db`. The function now deletes the rows idempotently via `rusqlite` (a non-optional dependency) in every build, clearing both `acp_events` and `acp_attachments`. A real db open/write failure still returns `Err`, so callers keep the row and can retry.
- **#2525 (workspace branches survive purge):** `rm --purge --delete-worktree --delete-branch` gated branch deletion on `worktree_info.managed_by_aoe`, which is `None` for multi-repo workspace sessions, so their AoE-created branches were left behind. Branch deletion is now gated on the shape-agnostic `has_managed_worktree_or_workspace()`, matching `empty-trash`; `perform_deletion` already cleans workspace-repo branches off that flag.
- **#2527 (misleading count):** `empty-trash` printed the candidate count (`trashed.len()`) even when some purges failed and their rows were intentionally kept. It now reports the number actually removed plus how many were kept for retry.
- **#2534 (concurrent restore lost):** both purge paths dropped the row by id under the storage lock without rechecking it was still trashed, so a session restored between the unlocked snapshot and the locked removal was silently deleted. The final removal now revalidates under the lock; a concurrent restore wins, and the user is warned that a kept row's worktree/branch/container/transcript may already have been torn down (the irreversible teardown ran on the pre-restore snapshot).

Two deeper issues surfaced during review were deliberately left out of this batch to keep it a scoped bug fix, and filed as follow-ups: serve-gated `Instance` fields corrupting structured metadata on non-serve rewrites (#2540), and the lack of full purge/restore mutual exclusion since teardown runs on a stale snapshot (#2541).

Closes #2524
Closes #2525
Closes #2527
Closes #2534

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On a default (non-`serve`) build, purge a structured session that has rows in `acp_events.db`; confirm the session row is removed AND its `acp_events` + `acp_attachments` rows are gone (no orphan).
- [ ] `aoe rm --purge --delete-worktree --delete-branch` a multi-repo workspace session; confirm each managed repo branch is deleted, not just the worktrees.
- [ ] Trash two sessions, make one purge fail, run `aoe session empty-trash`; confirm the summary reports the count actually removed plus the kept-for-retry count.
- [ ] Trash a session, start `aoe rm --purge <id>`, restore it from another process before the purge finishes; confirm the restored session is NOT deleted and a warning is printed.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Skipped a test, because: the corrected logic is pinned by deterministic unit tests in `src/cli` (the ACP-row delete, the workspace branch gate, the removed/kept count, and the restore-revalidation predicate). An e2e would only exercise happy paths that don't trigger these bugs: the count bug shows only on a failed purge, and #2534 is an inherently nondeterministic restore race, so unit coverage is the higher-value anchor.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (hardened with a `/debate` consult), and implementation drafted by Claude under my direction. I made the scope calls, including deferring the two architectural follow-ups, reviewed the commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785267243&installation_id=139138837&pr_number=2542&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2542&signature=cd6b536a49588d708ec3a0ae2a5de539beaa34f399630e79b46f2e0dd6c1d43c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### What changed
- Fixed permanent purge paths to more reliably remove leftover ACP transcript data by deleting the related local database rows (events + attachments) safely and idempotently when they exist.
- Corrected `--delete-branch` behavior for workspace sessions, including multi-repo workspace sessions where the expected worktree info may be missing.
- Improved `empty-trash` reporting to reflect what actually happened: how many sessions were removed versus how many were kept for retry after failures/restores.
- Added safeguards so if a session is restored while an `empty-trash` purge is in progress, the restored items won’t be incorrectly deleted.

### Benefits
- Prevents stale transcript data from persisting after purge.
- Makes CLI outcomes more accurate and trustworthy (especially for trash-emptying).
- Reduces the risk of accidental data loss when purge and restore overlap.
- Improves correctness of workspace-session branch cleanup.

### Technical notes
- ACP purge now does a single-transaction row cleanup (and treats missing tables as a no-op).
- Trash emptying now revalidates state under the storage lock and differentiates “removed” vs “kept/restored” outcomes.
- Added/updated unit tests for the targeted/restore keep conditions, purge bookkeeping counts, and ACP table-missing no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->