### PR TITLE
feat(tui): add session.confirm_delete toggle to guard delete

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1035,6 +1035,17 @@ pub struct SessionConfig {
     #[setting(label = "Delete to Trash", widget = "toggle")]
     pub delete_to_trash: bool,
 
+    /// Ask for confirmation before deleting a session with the TUI `d` key.
+    /// Off by default so the trash-first flow stays low-friction: `d` moves
+    /// the session straight to the trash. When on, `d` opens a confirmation
+    /// dialog first, guarding against a fumbled keystroke trashing the wrong
+    /// (possibly running) session. Only affects the TUI trash path; the web
+    /// delete dialog already confirms, and the permanent-delete/force-remove
+    /// paths are gated by their own dialogs regardless. See #2583.
+    #[serde(default)]
+    #[setting(label = "Confirm Before Delete", widget = "toggle")]
+    pub confirm_delete: bool,
+
     /// Days a session stays in the trash before it is automatically purged,
     /// measured from when it was trashed. `0` keeps trashed sessions
     /// forever (manual purge only). Auto-purge is enforced by the `aoe serve`
@@ -1336,6 +1347,7 @@ impl Default for SessionConfig {
             strict_hotkeys: false,
             snooze_duration_minutes: 30,
             delete_to_trash: true,
+            confirm_delete: false,
             trash_retention_days: default_trash_retention_days(),
             auto_stop_idle_secs: default_auto_stop_idle_secs(),
             restart_wake_message: default_restart_wake_message(),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -941,7 +941,7 @@ impl HomeView {
     /// Dispatch the Submit branch of a confirm dialog. Returns
     /// `Some(Action)` for confirm actions that emit a TUI action
     /// (`stop_session`, `quit_during_creation`); side-effect-only
-    /// actions (`delete_group`, `force_remove_session`) run inline and
+    /// actions (`delete_group`, `force_remove_session`, `trash_session`) run inline and
     /// return None. Shared by the keyboard Enter path and the
     /// mouse-click path so both flows produce the same end state.
     pub(super) fn dispatch_confirm_submit(&mut self, action: &str) -> Option<Action> {
@@ -964,6 +964,12 @@ impl HomeView {
                     if let Err(e) = self.force_remove_session(&session_id) {
                         tracing::error!(target: "tui.input", "Failed to force remove session: {}", e);
                     }
+                }
+                None
+            }
+            "trash_session" => {
+                if let Some(session_id) = self.pending_trash_session.take() {
+                    self.trash_session_by_id(&session_id);
                 }
                 None
             }
@@ -1148,6 +1154,7 @@ impl HomeView {
                         self.confirm_dialog = None;
                         self.pending_stop_session = None;
                         self.pending_force_remove_session = None;
+                        self.pending_trash_session = None;
                         self.pending_image_pull = None;
                         // The settings close path mirrors the keyboard
                         // route: Cancel here means "don't discard," so
@@ -1959,6 +1966,7 @@ impl HomeView {
                     self.confirm_dialog = None;
                     self.pending_stop_session = None;
                     self.pending_force_remove_session = None;
+                    self.pending_trash_session = None;
                     self.pending_image_pull = None;
                 }
                 DialogResult::Submit(_) => {
@@ -4268,11 +4276,28 @@ impl HomeView {
                 // can differ from the row's `source_profile`, which would
                 // trash/purge under the wrong profile's retention policy.
                 // See #2489.
-                let delete_to_trash = crate::session::resolve_config_or_warn(&inst.source_profile)
-                    .session
-                    .delete_to_trash;
+                let session_cfg =
+                    crate::session::resolve_config_or_warn(&inst.source_profile).session;
+                let delete_to_trash = session_cfg.delete_to_trash;
                 if delete_to_trash && !already_trashed {
                     let sid = session_id.clone();
+                    // When session.confirm_delete is on, guard the trash with a
+                    // confirmation dialog instead of trashing on the keystroke.
+                    // The accept path (dispatch_confirm_submit "trash_session")
+                    // runs the same trash_session_by_id as the instant path.
+                    if session_cfg.confirm_delete {
+                        let message = format!(
+                            "Move '{}' to the trash? It can be restored from the Trash section.",
+                            inst.title
+                        );
+                        self.pending_trash_session = Some(sid);
+                        self.confirm_dialog = Some(ConfirmDialog::new(
+                            "Confirm Delete",
+                            &message,
+                            "trash_session",
+                        ));
+                        return;
+                    }
                     self.trash_session_by_id(&sid);
                     return;
                 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -616,6 +616,8 @@ pub struct HomeView {
     pub(super) pending_image_pull: Option<String>,
     /// Session to force-remove after the confirmation dialog is accepted
     pub(super) pending_force_remove_session: Option<String>,
+    /// Session to trash after the `session.confirm_delete` dialog is accepted
+    pub(super) pending_trash_session: Option<String>,
     /// Action emitted by a mouse-click on a modal dialog (e.g. clicking
     /// `[Yes]` on a stop-session confirm). The keyboard path returns
     /// these via `handle_key -> Option<Action>`, but the mouse path
@@ -2035,6 +2037,7 @@ impl HomeView {
             pending_stop_session: None,
             pending_image_pull: None,
             pending_force_remove_session: None,
+            pending_trash_session: None,
             pending_dialog_click_action: None,
             search_active: false,
             search_query: Input::default(),

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -387,6 +387,17 @@ fn disable_delete_to_trash() {
     crate::session::config::save_config(&config).unwrap();
 }
 
+/// Turn on `session.confirm_delete` so `d` guards the trash with a
+/// confirmation dialog instead of trashing on the keystroke. Must run after
+/// `setup_test_home` so it writes into the test HOME. See #2583.
+fn enable_confirm_delete() {
+    let mut config = crate::session::config::load_config()
+        .unwrap()
+        .unwrap_or_default();
+    config.session.confirm_delete = true;
+    crate::session::config::save_config(&config).unwrap();
+}
+
 fn create_test_env_with_groups() -> TestEnv {
     use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
@@ -6791,6 +6802,73 @@ fn d_on_session_with_default_trash_persists_trash_marker() {
     assert!(
         disk_row.is_trashed(),
         "pressing d must persist trashed_at so a storage refresh cannot resurrect a killed session"
+    );
+}
+
+/// With `session.confirm_delete` on, `d` opens a confirmation dialog and does
+/// not trash until the dialog is accepted; accepting then runs the same trash
+/// path as the instant flow. See #2583.
+#[test]
+#[serial]
+fn d_with_confirm_delete_prompts_before_trashing() {
+    let mut env = create_test_env_with_sessions(2);
+    enable_confirm_delete();
+    let id = env.view.selected_session.clone().unwrap();
+
+    env.view.handle_key(key(KeyCode::Char('d')), None);
+
+    assert!(
+        !env.view.get_instance(&id).unwrap().is_trashed(),
+        "confirm_delete on must not trash the session on the keystroke"
+    );
+    let dialog = env
+        .view
+        .confirm_dialog
+        .as_ref()
+        .expect("confirm_delete on must open a confirmation dialog");
+    assert_eq!(dialog.action(), "trash_session");
+    assert_eq!(
+        env.view.pending_trash_session.as_deref(),
+        Some(id.as_str()),
+        "the pending trash target must be the selected session"
+    );
+
+    // Accepting the dialog trashes via the same trash_session_by_id path.
+    env.view.dispatch_confirm_submit("trash_session");
+    assert!(
+        env.view.get_instance(&id).unwrap().is_trashed(),
+        "accepting the confirm dialog must trash the session"
+    );
+    assert!(
+        env.view.pending_trash_session.is_none(),
+        "the pending trash target must be cleared once consumed"
+    );
+}
+
+/// Cancelling the `session.confirm_delete` dialog leaves the session untouched
+/// and clears the pending target. See #2583.
+#[test]
+#[serial]
+fn confirm_delete_dialog_cancel_leaves_session() {
+    let mut env = create_test_env_with_sessions(2);
+    enable_confirm_delete();
+    let id = env.view.selected_session.clone().unwrap();
+
+    env.view.handle_key(key(KeyCode::Char('d')), None);
+    assert!(env.view.confirm_dialog.is_some());
+
+    env.view.handle_key(key(KeyCode::Esc), None);
+    assert!(
+        env.view.confirm_dialog.is_none(),
+        "Esc must dismiss the confirm dialog"
+    );
+    assert!(
+        !env.view.get_instance(&id).unwrap().is_trashed(),
+        "cancelling the confirm dialog must not trash the session"
+    );
+    assert!(
+        env.view.pending_trash_session.is_none(),
+        "cancelling must clear the pending trash target"
     );
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Since the trash-first change in #2502, pressing `d` on a session in the TUI moves it to the Trash immediately with no confirmation. A fumbled `d` on the wrong row is easy, and for an in-progress session the recovery is not free: restore brings it back Stopped, so it then needs a manual continue.

This adds an opt-in `session.confirm_delete` toggle. When on, `d` opens a confirmation dialog before trashing; accepting runs the exact same `trash_session_by_id` path as today, cancelling leaves the session untouched. When off (the default), `d` behaves exactly as it does now, so the low-friction trash-first flow is unchanged for everyone who likes it.

The field is declared once on `SessionConfig` with a `#[setting]` annotation, so the single-source schema (#1692) surfaces the toggle in both the TUI settings screen and the web settings panel with no per-surface wiring. The behavior change is TUI-only: the web delete flow already confirms via `DeleteSessionDialog`, and the permanent-delete and force-remove paths are gated by their own dialogs regardless of this setting.

Closes #2583

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With `session.confirm_delete` off (default), select a session and press `d`; confirm it moves straight to the Trash section (unchanged behavior).
- [ ] Turn on Session > Confirm Before Delete in TUI settings, press `d` on a session; confirm a "Confirm Delete" dialog appears and the session is NOT trashed yet.
- [ ] Accept that dialog (Enter / Yes); confirm the session moves to the Trash section.
- [ ] Repeat, but press Esc / No; confirm the session stays put and nothing is trashed.
- [ ] Open the web settings panel; confirm the "Confirm Before Delete" toggle is present under the Session section.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The toggle renders through the generic schema-driven settings form with no web code change; the web delete behavior is unchanged.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a full-binary e2e test, because: the flow is a config-gated branch in `open_delete_for_selected` reachable through `handle_key`, so it is covered by unit tests in `src/tui/home/tests.rs` (`d_with_confirm_delete_prompts_before_trashing`, `confirm_delete_dialog_cancel_leaves_session`) that assert the dialog opens, accept trashes, and cancel leaves the session, plus the existing `d_on_session_with_default_trash_persists_trash_marker` guarding the default path.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (default off, TUI-only behavior) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785485899&installation_id=139138837&pr_number=2595&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2595&signature=79dadb2a58a4986b101ee5a400a237af14d909879b4117d64100a38b42015bdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds an optional delete confirmation for TUI sessions, so accidental trashing is less likely. By default, deletion still works the same as before, but users can now turn on a setting to require confirmation before a session is moved to Trash.

The setting is added through the shared session config, so it appears in both TUI and web settings without extra wiring. The TUI delete flow was updated to pause for confirmation when the option is enabled, while canceling leaves the session untouched. Tests were added to cover the new confirm-and-cancel behavior.

Benefits:
- Reduces accidental session deletion
- Keeps existing behavior unchanged unless the new toggle is enabled
- Makes the setting available in the shared settings UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->