### PR TITLE
feat(web): scope Cmd+K palette results with category tabs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,7 +29,7 @@ import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useDiffComments } from "./hooks/useDiffComments";
 import { clearStoredComments, sweepOrphanComments } from "./components/diff/comments/storage";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
-import { useCommandActions, buildConversationActions } from "./hooks/useCommandActions";
+import { useCommandActions, buildConversationActions, type SessionStateAction } from "./hooks/useCommandActions";
 import { usePluginCommands } from "./hooks/usePluginCommands";
 import { useSettingsCommands } from "./hooks/useSettingsCommands";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
@@ -59,17 +59,22 @@ import {
   deleteProject,
   setSessionUnread,
   killTerminal,
+  setSessionPin,
+  setSessionArchive,
+  setSessionSnooze,
+  trashSession,
+  restoreSession,
 } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { normalizeProjectPathKey } from "./lib/registeredProjects";
 import { IdleDecayWindowContext, parseIdleDecayWindowMs, useIdleDecayWindowMs } from "./lib/idleDecay";
 import { parseUnreadIndicatorEnabled, UnreadIndicatorContext, useUnreadIndicatorEnabled } from "./lib/unreadIndicator";
-import { toastBus } from "./lib/toastBus";
+import { toastBus, reportError } from "./lib/toastBus";
 import { resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
 import { dispatchFocusTerminal, requestSessionInputFocus, setPendingTerminalFocus } from "./lib/terminalFocus";
 import { hydrateWebUiStateFromServer, initWebUiSync } from "./lib/webUiSync";
-import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
+import { WorkspaceSidebar, SnoozeModal } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { StopSessionDialog } from "./components/StopSessionDialog";
 import { TopBar } from "./components/TopBar";
@@ -583,6 +588,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // handlers below can clear it on close/toggle. Consumed lower down by
   // useConversationSearch.
   const [paletteQuery, setPaletteQuery] = useState("");
+  // Session id awaiting a snooze duration from the palette's "Snooze…" action;
+  // drives the shared SnoozeModal. Null when no snooze is in flight.
+  const [snoozeTargetId, setSnoozeTargetId] = useState<string | null>(null);
   const [showAbout, setShowAbout] = useState(false);
   const [telemetryConsentNeeded, setTelemetryConsentNeeded] = useState(false);
   // Whether the telemetry status fetch has settled. `telemetryConsentNeeded`
@@ -1310,15 +1318,43 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     ),
   );
 
