### PR TITLE
docs(plugins): add plugin author guide and API reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aoe-plugin-api"

--- a/docs/development/writing-plugins.md
+++ b/docs/development/writing-plugins.md
@@ -81,9 +81,11 @@ A request, and the response your `status` handler returns:
 {"jsonrpc": "2.0", "id": 1, "result": {"ok": true, "message": "running"}}
 ```
 
-The host maps a command id to a method, so dispatch on the trailing segment of
-`method`. Return a JSON-RPC error with code `-32601` for an unknown method. A
-message with no `id` is a notification; do not respond to it.
+The host maps a command id to a fully namespaced method, `plugin.<id>.<command-id>`,
+so the example above is abbreviated: a worker for `dev.example.my-plugin` actually
+receives `plugin.dev.example.my-plugin.status`. Dispatch on the trailing segment of
+`method` so either form works. Return a JSON-RPC error with code `-32601` for an
+unknown method. A message with no `id` is a notification; do not respond to it.
 
 ## Build and launch
 

--- a/docs/development/writing-plugins.md
+++ b/docs/development/writing-plugins.md
@@ -1,0 +1,137 @@
+# Writing Plugins
+
+This guide takes you from nothing to an installed, running Agent of Empires
+plugin. For the full manifest schema see the
+[Plugin API Reference](../plugin-api.md); for the architecture and security model
+see [Plugin System Internals](internals/plugin-system.md). For installing and
+managing plugins as a user, see [Plugins](../plugins.md).
+
+A plugin is a directory with an `aoe-plugin.toml` manifest and, optionally, a
+worker: an executable the host spawns that speaks JSON-RPC 2.0 over
+newline-delimited JSON on stdio, in any language. The host does not link your
+code; the manifest is the contract.
+
+## Scaffold from the template
+
+The official starter generates a complete plugin (manifest, worker, tests, CI)
+in Python, Node, or Rust:
+
+```sh
+cookiecutter gh:agent-of-empires/plugin-template
+```
+
+Pick a `runtime` when prompted. The generated project builds, passes its tests,
+and answers a `status` command out of the box. The rest of this guide explains
+what it generated.
+
+## The manifest
+
+Every plugin declares identity, what it contributes, and (if it has a worker)
+how to build and launch it:
+
+```toml
+id = "dev.example.my-plugin"
+name = "My Plugin"
+version = "0.1.0"
+api_version = 6
+aoe_version = ">=1.11.0, <2.0.0"
+description = "What the plugin does."
+
+capabilities = ["runtime.worker"]
+
+[[commands]]
+id = "status"
+title = "My Plugin: status"
+description = "Show the status summary."
+
+[[settings]]
+key = "enabled"
+label = "Enable My Plugin"
+type = "boolean"
+default = true
+
+[[ui]]
+slot = "pane"
+id = "my_plugin_pane"
+```
+
+Pick an `id` outside the reserved `aoe.*` and `agent-of-empires.*` namespaces.
+Set `api_version` to the schema version you target (currently `6`) and
+`aoe_version` to the host range you have tested against. Every key is documented
+in the [Plugin API Reference](../plugin-api.md).
+
+## Capabilities
+
+A worker requests only the runtime grants it uses. `runtime.worker` is required
+to run any code; add `net`, `session.read`, `notifications`, and so on as
+needed. Static contributions (commands, keybinds, themes, ui, status) need no
+capability. The user is prompted to grant the exact declared set at install, and
+the grant is pinned to the manifest hash, so an update that widens capabilities
+must be re-approved. Keep the list honest and minimal.
+
+## The worker
+
+The host spawns the worker, sends one JSON-RPC request per line on stdin, and
+reads one response per line on stdout. The worker exits when stdin reaches EOF.
+
+A request, and the response your `status` handler returns:
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "my-plugin.status", "params": {}}
+{"jsonrpc": "2.0", "id": 1, "result": {"ok": true, "message": "running"}}
+```
+
+The host maps a command id to a method, so dispatch on the trailing segment of
+`method`. Return a JSON-RPC error with code `-32601` for an unknown method. A
+message with no `id` is a notification; do not respond to it.
+
+## Build and launch
+
+The worker entrypoint must be **plugin-relative**, never resolved on the
+daemon's `PATH`. Build into `.aoe-build/`, which the host excludes from the
+plugin's integrity hash, then point `command` at the built artifact:
+
+```toml
+[runtime]
+kind = "command"
+command = [".aoe-build/venv/bin/my-plugin-worker"]
+
+[[runtime.build]]
+command = ["python3", "-m", "venv", ".aoe-build/venv"]
+platforms = ["linux", "macos"]
+
+[[runtime.build]]
+command = [".aoe-build/venv/bin/pip", "install", "."]
+platforms = ["linux", "macos"]
+```
+
+Build steps run once, at install and update, in the user's interactive shell
+(where `PATH` is reliable). A compiled plugin can instead ship a release asset
+with `kind = "release-binary"`; see the reference.
+
+## Install and test locally
+
+```sh
+aoe plugin install ./my-plugin     # runs the build steps, prompts for grants
+aoe plugin list
+aoe plugin update my-plugin         # re-runs build, re-approves changed grants
+aoe plugin uninstall my-plugin
+```
+
+Drive the worker by hand before installing, to confirm the protocol:
+
+```sh
+echo '{"jsonrpc":"2.0","id":1,"method":"my-plugin.status","params":{}}' | <your-worker>
+```
+
+The starter ships a worker-contract test (it spawns the worker, sends a request,
+and asserts the response) plus its CI. Keep that test green; it is the cheapest
+guard on the protocol.
+
+## Publish
+
+Push a `vX.Y.Z` tag to cut a GitHub release (the starter's release workflow does
+the rest). Users install the latest release with
+`aoe plugin install gh:your-org/my-plugin`. To be listed in the Agent of Empires
+featured index, which lets a plugin claim a verified namespace, open a PR adding
+your release's source tree hash to the featured index in the main repository.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -1,0 +1,291 @@
+# Plugin API Reference
+
+The field-by-field reference for `aoe-plugin.toml`, the manifest every Agent of
+Empires plugin ships. The schema lives in the `aoe-plugin-api` crate
+(`PluginManifest`) and is the source of truth; this page documents it for plugin
+authors. The host parses the manifest strictly (unknown keys are rejected), so
+every key here maps to a schema field.
+
+For a guided introduction see [Writing Plugins](development/writing-plugins.md).
+To scaffold a working plugin, use the starter template:
+
+```sh
+cookiecutter gh:agent-of-empires/plugin-template
+```
+
+## Versioning
+
+A manifest carries two independent version axes.
+
+| Key | Meaning |
+|---|---|
+| `api_version` | The manifest *schema* version. The current schema is `6`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
+
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`.
+
+## Top-level fields
+
+```toml
+id = "dev.example.my-plugin"
+name = "My Plugin"
+version = "0.1.0"
+api_version = 6
+aoe_version = ">=1.11.0, <2.0.0"
+description = "What the plugin does."
+capabilities = ["runtime.worker"]
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
+| `name` | string | yes | Human-readable display name. |
+| `version` | string | yes | Semantic version of the plugin. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `6`. |
+| `description` | string | no | Shown in plugin listings. Defaults to empty. |
+| `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
+| `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
+| `screenshots` | array | no | Up to 8. Requires `api_version >= 5`. See [Screenshots](#screenshots). |
+| `setting_defaults` | table | no | Overrides for core host settings, keyed by canonical path (e.g. `"theme.idle_decay_minutes"`). Resolution is user value, then plugin override, then core default. |
+
+## Plugin id
+
+A dotted, lowercase ASCII identifier such as `dev.example.review-helper`. Each
+dot-separated segment starts with a lowercase letter and may contain digits and
+hyphens; the whole id is at most 64 bytes. The `aoe.*` and `agent-of-empires.*`
+namespaces are reserved for bundled and officially featured plugins; a community
+install cannot claim them.
+
+## Capabilities
+
+Capabilities gate runtime resource access. They are prompted once at install and
+pinned to the manifest hash; an update that widens them must be re-approved.
+Declare only what the worker uses. Static contributions (commands, keybinds,
+themes, ui, status) need no capability.
+
+| Capability | Grants |
+|---|---|
+| `runtime.worker` | Running any plugin code at all (host RPCs the worker initiates). Any worker needs this. |
+| `session.read` | Reading the attached session. |
+| `session.write` | Mutating the attached session. |
+| `config.read` | Reading host or other-plugin configuration (not the plugin's own settings). |
+| `config.write` | Writing host or other-plugin configuration. |
+| `process.spawn` | Spawning processes beyond the plugin's own worker. |
+| `net` | Outbound network access. |
+| `fs.read` | Filesystem reads outside the plugin directory. |
+| `fs.write` | Filesystem writes outside the plugin directory. |
+| `clipboard.read` | Reading the clipboard. |
+| `clipboard.write` | Writing the clipboard. |
+| `notifications` | Posting desktop / TUI notifications. |
+| `browser_open` | Opening a URL in the user's browser from a command `action`. |
+
+A capability this host version does not recognize is rejected, not granted.
+
+## Commands
+
+Palette and CLI entries, namespaced by the host as `plugin.<id>.<command-id>`.
+
+```toml
+[[commands]]
+id = "status"
+title = "My Plugin: status"
+description = "Show the status summary."
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Command id. Empty is unaddressable. |
+| `title` | string | no | Display name. |
+| `description` | string | no | Help text. |
+| `action` | table | no | A client-executed action. Requires `api_version >= 6` and the `browser_open` capability. |
+
+### Command action
+
+```toml
+[commands.action]
+kind = "open-ui-link"
+slot = "row-badge"
+id = "my_badge"
+```
+
+The only `kind` is `open-ui-link`: it opens the `href` from the plugin's own
+`(slot, id)` UI-state entry in the browser, with no worker round-trip. The
+`(slot, id)` pair must match a declared `[[ui]]` entry on a per-session slot.
+
+## Keybinds
+
+```toml
+[[keybinds]]
+command = "status"
+key = "Ctrl+Shift+G"
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `command` | string | yes | Target command id (a plugin or core command). |
+| `key` | string | yes | Key chord, e.g. `Ctrl+Shift+G`. Core bindings win a collision. |
+
+## Settings
+
+Plugin-declared settings, rendered on the TUI and web settings surfaces and
+stored under `[plugins."<id>".settings]`. The worker reads them via the
+`config.get` host RPC.
+
+```toml
+[[settings]]
+key = "refresh_secs"
+label = "Refresh interval (seconds)"
+description = "How often the worker polls."
+type = "integer"
+default = 120
+min = 0
+max = 86400
+advanced = true
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `key` | string | yes | Setting key, stored under the plugin's settings table. |
+| `label` | string | no | Display label. |
+| `description` | string | no | Help text. |
+| `type` | string | no | Value type (see below). Defaults to `string`. |
+| `options` | array of string | no | Allowed values for `select`; ignored otherwise. |
+| `min` / `max` | integer | no | Inclusive bounds for `integer`; ignored otherwise. |
+| `default` | any | no | Declared default. Must match `type`. Absent means the type's zero value. |
+| `advanced` | bool | no | Group under the Advanced fold. Defaults to `false`. |
+
+Setting types:
+
+| `type` | Widget |
+|---|---|
+| `string` | Text input (default). |
+| `bool` (or `boolean`) | Toggle. |
+| `integer` | Number input, bounded by `min` / `max`. |
+| `select` | Dropdown over a non-empty `options` array. |
+
+## UI slots
+
+Declares the host-rendered slots the worker pushes state into via the
+`ui.state.set` host RPC.
+
+```toml
+[[ui]]
+slot = "pane"
+id = "my_pane"
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `slot` | string | yes | One of the slot names below. Unknown slots are rejected. |
+| `id` | string | no | Addressing id for `(slot, id)` state pushes. Required to be non-empty when a command `action` targets it. |
+
+| Slot | Scope | Renders |
+|---|---|---|
+| `status-bar` | global | A segment in the dashboard status bar. |
+| `card` | global | A card on the dashboard overview. |
+| `sort-key` | global | A named sort option over a `row-column` value. |
+| `filter-facet` | global | A named filter over a `row-column` value. |
+| `row-badge` | per-session | A badge on the session row. |
+| `row-column` | per-session | A text column on the session row. |
+| `detail-badge` | per-session | A badge in the session detail view. |
+| `pane` | per-session | A dockable tool-window pane (requires `api_version >= 3`). |
+| `notification` | n/a | A transient notification pushed via `ui.notify`; gated by the `notifications` capability, not a slot declaration. |
+
+## Status
+
+Status segments the plugin contributes, consumed by the status surface. Requires
+`api_version >= 4`.
+
+```toml
+[[status]]
+id = "pr_state"
+label = "PR state"
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Stable segment id. |
+| `label` | string | no | Human-readable text. |
+
+## Themes
+
+```toml
+[[themes]]
+name = "My Theme"
+path = "themes/my-theme.toml"
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Theme name in the picker. Must not collide with a builtin. |
+| `path` | string | yes | Theme TOML path, relative to the plugin directory. |
+
+## Screenshots
+
+Up to 8 marketplace screenshots, shown in the plugin detail view. Requires
+`api_version >= 5`.
+
+```toml
+[[screenshots]]
+path = "assets/screenshots/overview.png"
+alt = "The plugin's pane showing live status."
+caption = "Live status in the pane."
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `path` | string | yes | Repository-relative image path. No URL scheme, no leading separator, no `..`; must be PNG, JPEG, GIF, or WebP. |
+| `alt` | string | yes | Accessible description; non-empty. |
+| `caption` | string | no | Caption shown beneath the image. |
+
+## Runtime
+
+The worker the host spawns and supervises. Omit it for a static, metadata-only
+plugin. Two kinds.
+
+### Command
+
+The host runs the build steps at install or update, then launches `command`.
+
+```toml
+[runtime]
+kind = "command"
+command = [".aoe-build/venv/bin/my-plugin-worker"]
+
+[[runtime.build]]
+command = ["python3", "-m", "venv", ".aoe-build/venv"]
+platforms = ["linux", "macos"]
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `command` | array of string | yes | argv. Plugin-relative by default (must contain a path separator, never absolute) so the daemon's `PATH` never decides whether the worker launches. With `system = true` it must instead be a bare program name resolved on `PATH`. |
+| `system` | bool | no | Resolve `command[0]` on the host `PATH` (for genuine system tools only). Defaults to `false`. |
+| `build` | array | no | Ordered build steps, run once at install or update inside the plugin directory, in the user's interactive shell. |
+
+Build into `.aoe-build/` (the host's build-output directory); the host excludes
+it from the plugin tree hash, so a venv, `node_modules`, or `target/` there does
+not break integrity verification.
+
+#### Build step
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `command` | array of string | yes | argv, same resolution policy as the launch `command`. |
+| `platforms` | array of string | no | Restrict to OS names: `linux`, `macos`, `windows`. Empty runs on all. |
+
+### Release binary
+
+The host downloads a release asset instead of building from source.
+
+```toml
+[runtime]
+kind = "release-binary"
+asset = "my-plugin-${target}.tar.gz"
+bin = "my-plugin-worker"
+```
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `asset` | string | yes | Asset-name template; `${os}`, `${arch}`, `${target}` are substituted before matching the release. |
+| `bin` | string | no | Executable path inside the extracted archive. Omit to run the downloaded asset directly (a raw, non-archive binary). |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,6 +8,14 @@ directory. Per-plugin settings and plugin-contributed UI land in follow-up
 releases; running plugin code is not wired up yet, so an installed external
 plugin records its grant and files but does not execute until a later release.
 
+To build your own, start with [Writing Plugins](development/writing-plugins.md)
+and the [Plugin API Reference](plugin-api.md). The official starter scaffolds a
+working plugin in Python, Node, or Rust:
+
+```sh
+cookiecutter gh:agent-of-empires/plugin-template
+```
+
 ## Managing plugins
 
 Three equivalent surfaces:

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -245,6 +245,13 @@ const PAGES = [
       "Code-level design for the plugin system: subprocess JSON-RPC runtime, core event bus, contribution registries, capability model, and the phased rollout.",
   },
   {
+    source: "docs/development/writing-plugins.md",
+    dest: "docs/development/writing-plugins.md",
+    title: "Writing Plugins",
+    description:
+      "Build an Agent of Empires plugin end to end: scaffold from the template, declare the manifest, write the JSON-RPC worker, install locally, and publish.",
+  },
+  {
     source: "docs/development/internals/sessions.md",
     dest: "docs/development/internals/sessions.md",
     title: "Session & Worktree Internals",
@@ -350,6 +357,13 @@ const PAGES = [
       "REST endpoints for driving Agent of Empires sessions from external orchestrators.",
   },
   {
+    source: "docs/plugin-api.md",
+    dest: "docs/plugin-api.md",
+    title: "Plugin API Reference",
+    description:
+      "Field-by-field reference for the aoe-plugin.toml manifest: identity, capabilities, commands, settings, UI slots, status, screenshots, and runtime.",
+  },
+  {
     source: "docs/telemetry.md",
     dest: "docs/telemetry.md",
     title: "Telemetry",
@@ -379,6 +393,7 @@ const URL_MAP = {
   "docs/development/internals/structured-view.md": "/docs/development/internals/structured-view/",
   "docs/development/internals/sandbox.md": "/docs/development/internals/sandbox/",
   "docs/development/internals/plugin-system.md": "/docs/development/internals/plugin-system/",
+  "docs/development/writing-plugins.md": "/docs/development/writing-plugins/",
   "docs/development/internals/sessions.md": "/docs/development/internals/sessions/",
   "docs/guides/configuration.md": "/docs/guides/configuration/",
   "docs/cli/reference.md": "/docs/cli/reference/",
@@ -387,6 +402,7 @@ const URL_MAP = {
   "docs/structured-view/controls.md": "/docs/structured-view/controls/",
   "docs/structured-view/troubleshooting.md": "/docs/structured-view/troubleshooting/",
   "docs/api.md": "/docs/api/",
+  "docs/plugin-api.md": "/docs/plugin-api/",
   "docs/telemetry.md": "/docs/telemetry/",
   // Guides
   "docs/guides/shell-completions.md": "/guides/shell-completions/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -71,6 +71,7 @@ export const docsNav: NavSection[] = [
       { title: "GitHub Integration", href: "/docs/github-integration/" },
       { title: "Configuration", href: "/docs/guides/configuration/" },
       { title: "Plugins", href: "/docs/plugins/" },
+      { title: "Plugin API Reference", href: "/docs/plugin-api/" },
     ],
   },
   {
@@ -86,6 +87,7 @@ export const docsNav: NavSection[] = [
         title: "Web Dashboard Development",
         href: "/docs/development/web-dashboard/",
       },
+      { title: "Writing Plugins", href: "/docs/development/writing-plugins/" },
     ],
   },
   {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds the missing plugin-author experience for Agent of Empires. Today a would-be plugin author has to stitch together the user-facing install docs, the contributor-facing internals doc, and the `aoe-plugin-api` Rust source to understand how to build a plugin, and the crate's README points at a `docs/development/writing-plugins.md` that does not exist.

This PR ships two docs pages:

- `docs/development/writing-plugins.md`, a task-oriented authoring guide: scaffold from the official template, declare the manifest, request capabilities, write the JSON-RPC worker, build plugin-relative into `.aoe-build/`, install and test locally, and publish.
- `docs/plugin-api.md`, a field-by-field reference for `aoe-plugin.toml` generated from the `aoe-plugin-api` schema (api_version 6): identity, capabilities, commands and actions, keybinds, settings and types, UI slots, status, screenshots, themes, and the command/release-binary runtime variants.

Both are wired into the website sync (`sync-docs.mjs` PAGES + URL_MAP) and the docs nav (`docsNav.ts`), and linked from `docs/plugins.md`. Creating the authoring guide also resolves the dangling reference in `aoe-plugin-api/README.md`.

The companion cookiecutter starter repo (Python, Node, Rust) lives in `agent-of-empires/plugin-template` and is opened as a separate PR; this PR's docs link to it.

Closes #2485

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] Generate from the template once its repo is published: `cookiecutter gh:agent-of-empires/plugin-template`, pick `python`, confirm the project builds and `uv run pytest` passes (repeat for `node` with `npm test` and `rust` with `cargo test`).
- [ ] Run `node website/scripts/sync-docs.mjs`; confirm it exits 0 (both new pages are mapped and present in `docsNav.ts`).
- [ ] In the rendered docs nav, confirm "Plugin API Reference" appears under Reference and "Writing Plugins" under Contributing, and both pages open.
- [ ] From `docs/plugins.md`, confirm the "Writing Plugins" and "Plugin API Reference" links resolve.
- [ ] Confirm `aoe-plugin-api/README.md`'s reference to `docs/development/writing-plugins.md` now points at a real file.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (with a multi-model design debate on the template layout), and drafting were done by Claude under my direction. I made the design calls, reviewed each commit, and ran the validation steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785336827&installation_id=139138837&pr_number=2565&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2565&signature=3a5dc7a5376466bf396ead2784bac1d0eff30f2ef22a996247c1391442041fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added two new documentation pages for plugin authors: a task-oriented “Writing Plugins” guide and a field-by-field “Plugin API Reference” for the `aoe-plugin.toml` manifest (including runtime options). The writing guide walks authors through scaffolding from the official template, setting up the manifest and capabilities, implementing the JSON-RPC worker, building/bundling, local install/update/testing, troubleshooting protocol details, and publishing. The API reference provides an organized, complete breakdown of supported manifest sections and how host/runtime expectations map to them.

This PR also wires both pages into the website docs sync and sidebar navigation, updates `docs/plugins.md` to point authors to the new guides and starter template, and addresses a previously missing/broken reference to `aoe-plugin-api/README.md`.

Benefits:
- Provides a cohesive, end-to-end authoring path (start → build/test → publish) instead of scattering guidance
- Improves discoverability and clarity of the stable plugin surface, reducing integration guesswork
- Makes the manifest schema and runtime behavior easier to implement correctly

Technical:
- Added `docs/development/writing-plugins.md` and `docs/plugin-api.md`
- Updated `website/scripts/sync-docs.mjs` and `website/src/data/docsNav.ts`
- Updated `docs/plugins.md` to link the new docs (and fixed the missing `aoe-plugin-api/README.md` reference)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->