### PR TITLE
ci: parallelize Cargo Test (linux) into sharded matrix jobs

### DIFF
--- a/.github/workflows/e2e-recording.yml
+++ b/.github/workflows/e2e-recording.yml
@@ -45,12 +45,12 @@ jobs:
           agg --version
 
       - name: Build tests
-        run: cargo test --test e2e --no-run
+        run: cargo test --features e2e-tests --test e2e --no-run
 
       - name: Run e2e tests with recording
         env:
           RECORD_E2E: "1"
-        run: cargo test --test e2e -- --nocapture
+        run: cargo test --features e2e-tests --test e2e -- --nocapture
 
       - name: Upload recordings as artifact
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,33 +13,32 @@ permissions:
   contents: read
 
 jobs:
-  cargo:
-    # Job names use the stable `label`, not the runner, so the branch
-    # ruleset's required checks ("Cargo Test (linux)" / "Cargo Test
-    # (macos)") survive runner swaps. The runner itself comes from a
-    # repo Actions variable so Blacksmith can be dropped without a
-    # commit when the monthly credit pool runs dry: clearing
-    # RUNNER_CARGO_LINUX / RUNNER_CARGO_MACOS in Settings -> Actions ->
-    # Variables falls back to the free GitHub-hosted runners on the
-    # next run. Jobs already queued for Blacksmith sit "queued"
-    # forever (GitHub has no runner fallback primitive), so flip the
-    # variable, then re-run the stuck workflow.
-    name: Cargo Test (${{ matrix.label }})
-    runs-on: ${{ matrix.os }}
+  cargo-linux:
+    # Sharded Linux test matrix. Each leg runs on its own runner with its own
+    # rust-cache slot, so the feature-set switch that used to force a recompile
+    # between the sequential legs is gone and the legs run in parallel. The
+    # required-check context is the fan-in `cargo-linux-ok` job below (named
+    # "Cargo Test (linux)"), NOT these shard jobs; keep that in sync with the
+    # branch ruleset if the leg set changes. The runner comes from a repo
+    # Actions variable so Blacksmith can be dropped without a commit when the
+    # monthly credit pool runs dry: clearing RUNNER_CARGO_LINUX in Settings ->
+    # Actions -> Variables falls back to the free GitHub-hosted runner on the
+    # next run. Jobs already queued for Blacksmith sit "queued" forever (GitHub
+    # has no runner fallback primitive), so flip the variable, then re-run the
+    # stuck workflow.
+    name: Cargo Test (linux, ${{ matrix.leg }})
+    runs-on: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - label: linux
-            os: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
-          - label: macos
-            os: ${{ vars.RUNNER_CARGO_MACOS || 'macos-latest' }}
+        leg: [serve-e2e, serve-rest, bare-core]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Cache compiled binaries too. Same-PR pushes that don't
-          # touch Rust deps get a warm `target/` and skip the 4-minute
+          # touch Rust deps get a warm `target/` and skip the cold
           # cargo build entirely; the first push still pays cold cost.
           cache-bin: "true"
           # Save on PRs too. Swatinem keys the cache on Cargo.lock +
@@ -47,62 +46,95 @@ jobs:
           # the slot rather than thrashing the 10GB repo cache budget.
           save-if: true
       - name: Install tmux
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update && sudo apt-get install -y tmux
-          else
-            brew install tmux
-          fi
+        run: sudo apt-get update && sudo apt-get install -y tmux
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
       # tests/integration/acp_smoke.rs spawns the Node ACP shim under
       # acp-worker/test-shim/. The shim depends on @agentclientprotocol/sdk,
-      # so its deps must be installed before `cargo test --features serve`
-      # runs. The shim itself auto-skips if node is
-      # missing, but on a GitHub runner node is always present; without the
-      # install step the shim crashes before the ACP handshake completes.
-      # macOS only runs --lib --bins (no integration crates), so the shim
-      # isn't exercised there and we can skip the install.
+      # so its deps must be installed before the integration crate runs. Only
+      # the serve-rest leg runs the integration binary; the serve-e2e leg uses
+      # the fake ACP agent under web/tests/helpers/ instead, and bare-core does
+      # not exercise the shim.
       - name: Install ACP shim deps