+  // Palette triage toggles for the active session. "snooze" needs a duration,
+  // so it opens the shared modal; the rest are argless server toggles that
+  // apply the returned snapshot immediately (re-bucketing without waiting for
+  // the poll) and surface a toast on failure.
+  const handleSessionStateAction = useCallback(
+    async (id: string, action: SessionStateAction) => {
+      if (action === "snooze") {
+        setSnoozeTargetId(id);
+        return;
+      }
+      const run: Record<Exclude<SessionStateAction, "snooze">, () => Promise<SessionResponse | null>> = {
+        pin: () => setSessionPin(id, true),
+        unpin: () => setSessionPin(id, false),
+        archive: () => setSessionArchive(id, true),
+        unarchive: () => setSessionArchive(id, false),
+        unsnooze: () => setSessionSnooze(id, null),
+        trash: () => trashSession(id),
+        untrash: () => restoreSession(id),
+      };
+      const result = await run[action]();
+      if (result) applySession(result);
+      else reportError(`Failed to ${action} session`);
+    },
+    [applySession],
+  );
+
   const commandActions = useCommandActions({
     sessions,
     activeSessionId,
+    activeSession: activeSession ?? null,
     loginRequired,
     hasActiveSession: !!activeSession,
     readOnly: !!serverAbout?.read_only,
     onNewSession: handleNewSession,
     onNewScratch: handleNewScratch,
     onSelectSession: handleSelectSession,
+    onSessionStateAction: handleSessionStateAction,
     onToggleDiff: toggleDiff,
     onOpenSettings: handleOpenSettings,
     onOpenHelp: handleOpenHelp,
@@ -1877,6 +1913,21 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           onSearchChange={setPaletteQuery}
           searching={conversationSearching}
         />
+
+        {snoozeTargetId && (
+          <SnoozeModal
+            title="Snooze session"
+            onCancel={() => setSnoozeTargetId(null)}
+            onPick={(minutes) => {
+              const id = snoozeTargetId;
+              setSnoozeTargetId(null);
+              void setSessionSnooze(id, minutes).then((result) => {
+                if (result) applySession(result);
+                else reportError("Failed to snooze session");
+              });
+            }}
+          />
+        )}
 
         {activeWorkspace && activeSession && (
           <MobileRightPanelPicker

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -14,14 +14,27 @@ function actionValue(a: CommandAction): string {
   return `${a.id} ${[a.title, a.subtitle ?? "", ...(a.keywords ?? [])].join(" ")}`;
 }
 
-// Does this row survive the current query? Mirrors the <Command> filter:
-// conversation hits are server-matched (force-kept), everything else uses
-// cmdk's default fuzzy scoring. An empty query keeps everything.
+// cmdk's fuzzy scorer keeps any nonzero score, but a short query like "test"
+// scatter-matches across a row's id + keywords (t·e·s·t picked from
+// "acTion nEw seSsion sTart") for a tiny ~0.15 score, surfacing unrelated
+// rows. Real substring / prefix / acronym hits score ~0.9+, so require a
+// floor well above the scatter band. Tune here if legitimate fuzzy matches
+// start dropping.
+const MIN_SCORE = 0.3;
+
+// The single scoring predicate for a row against the current query, used both
+// to pre-filter groups (tab/count visibility) and as the <Command> filter so
+// the two never disagree. Conversation hits are matched server-side by content
+// the client text lacks, so force-keep them; an empty query keeps everything.
+function scoreValue(value: string, search: string): number {
+  if (value.startsWith("conversation:")) return 1;
+  if (!search) return 1;
+  const score = defaultFilter!(value, search) ?? 0;
+  return score >= MIN_SCORE ? score : 0;
+}
+
 function matches(a: CommandAction, search: string): boolean {
-  if (!search) return true;
-  const value = actionValue(a);
-  if (value.startsWith("conversation:")) return true;
-  return (defaultFilter!(value, search) ?? 0) > 0;
+  return scoreValue(actionValue(a), search) > 0;
 }
 
 interface Props {
@@ -162,12 +175,7 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
       <Command
         label="Command palette"
         loop
-        filter={(value, searchText, keywords) =>
-          // Conversation hits are already filtered server-side by content
-          // (which the client text does not contain), so force-keep them;
-          // everything else uses cmdk's default fuzzy scoring.
-          value.startsWith("conversation:") ? 1 : defaultFilter!(value, searchText, keywords)
-        }
+        filter={(value, searchText) => scoreValue(value, searchText)}
         className="w-full max-w-[600px] bg-surface-800 border border-surface-700/50 rounded-lg shadow-2xl overflow-hidden animate-slide-up"
         onClick={(e) => e.stopPropagation()}
       >

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Command, defaultFilter } from "cmdk";
 import { StatusGlyph } from "../StatusGlyph";
 import { CheatOverlay } from "./CheatOverlay";
-import { GROUP_ORDER } from "./groups";
+import { GROUP_ORDER, TAB_ORDER, type PaletteTab } from "./groups";
 import type { CommandAction, CommandActionGroup } from "./types";
 import { matchCheat, type CheatEffect } from "../../lib/cheats";
 import { reportInfo } from "../../lib/toastBus";
@@ -23,6 +23,9 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
   const inputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [search, setSearch] = useState("");
+  // JetBrains "Search Everywhere"-style tabs: "All" shows every group (the
+  // default flat view), a category tab scopes the list to one group.
+  const [activeTab, setActiveTab] = useState<PaletteTab>("All");
   // Active easter-egg effect plus a monotonic id so retyping the same cheat
   // replays the animation (the id is the overlay's React key).
   const [cheat, setCheat] = useState<{ effect: CheatEffect; id: number } | null>(null);
@@ -67,6 +70,7 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
     if (!open) {
       setSearch("");
       setCheat(null);
+      setActiveTab("All");
     }
   }
 
@@ -84,11 +88,44 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
     return map;
   }, [actions]);
 
+  // Tabs to render: "All" always, plus any group that has rows for the current
+  // query. The Conversations tab also shows while a content search is in
+  // flight so it is reachable before the first hit lands.
+  const tabs = useMemo(
+    () =>
+      TAB_ORDER.filter(
+        (t) => t === "All" || (grouped.get(t)?.length ?? 0) > 0 || (t === "Conversations" && !!searching),
+      ),
+    [grouped, searching],
+  );
+
+  // The active tab can go stale when the query changes out from under it (its
+  // group emptied). Fall back to "All" rather than render an empty scope.
+  if (activeTab !== "All" && !tabs.includes(activeTab)) setActiveTab("All");
+
+  const visibleGroups = activeTab === "All" ? GROUP_ORDER : [activeTab];
+  const visibleCount = visibleGroups.reduce((n, g) => n + (grouped.get(g)?.length ?? 0), 0);
+
   if (!open) return null;
 
   const run = (action: CommandAction) => {
     onClose();
     queueMicrotask(() => action.perform());
+  };
+
+  // Tab / Shift+Tab cycle the scope tabs (JetBrains mirror). preventDefault so
+  // the key does not move focus out of the input or type into it.
+  const cycleTab = (dir: 1 | -1) => {
+    if (tabs.length < 3) return;
+    const i = tabs.indexOf(activeTab);
+    const next = tabs[(i + dir + tabs.length) % tabs.length];
+    if (next) setActiveTab(next);
+  };
+
+  const onKeyDown = (e: ReactKeyboardEvent) => {
+    if (e.key !== "Tab") return;
+    e.preventDefault();
+    cycleTab(e.shiftKey ? -1 : 1);
   };
 
   return (
@@ -98,6 +135,7 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
       aria-label="Command palette"
       className="fixed inset-0 z-[60] flex items-start justify-center bg-black/80 backdrop-blur-sm animate-fade-in pt-[15vh] px-3"
       onClick={onClose}
+      onKeyDown={onKeyDown}
       data-testid="command-palette-backdrop"
     >
       <Command
@@ -139,10 +177,39 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
           </kbd>
         </div>
 
+        {tabs.length > 2 && (
+          <div
+            role="tablist"
+            aria-label="Result categories"
+            className="flex items-center gap-1 px-2 h-9 border-b border-surface-700/50"
+          >
+            {tabs.map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab}
+                onClick={() => setActiveTab(tab)}
+                className={`px-2.5 py-1 rounded text-xs font-medium ${
+                  activeTab === tab
+                    ? "bg-surface-700 text-text-bright"
+                    : "text-text-muted hover:text-text-primary hover:bg-surface-700/50"
+                }`}
+              >
+                {tab}
+              </button>
+            ))}
+            <span className="flex-1" />
+            <kbd className="font-mono text-[10px] px-1.5 py-0.5 rounded bg-surface-900 border border-surface-700 text-text-muted">
+              tab
+            </kbd>
+          </div>
+        )}
+
         <Command.List className="max-h-[50vh] overflow-y-auto p-1">
           <Command.Empty className="px-4 py-8 text-center text-sm text-text-muted">No matches</Command.Empty>
 
