### PR TITLE
fix: update Codex ACP package scope

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,7 @@ RUN npm install -g @qwen-code/qwen-code
 # CLIs above.
 RUN npm install -g \
     @agentclientprotocol/claude-agent-acp@^0.49.0 \
-    @zed-industries/codex-acp \
+    @agentclientprotocol/codex-acp@latest \
     pi-acp
 
 # Create directories for credential mounts

--- a/docs/development/internals/sandbox.md
+++ b/docs/development/internals/sandbox.md
@@ -57,7 +57,7 @@ docker volume rm aoe-claude-auth aoe-opencode-auth aoe-codex-auth aoe-gemini-aut
 Agent-view sessions can run inside the container. When both are enabled, the structured view runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters:
 
 - `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp`, pinned to the host floor; see `docker/Dockerfile`)
-- `codex-acp` (`@zed-industries/codex-acp`)
+- `codex-acp` (`@agentclientprotocol/codex-acp`)
 - `pi-acp`
 
 Native adapters that share a binary with the underlying CLI (`opencode acp`, `gemini --acp`, `vibe-acp`) work because the CLI is already installed. A **custom sandbox image** must install the same adapters, or the handshake fails with `agent did not complete the ACP initialize handshake within 30s` (the agent process exits with status 127 the moment the runner exec's it).

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -21,7 +21,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 | Agent | ACP adapter | Install | Auth |
 |-------|-------------|---------|------|
 | `claude` | `claude-agent-acp` (Zed, recent version required) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` | `claude login`, or `ANTHROPIC_API_KEY` |
-| `codex` | `codex-acp` (Zed) | `npm install -g @zed-industries/codex-acp` | `OPENAI_API_KEY`, or ChatGPT login (local-only) |
+| `codex` | `codex-acp` (ACP) | `npm install -g @agentclientprotocol/codex-acp@latest` | `OPENAI_API_KEY`, or ChatGPT login (local-only) |
 | `opencode` | `opencode acp` (native, ≥1.16.0 recommended) | `curl -fsSL https://opencode.ai/install \| bash` | `opencode auth` / provider env |
 | `gemini` | `gemini --acp` (native) | `npm install -g @google/gemini-cli` | `GEMINI_API_KEY`, OAuth, or Vertex |
 | `vibe` | `vibe-acp` (native) | see [mistral-vibe](https://github.com/mistralai/mistral-vibe) | Mistral API key |

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -8588,7 +8588,9 @@ mod tests {
             AcpError::Spawn(msg) => {
                 assert!(msg.contains("codex-acp"), "should echo the binary: {msg}");
                 assert!(
-                    msg.contains("Install with: npm install -g @zed-industries/codex-acp"),
+                    msg.contains(
+                        "Install with: npm install -g @agentclientprotocol/codex-acp@latest"
+                    ),
                     "should append the exact install command: {msg}"
                 );
             }

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn non_claude_permissive_on_old_version() {
-        let init = make_init("@zed-industries/codex-acp", "0.0.1");
+        let init = make_init("@agentclientprotocol/codex-acp", "0.0.1");
         validate(ExpectedAgent::CodexAcp, &init).unwrap();
     }
 

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -67,7 +67,7 @@ impl AgentRegistry {
     ///   claude   → claude-agent-acp     (Zed adapter for Claude SDK)
     ///   opencode → `opencode acp`       (native, SST)
     ///   gemini   → `gemini --acp`       (native, Google)
-    ///   codex    → codex-acp            (Zed adapter, OpenAI Codex CLI)
+    ///   codex    → codex-acp            (ACP adapter, OpenAI Codex CLI)
     ///   vibe     → vibe-acp             (native, Mistral)
     ///   pi       → pi-acp               (adapter, Pi coding agent)
     ///
@@ -127,7 +127,7 @@ impl AgentRegistry {
                 command: "codex-acp".into(),
                 args: vec![],
                 description:
-                    "OpenAI Codex CLI via Zed adapter (npm i -g @zed-industries/codex-acp)".into(),
+                    "OpenAI Codex CLI via ACP adapter (npm i -g @agentclientprotocol/codex-acp@latest)".into(),
                 env_allowlist: None,
             },
         );

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -9,7 +9,7 @@
 pub fn install_hint_for(binary: &str) -> Option<&'static str> {
     Some(match binary {
         "claude-agent-acp" => "npm install -g @agentclientprotocol/claude-agent-acp@latest",
-        "codex-acp" => "npm install -g @zed-industries/codex-acp",
+        "codex-acp" => "npm install -g @agentclientprotocol/codex-acp@latest",
         "pi-acp" => {
             "npm install -g pi-acp (also requires `npm install -g @earendil-works/pi-coding-agent`)"
         }
@@ -31,7 +31,7 @@ pub fn install_hint_for(binary: &str) -> Option<&'static str> {
 pub fn npm_package_for(binary: &str) -> Option<&'static str> {
     Some(match binary {
         "claude-agent-acp" => "@agentclientprotocol/claude-agent-acp@latest",
-        "codex-acp" => "@zed-industries/codex-acp",
+        "codex-acp" => "@agentclientprotocol/codex-acp@latest",
         "gemini" => "@google/gemini-cli",
         _ => return None,
     })
@@ -45,7 +45,7 @@ mod tests {
     fn npm_package_only_for_clean_npm_agents() {
         assert_eq!(
             npm_package_for("codex-acp"),
-            Some("@zed-industries/codex-acp")
+            Some("@agentclientprotocol/codex-acp@latest")
         );
         assert_eq!(
             npm_package_for("claude-agent-acp"),

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -213,7 +213,7 @@ const NPM_INSTALLABLE_ACP: &[(&str, &str)] = &[
         "claude-agent-acp",
         "@agentclientprotocol/claude-agent-acp@latest",
     ),
-    ("codex-acp", "@zed-industries/codex-acp"),
+    ("codex-acp", "@agentclientprotocol/codex-acp@latest"),
     ("pi-acp", "pi-acp"),
 ];
 

--- a/web/src/components/acp/SwitchAgentModal.tsx
+++ b/web/src/components/acp/SwitchAgentModal.tsx
@@ -190,7 +190,7 @@ export function SwitchAgentModal({ open, sessionId, currentAgent, onClose, onPre
         ) : agents.length === 0 ? (
           <div className="mt-4 text-xs text-status-error">
             No alternative structured view agents are registered. Install one (e.g. `npm i -g
-            @zed-industries/codex-acp`) and try again.
+            @agentclientprotocol/codex-acp@latest`) and try again.
           </div>
         ) : (
           <ul className="mt-4 max-h-64 space-y-1 overflow-y-auto">

--- a/web/src/lib/api.acp.test.ts
+++ b/web/src/lib/api.acp.test.ts
@@ -129,7 +129,7 @@ describe("installAcpAgent", () => {
   it("POSTs to /api/sessions/:id/acp/install-agent and returns the parsed body", async () => {
     const body = {
       session_id: "s-1",
-      package: "@zed-industries/codex-acp",
+      package: "@agentclientprotocol/codex-acp@latest",
       success: true,
       exit_code: 0,
       stdout: "added 1 package",


### PR DESCRIPTION
## Description
The Codex ACP adapter has moved from `@zed-industries/codex-acp` to `@agentclientprotocol/codex-acp`. The published binary is still `codex-acp`, so aoe does not need to change the runtime command, but install hints, doctor auto-install metadata, sandbox image dependencies, docs, and dashboard fallback copy should point at the maintained package.

This updates all remaining `@zed-industries/codex-acp` references to `@agentclientprotocol/codex-acp@latest` where aoe installs or tells users what to install.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot needed; the UI change is package-name fallback copy only.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this only changes install package metadata and user-facing package hints while preserving the same `codex-acp` binary command; focused unit tests cover the changed hints.

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p agent-of-empires --features serve install_hints`
- `cargo test -p agent-of-empires --features serve non_claude_permissive_on_old_version`
- `cargo test -p agent-of-empires --features serve missing_binary_spawn_error_appends_install_hint_for_known_agent`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npm run test:unit -- src/lib/api.acp.test.ts`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:**

Used Codex to update package references and run focused validation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785321351&installation_id=139138837&pr_number=2555&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2555&signature=40e5ddcfbbdacf10a254d387c350293b822a2fdf41f4effef288f1504cc633e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the Codex ACP package reference across the app, docs, sandbox image, and UI hints from the old Zed-maintained package to the current `@agentclientprotocol/codex-acp@latest` package.

It also updates the related install and auto-fix paths so users are shown the right package to install when `codex-acp` is missing. Tests were adjusted to match the new package name, and no runtime command changes were made.

Benefits: keeps install guidance accurate, reduces confusion around deprecated package names, and aligns the product with the maintained distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->