-        if: runner.os == 'Linux'
+        if: matrix.leg == 'serve-rest'
         working-directory: acp-worker/test-shim
         run: npm ci
-      # `--features serve` is a strict superset of the default suite and pulls
-      # in the aoe.web plugin (serve-gated) that the e2e tests assert on, so a
-      # single run covers both feature gates. macOS-specific code lives in
-      # src/process/macos.rs plus one cfg in container_config.rs; the
-      # integration and e2e crates exercise OS-portable code that the Linux leg
-      # already covers, so macOS only runs --lib --bins.
-      - name: Cargo test (Linux, full suite incl. integration + e2e)
-        if: runner.os == 'Linux'
+      # serve-e2e: just the e2e binary (tmux-serial, the wall-clock long pole).
+      # The e2e target is gated behind the `e2e-tests` feature so the serve-rest
+      # leg below can skip it; this leg opts in.
+      - name: Cargo test (serve, e2e only)
+        if: matrix.leg == 'serve-e2e'
+        run: cargo test --features serve,e2e-tests --test e2e
+      # serve-rest: the full serve suite minus e2e (lib + bins + integration +
+      # the standalone test bins). `--features serve` leaves the e2e target
+      # gated off, so it is skipped here while every non-e2e test binary stays
+      # auto-discovered. `--features serve` is a strict superset of the default
+      # suite and pulls in the aoe.web plugin (serve-gated) the e2e tests assert
+      # on, so the two feature gates are both covered across this leg + serve-e2e.
+      - name: Cargo test (serve, everything except e2e)
+        if: matrix.leg == 'serve-rest'
         run: cargo test --features serve
-      - name: Cargo test (macOS, lib + bins only)
-        if: runner.os == 'macOS'
-        run: cargo test --features serve --lib --bins
-      # With every bundled plugin compiled out, core must still build and pass
-      # its lib/bin unit tests. `--no-default-features` also drops `serve`,
-      # so this doubles as the TUI-only compile gate, keeping the ~27
-      # cfg(feature = "serve") sites from rotting.
+      # bare-core: the three no-default-features feature corners.
+      #  - lib/bins: with every bundled plugin compiled out, core must still
+      #    build and pass its unit tests. `--no-default-features` also drops
+      #    `serve`, so this doubles as the TUI-only compile gate, keeping the
+      #    ~27 cfg(feature = "serve") sites from rotting.
+      #  - e2e: acceptance criterion 1 of #268 (issue #2097): with all default
+      #    plugins disabled, aoe still creates, attaches to, and destroys a
+      #    tmux + worktree session from CLI and TUI. The serve-gated e2e modules
+      #    self-gate to empty here. `e2e-tests` opts the gated target back in.
+      #  - check --all-targets: default-plugins on, serve off compile gate;
+      #    `e2e-tests` keeps the e2e target inside the --all-targets sweep, which
+      #    the gate would otherwise silently drop.
       - name: Cargo test (bare core, no default features)
