### PR TITLE
feat: add composer action extension point

### DIFF
--- a/aoe-plugin-api/src/capability.rs
+++ b/aoe-plugin-api/src/capability.rs
@@ -86,6 +86,11 @@ pub const KNOWN_CAPABILITIES: &[&str] = &[
     // `action` (or a future host RPC). Distinct from a rendered `href` anchor
     // the user clicks, which needs no grant.
     "browser_open",
+    // Reading and mutating the active ACP composer draft through a
+    // host-mediated composer action. The dashboard owns the actual draft state;
+    // plugins only receive a click-scoped snapshot or request a validated edit.
+    "composer.read",
+    "composer.write",
 ];
 
 /// How far a plugin is trusted. Host-assigned at load time, never declared in

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -34,5 +34,6 @@ pub use manifest::{
 /// `aoe_version` host-compatibility field were added; 5 when the `screenshots`
 /// presentation metadata was added; 6 when a command could declare a
 /// client-executed `action` (`ClientAction`); 7 when `icon` and `icon_asset`
-/// identity metadata were added.
-pub const API_VERSION: u32 = 7;
+/// identity metadata were added; 8 when plugins could contribute composer
+/// actions.
+pub const API_VERSION: u32 = 8;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -320,6 +320,10 @@ pub enum UiSlot {
     /// A dockable tool-window pane in a session's view (per session). The host
     /// renders it in the right or bottom dock per the entry's `default_location`.
     Pane,
+    /// An action button next to a session's ACP composer controls (per session).
+    /// The host renders the button and forwards clicks to the plugin worker;
+    /// optional draft edits are applied by the host surface, not by plugin JS.
+    ComposerAction,
     /// A badge in a session's detail view (per session).
     DetailBadge,
     /// A transient notification, pushed via `ui.notify` (gated by the
@@ -333,7 +337,11 @@ impl UiSlot {
     pub fn is_per_session(self) -> bool {
         matches!(
             self,
-            UiSlot::RowBadge | UiSlot::RowColumn | UiSlot::Pane | UiSlot::DetailBadge
+            UiSlot::RowBadge
+                | UiSlot::RowColumn
+                | UiSlot::Pane
+                | UiSlot::ComposerAction
+                | UiSlot::DetailBadge
         )
     }
 
@@ -349,6 +357,7 @@ impl UiSlot {
             UiSlot::FilterFacet => "filter-facet",
             UiSlot::Card => "card",
             UiSlot::Pane => "pane",
+            UiSlot::ComposerAction => "composer-action",
             UiSlot::DetailBadge => "detail-badge",
             UiSlot::Notification => "notification",
         }
@@ -822,6 +831,14 @@ impl PluginManifest {
             check(
                 self.icon_asset.is_none(),
                 "icon_asset requires api_version >= 7".into(),
+            );
+        }
+        // `composer-action` is an api_version 8 slot; force the bump for the
+        // same reason as the gates above.
+        if self.api_version < 8 {
+            check(
+                self.ui.iter().all(|u| u.slot != UiSlot::ComposerAction),
+                "composer-action UI slots require api_version >= 8".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -686,10 +686,30 @@ fn ui_slot_as_str_round_trips_the_wire_name() {
         ("status-bar", UiSlot::StatusBar),
         ("row-badge", UiSlot::RowBadge),
         ("pane", UiSlot::Pane),
+        ("composer-action", UiSlot::ComposerAction),
         ("notification", UiSlot::Notification),
     ] {
         assert_eq!(slot.as_str(), toml_slot);
     }
+}
+
+#[test]
+fn composer_action_requires_api_version_8() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 7
+
+[[ui]]
+slot = "composer-action"
+id = "voice"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("composer-action UI slots require api_version >= 8"),
+        "{err:?}"
+    );
 }
 
 #[test]

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -182,11 +182,12 @@ declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
 declares; they are defined in `aoe-plugin-api` and parsed/validated by the
 host, but consumed by later issues (the settings registry in #2094, the runtime
 host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is now
-7 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
+8 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
 became the dockable `pane` slot, 4 for the `status` section and the
-`aoe_version` field, 5 for screenshots, 6 for command actions, and 7 for the
-`composer-action` slot); an older `api_version` manifest still loads as long as
-it targets no newer field. Unknown top-level keys remain a hard parse error
+`aoe_version` field, 5 for screenshots, 6 for command actions, 7 for identity
+icons, and 8 for the `composer-action` slot); an older `api_version` manifest
+still loads as long as it targets no newer field. Unknown top-level keys remain
+a hard parse error
 (`deny_unknown_fields`).
 
 The `themes` section ships and is consumed by the theme registry (#2094); the

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -318,9 +318,9 @@ approval. A capability gates runtime access to a resource that can affect user
 data, host state, the OS, or the network. The v1 set
 (`aoe_plugin_api::KNOWN_CAPABILITIES`): `runtime.worker`, `session.read`,
 `session.write`, `config.read`, `config.write`, `process.spawn`, `net`,
-`fs.read`, `fs.write`, `clipboard.read`, `clipboard.write`, `notifications`. A
-plugin's own declared settings need no `config.*`; that gates host/global or
-other-plugin config.
+`fs.read`, `fs.write`, `clipboard.read`, `clipboard.write`, `notifications`,
+`browser_open`, `composer.read`, and `composer.write`. A plugin's own declared
+settings need no `config.*`; that gates host/global or other-plugin config.
 
 Capabilities are open strings (`CapabilityId`), so a follow-up can add one
 without an `api_version` bump. An unknown capability still parses (forward
@@ -637,11 +637,11 @@ either surface and the render path never awaits a worker: the host keeps an
 in-memory snapshot each surface reads synchronously (see Delivery below for what
 the TUI renders).
 
-The nine slots are a closed `UiSlot` set (`aoe-plugin-api`), kebab-case on the
+The slots are a closed `UiSlot` set (`aoe-plugin-api`), kebab-case on the
 wire: `status-bar`, `row-badge`, `row-column`, `sort-key`, `filter-facet`,
-`card`, `pane`, `detail-badge`, `notification`. A plugin declares the
-`(slot, id)` pairs it may fill in its manifest `[[ui]]` section; an unknown
-slot is a hard parse error (the host must know how to render each).
+`card`, `pane`, `composer-action`, `detail-badge`, `notification`. A plugin
+declares the `(slot, id)` pairs it may fill in its manifest `[[ui]]` section;
+an unknown slot is a hard parse error (the host must know how to render each).
 
 A UI contribution is not a capability and needs no grant, but the slots a
 plugin declares are disclosed so the user knows it modifies the dashboard
@@ -656,7 +656,7 @@ manager, and the web Plugins panel (via `PluginView.ui_contributions`).
   the `(slot, id)` being declared in the manifest: no dedicated `ui` capability
   is introduced. The `payload` is validated against the slot's typed shape and
   stored normalized; an unknown field or bad tone is rejected. Per-session slots
-  (`row-badge`, `row-column`, `pane`, `detail-badge`) require a
+  (`row-badge`, `row-column`, `pane`, `composer-action`, `detail-badge`) require a
   `session_id`; global slots must not carry one. The text-based slots
   (`status-bar`, `row-badge`, `detail-badge`) accept optional `icon` (a lucide
   icon name in kebab-case, e.g. `git-pull-request-arrow`; the client maps it
@@ -666,6 +666,18 @@ manager, and the web Plugins panel (via `PluginView.ui_contributions`).
 - `ui.notify { tone, title, body?, session_id? }`. Gated by the existing
   `notifications` capability (not a slot declaration). Returns a monotonic
   `seq`.
+- `composer-action` payloads have the shape
+  `{ label, method, icon?, tone?, tooltip?, disabled?, draft_operation? }`.
+  The dashboard renders the button in the ACP composer and POSTs the named
+  `method` to the same `/api/plugins/{id}/action` endpoint used by pane
+  actions, including the active session id. If the plugin declares
+  `composer.read`, the request params also include a click-scoped composer
+  snapshot (`text`, `selection_start`, `selection_end`); otherwise the server
+  strips that snapshot before forwarding. A `draft_operation`
+  (`insert-text`, `replace-selection`, or `set-text`) requests a host-mediated
+  edit to the current draft and requires `composer.write`. The web applies each
+  operation once per operation id so a persistent UI-state entry cannot replay
+  on every poll.
 
 #### Richer payloads: `row-badge` items and the `pane` block list
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -182,10 +182,11 @@ declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
 declares; they are defined in `aoe-plugin-api` and parsed/validated by the
 host, but consumed by later issues (the settings registry in #2094, the runtime
 host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is now
-4 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
-became the dockable `pane` slot, then 4 for the `status` section and the
-`aoe_version` field); an older `api_version` manifest still loads as long as it
-targets no newer field. Unknown top-level keys remain a hard parse error
+7 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
+became the dockable `pane` slot, 4 for the `status` section and the
+`aoe_version` field, 5 for screenshots, 6 for command actions, and 7 for the
+`composer-action` slot); an older `api_version` manifest still loads as long as
+it targets no newer field. Unknown top-level keys remain a hard parse error
 (`deny_unknown_fields`).
 
 The `themes` section ships and is consumed by the theme registry (#2094); the

--- a/docs/development/writing-plugins.md
+++ b/docs/development/writing-plugins.md
@@ -33,7 +33,7 @@ how to build and launch it:
 id = "dev.example.my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-api_version = 6
+api_version = 8
 aoe_version = ">=1.11.0, <2.0.0"
 description = "What the plugin does."
 
@@ -56,7 +56,7 @@ id = "my_plugin_pane"
 ```
 
 Pick an `id` outside the reserved `aoe.*` and `agent-of-empires.*` namespaces.
-Set `api_version` to the schema version you target (currently `6`) and
+Set `api_version` to the schema version you target (currently `8`) and
 `aoe_version` to the host range you have tested against. Every key is documented
 in the [Plugin API Reference](../plugin-api.md).
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `7`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `8`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added the `composer-action` UI slot.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot.
 
 ## Top-level fields
 
@@ -30,7 +30,7 @@ Schema additions by `api_version`: `2` added contributions (commands, keybinds, 
 id = "dev.example.my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-api_version = 7
+api_version = 8
 aoe_version = ">=1.11.0, <2.0.0"
 description = "What the plugin does."
 capabilities = ["runtime.worker"]
@@ -41,7 +41,7 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `7`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `8`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
@@ -191,7 +191,7 @@ id = "my_pane"
 | `row-column` | per-session | A text column on the session row. |
 | `detail-badge` | per-session | A badge in the session detail view. |
 | `pane` | per-session | A dockable tool-window pane (requires `api_version >= 3`). |
-| `composer-action` | per-session | A button beside the ACP composer controls (requires `api_version >= 7`). |
+| `composer-action` | per-session | A button beside the ACP composer controls (requires `api_version >= 8`). |
 | `notification` | n/a | A transient notification pushed via `ui.notify`; gated by the `notifications` capability, not a slot declaration. |
 
 ### Composer action payload

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `6`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `7`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added the `composer-action` UI slot.
 
 ## Top-level fields
 
@@ -30,7 +30,7 @@ Schema additions by `api_version`: `2` added contributions (commands, keybinds, 
 id = "dev.example.my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-api_version = 6
+api_version = 7
 aoe_version = ">=1.11.0, <2.0.0"
 description = "What the plugin does."
 capabilities = ["runtime.worker"]
@@ -41,7 +41,7 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `6`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `7`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
@@ -78,6 +78,8 @@ themes, ui, status) need no capability.
 | `clipboard.write` | Writing the clipboard. |
 | `notifications` | Posting desktop / TUI notifications. |
 | `browser_open` | Opening a URL in the user's browser from a command `action`. |
+| `composer.read` | Reading a click-scoped snapshot of the active ACP composer draft from a `composer-action`. |
+| `composer.write` | Publishing a host-validated draft edit from a `composer-action` UI-state payload. |
 
 A capability this host version does not recognize is rejected, not granted.
 
@@ -189,7 +191,60 @@ id = "my_pane"
 | `row-column` | per-session | A text column on the session row. |
 | `detail-badge` | per-session | A badge in the session detail view. |
 | `pane` | per-session | A dockable tool-window pane (requires `api_version >= 3`). |
+| `composer-action` | per-session | A button beside the ACP composer controls (requires `api_version >= 7`). |
 | `notification` | n/a | A transient notification pushed via `ui.notify`; gated by the `notifications` capability, not a slot declaration. |
+
+### Composer action payload
+
+A `composer-action` entry renders a host-owned button in the web dashboard ACP
+composer. The worker pushes it with `ui.state.set`:
+
+```json
+{
+  "label": "Dictate",
+  "method": "dictation.start",
+  "icon": "mic",
+  "tooltip": "Start dictation",
+  "tone": "info",
+  "disabled": false
+}
+```
+
+`label` and `method` are required. On click, the dashboard POSTs `method` to
+`/api/plugins/{id}/action` with the active `session_id`. When the plugin has
+`composer.read`, the forwarded params include:
+
+```json
+{
+  "composer": {
+    "text": "current draft",
+    "selection_start": 0,
+    "selection_end": 5
+  }
+}
+```
+
+Without `composer.read`, the server strips that snapshot before forwarding the
+action to the worker.
+
+To mutate the draft, include a `draft_operation` in the pushed payload. This
+requires `composer.write`.
+
+```json
+{
+  "label": "Dictate",
+  "method": "dictation.start",
+  "draft_operation": {
+    "kind": "insert-text",
+    "id": "transcript-1",
+    "text": "Hello from dictation."
+  }
+}
+```
+
+`kind` is `insert-text`, `replace-selection`, or `set-text`. `id` must be stable
+and non-empty; the web dashboard applies each operation id once so a persistent
+UI-state entry cannot replay the edit on every poll.
 
 ## Status
 

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -51,6 +51,7 @@ const CAP_SESSION_WRITE: &str = "session.write";
 /// capability. `ui.state.*` need no extra capability beyond `runtime.worker`:
 /// the gate is the manifest `ui` slot declaration (see [`PluginRpcContext`]).
 const CAP_NOTIFICATIONS: &str = "notifications";
+const CAP_COMPOSER_WRITE: &str = "composer.write";
 
 /// Shared, host-owned state behind the API: the plugin event bus and the
 /// profile whose session storage the API reads and writes. One per running
@@ -584,6 +585,9 @@ fn ui_state_set(
     let payload = params
         .get("payload")
         .ok_or_else(|| DispatchError::invalid_params("missing param \"payload\""))?;
+    if slot == UiSlot::ComposerAction && payload.get("draft_operation").is_some() {
+        ctx.require(CAP_COMPOSER_WRITE)?;
+    }
     state
         .ui
         .set(
@@ -1223,5 +1227,66 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn composer_action_draft_operation_requires_composer_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::ComposerAction, "voice");
+
+        dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({
+                "slot": "composer-action",
+                "id": "voice",
+                "session_id": "s1",
+                "payload": {"label": "Voice", "method": "voice.start"}
+            }),
+        )
+        .unwrap();
+
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({
+                "slot": "composer-action",
+                "id": "voice",
+                "session_id": "s1",
+                "payload": {
+                    "label": "Voice",
+                    "method": "voice.start",
+                    "draft_operation": {"kind": "insert-text", "id": "op-1", "text": "hello"}
+                }
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        let c = ui_ctx(
+            &state,
+            &[CAP_WORKER, CAP_COMPOSER_WRITE],
+            UiSlot::ComposerAction,
+            "voice",
+        );
+        dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({
+                "slot": "composer-action",
+                "id": "voice",
+                "session_id": "s1",
+                "payload": {
+                    "label": "Voice",
+                    "method": "voice.start",
+                    "draft_operation": {"kind": "insert-text", "id": "op-1", "text": "hello"}
+                }
+            }),
+        )
+        .unwrap();
     }
 }

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -232,6 +232,43 @@ struct PanePayload {
     icon: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ComposerActionPayload {
+    label: String,
+    method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tooltip: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    draft_operation: Option<ComposerDraftOperation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+enum ComposerDraftOperation {
+    InsertText { id: String, text: String },
+    ReplaceSelection { id: String, text: String },
+    SetText { id: String, text: String },
+}
+
+impl ComposerDraftOperation {
+    fn valid(&self) -> bool {
+        match self {
+            ComposerDraftOperation::InsertText { id, text }
+            | ComposerDraftOperation::ReplaceSelection { id, text }
+            | ComposerDraftOperation::SetText { id, text } => {
+                !id.is_empty() && id.len() <= 128 && !text.is_empty() && text.len() <= 16 * 1024
+            }
+        }
+    }
+}
+
 /// Why a `ui.state.set`/`ui.state.remove` was rejected. The host API maps each
 /// to a JSON-RPC error code.
 #[derive(Debug, PartialEq, Eq)]
@@ -633,6 +670,26 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
         UiSlot::FilterFacet => normalize::<FilterFacetPayload>(raw),
         UiSlot::Card => normalize::<CardPayload>(raw),
         UiSlot::Pane => normalize::<PanePayload>(raw),
+        UiSlot::ComposerAction => {
+            let parsed: ComposerActionPayload =
+                serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
+            if parsed.label.is_empty() {
+                return Err("composer action label is required".into());
+            }
+            if parsed.method.is_empty() {
+                return Err("composer action method is required".into());
+            }
+            if parsed
+                .draft_operation
+                .as_ref()
+                .is_some_and(|op| !op.valid())
+            {
+                return Err(
+                    "composer draft operation requires a non-empty bounded id and text".into(),
+                );
+            }
+            serde_json::to_value(parsed).map_err(|e| e.to_string())
+        }
         UiSlot::Notification => Err("notification is pushed via ui.notify".into()),
     }
 }
@@ -697,6 +754,17 @@ mod tests {
             ),
             Err(UiError::BadRequest(_))
         ));
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ComposerAction,
+                "voice",
+                None,
+                &json!({"label": "Voice", "method": "voice.start"})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
         // Notification is not a ui.state.set target.
         assert!(matches!(
             s.set(
@@ -757,6 +825,36 @@ mod tests {
             ),
             Err(UiError::BadRequest(_))
         ));
+        // Composer draft operations need a stable operation id and bounded text.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ComposerAction,
+                "voice",
+                Some("s1"),
+                &json!({
+                    "label": "Voice",
+                    "method": "voice.start",
+                    "draft_operation": {"kind": "insert-text", "id": "", "text": "hello"}
+                })
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::ComposerAction,
+            "voice",
+            Some("s1"),
+            &json!({
+                "label": "Voice",
+                "method": "voice.start",
+                "icon": "mic",
+                "draft_operation": {"kind": "insert-text", "id": "op-1", "text": "hello"}
+            }),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -42,6 +42,8 @@ const MAX_ENTRIES_PER_PLUGIN: usize = 1024;
 /// pane can carry a full PR comment list, where a badge is a few words.
 const MAX_PAYLOAD_BYTES: usize = 8 * 1024;
 const MAX_PANE_PAYLOAD_BYTES: usize = 64 * 1024;
+const MAX_COMPOSER_DRAFT_TEXT_BYTES: usize = 16 * 1024;
+const MAX_COMPOSER_ACTION_PAYLOAD_BYTES: usize = 20 * 1024;
 /// Notifications kept on the shared ring before the oldest are dropped.
 const NOTIFICATION_RING: usize = 200;
 /// Caps on notification text, so one notify cannot post an unbounded blob.
@@ -263,7 +265,7 @@ impl ComposerDraftOperation {
             ComposerDraftOperation::InsertText { id, text }
             | ComposerDraftOperation::ReplaceSelection { id, text }
             | ComposerDraftOperation::SetText { id, text } => {
-                !id.is_empty() && id.len() <= 128 && !text.is_empty() && text.len() <= 16 * 1024
+                !id.is_empty() && id.len() <= 128 && text.len() <= MAX_COMPOSER_DRAFT_TEXT_BYTES
             }
         }
     }
@@ -631,6 +633,7 @@ impl UiStore {
 fn max_payload_bytes(slot: UiSlot) -> usize {
     match slot {
         UiSlot::Pane => MAX_PANE_PAYLOAD_BYTES,
+        UiSlot::ComposerAction => MAX_COMPOSER_ACTION_PAYLOAD_BYTES,
         _ => MAX_PAYLOAD_BYTES,
     }
 }
@@ -684,9 +687,7 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
                 .as_ref()
                 .is_some_and(|op| !op.valid())
             {
-                return Err(
-                    "composer draft operation requires a non-empty bounded id and text".into(),
-                );
+                return Err("composer draft operation requires a bounded id and text".into());
             }
             serde_json::to_value(parsed).map_err(|e| e.to_string())
         }
@@ -855,6 +856,55 @@ mod tests {
             }),
         )
         .unwrap();
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::ComposerAction,
+            "voice",
+            Some("s1"),
+            &json!({
+                "label": "Voice",
+                "method": "voice.start",
+                "draft_operation": {"kind": "set-text", "id": "op-2", "text": ""}
+            }),
+        )
+        .unwrap();
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::ComposerAction,
+            "voice",
+            Some("s1"),
+            &json!({
+                "label": "Voice",
+                "method": "voice.start",
+                "draft_operation": {
+                    "kind": "insert-text",
+                    "id": "op-3",
+                    "text": "x".repeat(MAX_PAYLOAD_BYTES + 512)
+                }
+            }),
+        )
+        .unwrap();
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ComposerAction,
+                "voice",
+                Some("s1"),
+                &json!({
+                    "label": "Voice",
+                    "method": "voice.start",
+                    "draft_operation": {
+                        "kind": "insert-text",
+                        "id": "op-4",
+                        "text": "x".repeat(MAX_COMPOSER_DRAFT_TEXT_BYTES + 1)
+                    }
+                })
+            ),
+            Err(UiError::BadRequest(_))
+        ));
     }
 
     #[test]

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -21,6 +21,8 @@ use crate::plugin;
 use crate::plugin::install::OperationLog;
 use crate::server::auth::{handler_elevated, AuthenticatedSession, LoopbackTrusted};
 
+const CAP_COMPOSER_READ: &str = "composer.read";
+
 fn error_response(status: StatusCode, code: &str, message: String) -> Response {
     (status, Json(json!({ "error": code, "message": message }))).into_response()
 }
@@ -246,25 +248,25 @@ pub async fn plugin_details(Query(query): Query<DetailsQuery>) -> Response {
 
 #[derive(Deserialize)]
 pub struct PluginActionBody {
-    /// The worker method to invoke (the plugin names it in its pane's action
-    /// block, e.g. `github.refresh`).
+    /// The worker method to invoke (the plugin names it in its UI action
+    /// payload, e.g. `github.refresh`).
     pub method: String,
     #[serde(default)]
     pub params: serde_json::Value,
-    /// The session whose pane fired the action, if any. The host reads the
+    /// The session whose UI fired the action, if any. The host reads the
     /// baseline revision for this `(plugin, session)` scope so the dashboard
-    /// waits only for that pane's re-pushed state; it is not forwarded to the
+    /// waits only for that scope's re-pushed state; it is not forwarded to the
     /// worker.
     #[serde(default)]
     pub session_id: Option<String>,
 }
 
-/// `POST /api/plugins/{id}/action`: forward a dashboard UI action (a pane
-/// button) to the plugin's worker as a fire-and-forget JSON-RPC notification.
+/// `POST /api/plugins/{id}/action`: forward a dashboard UI action to the
+/// plugin's worker as a fire-and-forget JSON-RPC notification.
 /// The worker is the trust boundary: it acts only on methods it implements and
 /// ignores the rest, so this never waits for or returns a worker result.
 ///
-/// Gated on read-write mode only, not elevation. Unlike enable/disable, a pane
+/// Gated on read-write mode only, not elevation. Unlike enable/disable, a UI
 /// action does not mutate host-managed state (config, registry, grants,
 /// lockfile) and grants no new host capability, so it does not warrant the
 /// passphrase step-up, the same reasoning as `update_theme` in `system.rs`.
@@ -288,18 +290,19 @@ pub async fn invoke_plugin_action(
             "Plugin host is not running".into(),
         );
     };
-    // Read the pane's UI revision before forwarding, not the value the dashboard
+    // Read the UI revision before forwarding, not the value the dashboard
     // last polled: that one is stale, so an unrelated push between the last poll
     // and this click would already exceed it and clear the spinner before the
-    // worker has done anything. Scoped to the firing pane's session so another
+    // worker has done anything. Scoped to the firing UI's session so another
     // session's activity cannot move it. The dashboard holds the spinner until
     // this scope's revision moves off the baseline.
     let baseline_revision = host.ui_revision(&id, body.session_id.as_deref());
-    // Forward the firing pane's session to the worker so a per-session action
+    // Forward the firing UI's session to the worker so a per-session action
     // (e.g. github.refresh) can scope its work to that session instead of every
     // one. Merged into the params object; a worker that does not use it ignores
     // it (the honest-plugin model).
     let mut params = body.params;
+    strip_composer_snapshot_without_capability(&id, &mut params);
     if let Some(sid) = &body.session_id {
         match &mut params {
             serde_json::Value::Object(map) => {
@@ -321,6 +324,24 @@ pub async fn invoke_plugin_action(
             "no_worker",
             format!("No running worker for plugin {id}"),
         )
+    }
+}
+
+fn strip_composer_snapshot_without_capability(plugin_id: &str, params: &mut serde_json::Value) {
+    let can_read = plugin::registry()
+        .get(plugin_id)
+        .filter(|p| p.active())
+        .is_some_and(|p| {
+            p.manifest
+                .capabilities
+                .iter()
+                .any(|cap| cap.as_str() == CAP_COMPOSER_READ)
+        });
+    if can_read {
+        return;
+    }
+    if let serde_json::Value::Object(map) = params {
+        map.remove("composer");
     }
 }
 

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -255,8 +255,8 @@ pub struct PluginActionBody {
     pub params: serde_json::Value,
     /// The session whose UI fired the action, if any. The host reads the
     /// baseline revision for this `(plugin, session)` scope so the dashboard
-    /// waits only for that scope's re-pushed state; it is not forwarded to the
-    /// worker.
+    /// waits only for that scope's re-pushed state. It is merged into
+    /// `params.session_id` before forwarding to the worker.
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -781,6 +781,8 @@ pub async fn plugin_job_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
+    use aoe_plugin_api::PluginManifest;
 
     #[test]
     fn registry_allows_one_active_job_then_releases_on_finish() {
@@ -872,5 +874,128 @@ mod tests {
         );
         assert_eq!(content_type_for_icon(std::path::Path::new("a.svg")), None);
         assert_eq!(content_type_for_icon(std::path::Path::new("a")), None);
+    }
+
+    struct AppDirEnvGuard {
+        _temp: tempfile::TempDir,
+        xdg_config_home: Option<std::ffi::OsString>,
+        home: Option<std::ffi::OsString>,
+        userprofile: Option<std::ffi::OsString>,
+    }
+
+    impl AppDirEnvGuard {
+        fn new() -> Self {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let guard = Self {
+                xdg_config_home: std::env::var_os("XDG_CONFIG_HOME"),
+                home: std::env::var_os("HOME"),
+                userprofile: std::env::var_os("USERPROFILE"),
+                _temp: temp,
+            };
+            std::env::set_var("XDG_CONFIG_HOME", guard._temp.path());
+            std::env::set_var("HOME", guard._temp.path());
+            std::env::set_var("USERPROFILE", guard._temp.path());
+            crate::plugin::reload_registry();
+            guard
+        }
+    }
+
+    impl Drop for AppDirEnvGuard {
+        fn drop(&mut self) {
+            match self.xdg_config_home.take() {
+                Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+            match self.home.take() {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.userprofile.take() {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+            crate::plugin::reload_registry();
+        }
+    }
+
+    fn write_plugin_manifest(dir_name: &str, id: &str, capabilities: &[&str]) -> String {
+        let capabilities = capabilities
+            .iter()
+            .map(|cap| format!("{cap:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest = format!(
+            r#"
+id = "{id}"
+name = "Test Plugin"
+version = "1.0.0"
+api_version = 8
+capabilities = [{capabilities}]
+
+[[ui]]
+slot = "composer-action"
+id = "voice"
+"#
+        );
+        let dir = crate::plugin::plugins_dir()
+            .expect("plugins dir")
+            .join(dir_name);
+        std::fs::create_dir_all(&dir).expect("create plugin dir");
+        std::fs::write(dir.join("aoe-plugin.toml"), &manifest).expect("write manifest");
+        PluginManifest::hash_bytes(manifest.as_bytes())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn composer_snapshot_forwarding_requires_active_composer_read_capability() {
+        let _app_dir = AppDirEnvGuard::new();
+
+        let reader_id = "dev.example.reader";
+        let plain_id = "dev.example.plain";
+        let reader_caps = ["runtime.worker", CAP_COMPOSER_READ];
+        let plain_caps = ["runtime.worker"];
+        let reader_hash = write_plugin_manifest("reader", reader_id, &reader_caps);
+        let plain_hash = write_plugin_manifest("plain", plain_id, &plain_caps);
+
+        let mut config = Config::default();
+        config.plugins.insert(
+            reader_id.to_string(),
+            PluginConfig {
+                grant: Some(CapabilityGrant {
+                    manifest_hash: reader_hash,
+                    capabilities: reader_caps.iter().map(|cap| cap.to_string()).collect(),
+                    granted_at: chrono::Utc::now(),
+                }),
+                ..PluginConfig::default()
+            },
+        );
+        config.plugins.insert(
+            plain_id.to_string(),
+            PluginConfig {
+                grant: Some(CapabilityGrant {
+                    manifest_hash: plain_hash,
+                    capabilities: plain_caps.iter().map(|cap| cap.to_string()).collect(),
+                    granted_at: chrono::Utc::now(),
+                }),
+                ..PluginConfig::default()
+            },
+        );
+        save_config(&config).expect("save config");
+        crate::plugin::reload_registry();
+
+        let mut reader_params = json!({
+            "composer": {"text": "secret draft", "selection_start": 0, "selection_end": 6},
+            "other": true,
+        });
+        strip_composer_snapshot_without_capability(reader_id, &mut reader_params);
+        assert!(reader_params.get("composer").is_some());
+
+        let mut plain_params = json!({
+            "composer": {"text": "secret draft", "selection_start": 0, "selection_end": 6},
+            "other": true,
+        });
+        strip_composer_snapshot_without_capability(plain_id, &mut plain_params);
+        assert!(plain_params.get("composer").is_none());
+        assert_eq!(plain_params.get("other"), Some(&json!(true)));
     }
 }

--- a/web/src/components/acp/Composer.pluginComposerActions.test.tsx
+++ b/web/src/components/acp/Composer.pluginComposerActions.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PluginUiEntry } from "../../lib/api";
+import { Composer } from "./Composer";
+
+const { entriesRef, pokeMock } = vi.hoisted(() => ({
+  entriesRef: { current: [] as PluginUiEntry[] },
+  pokeMock: vi.fn(),
+}));
+
+vi.mock("../../lib/pluginUiContext", () => ({
+  usePluginUiEntries: () => entriesRef.current,
+  usePluginUiPoke: () => pokeMock,
+  usePluginUiRefreshing: () => false,
+  usePluginUiRevision: () => 0,
+}));
+
+function HarnessComposer({ sessionId }: { sessionId: string }) {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages: [],
+    isRunning: false,
+    convertMessage: (m) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Composer
+        sessionId={sessionId}
+        currentAgent="claude"
+        availableModes={[]}
+        currentModeId={null}
+        legacyMode="Default"
+        configOptions={[]}
+        pendingConfigOption={null}
+        setConfigOption={() => {}}
+        sessionUsage={null}
+        availableCommands={[]}
+        connected
+        turnActive={false}
+        queuedCount={0}
+        enqueuePrompt={() => {}}
+        promptCapabilities={null}
+        pendingAttachments={[]}
+        setPendingAttachments={() => {}}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+function set(entries: PluginUiEntry[]) {
+  entriesRef.current = entries;
+}
+
+function composerEntry(draftOperation: Record<string, unknown>): PluginUiEntry {
+  return {
+    plugin_id: "acme.voice",
+    slot: "composer-action",
+    id: "dictate",
+    session_id: "sess-plugin",
+    payload: {
+      label: "Voice",
+      method: "voice.start",
+      draft_operation: draftOperation,
+    },
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  entriesRef.current = [];
+  pokeMock.mockClear();
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: [] }),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+});
+
+describe("Composer plugin composer actions", () => {
+  it("applies each plugin draft operation id once", async () => {
+    set([composerEntry({ kind: "insert-text", id: "op-1", text: "hello" })]);
+    const { container, rerender } = render(<HarnessComposer sessionId="sess-plugin" />);
+    const textarea = container.querySelector("textarea");
+    if (!textarea) throw new Error("composer textarea not rendered");
+
+    await waitFor(() => expect(textarea.value).toBe("hello"));
+
+    rerender(<HarnessComposer sessionId="sess-plugin" />);
+    await waitFor(() => expect(textarea.value).toBe("hello"));
+
+    set([composerEntry({ kind: "insert-text", id: "op-2", text: " world" })]);
+    rerender(<HarnessComposer sessionId="sess-plugin" />);
+    await waitFor(() => expect(textarea.value).toBe("hello world"));
+  });
+});

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -41,6 +41,10 @@ import { resolveModeChannel } from "../../lib/modeChannel";
 import { useFocusTerminalTarget } from "../../hooks/useFocusTerminalTarget";
 import { useDictationBurstGuard } from "./useDictationBurstGuard";
 import { nextRecallTarget, recallBannerInfo, type RecallCursor, type RecallNav } from "./recallNav";
+import { PluginComposerActions } from "../plugin/PluginSlots";
+import { composerDraftOperation, type ComposerDraftOperation } from "../plugin/composerDraftOperation";
+import { usePluginUiEntries } from "../../lib/pluginUiContext";
+import { sessionEntries } from "../../lib/pluginUi";
 
 export {
   DICTATION_BURST_TIMEOUT_MS,
@@ -586,6 +590,57 @@ export function Composer({
     editQueuedPrompt,
     applyRecall,
   ]);
+  const getPluginComposerSnapshot = useCallback(() => {
+    const ta = taRef.current;
+    const text = composerRuntime.getState().text;
+    const fallbackPos = text.length;
+    return {
+      text,
+      selectionStart: ta?.selectionStart ?? fallbackPos,
+      selectionEnd: ta?.selectionEnd ?? ta?.selectionStart ?? fallbackPos,
+    };
+  }, [composerRuntime]);
+  const applyPluginDraftOperation = useCallback(
+    (operation: ComposerDraftOperation) => {
+      const ta = taRef.current;
+      if (!ta) {
+        if (operation.kind === "set-text") composerRuntime.setText(operation.text);
+        else composerRuntime.setText(`${composerRuntime.getState().text}${operation.text}`);
+        return;
+      }
+      if (operation.kind === "set-text") {
+        composerRuntime.setText(operation.text);
+        requestAnimationFrame(() => {
+          const el = taRef.current;
+          if (!el) return;
+          el.focus();
+          const len = operation.text.length;
+          el.setSelectionRange(len, len);
+          el.style.height = "auto";
+          el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+        });
+        return;
+      }
+      insertRawTextAtCaret(ta, operation.text, operation.kind === "replace-selection");
+    },
+    [composerRuntime],
+  );
+  const pluginUiEntries = usePluginUiEntries();
+  const pluginComposerEntries = useMemo(
+    () => sessionEntries(pluginUiEntries, "composer-action", sessionId),
+    [pluginUiEntries, sessionId],
+  );
+  const seenPluginDraftOpsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const entry of pluginComposerEntries) {
+      const draft = composerDraftOperation(entry);
+      if (!draft) continue;
+      const key = `${entry.plugin_id}:${entry.id}:${draft.id}`;
+      if (seenPluginDraftOpsRef.current.has(key)) continue;
+      seenPluginDraftOpsRef.current.add(key);
+      applyPluginDraftOperation(draft.operation);
+    }
+  }, [applyPluginDraftOperation, pluginComposerEntries]);
 
   // Manual agent switch dialog. Opened from the sidebar row context menu
   // (see WorkspaceSidebar's "Switch agent" item) via the cross-component
@@ -1088,6 +1143,7 @@ export function Composer({
 
               <div data-testid="composer-actions" className="flex shrink-0 items-center gap-2">
                 <UsageHint usage={sessionUsage} />
+                <PluginComposerActions sessionId={sessionId} getSnapshot={getPluginComposerSnapshot} />
                 {turnActive ? (
                   <>
                     <StopButton />
@@ -1245,6 +1301,26 @@ export function insertAtCaret(ref: React.RefObject<HTMLTextAreaElement | null>, 
   const pos = before.length + needsSpace.length + text.length;
   ta.focus();
   ta.setSelectionRange(pos, pos);
+}
+
+function insertRawTextAtCaret(ta: HTMLTextAreaElement, text: string, replaceSelection: boolean) {
+  const start = ta.selectionStart ?? ta.value.length;
+  const end = replaceSelection ? (ta.selectionEnd ?? start) : start;
+  const next = ta.value.slice(0, start) + text + ta.value.slice(end);
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(ta, next);
+  ta.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertText",
+      data: text,
+    }),
+  );
+  const pos = start + text.length;
+  ta.focus();
+  ta.setSelectionRange(pos, pos);
+  ta.style.height = "auto";
+  ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
 }
 
 function extDescription(path: string): string | undefined {

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -2,7 +2,7 @@
 // typed display state; these components draw it. No plugin code runs here.
 // Each reads the shared snapshot via context and the pure selectors in
 // `pluginUi.ts`. Slots shipped here: status-bar, row-badge, row-column, card,
-// pane, detail-badge. Notifications surface as toasts via the hook; the
+// pane, detail-badge, composer-action. Notifications surface as toasts via the hook; the
 // sort-key and filter-facet slots render as sidebar sort options and a facet
 // filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
@@ -29,6 +29,12 @@ import {
   validTone,
 } from "../../lib/pluginUi";
 import type { PluginUiEntry, PluginUiTone } from "../../lib/api";
+
+export interface ComposerActionSnapshot {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
 
 // Plugin strings are untrusted: only follow http/https hrefs, never
 // javascript:/data: and friends. Returns undefined for anything else, so the
@@ -254,6 +260,91 @@ export function PluginDetailBadges({ sessionId }: { sessionId: string }) {
         <Badge key={`${e.plugin_id}:${e.id}`} entry={e} />
       ))}
     </div>
+  );
+}
+
+export function PluginComposerActions({
+  sessionId,
+  getSnapshot,
+}: {
+  sessionId: string;
+  getSnapshot: () => ComposerActionSnapshot;
+}) {
+  const entries = sessionEntries(usePluginUiEntries(), "composer-action", sessionId);
+  if (entries.length === 0) return null;
+  return (
+    <>
+      {entries.map((entry) => (
+        <PluginComposerActionButton
+          key={`${entry.plugin_id}:${entry.id}`}
+          entry={entry}
+          sessionId={sessionId}
+          getSnapshot={getSnapshot}
+        />
+      ))}
+    </>
+  );
+}
+
+function PluginComposerActionButton({
+  entry,
+  sessionId,
+  getSnapshot,
+}: {
+  entry: PluginUiEntry;
+  sessionId: string;
+  getSnapshot: () => ComposerActionSnapshot;
+}) {
+  const label = payloadStr(entry, "label");
+  const method = payloadStr(entry, "method");
+  const tooltip = payloadStr(entry, "tooltip") || label;
+  const iconComp = lucideIcon(payloadStr(entry, "icon") || undefined);
+  const disabled = entry.payload.disabled === true || !method || !label;
+  const [posting, setPosting] = useState(false);
+  const postingRef = useRef(false);
+  const poke = usePluginUiPoke();
+  if (!label || !method) return null;
+  const onClick = async () => {
+    if (postingRef.current || disabled) return;
+    postingRef.current = true;
+    setPosting(true);
+    try {
+      const snapshot = getSnapshot();
+      const accepted = await invokePluginAction(entry.plugin_id, method, sessionId, {
+        composer: {
+          text: snapshot.text,
+          selection_start: snapshot.selectionStart,
+          selection_end: snapshot.selectionEnd,
+        },
+      });
+      if (accepted) poke();
+    } finally {
+      postingRef.current = false;
+      setPosting(false);
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || posting}
+      title={tooltip}
+      aria-label={label}
+      aria-busy={posting || undefined}
+      data-testid="plugin-composer-action"
+      className={[
+        "inline-flex h-8 items-center justify-center gap-1 rounded-md border border-surface-700 bg-surface-800 px-2.5 text-[12px]",
+        toneClasses(entryTone(entry)),
+        "hover:bg-surface-700 disabled:cursor-not-allowed disabled:opacity-60 transition-colors duration-100",
+      ].join(" ")}
+    >
+      {posting ? (
+        <Spinner className="size-3.5" />
+      ) : (
+        iconComp && createElement(iconComp, { className: "size-3.5 shrink-0", "aria-hidden": true })
+      )}
+      <span className="max-w-24 truncate">{label}</span>
+    </button>
   );
 }
 

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -1,9 +1,16 @@
 // @vitest-environment jsdom
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginUiEntry } from "../../../lib/api";
-import { PluginCards, PluginPaneBody, PluginRowBadges, PluginStatusBarSegments } from "../PluginSlots";
+import {
+  PluginCards,
+  PluginComposerActions,
+  PluginPaneBody,
+  PluginRowBadges,
+  PluginStatusBarSegments,
+} from "../PluginSlots";
+import { composerDraftOperation } from "../composerDraftOperation";
 
 // The slot components read entries, the refresh flag, the per-plugin revision,
 // and the poke fn from context; mock those hooks so each test drives a fixed
@@ -33,6 +40,15 @@ function set(entries: PluginUiEntry[]) {
 }
 
 describe("plugin slot renderers", () => {
+  beforeEach(() => {
+    entriesRef.current = [];
+    refreshingRef.current = false;
+    revisionRef.current = 0;
+    pokeMock.mockClear();
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(async () => ({ baselineRevision: 0 }));
+  });
+
   it("status-bar renders global segments and is empty otherwise", () => {
     set([]);
     const { container, rerender } = render(<PluginStatusBarSegments />);
@@ -111,6 +127,53 @@ describe("plugin slot renderers", () => {
     expect(btn.textContent).toContain("Refresh");
     fireEvent.click(btn);
     await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("acme.kit", "github.refresh", "s1"));
+  });
+
+  it("composer action button forwards a composer snapshot to the worker", async () => {
+    set([
+      {
+        plugin_id: "acme.voice",
+        slot: "composer-action",
+        id: "dictate",
+        session_id: "s1",
+        payload: { label: "Voice", method: "voice.start", icon: "mic" },
+      },
+    ]);
+    const getSnapshot = vi.fn(() => ({ text: "hello", selectionStart: 1, selectionEnd: 5 }));
+    render(<PluginComposerActions sessionId="s1" getSnapshot={getSnapshot} />);
+
+    fireEvent.click(screen.getByTestId("plugin-composer-action"));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("acme.voice", "voice.start", "s1", {
+        composer: { text: "hello", selection_start: 1, selection_end: 5 },
+      }),
+    );
+    expect(pokeMock).toHaveBeenCalled();
+  });
+
+  it("composer action parses valid draft operations", () => {
+    const entry: PluginUiEntry = {
+      plugin_id: "acme.voice",
+      slot: "composer-action",
+      id: "dictate",
+      session_id: "s1",
+      payload: {
+        label: "Voice",
+        method: "voice.start",
+        draft_operation: { kind: "insert-text", id: "op-1", text: "hello" },
+      },
+    };
+    expect(composerDraftOperation(entry)).toEqual({
+      id: "op-1",
+      operation: { kind: "insert-text", text: "hello" },
+    });
+    expect(
+      composerDraftOperation({
+        ...entry,
+        payload: { ...entry.payload, draft_operation: { kind: "bad", id: "op-2", text: "hello" } },
+      }),
+    ).toBeNull();
   });
 
   it("holds the spinner until the plugin revision advances, not just until the POST resolves", async () => {

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -171,6 +171,15 @@ describe("plugin slot renderers", () => {
     expect(
       composerDraftOperation({
         ...entry,
+        payload: { ...entry.payload, draft_operation: { kind: "set-text", id: "op-2", text: "" } },
+      }),
+    ).toEqual({
+      id: "op-2",
+      operation: { kind: "set-text", text: "" },
+    });
+    expect(
+      composerDraftOperation({
+        ...entry,
         payload: { ...entry.payload, draft_operation: { kind: "bad", id: "op-2", text: "hello" } },
       }),
     ).toBeNull();

--- a/web/src/components/plugin/composerDraftOperation.ts
+++ b/web/src/components/plugin/composerDraftOperation.ts
@@ -20,7 +20,7 @@ export function composerDraftOperation(entry: PluginUiEntry): { id: string; oper
   const id = str(raw, "id");
   const text = str(raw, "text");
   const kind = str(raw, "kind");
-  if (!id || !text) return null;
+  if (!id || text === undefined) return null;
   if (kind === "insert-text" || kind === "replace-selection" || kind === "set-text") {
     return { id, operation: { kind, text } };
   }

--- a/web/src/components/plugin/composerDraftOperation.ts
+++ b/web/src/components/plugin/composerDraftOperation.ts
@@ -1,0 +1,28 @@
+import type { PluginUiEntry } from "../../lib/api";
+
+export type ComposerDraftOperation =
+  | { kind: "insert-text"; text: string }
+  | { kind: "replace-selection"; text: string }
+  | { kind: "set-text"; text: string };
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function str(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+export function composerDraftOperation(entry: PluginUiEntry): { id: string; operation: ComposerDraftOperation } | null {
+  const raw = entry.payload.draft_operation;
+  if (!isObject(raw)) return null;
+  const id = str(raw, "id");
+  const text = str(raw, "text");
+  const kind = str(raw, "kind");
+  if (!id || !text) return null;
+  if (kind === "insert-text" || kind === "replace-selection" || kind === "set-text") {
+    return { id, operation: { kind, text } };
+  }
+  return null;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -703,7 +703,7 @@ export async function dismissPluginUpdate(id: string, fingerprint: string): Prom
  *  validates it to this closed set; each surface maps it to a color. */
 export type PluginUiTone = "neutral" | "info" | "success" | "warn" | "danger";
 
-/** The nine host-rendered slots, kebab-case as the host serializes them. */
+/** The host-rendered slots, kebab-case as the host serializes them. */
 export type PluginUiSlot =
   | "status-bar"
   | "row-badge"
@@ -712,6 +712,7 @@ export type PluginUiSlot =
   | "filter-facet"
   | "card"
   | "pane"
+  | "composer-action"
   | "detail-badge"
   | "notification";
 
@@ -774,19 +775,19 @@ export async function setPluginEnabled(id: string, enabled: boolean): Promise<Pl
 }
 
 /** A worker accepted an action. `baselineRevision` is the scope's UI mutation
- *  counter the host read before forwarding; the pane holds its spinner until
- *  the polled counter moves off this value. `null` means the daemon did not
- *  report a baseline (older daemon), so the caller skips the wait and just
+ *  counter the host read before forwarding; the UI action can hold its spinner
+ *  until the polled counter moves off this value. `null` means the daemon did
+ *  not report a baseline (older daemon), so the caller skips the wait and just
  *  clears when the POST settles. */
 export interface PluginActionAccepted {
   baselineRevision: number | null;
 }
 
 /**
- * Forward a plugin pane's UI action (e.g. a "Refresh" button) to the plugin's
- * worker. Fire-and-forget at the worker: the worker runs the named method and
- * re-pushes its UI state, which a later ui-state poll renders. `sessionId`
- * scopes the baseline revision to the firing pane's session. Returns the
+ * Forward a plugin UI action (e.g. a "Refresh" or composer button) to the
+ * plugin's worker. Fire-and-forget at the worker: the worker runs the named
+ * method and re-pushes its UI state, which a later ui-state poll renders.
+ * `sessionId` scopes the baseline revision to the firing UI's session. Returns the
  * accepted baseline (or null if the daemon omitted one), or null on read-only
  * (403), no running worker (404), or network failure.
  */

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3051,6 +3051,16 @@
         "src/hooks/usePluginUiState.test.tsx"
       ],
       "components": ["web/src/components/plugin/PluginSlots.tsx"]
+    },
+    {
+      "id": "plugins.composer-actions",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/plugin/__tests__/PluginSlots.test.tsx",
+        "src/components/acp/Composer.pluginComposerActions.test.tsx"
+      ],
+      "components": ["web/src/components/plugin/PluginSlots.tsx", "web/src/components/acp/Composer.tsx"]
     }
   ]
 }


### PR DESCRIPTION
## Description
Adds the minimal plugin extension point needed for composer/input actions, split out from the voice dictation discussion in #2567.

This PR adds a per-session `composer-action` UI slot, `composer.read` / `composer.write` capabilities, host-side composer draft operation validation, and web composer integration for plugin-provided action buttons. Provider-specific speech-to-text and the voice dictation implementation are intentionally left out of this PR so the plugin API can be reviewed on its own.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: covered with focused Vitest component tests for the plugin slot renderer and Composer draft insertion bridge; no end-user plugin exists in this PR yet.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## Validation

- `cargo fmt --check`
- `cargo check -p aoe-plugin-api`
- `cargo test -p aoe-plugin-api composer_action_requires_api_version_7`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `cd web && npm run test:unit -- src/components/plugin/__tests__/PluginSlots.test.tsx src/components/acp/Composer.pluginComposerActions.test.tsx`
- `cd web && node tests/validate-coverage-matrix.mjs`

Local `cargo check --features serve` and `cargo test --features serve plugin::ui_state::tests::` currently fail before reaching this code on `libsqlite3-sys` build script usage of unstable `cfg_select` with the local stable toolchain. The same commands passed in the original worktree before rebasing this split onto current `upstream/main`.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Codex


**Any Additional AI Details you'd like to share:**
Used to split the plugin composer API work out of the existing voice dictation branch and prepare this draft PR.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785438994&installation_id=139138837&pr_number=2585&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2585&signature=24a3c75f6aeb7562e95e4ad5507729365b1e70cb30ac4b767460852ce6cfef42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a new plugin-driven **“composer action”** extension point so plugins can contribute action buttons and trigger **safe, host-validated edits** to the active composer draft.

**What changed / what was added**
- **New UI slot:** Adds a per-session **`composer-action`** UI slot (manifest/API-version gated).
- **New plugin capabilities:** Introduces **`composer.read`** (get a click-scoped snapshot of the active composer draft) and **`composer.write`** (submit a validated request to edit the host-owned draft).
- **Host-side control & validation:**
  - Enforces capability requirements for reading composer snapshots and publishing draft edits.
  - Validates `draft_operation` payloads (including operation id and text-size limits).
  - Conditionally strips composer snapshot data from action requests when the plugin lacks `composer.read`.
- **Web composer integration:** The composer UI renders plugin-provided action buttons, captures the current composer text + selection as a snapshot, forwards the action to the plugin, and applies the resulting draft edit.
- **Versioning + docs:** Bumps the plugin API to **v8** and documents the new slot, payload behavior, and capability semantics.
- **Tests:** Adds/updates Vitest coverage for the composer action button flow and `draft_operation` validation/normalization, plus manifest/capability gating.

**Benefits**
- Gives plugins a **controlled way** to interact with composer input without letting plugins directly own or mutate draft state.
- Improves safety and consistency by making the **host** validate edits and manage replay/duplication behavior.
- Cleanly separates composer-action support from speech/voice dictation work, creating a foundation for future composer-related plugins.

**Potential further enhancement**
- Add more end-to-end coverage for sequences of multiple plugin actions (including mixed operation kinds and repeated polling/replay edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->