### PR TITLE
feat(plugins): show an update changelog before applying, in the web modal and TUI

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -222,7 +222,13 @@ uninstalls a `gh:` plugin without a terminal. The same disclosure the CLI
 prompts for (capabilities, build commands, UI slots, unverified-source warning)
 is returned as structured data and approved in a modal; the host then runs the
 operation as a job whose progress and build output stream to a per-job log file
-under `<plugins_dir>/jobs/<job_id>.log`, which the dashboard tails. One
+under `<plugins_dir>/jobs/<job_id>.log`, which the dashboard tails. Every update
+(in the web modal and the TUI plugin manager) first shows a changelog between
+the installed and target version, release notes when the refs bracket release
+tags, otherwise commit subjects from the GitHub compare endpoint
+(`plugin::changelog`, assembled best-effort in `preview_update` only). A safe
+version bump no longer auto-applies: it opens the same review surface so the
+changelog is seen before the update runs. One
 lifecycle mutation runs at a time (config and lockfile writes are not
 concurrency-safe; a second start is rejected). One PATH caveat: a dashboard
 build runs with the daemon's environment, not the user's interactive shell, so a

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -53,10 +53,49 @@ pub struct GitHubRelease {
     #[serde(default)]
     pub body: Option<String>,
     pub published_at: Option<String>,
+    /// A draft (unpublished) release. Excluded from a public list, but kept here
+    /// so the changelog can filter defensively.
+    #[serde(default)]
+    pub draft: bool,
+    /// A prerelease (alpha/beta/rc). `releases/latest` excludes these; the list
+    /// endpoint does not, so the changelog filters them to match the stable
+    /// channel the update path tracks.
+    #[serde(default)]
+    pub prerelease: bool,
     /// Release assets (downloadable binaries). Empty for the update check; used
     /// by plugin install to fetch a release-binary worker.
     #[serde(default)]
     pub assets: Vec<GitHubAsset>,
+}
+
+/// The result of comparing two commits (`/compare/{base}...{head}`). Only the
+/// fields the changelog needs are deserialized.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubCompare {
+    /// `ahead`, `behind`, `diverged`, or `identical`.
+    pub status: String,
+    /// Total commits between base and head. May exceed `commits.len()` because
+    /// the compare endpoint caps the returned list at 250.
+    #[serde(default)]
+    pub total_commits: u64,
+    #[serde(default)]
+    pub commits: Vec<GitHubCompareCommit>,
+}
+
+/// One commit in a compare result.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubCompareCommit {
+    pub sha: String,
+    #[serde(default)]
+    pub html_url: String,
+    pub commit: GitHubCommitInner,
+}
+
+/// The commit metadata nested under a compare commit.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubCommitInner {
+    #[serde(default)]
+    pub message: String,
 }
 
 /// A single downloadable asset attached to a release.
@@ -128,6 +167,29 @@ impl GitHubClient {
         let url = format!(
             "{}/repos/{}/{}/releases?per_page={}",
             self.api_base, owner, repo, per_page
+        );
+        self.send_json(self.http.get(url)).await
+    }
+
+    /// `GET /repos/{owner}/{repo}/compare/{base}...{head}`
+    ///
+    /// Returns the commits on `head` that are not on `base`, base-exclusive and
+    /// head-inclusive. The endpoint caps the returned list at 250 commits, so
+    /// `total_commits` may exceed `commits.len()`; callers mark truncation off
+    /// that gap. A ref containing `/` (a branch like `release/1.x`) is encoded so
+    /// it stays one path segment.
+    pub async fn compare_commits(
+        &self,
+        owner: &str,
+        repo: &str,
+        base: &str,
+        head: &str,
+    ) -> Result<GitHubCompare> {
+        let base = utf8_percent_encode(base, TAG_SEGMENT);
+        let head = utf8_percent_encode(head, TAG_SEGMENT);
+        let url = format!(
+            "{}/repos/{}/{}/compare/{}...{}",
+            self.api_base, owner, repo, base, head
         );
         self.send_json(self.http.get(url)).await
     }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -9,7 +9,10 @@
 pub mod client;
 pub mod error;
 
-pub use client::{GitHubAsset, GitHubClient, GitHubClientConfig, GitHubRelease, GitHubRepo};
+pub use client::{
+    GitHubAsset, GitHubClient, GitHubClientConfig, GitHubCompare, GitHubCompareCommit,
+    GitHubRelease, GitHubRepo,
+};
 pub use error::{GitHubError, Result};
 
 /// Default GitHub REST API base.

--- a/src/plugin/changelog.rs
+++ b/src/plugin/changelog.rs
@@ -41,6 +41,10 @@ pub struct UpdateChangelog {
     pub entries: Vec<ChangelogEntry>,
     pub truncated: bool,
     pub unavailable_reason: Option<String>,
+    /// A GitHub URL for the full history when the changelog is capped or a
+    /// surface cannot show it all (the releases page, or the compare view). The
+    /// non-scrollable TUI popup links to it; the web modal shows it on truncation.
+    pub more_url: Option<String>,
 }
 
 /// One changelog item: a published release's notes, or a single commit subject.
@@ -65,6 +69,7 @@ impl UpdateChangelog {
             entries: Vec::new(),
             truncated: false,
             unavailable_reason: None,
+            more_url: None,
         }
     }
 
@@ -73,8 +78,14 @@ impl UpdateChangelog {
             entries: Vec::new(),
             truncated: false,
             unavailable_reason: Some(reason.into()),
+            more_url: None,
         }
     }
+}
+
+/// The human GitHub base URL for a source, `https://github.com/{owner}/{repo}`.
+fn github_web_base(owner: &str, repo: &str) -> String {
+    format!("https://github.com/{owner}/{repo}")
 }
 
 /// Map a GitHub error to a short, user-facing "unavailable" reason. A rate limit
@@ -176,6 +187,7 @@ async fn release_changelog(
         entries,
         truncated,
         unavailable_reason: None,
+        more_url: Some(format!("{}/releases", github_web_base(owner, repo))),
     })
 }
 
@@ -255,6 +267,10 @@ async fn commit_changelog(
         entries,
         truncated,
         unavailable_reason: None,
+        more_url: Some(format!(
+            "{}/compare/{base}...{head}",
+            github_web_base(owner, repo)
+        )),
     }
 }
 

