### PR TITLE
feat: add mobile voice dictation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # HTTP client (for updates)
-reqwest = { version = "0.13", features = ["json", "rustls", "stream"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "multipart", "rustls", "stream"], default-features = false }
 
 # Percent-encode path segments (release tags) for GitHub API URLs.
 percent-encoding = "2"

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -180,4 +180,25 @@ When you leave the PWA and come back, it reopens to the session you last had ope
 
 `Ctrl-C` on a foreground server, or `aoe serve --stop` against a daemon, both exit within ~5 seconds even with open tabs. Live clients receive a `1001` ("going away") close frame and reconnect once a fresh server is running.
 
+## Mobile Voice Dictation
+
+On mobile structured-view sessions, the empty composer shows a microphone action in the send slot. Tap once to start recording, tap again to stop. The transcript is inserted into the composer and is not sent until you tap Send.
+
+AoE has two dictation paths:
+
+- **Enhanced transcription**: if `OPENAI_API_KEY` is present in the `aoe serve` environment, the PWA records audio in the browser and sends it to the local AoE server, which transcribes it with OpenAI. This is BYOK, so usage is billed to the server owner's OpenAI account.
+- **Browser fallback**: if enhanced transcription is unavailable or fails during the page session, AoE falls back to the browser speech-recognition API when the browser supports it.
+
+Enhanced transcription defaults to the higher-accuracy `gpt-4o-transcribe` model. Override it, add project vocabulary, or pin a language with environment variables:
+
+```bash
+OPENAI_API_KEY=sk-...
+AOE_TRANSCRIPTION_MODEL=gpt-4o-transcribe
+AOE_TRANSCRIPTION_GLOSSARY="Supabase, Drizzle, TanStack Query, Turborepo"
+AOE_TRANSCRIPTION_LANGUAGE=en
+aoe serve
+```
+
+You can replace the whole provider prompt with `AOE_TRANSCRIPTION_PROMPT`. Audio is sent only to the local AoE server and the configured OpenAI transcription endpoint; AoE does not store the audio.
+
 For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -186,19 +186,20 @@ On mobile structured-view sessions, the empty composer shows a microphone action
 
 AoE has two dictation paths:
 
-- **Enhanced transcription**: if `OPENAI_API_KEY` is present in the `aoe serve` environment, the PWA records audio in the browser and sends it to the local AoE server, which transcribes it with OpenAI. This is BYOK, so usage is billed to the server owner's OpenAI account.
-- **Browser fallback**: if enhanced transcription is unavailable or fails during the page session, AoE falls back to the browser speech-recognition API when the browser supports it.
+- **Enhanced transcription**: if `AOE_TRANSCRIPTION_ENABLED=1` and `OPENAI_API_KEY` are present in the `aoe serve` environment, and you grant the one-time enhanced dictation prompt, the PWA records audio in the browser and sends it to the local AoE server, which transcribes it with OpenAI. This is BYOK, so usage is billed to the server owner's OpenAI account.
+- **Browser fallback**: if enhanced transcription is unavailable, you decline the consent prompt, or transcription fails during the page session, AoE falls back to the browser speech-recognition API when the browser supports it.
 
 Enhanced transcription defaults to the higher-accuracy `gpt-4o-transcribe` model. Override it, add project vocabulary, or pin a language with environment variables:
 
 ```bash
 OPENAI_API_KEY=sk-...
+AOE_TRANSCRIPTION_ENABLED=1
 AOE_TRANSCRIPTION_MODEL=gpt-4o-transcribe
 AOE_TRANSCRIPTION_GLOSSARY="Supabase, Drizzle, TanStack Query, Turborepo"
 AOE_TRANSCRIPTION_LANGUAGE=en
 aoe serve
 ```
 
