### PR TITLE
fix(web): contain long Trash session names

### DIFF
--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -120,6 +120,7 @@ export function DeleteSessionDialog({
       onClick={onCancel}
     >
       <div
+        data-testid="delete-session-dialog-panel"
         className="bg-surface-800 border border-surface-700/50 rounded-lg w-[420px] max-w-[90vw] shadow-2xl animate-slide-up"
         onClick={(e) => e.stopPropagation()}
       >
@@ -133,7 +134,7 @@ export function DeleteSessionDialog({
         {/* Body */}
         <div className="px-5 py-4 space-y-3">
           <p className="text-[13px] text-text-secondary">
-            Delete <span className="font-mono text-text-primary">{sessionTitle}</span>?
+            Delete <span className="font-mono text-text-primary break-all">{sessionTitle}</span>?
           </p>
 
           {extraSessionCount > 0 && (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -503,11 +503,11 @@ export function formatSnoozeRemainingShort(snoozedUntilIso: string): string {
   return `${Math.floor(hours / 24)}d`;
 }
 
-/** Trash control in the sidebar footer, next to Settings (#2512). Trash is a
- *  terminal, rarely-touched state, so it lives as an icon with an upward
- *  popover rather than a full scrolling section. Outside click and Escape
- *  close it, mirroring SidebarSortPicker. Only rendered when something is
- *  trashed. */
+/** Trash control in the sidebar footer, next to Settings (#2512). Trash stays
+ *  outside the filtered session list so recovery remains reachable when search
+ *  hides every live row, but opens into a wider panel instead of a cramped
+ *  icon-only popover. Outside click and Escape close it, mirroring
+ *  SidebarSortPicker. Only rendered when something is trashed. */
 function TrashMenu({
   trashedWorkspaces,
   readOnly,
@@ -543,71 +543,128 @@ function TrashMenu({
   const count = trashedWorkspaces.length;
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} className="relative min-w-0 flex-1">
       <button
         onClick={() => setOpen((o) => !o)}
-        aria-haspopup="menu"
         aria-expanded={open}
+        aria-controls={open ? "sidebar-trash-panel" : undefined}
         data-testid="sidebar-trash-toggle"
-        className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
+        className="h-8 w-full min-w-0 flex items-center gap-2 rounded-md px-2.5 text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer transition-colors"
         title={`Trash (${count})`}
         aria-label={`Trash (${count})`}
       >
-        <Trash2 className="h-4 w-4" />
+        <Trash2 className="h-4 w-4 shrink-0" />
+        <span className="min-w-0 flex-1 truncate text-left text-[13px] font-medium">Trash</span>
+        <span className="shrink-0 rounded-full bg-surface-900 px-1.5 py-0.5 text-[10px] font-mono tabular-nums text-text-dim leading-none">
+          {count}
+        </span>
       </button>
       {open && (
         <div
-          role="menu"
+          id="sidebar-trash-panel"
+          role="region"
+          aria-label="Trash"
           data-testid="sidebar-trash-menu"
-          className="absolute bottom-full mb-1 left-0 w-[220px] max-w-[calc(100vw-1rem)] max-h-[50vh] overflow-y-auto bg-surface-800 border border-surface-700/50 rounded-md shadow-xl py-1 z-50 animate-fade-in"
+          className="absolute bottom-full mb-2 left-0 z-40 flex max-h-[min(520px,calc(100vh-5rem))] w-[min(420px,calc(100vw-1rem))] flex-col overflow-hidden rounded-lg border border-surface-700/60 bg-surface-800 shadow-2xl animate-fade-in"
         >
-          <div className="px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted">
-            Trash ({count})
-          </div>
-          {trashedWorkspaces.map((ws) => (
-            <div
-              key={ws.id}
-              data-testid="sidebar-trash-row"
-              className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-text-secondary"
-            >
-              <div className="min-w-0 flex-1">
-                <button
-                  type="button"
-                  onClick={(e) => onOpen(ws.id, e)}
-                  title={ws.displayName}
-                  data-testid="sidebar-trash-open"
-                  className="block w-full truncate text-left hover:text-text-primary cursor-pointer"
-                >
-                  {ws.displayName}
-                </button>
+          <div className="flex items-start justify-between gap-3 border-b border-surface-700/60 px-4 py-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <Trash2 className="h-4 w-4 shrink-0 text-text-muted" />
+                <h2 className="text-sm font-semibold text-text-primary">Trash</h2>
+                <span className="rounded-full bg-surface-900 px-2 py-0.5 text-[11px] font-mono tabular-nums text-text-dim leading-none">
+                  {count}
+                </span>
               </div>
-              {!readOnly && (
-                <>
-                  <button
-                    onClick={() => {
-                      const ids = ws.sessions.map((s) => s.id);
-                      if (ids.length > 0) onRestore(ids);
-                    }}
-                    data-testid="sidebar-trash-restore"
-                    title="Restore"
-                    aria-label="Restore"
-                    className="shrink-0 text-accent-500 hover:text-accent-600 cursor-pointer"
-                  >
-                    <RotateCcw className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    onClick={() => onDelete(ws.id)}
-                    data-testid="sidebar-trash-purge"
-                    title="Delete permanently"
-                    aria-label="Delete permanently"
-                    className="shrink-0 text-status-error/80 hover:text-status-error cursor-pointer"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </>
-              )}
+              <p className="mt-1 text-[12px] text-text-dim">Restore sessions, or delete them permanently.</p>
             </div>
-          ))}
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close Trash"
+              className="-mr-1 rounded-md p-1 text-text-muted hover:bg-surface-700/50 hover:text-text-primary cursor-pointer transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            <div className="space-y-1">
+              {trashedWorkspaces.map((ws) => {
+                const sessionCount = ws.sessions.length;
+                const sessionLabel = sessionCount === 1 ? "1 session" : `${sessionCount} sessions`;
+                return (
+                  <div
+                    key={ws.id}
+                    data-testid="sidebar-trash-row"
+                    className="rounded-md border border-surface-700/30 bg-surface-900/20 px-3 py-2.5 text-[13px] text-text-secondary"
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate font-medium text-text-primary" title={ws.displayName}>
+                        {ws.displayName}
+                      </div>
+                      <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-text-dim">
+                        <span className="max-w-full truncate font-mono" title={ws.projectPath}>
+                          {ws.projectPath}
+                        </span>
+                        {ws.branch && (
+                          <span className="max-w-full truncate font-mono text-accent-500" title={ws.branch}>
+                            {ws.branch}
+                          </span>
+                        )}
+                        <span>{sessionLabel}</span>
+                      </div>
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setOpen(false);
+                          onOpen(ws.id, { metaKey: false, ctrlKey: false, shiftKey: false });
+                        }}
+                        data-testid="sidebar-trash-open"
+                        className="inline-flex h-7 items-center rounded-md border border-surface-700/50 px-2.5 text-[12px] font-medium text-text-secondary hover:border-surface-600 hover:bg-surface-700/40 hover:text-text-primary cursor-pointer transition-colors"
+                      >
+                        Open
+                      </button>
+                      {!readOnly && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              const ids = ws.sessions.map((s) => s.id);
+                              if (ids.length > 0) onRestore(ids);
+                            }}
+                            data-testid="sidebar-trash-restore"
+                            title="Restore"
+                            aria-label="Restore"
+                            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-accent-500/30 bg-accent-500/10 px-2.5 text-[12px] font-medium text-accent-500 hover:border-accent-500/50 hover:bg-accent-500/15 hover:text-accent-600 cursor-pointer transition-colors"
+                          >
+                            <RotateCcw className="h-3.5 w-3.5 shrink-0" />
+                            Restore
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setOpen(false);
+                              onDelete(ws.id);
+                            }}
+                            data-testid="sidebar-trash-purge"
+                            title="Delete permanently"
+                            aria-label="Delete permanently"
+                            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-status-error/30 bg-status-error/10 px-2.5 text-[12px] font-medium text-status-error/85 hover:border-status-error/50 hover:bg-status-error/15 hover:text-status-error cursor-pointer transition-colors"
+                          >
+                            <X className="h-3.5 w-3.5 shrink-0" />
+                            Delete
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
       )}
     </div>
@@ -3430,7 +3487,7 @@ export function WorkspaceSidebar({
           <button
             onClick={onSettings}
             {...tourAnchor(TOUR_ANCHORS.sidebarSettings)}
-            className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
+            className="w-8 h-8 shrink-0 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
             title="Settings"
             aria-label="Settings"
           >

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -559,7 +559,7 @@ function TrashMenu({
         <div
           role="menu"
           data-testid="sidebar-trash-menu"
-          className="absolute bottom-full mb-1 left-0 min-w-[220px] max-h-[50vh] overflow-y-auto bg-surface-800 border border-surface-700/50 rounded-md shadow-xl py-1 z-50 animate-fade-in"
+          className="absolute bottom-full mb-1 left-0 w-[220px] max-w-[calc(100vw-1rem)] max-h-[50vh] overflow-y-auto bg-surface-800 border border-surface-700/50 rounded-md shadow-xl py-1 z-50 animate-fade-in"
         >
           <div className="px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted">
             Trash ({count})
@@ -570,15 +570,17 @@ function TrashMenu({
               data-testid="sidebar-trash-row"
               className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-text-secondary"
             >
-              <button
-                type="button"
-                onClick={(e) => onOpen(ws.id, e)}
-                title={ws.displayName}
-                data-testid="sidebar-trash-open"
-                className="flex-1 truncate text-left hover:text-text-primary cursor-pointer"
-              >
-                {ws.displayName}
-              </button>
+              <div className="min-w-0 flex-1">
+                <button
+                  type="button"
+                  onClick={(e) => onOpen(ws.id, e)}
+                  title={ws.displayName}
+                  data-testid="sidebar-trash-open"
+                  className="block w-full truncate text-left hover:text-text-primary cursor-pointer"
+                >
+                  {ws.displayName}
+                </button>
+              </div>
               {!readOnly && (
                 <>
                   <button
@@ -589,7 +591,7 @@ function TrashMenu({
                     data-testid="sidebar-trash-restore"
                     title="Restore"
                     aria-label="Restore"
-                    className="text-accent-500 hover:text-accent-600 cursor-pointer"
+                    className="shrink-0 text-accent-500 hover:text-accent-600 cursor-pointer"
                   >
                     <RotateCcw className="h-3.5 w-3.5" />
                   </button>
@@ -598,7 +600,7 @@ function TrashMenu({
                     data-testid="sidebar-trash-purge"
                     title="Delete permanently"
                     aria-label="Delete permanently"
-                    className="text-status-error/80 hover:text-status-error cursor-pointer"
+                    className="shrink-0 text-status-error/80 hover:text-status-error cursor-pointer"
                   >
                     <X className="h-3.5 w-3.5" />
                   </button>

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -522,12 +522,25 @@ function TrashMenu({
   onDelete: (workspaceId: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [panelPosition, setPanelPosition] = useState<{ left: number; bottom: number; width: number } | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const positionPanel = useCallback(() => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    const gutter = 8;
+    const width = Math.min(420, window.innerWidth - gutter * 2);
+    const left = Math.min(Math.max(gutter, rect.left), Math.max(gutter, window.innerWidth - width - gutter));
+    setPanelPosition({ left, bottom: Math.max(gutter, window.innerHeight - rect.top + gutter), width });
+  }, []);
 
   useEffect(() => {
     if (!open) return;
     const onDocClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const onKeydown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
@@ -540,12 +553,26 @@ function TrashMenu({
     };
   }, [open]);
 
+  useLayoutEffect(() => {
+    if (!open) return;
+    positionPanel();
+    window.addEventListener("resize", positionPanel);
+    window.addEventListener("scroll", positionPanel, true);
+    return () => {
+      window.removeEventListener("resize", positionPanel);
+      window.removeEventListener("scroll", positionPanel, true);
+    };
+  }, [open, positionPanel]);
+
   const count = trashedWorkspaces.length;
 
   return (
     <div ref={ref} className="relative min-w-0 flex-1">
       <button
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          if (!open) positionPanel();
+          setOpen((o) => !o);
+        }}
         aria-expanded={open}
         aria-controls={open ? "sidebar-trash-panel" : undefined}
         data-testid="sidebar-trash-toggle"
@@ -559,114 +586,119 @@ function TrashMenu({
           {count}
         </span>
       </button>
-      {open && (
-        <div
-          id="sidebar-trash-panel"
-          role="region"
-          aria-label="Trash"
-          data-testid="sidebar-trash-menu"
-          className="absolute bottom-full mb-2 left-0 z-40 flex max-h-[min(520px,calc(100vh-5rem))] w-[min(420px,calc(100vw-1rem))] flex-col overflow-hidden rounded-lg border border-surface-700/60 bg-surface-800 shadow-2xl animate-fade-in"
-        >
-          <div className="flex items-start justify-between gap-3 border-b border-surface-700/60 px-4 py-3">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <Trash2 className="h-4 w-4 shrink-0 text-text-muted" />
-                <h2 className="text-sm font-semibold text-text-primary">Trash</h2>
-                <span className="rounded-full bg-surface-900 px-2 py-0.5 text-[11px] font-mono tabular-nums text-text-dim leading-none">
-                  {count}
-                </span>
+      {open &&
+        panelPosition &&
+        createPortal(
+          <div
+            ref={panelRef}
+            id="sidebar-trash-panel"
+            role="region"
+            aria-label="Trash"
+            data-testid="sidebar-trash-menu"
+            className="fixed z-40 flex max-h-[min(520px,calc(100vh-5rem))] flex-col overflow-hidden rounded-lg border border-surface-700/60 bg-surface-800 shadow-2xl animate-fade-in"
+            style={{ left: panelPosition.left, bottom: panelPosition.bottom, width: panelPosition.width }}
+          >
+            <div className="flex items-start justify-between gap-3 border-b border-surface-700/60 px-4 py-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <Trash2 className="h-4 w-4 shrink-0 text-text-muted" />
+                  <h2 className="text-sm font-semibold text-text-primary">Trash</h2>
+                  <span className="rounded-full bg-surface-900 px-2 py-0.5 text-[11px] font-mono tabular-nums text-text-dim leading-none">
+                    {count}
+                  </span>
+                </div>
+                <p className="mt-1 text-[12px] text-text-dim">Restore sessions, or delete them permanently.</p>
               </div>
-              <p className="mt-1 text-[12px] text-text-dim">Restore sessions, or delete them permanently.</p>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close Trash"
+                className="-mr-1 rounded-md p-1 text-text-muted hover:bg-surface-700/50 hover:text-text-primary cursor-pointer transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
             </div>
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              aria-label="Close Trash"
-              className="-mr-1 rounded-md p-1 text-text-muted hover:bg-surface-700/50 hover:text-text-primary cursor-pointer transition-colors"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-2">
-            <div className="space-y-1">
-              {trashedWorkspaces.map((ws) => {
-                const sessionCount = ws.sessions.length;
-                const sessionLabel = sessionCount === 1 ? "1 session" : `${sessionCount} sessions`;
-                return (
-                  <div
-                    key={ws.id}
-                    data-testid="sidebar-trash-row"
-                    className="rounded-md border border-surface-700/30 bg-surface-900/20 px-3 py-2.5 text-[13px] text-text-secondary"
-                  >
-                    <div className="min-w-0">
-                      <div className="truncate font-medium text-text-primary" title={ws.displayName}>
-                        {ws.displayName}
-                      </div>
-                      <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-text-dim">
-                        <span className="max-w-full truncate font-mono" title={ws.projectPath}>
-                          {ws.projectPath}
-                        </span>
-                        {ws.branch && (
-                          <span className="max-w-full truncate font-mono text-accent-500" title={ws.branch}>
-                            {ws.branch}
+            <div className="min-h-0 flex-1 overflow-y-auto p-2">
+              <div className="space-y-1">
+                {trashedWorkspaces.map((ws) => {
+                  const sessionCount = ws.sessions.length;
+                  const sessionLabel = sessionCount === 1 ? "1 session" : `${sessionCount} sessions`;
+                  return (
+                    <div
+                      key={ws.id}
+                      data-testid="sidebar-trash-row"
+                      className="rounded-md border border-surface-700/30 bg-surface-900/20 px-3 py-2.5 text-[13px] text-text-secondary"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate font-medium text-text-primary" title={ws.displayName}>
+                          {ws.displayName}
+                        </div>
+                        <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-text-dim">
+                          <span className="max-w-full truncate font-mono" title={ws.projectPath}>
+                            {ws.projectPath}
                           </span>
+                          {ws.branch && (
+                            <span className="max-w-full truncate font-mono text-accent-500" title={ws.branch}>
+                              {ws.branch}
+                            </span>
+                          )}
+                          <span>{sessionLabel}</span>
+                        </div>
+                      </div>
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setOpen(false);
+                            onOpen(ws.id, { metaKey: false, ctrlKey: false, shiftKey: false });
+                          }}
+                          data-testid="sidebar-trash-open"
+                          className="inline-flex h-7 items-center rounded-md border border-surface-700/50 px-2.5 text-[12px] font-medium text-text-secondary hover:border-surface-600 hover:bg-surface-700/40 hover:text-text-primary cursor-pointer transition-colors"
+                        >
+                          Open
+                        </button>
+                        {!readOnly && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const ids = ws.sessions.map((s) => s.id);
+                                if (ids.length > 0) onRestore(ids);
+                              }}
+                              data-testid="sidebar-trash-restore"
+                              title="Restore"
+                              aria-label="Restore"
+                              className="inline-flex h-7 items-center gap-1.5 rounded-md border border-accent-500/30 bg-accent-500/10 px-2.5 text-[12px] font-medium text-accent-500 hover:border-accent-500/50 hover:bg-accent-500/15 hover:text-accent-600 cursor-pointer transition-colors"
+                            >
+                              <RotateCcw className="h-3.5 w-3.5 shrink-0" />
+                              Restore
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setOpen(false);
+                                onDelete(ws.id);
+                              }}
+                              data-testid="sidebar-trash-purge"
+                              title="Delete permanently"
+                              aria-label="Delete permanently"
+                              className="inline-flex h-7 items-center gap-1.5 rounded-md border border-status-error/30 bg-status-error/10 px-2.5 text-[12px] font-medium text-status-error/85 hover:border-status-error/50 hover:bg-status-error/15 hover:text-status-error cursor-pointer transition-colors"
+                            >
+                              <X className="h-3.5 w-3.5 shrink-0" />
+                              Delete
+                            </button>
+                          </>
                         )}
-                        <span>{sessionLabel}</span>
                       </div>
                     </div>
-                    <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setOpen(false);
-                          onOpen(ws.id, { metaKey: false, ctrlKey: false, shiftKey: false });
-                        }}
-                        data-testid="sidebar-trash-open"
-                        className="inline-flex h-7 items-center rounded-md border border-surface-700/50 px-2.5 text-[12px] font-medium text-text-secondary hover:border-surface-600 hover:bg-surface-700/40 hover:text-text-primary cursor-pointer transition-colors"
-                      >
-                        Open
-                      </button>
-                      {!readOnly && (
-                        <>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const ids = ws.sessions.map((s) => s.id);
-                              if (ids.length > 0) onRestore(ids);
-                            }}
-                            data-testid="sidebar-trash-restore"
-                            title="Restore"
-                            aria-label="Restore"
-                            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-accent-500/30 bg-accent-500/10 px-2.5 text-[12px] font-medium text-accent-500 hover:border-accent-500/50 hover:bg-accent-500/15 hover:text-accent-600 cursor-pointer transition-colors"
-                          >
-                            <RotateCcw className="h-3.5 w-3.5 shrink-0" />
-                            Restore
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setOpen(false);
-                              onDelete(ws.id);
-                            }}
-                            data-testid="sidebar-trash-purge"
-                            title="Delete permanently"
-                            aria-label="Delete permanently"
-                            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-status-error/30 bg-status-error/10 px-2.5 text-[12px] font-medium text-status-error/85 hover:border-status-error/50 hover:bg-status-error/15 hover:text-status-error cursor-pointer transition-colors"
-                          >
-                            <X className="h-3.5 w-3.5 shrink-0" />
-                            Delete
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
+++ b/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 //
 // Coverage for the WorkspaceSidebar Trash control (#2489, reworked in #2512):
-// a workspace whose sessions are all trashed is reachable from a Trash icon in
-// the sidebar footer next to Settings, which opens a popover with Open /
-// Restore / Delete actions. Trash is no longer an inline scrolling section.
+// a workspace whose sessions are all trashed is reachable from a labeled Trash
+// control in the sidebar footer next to Settings, which opens a wider panel
+// with Open / Restore / Delete actions. Trash is no longer an inline scrolling
+// section.
 // Also asserts the Projects section renders below "Snoozed & archived" (#2512).
 // Vitest (accurate per-file V8) rather than Playwright, whose bundle->source
 // remap is lossy for this large file.
@@ -121,22 +122,28 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
     return renderSidebar({ groups: trashedGroups(), trashedWorkspaces: [trashedWorkspace()], ...over });
   }
 
-  it("reaches a trashed workspace via the footer Trash popover and exposes its actions", () => {
+  it("reaches a trashed workspace via the footer Trash panel and exposes its actions", () => {
     const props = renderWithTrash();
 
     // No inline section in the scrolling list; only the footer toggle.
     expect(screen.queryByTestId("sidebar-trash-section")).toBeNull();
-    // Closed by default: popover and rows hidden until the icon is clicked.
+    expect(screen.getByTestId("sidebar-trash-toggle").textContent).toContain("Trash");
+    // Closed by default: panel and rows hidden until the footer control is clicked.
     expect(screen.queryByTestId("sidebar-trash-menu")).toBeNull();
     expect(screen.queryByTestId("sidebar-trash-row")).toBeNull();
 
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
     expect(screen.getByTestId("sidebar-trash-menu")).toBeTruthy();
     expect(screen.getByTestId("sidebar-trash-row")).toBeTruthy();
+    expect(screen.getByTestId("sidebar-trash-open").textContent).toContain("Open");
+    expect(screen.getByTestId("sidebar-trash-restore").textContent).toContain("Restore");
+    expect(screen.getByTestId("sidebar-trash-purge").textContent).toContain("Delete");
 
     fireEvent.click(screen.getByTestId("sidebar-trash-open"));
     expect(props.onSelect).toHaveBeenCalledWith("trashed-ws");
+    expect(screen.queryByTestId("sidebar-trash-menu")).toBeNull();
 
+    fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
     fireEvent.click(screen.getByTestId("sidebar-trash-restore"));
     expect(props.onRestoreSession).toHaveBeenCalledWith(["s1"]);
 
@@ -166,7 +173,7 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
     renderWithTrash();
     fireEvent.click(screen.getByLabelText("Filter sessions"));
     fireEvent.change(screen.getByTestId("sidebar-filter-input"), { target: { value: "zzz-no-match" } });
-    expect(screen.getByTestId("sidebar-trash-toggle")).toBeTruthy();
+    expect(screen.getByTestId("sidebar-trash-toggle").textContent).toContain("Trash");
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));
     expect(screen.getByTestId("sidebar-trash-row")).toBeTruthy();
   });

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -20,10 +20,10 @@ interface Handle {
   failRestore: boolean;
 }
 
-function sessionPayload(trashed: boolean) {
+function sessionPayload(trashed: boolean, title = "story-trash") {
   return {
     id: "sess-trash",
-    title: "story-trash",
+    title,
     project_path: "/tmp/story",
     group_path: "/tmp",
     tool: "claude",
@@ -45,7 +45,7 @@ function sessionPayload(trashed: boolean) {
   };
 }
 
-async function mockApis(page: Page): Promise<Handle> {
+async function mockApis(page: Page, options: { title?: string } = {}): Promise<Handle> {
   const handle: Handle = {
     trashed: false,
     trashCalls: 0,
@@ -58,7 +58,7 @@ async function mockApis(page: Page): Promise<Handle> {
   await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
   await page.route("**/api/sessions", (r) => {
     if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
-    const sessions = handle.deletes > 0 ? [] : [sessionPayload(handle.trashed)];
+    const sessions = handle.deletes > 0 ? [] : [sessionPayload(handle.trashed, options.title)];
     return r.fulfill({ json: { sessions, workspace_ordering: [] } });
   });
   await page.route("**/api/sessions/sess-trash/trash", (r) => {
@@ -66,14 +66,14 @@ async function mockApis(page: Page): Promise<Handle> {
     handle.trashCalls += 1;
     if (handle.failTrash) return r.fulfill({ status: 500, body: "boom" });
     handle.trashed = true;
-    return r.fulfill({ json: sessionPayload(true) });
+    return r.fulfill({ json: sessionPayload(true, options.title) });
   });
   await page.route("**/api/sessions/sess-trash/restore", (r) => {
     if (r.request().method() !== "POST") return r.fulfill({ status: 400 });
     handle.restoreCalls += 1;
     if (handle.failRestore) return r.fulfill({ status: 500, body: "boom" });
     handle.trashed = false;
-    return r.fulfill({ json: sessionPayload(false) });
+    return r.fulfill({ json: sessionPayload(false, options.title) });
   });
   await page.route("**/api/sessions/sess-trash", (r) => {
     if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
@@ -163,6 +163,35 @@ test.describe("Session trash flow", () => {
     const dialog = page.locator('[data-testid="delete-session-dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     await expect(dialog.locator('[data-testid="delete-session-permanent"]')).toHaveCount(0);
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+    await expect.poll(() => handle.deletes, { timeout: 10_000 }).toBe(1);
+  });
+
+  test("long trashed session names keep Trash actions and the delete dialog usable", async ({ page }) => {
+    const longTitle = `story-trash-${"x".repeat(240)}`;
+    const handle = await mockApis(page, { title: longTitle });
+    handle.trashed = true;
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+    const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: longTitle });
+    await expect(trashRow).toBeVisible({ timeout: 10_000 });
+
+    await expect(trashRow.locator('[data-testid="sidebar-trash-restore"]')).toBeInViewport({ ratio: 1 });
+    const purge = trashRow.locator('[data-testid="sidebar-trash-purge"]');
+    await expect(purge).toBeInViewport({ ratio: 1 });
+
+    await purge.click();
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await expect(dialog).toContainText(longTitle);
+    await expect(dialog.getByRole("button", { name: /^Delete$/ })).toBeInViewport({ ratio: 1 });
+    const panelFits = await dialog.locator('[data-testid="delete-session-dialog-panel"]').evaluate((node) => {
+      return node.scrollWidth <= node.clientWidth;
+    });
+    expect(panelFits).toBe(true);
+
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
     await expect.poll(() => handle.deletes, { timeout: 10_000 }).toBe(1);
   });

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -9,7 +9,7 @@ import { Page } from "@playwright/test";
 // The dialog's checkbox-to-body mapping is covered by the DeleteSessionDialog
 // vitest and the live session-trash spec covers the backend round trip; this
 // mocked spec deterministically exercises the App trash/restore handlers and
-// the WorkspaceSidebar Trash section render + actions for coverage.
+// the WorkspaceSidebar Trash panel render + actions for coverage.
 
 interface Handle {
   trashed: boolean;
@@ -111,13 +111,17 @@ test.describe("Session trash flow", () => {
 
     await expect.poll(() => handle.trashCalls, { timeout: 10_000 }).toBe(1);
 
-    // Row leaves the active list; the footer Trash icon appears and its
-    // popover lists the trashed workspace.
+    // Row leaves the active list; the footer Trash control appears and its
+    // panel lists the trashed workspace.
     const trashToggle = page.locator('[data-testid="sidebar-trash-toggle"]');
     await expect(trashToggle).toBeVisible({ timeout: 10_000 });
+    await expect(trashToggle).toContainText("Trash");
     await trashToggle.click();
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: "story-trash" });
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
+    await expect(trashRow.locator('[data-testid="sidebar-trash-open"]')).toContainText("Open");
+    await expect(trashRow.locator('[data-testid="sidebar-trash-restore"]')).toContainText("Restore");
+    await expect(trashRow.locator('[data-testid="sidebar-trash-purge"]')).toContainText("Delete");
 
     // Restore brings it back to the active list.
     await trashRow.locator('[data-testid="sidebar-trash-restore"]').click();
@@ -147,7 +151,7 @@ test.describe("Session trash flow", () => {
     await expect(page.locator('[data-testid="sidebar-trash-toggle"]')).toHaveCount(0, { timeout: 5_000 });
   });
 
-  test("Delete from the Trash popover opens the permanent-delete dialog", async ({ page }) => {
+  test("Delete from the Trash panel opens the permanent-delete dialog", async ({ page }) => {
     const handle = await mockApis(page);
     handle.trashed = true; // start already trashed
     await page.setViewportSize({ width: 1280, height: 720 });
@@ -157,7 +161,7 @@ test.describe("Session trash flow", () => {
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: "story-trash" });
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
 
-    // The Trash-popover Delete re-opens the dialog; with the row already
+    // The Trash panel Delete re-opens the dialog; with the row already
     // trashed it goes straight to permanent delete (no trash checkbox).
     await trashRow.locator('[data-testid="sidebar-trash-purge"]').click();
     const dialog = page.locator('[data-testid="delete-session-dialog"]');
@@ -178,8 +182,11 @@ test.describe("Session trash flow", () => {
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: longTitle });
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
 
+    await expect(trashRow.locator('[data-testid="sidebar-trash-open"]')).toContainText("Open");
+    await expect(trashRow.locator('[data-testid="sidebar-trash-restore"]')).toContainText("Restore");
     await expect(trashRow.locator('[data-testid="sidebar-trash-restore"]')).toBeInViewport({ ratio: 1 });
     const purge = trashRow.locator('[data-testid="sidebar-trash-purge"]');
+    await expect(purge).toContainText("Delete");
     await expect(purge).toBeInViewport({ ratio: 1 });
 
     await purge.click();

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -178,7 +178,13 @@ test.describe("Session trash flow", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
     await page.goto("/");
-    await page.locator('[data-testid="sidebar-trash-toggle"]').click();
+    const trashToggle = page.locator('[data-testid="sidebar-trash-toggle"]');
+    await trashToggle.click();
+    const panelBox = await page.locator('[data-testid="sidebar-trash-menu"]').boundingBox();
+    const toggleBox = await trashToggle.boundingBox();
+    expect(panelBox).not.toBeNull();
+    expect(toggleBox).not.toBeNull();
+    expect(panelBox!.x + panelBox!.width).toBeGreaterThan(toggleBox!.x + toggleBox!.width + 100);
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').filter({ hasText: longTitle });
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

Trash rows with very long unbroken session titles could push the Restore and Delete permanently controls out of reach. This replaces the cramped icon-only Trash popover with a labeled footer control and a wider Trash panel with visible Open, Restore, and Delete actions.

The panel shows the trashed workspace name, project path, branch when present, and session count while keeping action buttons reachable. The permanent delete confirmation still wraps long session titles inside the dialog instead of allowing horizontal overflow. The regression test covers a 240-character trashed session name, verifies Trash actions remain fully visible, and confirms the delete dialog stays usable.

Closes #2557

## How to test

- [ ] Move a session with a very long unbroken name to Trash, open the web dashboard Trash panel, and verify Open, Restore, and Delete remain visible and clickable.
- [ ] Click Delete permanently for that trashed session and verify the confirmation dialog shows the full name without horizontal overflow.
- [ ] Confirm Delete in the dialog and verify the session is permanently removed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json` (existing `session.trash.flow` matrix entry already covers this flow; validator passes)
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenCode using gpt-5.5, with `/debate` consultation via Gemini and Anthropic.

**Any Additional AI Details you'd like to share:**

OpenCode drafted the investigation, plan, tests, implementation, and PR prose under user approval. The user made the product decision and approved the implementation plan before code changes.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**High-level summary**
- Fixed the Trash area layout in the web dashboard so extremely long, unbroken session titles don’t push the **Restore** and **Delete/Purge** actions out of view.
- Updated the permanent delete confirmation dialog so long session titles wrap safely instead of causing horizontal overflow.
- Added regression coverage using a deliberately **240-character** trashed session name to verify the Trash row actions stay visible/clickable and the delete dialog remains readable.

**Benefits**
- Keeps destructive actions (Restore + permanent Delete/Purge) reachable even for worst-case long titles.
- Prevents side-scrolling/overflow issues in the delete confirmation dialog.
- Improves confidence via end-to-end coverage for this edge case.

**Technical notes**
- Constrained the Trash panel width/height and ensured the title area and row layout can shrink/truncate without displacing the fixed-size action buttons.
- Rendered the dialog title with `break-all` inside the `DeleteSessionDialog` panel and added a `data-testid` to validate layout fit in tests.
- Updated Trash row structure to use a multi-line layout with separate “Open” and action controls, with icons set to `shrink-0`.
- Extended the Trash flow test utilities to accept custom session titles and added a Playwright regression that checks action visibility in-viewport and that the delete dialog panel doesn’t overflow when rendering the long title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->