### PR TITLE
fix: suppress PWA lifecycle network toasts

### DIFF
--- a/web/src/lib/fetchInterceptor.more.test.ts
+++ b/web/src/lib/fetchInterceptor.more.test.ts
@@ -75,6 +75,11 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
+  Object.defineProperty(document, "visibilityState", {
+    value: "visible",
+    configurable: true,
+  });
 });
 
 describe("installFetchErrorToasts lifecycle", () => {
@@ -389,6 +394,37 @@ describe("network error handling", () => {
 
     await expect(window.fetch("/api/sessions")).rejects.toBe(timeout);
     expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("suppresses a lifecycle network toast while the document is hidden", async () => {
+    const { original } = await freshInstall();
+    const boom = new TypeError("Failed to fetch");
+    original.mockRejectedValue(boom);
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await expect(window.fetch("/api/sessions")).rejects.toBe(boom);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("suppresses transient lifecycle network toasts only briefly after focus returns", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const { original } = await freshInstall();
+    const boom = new TypeError("Failed to fetch");
+    original.mockRejectedValue(boom);
+
+    window.dispatchEvent(new Event("focus"));
+
+    await expect(window.fetch("/api/sessions")).rejects.toBe(boom);
+    expect(reportError).not.toHaveBeenCalled();
+
+    vi.setSystemTime(13_000);
+    await expect(window.fetch("/api/sessions")).rejects.toBe(boom);
+    expect(reportError).toHaveBeenCalledWith("Network error contacting /api/sessions. Check your connection.");
   });
 
   it("does not toast a network error on a non-/api path but still rethrows", async () => {

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -3,6 +3,8 @@ import { getOrCreateDeviceBindingSecret } from "./deviceBinding";
 import { reportError } from "./toastBus";
 import { clearToken, getToken, saveToken } from "./token";
 
+const LIFECYCLE_NETWORK_TOAST_SUPPRESS_MS = 2_000;
+
 /** Dispatched on `window` when the auth token is rejected or missing. App.tsx
  *  listens for this to show the token entry page instead of just a toast. */
 export const TOKEN_EXPIRED_EVENT = "aoe:token-expired";
@@ -68,6 +70,7 @@ export function installFetchErrorToasts(): void {
     return;
   }
   (window as unknown as { __aoeFetchPatched?: boolean }).__aoeFetchPatched = true;
+  installPageLifecycleTracking();
 
   const original = window.fetch.bind(window);
 
@@ -138,7 +141,7 @@ export function installFetchErrorToasts(): void {
       }
       // When the server is known to be down, suppress per-request toasts.
       // The DisconnectBanner handles the user-facing notification instead.
-      if (isApi && !isServerDown()) {
+      if (isApi && !isServerDown() && !isPageLifecycleNetworkGlitch()) {
         reportError(`Network error contacting ${path}. Check your connection.`);
       }
       throw err;
@@ -171,6 +174,27 @@ function handleLoginRequired(): void {
   if (loginRequiredDispatched) return;
   loginRequiredDispatched = true;
   window.dispatchEvent(new CustomEvent(LOGIN_REQUIRED_EVENT));
+}
+
+let lastPageLifecycleChangeAt = 0;
+let lifecycleTrackingInstalled = false;
+
+function installPageLifecycleTracking(): void {
+  if (lifecycleTrackingInstalled) return;
+  lifecycleTrackingInstalled = true;
+  const mark = () => {
+    lastPageLifecycleChangeAt = Date.now();
+  };
+  document.addEventListener("visibilitychange", mark);
+  window.addEventListener("pagehide", mark);
+  window.addEventListener("pageshow", mark);
+  window.addEventListener("blur", mark);
+  window.addEventListener("focus", mark);
+}
+
+function isPageLifecycleNetworkGlitch(): boolean {
+  if (document.visibilityState === "hidden") return true;
+  return lastPageLifecycleChangeAt > 0 && Date.now() - lastPageLifecycleChangeAt < LIFECYCLE_NETWORK_TOAST_SUPPRESS_MS;
 }
 
 /** Reset the dedup flags so a new 401 after re-authentication will be

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1378,6 +1378,13 @@
       "components": ["web/src/components/DisconnectBanner.tsx"]
     },
     {
+      "id": "connectivity.lifecycle-fetch-toasts",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/fetchInterceptor.more.test.ts"],
+      "components": ["web/src/lib/fetchInterceptor.ts"]
+    },
+    {
       "id": "git-clone",
       "kind": "live-playwright",
       "risk": "medium",


### PR DESCRIPTION
## Description

Suppress noisy global network-error toasts during browser/PWA lifecycle transitions.

When a dashboard tab or installed PWA is backgrounded and then resumed, in-flight `/api/*` fetches can fail before the app’s normal connectivity state catches up. The top bar / disconnected UI already handles that state, so this PR treats network failures around `visibilitychange`, `pagehide/pageshow`, `blur`, and `focus` as lifecycle noise instead of showing an extra toast.

True API network errors outside that short lifecycle window still toast as before.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot/recording: behavior-only toast suppression, no visual layout change.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is interceptor-level behavior covered by Vitest; `web/tests/coverage-matrix.json` includes `connectivity.lifecycle-fetch-toasts`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Codex

**Any Additional AI Details you'd like to share:**
Used Codex to inspect the existing fetch interceptor behavior, validate the branch diff, and run targeted checks.

- [x] I am an AI Agent filling out this form

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785446415&installation_id=139138837&pr_number=2588&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2588&signature=4d77dcf6f2148634a01d80166ddf862c66f7a9deb4368cd868ef7d86655e119c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR reduces noisy network-error toasts that can happen when the dashboard or PWA is being backgrounded, resumed, or refocused.

What changed:
- Added a short suppression window for network-error toasts during page lifecycle transitions.
- Treated hidden/resuming states as lifecycle-related noise instead of user-facing failures.
- Kept normal API error toasts working outside that brief transition period.
- Expanded tests to cover hidden-tab suppression and focus/resume timing.
- Added coverage tracking for the new lifecycle fetch-toast behavior.

Benefits:
- Fewer confusing toasts during normal browser/PWA lifecycle changes.
- Better match between UI connectivity indicators and toast behavior.
- Preserves genuine network-error reporting when the app is actually offline or the request truly fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->