-You can replace the whole provider prompt with `AOE_TRANSCRIPTION_PROMPT`. Audio is sent only to the local AoE server and the configured OpenAI transcription endpoint; AoE does not store the audio.
+You can replace the whole provider prompt with `AOE_TRANSCRIPTION_PROMPT`. Audio is sent only after you grant the enhanced dictation prompt, and only to the local AoE server and the configured OpenAI transcription endpoint; AoE does not store the audio.
 
 For build, architecture, and frontend-development details, see [Web Dashboard Development](../development/web-dashboard.md).

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -258,6 +258,11 @@ mod tests {
                 ],
             ),
             (
+                "api/transcription.rs",
+                include_str!("transcription.rs"),
+                &["transcribe_audio"],
+            ),
+            (
                 "api/plugins.rs",
                 include_str!("plugins.rs"),
                 &["invoke_plugin_action"],

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -22,6 +22,8 @@ mod projects;
 mod sessions;
 pub(crate) mod system;
 mod telemetry;
+#[cfg(feature = "serve")]
+mod transcription;
 
 #[cfg(feature = "serve")]
 pub use acp::{
@@ -74,6 +76,8 @@ pub use telemetry::{
     get_telemetry_status, post_telemetry_seen, post_telemetry_structured_interaction,
     set_telemetry_consent,
 };
+#[cfg(feature = "serve")]
+pub use transcription::{transcribe_audio, transcription_status};
 
 const SHELL_METACHARACTERS: &[char] = &[
     ';', '&', '|', '$', '`', '(', ')', '{', '}', '<', '>', '\n', '\r', '\\', '"', '\'', '!', '#',

--- a/src/server/api/transcription.rs
+++ b/src/server/api/transcription.rs
@@ -29,6 +29,7 @@ SQLite, WebSocket, PWA, API, CLI, TUI, MCP, ACP, OpenAI, Whisper, Claude Code, a
 
 #[derive(Debug, Clone)]
 struct TranscriptionConfig {
+    enabled: bool,
     api_key: Option<String>,
     model: String,
     prompt: String,
@@ -56,8 +57,24 @@ pub struct TranscriptionResponse {
     corrected: bool,
 }
 
-pub async fn transcription_status() -> impl IntoResponse {
+pub async fn transcription_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let config = TranscriptionConfig::from_env();
+    if state.read_only {
+        return Json(TranscriptionStatusResponse {
+            available: false,
+            provider: None,
+            model: None,
+            reason: Some("read_only"),
+        });
+    }
+    if !config.enabled {
+        return Json(TranscriptionStatusResponse {
+            available: false,
+            provider: None,
+            model: None,
+            reason: Some("disabled"),
+        });
+    }
     if config.api_key.is_none() {
         return Json(TranscriptionStatusResponse {
             available: false,
@@ -81,9 +98,12 @@ pub async fn transcribe_audio(
     audio: Bytes,
 ) -> impl IntoResponse {
     let config = TranscriptionConfig::from_env();
-    if let Err((status, message)) =
-        validate_transcription_request(state.read_only, audio.len(), config.api_key.is_some())
-    {
+    if let Err((status, message)) = validate_transcription_request(
+        state.read_only,
+        audio.len(),
+        config.ready(),
+        request_content_type(&headers),
+    ) {
         return (status, message).into_response();
     }
     let api_key = config
@@ -122,6 +142,7 @@ fn validate_transcription_request(
     read_only: bool,
     audio_len: usize,
     configured: bool,
+    content_type: &str,
 ) -> Result<(), (StatusCode, &'static str)> {
     if read_only {
         return Err((StatusCode::FORBIDDEN, "server is in read-only mode"));
@@ -136,6 +157,12 @@ fn validate_transcription_request(
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             "server transcription is not configured",
+        ));
+    }
+    if !is_allowed_audio_content_type(content_type) {
+        return Err((
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "unsupported audio content type",
         ));
     }
     Ok(())
@@ -206,6 +233,7 @@ async fn transcribe_with_openai(
 
 impl TranscriptionConfig {
     fn from_env() -> Self {
+        let enabled = truthy_env("AOE_TRANSCRIPTION_ENABLED");
         let provider =
             env::var("AOE_TRANSCRIPTION_PROVIDER").unwrap_or_else(|_| "openai".to_string());
         let api_key = if provider.eq_ignore_ascii_case("openai") {
@@ -235,12 +263,31 @@ impl TranscriptionConfig {
             .filter(|value| !value.trim().is_empty());
 
         Self {
+            enabled,
             api_key,
             model,
             prompt,
             language,
         }
     }
+
+    fn ready(&self) -> bool {
+        self.enabled && self.api_key.is_some()
+    }
+}
+
+fn truthy_env(name: &str) -> bool {
+    env::var(name)
+        .ok()
+        .map(|value| parse_truthy(&value))
+        .unwrap_or(false)
+}
+
+fn parse_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 fn request_content_type(headers: &HeaderMap) -> &str {
@@ -249,6 +296,28 @@ fn request_content_type(headers: &HeaderMap) -> &str {
         .and_then(|value| value.to_str().ok())
         .filter(|value| !value.trim().is_empty())
         .unwrap_or("audio/webm")
+}
+
+fn is_allowed_audio_content_type(content_type: &str) -> bool {
+    let base = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        base.as_str(),
+        "audio/webm"
+            | "audio/ogg"
+            | "audio/mpeg"
+            | "audio/mp3"
+            | "audio/mp4"
+            | "audio/wav"
+            | "audio/x-wav"
+            | "audio/wave"
+            | "audio/flac"
+            | "audio/aac"
+    )
 }
 
 fn filename_for_content_type(content_type: &str) -> &'static str {
@@ -318,6 +387,23 @@ mod tests {
     }
 
     #[test]
+    fn allows_expected_audio_content_types() {
+        assert!(is_allowed_audio_content_type("audio/webm;codecs=opus"));
+        assert!(is_allowed_audio_content_type("audio/mp4"));
+        assert!(!is_allowed_audio_content_type("text/plain"));
+        assert!(!is_allowed_audio_content_type("application/json"));
+    }
+
+    #[test]
+    fn parses_explicit_transcription_enablement() {
+        assert!(parse_truthy("1"));
+        assert!(parse_truthy("true"));
+        assert!(parse_truthy("YES"));
+        assert!(!parse_truthy(""));
+        assert!(!parse_truthy("false"));
+    }
+
+    #[test]
     fn uses_audio_filename_extensions_for_uploads() {
         assert_eq!(filename_for_content_type("audio/mpeg"), "dictation.mp3");
         assert_eq!(
@@ -329,22 +415,29 @@ mod tests {
     #[test]
     fn rejects_unavailable_or_unsafe_requests_before_provider_call() {
         assert_eq!(
-            validate_transcription_request(true, 1024, true),
+            validate_transcription_request(true, 1024, true, "audio/webm"),
             Err((StatusCode::FORBIDDEN, "server is in read-only mode")),
         );
         assert_eq!(
-            validate_transcription_request(false, 0, true),
+            validate_transcription_request(false, 0, true, "audio/webm"),
             Err((StatusCode::BAD_REQUEST, "empty audio body")),
         );
         assert_eq!(
-            validate_transcription_request(false, MAX_AUDIO_BYTES + 1, true),
+            validate_transcription_request(false, MAX_AUDIO_BYTES + 1, true, "audio/webm"),
             Err((StatusCode::PAYLOAD_TOO_LARGE, "audio body too large")),
         );
         assert_eq!(
-            validate_transcription_request(false, 1024, false),
+            validate_transcription_request(false, 1024, false, "audio/webm"),
             Err((
                 StatusCode::SERVICE_UNAVAILABLE,
                 "server transcription is not configured"
+            )),
+        );
+        assert_eq!(
+            validate_transcription_request(false, 1024, true, "text/plain"),
+            Err((
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "unsupported audio content type"
             )),
         );
     }

--- a/src/server/api/transcription.rs
+++ b/src/server/api/transcription.rs
@@ -1,0 +1,291 @@
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use regex::RegexBuilder;
+use serde::{Deserialize, Serialize};
+
+use super::AppState;
+
+const DEFAULT_MODEL: &str = "gpt-4o-mini-transcribe";
+const OPENAI_TRANSCRIPTIONS_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
+const MAX_AUDIO_BYTES: usize = 28 * 1024 * 1024;
+
+const DEFAULT_PROMPT: &str = "This is dictated text for a technical coding assistant. \
+Preserve developer terms, product names, acronyms, package names, and code-like words. \
+Examples include Agent of Empires, AoE, Supabase, TypeScript, JavaScript, React, Rust, \
+Cargo, tmux, GitHub, GitLab, npm, pnpm, Vite, Tailwind, Docker, Kubernetes, Postgres, \
+SQLite, WebSocket, PWA, API, CLI, TUI, MCP, ACP, OpenAI, Whisper, Claude Code, and Codex.";
+
+#[derive(Debug, Clone)]
+struct TranscriptionConfig {
+    api_key: Option<String>,
+    model: String,
+    prompt: String,
+    language: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TranscriptionStatusResponse {
+    available: bool,
+    provider: Option<&'static str>,
+    model: Option<String>,
+    reason: Option<&'static str>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiTranscriptionResponse {
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TranscriptionResponse {
+    text: String,
+    provider: &'static str,
+    model: String,
+    corrected: bool,
+}
+
+pub async fn transcription_status() -> impl IntoResponse {
+    let config = TranscriptionConfig::from_env();
+    if config.api_key.is_none() {
+        return Json(TranscriptionStatusResponse {
+            available: false,
+            provider: None,
+            model: None,
+            reason: Some("missing_openai_api_key"),
+        });
+    }
+
+    Json(TranscriptionStatusResponse {
+        available: true,
+        provider: Some("openai"),
+        model: Some(config.model),
+        reason: None,
+    })
+}
+
+pub async fn transcribe_audio(
+    State(_state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    audio: Bytes,
+) -> impl IntoResponse {
+    if audio.is_empty() {
+        return (StatusCode::BAD_REQUEST, "empty audio body").into_response();
+    }
+    if audio.len() > MAX_AUDIO_BYTES {
+        return (StatusCode::PAYLOAD_TOO_LARGE, "audio body too large").into_response();
+    }
+
+    let config = TranscriptionConfig::from_env();
+    let Some(api_key) = config.api_key.as_deref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "server transcription is not configured",
+        )
+            .into_response();
+    };
+
+    match transcribe_with_openai(&config, api_key, &headers, audio).await {
+        Ok(raw_text) => {
+            let corrected_text = correct_technical_terms(&raw_text);
+            let corrected = corrected_text != raw_text;
+            (
+                StatusCode::OK,
+                Json(TranscriptionResponse {
+                    text: corrected_text,
+                    provider: "openai",
+                    model: config.model,
+                    corrected,
+                }),
+            )
+                .into_response()
+        }
+        Err(message) => (StatusCode::BAD_GATEWAY, message).into_response(),
+    }
+}
+
+async fn transcribe_with_openai(
+    config: &TranscriptionConfig,
+    api_key: &str,
+    headers: &HeaderMap,
+    audio: Bytes,
+) -> Result<String, String> {
+    let content_type = request_content_type(headers);
+    let part = reqwest::multipart::Part::bytes(audio.to_vec())
+        .file_name(filename_for_content_type(content_type))
+        .mime_str(content_type)
+        .or_else(|_| {
+            reqwest::multipart::Part::bytes(audio.to_vec())
+                .file_name("dictation.webm")
+                .mime_str("application/octet-stream")
+        })
+        .map_err(|e| format!("failed to build audio upload: {e}"))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", part)
+        .text("model", config.model.clone())
+        .text("prompt", config.prompt.clone())
+        .text("response_format", "json");
+    if let Some(language) = &config.language {
+        form = form.text("language", language.clone());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(45))
+        .build()
+        .map_err(|e| format!("failed to build transcription client: {e}"))?;
+
+    let response = client
+        .post(OPENAI_TRANSCRIPTIONS_URL)
+        .bearer_auth(api_key)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| format!("transcription request failed: {e}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("failed to read transcription response: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("transcription provider returned {status}: {body}"));
+    }
+
+    let parsed: OpenAiTranscriptionResponse =
+        serde_json::from_str(&body).map_err(|e| format!("invalid transcription response: {e}"))?;
+    let text = parsed.text.trim();
+    if text.is_empty() {
+        return Err("transcription provider returned empty text".to_string());
+    }
+    Ok(text.to_string())
+}
+
+impl TranscriptionConfig {
+    fn from_env() -> Self {
+        let provider =
+            env::var("AOE_TRANSCRIPTION_PROVIDER").unwrap_or_else(|_| "openai".to_string());
+        let api_key = if provider.eq_ignore_ascii_case("openai") {
+            env::var("OPENAI_API_KEY")
+                .ok()
+                .filter(|key| !key.trim().is_empty())
+        } else {
+            None
+        };
+        let model = env::var("AOE_TRANSCRIPTION_MODEL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        let extra_glossary = env::var("AOE_TRANSCRIPTION_GLOSSARY").unwrap_or_default();
+        let prompt = env::var("AOE_TRANSCRIPTION_PROMPT")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| {
+                if extra_glossary.trim().is_empty() {
+                    DEFAULT_PROMPT.to_string()
+                } else {
+                    format!("{DEFAULT_PROMPT} Additional project glossary: {extra_glossary}")
+                }
+            });
+        let language = env::var("AOE_TRANSCRIPTION_LANGUAGE")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+
+        Self {
+            api_key,
+            model,
+            prompt,
+            language,
+        }
+    }
+}
+
+fn request_content_type(headers: &HeaderMap) -> &str {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("audio/webm")
+}
+
+fn filename_for_content_type(content_type: &str) -> &'static str {
+    if content_type.contains("mpeg") || content_type.contains("mp3") {
+        "dictation.mp3"
+    } else if content_type.contains("mp4") {
+        "dictation.mp4"
+    } else if content_type.contains("wav") {
+        "dictation.wav"
+    } else {
+        "dictation.webm"
+    }
+}
+
+pub fn correct_technical_terms(text: &str) -> String {
+    let replacements = [
+        (r"\bsuper\s+bass\b", "Supabase"),
+        (r"\bsuperbase\b", "Supabase"),
+        (r"\btype\s+script\b", "TypeScript"),
+        (r"\bjava\s+script\b", "JavaScript"),
+        (r"\bpost\s+gress\b", "Postgres"),
+        (r"\bpostgre\s*s\s*q\s*l\b", "PostgreSQL"),
+        (r"\bweb\s+socket\b", "WebSocket"),
+        (r"\bgithub\b", "GitHub"),
+        (r"\bgit\s+hub\b", "GitHub"),
+        (r"\bgit\s+lab\b", "GitLab"),
+        (r"\bt\s+mux\b", "tmux"),
+        (r"\bnode\s+j\s+s\b", "Node.js"),
+        (r"\breact\s+query\b", "TanStack Query"),
+        (r"\btail\s+wind\b", "Tailwind"),
+        (r"\bopen\s+a\s+i\b", "OpenAI"),
+        (r"\bwhispe?r\b", "Whisper"),
+        (r"\bclaude\s+coat\b", "Claude Code"),
+        (r"\bclaude\s+code\b", "Claude Code"),
+        (r"\bco\s+dex\b", "Codex"),
+    ];
+
+    let mut corrected = text.to_string();
+    for (pattern, replacement) in replacements {
+        let re = RegexBuilder::new(pattern)
+            .case_insensitive(true)
+            .build()
+            .expect("technical correction regex must compile");
+        corrected = re.replace_all(&corrected, replacement).into_owned();
+    }
+    corrected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn corrects_common_technical_misrecognitions() {
+        assert_eq!(
+            correct_technical_terms("Use Super Bass with Type Script and git hub."),
+            "Use Supabase with TypeScript and GitHub.",
+        );
+    }
+
+    #[test]
+    fn preserves_unrelated_text() {
+        assert_eq!(
+            correct_technical_terms("Review the diff before sending."),
+            "Review the diff before sending.",
+        );
+    }
+
+    #[test]
+    fn uses_audio_filename_extensions_for_uploads() {
+        assert_eq!(filename_for_content_type("audio/mpeg"), "dictation.mp3");
+        assert_eq!(
+            filename_for_content_type("audio/webm;codecs=opus"),
+            "dictation.webm"
+        );
+    }
+}

--- a/src/server/api/transcription.rs
+++ b/src/server/api/transcription.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use super::AppState;
 
-const DEFAULT_MODEL: &str = "gpt-4o-mini-transcribe";
+const DEFAULT_MODEL: &str = "gpt-4o-transcribe";
 const OPENAI_TRANSCRIPTIONS_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
 const MAX_AUDIO_BYTES: usize = 28 * 1024 * 1024;
 

--- a/src/server/api/transcription.rs
+++ b/src/server/api/transcription.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use axum::body::Bytes;
@@ -9,12 +10,16 @@ use axum::response::IntoResponse;
 use axum::Json;
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
 
 use super::AppState;
 
 const DEFAULT_MODEL: &str = "gpt-4o-transcribe";
 const OPENAI_TRANSCRIPTIONS_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
-const MAX_AUDIO_BYTES: usize = 28 * 1024 * 1024;
+const MAX_AUDIO_BYTES: usize = 24 * 1024 * 1024;
+const MAX_CONCURRENT_TRANSCRIPTIONS: usize = 2;
+static TRANSCRIPTION_IN_FLIGHT: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_TRANSCRIPTIONS));
 
 const DEFAULT_PROMPT: &str = "This is dictated text for a technical coding assistant. \
 Preserve developer terms, product names, acronyms, package names, and code-like words. \
@@ -71,22 +76,25 @@ pub async fn transcription_status() -> impl IntoResponse {
 }
 
 pub async fn transcribe_audio(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     audio: Bytes,
 ) -> impl IntoResponse {
-    if audio.is_empty() {
-        return (StatusCode::BAD_REQUEST, "empty audio body").into_response();
-    }
-    if audio.len() > MAX_AUDIO_BYTES {
-        return (StatusCode::PAYLOAD_TOO_LARGE, "audio body too large").into_response();
-    }
-
     let config = TranscriptionConfig::from_env();
-    let Some(api_key) = config.api_key.as_deref() else {
+    if let Err((status, message)) =
+        validate_transcription_request(state.read_only, audio.len(), config.api_key.is_some())
+    {
+        return (status, message).into_response();
+    }
+    let api_key = config
+        .api_key
+        .as_deref()
+        .expect("validated transcription config must include an API key");
+
+    let Ok(_permit) = TRANSCRIPTION_IN_FLIGHT.try_acquire() else {
         return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            "server transcription is not configured",
+            StatusCode::TOO_MANY_REQUESTS,
+            "too many transcription requests in flight",
         )
             .into_response();
     };
@@ -108,6 +116,29 @@ pub async fn transcribe_audio(
         }
         Err(message) => (StatusCode::BAD_GATEWAY, message).into_response(),
     }
+}
+
+fn validate_transcription_request(
+    read_only: bool,
+    audio_len: usize,
+    configured: bool,
+) -> Result<(), (StatusCode, &'static str)> {
+    if read_only {
+        return Err((StatusCode::FORBIDDEN, "server is in read-only mode"));
+    }
+    if audio_len == 0 {
+        return Err((StatusCode::BAD_REQUEST, "empty audio body"));
+    }
+    if audio_len > MAX_AUDIO_BYTES {
+        return Err((StatusCode::PAYLOAD_TOO_LARGE, "audio body too large"));
+    }
+    if !configured {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "server transcription is not configured",
+        ));
+    }
+    Ok(())
 }
 
 async fn transcribe_with_openai(
@@ -155,7 +186,13 @@ async fn transcribe_with_openai(
         .map_err(|e| format!("failed to read transcription response: {e}"))?;
 
     if !status.is_success() {
-        return Err(format!("transcription provider returned {status}: {body}"));
+        tracing::warn!(
+            target: "http.api.transcription",
+            %status,
+            response_bytes = body.len(),
+            "transcription provider returned an error"
+        );
+        return Err(format!("transcription provider returned {status}"));
     }
 
     let parsed: OpenAiTranscriptionResponse =
@@ -286,6 +323,29 @@ mod tests {
         assert_eq!(
             filename_for_content_type("audio/webm;codecs=opus"),
             "dictation.webm"
+        );
+    }
+
+    #[test]
+    fn rejects_unavailable_or_unsafe_requests_before_provider_call() {
+        assert_eq!(
+            validate_transcription_request(true, 1024, true),
+            Err((StatusCode::FORBIDDEN, "server is in read-only mode")),
+        );
+        assert_eq!(
+            validate_transcription_request(false, 0, true),
+            Err((StatusCode::BAD_REQUEST, "empty audio body")),
+        );
+        assert_eq!(
+            validate_transcription_request(false, MAX_AUDIO_BYTES + 1, true),
+            Err((StatusCode::PAYLOAD_TOO_LARGE, "audio body too large")),
+        );
+        assert_eq!(
+            validate_transcription_request(false, 1024, false),
+            Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "server transcription is not configured"
+            )),
         );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1658,7 +1658,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/transcription",
             post(api::transcribe_audio)
-                .layer(axum::extract::DefaultBodyLimit::max(28 * 1024 * 1024)),
+                .layer(axum::extract::DefaultBodyLimit::max(24 * 1024 * 1024)),
         )
         // Terminal WebSockets (capture-streaming live view; the agent pane and
         // the paired host/container shells). The xterm PTY relay was removed.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1654,6 +1654,12 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/telemetry/structured-interaction",
             post(api::post_telemetry_structured_interaction),
         )
+        .route("/api/transcription/status", get(api::transcription_status))
+        .route(
+            "/api/transcription",
+            post(api::transcribe_audio)
+                .layer(axum::extract::DefaultBodyLimit::max(28 * 1024 * 1024)),
+        )
         // Terminal WebSockets (capture-streaming live view; the agent pane and
         // the paired host/container shells). The xterm PTY relay was removed.
         .route("/sessions/{id}/live-ws", get(live_ws::live_terminal_ws))

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -8939,6 +8939,12 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
                 "-y",
                 "40",
                 &launch,
+                ";",
+                "set-option",
+                "-t",
+                &session_name,
+                "pane-base-index",
+                "0",
             ])
             .output()
             .expect("spawn tmux");

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1768,14 +1768,9 @@ mod tests {
             )
             .expect("subscribe groups");
 
-        while tokio::time::timeout(std::time::Duration::from_millis(400), sessions_rx.recv())
-            .await
-            .is_ok()
-        {}
-        while tokio::time::timeout(std::time::Duration::from_millis(50), groups_rx.recv())
-            .await
-            .is_ok()
-        {}
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        while sessions_rx.try_recv().is_ok() {}
+        while groups_rx.try_recv().is_ok() {}
 
         let original_mode = fs::metadata(&profile_dir)?.permissions().mode();
         let mut readonly = fs::metadata(&profile_dir)?.permissions();

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1768,9 +1768,35 @@ mod tests {
             )
             .expect("subscribe groups");
 
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        while sessions_rx.try_recv().is_ok() {}
-        while groups_rx.try_recv().is_ok() {}
+        let drain_deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+        loop {
+            let mut drained = false;
+            while sessions_rx.try_recv().is_ok() {
+                drained = true;
+            }
+            while groups_rx.try_recv().is_ok() {
+                drained = true;
+            }
+            if drained {
+                continue;
+            }
+
+            let remaining = drain_deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let wait_for = remaining.min(std::time::Duration::from_millis(50));
+            let received = tokio::time::timeout(wait_for, async {
+                tokio::select! {
+                    event = sessions_rx.recv() => event.is_some(),
+                    event = groups_rx.recv() => event.is_some(),
+                }
+            })
+            .await;
+            if !matches!(received, Ok(true)) {
+                break;
+            }
+        }
 
         let original_mode = fs::metadata(&profile_dir)?.permissions().mode();
         let mut readonly = fs::metadata(&profile_dir)?.permissions();

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1131,6 +1131,12 @@ mod tests {
                 "-y",
                 "24",
                 "bash -c 'i=0; while true; do echo line-$((i++)); done'",
+                ";",
+                "set-option",
+                "-t",
+                guard.name(),
+                "pane-base-index",
+                "0",
             ])
             .output()
             .expect("tmux new-session");
@@ -1248,6 +1254,20 @@ mod tests {
                 "-y",
                 "10",
                 "sh -c 'printf hello; sleep 60'",
+                ";",
+                "set-option",
+                "-t",
+                &name,
+                "pane-base-index",
+                "0",
+                ";",
+                "resize-window",
+                "-t",
+                &name,
+                "-x",
+                "40",
+                "-y",
+                "10",
             ])
             .status()
             .expect("tmux new-session");

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -16,7 +16,7 @@ import {
   type Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { AtSign, ChevronUp, Paperclip, Pencil, Slash, Square, X } from "lucide-react";
+import { AtSign, ChevronUp, Mic, Paperclip, Pencil, Slash, Square, X } from "lucide-react";
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
@@ -40,6 +40,7 @@ import { useAgentProfile } from "../../lib/agentProfileContext";
 import { resolveModeChannel } from "../../lib/modeChannel";
 import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
 import { useDictationBurstGuard } from "./useDictationBurstGuard";
+import { useVoiceDictation } from "./useVoiceDictation";
 import { nextRecallTarget, recallBannerInfo, type RecallCursor, type RecallNav } from "./recallNav";
 
 export {
@@ -465,6 +466,8 @@ export function Composer({
   );
 
   const composerRuntime = useComposerRuntime();
+  const [composerText, setComposerText] = useState(() => composerRuntime.getState().text);
+  const voiceDictationRangeRef = useRef<{ start: number; end: number } | null>(null);
 
   // ArrowUp/ArrowDown queue recall (shell-history style). recallRef holds
   // the id of the queued prompt currently loaded into the composer plus
@@ -609,6 +612,26 @@ export function Composer({
   const dictationGuard = useDictationBurstGuard((text) => {
     composerRuntime.setText(text);
   });
+  const voiceDictation = useVoiceDictation((text) => {
+    replaceVoiceDictationTextAtCaret(taRef, voiceDictationRangeRef, text);
+  });
+  const showVoiceDictation = isMobile && voiceDictation.supported;
+  const hasSubmittableDraft = composerText.trim().length > 0 || supportedPendingAttachments.length > 0;
+  const showVoiceAction = showVoiceDictation && (voiceDictation.listening || !hasSubmittableDraft);
+  const startVoiceDictation = useCallback(() => {
+    const ta = taRef.current;
+    if (ta) {
+      const start = ta.selectionStart ?? ta.value.length;
+      const end = ta.selectionEnd ?? start;
+      voiceDictationRangeRef.current = { start, end };
+    } else {
+      voiceDictationRangeRef.current = null;
+    }
+    voiceDictation.start();
+  }, [voiceDictation]);
+  const stopVoiceDictation = useCallback(() => {
+    voiceDictation.stop();
+  }, [voiceDictation]);
 
   // Context-primer prefill: when the parent passes a `primerPrefill`
   // payload (after the user clicked "Resume with prior context" on the
@@ -686,6 +709,7 @@ export function Composer({
       setDraft(sessionId, composerRuntime.getState().text);
     };
     const unsub = composerRuntime.subscribe(() => {
+      setComposerText(composerRuntime.getState().text);
       if (writeTimer !== null) window.clearTimeout(writeTimer);
       writeTimer = window.setTimeout(flush, 250);
     });
@@ -1088,14 +1112,22 @@ export function Composer({
 
               <div data-testid="composer-actions" className="flex shrink-0 items-center gap-2">
                 <UsageHint usage={sessionUsage} />
-                {turnActive ? (
+                {showVoiceAction ? (
+                  <VoiceDictationButton
+                    listening={voiceDictation.listening}
+                    error={voiceDictation.error}
+                    onStart={startVoiceDictation}
+                    onStop={stopVoiceDictation}
+                  />
+                ) : turnActive ? (
                   <>
                     <StopButton />
                     <QueueSendButton connected={connected} queuedCount={queuedCount} onSend={submitComposer} />
                   </>
-                ) : (
+                ) : hasSubmittableDraft || !isMobile ? (
                   <SendButton connected={connected} onSend={submitComposer} />
-                )}
+                ) : null}
+                {showVoiceAction && turnActive && <StopButton />}
               </div>
             </div>
           </ComposerPrimitive.Root>
@@ -1247,6 +1279,66 @@ export function insertAtCaret(ref: React.RefObject<HTMLTextAreaElement | null>, 
   ta.setSelectionRange(pos, pos);
 }
 
+export function insertPlainTextAtCaret(ref: React.RefObject<HTMLTextAreaElement | null>, text: string) {
+  const ta = ref.current;
+  if (!ta) return;
+  const start = ta.selectionStart ?? ta.value.length;
+  const end = ta.selectionEnd ?? start;
+  const before = ta.value.slice(0, start);
+  const after = ta.value.slice(end);
+  const needsLeadingSpace = text.length > 0 && before.length > 0 && !/\s$/.test(before) && !/^[\s.,!?;:)]/.test(text);
+  const insertion = `${needsLeadingSpace ? " " : ""}${text}`;
+  const next = before + insertion + after;
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(ta, next);
+  ta.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertText",
+      data: insertion,
+    }),
+  );
+  const pos = before.length + insertion.length;
+  ta.focus();
+  ta.setSelectionRange(pos, pos);
+  ta.style.height = "auto";
+  ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+}
+
+export function replaceVoiceDictationTextAtCaret(
+  ref: React.RefObject<HTMLTextAreaElement | null>,
+  rangeRef: React.MutableRefObject<{ start: number; end: number } | null>,
+  text: string,
+) {
+  const ta = ref.current;
+  if (!ta) return;
+  const range = rangeRef.current ?? {
+    start: ta.selectionStart ?? ta.value.length,
+    end: ta.selectionEnd ?? ta.selectionStart ?? ta.value.length,
+  };
+  const before = ta.value.slice(0, range.start);
+  const after = ta.value.slice(range.end);
+  const needsLeadingSpace = text.length > 0 && before.length > 0 && !/\s$/.test(before) && !/^[\s.,!?;:)]/.test(text);
+  const insertion = `${needsLeadingSpace ? " " : ""}${text}`;
+  const next = before + insertion + after;
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(ta, next);
+  ta.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertText",
+      data: insertion,
+    }),
+  );
+  const start = range.start;
+  const end = start + insertion.length;
+  rangeRef.current = { start, end };
+  ta.focus();
+  ta.setSelectionRange(end, end);
+  ta.style.height = "auto";
+  ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+}
+
 function extDescription(path: string): string | undefined {
   const m = path.match(/\.([a-z0-9]+)$/i);
   return m?.[1]?.toLowerCase();
@@ -1283,6 +1375,42 @@ function ToolbarButton({
     >
       {icon}
       {hint && <span className="font-mono">{hint}</span>}
+    </button>
+  );
+}
+
+function VoiceDictationButton({
+  listening,
+  error,
+  onStart,
+  onStop,
+}: {
+  listening: boolean;
+  error: string | null;
+  onStart: () => void;
+  onStop: () => void;
+}) {
+  const label = listening ? "Stop voice dictation" : "Start voice dictation";
+  const title = error ? "Voice dictation unavailable" : listening ? "Stop voice dictation" : "Start voice dictation";
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={listening}
+      title={title}
+      onClick={() => {
+        if (listening) onStop();
+        else onStart();
+      }}
+      className={[
+        "inline-flex items-center justify-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px]",
+        listening
+          ? "bg-rose-600 text-white shadow-sm hover:bg-rose-500"
+          : "border border-surface-600 bg-surface-800 text-text-secondary hover:border-surface-500 hover:bg-surface-700",
+        "active:scale-[0.98] transition-all duration-100",
+      ].join(" ")}
+    >
+      <Mic className="h-3.5 w-3.5" />
     </button>
   );
 }

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -617,7 +617,8 @@ export function Composer({
   });
   const showVoiceDictation = isMobile && voiceDictation.supported;
   const hasSubmittableDraft = composerText.trim().length > 0 || supportedPendingAttachments.length > 0;
-  const showVoiceAction = showVoiceDictation && (voiceDictation.listening || !hasSubmittableDraft);
+  const showVoiceAction =
+    showVoiceDictation && (voiceDictation.listening || voiceDictation.processing || !hasSubmittableDraft);
   const startVoiceDictation = useCallback(() => {
     const ta = taRef.current;
     if (ta) {
@@ -1115,6 +1116,7 @@ export function Composer({
                 {showVoiceAction ? (
                   <VoiceDictationButton
                     listening={voiceDictation.listening}
+                    processing={voiceDictation.processing}
                     error={voiceDictation.error}
                     onStart={startVoiceDictation}
                     onStop={stopVoiceDictation}
@@ -1381,33 +1383,48 @@ function ToolbarButton({
 
 function VoiceDictationButton({
   listening,
+  processing,
   error,
   onStart,
   onStop,
 }: {
   listening: boolean;
+  processing: boolean;
   error: string | null;
   onStart: () => void;
   onStop: () => void;
 }) {
-  const label = listening ? "Stop voice dictation" : "Start voice dictation";
-  const title = error ? "Voice dictation unavailable" : listening ? "Stop voice dictation" : "Start voice dictation";
+  const label = processing
+    ? "Transcribing voice dictation"
+    : listening
+      ? "Stop voice dictation"
+      : "Start voice dictation";
+  const title = error
+    ? "Voice dictation unavailable"
+    : processing
+      ? "Transcribing voice dictation"
+      : listening
+        ? "Stop voice dictation"
+        : "Start voice dictation";
   return (
     <button
       type="button"
       aria-label={label}
       aria-pressed={listening}
       title={title}
+      disabled={processing}
       onClick={() => {
+        if (processing) return;
         if (listening) onStop();
         else onStart();
       }}
       className={[
         "inline-flex items-center justify-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px]",
-        listening
+        listening || processing
           ? "bg-rose-600 text-white shadow-sm hover:bg-rose-500"
           : "border border-surface-600 bg-surface-800 text-text-secondary hover:border-surface-500 hover:bg-surface-700",
-        "active:scale-[0.98] transition-all duration-100",
+        processing ? "opacity-80" : "active:scale-[0.98]",
+        "transition-all duration-100",
       ].join(" ")}
     >
       <Mic className="h-3.5 w-3.5" />

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -1395,7 +1395,7 @@ function VoiceDictationButton({
         "inline-flex h-8 items-center justify-center gap-1 rounded-md px-2.5 text-[12px]",
         listening || processing
           ? "border border-status-error/50 bg-surface-800 text-status-error hover:bg-surface-700"
-          : "border border-surface-600 bg-surface-800 text-text-secondary hover:border-surface-500 hover:bg-surface-700",
+          : "border border-surface-700 bg-surface-800 text-text-secondary hover:border-surface-700 hover:bg-surface-700",
         processing ? "opacity-80" : "",
         "transition-colors duration-100",
       ].join(" ")}

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -1281,32 +1281,6 @@ export function insertAtCaret(ref: React.RefObject<HTMLTextAreaElement | null>, 
   ta.setSelectionRange(pos, pos);
 }
 
-export function insertPlainTextAtCaret(ref: React.RefObject<HTMLTextAreaElement | null>, text: string) {
-  const ta = ref.current;
-  if (!ta) return;
-  const start = ta.selectionStart ?? ta.value.length;
-  const end = ta.selectionEnd ?? start;
-  const before = ta.value.slice(0, start);
-  const after = ta.value.slice(end);
-  const needsLeadingSpace = text.length > 0 && before.length > 0 && !/\s$/.test(before) && !/^[\s.,!?;:)]/.test(text);
-  const insertion = `${needsLeadingSpace ? " " : ""}${text}`;
-  const next = before + insertion + after;
-  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
-  setter?.call(ta, next);
-  ta.dispatchEvent(
-    new InputEvent("input", {
-      bubbles: true,
-      inputType: "insertText",
-      data: insertion,
-    }),
-  );
-  const pos = before.length + insertion.length;
-  ta.focus();
-  ta.setSelectionRange(pos, pos);
-  ta.style.height = "auto";
-  ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
-}
-
 export function replaceVoiceDictationTextAtCaret(
   ref: React.RefObject<HTMLTextAreaElement | null>,
   rangeRef: React.MutableRefObject<{ start: number; end: number } | null>,

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -1116,6 +1116,7 @@ export function Composer({
                   <VoiceDictationButton
                     listening={voiceDictation.listening}
                     processing={voiceDictation.processing}
+                    audioLevel={voiceDictation.audioLevel}
                     error={voiceDictation.error}
                     onStart={startVoiceDictation}
                     onStop={stopVoiceDictation}
@@ -1357,12 +1358,14 @@ function ToolbarButton({
 function VoiceDictationButton({
   listening,
   processing,
+  audioLevel,
   error,
   onStart,
   onStop,
 }: {
   listening: boolean;
   processing: boolean;
+  audioLevel: number | null;
   error: string | null;
   onStart: () => void;
   onStop: () => void;
@@ -1400,8 +1403,43 @@ function VoiceDictationButton({
         "transition-colors duration-100",
       ].join(" ")}
     >
-      <Mic className="h-3.5 w-3.5" />
+      {processing ? (
+        <>
+          <span
+            className="h-3.5 w-3.5 rounded-full border-2 border-current border-r-transparent motion-safe:animate-spin"
+            aria-hidden="true"
+          />
+        </>
+      ) : (
+        <>
+          <Mic className="h-3.5 w-3.5" />
+          {listening && <VoiceWaveform level={audioLevel} />}
+        </>
+      )}
     </button>
+  );
+}
+
+function VoiceWaveform({ level }: { level: number | null }) {
+  const clamped = level == null ? null : Math.max(0, Math.min(1, level));
+  const bars =
+    clamped == null
+      ? [0.38, 0.72, 0.5, 0.85]
+      : [0.28 + clamped * 0.55, 0.42 + clamped * 0.58, 0.34 + clamped * 0.66, 0.24 + clamped * 0.5];
+
+  return (
+    <span className="flex h-4 w-5 items-center justify-center gap-[2px]" aria-hidden="true">
+      {bars.map((scale, index) => (
+        <span
+          key={index}
+          className="aoe-voice-wave-bar h-3.5 w-[2px] rounded-full bg-current opacity-90 transition-transform duration-75"
+          style={{
+            transform: `scaleY(${scale})`,
+            animation: clamped == null ? `aoe-voice-wave 720ms ease-in-out ${index * 90}ms infinite` : undefined,
+          }}
+        />
+      ))}
+    </span>
   );
 }
 

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -686,6 +686,19 @@ export function Composer({
   // Keyed by sessionId; cleared when the text goes empty (user deleted
   // it, or the runtime cleared after a successful send).
   useEffect(() => {
+    let writeTimer: number | null = null;
+    const flush = () => {
+      if (writeTimer !== null) {
+        window.clearTimeout(writeTimer);
+        writeTimer = null;
+      }
+      setDraft(sessionId, composerRuntime.getState().text);
+    };
+    const unsub = composerRuntime.subscribe(() => {
+      setComposerText(composerRuntime.getState().text);
+      if (writeTimer !== null) window.clearTimeout(writeTimer);
+      writeTimer = window.setTimeout(flush, 250);
+    });
     const saved = getDraft(sessionId);
     if (saved && composerRuntime.getState().text === "") {
       composerRuntime.setText(saved);
@@ -700,20 +713,6 @@ export function Composer({
         }
       });
     }
-
-    let writeTimer: number | null = null;
-    const flush = () => {
-      if (writeTimer !== null) {
-        window.clearTimeout(writeTimer);
-        writeTimer = null;
-      }
-      setDraft(sessionId, composerRuntime.getState().text);
-    };
-    const unsub = composerRuntime.subscribe(() => {
-      setComposerText(composerRuntime.getState().text);
-      if (writeTimer !== null) window.clearTimeout(writeTimer);
-      writeTimer = window.setTimeout(flush, 250);
-    });
     // Page-unload flush. Effect cleanup runs on React unmount (sidebar
     // navigation) but not on a full reload, PWA cold start, or mobile
     // OS evicting the tab. Without these listeners, whatever sits in
@@ -1393,12 +1392,12 @@ function VoiceDictationButton({
         else onStart();
       }}
       className={[
-        "inline-flex items-center justify-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px]",
+        "inline-flex h-8 items-center justify-center gap-1 rounded-md px-2.5 text-[12px]",
         listening || processing
-          ? "bg-rose-600 text-white shadow-sm hover:bg-rose-500"
+          ? "border border-status-error/50 bg-surface-800 text-status-error hover:bg-surface-700"
           : "border border-surface-600 bg-surface-800 text-text-secondary hover:border-surface-500 hover:bg-surface-700",
-        processing ? "opacity-80" : "active:scale-[0.98]",
-        "transition-all duration-100",
+        processing ? "opacity-80" : "",
+        "transition-colors duration-100",
       ].join(" ")}
     >
       <Mic className="h-3.5 w-3.5" />

--- a/web/src/components/acp/Composer.voiceDictation.test.tsx
+++ b/web/src/components/acp/Composer.voiceDictation.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
 
 import { Composer } from "./Composer";
@@ -32,6 +32,10 @@ class MockSpeechRecognition implements SpeechRecognitionLike {
       resultIndex: 0,
       results: Object.assign(list, { length: list.length }),
     });
+  }
+
+  emitEnd() {
+    this.onend?.();
   }
 }
 
@@ -120,6 +124,21 @@ describe("Composer voice dictation", () => {
     fireEvent.click(screen.getByRole("button", { name: "Stop voice dictation" }));
     expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy();
     expect(enqueuePrompt).not.toHaveBeenCalled();
+  });
+
+  it("keeps dictated text cumulative after browser recognition auto-restarts", async () => {
+    const { container } = render(<Harness />);
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("composer textarea not rendered");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start voice dictation" }));
+    MockSpeechRecognition.instances[0]!.emitFinal("review the");
+    MockSpeechRecognition.instances[0]!.emitEnd();
+
+    await waitFor(() => expect(MockSpeechRecognition.instances).toHaveLength(2));
+    MockSpeechRecognition.instances[1]!.emitFinal("diff please");
+
+    expect(textarea.value).toBe("review the diff please");
   });
 
   it("swaps to Send once the user starts typing", () => {

--- a/web/src/components/acp/Composer.voiceDictation.test.tsx
+++ b/web/src/components/acp/Composer.voiceDictation.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
+
+import { Composer } from "./Composer";
+import type { SpeechRecognitionLike } from "./useVoiceDictation";
+
+class MockSpeechRecognition implements SpeechRecognitionLike {
+  static instances: MockSpeechRecognition[] = [];
+
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onresult: SpeechRecognitionLike["onresult"] = null;
+  onerror: SpeechRecognitionLike["onerror"] = null;
+  onend: SpeechRecognitionLike["onend"] = null;
+  start = vi.fn();
+  stop = vi.fn(() => {
+    this.onend?.();
+  });
+  abort = vi.fn();
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
+
+  emitFinal(transcript: string) {
+    const list = [{ isFinal: true, 0: { transcript } }];
+    this.onresult?.({
+      resultIndex: 0,
+      results: Object.assign(list, { length: list.length }),
+    });
+  }
+}
+
+function Harness({ enqueuePrompt = vi.fn() }: { enqueuePrompt?: (text: string) => void }) {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages: [],
+    isRunning: false,
+    convertMessage: (m) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Composer
+        sessionId="sess-voice"
+        currentAgent="claude"
+        availableModes={[]}
+        currentModeId={null}
+        legacyMode="Default"
+        configOptions={[]}
+        pendingConfigOption={null}
+        setConfigOption={() => {}}
+        sessionUsage={null}
+        availableCommands={[]}
+        connected
+        turnActive={false}
+        queuedCount={0}
+        enqueuePrompt={enqueuePrompt}
+        promptCapabilities={null}
+        pendingAttachments={[]}
+        setPendingAttachments={() => {}}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+beforeEach(() => {
+  MockSpeechRecognition.instances = [];
+  window.localStorage.clear();
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(pointer: coarse)",
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  );
+  vi.stubGlobal("webkitSpeechRecognition", MockSpeechRecognition);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: [] }),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+});
+
+describe("Composer voice dictation", () => {
+  it("shows a mobile mic button in the action slot when the draft is empty", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: "Start voice dictation" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
+  });
+
+  it("replaces cumulative transcript updates in the draft without sending", () => {
+    const enqueuePrompt = vi.fn();
+    const { container } = render(<Harness enqueuePrompt={enqueuePrompt} />);
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("composer textarea not rendered");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start voice dictation" }));
+    MockSpeechRecognition.instances[0]!.emitFinal("review");
+    MockSpeechRecognition.instances[0]!.emitFinal("review the diff");
+
+    expect(textarea.value).toBe("review the diff");
+    expect(enqueuePrompt).not.toHaveBeenCalled();
+  });
+
+  it("swaps to Send once the user starts typing", () => {
+    const { container } = render(<Harness />);
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("composer textarea not rendered");
+
+    fireEvent.change(textarea, { target: { value: "please" } });
+
+    expect(screen.queryByRole("button", { name: "Start voice dictation" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy();
+  });
+});

--- a/web/src/components/acp/Composer.voiceDictation.test.tsx
+++ b/web/src/components/acp/Composer.voiceDictation.test.tsx
@@ -117,6 +117,8 @@ describe("Composer voice dictation", () => {
     MockSpeechRecognition.instances[0]!.emitFinal("review the diff");
 
     expect(textarea.value).toBe("review the diff");
+    fireEvent.click(screen.getByRole("button", { name: "Stop voice dictation" }));
+    expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy();
     expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -39,6 +39,10 @@ class MockSpeechRecognition implements SpeechRecognitionLike {
       results: Object.assign(list, { length: list.length }),
     });
   }
+
+  emitEnd() {
+    this.onend?.();
+  }
 }
 
 class MockMediaRecorder {
@@ -167,6 +171,31 @@ describe("useVoiceDictation", () => {
     expect(result.current.listening).toBe(false);
   });
 
+  it("restarts browser recognition after a spontaneous end and keeps a cumulative transcript", async () => {
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+    act(() => result.current.start());
+
+    act(() => {
+      MockSpeechRecognition.instances[0]!.emitResult([{ transcript: "review the", isFinal: false }]);
+      MockSpeechRecognition.instances[0]!.emitEnd();
+    });
+
+    expect(result.current.listening).toBe(true);
+    await waitFor(() => expect(MockSpeechRecognition.instances).toHaveLength(2));
+
+    act(() => {
+      MockSpeechRecognition.instances[1]!.emitResult([{ transcript: "diff please", isFinal: false }]);
+    });
+
+    expect(onTranscript).toHaveBeenNthCalledWith(1, "review the");
+    expect(onTranscript).toHaveBeenNthCalledWith(2, "review the diff please");
+    expect(result.current.listening).toBe(true);
+
+    act(() => result.current.stop());
+    expect(result.current.listening).toBe(false);
+  });
+
   it("reports unsupported browsers without calling the transcript sink", () => {
     vi.unstubAllGlobals();
     resetVoiceDictationServerStatusForTests();
@@ -225,6 +254,53 @@ describe("useVoiceDictation", () => {
       }),
     );
     expect(onTranscript).toHaveBeenCalledWith("Supabase TypeScript project");
+  });
+
+  it("enters processing state immediately after enhanced recording stops", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    stubMediaRecording();
+    let resolveTranscription!: (response: { ok: boolean; json: () => Promise<{ text: string }> }) => void;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+      })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveTranscription = resolve;
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.stop();
+      await Promise.resolve();
+    });
+
+    expect(result.current.processing).toBe(true);
+    expect(result.current.listening).toBe(false);
+
+    await act(async () => {
+      resolveTranscription({
+        ok: true,
+        json: async () => ({ text: "queued transcription" }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.processing).toBe(false);
+    expect(onTranscript).toHaveBeenCalledWith("queued transcription");
   });
 
   it("does not start enhanced recording when the user declines audio egress consent", async () => {

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { mergeSpeechRecognitionSegments, useVoiceDictation, type SpeechRecognitionLike } from "./useVoiceDictation";
+
+class MockSpeechRecognition implements SpeechRecognitionLike {
+  static instances: MockSpeechRecognition[] = [];
+
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onresult: SpeechRecognitionLike["onresult"] = null;
+  onerror: SpeechRecognitionLike["onerror"] = null;
+  onend: SpeechRecognitionLike["onend"] = null;
+  start = vi.fn();
+  stop = vi.fn(() => {
+    this.onend?.();
+  });
+  abort = vi.fn();
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
+
+  emitResult(results: Array<{ transcript: string; isFinal: boolean }>, resultIndex = 0) {
+    const list = results.map((result) => ({
+      isFinal: result.isFinal,
+      0: { transcript: result.transcript },
+    }));
+    this.onresult?.({
+      resultIndex,
+      results: Object.assign(list, { length: list.length }),
+    });
+  }
+}
+
+beforeEach(() => {
+  MockSpeechRecognition.instances = [];
+  vi.stubGlobal("webkitSpeechRecognition", MockSpeechRecognition);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useVoiceDictation", () => {
+  it("configures browser speech recognition and starts listening", () => {
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+
+    act(() => result.current.start());
+
+    const recognition = MockSpeechRecognition.instances[0];
+    expect(recognition).toBeTruthy();
+    expect(recognition.continuous).toBe(true);
+    expect(recognition.interimResults).toBe(true);
+    expect(recognition.lang).toBe(navigator.language || "en-US");
+    expect(recognition.start).toHaveBeenCalledTimes(1);
+    expect(result.current.listening).toBe(true);
+  });
+
+  it("emits the full cumulative transcript on each result", () => {
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+    act(() => result.current.start());
+
+    act(() => {
+      MockSpeechRecognition.instances[0]!.emitResult([{ transcript: " build ", isFinal: true }]);
+      MockSpeechRecognition.instances[0]!.emitResult([
+        { transcript: " build ", isFinal: true },
+        { transcript: "the feature ", isFinal: true },
+      ]);
+    });
+
+    expect(onTranscript).toHaveBeenNthCalledWith(1, "build");
+    expect(onTranscript).toHaveBeenNthCalledWith(2, "build the feature");
+    expect(onTranscript).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates overlapping mobile recognition hypotheses", () => {
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+    act(() => result.current.start());
+
+    act(() => {
+      MockSpeechRecognition.instances[0]!.emitResult([{ transcript: "Alpha", isFinal: false }]);
+      MockSpeechRecognition.instances[0]!.emitResult([
+        { transcript: "Alpha", isFinal: false },
+        { transcript: "Alpha Beta", isFinal: false },
+        { transcript: "Alpha Beta Charlie", isFinal: false },
+      ]);
+    });
+
+    expect(onTranscript).toHaveBeenNthCalledWith(1, "Alpha");
+    expect(onTranscript).toHaveBeenNthCalledWith(2, "Alpha Beta Charlie");
+    expect(onTranscript).toHaveBeenCalledTimes(2);
+  });
+
+  it("flushes the latest interim transcript when recording ends without a final result", () => {
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+    act(() => result.current.start());
+
+    act(() => {
+      MockSpeechRecognition.instances[0]!.emitResult([{ transcript: "drafted phrase", isFinal: false }]);
+      result.current.stop();
+    });
+
+    expect(onTranscript).toHaveBeenCalledWith("drafted phrase");
+    expect(onTranscript).toHaveBeenCalledTimes(1);
+    expect(result.current.listening).toBe(false);
+  });
+
+  it("reports unsupported browsers without calling the transcript sink", () => {
+    vi.unstubAllGlobals();
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+
+    act(() => result.current.start());
+
+    expect(result.current.supported).toBe(false);
+    expect(result.current.error).toBe("unsupported");
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+});
+
+describe("mergeSpeechRecognitionSegments", () => {
+  it("keeps distinct recognition segments", () => {
+    expect(mergeSpeechRecognitionSegments([" build ", "the feature "])).toBe("build the feature");
+  });
+
+  it("collapses repeated growing prefixes", () => {
+    expect(mergeSpeechRecognitionSegments(["Alpha", "Alpha Beta", "Alpha Beta Charlie"])).toBe("Alpha Beta Charlie");
+  });
+
+  it("merges suffix and prefix overlap", () => {
+    expect(mergeSpeechRecognitionSegments(["Alpha Beta", "Beta Charlie"])).toBe("Alpha Beta Charlie");
+  });
+});

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -182,7 +182,7 @@ describe("useVoiceDictation", () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-mini-transcribe" }),
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
       })
       .mockResolvedValueOnce({
         ok: true,

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -253,6 +253,49 @@ describe("useVoiceDictation", () => {
     expect(result.current.error).toBe("enhanced-consent-declined");
   });
 
+  it("asks for enhanced recording consent only once", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    const { stopTrack } = stubMediaRecording();
+    const confirmMock = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirmMock);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+        })
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ text: "second pass" }),
+        }),
+    );
+    const { result } = renderHook(() => useVoiceDictation(vi.fn()));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.stop();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(2);
+    expect(MockMediaRecorder.instances).toHaveLength(2);
+    expect(stopTrack).toHaveBeenCalled();
+  });
+
   it("coalesces rapid enhanced recording starts while microphone permission is pending", async () => {
     vi.stubGlobal("webkitSpeechRecognition", undefined);
     stubMediaRecording();
@@ -285,6 +328,47 @@ describe("useVoiceDictation", () => {
 
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
     expect(MockMediaRecorder.instances).toHaveLength(1);
+  });
+
+  it("cancels enhanced recording while microphone permission is pending", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    stubMediaRecording();
+    const stopTrack = vi.fn();
+    let resolveStream!: (stream: MediaStream) => void;
+    const stream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream;
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockReturnValue(
+      new Promise<MediaStream>((resolve) => {
+        resolveStream = resolve;
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+      }),
+    );
+    const { result } = renderHook(() => useVoiceDictation(vi.fn()));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    act(() => {
+      result.current.start();
+    });
+    expect(result.current.listening).toBe(true);
+
+    act(() => {
+      result.current.stop();
+    });
+    expect(result.current.listening).toBe(false);
+
+    await act(async () => {
+      resolveStream(stream);
+      await Promise.resolve();
+    });
+
+    expect(stopTrack).toHaveBeenCalled();
+    expect(MockMediaRecorder.instances).toHaveLength(0);
   });
 
   it("stops acquired tracks when MediaRecorder construction fails", async () => {

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -80,6 +80,10 @@ function stubMediaRecording() {
     },
   });
   vi.stubGlobal("MediaRecorder", MockMediaRecorder);
+  vi.stubGlobal(
+    "confirm",
+    vi.fn(() => true),
+  );
   return { stopTrack };
 }
 
@@ -87,6 +91,7 @@ beforeEach(() => {
   MockSpeechRecognition.instances = [];
   MockMediaRecorder.instances = [];
   resetVoiceDictationServerStatusForTests();
+  window.localStorage.clear();
   vi.stubGlobal("webkitSpeechRecognition", MockSpeechRecognition);
 });
 
@@ -220,6 +225,134 @@ describe("useVoiceDictation", () => {
       }),
     );
     expect(onTranscript).toHaveBeenCalledWith("Supabase TypeScript project");
+  });
+
+  it("does not start enhanced recording when the user declines audio egress consent", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    stubMediaRecording();
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => false),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+      }),
+    );
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    act(() => result.current.start());
+
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(result.current.error).toBe("enhanced-consent-declined");
+  });
+
+  it("coalesces rapid enhanced recording starts while microphone permission is pending", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    stubMediaRecording();
+    let resolveStream!: (stream: MediaStream) => void;
+    const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream;
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockReturnValue(
+      new Promise<MediaStream>((resolve) => {
+        resolveStream = resolve;
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+      }),
+    );
+    const { result } = renderHook(() => useVoiceDictation(vi.fn()));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    act(() => {
+      result.current.start();
+      result.current.start();
+    });
+    await act(async () => {
+      resolveStream(stream);
+      await Promise.resolve();
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(MockMediaRecorder.instances).toHaveLength(1);
+  });
+
+  it("stops acquired tracks when MediaRecorder construction fails", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    const { stopTrack } = stubMediaRecording();
+    vi.stubGlobal(
+      "MediaRecorder",
+      class {
+        static isTypeSupported = vi.fn(() => true);
+        constructor() {
+          throw new Error("unsupported");
+        }
+      },
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+      }),
+    );
+    const { result } = renderHook(() => useVoiceDictation(vi.fn()));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+
+    expect(stopTrack).toHaveBeenCalled();
+    expect(result.current.error).toBe("microphone-unavailable");
+  });
+
+  it("falls back to browser speech after a server transcription failure", async () => {
+    stubMediaRecording();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: async () => ({}),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.stop();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.error).toBe("transcription-failed"));
+
+    act(() => result.current.start());
+
+    expect(MockSpeechRecognition.instances).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -348,7 +348,7 @@ describe("useVoiceDictation", () => {
         json: async () => ({ available: true, provider: "openai", model: "gpt-4o-transcribe" }),
       }),
     );
-    const { result } = renderHook(() => useVoiceDictation(vi.fn()));
+    const { result, unmount } = renderHook(() => useVoiceDictation(vi.fn()));
 
     await waitFor(() => expect(result.current.supported).toBe(true));
 
@@ -367,8 +367,11 @@ describe("useVoiceDictation", () => {
       await Promise.resolve();
     });
 
-    expect(stopTrack).toHaveBeenCalled();
+    expect(stopTrack).toHaveBeenCalledTimes(1);
     expect(MockMediaRecorder.instances).toHaveLength(0);
+
+    unmount();
+    expect(stopTrack).toHaveBeenCalledTimes(1);
   });
 
   it("stops acquired tracks when MediaRecorder construction fails", async () => {

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -434,11 +434,8 @@ describe("useVoiceDictation", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    await waitFor(() => expect(result.current.error).toBe("transcription-failed"));
-
-    act(() => result.current.start());
-
-    expect(MockSpeechRecognition.instances).toHaveLength(1);
+    await waitFor(() => expect(MockSpeechRecognition.instances).toHaveLength(1));
+    expect(result.current.error).toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/components/acp/useVoiceDictation.test.ts
+++ b/web/src/components/acp/useVoiceDictation.test.ts
@@ -1,9 +1,14 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
-import { mergeSpeechRecognitionSegments, useVoiceDictation, type SpeechRecognitionLike } from "./useVoiceDictation";
+import {
+  mergeSpeechRecognitionSegments,
+  resetVoiceDictationServerStatusForTests,
+  useVoiceDictation,
+  type SpeechRecognitionLike,
+} from "./useVoiceDictation";
 
 class MockSpeechRecognition implements SpeechRecognitionLike {
   static instances: MockSpeechRecognition[] = [];
@@ -36,8 +41,52 @@ class MockSpeechRecognition implements SpeechRecognitionLike {
   }
 }
 
+class MockMediaRecorder {
+  static instances: MockMediaRecorder[] = [];
+  static isTypeSupported = vi.fn(() => true);
+
+  mimeType: string;
+  state: RecordingState = "inactive";
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onstop: ((event: Event) => void) | null = null;
+
+  constructor(
+    public stream: MediaStream,
+    options?: MediaRecorderOptions,
+  ) {
+    this.mimeType = options?.mimeType ?? "audio/webm";
+    MockMediaRecorder.instances.push(this);
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["audio"], { type: this.mimeType }) } as BlobEvent);
+    this.onstop?.(new Event("stop"));
+  }
+}
+
+function stubMediaRecording() {
+  const stopTrack = vi.fn();
+  const stream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream;
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: {
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    },
+  });
+  vi.stubGlobal("MediaRecorder", MockMediaRecorder);
+  return { stopTrack };
+}
+
 beforeEach(() => {
   MockSpeechRecognition.instances = [];
+  MockMediaRecorder.instances = [];
+  resetVoiceDictationServerStatusForTests();
   vi.stubGlobal("webkitSpeechRecognition", MockSpeechRecognition);
 });
 