-          {GROUP_ORDER.map((groupName) => {
+          {visibleGroups.map((groupName) => {
             const items = grouped.get(groupName) ?? [];
             // The Conversations group still renders while a content search
             // is in flight, so the spinner replaces a premature "No matches".
@@ -198,7 +265,7 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
         <div className="flex items-center justify-between px-4 h-8 border-t border-surface-700/50 text-[11px] font-mono text-text-muted">
           <span>↑↓ navigate · ↵ select · esc close</span>
           <span>
-            {actions.length} action{actions.length === 1 ? "" : "s"}
+            {visibleCount} action{visibleCount === 1 ? "" : "s"}
           </span>
         </div>
       </Command>

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -7,6 +7,23 @@ import type { CommandAction, CommandActionGroup } from "./types";
 import { matchCheat, type CheatEffect } from "../../lib/cheats";
 import { reportInfo } from "../../lib/toastBus";
 
+// The cmdk item value: id plus the searchable text. Kept in one place so the
+// pre-filter that drives tab/count visibility and the <Command.Item value=...>
+// that cmdk actually scores stay in sync.
+function actionValue(a: CommandAction): string {
+  return `${a.id} ${[a.title, a.subtitle ?? "", ...(a.keywords ?? [])].join(" ")}`;
+}
+
+// Does this row survive the current query? Mirrors the <Command> filter:
+// conversation hits are server-matched (force-kept), everything else uses
+// cmdk's default fuzzy scoring. An empty query keeps everything.
+function matches(a: CommandAction, search: string): boolean {
+  if (!search) return true;
+  const value = actionValue(a);
+  if (value.startsWith("conversation:")) return true;
+  return (defaultFilter!(value, search) ?? 0) > 0;
+}
+
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -78,15 +95,19 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
   // (e.g. the user typing again while an effect is still on screen).
   const clearCheat = useCallback(() => setCheat(null), []);
 
+  // Group only the rows that survive cmdk's search filter, so tab visibility
+  // and the footer count reflect what actually renders for the current query
+  // (not the raw group sizes). Mirrors the same value string and force-keep
+  // rule the <Command> filter uses below.
   const grouped = useMemo(() => {
     const map = new Map<CommandActionGroup, CommandAction[]>();
     for (const g of GROUP_ORDER) map.set(g, []);
     for (const a of actions) {
       const arr = map.get(a.group);
-      if (arr) arr.push(a);
+      if (arr && matches(a, search)) arr.push(a);
     }
     return map;
-  }, [actions]);
+  }, [actions, search]);
 
   // Tabs to render: "All" always, plus any group that has rows for the current
   // query. The Conversations tab also shows while a content search is in
@@ -232,11 +253,10 @@ export function CommandPalette({ open, onClose, actions, onSearchChange, searchi
                   </Command.Item>
                 )}
                 {items.map((action) => {
-                  const searchValue = [action.title, action.subtitle ?? "", ...(action.keywords ?? [])].join(" ");
                   return (
                     <Command.Item
                       key={action.id}
-                      value={`${action.id} ${searchValue}`}
+                      value={actionValue(action)}
                       onSelect={() => run(action)}
                       className="flex items-center gap-2 px-3 h-9 rounded-md cursor-pointer text-sm text-text-primary data-[selected=true]:bg-surface-700 data-[selected=true]:text-text-bright"
                     >

--- a/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
+++ b/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
@@ -169,6 +169,52 @@ describe("CommandPalette", () => {
       expect(selected()).toBe("Settings");
     });
 
+    it("drops a tab and trims the footer count when a query filters a group out", () => {
+      render(
+        <CommandPalette
+          open
+          onClose={() => {}}
+          actions={[
+            action({ id: "a1", title: "alpha run", group: "Actions" }),
+            action({ id: "s1", title: "alpha save", group: "Settings" }),
+            action({ id: "sess1", title: "beta sit", group: "Sessions" }),
+          ]}
+        />,
+      );
+      expect(screen.getByText("3 actions")).toBeTruthy();
+      // "alpha" matches the Actions + Settings rows but not the Sessions row.
+      fireEvent.change(screen.getByPlaceholderText("Search actions, sessions, settings…"), {
+        target: { value: "alpha" },
+      });
+      expect(screen.getByText("2 actions")).toBeTruthy();
+      expect(screen.queryByRole("tab", { name: "Sessions" })).toBeNull();
+      expect(screen.getByRole("tab", { name: "Actions" })).toBeTruthy();
+      expect(screen.getByRole("tab", { name: "Settings" })).toBeTruthy();
+    });
+
+    it("hides the strip and counts only matches when a query leaves one group", () => {
+      render(
+        <CommandPalette
+          open
+          onClose={() => {}}
+          actions={[
+            action({ id: "a1", title: "Run thing", group: "Actions" }),
+            action({ id: "s1", title: "Save setting", group: "Settings" }),
+            action({ id: "sess1", title: "Some session", group: "Sessions" }),
+          ]}
+        />,
+      );
+      // "setting" only matches the Settings row; the strip collapses (one real
+      // category) and the footer reflects the single surviving row.
+      fireEvent.change(screen.getByPlaceholderText("Search actions, sessions, settings…"), {
+        target: { value: "setting" },
+      });
+      expect(screen.queryByRole("tablist")).toBeNull();
+      expect(screen.getByText("1 action")).toBeTruthy();
+      expect(screen.queryByText("Run thing")).toBeNull();
+      expect(screen.queryByText("Some session")).toBeNull();
+    });
+
     it("resets to All when reopened", () => {
       const { rerender } = render(<CommandPalette open onClose={() => {}} actions={mixed} />);
       fireEvent.click(screen.getByRole("tab", { name: "Settings" }));

--- a/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
+++ b/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
@@ -96,4 +96,86 @@ describe("CommandPalette", () => {
     });
     expect(onSearchChange).toHaveBeenCalledWith("reconciler");
   });
+
+  describe("category tabs", () => {
+    const mixed = [
+      action({ id: "a1", title: "Run thing", group: "Actions" }),
+      action({ id: "s1", title: "Save setting", group: "Settings" }),
+      action({ id: "sess1", title: "Some session", group: "Sessions" }),
+    ];
+
+    it("defaults to All and shows every group's rows (no regression)", () => {
+      render(<CommandPalette open onClose={() => {}} actions={mixed} />);
+      expect(screen.getByRole("tab", { name: "All" }).getAttribute("aria-selected")).toBe("true");
+      expect(screen.getByText("Run thing")).toBeTruthy();
+      expect(screen.getByText("Save setting")).toBeTruthy();
+      expect(screen.getByText("Some session")).toBeTruthy();
+    });
+
+    it("scopes the list to one group when a category tab is clicked", () => {
+      render(<CommandPalette open onClose={() => {}} actions={mixed} />);
+      fireEvent.click(screen.getByRole("tab", { name: "Settings" }));
+      expect(screen.getByText("Save setting")).toBeTruthy();
+      expect(screen.queryByText("Run thing")).toBeNull();
+      expect(screen.queryByText("Some session")).toBeNull();
+    });
+
+    it("offers no tab for an empty category", () => {
+      render(<CommandPalette open onClose={() => {}} actions={mixed} />);
+      // No Conversations actions and not searching, so no Conversations tab.
+      expect(screen.queryByRole("tab", { name: "Conversations" })).toBeNull();
+      expect(screen.getByRole("tab", { name: "Settings" })).toBeTruthy();
+    });
+
+    it("offers the Conversations tab while a content search is in flight", () => {
+      render(<CommandPalette open onClose={() => {}} actions={mixed} searching />);
+      expect(screen.getByRole("tab", { name: "Conversations" })).toBeTruthy();
+    });
+
+    it("hides the tab strip when only one category has results", () => {
+      render(<CommandPalette open onClose={() => {}} actions={[action({ title: "Lonely", group: "Actions" })]} />);
+      expect(screen.queryByRole("tablist")).toBeNull();
+    });
+
+    it("reflects the active tab's count in the footer", () => {
+      render(
+        <CommandPalette
+          open
+          onClose={() => {}}
+          actions={[
+            action({ id: "a1", title: "One", group: "Actions" }),
+            action({ id: "a2", title: "Two", group: "Actions" }),
+            action({ id: "s1", title: "Setting", group: "Settings" }),
+          ]}
+        />,
+      );
+      expect(screen.getByText("3 actions")).toBeTruthy();
+      fireEvent.click(screen.getByRole("tab", { name: "Settings" }));
+      expect(screen.getByText("1 action")).toBeTruthy();
+    });
+
+    it("cycles tabs with Tab and Shift+Tab", () => {
+      render(<CommandPalette open onClose={() => {}} actions={mixed} />);
+      const dialog = screen.getByRole("dialog", { name: "Command palette" });
+      const selected = () =>
+        screen.getAllByRole("tab").find((t) => t.getAttribute("aria-selected") === "true")?.textContent;
+      expect(selected()).toBe("All");
+      // Tab order is All, Actions, Sessions, Settings (no Conversations here).
+      fireEvent.keyDown(dialog, { key: "Tab" });
+      expect(selected()).toBe("Actions");
+      fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+      expect(selected()).toBe("All");
+      fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+      expect(selected()).toBe("Settings");
+    });
+
+    it("resets to All when reopened", () => {
+      const { rerender } = render(<CommandPalette open onClose={() => {}} actions={mixed} />);
+      fireEvent.click(screen.getByRole("tab", { name: "Settings" }));
+      expect(screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")).toBe("true");
+      rerender(<CommandPalette open={false} onClose={() => {}} actions={mixed} />);
+      rerender(<CommandPalette open onClose={() => {}} actions={mixed} />);
+      expect(screen.getByRole("tab", { name: "All" }).getAttribute("aria-selected")).toBe("true");
+    });
+  });
 });

--- a/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
+++ b/web/src/components/command-palette/__tests__/CommandPalette.test.tsx
@@ -215,6 +215,32 @@ describe("CommandPalette", () => {
       expect(screen.queryByText("Some session")).toBeNull();
     });
 
+    it("excludes scatter-only fuzzy matches while keeping real matches", () => {
+      render(
+        <CommandPalette
+          open
+          onClose={() => {}}
+          actions={[
+            // "test" only scatter-matches this row (t·e·s·t across the id and
+            // keywords), which used to surface it under a short query.
+            action({
+              id: "action:new-session",
+              title: "New session",
+              group: "Actions",
+              keywords: ["create", "start", "agent", "worktree"],
+            }),
+            action({ id: "session:x", title: "plugin-host-test", group: "Sessions" }),
+          ]}
+        />,
+      );
+      fireEvent.change(screen.getByPlaceholderText("Search actions, sessions, settings…"), {
+        target: { value: "test" },
+      });
+      expect(screen.queryByText("New session")).toBeNull();
+      expect(screen.getByText("plugin-host-test")).toBeTruthy();
+      expect(screen.getByText("1 action")).toBeTruthy();
+    });
+
     it("resets to All when reopened", () => {
       const { rerender } = render(<CommandPalette open onClose={() => {}} actions={mixed} />);
       fireEvent.click(screen.getByRole("tab", { name: "Settings" }));

--- a/web/src/components/command-palette/groups.ts
+++ b/web/src/components/command-palette/groups.ts
@@ -1,3 +1,9 @@
 import type { CommandActionGroup } from "./types";
 
 export const GROUP_ORDER: CommandActionGroup[] = ["Actions", "Sessions", "Conversations", "Settings"];
+
+// "All" scopes to every group (the default flat view); the rest scope to a
+// single CommandActionGroup. Tab order is "All" first, then GROUP_ORDER.
+export type PaletteTab = "All" | CommandActionGroup;
+
+export const TAB_ORDER: PaletteTab[] = ["All", ...GROUP_ORDER];

--- a/web/src/hooks/__tests__/useCommandActions.test.tsx
+++ b/web/src/hooks/__tests__/useCommandActions.test.tsx
@@ -17,12 +17,14 @@ function baseArgs(overrides: Partial<Args> = {}): Args {
   return {
     sessions: [] as SessionResponse[],
     activeSessionId: null,
+    activeSession: null,
     loginRequired: false,
     hasActiveSession: false,
     readOnly: false,
     onNewSession: vi.fn(),
     onNewScratch: vi.fn(),
     onSelectSession: vi.fn(),
+    onSessionStateAction: vi.fn(),
     onToggleDiff: vi.fn(),
     onOpenSettings: vi.fn(),
     onOpenHelp: vi.fn(),
@@ -109,5 +111,66 @@ describe("buildConversationActions", () => {
     expect(trashed[0]!.subtitle).toBe("matched text (3 matches)");
     const snoozed = buildConversationActions([hit()], [session({ snoozed_until: "2099-01-01T00:00:00Z" })], null);
     expect(snoozed[0]!.title).toBe("My Session · snoozed");
+  });
+});
+
+describe("useCommandActions: active-session triage toggles", () => {
+  const active = (over: Partial<SessionResponse> = {}) =>
+    ({ id: "act", title: "Alpha", status: "idle", created_at: "2026-01-01T00:00:00Z", ...over }) as SessionResponse;
+  const ids = (actions: ReturnType<typeof useCommandActions>) => actions.map((a) => a.id);
+
+  it("offers the forward toggles when the session is in no sunk state", () => {
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ activeSession: active(), hasActiveSession: true })),
+    );
+    const got = ids(result.current);
+    expect(got).toContain("session-state:pin:act");
+    expect(got).toContain("session-state:archive:act");
+    expect(got).toContain("session-state:snooze:act");
+    expect(got).toContain("session-state:trash:act");
+    expect(got).not.toContain("session-state:unpin:act");
+    expect(got).not.toContain("session-state:unarchive:act");
+    const pin = result.current.find((a) => a.id === "session-state:pin:act");
+    expect(pin?.title).toBe("Pin Alpha");
+    expect(pin?.group).toBe("Actions");
+  });
+
+  it("flips each toggle to its restore direction per state", () => {
+    const { result } = renderHook(() =>
+      useCommandActions(
+        baseArgs({
+          hasActiveSession: true,
+          activeSession: active({
+            pinned_at: "2026-01-02T00:00:00Z",
+            archived_at: "2026-01-02T00:00:00Z",
+            snoozed_until: "2099-01-01T00:00:00Z",
+            trashed_at: "2026-01-02T00:00:00Z",
+          }),
+        }),
+      ),
+    );
+    const got = ids(result.current);
+    expect(got).toContain("session-state:unpin:act");
+    expect(got).toContain("session-state:unarchive:act");
+    expect(got).toContain("session-state:unsnooze:act");
+    expect(got).toContain("session-state:untrash:act");
+    expect(got).not.toContain("session-state:pin:act");
+    expect(result.current.find((a) => a.id === "session-state:untrash:act")?.title).toBe("Untrash Alpha");
+  });
+
+  it("routes a toggle's perform to onSessionStateAction with the session id and action", () => {
+    const onSessionStateAction = vi.fn();
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ activeSession: active(), hasActiveSession: true, onSessionStateAction })),
+    );
+    result.current.find((a) => a.id === "session-state:archive:act")!.perform();
+    expect(onSessionStateAction).toHaveBeenCalledWith("act", "archive");
+  });
+
+  it("omits the toggles in read-only mode", () => {
+    const { result } = renderHook(() =>
+      useCommandActions(baseArgs({ activeSession: active(), hasActiveSession: true, readOnly: true })),
+    );
+    expect(ids(result.current).some((id) => id.startsWith("session-state:"))).toBe(false);
   });
 });

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -48,15 +48,31 @@ export function buildConversationActions(
   });
 }
 
