### PR TITLE
fix(web): send backtab (CSI Z) for Shift+Tab in the live terminal

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -987,7 +987,7 @@ export function MobileLiveTerminal({
           case "Backspace":
             return "\x7f";
           case "Tab":
-            return "\t";
+            return e.shiftKey ? "\x1b[Z" : "\t";
           case "Escape":
             return "\x1b";
           case "ArrowUp":

--- a/web/tests/desktop-live-input.spec.ts
+++ b/web/tests/desktop-live-input.spec.ts
@@ -122,9 +122,7 @@ test.describe("Desktop live terminal input", () => {
     const before = handle.liveMessages.length;
     await page.keyboard.press("Shift+Tab");
 
-    await expect
-      .poll(() => handle.liveMessages.slice(before).map((m) => m.toString("utf8")))
-      .toContainEqual("\x1b[Z");
+    await expect.poll(() => handle.liveMessages.slice(before).map((m) => m.toString("utf8"))).toContainEqual("\x1b[Z");
     const sentPlainTab = handle.liveMessages.slice(before).some((m) => m.toString("utf8") === "\t");
     expect(sentPlainTab).toBe(false);
   });

--- a/web/tests/desktop-live-input.spec.ts
+++ b/web/tests/desktop-live-input.spec.ts
@@ -106,6 +106,29 @@ test.describe("Desktop live terminal input", () => {
     expect(sentSigint).toBe(false);
   });
 
+  test("Shift+Tab sends backtab (CSI Z), not a plain Tab", async ({ page }) => {
+    // The keydown handler keyed only on e.key === "Tab" and always returned
+    // "\t", dropping the Shift. Shift+Tab must reach the agent as the backtab
+    // sequence \x1b[Z, which is what the TUI's live_send already emits for BTab.
+    // Without it, apps that read backtab (e.g. Claude Code's permission-mode
+    // cycle) never see Shift+Tab in the web terminal.
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator("[data-live-terminal]").first().waitFor({ state: "visible", timeout: 10_000 });
+    await page.locator("[data-live-terminal]").first().click();
+    await expect(page.locator('textarea[aria-label="Live terminal input"]').first()).toBeFocused();
+
+    const before = handle.liveMessages.length;
+    await page.keyboard.press("Shift+Tab");
+
+    await expect
+      .poll(() => handle.liveMessages.slice(before).map((m) => m.toString("utf8")))
+      .toContainEqual("\x1b[Z");
+    const sentPlainTab = handle.liveMessages.slice(before).some((m) => m.toString("utf8") === "\t");
+    expect(sentPlainTab).toBe(false);
+  });
+
   test("renders at the desktop font size, not the small mobile default", async ({ page }) => {
     // The live view used to always read `mobileFontSize` (default 8px), so on
     // desktop it came up tiny and ignored the dashboard's terminal font-size


### PR DESCRIPTION
## Description

In the browser live terminal, Shift+Tab does nothing. It should send the backtab sequence (CSI Z, `\x1b[Z`) so the agent can read it.

The keydown handler in `web/src/components/MobileLiveTerminal.tsx` switches on `e.key`. The `"Tab"` case always returned `"\t"` and never checked `e.shiftKey`, so the Shift was dropped and Shift+Tab arrived as a plain Tab.

This matters for Claude Code, which uses Shift+Tab (backtab) to cycle permission modes (default, accept-edits, plan, bypass). In the web terminal that key never reached the agent, so the mode could not be changed from the browser. The same key works over a normal SSH/tmux terminal, which is what pointed to the web layer.

The TUI side already does the right thing: `src/tui/home/live_send.rs` maps `BTab` to `b"\x1b[Z"` (see the `enc("BTab", false)` test). The web handler was just missing the same case.

The change is one line:

```ts
case "Tab":
  return e.shiftKey ? "\x1b[Z" : "\t";
```

Plain Tab is unchanged. Shift+Tab now emits `\x1b[Z`.

To verify by hand: open a session in the web dashboard, focus the live terminal, run Claude Code, and press Shift+Tab. The permission mode indicator cycles.

## PR Type

- [x] Bug Fix

## Checklist

- [ ] New and existing tests pass: I added a regression test that mirrors the existing Ctrl+V and Ctrl+Shift+C specs in this same file, but I was not able to run the full Playwright suite in my environment. Please rely on CI to confirm.
- [x] Documentation was updated where necessary: no documentation changes needed.
- [x] For UI changes: included screenshot or recording: not applicable, this only changes a key encoding, there is no visual change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`: added a test to `web/tests/desktop-live-input.spec.ts` that presses Shift+Tab and asserts the live socket receives `\x1b[Z` and not a plain `\t`. That spec and `MobileLiveTerminal.tsx` are already tracked in `coverage-matrix.json` under `terminal.desktop-live-input`, so no matrix change was needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus 4.8)

**Any Additional AI Details you'd like to share:** A human who runs a downstream deployment hit this bug (Shift+Tab not cycling Claude Code permission modes in the web terminal), diagnosed it with Claude Code, and used it to write the one-line fix and the regression test. The human account owner is submitting this PR and owns the outcome. He is not a developer, so he may use AI to help him understand review feedback, but he will be the one in the conversation.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785322328&installation_id=139138837&pr_number=2556&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2556&signature=679e784f46a8f0f6cfb6c1343d55e45574733cae587d59f257d838fd79a13f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes keyboard input in the browser live terminal so **Shift+Tab** is handled correctly instead of being treated like a normal Tab.

- Updated `MobileLiveTerminal` so **Shift+Tab** sends the correct **backtab** escape sequence (`\x1b[Z`), while plain **Tab** still sends `\t`.
- Added a Playwright regression test to verify **Shift+Tab** sends `\x1b[Z` (and not `\t`) to the live terminal.

**Benefit:** Restores expected keyboard behavior in the web terminal and brings it back in sync with the desktop/TUI experience—important for features like cycling permission modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->