@@ -115,6 +164,7 @@ describe("useVoiceDictation", () => {
 
   it("reports unsupported browsers without calling the transcript sink", () => {
     vi.unstubAllGlobals();
+    resetVoiceDictationServerStatusForTests();
     const onTranscript = vi.fn();
     const { result } = renderHook(() => useVoiceDictation(onTranscript));
 
@@ -123,6 +173,53 @@ describe("useVoiceDictation", () => {
     expect(result.current.supported).toBe(false);
     expect(result.current.error).toBe("unsupported");
     expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("records audio and inserts server transcription when configured", async () => {
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    const { stopTrack } = stubMediaRecording();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available: true, provider: "openai", model: "gpt-4o-mini-transcribe" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ text: "Supabase TypeScript project" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceDictation(onTranscript));
+
+    await waitFor(() => expect(result.current.supported).toBe(true));
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+
+    expect(MockMediaRecorder.instances).toHaveLength(1);
+    expect(result.current.listening).toBe(true);
+
+    await act(async () => {
+      result.current.stop();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(stopTrack).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/transcription/status");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/transcription",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "audio/webm;codecs=opus" },
+        body: expect.any(Blob),
+      }),
+    );
+    expect(onTranscript).toHaveBeenCalledWith("Supabase TypeScript project");
   });
 });
 

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -195,6 +195,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const latestTranscriptRef = useRef<string | null>(null);
   const lastEmittedTranscriptRef = useRef<string | null>(null);
   const [browserListening, setBrowserListening] = useState(false);
+  const [serverRecordingStarting, setServerRecordingStarting] = useState(false);
   const [serverRecording, setServerRecording] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [serverTranscriptionAvailable, setServerTranscriptionAvailable] = useState(false);
@@ -202,7 +203,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const browserSupported = getSpeechRecognitionConstructor() !== null;
   const mediaSupported = getMediaRecordingSupported();
   const supported = serverTranscriptionAvailable || browserSupported;
-  const listening = browserListening || serverRecording;
+  const listening = browserListening || serverRecordingStarting || serverRecording;
 
   useEffect(() => {
     onTranscriptRef.current = onTranscript;
@@ -220,6 +221,13 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   }, [mediaSupported]);
 
   const stop = useCallback(() => {
+    if (serverRecordingStartingRef.current && !mediaRecorderRef.current) {
+      discardRecordingRef.current = true;
+      serverRecordingStartingRef.current = false;
+      setServerRecordingStarting(false);
+      setServerRecording(false);
+      return;
+    }
     const recorder = mediaRecorderRef.current;
     if (recorder && recorder.state === "recording") {
       discardRecordingRef.current = false;
@@ -250,6 +258,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
     mediaRecorderRef.current = null;
     audioChunksRef.current = [];
     serverRecordingStartingRef.current = false;
+    setServerRecordingStarting(false);
     setServerRecording(false);
   }, []);
 
@@ -316,6 +325,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const startServerRecording = useCallback(async () => {
     if (serverRecordingStartingRef.current || mediaRecorderRef.current || processing) return;
     serverRecordingStartingRef.current = true;
+    setServerRecordingStarting(true);
     discardRecordingRef.current = false;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -323,6 +333,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       if (discardRecordingRef.current) {
         stream.getTracks().forEach((track) => track.stop());
         serverRecordingStartingRef.current = false;
+        setServerRecordingStarting(false);
         return;
       }
       const recorder = new MediaRecorder(stream, mediaRecorderOptions());
@@ -366,6 +377,8 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
 
       recorder.start();
       setError(null);
+      serverRecordingStartingRef.current = false;
+      setServerRecordingStarting(false);
       setServerRecording(true);
     } catch {
       cleanupMediaRecording(true);

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type SpeechRecognitionAlternativeLike = { transcript: string };
+type SpeechRecognitionResultLike = {
+  readonly isFinal: boolean;
+  readonly 0: SpeechRecognitionAlternativeLike;
+};
+type SpeechRecognitionResultListLike = {
+  readonly length: number;
+  readonly [index: number]: SpeechRecognitionResultLike;
+};
+type SpeechRecognitionResultEventLike = {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultListLike;
+};
+type SpeechRecognitionErrorEventLike = { readonly error?: string };
+
+export interface SpeechRecognitionLike {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: SpeechRecognitionResultEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort?: () => void;
+}
+
+export type SpeechRecognitionConstructorLike = new () => SpeechRecognitionLike;
+
+type SpeechRecognitionWindow = Window &
+  typeof globalThis & {
+    SpeechRecognition?: SpeechRecognitionConstructorLike;
+    webkitSpeechRecognition?: SpeechRecognitionConstructorLike;
+  };
+
+export function getSpeechRecognitionConstructor(): SpeechRecognitionConstructorLike | null {
+  if (typeof window === "undefined") return null;
+  const speechWindow = window as SpeechRecognitionWindow;
+  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition ?? null;
+}
+
+function normalizeTranscriptSegment(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function isBoundaryPrefix(previous: string, next: string): boolean {
+  const previousLower = previous.toLocaleLowerCase();
+  const nextLower = next.toLocaleLowerCase();
+  if (!nextLower.startsWith(previousLower)) return false;
+  const boundary = next.charAt(previous.length);
+  return boundary === "" || !/[A-Za-z0-9]/.test(boundary);
+}
+
+function findWordOverlap(previous: string, next: string): number {
+  const previousWords = previous.split(/\s+/);
+  const nextWords = next.split(/\s+/);
+  const maxOverlap = Math.min(previousWords.length, nextWords.length);
+
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    const previousSuffix = previousWords
+      .slice(previousWords.length - overlap)
+      .join(" ")
+      .toLocaleLowerCase();
+    const nextPrefix = nextWords.slice(0, overlap).join(" ").toLocaleLowerCase();
+    if (previousSuffix === nextPrefix) return overlap;
+  }
+
+  return 0;
+}
+
+export function mergeSpeechRecognitionSegments(segments: string[]): string {
+  let merged = "";
+
+  for (const segment of segments) {
+    const next = normalizeTranscriptSegment(segment);
+    if (!next) continue;
+
+    if (!merged) {
+      merged = next;
+      continue;
+    }
+
+    if (isBoundaryPrefix(merged, next)) {
+      merged = next;
+      continue;
+    }
+
+    const overlap = findWordOverlap(merged, next);
+    if (overlap > 0) {
+      const nextRemainder = next.split(/\s+/).slice(overlap).join(" ");
+      merged = nextRemainder ? `${merged} ${nextRemainder}` : merged;
+      continue;
+    }
+
+    merged = `${merged} ${next}`;
+  }
+
+  return merged.trim();
+}
+
+export interface VoiceDictationState {
+  supported: boolean;
+  listening: boolean;
+  error: string | null;
+  start: () => void;
+  stop: () => void;
+}
+
+export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDictationState {
+  const onTranscriptRef = useRef(onTranscript);
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const transcriptSegmentsRef = useRef<string[]>([]);
+  const latestTranscriptRef = useRef<string | null>(null);
+  const lastEmittedTranscriptRef = useRef<string | null>(null);
+  const [listening, setListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const supported = getSpeechRecognitionConstructor() !== null;
+
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+  }, []);
+
+  const start = useCallback(() => {
+    if (recognitionRef.current) return;
+    const Recognition = getSpeechRecognitionConstructor();
+    if (!Recognition) {
+      setError("unsupported");
+      return;
+    }
+
+    const recognition = new Recognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language || "en-US";
+    recognitionRef.current = recognition;
+    transcriptSegmentsRef.current = [];
+    latestTranscriptRef.current = null;
+    lastEmittedTranscriptRef.current = null;
+
+    recognition.onresult = (event) => {
+      const segments = transcriptSegmentsRef.current;
+      for (let i = 0; i < event.results.length; i += 1) {
+        const result = event.results[i];
+        if (!result) continue;
+        const transcript = result?.[0]?.transcript ?? "";
+        segments[i] = transcript;
+      }
+      segments.length = event.results.length;
+
+      const cleaned = mergeSpeechRecognitionSegments(segments);
+      latestTranscriptRef.current = cleaned || null;
+      if (cleaned && cleaned !== lastEmittedTranscriptRef.current) {
+        lastEmittedTranscriptRef.current = cleaned;
+        onTranscriptRef.current(cleaned);
+      }
+    };
+    recognition.onerror = (event) => {
+      setError(event.error ?? "speech-recognition-error");
+    };
+    recognition.onend = () => {
+      const fallback = latestTranscriptRef.current;
+      transcriptSegmentsRef.current = [];
+      latestTranscriptRef.current = null;
+      recognitionRef.current = null;
+      setListening(false);
+      if (fallback && fallback !== lastEmittedTranscriptRef.current) {
+        lastEmittedTranscriptRef.current = fallback;
+        onTranscriptRef.current(fallback);
+      }
+    };
+
+    try {
+      recognition.start();
+      setError(null);
+      setListening(true);
+    } catch {
+      recognitionRef.current = null;
+      setListening(false);
+      setError("start-failed");
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort?.();
+      recognitionRef.current = null;
+      transcriptSegmentsRef.current = [];
+      latestTranscriptRef.current = null;
+      lastEmittedTranscriptRef.current = null;
+    };
+  }, []);
+
+  return { supported, listening, error, start, stop };
+}

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -332,6 +332,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       mediaStreamRef.current = stream;
       if (discardRecordingRef.current) {
         stream.getTracks().forEach((track) => track.stop());
+        mediaStreamRef.current = null;
         serverRecordingStartingRef.current = false;
         setServerRecordingStarting(false);
         return;

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -35,10 +35,63 @@ type SpeechRecognitionWindow = Window &
     webkitSpeechRecognition?: SpeechRecognitionConstructorLike;
   };
 
+interface TranscriptionStatusResponse {
+  available?: boolean;
+}
+
+interface TranscriptionResponse {
+  text?: string;
+}
+
+let serverTranscriptionStatusPromise: Promise<boolean> | null = null;
+
 export function getSpeechRecognitionConstructor(): SpeechRecognitionConstructorLike | null {
   if (typeof window === "undefined") return null;
   const speechWindow = window as SpeechRecognitionWindow;
   return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition ?? null;
+}
+
+export function getMediaRecordingSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof MediaRecorder !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function"
+  );
+}
+
+export function resetVoiceDictationServerStatusForTests(): void {
+  serverTranscriptionStatusPromise = null;
+}
+
+async function getServerTranscriptionAvailable(): Promise<boolean> {
+  serverTranscriptionStatusPromise ??= fetch("/api/transcription/status")
+    .then(async (response) => {
+      if (!response.ok) return false;
+      const status = (await response.json()) as TranscriptionStatusResponse;
+      return status.available === true;
+    })
+    .catch(() => false);
+  return serverTranscriptionStatusPromise;
+}
+
+function mediaRecorderOptions(): MediaRecorderOptions | undefined {
+  const preferredTypes = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/mpeg"];
+  const mimeType = preferredTypes.find((type) => MediaRecorder.isTypeSupported?.(type));
+  return mimeType ? { mimeType } : undefined;
+}
+
+async function transcribeAudio(blob: Blob): Promise<string> {
+  const response = await fetch("/api/transcription", {
+    method: "POST",
+    headers: blob.type ? { "Content-Type": blob.type } : undefined,
+    body: blob,
+  });
+  if (!response.ok) throw new Error(`transcription failed: ${response.status}`);
+  const body = (await response.json()) as TranscriptionResponse;
+  const text = body.text?.trim();
+  if (!text) throw new Error("empty transcription");
+  return text;
 }
 
 function normalizeTranscriptSegment(text: string): string {
@@ -103,6 +156,7 @@ export function mergeSpeechRecognitionSegments(segments: string[]): string {
 export interface VoiceDictationState {
   supported: boolean;
   listening: boolean;
+  processing: boolean;
   error: string | null;
   start: () => void;
   stop: () => void;
@@ -111,22 +165,56 @@ export interface VoiceDictationState {
 export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDictationState {
   const onTranscriptRef = useRef(onTranscript);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
   const transcriptSegmentsRef = useRef<string[]>([]);
   const latestTranscriptRef = useRef<string | null>(null);
   const lastEmittedTranscriptRef = useRef<string | null>(null);
-  const [listening, setListening] = useState(false);
+  const [browserListening, setBrowserListening] = useState(false);
+  const [serverRecording, setServerRecording] = useState(false);
+  const [processing, setProcessing] = useState(false);
+  const [serverTranscriptionAvailable, setServerTranscriptionAvailable] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const supported = getSpeechRecognitionConstructor() !== null;
+  const browserSupported = getSpeechRecognitionConstructor() !== null;
+  const mediaSupported = getMediaRecordingSupported();
+  const supported = serverTranscriptionAvailable || browserSupported;
+  const listening = browserListening || serverRecording;
 
   useEffect(() => {
     onTranscriptRef.current = onTranscript;
   }, [onTranscript]);
 
+  useEffect(() => {
+    if (!mediaSupported) return;
+    let cancelled = false;
+    void getServerTranscriptionAvailable().then((available) => {
+      if (!cancelled) setServerTranscriptionAvailable(available);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mediaSupported]);
+
   const stop = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state === "recording") {
+      recorder.stop();
+      setServerRecording(false);
+      return;
+    }
     recognitionRef.current?.stop();
   }, []);
 
-  const start = useCallback(() => {
+  const cleanupMediaRecording = useCallback(() => {
+    mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+    mediaStreamRef.current = null;
+    mediaRecorderRef.current = null;
+    audioChunksRef.current = [];
+    setServerRecording(false);
+  }, []);
+
+  const startBrowserRecognition = useCallback(() => {
     if (recognitionRef.current) return;
     const Recognition = getSpeechRecognitionConstructor();
     if (!Recognition) {
@@ -168,7 +256,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       transcriptSegmentsRef.current = [];
       latestTranscriptRef.current = null;
       recognitionRef.current = null;
-      setListening(false);
+      setBrowserListening(false);
       if (fallback && fallback !== lastEmittedTranscriptRef.current) {
         lastEmittedTranscriptRef.current = fallback;
         onTranscriptRef.current(fallback);
@@ -178,23 +266,79 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
     try {
       recognition.start();
       setError(null);
-      setListening(true);
+      setBrowserListening(true);
     } catch {
       recognitionRef.current = null;
-      setListening(false);
+      setBrowserListening(false);
       setError("start-failed");
     }
   }, []);
+
+  const startServerRecording = useCallback(async () => {
+    if (mediaRecorderRef.current || processing) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream, mediaRecorderOptions());
+      mediaStreamRef.current = stream;
+      mediaRecorderRef.current = recorder;
+      audioChunksRef.current = [];
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) audioChunksRef.current.push(event.data);
+      };
+      recorder.onerror = () => {
+        setError("recording-error");
+        cleanupMediaRecording();
+      };
+      recorder.onstop = () => {
+        const mimeType = recorder.mimeType || audioChunksRef.current[0]?.type || "audio/webm";
+        const audio = new Blob(audioChunksRef.current, { type: mimeType });
+        cleanupMediaRecording();
+        if (audio.size === 0) {
+          setError("empty-recording");
+          return;
+        }
+        setProcessing(true);
+        void transcribeAudio(audio)
+          .then((text) => {
+            setError(null);
+            onTranscriptRef.current(text);
+          })
+          .catch(() => {
+            setError("transcription-failed");
+          })
+          .finally(() => {
+            setProcessing(false);
+          });
+      };
+
+      recorder.start();
+      setError(null);
+      setServerRecording(true);
+    } catch {
+      cleanupMediaRecording();
+      setError("microphone-unavailable");
+    }
+  }, [cleanupMediaRecording, processing]);
+
+  const start = useCallback(() => {
+    if (serverTranscriptionAvailable && mediaSupported) {
+      void startServerRecording();
+      return;
+    }
+    startBrowserRecognition();
+  }, [mediaSupported, serverTranscriptionAvailable, startBrowserRecognition, startServerRecording]);
 
   useEffect(() => {
     return () => {
       recognitionRef.current?.abort?.();
       recognitionRef.current = null;
+      cleanupMediaRecording();
       transcriptSegmentsRef.current = [];
       latestTranscriptRef.current = null;
       lastEmittedTranscriptRef.current = null;
     };
-  }, []);
+  }, [cleanupMediaRecording]);
 
-  return { supported, listening, error, start, stop };
+  return { supported, listening, processing, error, start, stop };
 }

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -369,7 +369,11 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
           .catch(() => {
             disableServerTranscriptionForSession();
             setServerTranscriptionAvailable(false);
-            setError("transcription-failed");
+            if (browserSupported) {
+              startBrowserRecognition();
+            } else {
+              setError("transcription-failed");
+            }
           })
           .finally(() => {
             setProcessing(false);
@@ -385,7 +389,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       cleanupMediaRecording(true);
       setError("microphone-unavailable");
     }
-  }, [cleanupMediaRecording, processing]);
+  }, [browserSupported, cleanupMediaRecording, processing, startBrowserRecognition]);
 
   const start = useCallback(() => {
     if (serverTranscriptionAvailable && mediaSupported) {

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { safeGetItem, safeSetItem } from "../../lib/safeStorage";
+
 type SpeechRecognitionAlternativeLike = { transcript: string };
 type SpeechRecognitionResultLike = {
   readonly isFinal: boolean;
@@ -44,6 +46,7 @@ interface TranscriptionResponse {
 }
 
 let serverTranscriptionStatusPromise: Promise<boolean> | null = null;
+const ENHANCED_DICTATION_CONSENT_KEY = "aoe.voiceDictation.enhancedConsent";
 
 export function getSpeechRecognitionConstructor(): SpeechRecognitionConstructorLike | null {
   if (typeof window === "undefined") return null;
@@ -62,6 +65,24 @@ export function getMediaRecordingSupported(): boolean {
 
 export function resetVoiceDictationServerStatusForTests(): void {
   serverTranscriptionStatusPromise = null;
+}
+
+function disableServerTranscriptionForSession(): void {
+  serverTranscriptionStatusPromise = Promise.resolve(false);
+}
+
+function hasEnhancedDictationConsent(): boolean {
+  return safeGetItem(ENHANCED_DICTATION_CONSENT_KEY) === "1";
+}
+
+function requestEnhancedDictationConsent(): boolean {
+  if (hasEnhancedDictationConsent()) return true;
+  const accepted = window.confirm(
+    "Enhanced voice dictation sends recorded audio to this AoE server for OpenAI transcription using the server owner's API key. Continue?",
+  );
+  if (!accepted) return false;
+  safeSetItem(ENHANCED_DICTATION_CONSENT_KEY, "1");
+  return true;
 }
 
 async function getServerTranscriptionAvailable(): Promise<boolean> {
@@ -168,6 +189,8 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
+  const serverRecordingStartingRef = useRef(false);
+  const discardRecordingRef = useRef(false);
   const transcriptSegmentsRef = useRef<string[]>([]);
   const latestTranscriptRef = useRef<string | null>(null);
   const lastEmittedTranscriptRef = useRef<string | null>(null);
@@ -199,6 +222,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const stop = useCallback(() => {
     const recorder = mediaRecorderRef.current;
     if (recorder && recorder.state === "recording") {
+      discardRecordingRef.current = false;
       recorder.stop();
       setServerRecording(false);
       return;
@@ -206,11 +230,26 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
     recognitionRef.current?.stop();
   }, []);
 
-  const cleanupMediaRecording = useCallback(() => {
+  const cleanupMediaRecording = useCallback((discard = true) => {
+    const recorder = mediaRecorderRef.current;
+    if (discard) discardRecordingRef.current = true;
+    if (recorder) {
+      recorder.ondataavailable = null;
+      recorder.onerror = null;
+      recorder.onstop = null;
+      if (discard && recorder.state === "recording") {
+        try {
+          recorder.stop();
+        } catch {
+          // ignore: the browser may already be stopping the recorder
+        }
+      }
+    }
     mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
     mediaStreamRef.current = null;
     mediaRecorderRef.current = null;
     audioChunksRef.current = [];
+    serverRecordingStartingRef.current = false;
     setServerRecording(false);
   }, []);
 
@@ -275,11 +314,18 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   }, []);
 
   const startServerRecording = useCallback(async () => {
-    if (mediaRecorderRef.current || processing) return;
+    if (serverRecordingStartingRef.current || mediaRecorderRef.current || processing) return;
+    serverRecordingStartingRef.current = true;
+    discardRecordingRef.current = false;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const recorder = new MediaRecorder(stream, mediaRecorderOptions());
       mediaStreamRef.current = stream;
+      if (discardRecordingRef.current) {
+        stream.getTracks().forEach((track) => track.stop());
+        serverRecordingStartingRef.current = false;
+        return;
+      }
+      const recorder = new MediaRecorder(stream, mediaRecorderOptions());
       mediaRecorderRef.current = recorder;
       audioChunksRef.current = [];
 
@@ -288,12 +334,16 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       };
       recorder.onerror = () => {
         setError("recording-error");
-        cleanupMediaRecording();
+        cleanupMediaRecording(true);
       };
       recorder.onstop = () => {
+        if (discardRecordingRef.current) {
+          cleanupMediaRecording(true);
+          return;
+        }
         const mimeType = recorder.mimeType || audioChunksRef.current[0]?.type || "audio/webm";
         const audio = new Blob(audioChunksRef.current, { type: mimeType });
-        cleanupMediaRecording();
+        cleanupMediaRecording(false);
         if (audio.size === 0) {
           setError("empty-recording");
           return;
@@ -305,6 +355,8 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
             onTranscriptRef.current(text);
           })
           .catch(() => {
+            disableServerTranscriptionForSession();
+            setServerTranscriptionAvailable(false);
             setError("transcription-failed");
           })
           .finally(() => {
@@ -316,13 +368,17 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       setError(null);
       setServerRecording(true);
     } catch {
-      cleanupMediaRecording();
+      cleanupMediaRecording(true);
       setError("microphone-unavailable");
     }
   }, [cleanupMediaRecording, processing]);
 
   const start = useCallback(() => {
     if (serverTranscriptionAvailable && mediaSupported) {
+      if (!requestEnhancedDictationConsent()) {
+        setError("enhanced-consent-declined");
+        return;
+      }
       void startServerRecording();
       return;
     }
@@ -333,7 +389,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
     return () => {
       recognitionRef.current?.abort?.();
       recognitionRef.current = null;
-      cleanupMediaRecording();
+      cleanupMediaRecording(true);
       transcriptSegmentsRef.current = [];
       latestTranscriptRef.current = null;
       lastEmittedTranscriptRef.current = null;

--- a/web/src/components/acp/useVoiceDictation.ts
+++ b/web/src/components/acp/useVoiceDictation.ts
@@ -36,6 +36,10 @@ type SpeechRecognitionWindow = Window &
     SpeechRecognition?: SpeechRecognitionConstructorLike;
     webkitSpeechRecognition?: SpeechRecognitionConstructorLike;
   };
+type AudioContextWindow = Window &
+  typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext;
+  };
 
 interface TranscriptionStatusResponse {
   available?: boolean;
@@ -178,6 +182,7 @@ export interface VoiceDictationState {
   supported: boolean;
   listening: boolean;
   processing: boolean;
+  audioLevel: number | null;
   error: string | null;
   start: () => void;
   stop: () => void;
@@ -188,9 +193,16 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const audioLevelFrameRef = useRef<number | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const serverRecordingStartingRef = useRef(false);
   const discardRecordingRef = useRef(false);
+  const browserSessionActiveRef = useRef(false);
+  const browserRestartTimerRef = useRef<number | null>(null);
+  const startBrowserRecognitionInstanceRef = useRef<() => void>(() => {});
+  const browserCommittedTranscriptRef = useRef("");
+  const currentRecognitionTranscriptRef = useRef<string | null>(null);
   const transcriptSegmentsRef = useRef<string[]>([]);
   const latestTranscriptRef = useRef<string | null>(null);
   const lastEmittedTranscriptRef = useRef<string | null>(null);
@@ -198,6 +210,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   const [serverRecordingStarting, setServerRecordingStarting] = useState(false);
   const [serverRecording, setServerRecording] = useState(false);
   const [processing, setProcessing] = useState(false);
+  const [audioLevel, setAudioLevel] = useState<number | null>(null);
   const [serverTranscriptionAvailable, setServerTranscriptionAvailable] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const browserSupported = getSpeechRecognitionConstructor() !== null;
@@ -208,6 +221,77 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
   useEffect(() => {
     onTranscriptRef.current = onTranscript;
   }, [onTranscript]);
+
+  const clearBrowserRestartTimer = useCallback(() => {
+    if (browserRestartTimerRef.current == null) return;
+    window.clearTimeout(browserRestartTimerRef.current);
+    browserRestartTimerRef.current = null;
+  }, []);
+
+  const emitBrowserTranscript = useCallback((currentRecognitionTranscript: string) => {
+    const cleaned = mergeSpeechRecognitionSegments([
+      browserCommittedTranscriptRef.current,
+      currentRecognitionTranscript,
+    ]);
+    latestTranscriptRef.current = cleaned || null;
+    if (cleaned && cleaned !== lastEmittedTranscriptRef.current) {
+      lastEmittedTranscriptRef.current = cleaned;
+      onTranscriptRef.current(cleaned);
+    }
+  }, []);
+
+  const cleanupAudioLevelMeter = useCallback(() => {
+    if (audioLevelFrameRef.current != null) {
+      window.cancelAnimationFrame(audioLevelFrameRef.current);
+      audioLevelFrameRef.current = null;
+    }
+    const context = audioContextRef.current;
+    audioContextRef.current = null;
+    if (context && context.state !== "closed") {
+      void context.close().catch(() => {});
+    }
+    setAudioLevel(null);
+  }, []);
+
+  const startAudioLevelMeter = useCallback(
+    (stream: MediaStream) => {
+      cleanupAudioLevelMeter();
+      const audioWindow = window as AudioContextWindow;
+      const AudioContextCtor = window.AudioContext ?? audioWindow.webkitAudioContext;
+      if (!AudioContextCtor) {
+        setAudioLevel(null);
+        return;
+      }
+
+      try {
+        const context = new AudioContextCtor();
+        const analyser = context.createAnalyser();
+        analyser.fftSize = 256;
+        const source = context.createMediaStreamSource(stream);
+        source.connect(analyser);
+        const samples = new Uint8Array(analyser.fftSize);
+        audioContextRef.current = context;
+
+        const tick = () => {
+          analyser.getByteTimeDomainData(samples);
+          let sum = 0;
+          for (const sample of samples) {
+            const centered = sample - 128;
+            sum += centered * centered;
+          }
+          const rms = Math.sqrt(sum / samples.length);
+          setAudioLevel(Math.min(1, rms / 42));
+          audioLevelFrameRef.current = window.requestAnimationFrame(tick);
+        };
+
+        void context.resume().catch(() => {});
+        tick();
+      } catch {
+        cleanupAudioLevelMeter();
+      }
+    },
+    [cleanupAudioLevelMeter],
+  );
 
   useEffect(() => {
     if (!mediaSupported) return;
@@ -231,41 +315,59 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
     const recorder = mediaRecorderRef.current;
     if (recorder && recorder.state === "recording") {
       discardRecordingRef.current = false;
+      setProcessing(true);
       recorder.stop();
       setServerRecording(false);
       return;
     }
-    recognitionRef.current?.stop();
-  }, []);
+    browserSessionActiveRef.current = false;
+    clearBrowserRestartTimer();
+    const recognition = recognitionRef.current;
+    if (recognition) {
+      recognition.stop();
+      return;
+    }
+    setBrowserListening(false);
+    transcriptSegmentsRef.current = [];
+    currentRecognitionTranscriptRef.current = null;
+    latestTranscriptRef.current = null;
+    lastEmittedTranscriptRef.current = null;
+    browserCommittedTranscriptRef.current = "";
+  }, [clearBrowserRestartTimer]);
 
-  const cleanupMediaRecording = useCallback((discard = true) => {
-    const recorder = mediaRecorderRef.current;
-    if (discard) discardRecordingRef.current = true;
-    if (recorder) {
-      recorder.ondataavailable = null;
-      recorder.onerror = null;
-      recorder.onstop = null;
-      if (discard && recorder.state === "recording") {
-        try {
-          recorder.stop();
-        } catch {
-          // ignore: the browser may already be stopping the recorder
+  const cleanupMediaRecording = useCallback(
+    (discard = true) => {
+      const recorder = mediaRecorderRef.current;
+      if (discard) discardRecordingRef.current = true;
+      if (recorder) {
+        recorder.ondataavailable = null;
+        recorder.onerror = null;
+        recorder.onstop = null;
+        if (discard && recorder.state === "recording") {
+          try {
+            recorder.stop();
+          } catch {
+            // ignore: the browser may already be stopping the recorder
+          }
         }
       }
-    }
-    mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
-    mediaStreamRef.current = null;
-    mediaRecorderRef.current = null;
-    audioChunksRef.current = [];
-    serverRecordingStartingRef.current = false;
-    setServerRecordingStarting(false);
-    setServerRecording(false);
-  }, []);
+      mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+      mediaStreamRef.current = null;
+      mediaRecorderRef.current = null;
+      audioChunksRef.current = [];
+      cleanupAudioLevelMeter();
+      serverRecordingStartingRef.current = false;
+      setServerRecordingStarting(false);
+      setServerRecording(false);
+    },
+    [cleanupAudioLevelMeter],
+  );
 
-  const startBrowserRecognition = useCallback(() => {
+  const startBrowserRecognitionInstance = useCallback(() => {
     if (recognitionRef.current) return;
     const Recognition = getSpeechRecognitionConstructor();
     if (!Recognition) {
+      browserSessionActiveRef.current = false;
       setError("unsupported");
       return;
     }
@@ -276,8 +378,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
     recognition.lang = navigator.language || "en-US";
     recognitionRef.current = recognition;
     transcriptSegmentsRef.current = [];
-    latestTranscriptRef.current = null;
-    lastEmittedTranscriptRef.current = null;
+    currentRecognitionTranscriptRef.current = null;
 
     recognition.onresult = (event) => {
       const segments = transcriptSegmentsRef.current;
@@ -290,25 +391,46 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       segments.length = event.results.length;
 
       const cleaned = mergeSpeechRecognitionSegments(segments);
-      latestTranscriptRef.current = cleaned || null;
-      if (cleaned && cleaned !== lastEmittedTranscriptRef.current) {
-        lastEmittedTranscriptRef.current = cleaned;
-        onTranscriptRef.current(cleaned);
-      }
+      currentRecognitionTranscriptRef.current = cleaned || null;
+      if (cleaned) emitBrowserTranscript(cleaned);
     };
     recognition.onerror = (event) => {
-      setError(event.error ?? "speech-recognition-error");
+      const reason = event.error ?? "speech-recognition-error";
+      if (["audio-capture", "language-not-supported", "not-allowed", "service-not-allowed"].includes(reason)) {
+        browserSessionActiveRef.current = false;
+        setError(reason);
+      } else if (!browserSessionActiveRef.current) {
+        setError(reason);
+      }
     };
     recognition.onend = () => {
-      const fallback = latestTranscriptRef.current;
+      const currentRecognitionTranscript = currentRecognitionTranscriptRef.current;
+      if (currentRecognitionTranscript) {
+        browserCommittedTranscriptRef.current = mergeSpeechRecognitionSegments([
+          browserCommittedTranscriptRef.current,
+          currentRecognitionTranscript,
+        ]);
+      }
       transcriptSegmentsRef.current = [];
-      latestTranscriptRef.current = null;
+      currentRecognitionTranscriptRef.current = null;
       recognitionRef.current = null;
-      setBrowserListening(false);
+      if (browserSessionActiveRef.current) {
+        setBrowserListening(true);
+        clearBrowserRestartTimer();
+        browserRestartTimerRef.current = window.setTimeout(() => {
+          browserRestartTimerRef.current = null;
+          startBrowserRecognitionInstanceRef.current();
+        }, 100);
+        return;
+      }
+      const fallback = browserCommittedTranscriptRef.current || latestTranscriptRef.current;
       if (fallback && fallback !== lastEmittedTranscriptRef.current) {
         lastEmittedTranscriptRef.current = fallback;
         onTranscriptRef.current(fallback);
       }
+      setBrowserListening(false);
+      latestTranscriptRef.current = null;
+      browserCommittedTranscriptRef.current = "";
     };
 
     try {
@@ -317,10 +439,27 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       setBrowserListening(true);
     } catch {
       recognitionRef.current = null;
+      browserSessionActiveRef.current = false;
       setBrowserListening(false);
       setError("start-failed");
     }
-  }, []);
+  }, [clearBrowserRestartTimer, emitBrowserTranscript]);
+
+  useEffect(() => {
+    startBrowserRecognitionInstanceRef.current = startBrowserRecognitionInstance;
+  }, [startBrowserRecognitionInstance]);
+
+  const startBrowserRecognition = useCallback(() => {
+    if (browserSessionActiveRef.current || recognitionRef.current) return;
+    browserSessionActiveRef.current = true;
+    clearBrowserRestartTimer();
+    browserCommittedTranscriptRef.current = "";
+    transcriptSegmentsRef.current = [];
+    currentRecognitionTranscriptRef.current = null;
+    latestTranscriptRef.current = null;
+    lastEmittedTranscriptRef.current = null;
+    startBrowserRecognitionInstance();
+  }, [clearBrowserRestartTimer, startBrowserRecognitionInstance]);
 
   const startServerRecording = useCallback(async () => {
     if (serverRecordingStartingRef.current || mediaRecorderRef.current || processing) return;
@@ -337,6 +476,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
         setServerRecordingStarting(false);
         return;
       }
+      startAudioLevelMeter(stream);
       const recorder = new MediaRecorder(stream, mediaRecorderOptions());
       mediaRecorderRef.current = recorder;
       audioChunksRef.current = [];
@@ -346,6 +486,7 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       };
       recorder.onerror = () => {
         setError("recording-error");
+        setProcessing(false);
         cleanupMediaRecording(true);
       };
       recorder.onstop = () => {
@@ -358,9 +499,9 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
         cleanupMediaRecording(false);
         if (audio.size === 0) {
           setError("empty-recording");
+          setProcessing(false);
           return;
         }
-        setProcessing(true);
         void transcribeAudio(audio)
           .then((text) => {
             setError(null);
@@ -387,9 +528,10 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
       setServerRecording(true);
     } catch {
       cleanupMediaRecording(true);
+      setProcessing(false);
       setError("microphone-unavailable");
     }
-  }, [browserSupported, cleanupMediaRecording, processing, startBrowserRecognition]);
+  }, [browserSupported, cleanupMediaRecording, processing, startAudioLevelMeter, startBrowserRecognition]);
 
   const start = useCallback(() => {
     if (serverTranscriptionAvailable && mediaSupported) {
@@ -405,14 +547,18 @@ export function useVoiceDictation(onTranscript: (text: string) => void): VoiceDi
 
   useEffect(() => {
     return () => {
+      browserSessionActiveRef.current = false;
+      clearBrowserRestartTimer();
       recognitionRef.current?.abort?.();
       recognitionRef.current = null;
       cleanupMediaRecording(true);
       transcriptSegmentsRef.current = [];
+      currentRecognitionTranscriptRef.current = null;
       latestTranscriptRef.current = null;
       lastEmittedTranscriptRef.current = null;
+      browserCommittedTranscriptRef.current = "";
     };
-  }, [cleanupMediaRecording]);
+  }, [cleanupMediaRecording, clearBrowserRestartTimer]);
 
-  return { supported, listening, processing, error, start, stop };
+  return { supported, listening, processing, audioLevel, error, start, stop };
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -196,6 +196,28 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.aoe-voice-wave-bar {
+  transform-origin: center;
+}
+
+@keyframes aoe-voice-wave {
+  0%,
+  100% {
+    transform: scaleY(0.35);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aoe-voice-wave-bar {
+    animation: none !important;
+  }
+}
+
 /* Structured view markdown — assistant-ui's MarkdownTextPrimitive renders
    raw <p>/<ul>/<ol>/<h*>/<blockquote>/<code> elements (no class
    names). Style them via descendant selectors so the prose looks

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2374,6 +2374,13 @@
       "components": ["web/src/components/acp/Composer.tsx"]
     },
     {
+      "id": "acp.story.composer-mobile-voice-dictation",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/acp/Composer.voiceDictation.test.tsx", "src/components/acp/useVoiceDictation.test.ts"],
+      "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/useVoiceDictation.ts"]
+    },
+    {
       "id": "acp.composer-ios-dictation-state-machine",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2378,7 +2378,11 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": ["src/components/acp/Composer.voiceDictation.test.tsx", "src/components/acp/useVoiceDictation.test.ts"],
-      "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/useVoiceDictation.ts"]
+      "components": [
+        "web/src/components/acp/Composer.tsx",
+        "web/src/components/acp/useVoiceDictation.ts",
+        "src/server/api/transcription.rs"
+      ]
     },
     {
       "id": "acp.composer-ios-dictation-state-machine",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2378,11 +2378,7 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": ["src/components/acp/Composer.voiceDictation.test.tsx", "src/components/acp/useVoiceDictation.test.ts"],
-      "components": [
-        "web/src/components/acp/Composer.tsx",
-        "web/src/components/acp/useVoiceDictation.ts",
-        "src/server/api/transcription.rs"
-      ]
+      "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/useVoiceDictation.ts"]
     },
     {
       "id": "acp.composer-ios-dictation-state-machine",


### PR DESCRIPTION
## Description

Adds mobile voice dictation to the ACP composer. On mobile, the microphone action replaces the send button while the draft is empty, then send returns once the user types text. Dictation inserts transcribed text into the composer without submitting it.

The initial path keeps a browser Web Speech fallback, but the preferred path now records audio with `MediaRecorder` and sends it to a new server transcription endpoint when `AOE_TRANSCRIPTION_ENABLED=1` and `OPENAI_API_KEY` are configured. The backend defaults to `gpt-4o-transcribe`, supports model/prompt/glossary/language env overrides, and applies a small technical-term correction pass for common coding-product misrecognitions such as `Super Bass` -> `Supabase`.

This is BYOK and explicit opt-in: enhanced transcription is only available when the server environment has both `AOE_TRANSCRIPTION_ENABLED=1` and `OPENAI_API_KEY`; otherwise the UI falls back to browser speech recognition. The client asks for one-time enhanced dictation consent before audio leaves the browser, and the endpoint rejects read-only servers, empty/oversized bodies, disabled/unconfigured servers, non-audio uploads, and excess concurrent requests before calling OpenAI.

This also hardens a few existing async/tmux tests that the review pass exposed under local tmux base-index and WSL watcher-limit settings.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Screenshots

Empty composer: mic replaces Send on mobile.

![mobile-empty-mic](https://github.com/amanzainal/gitshot-images/releases/download/_gitshot/mobile-empty-mic-4bb8f4f2.png)

Typed draft: Send returns once text is present.

![mobile-typed-send](https://github.com/amanzainal/gitshot-images/releases/download/_gitshot/mobile-typed-send-4778d76d.png)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR does not change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: real microphone permission, `MediaRecorder`, and remote transcription are not reliable in Playwright; the user-facing mobile composer behavior is covered by focused Vitest tests, the coverage matrix was updated, and the flow was manually tested on a phone over Tailscale.

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `cd web && npm run test:unit -- src/components/acp/useVoiceDictation.test.ts src/components/acp/Composer.voiceDictation.test.tsx`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `cd web && node tests/validate-coverage-matrix.mjs`
- `cd web && npm run build`
- `cargo fmt --check`
- `cargo clippy --features serve -- -D warnings`
- `cargo build --features serve`
- `cargo test --features serve server::api::transcription -- --nocapture`
- `cargo test --features serve server::api::tests::every_mutating_handler_has_read_only_guard -- --nocapture`
- `cargo test --features serve session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt -- --nocapture`
- `cargo test --features serve tmux::session::tests::capture_pane_with_cursor_returns_content_and_cursor -- --nocapture`
- `cargo test --features serve tmux::session::tests::capture_with_cursor_stays_consistent_under_streaming_load -- --nocapture`
- `cargo test --features serve tmux::tests::test_export_exec_compound_command_passes_env -- --nocapture`
- `cargo test --features serve session::storage::tests::test_update_write_failure_emits_no_notify -- --nocapture`
- Review-gap regression coverage: consent is only prompted once, pending microphone permission can be cancelled, dictated text restores Send after stopping, explicit transcription enablement is parsed, and non-audio transcription uploads are rejected.
- `cargo test --features serve session::storage::tests::test_update -- --nocapture --test-threads=1`
- `cargo test --features serve session::storage::tests::test_workspace_ordering -- --nocapture --test-threads=1`
- `cargo test --features serve session::sync::tests::drain_ -- --nocapture --test-threads=1`
- Live endpoint smoke: posted a small public-domain speech clip to `/api/transcription` with `OPENAI_API_KEY` configured and received a successful transcription.
- Manual phone smoke: tested the installed PWA/mobile browser over Tailscale; enhanced dictation was materially more accurate for technical input.
- Local full-suite note: `cargo test --features serve` now runs past the previously failing tmux and storage cases, but this WSL session is currently exhausting inotify watcher instances (`/proc/sys/fs/inotify/max_user_instances=128`), so file-watch tests fail locally because the live watcher cannot initialize. CI should be the authoritative full-suite signal.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you would like to share:**

Implemented by an AI coding agent with human-directed testing and acceptance.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785372200&installation_id=139138837&pr_number=2567&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2567&signature=520bf8391b110d5fde4749b62654855b3c385993cb2e2385ad8b3c9f5532a79e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Added **mobile voice dictation** to the ACP composer so the **mic button replaces “Send”** when the draft is empty; **dictated text is inserted without submitting**, and **“Send” reappears** once there’s text.
- Implemented **two transcription paths**:
  - **Enhanced server-backed transcription** (preferred): records audio in-browser, uploads it to a new transcription API, and inserts the returned transcript.
  - **Browser speech-recognition fallback**: used when enhanced mode isn’t available/consented, or when enhanced transcription fails.
- Added new **server API endpoints**:
  - A status endpoint to indicate whether enhanced transcription is available.
  - An audio transcription endpoint that enforces **explicit opt-in consent**, **read-only rejection**, **empty/oversized request rejection**, **allowed audio-type checks**, and **concurrency limiting**; responses include a **correction pass** for common technical misrecognitions.
- Updated frontend composer behavior for a smoother mobile experience:
  - Caret/range-aware insertion of transcribed text into the textarea.
  - Draft persistence/debounced saves with improved “page is hidden” flushing.
  - Mic UI improvements (waveform, spinner while transcribing, accessible labels, and proper start/stop behavior).
- Added substantial **test coverage**:
  - Frontend hook + UI behavior (browser STT flow, enhanced flow, consent handling, fallback behavior, and transcript merging).
  - Backend validation/correction logic and API behavior.
- Hardened a few **tmux/async tests** to be more deterministic across different local tmux/WSL settings.
- Updated `reqwest` to support **multipart uploads** for audio.

### Benefits
- Makes mobile dictation fast and safer by **preventing accidental submissions** while speaking.
- Improves transcription quality when enhanced mode is enabled, while keeping a **reliable fallback**.
- Keeps enhanced transcription **explicitly opt-in** so audio is only sent after clear user consent.

### Potential areas for further enhancement
- Consider whether voice dictation should be packaged as a **plugin/module** instead of being tightly integrated into the composer, to better support extensibility if the project has a plugin direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
