### PR TITLE
fix(web): place sidebar Trash count badge next to the Trash icon

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -581,10 +581,13 @@ function TrashMenu({
         aria-label={`Trash (${count})`}
       >
         <Trash2 className="h-4 w-4 shrink-0" />
-        <span className="min-w-0 flex-1 truncate text-left text-[13px] font-medium">Trash</span>
-        <span className="shrink-0 rounded-full bg-surface-900 px-1.5 py-0.5 text-[10px] font-mono tabular-nums text-text-dim leading-none">
+        <span
+          data-testid="sidebar-trash-count"
+          className="shrink-0 rounded-full bg-surface-900 px-1.5 py-0.5 text-[10px] font-mono tabular-nums text-text-dim leading-none"
+        >
           {count}
         </span>
+        <span className="min-w-0 flex-1 truncate text-left text-[13px] font-medium">Trash</span>
       </button>
       {open &&
         panelPosition &&

--- a/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
+++ b/web/src/components/__tests__/WorkspaceSidebarTrash.test.tsx
@@ -151,6 +151,23 @@ describe("WorkspaceSidebar Trash control (#2489, #2512)", () => {
     expect(props.onDeleteSession).toHaveBeenCalledWith("trashed-ws");
   });
 
+  it("renders the count badge next to the Trash icon, not against Settings (#2574)", () => {
+    // The badge must sit right after the Trash icon at the left of the control.
+    // A `flex-1` label that preceded the badge would shove the count to the
+    // button's right edge, where it reads as belonging to the Settings gear.
+    renderWithTrash();
+    const toggle = screen.getByTestId("sidebar-trash-toggle");
+    const badge = screen.getByTestId("sidebar-trash-count");
+    expect(badge.textContent).toBe("1");
+    // Badge is inside the Trash control, not the Settings button.
+    expect(toggle.contains(badge)).toBe(true);
+    // The "Trash" label follows the badge in DOM order; the badge is not the
+    // right-most child pushed up against Settings.
+    const label = Array.from(toggle.querySelectorAll("span")).find((s) => s.textContent === "Trash");
+    expect(label).toBeTruthy();
+    expect(badge.compareDocumentPosition(label!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("closes the Trash popover on Escape", () => {
     renderWithTrash();
     fireEvent.click(screen.getByTestId("sidebar-trash-toggle"));

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -893,6 +893,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.trash-control",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/WorkspaceSidebarTrash.test.tsx"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.new-session-tooltips",
       "kind": "mocked-playwright",
       "risk": "low",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web dashboard sidebar footer, the Trash count badge rendered hard against the right edge of the full-width Trash button, immediately left of the Settings gear, so the number read as belonging to Settings rather than Trash. The count value was always correct; only its placement was wrong.

Root cause: the `flex-1` label span in the Trash button consumed all the slack and pushed the `{count}` badge to the button's right edge. The fix reorders the badge to follow the `Trash2` icon directly and lets the label keep `flex-1` so the trailing slack falls harmlessly on the right.

Adds a Vitest regression in `WorkspaceSidebarTrash.test.tsx` asserting the badge precedes the "Trash" label inside the Trash control (it would fail on the pre-fix label-first order, confirmed red), plus a `sidebar.trash-control` entry in `web/tests/coverage-matrix.json`.

Closes #2574

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

(Covered with a Vitest + RTL spec rather than Playwright: the bug is DOM/layout ordering in the sidebar footer, which Vitest exercises accurately for this large file per the existing trash-control test. Coverage matrix updated with `sidebar.trash-control`.)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Open the web dashboard with at least one workspace in the Trash.
- [ ] Look at the sidebar footer: the count badge sits right next to the Trash icon, not next to the Settings gear.
- [ ] Confirm the count value still matches the number of trashed workspaces.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785429733&installation_id=139138837&pr_number=2577&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2577&signature=9517abcebf7d0c18c22ead120014d5d9afa57f841f72cd7d7416b16c7a8150a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed the sidebar Trash control so the count badge now sits next to the Trash icon instead of drifting to the far right near Settings. The Trash label was kept flexible so the layout preserves space correctly.

Added a regression test to confirm the badge stays attached to the Trash control and appears in the right place, and updated the coverage matrix to include this new sidebar trash control coverage.

Benefit: the footer now matches the expected visual layout, making the Trash count easier to associate with the correct action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->