--- a/src/plugin/changelog.rs
+++ b/src/plugin/changelog.rs
@@ -1,0 +1,432 @@
+//! Best-effort changelog assembly for an in-UI plugin update preview.
+//!
+//! Given the prior installed ref/commit and the target ref/commit, produce a
+//! human-readable list of what changed between them. Release-tracking updates
+//! show GitHub release notes; everything else (a branch/ref-tracked install, a
+//! moved tag whose content changed, or a release whose notes cannot be
+//! bracketed) falls back to commit subjects from the compare endpoint.
+//!
+//! This is presentation metadata, not a gate: every failure path (rate limit,
+//! 404, a local source) returns [`UpdateChangelog::unavailable`] rather than an
+//! error, so a missing changelog never blocks an update the user already chose
+//! to review. It is assembled only in `install::preview_update`, behind an
+//! explicit user action, so the extra unauthenticated GitHub request (60/hr/IP)
+//! is never spent on a background sweep.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::github::{
+    GitHubClient, GitHubClientConfig, GitHubCompareCommit, GitHubError, GitHubRelease,
+    DEFAULT_USER_AGENT,
+};
+
+use super::source::PluginSource;
+
+/// At most this many release entries before marking the changelog truncated.
+const RELEASES_CAP: usize = 20;
+/// At most this many commit entries before marking the changelog truncated.
+const COMMITS_CAP: usize = 50;
+/// Truncate a release body to this many bytes (on a char boundary) so a
+/// pathological release note does not bloat the preview payload.
+const BODY_CAP: usize = 8 * 1024;
+
+/// What changed between the installed version and the update target. `entries`
+/// is newest-first. `truncated` flags that more existed than are shown.
+/// `unavailable_reason` distinguishes "could not load the changelog" from "there
+/// were genuinely no entries" (both leave `entries` empty).
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateChangelog {
+    pub entries: Vec<ChangelogEntry>,
+    pub truncated: bool,
+    pub unavailable_reason: Option<String>,
+}
+
+/// One changelog item: a published release's notes, or a single commit subject.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChangelogEntry {
+    Release {
+        tag: String,
+        body: Option<String>,
+        published_at: Option<String>,
+    },
+    Commit {
+        sha: String,
+        subject: String,
+        url: Option<String>,
+    },
+}
+
+impl UpdateChangelog {
+    fn empty() -> Self {
+        Self {
+            entries: Vec::new(),
+            truncated: false,
+            unavailable_reason: None,
+        }
+    }
+
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            entries: Vec::new(),
+            truncated: false,
+            unavailable_reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Map a GitHub error to a short, user-facing "unavailable" reason. A rate limit
+/// is the common one worth naming so the user knows to retry later.
+fn unavailable_for(err: &GitHubError) -> UpdateChangelog {
+    let reason = match err {
+        GitHubError::RateLimited => "GitHub rate limit reached; changelog unavailable.",
+        _ => "Changelog unavailable.",
+    };
+    UpdateChangelog::unavailable(reason)
+}
+
+fn client() -> Result<GitHubClient, GitHubError> {
+    GitHubClient::unauthenticated(GitHubClientConfig {
+        api_base: super::fetch::github_api_base(),
+        user_agent: DEFAULT_USER_AGENT.to_string(),
+        timeout: Duration::from_secs(30),
+    })
+}
+
+/// The first line of a commit message, the conventional "subject".
+fn subject(message: &str) -> String {
+    message.lines().next().unwrap_or("").trim().to_string()
+}
+
+/// Truncate `body` to [`BODY_CAP`] bytes on a char boundary, appending an
+/// ellipsis when cut.
+fn cap_body(body: String) -> String {
+    if body.len() <= BODY_CAP {
+        return body;
+    }
+    let mut end = BODY_CAP;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &body[..end])
+}
+
+/// Build the changelog between the installed version and the update target.
+/// Best-effort: returns an `unavailable` changelog rather than erroring on any
+/// failure.
+pub async fn build(
+    source: &PluginSource,
+    prior_ref: Option<&str>,
+    prior_commit: Option<&str>,
+    target_ref: Option<&str>,
+    target_commit: Option<&str>,
+) -> UpdateChangelog {
+    let (owner, repo) = match source {
+        PluginSource::Github { owner, repo, .. } => (owner.as_str(), repo.as_str()),
+        PluginSource::Local(_) => {
+            return UpdateChangelog::unavailable("Changelog is only available for GitHub plugins.")
+        }
+    };
+
+    let client = match client() {
+        Ok(c) => c,
+        Err(e) => return unavailable_for(&e),
+    };
+
+    // Release path: only when the refs are distinct release tags we can bracket
+    // in the releases list. A moved tag (same ref, changed content) or an
+    // unbracketable pair falls through to the commit compare.
+    if let (Some(prior_ref), Some(target_ref)) = (prior_ref, target_ref) {
+        if prior_ref != target_ref {
+            if let Some(changelog) =
+                release_changelog(&client, owner, repo, prior_ref, target_ref).await
+            {
+                return changelog;
+            }
+        }
+    }
+
+    match (prior_commit, target_commit) {
+        (Some(base), Some(head)) => commit_changelog(&client, owner, repo, base, head).await,
+        _ => UpdateChangelog::unavailable("Changelog unavailable."),
+    }
+}
+
+/// Collect release notes for the published releases strictly newer than
+/// `prior_ref` up to and including `target_ref`, bracketed by tag identity in
+/// the list order GitHub returns (newest-first). Returns `None` to signal "fall
+/// back to commits" when the pair cannot be bracketed (target tag absent, no
+/// release entries between them); returns `Some(unavailable)` on an API error so
+/// a rate limit does not silently turn into a noisy commit dump.
+async fn release_changelog(
+    client: &GitHubClient,
+    owner: &str,
+    repo: &str,
+    prior_ref: &str,
+    target_ref: &str,
+) -> Option<UpdateChangelog> {
+    let releases = match client.list_releases(owner, repo, 100).await {
+        Ok(r) => r,
+        Err(GitHubError::NotFound { .. }) => return None,
+        Err(e) => return Some(unavailable_for(&e)),
+    };
+    bracket_releases(&releases, prior_ref, target_ref).map(|(entries, truncated)| UpdateChangelog {
+        entries,
+        truncated,
+        unavailable_reason: None,
+    })
+}
+
+/// Pure release-bracketing: from the releases list (newest-first as GitHub
+/// returns it), collect published (non-draft, non-prerelease) entries from
+/// `target_ref` down to, but excluding, `prior_ref`. Returns `None` when the
+/// pair cannot be bracketed (target tag absent, or nothing sits between them),
+/// signalling the caller to fall back to commits. The bool is the truncation
+/// flag (cap hit, or the prior tag was older than the fetched page).
+fn bracket_releases(
+    releases: &[GitHubRelease],
+    prior_ref: &str,
+    target_ref: &str,
+) -> Option<(Vec<ChangelogEntry>, bool)> {
+    let mut entries = Vec::new();
+    let mut truncated = false;
+    let mut collecting = false;
+    let mut found_prior = false;
+    for release in releases.iter().filter(|r| !r.draft && !r.prerelease) {
+        if release.tag_name == target_ref {
+            collecting = true;
+        }
+        if !collecting {
+            continue;
+        }
+        if release.tag_name == prior_ref {
+            found_prior = true;
+            break;
+        }
+        if entries.len() >= RELEASES_CAP {
+            truncated = true;
+            break;
+        }
+        entries.push(ChangelogEntry::Release {
+            tag: release.tag_name.clone(),
+            body: release
+                .body
+                .clone()
+                .map(|b| cap_body(b.trim().to_string()))
+                .filter(|b| !b.is_empty()),
+            published_at: release.published_at.clone(),
+        });
+    }
+
+    if entries.is_empty() {
+        // Target tag never appeared, or nothing sits between the two tags: not a
+        // usable release bracket.
+        return None;
+    }
+    // The prior tag was older than the fetched page (or filtered out), so there
+    // may be releases we did not show.
+    Some((entries, truncated || !found_prior))
+}
+
+/// Commit subjects on `head` not on `base`, newest-first. The compare endpoint
+/// returns commits oldest-first and caps the list at 250, so reverse for display
+/// and mark truncation off `total_commits`.
+async fn commit_changelog(
+    client: &GitHubClient,
+    owner: &str,
+    repo: &str,
+    base: &str,
+    head: &str,
+) -> UpdateChangelog {
+    let compare = match client.compare_commits(owner, repo, base, head).await {
+        Ok(c) => c,
+        Err(e) => return unavailable_for(&e),
+    };
+
+    // identical / behind have nothing meaningful to show going forward.
+    if compare.commits.is_empty() {
+        return UpdateChangelog::empty();
+    }
+
+    let (entries, truncated) = map_commits(&compare.commits, compare.total_commits);
+    UpdateChangelog {
+        entries,
+        truncated,
+        unavailable_reason: None,
+    }
+}
+
+/// Pure commit mapping: the compare endpoint returns commits oldest-first and
+/// caps the list at 250, so reverse for newest-first display, take [`COMMITS_CAP`],
+/// and mark truncation off the gap between `total_commits` and what was returned
+/// or shown.
+fn map_commits(commits: &[GitHubCompareCommit], total_commits: u64) -> (Vec<ChangelogEntry>, bool) {
+    let returned = commits.len() as u64;
+    let entries: Vec<ChangelogEntry> = commits
+        .iter()
+        .rev()
+        .take(COMMITS_CAP)
+        .map(|c| ChangelogEntry::Commit {
+            sha: c.sha.clone(),
+            subject: subject(&c.commit.message),
+            url: (!c.html_url.is_empty()).then(|| c.html_url.clone()),
+        })
+        .collect();
+    let truncated = total_commits > returned || returned as usize > COMMITS_CAP;
+    (entries, truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subject_takes_first_line() {
+        assert_eq!(subject("feat: add thing\n\nlong body"), "feat: add thing");
+        assert_eq!(subject("  trimmed  "), "trimmed");
+        assert_eq!(subject(""), "");
+    }
+
+    #[test]
+    fn cap_body_truncates_on_char_boundary() {
+        let body = "é".repeat(BODY_CAP); // each 'é' is 2 bytes, so this exceeds the cap
+        let capped = cap_body(body);
+        assert!(capped.ends_with('…'));
+        // The slice point landed on a valid boundary (no panic) and is bounded.
+        assert!(capped.len() <= BODY_CAP + "…".len());
+    }
+
+    #[test]
+    fn cap_body_keeps_short_bodies() {
+        assert_eq!(cap_body("short".to_string()), "short");
+    }
+
+    fn release(tag: &str, body: Option<&str>, prerelease: bool, draft: bool) -> GitHubRelease {
+        GitHubRelease {
+            tag_name: tag.to_string(),
+            body: body.map(str::to_string),
+            published_at: Some("2026-01-01T00:00:00Z".to_string()),
+            draft,
+            prerelease,
+            assets: vec![],
+        }
+    }
+
+    fn release_tags(entries: &[ChangelogEntry]) -> Vec<&str> {
+        entries
+            .iter()
+            .map(|e| match e {
+                ChangelogEntry::Release { tag, .. } => tag.as_str(),
+                ChangelogEntry::Commit { .. } => panic!("expected release entry"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn bracket_collects_between_target_and_prior_exclusive() {
+        // Newest-first, as GitHub returns. prior=v1.0.0, target=v1.2.0.
+        let releases = vec![
+            release("v1.3.0", Some("newer, excluded"), false, false),
+            release("v1.2.0", Some("target notes"), false, false),
+            release("v1.1.0", Some("middle notes"), false, false),
+            release("v1.0.0", Some("prior, excluded"), false, false),
+        ];
+        let (entries, truncated) = bracket_releases(&releases, "v1.0.0", "v1.2.0").unwrap();
+        assert_eq!(release_tags(&entries), vec!["v1.2.0", "v1.1.0"]);
+        assert!(!truncated, "prior tag was found in the page");
+    }
+
+    #[test]
+    fn bracket_filters_drafts_and_prereleases() {
+        let releases = vec![
+            release("v1.2.0", Some("target"), false, false),
+            release("v1.2.0-rc1", Some("rc"), true, false),
+            release("v1.1.5-draft", Some("draft"), false, true),
+            release("v1.1.0", Some("middle"), false, false),
+            release("v1.0.0", None, false, false),
+        ];
+        let (entries, _) = bracket_releases(&releases, "v1.0.0", "v1.2.0").unwrap();
+        assert_eq!(release_tags(&entries), vec!["v1.2.0", "v1.1.0"]);
+    }
+
+    #[test]
+    fn bracket_returns_none_when_target_absent() {
+        let releases = vec![release("v1.1.0", None, false, false)];
+        assert!(bracket_releases(&releases, "v1.0.0", "v9.9.9").is_none());
+    }
+
+    #[test]
+    fn bracket_truncates_when_prior_older_than_page() {
+        // prior tag is not present (older than the fetched page) => truncated.
+        let releases = vec![
+            release("v2.0.0", Some("a"), false, false),
+            release("v1.9.0", Some("b"), false, false),
+        ];
+        let (entries, truncated) = bracket_releases(&releases, "v1.0.0", "v2.0.0").unwrap();
+        assert_eq!(release_tags(&entries), vec!["v2.0.0", "v1.9.0"]);
+        assert!(truncated, "prior tag not in page should flag truncation");
+    }
+
+    #[test]
+    fn bracket_empty_body_becomes_none() {
+        let releases = vec![
+            release("v1.1.0", Some("   "), false, false),
+            release("v1.0.0", None, false, false),
+        ];
+        let (entries, _) = bracket_releases(&releases, "v1.0.0", "v1.1.0").unwrap();
+        match &entries[0] {
+            ChangelogEntry::Release { body, .. } => assert!(body.is_none()),
+            _ => panic!("expected release"),
+        }
+    }
+
+    fn commit(sha: &str, message: &str, url: &str) -> GitHubCompareCommit {
+        GitHubCompareCommit {
+            sha: sha.to_string(),
+            html_url: url.to_string(),
+            commit: crate::github::client::GitHubCommitInner {
+                message: message.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn map_commits_reverses_to_newest_first_and_takes_subject() {
+        // GitHub returns oldest-first; display is newest-first.
+        let commits = vec![
+            commit("aaa", "first\n\nbody", "http://x/aaa"),
+            commit("bbb", "second", ""),
+        ];
+        let (entries, truncated) = map_commits(&commits, 2);
+        match (&entries[0], &entries[1]) {
+            (
+                ChangelogEntry::Commit {
+                    sha: s0,
+                    subject: j0,
+                    url: u0,
+                },
+                ChangelogEntry::Commit {
+                    sha: s1,
+                    subject: j1,
+                    url: u1,
+                },
+            ) => {
+                assert_eq!((s0.as_str(), j0.as_str()), ("bbb", "second"));
+                assert_eq!(u0, &None, "empty html_url maps to None");
+                assert_eq!((s1.as_str(), j1.as_str()), ("aaa", "first"));
+                assert_eq!(u1.as_deref(), Some("http://x/aaa"));
+            }
+            _ => panic!("expected commit entries"),
+        }
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn map_commits_flags_truncation_when_total_exceeds_returned() {
+        let commits = vec![commit("aaa", "x", "")];
+        let (_, truncated) = map_commits(&commits, 300);
+        assert!(truncated, "total_commits > returned must flag truncation");
+    }
+}

--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -336,7 +336,7 @@ fn copy_tree(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-fn github_api_base() -> String {
+pub(super) fn github_api_base() -> String {
     std::env::var("AOE_UPDATE_API_BASE")
         .unwrap_or_else(|_| crate::github::DEFAULT_GITHUB_API_BASE.to_string())
 }

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -202,8 +202,8 @@ pub struct UpdateConsent {
 pub enum UpdatePreview {
     /// The remote matches the installed content; nothing to do.
     NoUpdate,
-    /// A newer version that needs no fresh consent; safe to apply directly. The
-    /// changelog is still surfaced so the user sees what they are pulling in.
+    /// A newer version that needs no fresh consent; still returned to the UI for
+    /// review so the user sees the changelog before applying.
     SafeUpdate {
         to_version: String,
         fingerprint: String,

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 
 use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
 
+use super::changelog::UpdateChangelog;
 use super::featured::FeaturedIndex;
 use super::fetch::{self, FetchedPlugin};
 use super::lockfile::{LockedPlugin, Lockfile};
@@ -189,6 +190,10 @@ pub struct UpdateConsent {
     /// Whether declining keeps the current version active (always true for the
     /// in-app path, which never touches the tree on decline).
     pub stays_active_if_declined: bool,
+    /// What changed between the installed version and this one, for the user to
+    /// review before approving. Best-effort; empty or unavailable on any fetch
+    /// failure.
+    pub changelog: UpdateChangelog,
 }
 
 /// What a non-interactive update preview found for one installed plugin.
@@ -197,10 +202,12 @@ pub struct UpdateConsent {
 pub enum UpdatePreview {
     /// The remote matches the installed content; nothing to do.
     NoUpdate,
-    /// A newer version that needs no fresh consent; safe to apply directly.
+    /// A newer version that needs no fresh consent; safe to apply directly. The
+    /// changelog is still surfaced so the user sees what they are pulling in.
     SafeUpdate {
         to_version: String,
         fingerprint: String,
+        changelog: UpdateChangelog,
     },
     /// A newer version that expands access (capabilities, build steps, UI,
     /// runtime, or trust) and must be explicitly approved. `dismissed` is set
@@ -484,6 +491,15 @@ struct Prepared {
     /// Content fingerprint of the currently installed version, from the
     /// lockfile; `None` when no lock entry exists.
     prior_fingerprint: Option<String>,
+    /// The installed source ref and resolved commit (from the lockfile), and the
+    /// fetched target ref and commit. Drive the changelog assembly in
+    /// `preview_update`. `requested_ref` is the source tag/branch (a no-`@ref`
+    /// release install resolves to the release tag here); `release_tag` is NOT
+    /// used (it is release-binary asset provenance only).
+    prior_requested_ref: Option<String>,
+    prior_resolved_commit: Option<String>,
+    target_requested_ref: Option<String>,
+    target_resolved_commit: Option<String>,
     from_version: String,
     caps_changed: bool,
     added_capabilities: Vec<String>,
@@ -552,6 +568,13 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
     let from_version = prior_locked
         .map(|l| l.version.clone())
         .unwrap_or_else(|| "?".to_string());
+    // Captured before `fetched` is moved into the returned struct. The source
+    // ref is `requested_ref` (a no-`@ref` release install resolved its tag into
+    // this field), never `release_tag`.
+    let prior_requested_ref = prior_locked.and_then(|l| l.requested_ref.clone());
+    let prior_resolved_commit = prior_locked.and_then(|l| l.resolved_commit.clone());
+    let target_requested_ref = fetched.requested_ref.clone();
+    let target_resolved_commit = fetched.resolved_commit.clone();
 
     let trust = if featured_verified {
         "featured"
@@ -637,6 +660,10 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
         manifest_hash,
         fingerprint,
         prior_fingerprint,
+        prior_requested_ref,
+        prior_resolved_commit,
+        target_requested_ref,
+        target_resolved_commit,
         from_version,
         caps_changed,
         added_capabilities,
@@ -750,8 +777,10 @@ async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcom
     )?))
 }
 
-/// Build the structured consent disclosure from a prepared update.
-fn consent_of(p: &Prepared) -> UpdateConsent {
+/// Build the structured consent disclosure from a prepared update. The
+/// changelog is assembled by the caller (`preview_update`) and passed in, so the
+/// disclosure stays free of network work.
+fn consent_of(p: &Prepared, changelog: UpdateChangelog) -> UpdateConsent {
     UpdateConsent {
         id: p.id.clone(),
         from_version: p.from_version.clone(),
@@ -782,7 +811,25 @@ fn consent_of(p: &Prepared) -> UpdateConsent {
         trust_downgrade: p.trust_downgrade,
         fingerprint: p.fingerprint.clone(),
         stays_active_if_declined: true,
+        changelog,
     }
+}
+
+/// Assemble the changelog for a prepared update from its prior/target refs and
+/// commits. Best-effort and network-bound; only called from `preview_update`.
+async fn changelog_of(p: &Prepared) -> UpdateChangelog {
+    let source = match PluginSource::parse(&p.source_str) {
+        Ok(s) => s,
+        Err(_) => return UpdateChangelog::unavailable("Changelog unavailable."),
+    };
+    super::changelog::build(
+        &source,
+        p.prior_requested_ref.as_deref(),
+        p.prior_resolved_commit.as_deref(),
+        p.target_requested_ref.as_deref(),
+        p.target_resolved_commit.as_deref(),
+    )
+    .await
 }
 
 /// Classify an available update for one installed plugin without applying it:
@@ -792,10 +839,13 @@ pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
     if prepared.prior_fingerprint.as_ref() == Some(&prepared.fingerprint) {
         return Ok(UpdatePreview::NoUpdate);
     }
+    // One best-effort changelog fetch, behind this explicit user-driven preview.
+    let changelog = changelog_of(&prepared).await;
     if !prepared.needs_consent {
         return Ok(UpdatePreview::SafeUpdate {
             to_version: prepared.fetched.manifest.version.clone(),
             fingerprint: prepared.fingerprint.clone(),
+            changelog,
         });
     }
     let dismissed = Config::load()
@@ -803,7 +853,7 @@ pub async fn preview_update(id: &str) -> Result<UpdatePreview> {
         .and_then(|c| c.plugins.get(id).and_then(|p| p.dismissed_update.clone()))
         == Some(prepared.fingerprint.clone());
     Ok(UpdatePreview::ConsentRequired {
-        consent: Box::new(consent_of(&prepared)),
+        consent: Box::new(consent_of(&prepared, changelog)),
         dismissed,
     })
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -7,6 +7,7 @@
 //! return in follow-up PRs.
 
 pub mod auto_update;
+pub mod changelog;
 pub mod contributions;
 pub mod discover;
 pub mod featured;

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -1,6 +1,7 @@
 //! Plugin manager: list plugins (builtin and external) with their trust and
 //! enabled/approval state, enable/disable them, and update an external plugin
-//! with an in-TUI consent popup when the new version expands access. The TUI
+//! through an in-TUI review popup that shows the changelog (and the access
+//! disclosure when the new version expands what the plugin can do). The TUI
 //! twin of `aoe plugin list` and the web Plugins tab. Installing a new plugin is
 //! still CLI-driven (`aoe plugin install`); the TUI shows the resulting state.
 

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -12,10 +12,24 @@ use ratatui::widgets::*;
 use tokio::sync::oneshot;
 
 use super::{centered_rect, DialogResult};
+use crate::plugin::changelog::{ChangelogEntry, UpdateChangelog};
 use crate::plugin::discover::DiscoveryResult;
 use crate::plugin::install::{UpdateConsent, UpdatePreview};
 use crate::plugin::update_check::UpdateStatus;
 use crate::tui::styles::Theme;
+
+/// An open update review popup. Every update (safe or consent-required) shows
+/// the changelog; `consent` is `Some` only when the update also expands access,
+/// adding the capability / build / UI / runtime / trust disclosures and the
+/// Decline (dismiss) action.
+struct Review {
+    id: String,
+    from_version: String,
+    to_version: String,
+    fingerprint: String,
+    changelog: UpdateChangelog,
+    consent: Option<UpdateConsent>,
+}
 
 /// Which view the manager is showing: the installed list or GitHub discovery
 /// results.
@@ -67,14 +81,69 @@ pub struct PluginManagerDialog {
     /// The plugin id a preview/apply is running for, so `tick` knows which row
     /// the result belongs to.
     pending_plugin: Option<String>,
-    /// An open update-consent popup: the structured disclosure to render and
-    /// approve / decline.
-    consent: Option<UpdateConsent>,
+    /// An open update review popup: the changelog plus, when access expands, the
+    /// consent disclosure to render and approve / decline.
+    review: Option<Review>,
 }
 
 impl Default for PluginManagerDialog {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Append the changelog to a review popup's lines: release notes or commit
+/// subjects, or a single "unavailable" / "none" line. Best-effort presentation;
+/// the entries are already capped by the backend.
+fn push_changelog_lines(lines: &mut Vec<Line>, changelog: &UpdateChangelog, theme: &Theme) {
+    if let Some(reason) = &changelog.unavailable_reason {
+        lines.push(Line::from(Span::styled(
+            reason.clone(),
+            Style::default().fg(theme.dimmed),
+        )));
+        return;
+    }
+    if changelog.entries.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No changelog available.",
+            Style::default().fg(theme.dimmed),
+        )));
+        return;
+    }
+    lines.push(Line::from(Span::styled(
+        "What's new:",
+        Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+    )));
+    for entry in &changelog.entries {
+        match entry {
+            ChangelogEntry::Release { tag, body, .. } => {
+                lines.push(Line::from(Span::styled(
+                    tag.clone(),
+                    Style::default().fg(theme.text),
+                )));
+                if let Some(body) = body {
+                    for line in body.lines() {
+                        lines.push(Line::from(Span::styled(
+                            format!("  {line}"),
+                            Style::default().fg(theme.dimmed),
+                        )));
+                    }
+                }
+            }
+            ChangelogEntry::Commit { sha, subject, .. } => {
+                let short: String = sha.chars().take(7).collect();
+                lines.push(Line::from(Span::styled(
+                    format!("  {short} {subject}"),
+                    Style::default().fg(theme.dimmed),
+                )));
+            }
+        }
+    }
+    if changelog.truncated {
+        lines.push(Line::from(Span::styled(
+            "  ... older history on GitHub",
+            Style::default().fg(theme.dimmed),
+        )));
     }
 }
 
@@ -95,7 +164,7 @@ impl PluginManagerDialog {
             discover_rows: Vec::new(),
             discover_selected: 0,
             pending_plugin: None,
-            consent: None,
+            review: None,
         };
         dialog.reload();
         dialog.mutated = false; // Initial load is not a user mutation.
@@ -130,9 +199,9 @@ impl PluginManagerDialog {
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         self.info = None;
-        // An open consent popup owns the keyboard until the user decides.
-        if self.consent.is_some() {
-            return self.handle_consent_key(key);
+        // An open review popup owns the keyboard until the user decides.
+        if self.review.is_some() {
+            return self.handle_review_key(key);
         }
         if self.mode == Mode::Discover {
             return self.handle_discover_key(key);
@@ -190,36 +259,42 @@ impl PluginManagerDialog {
         }
     }
 
-    /// Keys while the update-consent popup is open: approve, decline, or close.
-    fn handle_consent_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+    /// Keys while the update review popup is open: approve/update, decline (only
+    /// when access expands), or close.
+    fn handle_review_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         match key.code {
             KeyCode::Char('y') | KeyCode::Enter => {
-                if let Some(consent) = self.consent.take() {
-                    self.start_apply(consent.id, Some(consent.fingerprint));
+                if let Some(review) = self.review.take() {
+                    self.start_apply(review.id, Some(review.fingerprint));
                 }
                 DialogResult::Continue
             }
-            // Decline: record the dismissal so it stops nagging, keep the active
-            // version. `dismiss_update` is a quick local config write.
+            // Decline only applies to a consent-expanding update: record the
+            // dismissal so it stops nagging, keep the active version. A safe
+            // update has nothing to dismiss, so `n` just closes it.
             KeyCode::Char('n') => {
-                if let Some(consent) = self.consent.take() {
-                    match crate::plugin::install::dismiss_update(&consent.id, &consent.fingerprint)
-                    {
-                        Ok(()) => {
-                            // dismiss_update wrote plugin config; flag it so an
-                            // embedding settings surface resyncs and a later save
-                            // does not clobber the dismissal.
-                            self.mutated = true;
-                            self.info = Some(format!("Declined update for {}.", consent.id));
+                if let Some(review) = self.review.take() {
+                    if review.consent.is_some() {
+                        match crate::plugin::install::dismiss_update(
+                            &review.id,
+                            &review.fingerprint,
+                        ) {
+                            Ok(()) => {
+                                // dismiss_update wrote plugin config; flag it so
+                                // an embedding settings surface resyncs and a
+                                // later save does not clobber the dismissal.
+                                self.mutated = true;
+                                self.info = Some(format!("Declined update for {}.", review.id));
+                            }
+                            Err(e) => self.error = Some(format!("{e:#}")),
                         }
-                        Err(e) => self.error = Some(format!("{e:#}")),
                     }
                 }
                 DialogResult::Continue
             }
             // Close without deciding.
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.consent = None;
+                self.review = None;
                 DialogResult::Continue
             }
             _ => DialogResult::Continue,
@@ -402,10 +477,28 @@ impl PluginManagerDialog {
                         Ok(UpdatePreview::NoUpdate) => {
                             self.info = Some("Already up to date.".to_string());
                         }
-                        // A safe update needs no consent: apply it straight away.
-                        Ok(UpdatePreview::SafeUpdate { fingerprint, .. }) => {
+                        // A safe update needs no consent, but still shows its
+                        // changelog in a review popup before applying.
+                        Ok(UpdatePreview::SafeUpdate {
+                            to_version,
+                            fingerprint,
+                            changelog,
+                        }) => {
                             if let Some(id) = self.pending_plugin.clone() {
-                                self.start_apply(id, Some(fingerprint));
+                                let from_version = self
+                                    .rows
+                                    .iter()
+                                    .find(|r| r.id == id)
+                                    .map(|r| r.version.clone())
+                                    .unwrap_or_default();
+                                self.review = Some(Review {
+                                    id,
+                                    from_version,
+                                    to_version,
+                                    fingerprint,
+                                    changelog,
+                                    consent: None,
+                                });
                             }
                         }
                         // An already-dismissed version must not re-prompt; it
@@ -417,7 +510,14 @@ impl PluginManagerDialog {
                                     consent.id
                                 ));
                             } else {
-                                self.consent = Some(*consent);
+                                self.review = Some(Review {
+                                    id: consent.id.clone(),
+                                    from_version: consent.from_version.clone(),
+                                    to_version: consent.to_version.clone(),
+                                    fingerprint: consent.fingerprint.clone(),
+                                    changelog: consent.changelog.clone(),
+                                    consent: Some(*consent),
+                                });
                             }
                         }
                         Err(message) => self.error = Some(message),
@@ -506,27 +606,42 @@ impl PluginManagerDialog {
         let inner = block.inner(rect);
         f.render_widget(block, rect);
         self.render_browse(f, inner, theme);
-        // The consent popup floats over the list, centered on the dialog rect.
-        if let Some(consent) = &self.consent {
-            self.render_consent(f, rect, theme, consent);
+        // The review popup floats over the list, centered on the dialog rect.
+        if let Some(review) = &self.review {
+            self.render_review(f, rect, theme, review);
         }
     }
 
-    fn render_consent(&self, f: &mut Frame, area: Rect, theme: &Theme, consent: &UpdateConsent) {
-        let mut lines: Vec<Line> = vec![
-            Line::from(Span::styled(
-                format!(
-                    "Update {}? v{} -> v{}",
-                    consent.id, consent.from_version, consent.to_version
-                ),
-                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
-            )),
-            Line::from(Span::styled(
+    fn render_review(&self, f: &mut Frame, area: Rect, theme: &Theme, review: &Review) {
+        let mut lines: Vec<Line> = vec![Line::from(Span::styled(
+            format!(
+                "Update {}? v{} -> v{}",
+                review.id, review.from_version, review.to_version
+            ),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        ))];
+        if review.consent.is_some() {
+            lines.push(Line::from(Span::styled(
                 "This update expands what the plugin can do.",
                 Style::default().fg(theme.dimmed),
-            )),
-            Line::from(""),
-        ];
+            )));
+        }
+        lines.push(Line::from(""));
+
+        // Changelog, shown for every update.
+        push_changelog_lines(&mut lines, &review.changelog, theme);
+        lines.push(Line::from(""));
+
+        let Some(consent) = &review.consent else {
+            // Safe update: changelog only, with an update/cancel hint.
+            lines.push(Line::from(Span::styled(
+                "enter update · esc cancel",
+                Style::default().fg(theme.dimmed),
+            )));
+            self.draw_review_popup(f, area, theme, lines, " Update plugin ");
+            return;
+        };
+
         if !consent.added_capabilities.is_empty() {
             lines.push(Line::from(Span::styled(
                 format!(
@@ -588,7 +703,18 @@ impl PluginManagerDialog {
             "y approve · n decline · esc close",
             Style::default().fg(theme.dimmed),
         )));
+        self.draw_review_popup(f, area, theme, lines, " Approve update ");
+    }
 
+    /// Draw the review popup body into a clamped, centered sub-rect.
+    fn draw_review_popup(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        lines: Vec<Line>,
+        title: &str,
+    ) {
         // A tiny terminal can be narrower/shorter than our preferred size;
         // never pass clamp/centered_rect a max below the min (it panics).
         if area.width == 0 || area.height == 0 {
@@ -599,7 +725,7 @@ impl PluginManagerDialog {
         let rect = centered_rect(area, width, height);
         f.render_widget(Clear, rect);
         let block = Block::default()
-            .title(" Approve update ")
+            .title(title.to_string())
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(theme.accent));

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -93,9 +93,16 @@ impl Default for PluginManagerDialog {
     }
 }
 
+/// Most changelog lines the non-scrollable popup renders before linking out to
+/// GitHub for the rest, so a long release body can never push the consent
+/// disclosure and the approve/decline hint off screen.
+const MAX_CHANGELOG_LINES: usize = 12;
+
 /// Append the changelog to a review popup's lines: release notes or commit
-/// subjects, or a single "unavailable" / "none" line. Best-effort presentation;
-/// the entries are already capped by the backend.
+/// subjects, or a single "unavailable" / "none" line. The popup `Paragraph` is
+/// not scrollable, so the rendered body is hard-capped at [`MAX_CHANGELOG_LINES`]
+/// and the full history is linked via `more_url`; the entry counts are already
+/// capped by the backend, this bounds multi-line release bodies too.
 fn push_changelog_lines(lines: &mut Vec<Line>, changelog: &UpdateChangelog, theme: &Theme) {
     if let Some(reason) = &changelog.unavailable_reason {
         lines.push(Line::from(Span::styled(
@@ -115,34 +122,57 @@ fn push_changelog_lines(lines: &mut Vec<Line>, changelog: &UpdateChangelog, them
         "What's new:",
         Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
     )));
-    for entry in &changelog.entries {
+    let mut remaining = MAX_CHANGELOG_LINES;
+    let mut clipped = false;
+    'entries: for entry in &changelog.entries {
         match entry {
             ChangelogEntry::Release { tag, body, .. } => {
+                if remaining == 0 {
+                    clipped = true;
+                    break;
+                }
                 lines.push(Line::from(Span::styled(
                     tag.clone(),
                     Style::default().fg(theme.text),
                 )));
+                remaining -= 1;
                 if let Some(body) = body {
                     for line in body.lines() {
+                        if remaining == 0 {
+                            clipped = true;
+                            break 'entries;
+                        }
                         lines.push(Line::from(Span::styled(
                             format!("  {line}"),
                             Style::default().fg(theme.dimmed),
                         )));
+                        remaining -= 1;
                     }
                 }
             }
             ChangelogEntry::Commit { sha, subject, .. } => {
+                if remaining == 0 {
+                    clipped = true;
+                    break;
+                }
                 let short: String = sha.chars().take(7).collect();
                 lines.push(Line::from(Span::styled(
                     format!("  {short} {subject}"),
                     Style::default().fg(theme.dimmed),
                 )));
+                remaining -= 1;
             }
         }
     }
-    if changelog.truncated {
+    // Link to the full history when the changelog was clipped here or already
+    // truncated upstream. Fall back to a plain marker if there is no URL.
+    if clipped || changelog.truncated {
+        let marker = match &changelog.more_url {
+            Some(url) => format!("  ... full changelog: {url}"),
+            None => "  ... older history on GitHub".to_string(),
+        };
         lines.push(Line::from(Span::styled(
-            "  ... older history on GitHub",
+            marker,
             Style::default().fg(theme.dimmed),
         )));
     }

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -1,32 +1,44 @@
 import { useEffect } from "react";
 
-import type { PluginUpdateConsent } from "../../lib/api";
+import type { PluginUpdateChangelog, PluginUpdateConsent } from "../../lib/api";
 
 interface PluginUpdateConsentModalProps {
-  /** The structured disclosure for the available update. */
-  consent: PluginUpdateConsent;
+  /** The access disclosure when the update expands what the plugin can do, or
+   *  null for a safe version bump (changelog only, no consent). */
+  consent: PluginUpdateConsent | null;
   /** Plugin display name for the header. */
   name: string;
+  /** Installed version, for the v{from} -> v{to} header. */
+  fromVersion: string;
+  /** Target version. */
+  toVersion: string;
+  /** What changed between the two versions. */
+  changelog: PluginUpdateChangelog;
   /** True while an apply/dismiss request is in flight. */
   busy: boolean;
   /** Inline error from the last apply/dismiss attempt, if any. */
   error: string | null;
-  /** Approve the expanded access and apply the update. */
+  /** Apply the update (safe: "Update"; consent: "Approve and update"). */
   onApprove: () => void;
-  /** Decline: keep the current version and stop nagging until the next version. */
-  onDecline: () => void;
-  /** Close without recording a decision (Esc / backdrop / Close button). */
+  /** Consent mode only: decline and stop nagging until the next version. Absent
+   *  for a safe update, which has nothing to dismiss. */
+  onDecline?: () => void;
+  /** Close without recording a decision (Esc / backdrop / Close / Cancel). */
   onClose: () => void;
 }
 
-/// The in-app capability-consent popup for a plugin update that expands access.
-/// Renders the same disclosure the terminal prompt prints (capability diff, UI
-/// slots, build commands, runtime / trust changes) and gates the update behind
-/// an explicit Approve. Declining keeps the active version and records the
-/// dismissal; closing makes no decision.
+/// The in-app update review popup, used for every in-UI plugin update. It always
+/// shows the changelog between the installed and target version. When the update
+/// also expands access (`consent` is non-null) it adds the capability diff, UI
+/// slots, build commands, and runtime / trust disclosures, and gates behind an
+/// explicit Approve with a Decline that records the dismissal. A safe version
+/// bump (`consent` is null) shows only the changelog with Cancel / Update.
 export function PluginUpdateConsentModal({
   consent,
   name,
+  fromVersion,
+  toVersion,
+  changelog,
   busy,
   error,
   onApprove,
@@ -47,12 +59,14 @@ export function PluginUpdateConsentModal({
     return () => window.removeEventListener("keydown", onKey);
   }, [busy, onClose]);
 
+  const needsConsent = consent !== null;
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       role="dialog"
       aria-modal="true"
-      aria-label={`Approve update for ${name}`}
+      aria-label={`${needsConsent ? "Approve update for" : "Update"} ${name}`}
       onClick={closeIfIdle}
       data-testid="plugin-update-consent-modal"
     >
@@ -64,7 +78,7 @@ export function PluginUpdateConsentModal({
           <div>
             <h2 className="font-semibold">Update {name}?</h2>
             <p className="text-xs text-text-dim">
-              v{consent.from_version} → v{consent.to_version}
+              v{fromVersion} → v{toVersion}
             </p>
           </div>
           <button
@@ -78,11 +92,15 @@ export function PluginUpdateConsentModal({
           </button>
         </div>
 
-        <p className="mb-3 text-xs text-text-dim">
-          This update expands what the plugin can do. Review the new access before approving.
-        </p>
+        <PluginChangelogSection changelog={changelog} />
 
-        {consent.added_capabilities.length > 0 && (
+        {needsConsent && (
+          <p className="mb-3 text-xs text-text-dim">
+            This update expands what the plugin can do. Review the new access before approving.
+          </p>
+        )}
+
+        {consent && consent.added_capabilities.length > 0 && (
           <div className="mb-3" data-testid="plugin-update-added-caps">
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">
               New capabilities
@@ -91,26 +109,26 @@ export function PluginUpdateConsentModal({
           </div>
         )}
 
-        {consent.removed_capabilities.length > 0 && (
+        {consent && consent.removed_capabilities.length > 0 && (
           <div className="mb-3">
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Removed capabilities</p>
             <p className="text-xs text-text-dim">{consent.removed_capabilities.join(", ")}</p>
           </div>
         )}
 
-        {consent.runtime_change && (
+        {consent?.runtime_change && (
           <p className="mb-3 text-xs text-status-warning" data-testid="plugin-update-runtime-change">
             Runtime change: {consent.runtime_change}
           </p>
         )}
 
-        {consent.trust_downgrade && (
+        {consent?.trust_downgrade && (
           <p className="mb-3 text-xs text-status-warning" data-testid="plugin-update-trust-downgrade">
             This version is no longer a verified featured plugin (community trust).
           </p>
         )}
 
-        {consent.build_steps.length > 0 && (
+        {consent && consent.build_steps.length > 0 && (
           <div className="mb-3" data-testid="plugin-update-build-steps">
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-status-warning">
               Build commands (run as you, unsandboxed)
@@ -125,18 +143,20 @@ export function PluginUpdateConsentModal({
           </div>
         )}
 
-        {consent.ui.length > 0 && (
+        {consent && consent.ui.length > 0 && (
           <div className="mb-3">
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">Dashboard UI slots</p>
             <p className="text-xs text-text-dim">{[...new Set(consent.ui.map((u) => u.slot))].join(", ")}</p>
           </div>
         )}
 
-        <p className="mb-3 text-[11px] text-text-dim">
-          Approving trusts this plugin. The host enforces capabilities at its API boundary, but a plugin worker (and any
-          build step) runs without OS-level sandboxing, so a malicious plugin is not contained. Only approve updates
-          from sources you trust.
-        </p>
+        {needsConsent && (
+          <p className="mb-3 text-[11px] text-text-dim">
+            Approving trusts this plugin. The host enforces capabilities at its API boundary, but a plugin worker (and
+            any build step) runs without OS-level sandboxing, so a malicious plugin is not contained. Only approve
+            updates from sources you trust.
+          </p>
+        )}
 
         {error && (
           <p className="mb-3 text-xs text-status-error" data-testid="plugin-update-consent-error">
@@ -149,10 +169,10 @@ export function PluginUpdateConsentModal({
             type="button"
             className="rounded border border-surface-700 px-3 py-1 text-xs hover:bg-surface-800 disabled:opacity-50"
             disabled={busy}
-            onClick={onDecline}
+            onClick={needsConsent ? onDecline : closeIfIdle}
             data-testid="plugin-update-decline"
           >
-            Decline
+            {needsConsent ? "Decline" : "Cancel"}
           </button>
           <button
             type="button"
@@ -161,10 +181,55 @@ export function PluginUpdateConsentModal({
             onClick={onApprove}
             data-testid="plugin-update-approve"
           >
-            {busy ? "Updating…" : "Approve and update"}
+            {busy ? "Updating…" : needsConsent ? "Approve and update" : "Update"}
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+/// The changelog list between the installed and target version. Release notes
+/// render as escaped plain text (React escapes by default; no raw HTML). An
+/// unavailable changelog says so rather than looking like "no changes".
+function PluginChangelogSection({ changelog }: { changelog: PluginUpdateChangelog }) {
+  if (changelog.unavailable_reason) {
+    return (
+      <p className="mb-3 text-xs text-text-dim" data-testid="plugin-update-changelog-unavailable">
+        {changelog.unavailable_reason}
+      </p>
+    );
+  }
+  if (changelog.entries.length === 0) {
+    return (
+      <p className="mb-3 text-xs text-text-dim" data-testid="plugin-update-changelog-empty">
+        No changelog available.
+      </p>
+    );
+  }
+  return (
+    <div className="mb-3" data-testid="plugin-update-changelog">
+      <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-text-dim">What's new</p>
+      <ul className="space-y-2">
+        {changelog.entries.map((entry, i) =>
+          entry.kind === "release" ? (
+            <li key={`r-${entry.tag}-${i}`} className="text-xs">
+              <p className="font-medium text-text">{entry.tag}</p>
+              {entry.body && <p className="whitespace-pre-wrap text-text-dim">{entry.body}</p>}
+            </li>
+          ) : (
+            <li key={`c-${entry.sha}-${i}`} className="flex gap-2 text-xs">
+              <span className="font-mono text-text-dim">{entry.sha.slice(0, 7)}</span>
+              <span className="text-text-dim">{entry.subject}</span>
+            </li>
+          ),
+        )}
+      </ul>
+      {changelog.truncated && (
+        <p className="mt-1 text-[11px] text-text-dim" data-testid="plugin-update-changelog-truncated">
+          Showing the most recent entries; older history is on GitHub.
+        </p>
+      )}
     </div>
   );
 }

--- a/web/src/components/settings/PluginUpdateConsentModal.tsx
+++ b/web/src/components/settings/PluginUpdateConsentModal.tsx
@@ -227,7 +227,18 @@ function PluginChangelogSection({ changelog }: { changelog: PluginUpdateChangelo
       </ul>
       {changelog.truncated && (
         <p className="mt-1 text-[11px] text-text-dim" data-testid="plugin-update-changelog-truncated">
-          Showing the most recent entries; older history is on GitHub.
+          Showing the most recent entries.{" "}
+          {changelog.more_url && (
+            <a
+              href={changelog.more_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-brand-400 underline hover:text-brand-300"
+              data-testid="plugin-update-changelog-more"
+            >
+              View the full changelog on GitHub
+            </a>
+          )}
         </p>
       )}
     </div>

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -14,6 +14,7 @@ import {
   type PluginDiscoveryResult,
   type PluginInstallConsent,
   type PluginListResponse,
+  type PluginUpdateChangelog,
   type PluginUpdateConsent,
   type PluginUpdateStatus,
   type PluginView,
@@ -65,9 +66,18 @@ export function PluginsSettings() {
   const [detail, setDetail] = useState<DetailTarget | null>(null);
 
   // The in-app update flow: which plugin's Update button is previewing, and the
-  // consent modal when a fetched update needs explicit approval.
+  // review modal once the preview lands. Every update (safe or consent-required)
+  // goes through the one review modal, which always shows the changelog;
+  // `consent` is non-null only when the update also expands access.
   const [updatingId, setUpdatingId] = useState<string | null>(null);
-  const [consentModal, setConsentModal] = useState<{ plugin: PluginView; consent: PluginUpdateConsent } | null>(null);
+  const [reviewModal, setReviewModal] = useState<{
+    plugin: PluginView;
+    fromVersion: string;
+    toVersion: string;
+    changelog: PluginUpdateChangelog;
+    consent: PluginUpdateConsent | null;
+    fingerprint: string;
+  } | null>(null);
   const [consentBusy, setConsentBusy] = useState(false);
   const [consentError, setConsentError] = useState<string | null>(null);
 
@@ -173,20 +183,30 @@ export function PluginsSettings() {
         return;
       }
       const preview = res.preview;
+      setConsentError(null);
       if (preview.kind === "no_update") {
         reportInfo(`${plugin.name} is already up to date.`);
         clearUpdateBadge(plugin.id);
       } else if (preview.kind === "safe_update") {
-        const started = await applyPluginUpdate(plugin.id, preview.fingerprint);
-        if (started.kind === "ok") {
-          clearUpdateBadge(plugin.id);
-          setJob({ id: started.jobId, title: `Updating ${plugin.name}` });
-        } else {
-          setError(started.message);
-        }
+        // A safe version bump no longer auto-applies: show the changelog first
+        // so the user sees what they are pulling in, then confirm.
+        setReviewModal({
+          plugin,
+          fromVersion: plugin.version,
+          toVersion: preview.to_version,
+          changelog: preview.changelog,
+          consent: null,
+          fingerprint: preview.fingerprint,
+        });
       } else {
-        setConsentError(null);
-        setConsentModal({ plugin, consent: preview.consent });
+        setReviewModal({
+          plugin,
+          fromVersion: preview.consent.from_version,
+          toVersion: preview.consent.to_version,
+          changelog: preview.consent.changelog,
+          consent: preview.consent,
+          fingerprint: preview.consent.fingerprint,
+        });
       }
     } finally {
       setUpdatingId(null);
@@ -194,15 +214,15 @@ export function PluginsSettings() {
   };
 
   const onApproveUpdate = async () => {
-    if (!consentModal) return;
+    if (!reviewModal) return;
     setConsentBusy(true);
     setConsentError(null);
     try {
-      const res = await applyPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
+      const res = await applyPluginUpdate(reviewModal.plugin.id, reviewModal.fingerprint);
       if (res.kind === "ok") {
-        clearUpdateBadge(consentModal.plugin.id);
-        const name = consentModal.plugin.name;
-        setConsentModal(null);
+        clearUpdateBadge(reviewModal.plugin.id);
+        const name = reviewModal.plugin.name;
+        setReviewModal(null);
         setJob({ id: res.jobId, title: `Updating ${name}` });
       } else {
         // Any failure keeps the modal open with the message; the user can close
@@ -214,18 +234,20 @@ export function PluginsSettings() {
     }
   };
 
+  // Consent mode only (the modal's Decline button). A safe update has nothing to
+  // dismiss; its Cancel button just closes the modal.
   const onDeclineUpdate = async () => {
-    if (!consentModal) return;
+    if (!reviewModal?.consent) return;
     setConsentBusy(true);
     setConsentError(null);
     try {
       // The current version stays active either way, but only clear local state
       // once the backend actually recorded the decline; otherwise a failed
       // dismiss would look persisted and the prompt would return on reload.
-      const res = await dismissPluginUpdate(consentModal.plugin.id, consentModal.consent.fingerprint);
+      const res = await dismissPluginUpdate(reviewModal.plugin.id, reviewModal.consent.fingerprint);
       if (res.kind === "ok") {
-        clearUpdateBadge(consentModal.plugin.id);
-        setConsentModal(null);
+        clearUpdateBadge(reviewModal.plugin.id);
+        setReviewModal(null);
       } else {
         setConsentError(res.message);
       }
@@ -578,16 +600,19 @@ export function PluginsSettings() {
         />
       )}
 
-      {consentModal && (
+      {reviewModal && (
         <PluginUpdateConsentModal
-          key={consentModal.plugin.id}
-          consent={consentModal.consent}
-          name={consentModal.plugin.name}
+          key={reviewModal.plugin.id}
+          consent={reviewModal.consent}
+          name={reviewModal.plugin.name}
+          fromVersion={reviewModal.fromVersion}
+          toVersion={reviewModal.toVersion}
+          changelog={reviewModal.changelog}
           busy={consentBusy}
           error={consentError}
           onApprove={() => void onApproveUpdate()}
-          onDecline={() => void onDeclineUpdate()}
-          onClose={() => setConsentModal(null)}
+          onDecline={reviewModal.consent ? () => void onDeclineUpdate() : undefined}
+          onClose={() => setReviewModal(null)}
         />
       )}
 

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -23,16 +23,23 @@ import type {
   PluginUpdatesResult,
 } from "../../../lib/api";
 
-const emptyChangelog: PluginUpdateChangelog = { entries: [], truncated: false, unavailable_reason: null };
+const emptyChangelog: PluginUpdateChangelog = {
+  entries: [],
+  truncated: false,
+  unavailable_reason: null,
+  more_url: null,
+};
 const releaseChangelog: PluginUpdateChangelog = {
   entries: [{ kind: "release", tag: "v0.2.0", body: "Added a thing.", published_at: null }],
   truncated: false,
   unavailable_reason: null,
+  more_url: null,
 };
 const commitChangelog: PluginUpdateChangelog = {
   entries: [{ kind: "commit", sha: "abcdef1234", subject: "fix: a bug", url: null }],
   truncated: true,
   unavailable_reason: null,
+  more_url: "https://github.com/example/plugin/compare/aaa...bbb",
 };
 
 const fetchPlugins = vi.fn<[], Promise<PluginListResponse | null>>();
@@ -646,6 +653,9 @@ describe("PluginsSettings", () => {
     // changelog, and has no access disclosure.
     await findByTestId("plugin-update-consent-modal");
     expect((await findByTestId("plugin-update-changelog")).textContent).toContain("fix: a bug");
+    // A truncated changelog links out to the full history on GitHub.
+    const more = await findByTestId("plugin-update-changelog-more");
+    expect(more.getAttribute("href")).toBe("https://github.com/example/plugin/compare/aaa...bbb");
     expect(queryByTestId("plugin-update-added-caps")).toBeNull();
     expect(applyPluginUpdate).not.toHaveBeenCalled();
     fireEvent.click(await findByTestId("plugin-update-approve"));
@@ -665,6 +675,7 @@ describe("PluginsSettings", () => {
           entries: [],
           truncated: false,
           unavailable_reason: "GitHub rate limit reached; changelog unavailable.",
+          more_url: null,
         },
       },
     });

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -18,9 +18,22 @@ import type {
   PluginJobStartResult,
   PluginListResponse,
   PluginToggleResult,
+  PluginUpdateChangelog,
   PluginUpdatePreviewResult,
   PluginUpdatesResult,
 } from "../../../lib/api";
+
+const emptyChangelog: PluginUpdateChangelog = { entries: [], truncated: false, unavailable_reason: null };
+const releaseChangelog: PluginUpdateChangelog = {
+  entries: [{ kind: "release", tag: "v0.2.0", body: "Added a thing.", published_at: null }],
+  truncated: false,
+  unavailable_reason: null,
+};
+const commitChangelog: PluginUpdateChangelog = {
+  entries: [{ kind: "commit", sha: "abcdef1234", subject: "fix: a bug", url: null }],
+  truncated: true,
+  unavailable_reason: null,
+};
 
 const fetchPlugins = vi.fn<[], Promise<PluginListResponse | null>>();
 const setPluginEnabled = vi.fn<[string, boolean], Promise<PluginToggleResult>>();
@@ -552,6 +565,7 @@ describe("PluginsSettings", () => {
         trust_downgrade: false,
         fingerprint: "treeB||community",
         stays_active_if_declined: true,
+        changelog: releaseChangelog,
       },
     },
   };
@@ -566,6 +580,8 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-update-consent-modal");
     expect((await findByTestId("plugin-update-added-caps")).textContent).toContain("fs.read");
     expect((await findByTestId("plugin-update-build-steps")).textContent).toContain("sh build.sh");
+    // The changelog is shown alongside the access disclosure.
+    expect((await findByTestId("plugin-update-changelog")).textContent).toContain("v0.2.0");
   });
 
   it("Approving applies the update pinned to the previewed fingerprint and opens the job modal", async () => {
@@ -611,19 +627,56 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-update-available-example.plugin");
   });
 
-  it("a safe update applies directly without a consent modal and follows the job", async () => {
+  it("a safe update shows the changelog in a review modal, then applies on Update", async () => {
     markOutdated();
     previewPluginUpdate.mockResolvedValue({
       kind: "ok",
-      preview: { kind: "safe_update", to_version: "0.2.0", fingerprint: "treeC||community" },
+      preview: {
+        kind: "safe_update",
+        to_version: "0.2.0",
+        fingerprint: "treeC||community",
+        changelog: commitChangelog,
+      },
     });
     applyPluginUpdate.mockResolvedValue({ kind: "ok", jobId: "job1" });
     const { findByTestId, queryByTestId } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugins-check-updates"));
     fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    // Safe updates no longer auto-apply: the review modal opens first, shows the
+    // changelog, and has no access disclosure.
+    await findByTestId("plugin-update-consent-modal");
+    expect((await findByTestId("plugin-update-changelog")).textContent).toContain("fix: a bug");
+    expect(queryByTestId("plugin-update-added-caps")).toBeNull();
+    expect(applyPluginUpdate).not.toHaveBeenCalled();
+    fireEvent.click(await findByTestId("plugin-update-approve"));
     await waitFor(() => expect(applyPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeC||community"));
-    expect(queryByTestId("plugin-update-consent-modal")).toBeNull();
     await findByTestId("plugin-job-modal");
+  });
+
+  it("an unavailable changelog says so and still lets the update proceed", async () => {
+    markOutdated();
+    previewPluginUpdate.mockResolvedValue({
+      kind: "ok",
+      preview: {
+        kind: "safe_update",
+        to_version: "0.2.0",
+        fingerprint: "treeC||community",
+        changelog: {
+          entries: [],
+          truncated: false,
+          unavailable_reason: "GitHub rate limit reached; changelog unavailable.",
+        },
+      },
+    });
+    applyPluginUpdate.mockResolvedValue({ kind: "ok", jobId: "job1" });
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugins-check-updates"));
+    fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    const note = await findByTestId("plugin-update-changelog-unavailable");
+    expect(note.textContent).toContain("rate limit");
+    // The update is still offered: approving applies it.
+    fireEvent.click(await findByTestId("plugin-update-approve"));
+    await waitFor(() => expect(applyPluginUpdate).toHaveBeenCalledWith("example.plugin", "treeC||community"));
   });
 
   it("surfaces an apply error in the consent modal and keeps it open", async () => {
@@ -662,6 +715,7 @@ describe("PluginsSettings", () => {
           trust_downgrade: true,
           fingerprint: "treeD||community",
           stays_active_if_declined: true,
+          changelog: emptyChangelog,
         },
       },
     });
@@ -671,6 +725,8 @@ describe("PluginsSettings", () => {
     await findByTestId("plugin-update-consent-modal");
     expect((await findByTestId("plugin-update-runtime-change")).textContent).toContain("release binary");
     await findByTestId("plugin-update-trust-downgrade");
+    // An empty (but available) changelog reads as "No changelog available".
+    await findByTestId("plugin-update-changelog-empty");
   });
 
   it("Update reports up-to-date and clears the badge when preview finds no update", async () => {
@@ -696,12 +752,13 @@ describe("PluginsSettings", () => {
     markOutdated();
     previewPluginUpdate.mockResolvedValue({
       kind: "ok",
-      preview: { kind: "safe_update", to_version: "0.2.0", fingerprint: "treeC||community" },
+      preview: { kind: "safe_update", to_version: "0.2.0", fingerprint: "treeC||community", changelog: emptyChangelog },
     });
     applyPluginUpdate.mockResolvedValue({ kind: "error", message: "apply boom" });
     const { findByTestId, findByText } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugins-check-updates"));
     fireEvent.click(await findByTestId("plugin-update-example.plugin"));
+    fireEvent.click(await findByTestId("plugin-update-approve"));
     await findByText("apply boom");
   });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -402,6 +402,22 @@ export interface PluginUpdateUiView {
   id: string;
 }
 
+/** One changelog item between the installed and target version: a release's
+ *  notes, or a single commit subject. Mirrors Rust `ChangelogEntry`. */
+export type PluginChangelogEntry =
+  | { kind: "release"; tag: string; body: string | null; published_at: string | null }
+  | { kind: "commit"; sha: string; subject: string; url: string | null };
+
+/** What changed between the installed version and the update target, mirroring
+ *  Rust `UpdateChangelog`. `unavailable_reason` distinguishes "could not load"
+ *  from "no entries" (both leave `entries` empty); `truncated` flags that more
+ *  existed than are shown. */
+export interface PluginUpdateChangelog {
+  entries: PluginChangelogEntry[];
+  truncated: boolean;
+  unavailable_reason: string | null;
+}
+
 /** Structured disclosure for a capability-expanding plugin update, mirroring the
  *  Rust `UpdateConsent`. Drives the consent modal. */
 export interface PluginUpdateConsent {
@@ -418,13 +434,14 @@ export interface PluginUpdateConsent {
   trust_downgrade: boolean;
   fingerprint: string;
   stays_active_if_declined: boolean;
+  changelog: PluginUpdateChangelog;
 }
 
 /** Result of `GET /api/plugins/{id}/update/preview`: a tagged union mirroring the
  *  Rust `UpdatePreview`. */
 export type PluginUpdatePreview =
   | { kind: "no_update" }
-  | { kind: "safe_update"; to_version: string; fingerprint: string }
+  | { kind: "safe_update"; to_version: string; fingerprint: string; changelog: PluginUpdateChangelog }
   | { kind: "consent_required"; consent: PluginUpdateConsent; dismissed: boolean };
 
 export type PluginUpdatePreviewResult =

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -416,6 +416,9 @@ export interface PluginUpdateChangelog {
   entries: PluginChangelogEntry[];
   truncated: boolean;
   unavailable_reason: string | null;
+  /** GitHub URL for the full history (releases page or compare view), shown when
+   *  the changelog is truncated. */
+  more_url: string | null;
 }
 
 /** Structured disclosure for a capability-expanding plugin update, mirroring the


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When you update an installed external plugin, the in-UI flow previously showed only the version numbers (`v1.2.0 -> v1.2.3`) and, for a safe version bump, nothing at all (it applied on one click). This adds a changelog so you can see what you are pulling in before approving.

Every in-UI update now flows through one review surface (the web modal and the TUI plugin manager popup) that always renders a changelog between the installed and target version:

- A plugin that publishes GitHub releases shows the release notes for each release between the two versions.
- A plugin with no bracketable releases (commit/ref tracked, a moved tag, or an empty release set) falls back to commit subjects from the GitHub compare endpoint.
- If the changelog cannot be fetched (rate limit, dead remote, local source), the modal says "Changelog unavailable" rather than looking like "no changes", and the update still proceeds.

A safe version bump no longer auto-applies on the first click: it opens the same review surface in a changelog-only mode (Cancel / Update). A consent-expanding update keeps its capability diff, build commands, UI slots, and runtime/trust disclosures, with Decline.

The changelog is assembled best-effort, network-bound, and only inside `preview_update` (behind the explicit user-driven preview), so the CLI apply/update path and the background auto-update sweep pay no extra GitHub round-trip. It keys off the lockfile's `requested_ref` + `resolved_commit`, not `release_tag` (which is release-binary asset provenance only).

Closes #2570

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Install a release-publishing `gh:` plugin an older version behind, open Settings -> Plugins, click "Check for updates", then "Update": the modal shows release notes between the installed and target version.
- [ ] Update a plugin tracked by a branch/`@ref` (no releases): the modal shows commit subjects instead of release notes.
- [ ] Update a plugin whose new version needs no new capabilities (a safe bump): confirm it no longer applies on the first click, the modal opens with the changelog and a Cancel / Update pair, and Update then applies it.
- [ ] Update a capability-expanding version: the modal still shows the access disclosure (new capabilities, build commands) alongside the changelog, with Decline.
- [ ] Trigger a changelog fetch failure (e.g. hit the unauthenticated GitHub rate limit): the modal reads "Changelog unavailable" and the update still applies.
- [ ] In the TUI plugin manager, press `c` then `u` on an outdated plugin: the review popup shows the same changelog; a safe update opens the popup (enter to update, esc to cancel) instead of auto-applying.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Updated the Vitest for the plugins settings flow (`web/src/components/settings/__tests__/PluginsSettings.test.tsx`): the safe-update review modal, the changelog rendering in the consent modal, and the unavailable-changelog case. The `settings.plugins` entry in `web/tests/coverage-matrix.json` already maps `PluginUpdateConsentModal.tsx` and `PluginsSettings.tsx` (request-payload / render permutations belong in Vitest per `AGENTS.md`, not Playwright).
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a TUI e2e, because: the changelog assembly (release bracketing, commit mapping, draft/prerelease filtering, truncation) is covered by Rust unit tests in `src/plugin/changelog.rs`; the TUI popup is a thin render of that same data with no new network/lifecycle logic, and the plugin-manager update flow has no existing e2e harness (it would need a live GitHub mock).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (pressure-tested with a multi-model `/debate`), and implementation were drafted by Claude under my direction. I made the design calls (one unified review surface rather than a second popup; structured changelog with an unavailable reason; keying off `requested_ref` not `release_tag`), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785431934&installation_id=139138837&pr_number=2581&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2581&signature=2ec93e8311d208bb97c4837d9fee5ea7cb1e38182dfe7df0bf8eba8e1343b7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Added an in-UI changelog/release-notes section to the plugin update review flow in both the web modal and the TUI plugin manager.
- Changed safe updates to no longer auto-apply on first click: they now open the same review UI (in “review/confirm” mode) where users can confirm after seeing the changelog.
- For release-published plugins, the UI shows release notes between the installed and target versions; for plugins without releases (or when tracking an explicit ref), it falls back to commit subjects between the installed and target commits.
- If changelog fetching fails, the update still proceeds and the UI clearly indicates the changelog is unavailable.
- Updated the backend/API layer to support building these changelogs efficiently (best-effort during the preview path only, avoiding extra background/CLI update GitHub calls), and wired the new changelog payload through the existing preview/consent/update models.
- Refreshed UI rendering and interaction logic (single shared review surface, centralized changelog rendering in the TUI, updated button/decline behavior), plus updated tests and developer documentation accordingly.

### Benefits
- Users get clearer “what will change” context before approving any plugin update.
- Safe updates are now transparent and consistent with consent-required updates across both web and TUI.
- Changelog failures don’t block updates, reducing friction while still informing users.
- More efficient preview behavior: changelog assembly happens only when needed for the review display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->