-        if: runner.os == 'Linux'
-        run: cargo test --no-default-features --lib --bins
-      # Acceptance criterion 1 of #268 (issue #2097): with all default plugins
-      # disabled, aoe still creates, attaches to, and destroys a tmux + worktree
-      # session from CLI and TUI. The --lib --bins leg above never spawns the
-      # binary under tmux, so the e2e crate is what actually proves the
-      # invariant; the serve-gated e2e modules self-gate to empty here. This is
-      # the forcing function that makes "default plugin" mean something: a
-      # default plugin that grows an undeclared core dependency turns this red.
-      - name: Cargo test (bare core e2e, no default features)
-        if: runner.os == 'Linux'
-        run: cargo test --no-default-features --test e2e
-      # The third feature corner: default-plugins on, serve off. Compile gate
-      # (including test/e2e targets, which plain check skips) so plugin
-      # registration code can't grow a hidden dependency on serve types.
-      - name: Cargo check (default plugins, no serve)
-        if: runner.os == 'Linux'
-        run: cargo check --no-default-features --features default-plugins --all-targets
+        if: matrix.leg == 'bare-core'
+        run: |
+          cargo test --no-default-features --lib --bins
+          cargo test --no-default-features --features e2e-tests --test e2e
+          cargo check --no-default-features --features default-plugins,e2e-tests --all-targets
+
+  cargo-linux-ok:
+    # Fan-in for the branch ruleset: "Cargo Test (linux)" is a required status
+    # check, and matrix jobs report per-leg contexts the ruleset doesn't know
+    # about. This job carries the stable context name and fails unless every
+    # leg succeeded.
+    name: Cargo Test (linux)
+    needs: cargo-linux
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check leg results
+        run: |
+          if [ "${{ needs.cargo-linux.result }}" != "success" ]; then
+            echo "linux legs result: ${{ needs.cargo-linux.result }}"
+            exit 1
+          fi
+
+  cargo-macos:
+    # macOS-specific code lives in src/process/macos.rs plus one cfg in
+    # container_config.rs; the integration and e2e crates exercise OS-portable
+    # code the Linux legs already cover, so macOS only runs --lib --bins.
+    # `--features serve` is a strict superset of the default suite, so a single
+    # run covers both feature gates. The runner comes from a repo Actions
+    # variable (clear RUNNER_CARGO_MACOS to fall back to the GitHub-hosted
+    # runner on the next run).
+    name: Cargo Test (macos)
+    runs-on: ${{ vars.RUNNER_CARGO_MACOS || 'macos-latest' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "true"
+          save-if: true
+      - name: Install tmux
+        run: brew install tmux
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+      - name: Cargo test (macOS, lib + bins only)
+        run: cargo test --features serve --lib --bins
 
   macos-acp-e2e:
     # The acp live-daemon e2e tests exercise the structured-view
@@ -131,7 +163,7 @@ jobs:
         with:
           node-version: '22'
       - name: Cargo test (macOS, acp live-daemon e2e)
-        run: cargo test --features serve --test e2e -- acp_ --test-threads=1 --nocapture
+        run: cargo test --features serve,e2e-tests --test e2e -- acp_ --test-threads=1 --nocapture
 
   vitest:
     name: Vitest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,12 @@ jobs:
         leg: [serve-e2e, serve-rest, bare-core]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -123,6 +129,12 @@ jobs:
     runs-on: ${{ vars.RUNNER_CARGO_MACOS || 'macos-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -152,6 +164,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -170,6 +188,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -229,6 +253,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -254,6 +284,12 @@ jobs:
     runs-on: ${{ vars.RUNNER_PLAYWRIGHT_MOCKED || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -345,6 +381,12 @@ jobs:
         shard: [1, 2]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # These jobs run repository-controlled build/test code after checkout
+          # and never push, so the job token must not linger in .git/config
+          # (zizmor artipacked). Matches the hardened convention in ci.yml and
+          # release.yml.
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,13 +120,13 @@ would need a breaking config-layout migration; the web does not surface it.
 
 ### E2E Tests
 
-Full-binary e2e tests live in `tests/e2e/`, exercising `aoe` through tmux (TUI) and as a subprocess (CLI). Run with `cargo test --test e2e` (add `-- --nocapture` for screen dumps on failure).
+Full-binary e2e tests live in `tests/e2e/`, exercising `aoe` through tmux (TUI) and as a subprocess (CLI). Run with `cargo test --features e2e-tests --test e2e` (add `-- --nocapture` for screen dumps on failure). The e2e target is gated behind the `e2e-tests` feature so CI can run the serve suite as parallel shards (one runs everything except e2e, one runs e2e only); `cargo test --features serve` skips e2e, and naming the target without the feature errors loudly instead of skipping. Run the full serve suite locally with `cargo test --features serve,e2e-tests`.
 
 The harness (`tests/e2e/harness.rs`) exposes `TuiTestHarness` with `spawn_tui()`/`spawn(args)`, `send_keys(keys)`/`type_text(text)`, `wait_for(text)` (10s timeout), `capture_screen()`/`assert_screen_contains(text)`, and `run_cli(args)`. TUI tests auto-skip without tmux; Docker tests use `#[ignore]`; all use `#[serial]` for tmux isolation.
 
 Agent-view live-daemon e2e (`tests/e2e/acp_focus_isolation_e2e.rs`) stands up a real `aoe serve --daemon` and attaches the native TUI structured view against it. It reuses the shared Node fake-ACP agent (`web/tests/helpers/fakeAcpAgent.mjs`) to drive a deterministic pending approval, so it needs `--features serve` and Node on `PATH` (it auto-skips via `require_node!` otherwise). The harness installs the fake as the `claude` / `claude-agent-acp` / `aoe-agent` shims (`install_acp_shim`), roots `$HOME` under `/tmp` (`new_in_tmp`, keeping the worker unix socket under the macOS `sun_path` limit), and stops the worker plus daemon on `Drop` (`stop_daemon_on_drop`).
 
-Recording (for PR reviews): `RECORD_E2E=1 cargo test --test e2e -- --nocapture` locally (needs `asciinema` + `agg`, outputs to `target/e2e-recordings/`), or add the `needs-recording` label in CI.
+Recording (for PR reviews): `RECORD_E2E=1 cargo test --features e2e-tests --test e2e -- --nocapture` locally (needs `asciinema` + `agg`, outputs to `target/e2e-recordings/`), or add the `needs-recording` label in CI.
 
 ### Web Dashboard Playwright Tests
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,15 @@ test-support = []
 # Compile in the bundled first-party plugins. Build the bare core (acceptance
 # criterion 1 of #268) by opting out with `--no-default-features`.
 default-plugins = []
+# Gates the `e2e` test target (tests/e2e/main.rs). Off by default so CI can run
+# the serve suite as two parallel shards without enumerating every non-e2e test
+# binary: `cargo test --features serve` runs everything except e2e (the target
+# is skipped when the feature is off), and `cargo test --features serve,e2e-tests
+# --test e2e` runs e2e only. Run the full serve suite locally with
+# `cargo test --features serve,e2e-tests`. Naming the target explicitly
+# (`cargo test --test e2e`) without the feature errors loudly rather than
+# skipping silently.
+e2e-tests = []
 serve = [
     "axum",
     "tower-http",
@@ -259,6 +268,15 @@ codegen-units = 16
 # builds. Use the default `dev` profile when you want the isolated
 # `-dev` namespace.
 debug-assertions = false
+
+[[test]]
+# Explicit target so the `e2e-tests` feature gate applies. Without this entry
+# Cargo auto-discovers tests/e2e/main.rs unconditionally; the gate lets CI split
+# the serve suite into "everything except e2e" and "e2e only" shards. The other
+# 16 test binaries stay auto-discovered.
+name = "e2e"
+path = "tests/e2e/main.rs"
+required-features = ["e2e-tests"]
 
 [[bin]]
 name = "aoe"

--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,10 @@
 
             aoe-clippy = craneLib.cargoClippy (commonArgs // {
               inherit cargoArtifacts;
-              cargoClippyExtraArgs = "--package agent-of-empires --all-targets -- --deny warnings";
+              # e2e-tests keeps the gated e2e target inside the --all-targets
+              # sweep; without it the required-features gate would silently drop
+              # e2e from clippy's --deny warnings coverage.
+              cargoClippyExtraArgs = "--package agent-of-empires --all-targets --features e2e-tests -- --deny warnings";
             });
 
             aoe-fmt = craneLib.cargoFmt {

--- a/tests/e2e/acp_focus_isolation_e2e.rs
+++ b/tests/e2e/acp_focus_isolation_e2e.rs
@@ -17,7 +17,7 @@
 //! don't exist otherwise). Run via:
 //!
 //! ```sh
-//! cargo test --test e2e -- acp_focus_isolation
+//! cargo test --features e2e-tests --test e2e -- acp_focus_isolation
 //! ```
 #![cfg(feature = "serve")]
 

--- a/tests/e2e/acp_orphan_runner_recovery_e2e.rs
+++ b/tests/e2e/acp_orphan_runner_recovery_e2e.rs
@@ -20,7 +20,7 @@
 //! Compiled only with the default `serve` feature (excluded by `--no-default-features`). Run via:
 //!
 //! ```sh
-//! cargo test --test e2e -- acp_orphan_runner_recovery
+//! cargo test --features e2e-tests --test e2e -- acp_orphan_runner_recovery
 //! ```
 #![cfg(feature = "serve")]
 

--- a/tests/e2e/acp_session_log_tee_e2e.rs
+++ b/tests/e2e/acp_session_log_tee_e2e.rs
@@ -11,7 +11,7 @@
 //! Compiled only with the default `serve` feature (excluded by `--no-default-features`). Run via:
 //!
 //! ```sh
-//! cargo test --test e2e -- acp_session_log_tee
+//! cargo test --features e2e-tests --test e2e -- acp_session_log_tee
 //! ```
 #![cfg(feature = "serve")]
 

--- a/tests/e2e/acp_tool_cards_e2e.rs
+++ b/tests/e2e/acp_tool_cards_e2e.rs
@@ -14,7 +14,7 @@
 //! Compiled only with the default `serve` feature (excluded by `--no-default-features`). Run via:
 //!
 //! ```sh
-//! cargo test --test e2e -- acp_tool_cards
+//! cargo test --features e2e-tests --test e2e -- acp_tool_cards
 //! ```
 #![cfg(feature = "serve")]
 

--- a/tests/e2e/archive_structured.rs
+++ b/tests/e2e/archive_structured.rs
@@ -34,7 +34,7 @@
 //! Compiled only with `--features serve`. Run via:
 //!
 //! ```sh
-//! cargo test --test e2e --features serve -- archive_structured
+//! cargo test --features serve,e2e-tests --test e2e -- archive_structured
 //! ```
 #![cfg(feature = "serve")]
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8,8 +8,8 @@
 //! # Running
 //!
 //! ```sh
-//! cargo test --test e2e              # run all e2e tests
-//! cargo test --test e2e -- --nocapture  # with screen dumps on failure
+//! cargo test --features e2e-tests --test e2e              # run all e2e tests
+//! cargo test --features e2e-tests --test e2e -- --nocapture  # with screen dumps on failure
 //! ```
 //!
 //! TUI tests require tmux and are skipped automatically if it is not installed.

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -6,7 +6,7 @@
 //! under `--no-default-features`; run via:
 //!
 //! ```sh
-//! cargo test --test e2e -- tui_serve_dialog
+//! cargo test --features e2e-tests --test e2e -- tui_serve_dialog
 //! ```
 #![cfg(feature = "serve")]
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`Cargo Test (linux)` ran four cargo legs sequentially on one runner (~8m42s warm, 13+ cold) and was the long pole of the whole Tests workflow; every other job finished inside ~4 minutes. Each leg used a different feature set, so switching between them forced a partial recompile and nothing overlapped.

This splits the Linux cargo work into a 3-leg matrix that runs in parallel, each leg on its own `Swatinem/rust-cache` slot so the feature-set switch no longer thrashes `target/`:

- `serve-e2e`: `cargo test --features serve,e2e-tests --test e2e` (the tmux-serial e2e binary, the wall-clock pole at ~4m12 warm)
- `serve-rest`: `cargo test --features serve` (the full serve suite minus e2e, ~3m15)
- `bare-core`: the three `--no-default-features` feature corners (~3m20)

To express "serve suite minus e2e" without enumerating every test binary (cargo has no exclude-target flag), the `e2e` test target is gated behind a new `e2e-tests` feature (`required-features`). `cargo test --features serve` then skips e2e while every non-e2e binary stays auto-discovered, and the dedicated `serve-e2e` leg opts the target back in. Naming the target without the feature (`cargo test --test e2e`) errors loudly instead of skipping silently. The bare e2e leg, `macos-acp-e2e`, `e2e-recording.yml`, and the nix clippy `--all-targets` sweep all opt the gated target back in, so coverage is unchanged.

A fan-in `cargo-linux-ok` job carries the required-check name `Cargo Test (linux)` (matrix legs report per-leg contexts the branch ruleset does not know about), mirroring the existing `playwright-live-ok` pattern. macOS moves to its own `cargo-macos` job keeping the `Cargo Test (macos)` check name.

Wall-clock pole drops from ~8m42 to ~4m12 warm; all legs land under 5 minutes. The cold-cache build floor (~3 min of dep compilation per runner, on a `Cargo.lock` change) is out of scope here and tracked as the sccache follow-up in the issue.

Closes #2572

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

These verify the e2e feature gate locally; the parallel-job timing is proven by this PR's own CI run.

- [ ] `cargo test --features serve,e2e-tests --test e2e --no-run` builds the e2e binary.
- [ ] `cargo test --features serve --no-run` builds the rest of the serve suite and does NOT build e2e.
- [ ] `cargo test --features serve --test e2e` errors with "target `e2e` requires the features: `e2e-tests`" (loud, not silent).
- [ ] `cargo test --no-default-features --features e2e-tests --test e2e --no-run` and `cargo check --no-default-features --features default-plugins,e2e-tests --all-targets` both succeed.
- [ ] On this PR, the Actions run shows `Cargo Test (linux, serve-e2e)`, `(serve-rest)`, `(bare-core)` running in parallel, the fan-in `Cargo Test (linux)` check green, and no single cargo job over 5 minutes (warm cache).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR is CI infrastructure only; it changes no TUI rendering, CLI subcommand, or session lifecycle. The same e2e suite still runs, now on its own shard.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, timing analysis, a two-model design debate (cargo feature-gate vs nextest vs source deletion), and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the local verification steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785430523&installation_id=139138837&pr_number=2580&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2580&signature=fb46df439ea71ba8c68afceeb66dafa8741e6d8bc646e91029c4ca1af092dfe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes Rust CI faster and more reliable by restructuring the GitHub Actions workflow.

- **Linux CI was sharded into a 3-leg parallel matrix**: `serve-e2e`, `serve-rest`, and `bare-core`, instead of running a single long sequential Linux job.
- **macOS tests were split into their own job** (`cargo-macos`) to keep the same required check name behavior while reducing contention.
- A **new Cargo feature flag, `e2e-tests`**, was added to prevent `cargo test --features serve` from accidentally running the e2e target. The e2e-only shards (and any e2e-needed jobs) explicitly enable `e2e-tests`.
- CI configuration was updated to **preserve the required “Cargo Test (linux)” check** using a fan-in gate job, while other jobs run independently.
- **Docs and test guidance** (AGENTS.md and e2e test file doc comments) were updated so local/recorded e2e runs use `--features e2e-tests --test e2e`.
- Minor CI hardening: **checkout now disables credentials persistence** for several non-Rust web jobs, and clippy’s Nix check was adjusted to include `e2e-tests`.

Benefits:
- **Lower Linux test wall-clock time** by running shards in parallel and reducing rebuild churn via per-leg cache usage.
- **Cleaner, more predictable test selection** (e2e runs only when intended).
- **Same overall coverage**, while keeping required CI check names consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->