### PR TITLE
fix: stop orphaning sandbox containers on session delete and create

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1119,16 +1119,14 @@ fn cleanup_partial_session(
     // an error. `Some` only when the session is sandboxed.
     if let Some(session_id) = container_session_id {
         let container = crate::containers::DockerContainer::from_session_id(session_id);
-        match container.remove(true) {
-            Ok(()) | Err(crate::containers::error::DockerError::ContainerNotFound(_)) => {}
-            Err(e) => tracing::warn!(
+        if let crate::containers::Teardown::Failed(e) = container.teardown(session_id) {
+            tracing::warn!(
                 target: "cli.add",
                 "failed to remove sandbox container during partial cleanup for {}: {}",
                 session_id,
                 e
-            ),
+            );
         }
-        container.remove_named_ignore_volumes(session_id);
     }
     if let Some(wt) = worktree_info {
         if wt.managed_by_aoe {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -429,6 +429,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             workspace_info_opt.as_ref(),
             args.create_branch,
             None,
+            None,
         );
         return Ok(());
     }
@@ -887,6 +888,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             } else {
                 None
             },
+            instance.sandbox_info.as_ref().map(|_| instance.id.as_str()),
         );
         return Err(e);
     }
@@ -924,6 +926,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 } else {
                     None
                 },
+                instance.sandbox_info.as_ref().map(|_| instance.id.as_str()),
             );
             return Ok(());
         }
@@ -938,6 +941,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 } else {
                     None
                 },
+                instance.sandbox_info.as_ref().map(|_| instance.id.as_str()),
             );
             return Err(e);
         }
