### PR TITLE
feat(web): add Restore button to the trashed-session banner

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,7 +40,12 @@ import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab } from "./lib/
 import { isPluginPaneId, usePluginPanes, type PluginPane } from "./lib/pluginPanes";
 import { PluginPaneBody } from "./components/plugin/PluginSlots";
 import { TOUR_ANCHORS, tourAnchor } from "./lib/tourSteps";
-import { deleteWorkspaceSessions, restoreSessions, trashSessions } from "./lib/trashActions";
+import {
+  deleteWorkspaceSessions,
+  restoreSessions,
+  trashedWorkspaceRestoreIds,
+  trashSessions,
+} from "./lib/trashActions";
 import {
   loginStatus,
   logout,
@@ -1498,14 +1503,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                         trashedAt={activeSession.trashed_at ?? null}
                         onRestore={
                           activeSession.trashed_at
-                            ? () => {
-                                // Restore the whole workspace (a workspace only
-                                // lands in Trash when all its sessions are), same
-                                // scope as the sidebar Trash action. See #2593.
-                                const ws = workspaces.find((w) => w.sessions.some((s) => s.id === activeSessionId));
-                                const ids = ws ? ws.sessions.map((s) => s.id) : [activeSessionId!];
-                                return handleRestoreSession(ids);
-                              }
+                            ? () => handleRestoreSession(trashedWorkspaceRestoreIds(workspaces, activeSessionId!))
                             : undefined
                         }
                         onOpenFileRef={handleOpenFileRef}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1496,6 +1496,18 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                         archivedAt={activeSession.archived_at ?? null}
                         snoozedUntil={activeSession.snoozed_until ?? null}
                         trashedAt={activeSession.trashed_at ?? null}
+                        onRestore={
+                          activeSession.trashed_at
+                            ? () => {
+                                // Restore the whole workspace (a workspace only
+                                // lands in Trash when all its sessions are), same
+                                // scope as the sidebar Trash action. See #2593.
+                                const ws = workspaces.find((w) => w.sessions.some((s) => s.id === activeSessionId));
+                                const ids = ws ? ws.sessions.map((s) => s.id) : [activeSessionId!];
+                                return handleRestoreSession(ids);
+                              }
+                            : undefined
+                        }
                         onOpenFileRef={handleOpenFileRef}
                         fileRefSession={activeSession}
                         onOpenAgentsPane={openAgentsPane}

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -94,6 +94,13 @@ interface Props {
    *  restoring it, so the banner replaces the composer and points at the
    *  Trash section. Takes precedence over archived/snoozed. See #2489. */
   trashedAt: string | null;
+  /** Restore this session's workspace out of the trash. Wired to the
+   *  Restore button on the trashed "worker stopped" banner so a trashed
+   *  session can be recovered in place without hunting for the row in the
+   *  sidebar Trash menu. Restores the whole workspace, matching the sidebar
+   *  Trash action. Omit to render the banner read-only. Resolves false when
+   *  the restore fails so the banner can reset its pending state. See #2593. */
+  onRestore?: () => Promise<boolean> | void;
   /** Open a local file reference cited in the transcript (Codex
    *  `path:line` markdown links). Provided to the markdown anchor
    *  override via context so a click opens the in-app file viewer
@@ -122,6 +129,7 @@ export function StructuredView(props: Props) {
     archivedAt,
     snoozedUntil,
     trashedAt,
+    onRestore,
     onOpenFileRef,
     fileRefSession,
     onOpenAgentsPane,
@@ -159,6 +167,7 @@ export function StructuredView(props: Props) {
                   archivedAt={archivedAt}
                   snoozedUntil={snoozedUntil}
                   trashedAt={trashedAt}
+                  onRestore={onRestore}
                   {...ctx}
                 />
               </BackgroundAgentsContext.Provider>
@@ -216,6 +225,7 @@ function AcpChrome({
   archivedAt,
   snoozedUntil,
   trashedAt,
+  onRestore,
   state,
   status,
   hasEverOpened,
@@ -253,6 +263,7 @@ function AcpChrome({
   archivedAt: string | null;
   snoozedUntil: string | null;
   trashedAt: string | null;
+  onRestore?: () => Promise<boolean> | void;
 }) {
   // Count how many activity rows precede the latest `session_cleared`
   // divider so the banner can say "12 earlier turns hidden". The
@@ -485,7 +496,7 @@ function AcpChrome({
           snoozedUntil,
         });
         if (variant === "trashed") {
-          return <TrashedWorkerStoppedBanner sessionId={sessionId} />;
+          return <TrashedWorkerStoppedBanner sessionId={sessionId} onRestore={onRestore} />;
         }
         if (variant === "archived") {
           return <ArchivedWorkerStoppedBanner sessionId={sessionId} />;
@@ -1771,17 +1782,53 @@ function WorkerStoppedBanner({ sessionId }: { sessionId: string }) {
  *  purge), but the worker is stopped and the reconciler will not respawn a
  *  trashed session, so the composer is disabled and the banner points at the
  *  sidebar Trash section to restore. */
-export function TrashedWorkerStoppedBanner({ sessionId }: { sessionId: string }) {
+export function TrashedWorkerStoppedBanner({
+  sessionId,
+  onRestore,
+}: {
+  sessionId: string;
+  onRestore?: () => Promise<boolean> | void;
+}) {
+  // Local pending flag: on success the reducer re-buckets the session and this
+  // banner unmounts, so the flag never has to clear on the happy path; on a
+  // failed restore we reset it and let the aggregate error toast explain.
+  const [restoring, setRestoring] = useState(false);
+
+  const handleRestore = () => {
+    if (!onRestore || restoring) return;
+    setRestoring(true);
+    void Promise.resolve(onRestore()).then(
+      (ok) => {
+        if (ok === false) setRestoring(false);
+      },
+      () => setRestoring(false),
+    );
+  };
+
   return (
     <div
       className="border-b border-status-warning/30 bg-status-warning/10 px-4 py-3 text-status-warning"
       data-testid={`acp-trashed-banner-${sessionId}`}
     >
-      <div className="text-sm font-medium">Session in trash</div>
-      <div className="mt-1 text-xs text-status-warning/90">
-        This session is in the trash. Its transcript and workspace are kept and shown here read-only, but the worker is
-        stopped and will not respawn. Restore it from the Trash section in the sidebar to resume, or delete it
-        permanently from there.
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium">Session in trash</div>
+          <div className="mt-1 text-xs text-status-warning/90">
+            This session is in the trash. Its transcript and workspace are kept and shown here read-only, but the worker
+            is stopped and will not respawn. Restore it to resume, or delete it permanently from the Trash section in
+            the sidebar.
+          </div>
+        </div>
+        {onRestore && (
+          <button
+            type="button"
+            onClick={handleRestore}
+            disabled={restoring}
+            className="shrink-0 rounded-md border border-status-warning/40 bg-status-warning/20 px-3 py-1 text-xs font-medium text-status-warning hover:bg-status-warning/30 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {restoring ? "Restoring…" : "Restore"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/acp/__tests__/TrashedWorkerStoppedBanner.test.tsx
+++ b/web/src/components/acp/__tests__/TrashedWorkerStoppedBanner.test.tsx
@@ -46,7 +46,7 @@ describe("TrashedWorkerStoppedBanner (#2489, #2593)", () => {
     resolve(true);
   });
 
-  it("resets the pending state when restore fails so the user can retry", async () => {
+  it("resets the pending state when restore resolves false so the user can retry", async () => {
     const onRestore = vi.fn(() => Promise.resolve(false));
 
     render(<TrashedWorkerStoppedBanner sessionId="sess-9" onRestore={onRestore} />);
@@ -55,6 +55,18 @@ describe("TrashedWorkerStoppedBanner (#2489, #2593)", () => {
     });
 
     // The banner stays and the button returns to the actionable label.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Restore" })).toBeTruthy());
+    expect((screen.getByRole("button", { name: "Restore" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("resets the pending state when restore rejects", async () => {
+    const onRestore = vi.fn(() => Promise.reject(new Error("boom")));
+
+    render(<TrashedWorkerStoppedBanner sessionId="sess-9" onRestore={onRestore} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    });
+
     await waitFor(() => expect(screen.getByRole("button", { name: "Restore" })).toBeTruthy());
     expect((screen.getByRole("button", { name: "Restore" }) as HTMLButtonElement).disabled).toBe(false);
   });

--- a/web/src/components/acp/__tests__/TrashedWorkerStoppedBanner.test.tsx
+++ b/web/src/components/acp/__tests__/TrashedWorkerStoppedBanner.test.tsx
@@ -1,22 +1,61 @@
 // @vitest-environment jsdom
 //
-// Coverage for TrashedWorkerStoppedBanner (#2489): the read-only banner shown
-// in the structured view when a trashed session's worker is stopped. The
-// variant selection is covered by workerStoppedBanner.ts tests; this pins the
-// banner's own render (copy + testid keyed by session id).
+// Coverage for TrashedWorkerStoppedBanner (#2489, #2593): the banner shown in
+// the structured view when a trashed session's worker is stopped. The variant
+// selection is covered by workerStoppedBanner.ts tests; this pins the banner's
+// own render (copy + testid keyed by session id) and the in-place Restore
+// button (#2593).
 
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { TrashedWorkerStoppedBanner } from "../StructuredView";
 
 afterEach(cleanup);
 
-describe("TrashedWorkerStoppedBanner (#2489)", () => {
+describe("TrashedWorkerStoppedBanner (#2489, #2593)", () => {
   it("renders the trash notice keyed by session id", () => {
     render(<TrashedWorkerStoppedBanner sessionId="sess-9" />);
     expect(screen.getByTestId("acp-trashed-banner-sess-9")).toBeTruthy();
     expect(screen.getByText("Session in trash")).toBeTruthy();
     expect(screen.getByText(/read-only/)).toBeTruthy();
+  });
+
+  it("shows no Restore button when onRestore is omitted (read-only)", () => {
+    render(<TrashedWorkerStoppedBanner sessionId="sess-9" />);
+    expect(screen.queryByRole("button", { name: "Restore" })).toBeNull();
+  });
+
+  it("restores in place and shows a pending label while the call is in flight", () => {
+    let resolve!: (ok: boolean) => void;
+    const onRestore = vi.fn(() => new Promise<boolean>((r) => (resolve = r)));
+
+    render(<TrashedWorkerStoppedBanner sessionId="sess-9" onRestore={onRestore} />);
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    // Button flips to the pending label and disables so a double-click can't
+    // fire a second restore.
+    const pending = screen.getByRole("button", { name: "Restoring…" });
+    expect((pending as HTMLButtonElement).disabled).toBe(true);
+
+    // A second click while pending is a no-op.
+    fireEvent.click(pending);
+    expect(onRestore).toHaveBeenCalledTimes(1);
+
+    resolve(true);
+  });
+
+  it("resets the pending state when restore fails so the user can retry", async () => {
+    const onRestore = vi.fn(() => Promise.resolve(false));
+
+    render(<TrashedWorkerStoppedBanner sessionId="sess-9" onRestore={onRestore} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    });
+
+    // The banner stays and the button returns to the actionable label.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Restore" })).toBeTruthy());
+    expect((screen.getByRole("button", { name: "Restore" }) as HTMLButtonElement).disabled).toBe(false);
   });
 });

--- a/web/src/lib/__tests__/trashActions.test.ts
+++ b/web/src/lib/__tests__/trashActions.test.ts
@@ -11,10 +11,12 @@ vi.mock("../api", () => ({
 }));
 
 import { deleteSession, restoreSession, trashSession } from "../api";
-import { deleteWorkspaceSessions, restoreSessions, trashSessions } from "../trashActions";
-import type { SessionResponse } from "../types";
+import { deleteWorkspaceSessions, restoreSessions, trashedWorkspaceRestoreIds, trashSessions } from "../trashActions";
+import type { SessionResponse, Workspace } from "../types";
 
 const snap = (id: string) => ({ id, title: id }) as unknown as SessionResponse;
+const ws = (id: string, sessionIds: string[]) =>
+  ({ id, sessions: sessionIds.map((sid) => ({ id: sid })) }) as unknown as Workspace;
 const trashMock = vi.mocked(trashSession);
 const restoreMock = vi.mocked(restoreSession);
 const deleteMock = vi.mocked(deleteSession);
@@ -89,6 +91,17 @@ describe("restoreSessions (#2489)", () => {
   it("tolerates a null notifier", async () => {
     restoreMock.mockResolvedValue(snap("a"));
     await expect(restoreSessions(["a"], { applySession: vi.fn(), notify: null })).resolves.toBe(true);
+  });
+});
+
+describe("trashedWorkspaceRestoreIds (#2593)", () => {
+  it("returns every session id in the workspace containing the session", () => {
+    const workspaces = [ws("w1", ["a", "b"]), ws("w2", ["c"])];
+    expect(trashedWorkspaceRestoreIds(workspaces, "b")).toEqual(["a", "b"]);
+  });
+
+  it("falls back to just the session id when no workspace groups it", () => {
+    expect(trashedWorkspaceRestoreIds([ws("w2", ["c"])], "orphan")).toEqual(["orphan"]);
   });
 });
 

--- a/web/src/lib/trashActions.ts
+++ b/web/src/lib/trashActions.ts
@@ -4,7 +4,18 @@
 
 import { deleteSession, restoreSession, trashSession } from "./api";
 import type { DeleteSessionOptions } from "./api";
-import type { SessionResponse, SessionStatus } from "./types";
+import type { SessionResponse, SessionStatus, Workspace } from "./types";
+
+/** Resolve the session ids to restore when the trashed-banner Restore button
+ *  fires for `sessionId`. Restore is a whole-workspace action (a workspace
+ *  only lands in Trash when all its sessions are), so this returns every
+ *  session id in the workspace containing `sessionId`, matching the sidebar
+ *  Trash action. Falls back to just `[sessionId]` when no workspace groups it.
+ *  See #2593. */
+export function trashedWorkspaceRestoreIds(workspaces: Workspace[], sessionId: string): string[] {
+  const ws = workspaces.find((w) => w.sessions.some((s) => s.id === sessionId));
+  return ws ? ws.sessions.map((s) => s.id) : [sessionId];
+}
 
 /** A toast sink; both methods are optional so callers can pass the bus
  *  handler before it is wired without a guard. */

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1146,6 +1146,13 @@
       "components": ["web/src/components/acp/StructuredView.tsx"]
     },
     {
+      "id": "session.trash.restore-banner",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/acp/__tests__/TrashedWorkerStoppedBanner.test.tsx"],
+      "components": ["web/src/components/acp/StructuredView.tsx"]
+    },
+    {
       "id": "session.group-edit",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When you open a trashed session in the structured view, the worker is stopped and the composer is disabled. The `TrashedWorkerStoppedBanner` was read-only text that pointed you at the sidebar Trash menu to restore. That is an unnecessary detour when you are already looking at the session you want back.

This adds a Restore button to the trashed banner, mirroring the `WorkerStoppedBanner` reconnect pattern (flex row, right-aligned button, inline pending state). Clicking it restores the session's whole workspace in place, matching the sidebar Trash action's scope (a workspace only lands in trash when all of its sessions are trashed). The button shows a `Restoring…` label and disables while the call is in flight, and resets on failure so the existing aggregate error toast explains what happened. On success the reducer re-buckets the session and the banner unmounts.

All the restore machinery already existed (`restoreSession` / `restoreSessions`, and `handleRestoreSession` in `App.tsx`); this change threads an `onRestore` callback from `App` through `StructuredView` and `AcpChrome` to the banner and adds the button.

Closes #2593

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Trash a structured-view session, then open it. The banner reads "Session in trash" and now shows a Restore button.
- [ ] Click Restore. The button flips to "Restoring…" and disables; the session leaves trash and the composer re-enables without visiting the sidebar.
- [ ] For a multi-session workspace, confirm Restore brings back every session in the workspace, matching the sidebar Trash menu.
- [ ] Omit the handler path (a non-trashed session) and confirm no Restore button renders.

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`

Extended `src/components/acp/__tests__/TrashedWorkerStoppedBanner.test.tsx` (Vitest + RTL) to cover the Restore button: click calls `onRestore` and shows the pending label, a second click while pending is a no-op, a failed restore resets the pending state, and no button renders when `onRestore` is omitted. Added a `session.trash.restore-banner` entry to the coverage matrix. Restore logic (`restoreSessions`) already has aggregate-toast coverage in `web/src/lib/__tests__/trashActions.test.ts`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed the diff, and own the review responses.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785485516&installation_id=139138837&pr_number=2594&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2594&signature=9e44e0434d2b7bb590d00a98e64f40146cd94a0e4fdd8c678820d34acdb2ca5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added an inline **Restore** action to the trashed-session banner in structured view, so users can recover a trashed session directly from the banner instead of navigating to the sidebar Trash menu.

What changed:
- Wired an app-level restore callback into `StructuredView`, down to the trashed worker stopped banner.
- Updated `TrashedWorkerStoppedBanner` to show a **Restore** button when restore is available.
- Matched the existing “pending/disabled while action runs” behavior (button switches to a disabled “Restoring…” state during restore).
- Ensured failure recovery resets the banner state so existing error handling can surface the right message and users can retry.
- Kept restore **workspace-scoped** (restores all sessions in the workspace that correspond to the trashed item), consistent with current Trash behavior.
- Left **permanent delete** out of the banner (still handled in the sidebar Trash section).
- Added tests covering: button present/absent, pending state, retry/reset on failure (including rejected promises), and success behavior.
- Added `trashedWorkspaceRestoreIds` to resolve which session IDs should be restored for the banner action, with unit tests.

Benefit:
- Makes the trash banner actionable in place, reducing friction and extra navigation when users want to restore trashed sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->