### PR TITLE
fix: clear idle dormant marker on unarchive

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1335,6 +1335,7 @@ impl Instance {
 
     pub fn unarchive(&mut self) {
         self.archived_at = None;
+        self.idle_dormant_since = None;
     }
 
     pub fn is_archived(&self) -> bool {
@@ -4550,6 +4551,23 @@ mod tests {
         assert!(inst.is_idle_dormant());
         inst.touch_last_accessed();
         assert!(!inst.is_idle_dormant());
+    }
+
+    #[test]
+    fn test_unarchive_clears_idle_dormant() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
+        inst.mark_idle_dormant();
+        assert!(inst.is_archived());
+        assert!(inst.is_idle_dormant());
+
+        inst.unarchive();
+
+        assert!(!inst.is_archived());
+        assert!(
+            !inst.is_idle_dormant(),
+            "unarchive should wake sessions blocked by idle auto-stop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Unarchiving an idle auto-stopped structured-view session cleared `archived_at` but left `idle_dormant_since` set. The ACP reconciler skips idle-dormant sessions by design, so the dashboard could show "starting structured view" after unarchive while no worker was eligible to spawn.

This updates `Instance::unarchive()` to clear `idle_dormant_since`, matching the existing wake semantics used by `touch_last_accessed()`, and adds a regression test for the state transition.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No docs or screenshots needed; this is a backend session-state fix with no visual UI change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the regression is the shared session-state invariant in `Instance::unarchive()`, covered by `session::instance::tests::test_unarchive_clears_idle_dormant`; no TUI rendering or CLI command behavior changes beyond using the fixed model method.

## Testing

- `cargo fmt --check`
- `cargo test -p agent-of-empires session::instance::tests::test_unarchive_clears_idle_dormant`
- `cargo test -p agent-of-empires session::instance::tests`
- `cargo clippy -p agent-of-empires --all-targets -- -D warnings`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:**

Investigated the stale `idle_dormant_since` state from a local structured-view session and applied the minimal model-level fix.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785318796&installation_id=139138837&pr_number=2554&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2554&signature=b6c814d974deb4680454193465ee50ca8ff30f61c32fc676b1883f7fc2040cab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change fixes a session recovery issue for structured-view auto-stopped sessions. When a session is unarchived, it now fully returns to an active state instead of staying stuck in a dormant state.

What changed:
- `unarchive()` now clears the idle-dormancy marker as well as the archived state.
- Added a regression test to confirm unarchiving properly wakes the session and removes the archived flag.

Benefit:
- Prevents the dashboard from getting stuck on “starting structured view” after unarchive.
- Keeps unarchive behavior consistent with the existing session wake-up flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->