@@ -1107,7 +1111,25 @@ fn cleanup_partial_session(
     workspace_info: Option<&crate::session::WorkspaceInfo>,
     created_branch: bool,
     scratch_dir: Option<&std::path::Path>,
+    container_session_id: Option<&str>,
 ) {
+    // Tear down the sandbox container first so its bind mount releases the
+    // worktree before the git removal below. Best-effort and idempotent: a
+    // container that was never started yields ContainerNotFound, which is not
+    // an error. `Some` only when the session is sandboxed.
+    if let Some(session_id) = container_session_id {
+        let container = crate::containers::DockerContainer::from_session_id(session_id);
+        match container.remove(true) {
+            Ok(()) | Err(crate::containers::error::DockerError::ContainerNotFound(_)) => {}
+            Err(e) => tracing::warn!(
+                target: "cli.add",
+                "failed to remove sandbox container during partial cleanup for {}: {}",
+                session_id,
+                e
+            ),
+        }
+        container.remove_named_ignore_volumes(session_id);
+    }
     if let Some(wt) = worktree_info {
         if wt.managed_by_aoe {
             if let Ok(git_wt) = crate::git::GitWorktree::new(PathBuf::from(&wt.main_repo_path)) {

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -51,6 +51,31 @@ pub fn batch_container_health() -> HashMap<String, bool> {
     map
 }
 
+/// Outcome of an idempotent container teardown.
+#[derive(Debug)]
+pub enum Teardown {
+    /// The container was force-removed.
+    Removed,
+    /// No container existed to remove; the teardown was a no-op.
+    AlreadyGone,
+    /// Removal failed for a reason other than the container being absent.
+    Failed(error::DockerError),
+}
+
+/// Classify a force-remove result into an idempotent teardown outcome.
+///
+/// A `ContainerNotFound` error means there was nothing to remove and maps to
+/// `AlreadyGone`; every other error is a genuine `Failed`. Keeping this
+/// classification separate from I/O lets it be reasoned about and tested
+/// without a live runtime.
+fn classify_removal(result: Result<()>) -> Teardown {
+    match result {
+        Ok(()) => Teardown::Removed,
+        Err(error::DockerError::ContainerNotFound(_)) => Teardown::AlreadyGone,
+        Err(e) => Teardown::Failed(e),
+    }
+}
+
 pub struct DockerContainer {
     pub name: String,
     pub image: String,
@@ -159,6 +184,21 @@ impl DockerContainer {
         }
     }
 
+    /// Force-remove this container, then sweep its named ignore volumes.
+    ///
+    /// Idempotent: a container that is already gone yields
+    /// [`Teardown::AlreadyGone`], not a failure. Named ignore volumes outlive
+    /// the container, so they are swept regardless of the removal outcome.
+    ///
+    /// NOTE: callers must invoke this unconditionally and act on the returned
+    /// outcome; it must never be gated behind a separate existence probe, whose
+    /// transient failure would skip removal and orphan a live container.
+    pub fn teardown(&self, session_id: &str) -> Teardown {
+        let outcome = classify_removal(self.remove(true));
+        self.remove_named_ignore_volumes(session_id);
+        outcome
+    }
+
     pub fn exec_command(&self, options: Option<&str>, cmd: &str) -> String {
         self.runtime.exec_command(&self.name, options, cmd)
     }
@@ -183,6 +223,25 @@ impl DockerContainer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_ok_is_removed() {
+        assert!(matches!(classify_removal(Ok(())), Teardown::Removed));
+    }
+
+    #[test]
+    fn classify_not_found_is_already_gone() {
+        let r = Err(error::DockerError::ContainerNotFound(
+            "aoe-sandbox-x".into(),
+        ));
+        assert!(matches!(classify_removal(r), Teardown::AlreadyGone));
+    }
+
+    #[test]
+    fn classify_other_error_is_failed() {
+        let r = Err(error::DockerError::RemoveFailed("daemon busy".into()));
+        assert!(matches!(classify_removal(r), Teardown::Failed(_)));
+    }
 
     #[test]
     fn test_container_generate_name_short_id() {

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -89,6 +89,11 @@ pub(crate) struct RuntimeBase {
     /// Whether this runtime supports the `:z`/`:Z` SELinux relabel volume flag
     /// (Docker and Podman do; Apple Container does not).
     pub supports_selinux_relabel: bool,
+    /// Case-insensitive stderr substrings that identify a "container does not
+    /// exist" error for this runtime. Each runtime words it differently (Docker
+    /// "No such container", Apple Container "notFound … not found"), so the
+    /// markers are per-runtime rather than a single shared string.
+    pub not_found_markers: &'static [&'static str],
 }
 
 impl RuntimeBase {
@@ -102,6 +107,7 @@ impl RuntimeBase {
         supports_remove_volumes: true,
         supports_named_volumes: true,
         supports_selinux_relabel: true,
+        not_found_markers: &["no such container"],
     };
 
     pub const APPLE_CONTAINER: Self = Self {
@@ -114,6 +120,9 @@ impl RuntimeBase {
         supports_remove_volumes: false,
         supports_named_volumes: false,
         supports_selinux_relabel: false,
+        // Apple Container reports a missing container as
+        // `notFound: "container with ID <id> not found"`.
+        not_found_markers: &["not found"],
     };
 
     pub const PODMAN: Self = Self {
@@ -129,7 +138,15 @@ impl RuntimeBase {
         supports_remove_volumes: true,
         supports_named_volumes: true,
         supports_selinux_relabel: true,
+        not_found_markers: &["no such container"],
     };
+
+    /// Whether `stderr` from a remove/stop indicates the container did not
+    /// exist. Case-insensitive; matches this runtime's own not-found wording.
+    pub fn is_not_found(&self, stderr: &str) -> bool {
+        let lower = stderr.to_lowercase();
+        self.not_found_markers.iter().any(|m| lower.contains(m))
+    }
 
     pub fn command(&self) -> Command {
         Command::new(self.binary)
@@ -385,7 +402,7 @@ impl RuntimeBase {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("No such container") {
+            if self.is_not_found(&stderr) {
                 return Err(DockerError::ContainerNotFound(name.to_string()));
             }
             return Err(DockerError::StopFailed(stderr.to_string()));
@@ -411,7 +428,7 @@ impl RuntimeBase {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("No such container") {
+            if self.is_not_found(&stderr) {
                 return Err(DockerError::ContainerNotFound(name.to_string()));
             }
             return Err(DockerError::RemoveFailed(stderr.to_string()));
@@ -497,6 +514,42 @@ impl RuntimeBase {
 mod tests {
     use super::*;
     use crate::containers::container_interface::{EnvEntry, VolumeMount};
+
+    // Real stderr captured from `<runtime> rm/delete <missing>` on 2026-07-01.
+    // These pin the per-runtime not-found classification that `remove()` and
+    // `stop_container()` rely on to stay idempotent.
+    const DOCKER_MISSING: &str =
+        "Error response from daemon: No such container: aoe-sandbox-abc123";
+    const APPLE_MISSING: &str = "Error: internalError: \"failed to delete container\" (cause: \"notFound: \"container with ID aoe-sandbox-abc123 not found\"\")";
+    // Podman not installed locally; representative of its documented output.
+    const PODMAN_MISSING: &str =
+        "Error: no container with name or ID \"aoe-sandbox-abc123\" found: no such container";
+
+    #[test]
+    fn docker_not_found_stderr_classifies() {
+        assert!(RuntimeBase::DOCKER.is_not_found(DOCKER_MISSING));
+    }
+
+    #[test]
+    fn apple_not_found_stderr_classifies() {
+        assert!(RuntimeBase::APPLE_CONTAINER.is_not_found(APPLE_MISSING));
+    }
+
+    #[test]
+    fn podman_not_found_stderr_classifies() {
+        assert!(RuntimeBase::PODMAN.is_not_found(PODMAN_MISSING));
+    }
+
+    #[test]
+    fn genuine_failure_is_not_classified_as_not_found() {
+        // A real removal failure must NOT be mistaken for "already gone",
+        // which would re-introduce the silent-orphan bug.
+        let busy = "Error response from daemon: container is running: stop it first";
+        assert!(!RuntimeBase::DOCKER.is_not_found(busy));
+        assert!(!RuntimeBase::APPLE_CONTAINER.is_not_found(
+            "Error: internalError: \"failed to delete container\" (cause: \"resource busy\")"
+        ));
+    }
 
     #[test]
     fn test_build_create_args_read_only_supported() {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -775,14 +775,13 @@ pub fn cleanup_instance(
 
     if let Some(sandbox) = &instance.sandbox_info {
         if sandbox.enabled {
+            // Direct idempotent teardown, never gated on a separate existence
+            // probe: a transient `inspect` failure must not skip removal and
+            // orphan a live container. Volumes are swept inside `teardown`.
             let container = containers::DockerContainer::from_session_id(&instance.id);
-            if container.exists().unwrap_or(false) {
-                if let Err(e) = container.remove(true) {
-                    tracing::warn!(target: "session.create", "Failed to clean up container: {}", e);
-                }
+            if let containers::Teardown::Failed(e) = container.teardown(&instance.id) {
+                tracing::warn!(target: "session.create", "Failed to clean up container: {}", e);
             }
-            // Remove named ignore volumes even if the container is already gone.
-            container.remove_named_ignore_volumes(&instance.id);
         }
     }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -35,6 +35,23 @@ pub struct DeletionResult {
 }
 
 pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
+    perform_deletion_with(request, |session_id| {
+        DockerContainer::from_session_id(session_id).teardown(session_id)
+    })
+}
+
+/// Core deletion routine, parameterized over how the sandbox container is torn
+/// down so the container-removal contract can be exercised without a live
+/// runtime.
+///
+/// NOTE: when the session is sandboxed and `delete_sandbox` is set, `teardown`
+/// must be invoked unconditionally; it must not be gated behind a separate
+/// existence probe, whose transient failure would skip removal and orphan a
+/// live container.
+fn perform_deletion_with(
+    request: &DeletionRequest,
+    teardown: impl FnOnce(&str) -> crate::containers::Teardown,
+) -> DeletionResult {
     let mut errors = Vec::new();
     let mut messages = Vec::new();
 
@@ -143,12 +160,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     // container processes.
     if request.delete_sandbox && is_sandboxed {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
-        let container = DockerContainer::from_session_id(&request.instance.id);
-        deletion_messages_for(
-            container.teardown(&request.instance.id),
-            &mut messages,
-            &mut errors,
-        );
+        deletion_messages_for(teardown(&request.instance.id), &mut messages, &mut errors);
     }
 
     // Stage 4: worktree cleanup. Container is gone, agent is gone, no
@@ -623,6 +635,63 @@ mod tests {
                 messages.is_empty(),
                 "no spurious 'removed' message when nothing was removed"
             );
+        }
+
+        fn sandboxed_request() -> DeletionRequest {
+            use crate::session::SandboxInfo;
+            let mut instance = create_test_instance();
+            instance.sandbox_info = Some(SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "alpine".to_string(),
+                container_name: "aoe-sandbox-calltest".to_string(),
+                extra_env: None,
+                custom_instruction: None,
+                before_start_env: Vec::new(),
+                container_workdir: None,
+            });
+            DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: false,
+                delete_branch: false,
+                delete_sandbox: true,
+                force_delete: false,
+                detach_hooks: true,
+                keep_scratch: false,
+            }
+        }
+
+        #[test]
+        fn call_site_surfaces_teardown_failure() {
+            // A failed container teardown must surface as an error so the
+            // caller keeps the session record, not silently succeed. Pins the
+            // `perform_deletion` call site, not just the mapping helper.
+            let request = sandboxed_request();
+            let result = perform_deletion_with(&request, |_id| {
+                Teardown::Failed(DockerError::RemoveFailed("daemon busy".into()))
+            });
+            assert!(!result.success, "a teardown failure must fail the deletion");
+            assert!(result.errors.iter().any(|e| e.contains("Container")));
+        }
+
+        #[test]
+        fn call_site_invokes_teardown_unconditionally() {
+            // Guards against re-introducing an existence-probe gate around the
+            // teardown: it must run whenever the session is sandboxed and
+            // delete_sandbox is set.
+            use std::cell::Cell;
+            let request = sandboxed_request();
+            let called = Cell::new(false);
+            let result = perform_deletion_with(&request, |_id| {
+                called.set(true);
+                Teardown::Removed
+            });
+            assert!(
+                called.get(),
+                "teardown must be invoked unconditionally, never gated behind a probe"
+            );
+            assert!(result.success);
         }
     }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -144,10 +144,11 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     if request.delete_sandbox && is_sandboxed {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
         let container = DockerContainer::from_session_id(&request.instance.id);
-        record_container_removal(|force| container.remove(force), &mut messages, &mut errors);
-        // Remove named ignore volumes even if the container is already gone — volumes created
-        // with volume_ignores_strategy = "named" outlive the container and need explicit cleanup.
-        container.remove_named_ignore_volumes(&request.instance.id);
+        deletion_messages_for(
+            container.teardown(&request.instance.id),
+            &mut messages,
+            &mut errors,
+        );
     }
 
     // Stage 4: worktree cleanup. Container is gone, agent is gone, no
@@ -431,24 +432,22 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     }
 }
 
-/// Attempt to remove a session's sandbox container, recording the outcome.
+/// Map a container [`Teardown`](crate::containers::Teardown) outcome onto a
+/// deletion's user-facing messages and errors.
 ///
-/// Removal forces stop+remove in one shot and is idempotent: a
-/// `ContainerNotFound` result means there was nothing to remove and is not
-/// surfaced. Any other failure is pushed to `errors` so the caller keeps the
-/// session record rather than silently orphaning a live container.
-///
-/// NOTE: callers must invoke this unconditionally, never gating it behind a
-/// separate existence probe; a transient probe failure must not skip removal.
-fn record_container_removal(
-    remove: impl FnOnce(bool) -> crate::containers::error::Result<()>,
+/// A `Failed` outcome is recorded as an error so the caller keeps the session
+/// record rather than dropping it and orphaning a live container; `AlreadyGone`
+/// is a silent no-op (there was nothing to remove).
+fn deletion_messages_for(
+    outcome: crate::containers::Teardown,
     messages: &mut Vec<String>,
     errors: &mut Vec<String>,
 ) {
-    match remove(true) {
-        Ok(()) => messages.push("Container removed".to_string()),
-        Err(crate::containers::error::DockerError::ContainerNotFound(_)) => {}
-        Err(e) => errors.push(format!("Container: {}", e)),
+    use crate::containers::Teardown;
+    match outcome {
+        Teardown::Removed => messages.push("Container removed".to_string()),
+        Teardown::AlreadyGone => {}
+        Teardown::Failed(e) => errors.push(format!("Container: {}", e)),
     }
 }
 
@@ -582,14 +581,14 @@ mod tests {
     mod container_removal {
         use super::*;
         use crate::containers::error::DockerError;
-        use std::cell::Cell;
+        use crate::containers::Teardown;
 
         #[test]
-        fn removal_failure_is_recorded_as_error() {
+        fn failure_is_recorded_as_error() {
             let mut messages = Vec::new();
             let mut errors = Vec::new();
-            record_container_removal(
-                |_force| Err(DockerError::RemoveFailed("daemon busy".into())),
+            deletion_messages_for(
+                Teardown::Failed(DockerError::RemoveFailed("daemon busy".into())),
                 &mut messages,
                 &mut errors,
             );
@@ -603,23 +602,19 @@ mod tests {
         }
 
         #[test]
-        fn successful_removal_records_message() {
+        fn removed_records_message() {
             let mut messages = Vec::new();
             let mut errors = Vec::new();
-            record_container_removal(|_force| Ok(()), &mut messages, &mut errors);
+            deletion_messages_for(Teardown::Removed, &mut messages, &mut errors);
             assert_eq!(messages, vec!["Container removed".to_string()]);
             assert!(errors.is_empty());
         }
 
         #[test]
-        fn absent_container_is_not_an_error() {
+        fn already_gone_is_silent() {
             let mut messages = Vec::new();
             let mut errors = Vec::new();
-            record_container_removal(
-                |_force| Err(DockerError::ContainerNotFound("aoe-sandbox-x".into())),
-                &mut messages,
-                &mut errors,
-            );
+            deletion_messages_for(Teardown::AlreadyGone, &mut messages, &mut errors);
             assert!(
                 errors.is_empty(),
                 "an already-gone container is idempotent, not a failure"
@@ -627,27 +622,6 @@ mod tests {
             assert!(
                 messages.is_empty(),
                 "no spurious 'removed' message when nothing was removed"
-            );
-        }
-
-        #[test]
-        fn removal_is_always_attempted() {
-            let calls = Cell::new(0);
-            let mut messages = Vec::new();
-            let mut errors = Vec::new();
-            record_container_removal(
-                |force| {
-                    calls.set(calls.get() + 1);
-                    assert!(force, "deletion forces stop+remove in one shot");
-                    Ok(())
-                },
-                &mut messages,
-                &mut errors,
-            );
-            assert_eq!(
-                calls.get(),
-                1,
-                "removal must not be gated behind a swallowed existence probe"
             );
         }
     }

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -144,13 +144,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     if request.delete_sandbox && is_sandboxed {
         tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
         let container = DockerContainer::from_session_id(&request.instance.id);
-        if container.exists().unwrap_or(false) {
-            if let Err(e) = container.remove(true) {
-                errors.push(format!("Container: {}", e));
-            } else {
-                messages.push("Container removed".to_string());
-            }
-        }
+        record_container_removal(|force| container.remove(force), &mut messages, &mut errors);
         // Remove named ignore volumes even if the container is already gone — volumes created
         // with volume_ignores_strategy = "named" outlive the container and need explicit cleanup.
         container.remove_named_ignore_volumes(&request.instance.id);
@@ -437,6 +431,27 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     }
 }
 
+/// Attempt to remove a session's sandbox container, recording the outcome.
+///
+/// Removal forces stop+remove in one shot and is idempotent: a
+/// `ContainerNotFound` result means there was nothing to remove and is not
+/// surfaced. Any other failure is pushed to `errors` so the caller keeps the
+/// session record rather than silently orphaning a live container.
+///
+/// NOTE: callers must invoke this unconditionally, never gating it behind a
+/// separate existence probe; a transient probe failure must not skip removal.
+fn record_container_removal(
+    remove: impl FnOnce(bool) -> crate::containers::error::Result<()>,
+    messages: &mut Vec<String>,
+    errors: &mut Vec<String>,
+) {
+    match remove(true) {
+        Ok(()) => messages.push("Container removed".to_string()),
+        Err(crate::containers::error::DockerError::ContainerNotFound(_)) => {}
+        Err(e) => errors.push(format!("Container: {}", e)),
+    }
+}
+
 /// Run on_destroy hooks for an instance. Uses best-effort execution so all
 /// hooks are attempted even if some fail. Failures are logged as warnings
 /// and never prevent deletion.
@@ -562,6 +577,79 @@ mod tests {
 
         assert!(result.success);
         assert!(result.errors.is_empty());
+    }
+
+    mod container_removal {
+        use super::*;
+        use crate::containers::error::DockerError;
+        use std::cell::Cell;
+
+        #[test]
+        fn removal_failure_is_recorded_as_error() {
+            let mut messages = Vec::new();
+            let mut errors = Vec::new();
+            record_container_removal(
+                |_force| Err(DockerError::RemoveFailed("daemon busy".into())),
+                &mut messages,
+                &mut errors,
+            );
+            assert_eq!(
+                errors.len(),
+                1,
+                "a removal failure must be surfaced so the caller keeps the session record"
+            );
+            assert!(errors[0].contains("Container"));
+            assert!(messages.is_empty());
+        }
+
+        #[test]
+        fn successful_removal_records_message() {
+            let mut messages = Vec::new();
+            let mut errors = Vec::new();
+            record_container_removal(|_force| Ok(()), &mut messages, &mut errors);
+            assert_eq!(messages, vec!["Container removed".to_string()]);
+            assert!(errors.is_empty());
+        }
+
+        #[test]
+        fn absent_container_is_not_an_error() {
+            let mut messages = Vec::new();
+            let mut errors = Vec::new();
+            record_container_removal(
+                |_force| Err(DockerError::ContainerNotFound("aoe-sandbox-x".into())),
+                &mut messages,
+                &mut errors,
+            );
+            assert!(
+                errors.is_empty(),
+                "an already-gone container is idempotent, not a failure"
+            );
+            assert!(
+                messages.is_empty(),
+                "no spurious 'removed' message when nothing was removed"
+            );
+        }
+
+        #[test]
+        fn removal_is_always_attempted() {
+            let calls = Cell::new(0);
+            let mut messages = Vec::new();
+            let mut errors = Vec::new();
+            record_container_removal(
+                |force| {
+                    calls.set(calls.get() + 1);
+                    assert!(force, "deletion forces stop+remove in one shot");
+                    Ok(())
+                },
+                &mut messages,
+                &mut errors,
+            );
+            assert_eq!(
+                calls.get(),
+                1,
+                "removal must not be gated behind a swallowed existence probe"
+            );
+        }
     }
 
     #[test]

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -175,6 +175,11 @@ impl CreationPoller {
                         &hook_env,
                     ) {
                         tracing::warn!(target: "session.create", "on_create hook failed in container: {:#}", e);
+                        builder::cleanup_instance(
+                            &instance,
+                            created_worktree.as_ref(),
+                            &created_workspace_worktrees,
+                        );
                         return CreationResult::Error(format!("on_create hook failed: {:#}", e));
                     }
                 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4245,7 +4245,7 @@ impl HomeView {
                 if inst.status == Status::Deleting {
                     let message = format!(
                         "'{}' is stuck deleting. Force remove it from the session list? \
-                         (worktrees, branches, and containers will not be cleaned up)",
+                         (the sandbox container is torn down; worktrees and branches will not be cleaned up)",
                         inst.title
                     );
                     self.pending_force_remove_session = Some(session_id.clone());

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -684,7 +684,7 @@ impl HomeView {
                     inst.kill_all_tmux_sessions()
                 })) {
                     tracing::error!(
-                        target: "session.tmux_cleanup",
+                        target: "session.delete",
                         session_id = %inst.id,
                         "force_remove tmux teardown panicked: {:?}",
                         panic

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -692,17 +692,14 @@ impl HomeView {
                 }
                 if inst.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
                     let container = crate::containers::DockerContainer::from_session_id(&inst.id);
-                    match container.remove(true) {
-                        Ok(())
-                        | Err(crate::containers::error::DockerError::ContainerNotFound(_)) => {}
-                        Err(e) => tracing::warn!(
+                    if let crate::containers::Teardown::Failed(e) = container.teardown(&inst.id) {
+                        tracing::warn!(
                             target: "session.delete",
                             session_id = %inst.id,
                             "force_remove container teardown failed: {}",
                             e
-                        ),
+                        );
                     }
-                    container.remove_named_ignore_volumes(&inst.id);
                 }
             });
         }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -669,12 +669,13 @@ impl HomeView {
         Ok(())
     }
 
-    /// Force-remove a session from storage. Worktree, branch, and
-    /// container cleanup are skipped (the original deletion already
-    /// attempted them); tmux teardown is fired off-thread so a hung
-    /// tmux call cannot block the storage update on the TUI input
-    /// thread. Used for sessions stuck in the Deleting state where
-    /// the background deletion thread never returned a result.
+    /// Force-remove a session from storage. Worktree and branch cleanup are
+    /// skipped (the original deletion already attempted them), but the sandbox
+    /// container IS torn down best-effort so a stuck delete cannot orphan a
+    /// live container. Both run off-thread so a hung tmux or docker call cannot
+    /// block the storage update on the TUI input thread. Used for sessions
+    /// stuck in the Deleting state where the background deletion thread never
+    /// returned a result.
     pub(super) fn force_remove_session(&mut self, session_id: &str) -> anyhow::Result<()> {
         if let Some(inst) = self.instances.iter().find(|i| i.id == session_id) {
             let inst = inst.clone();
@@ -688,6 +689,20 @@ impl HomeView {
                         "force_remove tmux teardown panicked: {:?}",
                         panic
                     );
+                }
+                if inst.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
+                    let container = crate::containers::DockerContainer::from_session_id(&inst.id);
+                    match container.remove(true) {
+                        Ok(())
+                        | Err(crate::containers::error::DockerError::ContainerNotFound(_)) => {}
+                        Err(e) => tracing::warn!(
+                            target: "session.delete",
+                            session_id = %inst.id,
+                            "force_remove container teardown failed: {}",
+                            e
+                        ),
+                    }
+                    container.remove_named_ignore_volumes(&inst.id);
                 }
             });
         }


### PR DESCRIPTION
## Description

Deleting a session with "remove container" sometimes left the Docker container running while the session row disappeared from the list. Container teardown in `perform_deletion` was gated behind `container.exists().unwrap_or(false)`. A transient `docker container inspect` failure (busy/slow daemon) made the probe return false, so `remove()` was skipped, **no error was recorded**, the deletion reported success, and the caller dropped the session record, orphaning a live container with no warning. The probe's failure mode was indistinguishable from "nothing to remove".

This replaces the swallowing existence gate with a direct, idempotent removal:

- `ContainerNotFound` → no-op (idempotent),
- any other failure → surfaced as an error, so the caller keeps the session record (the TUI re-shows it as `Error` and you can retry) instead of silently orphaning the container.

Because all three surfaces funnel through the shared `perform_deletion`, this fixes the **CLI, TUI, and web** delete paths at once.

It also closes the matching **creation-time** leaks, where a just-started container was orphaned if an `on_create` hook failed:

- **TUI** (`creation_poller`): now calls `cleanup_instance` on the sandboxed `on_create` failure path, matching its sibling error paths.
- **CLI** (`cleanup_partial_session`): now tears down the sandbox container (best-effort, idempotent) on partial-create failure.
- **TUI force-remove** of a stuck-deleting session now removes the container instead of explicitly skipping it (dialog wording updated to match).

## Update since initial review

Addressing review feedback (@Seluj78, @jerome-benoit, @coderabbitai):

- **Closed the gate at its source.** `builder::cleanup_instance` (which backs the TUI *and* web create-failure paths and two other TUI sites) no longer probes with `exists().unwrap_or(false)`. All teardown now goes through one idempotent `DockerContainer::teardown` returning a `Teardown { Removed, AlreadyGone, Failed }` outcome; each call site keeps its own policy inline (deletion surfaces `Failed` as an error, best-effort sites `warn`).
- **Correction:** the earlier claim that "the web create path already cleaned up correctly" was imprecise. It never leaked by omission (it did call `cleanup_instance`), but that function inherited the same swallowing gate, so it shared the transient-probe orphan risk. It is fixed now.
- **Runtime-aware not-found detection.** `remove()`/`stop_container()` classified "already gone" via a single Docker-worded `stderr.contains("No such container")`. Podman (lowercase) and Apple Container (`notFound … not found`) don't match it, so an already-gone container on those runtimes returned `RemoveFailed` and un-retriably failed the delete. Not-found markers are now per-runtime and matched case-insensitively, verified against the real stderr captured from `docker`/`container` on macOS.
- **Call-site regression test** now drives `perform_deletion` with an injected teardown failure and asserts the error surfaces (and that teardown runs unconditionally), pinning the contract the doc comment describes.
- Filed a separate issue for the same swallow shape in `worktree_edit.rs` (out of this PR's scope).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Unit tests (TDD, red-first):
- `classify_removal` / `deletion_messages_for`: failure is surfaced as an error (the regression guard for the orphaned-container symptom), success records the message, an already-gone container is an idempotent no-op.
- `is_not_found` per runtime, fed the **real** stderr captured from `docker`/`container` (plus a representative Podman string), and a genuine-failure string that must stay `Failed` (guards against a false positive re-introducing the orphan).
- `perform_deletion` call-site tests: an injected teardown failure surfaces as an error, and teardown is invoked unconditionally.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the web delete/create paths are unchanged; the shared `perform_deletion` fix is covered by Rust unit tests)

**TUI / CLI (e2e test)**
- [x] Added or updated tests: the shared teardown/classification logic and the `perform_deletion` call-site contract are unit-tested (see above). The remaining thread/subprocess wiring in `creation_poller`, `cleanup_partial_session`, and `force_remove_session` is not practical to drive without a real container runtime; those branches now route through the tested `teardown` helper rather than bespoke logic, so the untested surface is wiring, not decision logic.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used to investigate the leak across the CLI/TUI/web surfaces and implement the fix test-first. Findings were verified against a real orphaned container on the author's machine.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785429727&installation_id=139138837&pr_number=2576&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2576&signature=832b2c7e86fc45d483f2d279c8f8c5a9443fa5ad351e063e1f6dc21b8f7484fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-level summary
- Fixed session deletion cleanup to remove sandbox containers reliably, eliminating the fragile “check if container exists first” logic that could silently skip cleanup when inspection failed.
- Standardized sandbox teardown during deletion so all delete flows (CLI, TUI, and web) behave consistently: containers are torn down best-effort, “already gone” is treated as success/no-op, and real teardown failures are surfaced instead of being hidden.
- Improved cleanup when session creation fails:
  - If the TUI sandbox `on_create` hook fails, the partially created sandbox state is now cleaned up.
  - If the CLI hits an error during partial session creation, the sandbox container is torn down to prevent leaks.
- Updated the TUI “force remove” behavior to actually tear down the sandbox container (best-effort in the background), while keeping the existing behavior that skips worktree/branch cleanup, and adjusted the confirmation text to match.

## Benefits
- Fewer orphaned sandbox containers and leaked resources.
- More predictable deletion behavior across interfaces, with correct error reporting so failures don’t disappear and sessions can be retried safely.
- Safer failure handling during partial creations, reducing the chance of leaving behind half-built sandbox environments.

## Technical notes (optional)
- Introduced an idempotent teardown model (`Teardown` = Removed / AlreadyGone / Failed) and centralized mapping from teardown outcomes into user-visible messages/errors.
- Added runtime-aware “container not found” detection for Docker/Podman/Apple Container so “already gone” is recognized correctly across runtimes.
- Refactored deletion to use a shared teardown helper (parameterized so tests can inject teardown failures) and updated builder cleanup to always attempt teardown without a prior existence probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