+// State toggles the palette offers for the active session. Each is shown only
+// in the matching direction: e.g. "unarchive" on an archived session, "archive"
+// otherwise. "snooze" needs a duration, so the host opens the snooze modal; the
+// rest are argless server toggles.
+export type SessionStateAction =
+  | "pin"
+  | "unpin"
+  | "archive"
+  | "unarchive"
+  | "snooze"
+  | "unsnooze"
+  | "trash"
+  | "untrash";
+
 interface Args {
   sessions: SessionResponse[];
   activeSessionId: string | null;
+  activeSession: SessionResponse | null;
   loginRequired: boolean;
   hasActiveSession: boolean;
   readOnly: boolean;
   onNewSession: () => void;
   onNewScratch: () => void;
   onSelectSession: (sessionId: string) => void;
+  onSessionStateAction: (sessionId: string, action: SessionStateAction) => void;
   onToggleDiff: () => void;
   onOpenSettings: () => void;
   onOpenHelp: () => void;
@@ -69,12 +85,14 @@ interface Args {
 export function useCommandActions({
   sessions,
   activeSessionId,
+  activeSession,
   loginRequired,
   hasActiveSession,
   readOnly,
   onNewSession,
   onNewScratch,
   onSelectSession,
+  onSessionStateAction,
   onToggleDiff,
   onOpenSettings,
   onOpenHelp,
@@ -128,6 +146,38 @@ export function useCommandActions({
         shortcut: "D",
         perform: onToggleDiff,
       });
+    }
+
+    // Triage toggles for the active session, each shown only in the applicable
+    // direction (unarchive on an archived session, archive otherwise, etc.).
+    // These mutate the server, so they are dropped in read-only mode.
+    if (!readOnly && activeSession) {
+      const a = activeSession;
+      const label = a.title || a.branch || "session";
+      const toggles: { verb: string; action: SessionStateAction; keywords: string[] }[] = [
+        a.pinned_at != null
+          ? { verb: "Unpin", action: "unpin", keywords: ["pin", "favorite", "sidebar"] }
+          : { verb: "Pin", action: "pin", keywords: ["pin", "favorite", "sidebar"] },
+        a.archived_at != null
+          ? { verb: "Unarchive", action: "unarchive", keywords: ["archive", "restore"] }
+          : { verb: "Archive", action: "archive", keywords: ["archive"] },
+        a.snoozed_until != null
+          ? { verb: "Unsnooze", action: "unsnooze", keywords: ["snooze", "wake"] }
+          : { verb: "Snooze…", action: "snooze", keywords: ["snooze", "later", "remind"] },
+        a.trashed_at != null
+          ? { verb: "Untrash", action: "untrash", keywords: ["trash", "restore", "delete"] }
+          : { verb: "Trash", action: "trash", keywords: ["trash", "delete", "remove"] },
+      ];
+      for (const t of toggles) {
+        actions.push({
+          id: `session-state:${t.action}:${a.id}`,
+          title: `${t.verb} ${label}`,
+          subtitle: "current session",
+          group: "Actions",
+          keywords: [...t.keywords, label, "session"],
+          perform: () => onSessionStateAction(a.id, t.action),
+        });
+      }
     }
 
     actions.push({
@@ -195,12 +245,14 @@ export function useCommandActions({
   }, [
     sessions,
     activeSessionId,
+    activeSession,
     loginRequired,
     hasActiveSession,
     readOnly,
     onNewSession,
     onNewScratch,
     onSelectSession,
+    onSessionStateAction,
     onToggleDiff,
     onOpenSettings,
     onOpenHelp,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -830,6 +830,16 @@
       "components": ["web/src/App.tsx", "web/src/components/command-palette/CommandPalette.tsx"]
     },
     {
+      "id": "palette.category-tabs",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/command-palette/__tests__/CommandPalette.test.tsx"],
+      "components": [
+        "web/src/components/command-palette/CommandPalette.tsx",
+        "web/src/components/command-palette/groups.ts"
+      ]
+    },
+    {
       "id": "sidebar.scratch-group",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -840,6 +840,13 @@
       ]
     },
     {
+      "id": "palette.session-triage",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/hooks/__tests__/useCommandActions.test.tsx"],
+      "components": ["web/src/hooks/useCommandActions.ts", "web/src/App.tsx"]
+    },
+    {
       "id": "sidebar.scratch-group",
       "kind": "mocked-playwright",
       "risk": "medium",

--- a/web/tests/desktop-live-input.spec.ts
+++ b/web/tests/desktop-live-input.spec.ts
@@ -80,6 +80,23 @@ test.describe("Desktop live terminal input", () => {
     await clickSidebarSession(page, "pinch-test");
     await page.locator("[data-live-content]").first().waitFor({ state: "visible", timeout: 10_000 });
 
+    // The component requests a wider scrollback window after mount, so a second
+    // frame arrives with history rows. Wait for the content to stop changing
+    // before selecting; otherwise the captured Range drifts onto a row that
+    // renders in the later frame and the clipboard no longer matches `selected`.
+    let prevContent = "";
+    await expect
+      .poll(
+        async () => {
+          const cur = await page.evaluate(() => document.querySelector("[data-live-content]")?.textContent ?? "");
+          const stable = cur !== "" && cur === prevContent;
+          prevContent = cur;
+          return stable;
+        },
+        { timeout: 10_000, intervals: [200] },
+      )
+      .toBe(true);
+
     // Focus the input the way a user does (click the pane), then select a
     // rendered terminal row. The selection lives in the DOM while the hidden
     // input keeps focus, which is exactly the state Ctrl+Shift+C must read.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The Cmd/Ctrl+K command palette put every result source in one flat scroll: Actions, Sessions, Conversations, Settings, all stacked at once. When you know what kind of thing you want, there was no way to say so.

This adds a JetBrains "Search Everywhere"-style tab strip to the palette. `All` keeps the current flat grouped view (the default). Per-category tabs scope the visible list to one group. Tabs appear only for categories that have results for the current query (the `Conversations` tab also shows while a content search is in flight), the strip hides entirely when fewer than two categories are populated, `Tab` / `Shift+Tab` cycle the tabs, and the scope resets to `All` each time the palette reopens. The footer count reflects the active tab's visible rows.

All four result sources already existed (sessions by name, conversation content search, individual settings, actions); this is a render-time slice over the existing grouped map, no new data plumbing, no backend change.

Closes #2586

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, hit Cmd/Ctrl+K, type a query that matches across categories; confirm `All` is selected and the flat grouped view is unchanged.
- [ ] Click the `Settings` tab; confirm only Settings rows show and the footer count drops to the Settings count.
- [ ] Press `Tab` / `Shift+Tab`; confirm the active tab cycles and focus stays in the search input (no typing into the box).
- [ ] Type a query with no conversation hits; confirm no `Conversations` tab is offered and the active tab never lands on an empty category.
- [ ] Type a query that yields only one category; confirm the tab strip is hidden.
- [ ] Switch to a category tab, close the palette, reopen it; confirm it reopens on `All`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: tab scoping is pure component logic (state + render slice + keyboard handler), so it is covered by Vitest + RTL in `src/components/command-palette/__tests__/CommandPalette.test.tsx` (the layer AGENTS.md prescribes for non-browser-specific UI logic), and `web/tests/coverage-matrix.json` gains a `palette.category-tabs` entry.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (tab order, reset-on-open, hide-strip-when-redundant, Tab cycling) and reviewed the commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785446650&installation_id=139138837&pr_number=2589&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2589&signature=aaf28a2d44665ac9744210eacdf1ed7b1e2ba1707335754455e1ed64e894977c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added JetBrains-style category tabs to the web Cmd/Ctrl+K command palette so users can narrow results by type (Actions, Sessions, Conversations, Settings) instead of scanning one combined list.

- `All` preserves the existing mixed-results view
- Tabs are shown only for categories that actually have search-matching results (tab strip hides when fewer than two categories are populated)
- Switching works via click and keyboard (`Tab` / `Shift+Tab` cycles tabs); the palette resets back to `All` when reopened
- The footer count updates to match the number of rows visible in the active tab scope (after filtering)

Also added tab-order definitions and expanded palette tests to cover tab visibility, switching, keyboard cycling, footer count correctness, and reset behavior (plus a small unrelated test timing stabilization in the desktop live terminal clipboard test).

Benefits: faster result discovery with less scrolling, clearer separation by result type, and a more consistent UI where tabs and counts always match what’s rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->