### PR TITLE
docs: fix 37 rustdoc warnings on main

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1138,7 +1138,7 @@ Export a built-in theme as a TOML file for customization
 
 ###### **Options:**
 
-* `-o`, `--output <OUTPUT>` — Output file path (defaults to <name>.toml in the themes directory)
+* `-o`, `--output <OUTPUT>` — Output file path (defaults to `<name>.toml` in the themes directory)
 
 
 

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -61,7 +61,7 @@ impl AgentRegistry {
     /// to a registry key.
     ///
     /// Sources verified against
-    /// https://agentclientprotocol.com/get-started/agents.md
+    /// <https://agentclientprotocol.com/get-started/agents.md>
     /// (Jan 2026):
     ///
     ///   claude   → claude-agent-acp     (Zed adapter for Claude SDK)

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -92,7 +92,7 @@ pub struct AgentHookConfig {
     /// Hook events to register (status transitions and session lifecycle).
     pub events: &'static [HookEvent],
     /// On-disk format of the settings file. Drives target-kind selection in
-    /// [`crate::hooks::iter_hook_targets_in`], which feeds the v015 marker
+    /// `crate::hooks::iter_hook_targets_in`, which feeds the v015 marker
     /// walker and the uninstall path.
     pub format: HookFormat,
 }
@@ -131,10 +131,10 @@ pub struct SidecarHooks {
     /// config file instead of the standalone `host_config_subpath` agent, and
     /// skips `post_install_host`. `None` for agents whose hooks apply
     /// regardless of which agent is selected. See
-    /// [`crate::session::Instance::install_agent_status_hooks`].
+    /// `crate::session::Instance::install_agent_status_hooks`.
     pub selected_agent_hooks: Option<SelectedAgentHooks>,
     /// On-disk format of the sidecar's config file. Drives marker-presence
-    /// walker dispatch in [`crate::hooks::has_aoe_marker`].
+    /// walker dispatch in `crate::hooks::has_aoe_marker`.
     pub format: SidecarFormat,
 }
 
@@ -158,7 +158,7 @@ pub struct SelectedAgentHooks {
 }
 
 /// On-disk format of a sidecar agent's config file. Drives
-/// marker-presence walker dispatch in [`crate::hooks::has_aoe_marker`].
+/// marker-presence walker dispatch in `crate::hooks::has_aoe_marker`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SidecarFormat {
     /// Settl `[[hooks]]` table in `.settl/config.toml`.
@@ -852,10 +852,10 @@ pub fn get_agent(name: &str) -> Option<&'static AgentDef> {
 /// default), so AoE must not install hooks into `good`, an agent the CLI is not
 /// running. Returning `None` makes AoE fall back to its standalone hooks agent,
 /// which is what the CLI effectively does. This also gives extra-args the final
-/// say over a command override when [`crate::session::Instance::selected_agent_args`]
+/// say over a command override when `crate::session::Instance::selected_agent_args`
 /// concatenates command then extra-args.
 ///
-/// A value is rejected by [`is_safe_agent_name`] (empty, `.`/`..`, leading dash,
+/// A value is rejected by `is_safe_agent_name` (empty, `.`/`..`, leading dash,
 /// or a path separator) so a parsed value can be safely joined to an agents
 /// directory without path traversal. Whitespace-tokenized, which matches how AoE
 /// assembles the launch string; quoted values containing spaces are not handled

--- a/src/cli/theme.rs
+++ b/src/cli/theme.rs
@@ -19,7 +19,7 @@ pub enum ThemeCommands {
         /// Theme name to export
         name: String,
 
-        /// Output file path (defaults to <name>.toml in the themes directory)
+        /// Output file path (defaults to `<name>.toml` in the themes directory)
         #[arg(short, long)]
         output: Option<String>,
     },

--- a/src/file_watch.rs
+++ b/src/file_watch.rs
@@ -409,7 +409,7 @@ impl FileWatchService {
     /// Construct a noop service: no kernel watcher, no drain thread, no
     /// dispatcher. [`Self::subscribe_channel`] returns Ok with an
     /// immediately-closed receiver (its paired sender is dropped before
-    /// return). [`Self::notify_local_change`] is silently a no-op: the
+    /// return). `Self::notify_local_change` is silently a no-op: the
     /// dispatcher channel's receiver is dropped at construction so any
     /// `send` Errs, and `dispatcher_dead` is pre-set so the error log path
     /// short-circuits. Used by `Storage::new_unwatched` and as the

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -777,7 +777,7 @@ impl GitWorktree {
     }
 
     /// Lock `path`'s linked-worktree admin entry so `git worktree prune` skips
-    /// it (see [`WORKTREE_LOCK_REASON`]). Called once at the end of
+    /// it (see `WORKTREE_LOCK_REASON`). Called once at the end of
     /// `create_worktree`. Returns an error the caller can surface as a
     /// non-fatal warning; a missing lock only forfeits prune protection, it
     /// does not make the worktree unusable.

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -64,7 +64,7 @@ fn parse_status(bytes: &[u8]) -> Option<Status> {
 /// Read a Claude session UUID from the hook-written `session_id` sidecar.
 ///
 /// Returns `None` when the file is absent, malformed (non-UUID), or older
-/// than [`SESSION_ID_SIDECAR_MAX_AGE`].
+/// than `SESSION_ID_SIDECAR_MAX_AGE`.
 pub fn read_hook_session_id(instance_id: &str) -> Option<String> {
     let dir = dir_guard::open_instance_dir_read_only(instance_id).ok()??;
     let meta = dir_guard::metadata_at(dir.as_fd(), "session_id").ok()??;

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -3,7 +3,7 @@
 //!
 //! Every method maps to a capability the plugin must have declared in its
 //! manifest and had granted at install. The middleware
-//! ([`PluginRpcContext::require`]) refuses an undeclared or ungranted call
+//! (`PluginRpcContext::require`) refuses an undeclared or ungranted call
 //! before the method runs, so a worker can never reach a resource it was not
 //! approved for. This is the cooperative-plugin boundary of the honest v1
 //! model (D8): it stops a well-behaved plugin from overreaching; it does not

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -230,7 +230,7 @@ pub enum UiError {
     /// newer worker replaced it). The write is dropped rather than resurrecting
     /// stale state.
     StaleWorker,
-    /// The plugin already holds [`MAX_ENTRIES_PER_PLUGIN`] entries.
+    /// The plugin already holds `MAX_ENTRIES_PER_PLUGIN` entries.
     QuotaExceeded,
     /// The payload did not match the slot's typed shape, or a scope rule
     /// (per-session slot needs a `session_id`; a global slot must not have one).

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1619,7 +1619,7 @@ pub enum ColorMode {
     /// modern terminals and SSH sessions that pass RGB correctly.
     #[default]
     Truecolor,
-    /// Emit 256-palette escapes (\e[38;5;<idx>m) by converting every theme
+    /// Emit 256-palette escapes (`\e[38;5;<idx>m`) by converting every theme
     /// Rgb(r,g,b) to the nearest xterm-256 index. Use this when the transport
     /// (notably some mosh clients) mishandles 24-bit RGB; preview panes in
     /// aoe already use 256-palette via ansi-to-tui, so palette mode renders

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -1030,7 +1030,7 @@ pub fn append_trash_section(items: &mut Vec<Item>, instances: &[Instance], colla
 ///
 /// Layout:
 /// - Archived (depth 0)
-///   - <project name> (depth 1)
+///   - `<project name>` (depth 1)
 ///     - session row (depth 2)
 ///
 /// `section_collapsed` hides everything below the top header; per-project

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -314,11 +314,11 @@ pub struct SandboxInfo {
     pub container_workdir: Option<String>,
     /// `KEY=VALUE` pairs minted on the host by `host_hooks.before_start` when
     /// the container last came up. Injected into the container environment as
-    /// inherited (leak-safe) entries by [`super::environment::collect_environment`].
+    /// inherited (leak-safe) entries by `super::environment::collect_environment`.
     ///
     /// Runtime-only and secret: never serialized (so short-lived tokens never
     /// hit disk and a stale value never survives a restart) and re-minted on the
-    /// next container come-up. See [`Instance::ensure_before_start_env`].
+    /// next container come-up. See `Instance::ensure_before_start_env`.
     #[serde(skip)]
     pub before_start_env: Vec<(String, String)>,
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -102,7 +102,7 @@ use std::time::Duration;
 
 /// App dir name under the XDG config base (`$XDG_CONFIG_HOME`, default
 /// `~/.config`). Always used on Linux; used on macOS when the user opts into
-/// the XDG layout (see [`get_app_dir_path`] and issue #1948). Debug builds use
+/// the XDG layout (see `get_app_dir_path` and issue #1948). Debug builds use
 /// a `-dev` suffix so a `cargo run` instance shares no state with an installed
 /// release binary.
 pub const APP_DIR_NAME_XDG: &str = if cfg!(debug_assertions) {
@@ -308,7 +308,7 @@ pub fn get_profile_dir(profile: &str) -> Result<PathBuf> {
 /// Use this for read-only operations (loading config, looking up paths)
 /// where the directory-creation side effect of [`get_profile_dir`] would
 /// pollute `profiles/` with empty stub directories. Notably, GET
-/// /api/settings?profile=<name> for an unknown profile used to create
+/// `/api/settings?profile=<name>` for an unknown profile used to create
 /// that profile's directory as a side effect of the read, which then
 /// made the unknown profile appear in subsequent GET /api/profiles
 /// responses. Routing those reads through this helper keeps the lookup

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -43,7 +43,7 @@ impl ProfileConfig {
 /// Load profile-specific config. Returns empty config if file doesn't exist.
 ///
 /// Pure read: never creates the profile directory. Goes through the
-/// non-creating path resolver so a GET /api/settings?profile=<unknown>
+/// non-creating path resolver so a GET `/api/settings?profile=<unknown>`
 /// (which the dashboard fires on mount before profiles resolve) does
 /// not pollute `profiles/` with a stub directory.
 pub fn load_profile_config(profile: &str) -> Result<ProfileConfig> {
@@ -134,7 +134,7 @@ pub fn merge_configs(global: Config, profile: &ProfileConfig) -> Config {
 /// This works for every section without per-field arms, so adding a config
 /// field never touches a merge function. The deserialize is infallible in
 /// practice because every override-writing path (file load, server PATCH, TUI)
-/// type-checks against the schema first; see [`validate_overrides_typecheck`].
+/// type-checks against the schema first; see `validate_overrides_typecheck`.
 pub fn merge_configs_generic(global: &Config, overrides: &serde_json::Value) -> Config {
     let mut base = serde_json::to_value(global).expect("Config serializes to JSON");
     crate::session::settings_schema::merge_json(&mut base, overrides);

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -24,7 +24,7 @@ pub enum HookProgress {
 /// active [`crate::session::recovery::HookTimeoutScope`].
 ///
 /// `run_hook_with_timeout` is the sole producer of this value, and it only
-/// runs when [`crate::session::recovery::current_hook_timeout`] returns
+/// runs when `crate::session::recovery::current_hook_timeout` returns
 /// `Some`, which production code installs only inside the startup-recovery
 /// cascade (`run_recovery_for_instance`). Current production callers rely on
 /// this invariant: observing a `HookTimeout` in the error chain implies the
@@ -62,7 +62,7 @@ const REPO_OVERRIDABLE_SECTIONS: &[&str] = &[
 /// Repository-level configuration loaded from `.agent-of-empires/config.toml`.
 ///
 /// Stored as a sparse override tree like [`ProfileConfig`] (#1692): section
-/// tables keyed by config-section name. Only [`REPO_OVERRIDABLE_SECTIONS`] are
+/// tables keyed by config-section name. Only `REPO_OVERRIDABLE_SECTIONS` are
 /// honored; any other section is dropped on merge and on save, so a repo can
 /// never override personal/global settings.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -144,7 +144,7 @@ impl HooksConfig {
 /// Unlike [`HooksConfig`], which runs inside the container for sandboxed
 /// sessions, these run on the host before a sandbox container comes up. They
 /// are profile/global only and are never honored from a repo's
-/// `.agent-of-empires/config.toml` (see [`REPO_OVERRIDABLE_SECTIONS`]), because
+/// `.agent-of-empires/config.toml` (see `REPO_OVERRIDABLE_SECTIONS`), because
 /// a checked-out repo must not be able to run host commands.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HostHooksConfig {
@@ -1099,7 +1099,7 @@ fn run_hooks_streamed(
 
 /// Execute a list of hook commands in the given directory.
 ///
-/// `extra_env` is exported to each hook process; see [`lifecycle_env_vars`]
+/// `extra_env` is exported to each hook process; see `lifecycle_env_vars`
 /// for the canonical set of session env vars. Pass `&[]` if no session context
 /// is available.
 pub fn execute_hooks(
@@ -1132,7 +1132,7 @@ pub fn execute_hooks_in_container(
 /// Deliberately resolved without repo overrides ([`super::profile_config::resolve_config_or_warn`]
 /// rather than [`resolve_config_with_repo_or_warn`]) so a repo can never
 /// contribute host commands; this is belt-and-suspenders on top of
-/// `host_hooks` being excluded from [`REPO_OVERRIDABLE_SECTIONS`].
+/// `host_hooks` being excluded from `REPO_OVERRIDABLE_SECTIONS`.
 pub fn resolve_before_start_hooks(profile: &str) -> Vec<String> {
     let resolved = super::config::effective_profile(profile);
     super::profile_config::resolve_config_or_warn(&resolved)

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -6,9 +6,9 @@
 //! - **`DO_NOT_TRACK` is absolute.** When set (`1` / `true` / `yes`), it
 //!   suppresses both sending and install-id generation regardless of config.
 //! - **Endpoint.** Opted-in sends go to the collection gateway at
-//!   [`DEFAULT_ENDPOINT`] (which validates and re-sanitizes as a backstop);
+//!   `DEFAULT_ENDPOINT` (which validates and re-sanitizes as a backstop);
 //!   `AOE_TELEMETRY_ENDPOINT` overrides it, e.g. to point at a local sink. A
-//!   compiled-in [`TELEMETRY_KEY`] is sent as `X-Telemetry-Key` so the gateway
+//!   compiled-in `TELEMETRY_KEY` is sent as `X-Telemetry-Key` so the gateway
 //!   can shed drive-by noise (it is visible in source, so not real auth).
 //! - **Fire-and-forget.** Sends run detached with a hard timeout (plus a short
 //!   connect timeout so a down endpoint fails fast) and swallow every error
@@ -116,7 +116,7 @@ pub fn do_not_track() -> bool {
 }
 
 /// The send endpoint. `AOE_TELEMETRY_ENDPOINT` overrides when set to a
-/// non-empty value; otherwise the compiled-in [`DEFAULT_ENDPOINT`] is used.
+/// non-empty value; otherwise the compiled-in `DEFAULT_ENDPOINT` is used.
 /// Always returns a target, so the opt-in gate (not a missing endpoint) is
 /// what decides whether anything is sent.
 pub fn endpoint() -> String {
@@ -597,7 +597,7 @@ pub fn build_cli_usage() -> Option<CliUsage> {
 /// `aoe init`, ...) on a not-opted-in install never materialize the app dir and
 /// keep working in read-only / sandboxed environments. The daily slot is claimed
 /// only after a *confirmed* send, so a failed send leaves the counts and the slot
-/// intact for the next invocation to retry (bounded by [`CLI_USAGE_RETRY_GAP`]).
+/// intact for the next invocation to retry (bounded by `CLI_USAGE_RETRY_GAP`).
 /// Awaited with a hard timeout so a dead endpoint can never hang the CLI's exit.
 pub async fn track_cli_command(name: &str) {
     // Cheap non-creating gate first: opt-in creates the app dir, so its absence

--- a/src/telemetry/plugins.rs
+++ b/src/telemetry/plugins.rs
@@ -1,6 +1,6 @@
 //! Plugin-adoption census for `usage_snapshot` (#2367).
 //!
-//! Two maps, both fed straight from the loaded [`PluginRegistry`]:
+//! Two maps, both fed straight from the loaded [`crate::plugin::PluginRegistry`]:
 //! - `plugins_by_source`: installed count per source bucket
 //!   (`builtin` / `featured` / `community` / `local`). A count by category,
 //!   never an identity, so it is safe for every source.

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -316,7 +316,7 @@ impl ContainerTerminalSession {
 /// belonging to `id`. The single-index `kill` methods only target one
 /// deterministic name; this scans the live session list so the multi-terminal
 /// web tabs (`_t{N}` suffixes) and any title-change orphans are all reaped on
-/// session teardown. Mirrors [`kill_all_tool_sessions_for_id`].
+/// session teardown. Mirrors [`crate::tmux::kill_all_tool_sessions_for_id`].
 pub fn kill_all_terminals_for_id(id: &str) {
     let needle = format!("_{}", truncate_id(id, 8));
 

--- a/src/tui/dialogs/info.rs
+++ b/src/tui/dialogs/info.rs
@@ -85,7 +85,7 @@ impl InfoDialog {
     }
 
     /// Choose which end of an overflowing message stays visible. Defaults to
-    /// [`ScrollMode::Top`]; error dialogs override to [`ScrollMode::Tail`] so
+    /// `ScrollMode::Top`; error dialogs override to `ScrollMode::Tail` so
     /// the trailing payload (panic message, hook output) isn't scrolled off.
     pub fn with_scroll_mode(mut self, mode: ScrollMode) -> Self {
         self.scroll_mode = mode;

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -32,7 +32,7 @@ use crate::tui::styles::available_themes;
 use super::SettingsScope;
 
 /// Categories of settings. Each maps to a tab in the left-hand panel. The
-/// string returned by [`SettingsCategory::schema_name`] is matched against the
+/// string returned by `SettingsCategory::schema_name` is matched against the
 /// per-field `category` emitted by the schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsCategory {
@@ -104,7 +104,7 @@ impl SettingsCategory {
     }
 }
 
-/// Which lifecycle hook list a [`FieldKind::Hook`] row edits.
+/// Which lifecycle hook list a `FieldKind::Hook` row edits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookField {
     OnCreate,

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! Directory name is `structured_view` (not `structured view`) to avoid colliding
 //! with `src/acp/` per the recipe in
-//! https://github.com/agent-of-empires/agent-of-empires/issues/1018#issuecomment-4444040929.
+//! <https://github.com/agent-of-empires/agent-of-empires/issues/1018#issuecomment-4444040929>.
 
 pub mod input;
 pub mod mention;


### PR DESCRIPTION
## Description

Silences the 37 warnings emitted by `cargo doc --features serve --no-deps` on `main`. Four categories:

- 28 `rustdoc::private_intra_doc_links`: doc-links on `pub` items pointed at `pub(crate)` or private symbols, so rustdoc resolved them with `--document-private-items` but warned for the public build. Converted each to plain backticks, which keeps the symbol name readable without asking rustdoc to cross-link to an item invisible from the public docs.
- 5 `rustdoc::invalid_html_tags`: placeholders like `<name>`, `<idx>`, `<project name>`, `<unknown>` that rustdoc parsed as unclosed HTML. Wrapped in backticks.
- 2 `rustdoc::bare_urls`: wrapped in `<...>` so they render as hyperlinks.
- 2 `rustdoc::broken_intra_doc_links`: `PluginRegistry` in `src/telemetry/plugins.rs` and `kill_all_tool_sessions_for_id` in `src/tmux/terminal_session.rs` are both `pub` and reachable; qualified them to `crate::plugin::PluginRegistry` and `crate::tmux::kill_all_tool_sessions_for_id` respectively.

Flipping `RUSTDOCFLAGS=-D warnings` in CI is a separate follow-up.

Diff touches `///` and `//!` lines only: no `#[allow(rustdoc::...)]`, no visibility changes, no signatures, no tests.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo doc --features serve --no-deps 2>&1 | grep -cE "^warning:"` returns 0. `cargo fmt --check`, `cargo clippy --features serve --all-targets -- -D warnings`, and `cargo test --features serve --lib` are green on this branch except for the three pre-existing flakes on `main` (`session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt` tracking #1913, and the two `tmux::session::tests::capture_*` tests tracking the tmux flake #2231); they fail identically on `main` without this branch's changes and are out of scope.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (`claude-opus-4-7`).

**Any Additional AI Details you'd like to share:**

The 37-warning inventory was captured from `cargo doc --features serve --no-deps`, then each call site fixed by the smallest backtick / angle-bracket / qualification edit that drops the warning without touching surrounding prose or code.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR performs documentation-only cleanups across the codebase to eliminate 37 `rustdoc` warnings triggered by `cargo doc --features serve --no-deps`. It focuses on making existing doc text render correctly without changing any code behavior, signatures, or tests.

Key improvements:
- Replaced links to private/`pub(crate)` items with plain inline code so rustdoc stops warning about inaccessible targets.
- Fixed placeholder-style HTML text in docs (e.g., `<name>`, `<idx>`, `<unknown>`) by formatting them as inline code.
- Updated a couple of bare URL references and endpoint examples so they render in rustdoc without warnings.
- Corrected a small number of broken intra-doc links by qualifying them with fully qualified `crate::...` paths.

Benefits:
- Removes all identified rustdoc warning noise, making the docs build clean.
- Improves consistency and readability of rendered documentation (and the affected CLI/doc examples render more predictably).
- Keeps runtime logic, public APIs, and test behavior unchanged.

Follow-up noted: enabling `RUSTDOCFLAGS=-D warnings` in CI is intended as a separate step to prevent regressions. Seluj78 approved the change (“LGTM”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->