### PR TITLE
fix(serve): correct trash/purge server-side defaults (#2523, #2532)

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -579,7 +579,11 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
                 let cfg = crate::session::profile_config::resolve_config_or_warn(&session.profile);
                 CleanupDefaults {
                     delete_worktree: cfg.worktree.auto_cleanup,
-                    delete_branch: cfg.worktree.delete_branch_on_cleanup,
+                    // Branch deletion only makes sense when the worktree is
+                    // also removed; keeping the worktree keeps its branch
+                    // checked out, so a `git branch -d` would fail (#2532).
+                    delete_branch: cfg.worktree.auto_cleanup
+                        && cfg.worktree.delete_branch_on_cleanup,
                     delete_sandbox: cfg.sandbox.auto_cleanup,
                     delete_to_trash: cfg.session.delete_to_trash,
                 }
@@ -1899,13 +1903,24 @@ fn default_kill_pane() -> bool {
     true
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Deserialize)]
 pub struct TrashSessionBody {
     /// On trash, tear down every tmux session this instance owns. `false`
     /// keeps tmux state alive; structured-view supervisor shutdown (which
     /// preserves the transcript) is unconditional. Defaults to `true`.
     #[serde(default = "default_kill_pane")]
     pub kill_pane: bool,
+}
+
+// A no-body trash request resolves through `unwrap_or_default()`, so `Default`
+// must match the serde field default (`true`). The derived `Default` would use
+// `bool::default()` (`false`) and silently leave the pane running (#2523).
+impl Default for TrashSessionBody {
+    fn default() -> Self {
+        Self {
+            kill_pane: default_kill_pane(),
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -3436,7 +3451,10 @@ pub(crate) async fn purge_expired_trash(state: &Arc<AppState>) {
         let cfg = crate::session::profile_config::resolve_config_or_warn(&instance.source_profile);
         let body = DeleteSessionBody {
             delete_worktree: cfg.worktree.auto_cleanup,
-            delete_branch: cfg.worktree.delete_branch_on_cleanup,
+            // Tie branch cleanup to worktree cleanup: a preserved worktree
+            // keeps its branch checked out, so branch deletion would fail
+            // (#2532).
+            delete_branch: cfg.worktree.auto_cleanup && cfg.worktree.delete_branch_on_cleanup,
             delete_sandbox: cfg.sandbox.auto_cleanup,
             force_delete: true,
             keep_scratch: false,
@@ -5778,6 +5796,24 @@ mod tests {
         inst.status = Status::Running;
         inst.group_path = "work/projects".to_string();
         inst
+    }
+
+    #[test]
+    fn trash_body_default_keeps_kill_pane_true() {
+        // #2523: a no-body trash request resolves through
+        // `unwrap_or_default()`. The derived `Default` would yield
+        // `kill_pane = false` and leave the pane running; the hand impl must
+        // match the serde field default.
+        assert!(TrashSessionBody::default().kill_pane);
+
+        // An empty JSON object goes through serde, which honors the field
+        // default helper.
+        let from_empty: TrashSessionBody = serde_json::from_str("{}").unwrap();
+        assert!(from_empty.kill_pane);
+
+        // An explicit `false` is still respected.
+        let explicit: TrashSessionBody = serde_json::from_str(r#"{"kill_pane": false}"#).unwrap();
+        assert!(!explicit.kill_pane);
     }
 
     #[test]

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -579,11 +579,7 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
                 let cfg = crate::session::profile_config::resolve_config_or_warn(&session.profile);
                 CleanupDefaults {
                     delete_worktree: cfg.worktree.auto_cleanup,
-                    // Branch deletion only makes sense when the worktree is
-                    // also removed; keeping the worktree keeps its branch
-                    // checked out, so a `git branch -d` would fail (#2532).
-                    delete_branch: cfg.worktree.auto_cleanup
-                        && cfg.worktree.delete_branch_on_cleanup,
+                    delete_branch: cfg.worktree.should_delete_branch_on_cleanup(),
                     delete_sandbox: cfg.sandbox.auto_cleanup,
                     delete_to_trash: cfg.session.delete_to_trash,
                 }
@@ -3451,10 +3447,7 @@ pub(crate) async fn purge_expired_trash(state: &Arc<AppState>) {
         let cfg = crate::session::profile_config::resolve_config_or_warn(&instance.source_profile);
         let body = DeleteSessionBody {
             delete_worktree: cfg.worktree.auto_cleanup,
-            // Tie branch cleanup to worktree cleanup: a preserved worktree
-            // keeps its branch checked out, so branch deletion would fail
-            // (#2532).
-            delete_branch: cfg.worktree.auto_cleanup && cfg.worktree.delete_branch_on_cleanup,
+            delete_branch: cfg.worktree.should_delete_branch_on_cleanup(),
             delete_sandbox: cfg.sandbox.auto_cleanup,
             force_delete: true,
             keep_scratch: false,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1894,6 +1894,16 @@ pub struct WorktreeConfig {
     pub default_base_branch: Option<String>,
 }
 
+impl WorktreeConfig {
+    /// Branch cleanup only makes sense when the worktree is also removed; a
+    /// preserved worktree keeps its branch checked out, so deleting it would
+    /// fail (#2532). Single source for that invariant across the cleanup
+    /// default and auto-purge call sites.
+    pub fn should_delete_branch_on_cleanup(&self) -> bool {
+        self.auto_cleanup && self.delete_branch_on_cleanup
+    }
+}
+
 impl Default for WorktreeConfig {
     fn default() -> Self {
         Self {

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -175,6 +175,15 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         tracing::debug!(target: "session.delete", branch = %b, main_repo = %r.display(), "perform_deletion: branch_to_delete resolved");
     }
 
+    // Branch cleanup is gated on the worktree actually being removed, not on
+    // `request.delete_worktree`. A branch checked out in a preserved (or
+    // failed-to-remove) worktree cannot be deleted, so track real removal
+    // outcomes here instead of inferring them from error-message prefixes
+    // (#2532).
+    let mut main_worktree_removed = false;
+    let mut removed_workspace_repos: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
     if request.delete_worktree {
         if let Some(wt_info) = &request.instance.worktree_info {
             if wt_info.managed_by_aoe {
@@ -195,6 +204,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                                 errors.extend(errs);
                             } else {
                                 messages.push("Worktree removed".to_string());
+                                main_worktree_removed = true;
                             }
                         }
                         Err(e) => {
@@ -237,6 +247,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                                         "Workspace ({}) worktree removed",
                                         repo.name
                                     ));
+                                    removed_workspace_repos.insert(repo.name.clone());
                                 }
                             }
                             Err(e) => {
@@ -266,10 +277,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     // was successfully removed).
     tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "branch_delete", "perform_deletion: stage");
     if let Some((branch, main_repo)) = branch_to_delete {
-        let worktree_ok =
-            !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Worktree:"));
-        tracing::debug!(target: "session.delete", branch = %branch, main_repo = %main_repo.display(), worktree_ok, "perform_deletion: attempting branch deletion");
-        if worktree_ok {
+        tracing::debug!(target: "session.delete", branch = %branch, main_repo = %main_repo.display(), main_worktree_removed, "perform_deletion: attempting branch deletion");
+        if main_worktree_removed {
             match GitWorktree::new(main_repo.clone()) {
                 Ok(git_wt) => {
                     if let Err(e) = git_wt.delete_branch(&branch) {
@@ -286,30 +295,39 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
             }
         } else {
             tracing::debug!(target: "session.delete",
-                "perform_deletion: skipping branch deletion (worktree removal had errors)"
+                "perform_deletion: skipping branch deletion (worktree preserved or not removed)"
             );
+            messages.push(format!(
+                "Branch '{}' kept; its worktree was preserved",
+                branch
+            ));
         }
     }
 
     // Branch cleanup for workspace repos
     if request.delete_branch {
         if let Some(ws_info) = &request.instance.workspace_info {
-            let worktree_ok =
-                !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Workspace ("));
-            if worktree_ok {
-                for repo in &ws_info.repos {
-                    if repo.managed_by_aoe {
-                        let main_repo = PathBuf::from(&repo.main_repo_path);
-                        if let Ok(git_wt) = GitWorktree::new(main_repo) {
-                            if let Err(e) = git_wt.delete_branch(&repo.branch) {
-                                errors.push(format!("Branch ({}): {}", repo.name, e));
-                            } else {
-                                messages.push(format!(
-                                    "Branch '{}' ({}) deleted",
-                                    repo.branch, repo.name
-                                ));
-                            }
-                        }
+            for repo in &ws_info.repos {
+                if !repo.managed_by_aoe {
+                    continue;
+                }
+                // Per-repo gate: only delete a repo's branch when that repo's
+                // worktree was actually removed. A repo whose worktree was
+                // preserved (or failed to remove) keeps its branch checked
+                // out (#2532).
+                if !removed_workspace_repos.contains(&repo.name) {
+                    messages.push(format!(
+                        "Branch '{}' ({}) kept; its worktree was preserved",
+                        repo.branch, repo.name
+                    ));
+                    continue;
+                }
+                let main_repo = PathBuf::from(&repo.main_repo_path);
+                if let Ok(git_wt) = GitWorktree::new(main_repo) {
+                    if let Err(e) = git_wt.delete_branch(&repo.branch) {
+                        errors.push(format!("Branch ({}): {}", repo.name, e));
+                    } else {
+                        messages.push(format!("Branch '{}' ({}) deleted", repo.branch, repo.name));
                     }
                 }
             }
@@ -846,6 +864,105 @@ mod tests {
                     .trim()
                     .is_empty(),
                 "branch should be deleted: stdout={}",
+                String::from_utf8_lossy(&branches_out.stdout)
+            );
+        }
+
+        /// #2532 repro: requesting branch deletion while preserving the
+        /// worktree (`delete_worktree=false, delete_branch=true`) must NOT
+        /// attempt `git branch -d/-D` on the branch the preserved worktree
+        /// still has checked out. Pre-fix this pushed a `Branch:` error and
+        /// failed the deletion; post-fix the branch is kept with a message
+        /// and the worktree + branch survive intact.
+        #[test]
+        fn e2e_preserved_worktree_keeps_its_branch() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let main_repo = tmp.path().join("main");
+            let worktree_path = tmp.path().join("worktree");
+            std::fs::create_dir(&main_repo).unwrap();
+
+            let repo = git2::Repository::init(&main_repo).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+
+            let status = std::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "add",
+                    "-b",
+                    "feature/keep-me",
+                    worktree_path.to_str().unwrap(),
+                ])
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+            assert!(
+                status.status.success(),
+                "git worktree add failed: {}",
+                String::from_utf8_lossy(&status.stderr)
+            );
+
+            let mut instance = Instance::new("Test", worktree_path.to_str().unwrap());
+            instance.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: "feature/keep-me".to_string(),
+                main_repo_path: main_repo.to_string_lossy().to_string(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+                base_branch: None,
+            });
+
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: false,
+                delete_branch: true,
+                delete_sandbox: false,
+                force_delete: false,
+                detach_hooks: true,
+                keep_scratch: false,
+            };
+
+            let result = perform_deletion(&request);
+            assert!(
+                result.success,
+                "preserving the worktree must not fail deletion: {:?}",
+                result.errors
+            );
+            assert!(
+                !result.errors.iter().any(|e| e.starts_with("Branch:")),
+                "no branch-cleanup error expected: {:?}",
+                result.errors
+            );
+            assert!(
+                result.messages.iter().any(|m| m.contains("kept")),
+                "a kept-branch message is expected: {:?}",
+                result.messages
+            );
+
+            // Worktree directory and admin entry must survive.
+            assert!(
+                worktree_path.exists(),
+                "preserved worktree dir must still exist"
+            );
+            assert!(
+                main_repo.join(".git/worktrees/worktree").exists(),
+                "preserved worktree admin dir must still exist"
+            );
+
+            // Branch must still be present.
+            let branches_out = std::process::Command::new("git")
+                .args(["branch", "--list", "feature/keep-me"])
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+            assert!(
+                !String::from_utf8_lossy(&branches_out.stdout)
+                    .trim()
+                    .is_empty(),
+                "branch should be preserved: stdout={}",
                 String::from_utf8_lossy(&branches_out.stdout)
             );
         }

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -181,7 +181,9 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     // outcomes here instead of inferring them from error-message prefixes
     // (#2532).
     let mut main_worktree_removed = false;
-    let mut removed_workspace_repos: std::collections::HashSet<String> =
+    // Keyed by worktree path, not repo name: two workspace repos can share a
+    // name, and the path is what uniquely identifies the removed worktree.
+    let mut removed_workspace_worktrees: std::collections::HashSet<PathBuf> =
         std::collections::HashSet::new();
 
     if request.delete_worktree {
@@ -247,7 +249,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                                         "Workspace ({}) worktree removed",
                                         repo.name
                                     ));
-                                    removed_workspace_repos.insert(repo.name.clone());
+                                    removed_workspace_worktrees.insert(worktree_path.clone());
                                 }
                             }
                             Err(e) => {
@@ -304,7 +306,6 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         }
     }
 
-    // Branch cleanup for workspace repos
     if request.delete_branch {
         if let Some(ws_info) = &request.instance.workspace_info {
             for repo in &ws_info.repos {
@@ -315,7 +316,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                 // worktree was actually removed. A repo whose worktree was
                 // preserved (or failed to remove) keeps its branch checked
                 // out (#2532).
-                if !removed_workspace_repos.contains(&repo.name) {
+                if !removed_workspace_worktrees.contains(&PathBuf::from(&repo.worktree_path)) {
                     messages.push(format!(
                         "Branch '{}' ({}) kept; its worktree was preserved",
                         repo.branch, repo.name


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two linked server-side default bugs on the trash/purge paths, fixed together.

**#2523:** `POST /api/sessions/:id/trash` with no JSON body resolves through `body.unwrap_or_default()`. `TrashSessionBody` derived `Default`, which ignores the `#[serde(default = "default_kill_pane")]` field helper, so `kill_pane` came out `false` instead of the documented `true`, and the tmux pane kept running. Fixed by replacing the derived `Default` with a hand impl that delegates to `default_kill_pane()`, so the no-body path matches what a present `{}` body already does.

**#2532:** permanent delete and retention auto-purge could request `delete_branch = true` while `delete_worktree = false`. The deletion sink then ran `git branch -d/-D` against the branch the preserved worktree still had checked out, which git rejects, so the purge failed or emitted noisy branch-cleanup errors for a config combination the UI/settings allow. Fixed at the sink: `perform_deletion()` now gates branch deletion on the worktree actually being removed (a `main_worktree_removed` flag plus a per-repo removed set), not on a brittle error-message-prefix heuristic that also missed `remove_managed_worktree` failures. A preserved or failed-to-remove worktree keeps its branch with an explanatory message instead of an error. The web cleanup defaults and the retention purge body are also tightened so they never build the contradictory request in the first place.

The per-repo gate additionally fixes partial workspace cleanup (one repo failing no longer skips branch cleanup for the others) and the `cleanup_on_delete = false` case.

Out of scope: CLI `rm --purge --delete-branch` workspace skip (#2525, a separate under-deletion bug); the sink invariant here is unchanged when `delete_worktree = true`.

Closes #2523
Closes #2532

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `POST /api/sessions/:id/trash` with no request body: the session is trashed and its tmux pane is torn down (previously the pane kept running).
- [ ] `POST /api/sessions/:id/trash` with body `{"kill_pane": false}`: the session is trashed but the tmux pane is preserved.
- [ ] With `worktree.auto_cleanup = false` and `worktree.delete_branch_on_cleanup = true`, permanently delete a trashed worktree session from the web: the worktree and its branch are preserved, no branch-cleanup error is reported, and the result notes the branch was kept.
- [ ] Let retention auto-purge expire a trashed session under the same config: it purges without attempting (or erroring on) branch deletion.
- [ ] Permanently delete a session with both "delete worktree" and "delete branch" selected: both the worktree and the branch are still removed (happy path unaffected).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This is a Rust-only diff (no `web/` files). The web delete dialog's default checkbox derivation changes only under a non-default config (`auto_cleanup = false` with `delete_branch_on_cleanup = true`); the React code is untouched.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The shared `perform_deletion` logic is covered by a new on-disk unit test (`e2e_preserved_worktree_keeps_its_branch`) that builds a real git repo + worktree and asserts the preserved-worktree branch is kept; the `TrashSessionBody` default is covered by a unit test for the no-body, empty-object, and explicit-false cases. Both were confirmed red before the fix.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a multi-model design debate on whether to fix #2532 at the source or the sink. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785267660&installation_id=139138837&pr_number=2543&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2543&signature=52620ca21e65854aa295cb5194b564472fe7ba954016ee7cd8501bdc0cf601e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes two default-behavior bugs around session trashing and cleanup.

- Trash requests with no JSON body now match the documented default: the tmux pane is stopped by default unless `kill_pane` is explicitly set to `false`.
- Permanent-delete and expired-trash auto-purge flows now avoid attempting branch deletion when worktree deletion is disabled, preventing Git errors when the branch is still checked out by a preserved worktree.
- Branch cleanup is now consistently tied to whether the corresponding worktree was actually removed, instead of relying on indirect signals.
- Added regression coverage for the no-body trash default and for the “preserved worktree keeps its branch” scenario.

Benefits: more predictable behavior, safer cleanup when users choose to retain worktrees, and fewer purge/delete failures from incompatible delete settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->