### PR TITLE
fix(tmux): render base+VS16 emoji at two columns in control-mode panes

### DIFF
--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -621,8 +621,16 @@ fn row_to_ansi(screen: &vt100::Screen, row: u16, cols: u16) -> String {
             // `widen_vs16` reserves a trailing blank column for a base+VS16
             // emoji (width 1 to vt100, two cells on a real terminal). Own both
             // columns so that reserved blank is not serialised as a stray space
-            // and the following cell keeps its column.
-            if advance == 1 && cell.contents().ends_with('\u{fe0f}') {
+            // and the following cell keeps its column, but only when that column
+            // really is the reserved blank: a later absolute write or styled
+            // fill there must still be emitted, not swallowed.
+            if advance == 1
+                && cell.contents().ends_with('\u{fe0f}')
+                && col + 1 < last
+                && screen
+                    .cell(row, col + 1)
+                    .is_some_and(|next| !next.has_contents() && !cell_has_style(next))
+            {
                 advance = 2;
             }
         } else {
@@ -1134,6 +1142,17 @@ mod tests {
         let s = p.screen();
         // 😀 occupies cols 0-1 (wide), the bracket follows at col 2.
         assert_eq!(s.cell(0, 2).map(|c| c.contents()), Some("["));
+    }
+
+    #[test]
+    fn vs16_does_not_swallow_real_content_in_the_next_cell() {
+        // If a later write puts real content directly after a VS16 emoji (no
+        // reserved blank, e.g. bytes that never went through the widener),
+        // row_to_ansi must still emit it rather than treating it as the blank.
+        let mut p = vt100::Parser::new(3, 20, 0);
+        p.process("\u{2764}\u{fe0f}X".as_bytes());
+        let (content, _) = grid_content(&mut p, 3, 20, 3);
+        assert!(content.contains("\u{2764}\u{fe0f}X"), "row: {content:?}");
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -241,6 +241,17 @@ impl Vs16Widener {
         }
     }
 
+    /// Re-anchor the tracked cursor column and width to the parser's actual
+    /// state. Called before each live chunk so the last-column gate reflects the
+    /// post-seed cursor and any resize, and so drift from escapes the tracker
+    /// does not model cannot accumulate across chunks. `last`/`incomplete` are
+    /// stream-level and left untouched so a base/VS16 pair split across two
+    /// socket reads still pairs.
+    fn resync(&mut self, col: u16, cols: u16) {
+        self.cols = cols.max(1);
+        self.col = col.min(self.cols - 1);
+    }
+
     fn process(&mut self, input: &[u8]) -> Vec<u8> {
         let mut data = std::mem::take(&mut self.incomplete);
         data.extend_from_slice(input);
@@ -828,8 +839,15 @@ impl VtChannel {
                             while !seeded.load(Ordering::Relaxed) && !stop.load(Ordering::Relaxed) {
                                 std::thread::sleep(Duration::from_millis(1));
                             }
-                            let widened = vs16.process(&buf[..n]);
                             if let Ok(mut p) = parser.lock() {
+                                // Anchor the widener to the parser's live cursor
+                                // and width before widening, so the last-column
+                                // gate is correct after the seed positions the
+                                // cursor or a resize changes the width.
+                                let (_, col) = p.screen().cursor_position();
+                                let (_, cols_now) = p.screen().size();
+                                vs16.resync(col, cols_now);
+                                let widened = vs16.process(&buf[..n]);
                                 p.process(&widened);
                                 app_cursor
                                     .store(p.screen().application_cursor(), Ordering::Relaxed);
@@ -1142,6 +1160,27 @@ mod tests {
         let s = p.screen();
         // 😀 occupies cols 0-1 (wide), the bracket follows at col 2.
         assert_eq!(s.cell(0, 2).map(|c| c.contents()), Some("["));
+    }
+
+    #[test]
+    fn vs16_resync_drives_the_margin_gate() {
+        // After a resize/seed the widener is re-anchored from the parser. A base
+        // landing on the last column of the new width must not be nudged...
+        let mut narrow = Vs16Widener::new(20);
+        narrow.resync(5, 6);
+        let out = narrow.process("\u{2764}\u{fe0f}".as_bytes());
+        assert!(
+            !out.windows(3).any(|w| w == b"\x1b[C"),
+            "cursor-forward injected at the last column: {out:?}"
+        );
+        // ...but mid-row on the new width it is.
+        let mut wide = Vs16Widener::new(6);
+        wide.resync(0, 20);
+        let out = wide.process("\u{2764}\u{fe0f}".as_bytes());
+        assert!(
+            out.windows(3).any(|w| w == b"\x1b[C"),
+            "cursor-forward missing mid-row: {out:?}"
+        );
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -21,6 +21,8 @@ use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use unicode_width::UnicodeWidthChar;
+
 use crate::tmux::PaneCursor;
 
 /// `aoe __vt-pipe <socket>`: the bidirectional `pipe-pane -IO` forwarder. tmux
@@ -187,6 +189,200 @@ fn lf_to_crlf(raw: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Rewrites a pane byte stream so `<base> + U+FE0F` (emoji variation selector
+/// 16) reserves two columns in the vt100 grid.
+///
+/// tmux and real terminals lay such a grapheme out as two cells, but vt100
+/// measures width per codepoint: the base is width 1 and VS16 is a width-0
+/// combining mark, so the grapheme occupies one cell and the pane's cursor ends
+/// one column short of what the producing app assumed. Under relative redraws
+/// the app then writes onto the trailing column and the row shifts left,
+/// intermittently, as the app mixes absolute and relative moves (issue #2590).
+/// vt100's per-codepoint width can't be hooked, so we nudge its cursor instead:
+/// after a VS16 that follows a width-1 base, inject a cursor-forward (`ESC[C`) so
+/// the grapheme reserves its second column. An absolute reposition from the app
+/// overrides the nudge harmlessly; a relative write then lands in the right
+/// column. [`row_to_ansi`] owns the reserved blank so it is not serialised as a
+/// stray space.
+///
+/// The nudge is skipped when the base sits on the last column: there vt100
+/// already wraps the following char to the next row (like a real wide char), and
+/// a cursor-forward would instead clear the pending wrap and let the next char
+/// overwrite the emoji. That gate needs the cursor column, so the widener tracks
+/// it across the standard horizontal moves (CR, BS, HT, CUP/CHA/CUF/CUB),
+/// clamping at the right margin: on an over-long wrapped line the column pins to
+/// the last column, biasing toward NOT nudging (the original, non-destructive
+/// behaviour) rather than risking an overwrite.
+///
+/// The state persists across `process` chunks so a base/VS16 pair (or a cursor
+/// escape, or a UTF-8 sequence) split across two socket reads is still handled.
+struct Vs16Widener {
+    cols: u16,
+    /// Cursor column, tracked to gate the last-column case.
+    col: u16,
+    /// Previous scalar and the column it was written at, for VS16 pairing.
+    last: Option<char>,
+    last_col: u16,
+    /// Trailing partial UTF-8 bytes held for the next chunk.
+    incomplete: Vec<u8>,
+    /// Bytes of an in-flight escape sequence spanning a chunk boundary.
+    esc: Vec<u8>,
+}
+
+impl Vs16Widener {
+    fn new(cols: u16) -> Self {
+        Self {
+            cols: cols.max(1),
+            col: 0,
+            last: None,
+            last_col: 0,
+            incomplete: Vec::new(),
+            esc: Vec::new(),
+        }
+    }
+
+    fn process(&mut self, input: &[u8]) -> Vec<u8> {
+        let mut data = std::mem::take(&mut self.incomplete);
+        data.extend_from_slice(input);
+        let mut out = Vec::with_capacity(data.len() + 8);
+        let mut i = 0;
+        while i < data.len() {
+            match std::str::from_utf8(&data[i..]) {
+                Ok(s) => {
+                    self.push_run(s, &mut out);
+                    break;
+                }
+                Err(e) => {
+                    let valid_end = i + e.valid_up_to();
+                    if e.valid_up_to() > 0 {
+                        let s = std::str::from_utf8(&data[i..valid_end]).unwrap();
+                        self.push_run(s, &mut out);
+                    }
+                    match e.error_len() {
+                        // Trailing partial sequence: hold it for the next chunk.
+                        None => {
+                            self.incomplete.extend_from_slice(&data[valid_end..]);
+                            break;
+                        }
+                        // Invalid byte(s): pass through (vt100 renders U+FFFD).
+                        Some(bad) => {
+                            out.extend_from_slice(&data[valid_end..valid_end + bad]);
+                            self.last = None;
+                            i = valid_end + bad;
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn push_run(&mut self, s: &str, out: &mut Vec<u8>) {
+        let mut buf = [0u8; 4];
+        for c in s.chars() {
+            out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+            // Feed an in-flight escape sequence until its final byte, tracking
+            // only horizontal cursor moves; everything else leaves the column
+            // untouched.
+            if !self.esc.is_empty() {
+                self.feed_escape(c);
+                continue;
+            }
+            match c {
+                '\u{1b}' => self.esc.push(0x1b),
+                '\r' => self.col = 0,
+                '\u{08}' => self.col = self.col.saturating_sub(1),
+                '\t' => self.col = ((self.col / 8 + 1) * 8).min(self.cols - 1),
+                '\u{fe0f}' => {
+                    if matches!(self.last, Some(p) if UnicodeWidthChar::width(p) == Some(1))
+                        && self.last_col < self.cols - 1
+                    {
+                        out.extend_from_slice(b"\x1b[C");
+                        self.col = (self.last_col + 2).min(self.cols - 1);
+                    }
+                    self.last = Some(c);
+                }
+                c if (c as u32) < 0x20 => {}
+                c => {
+                    self.last = Some(c);
+                    self.last_col = self.col;
+                    let w = UnicodeWidthChar::width(c).unwrap_or(0) as u16;
+                    self.col = (self.col + w).min(self.cols - 1);
+                }
+            }
+        }
+    }
+
+    /// Consume one byte of an escape sequence begun with ESC. Recognises the CSI
+    /// horizontal-move finals (H/f/G set the column, C/D shift it) and treats
+    /// every other terminator as column-neutral. `esc` accumulates the numeric
+    /// params so the sequence can span a chunk boundary.
+    fn feed_escape(&mut self, c: char) {
+        // Non-ASCII cannot appear in an escape sequence; abort and re-scan it as
+        // text next iteration would be ideal, but such input is malformed, so we
+        // simply drop the tracking and treat the char as neutral.
+        let b = c as u32;
+        if b > 0x7f {
+            self.esc.clear();
+            return;
+        }
+        let b = b as u8;
+        if self.esc.len() == 1 {
+            // Byte right after ESC. Only CSI (`[`) carries cursor moves; any
+            // other introducer is column-neutral and ends the sequence here
+            // (single-char escapes) or is ignored.
+            if b == b'[' {
+                self.esc.push(b);
+            } else {
+                self.esc.clear();
+            }
+            return;
+        }
+        // Inside a CSI: final byte is 0x40..=0x7e.
+        if (0x40..=0x7e).contains(&b) {
+            let params = &self.esc[2..];
+            let first = ascii_num(params, 0);
+            match b {
+                b'H' | b'f' => {
+                    // CUP: row;col (1-based). Column is the second param.
+                    let col = ascii_semi_second(params).unwrap_or(1).max(1);
+                    self.col = (col - 1).min(self.cols - 1);
+                }
+                b'G' => self.col = (first.max(1) - 1).min(self.cols - 1),
+                b'C' => self.col = (self.col + first.max(1)).min(self.cols - 1),
+                b'D' => self.col = self.col.saturating_sub(first.max(1)),
+                _ => {}
+            }
+            self.esc.clear();
+        } else {
+            self.esc.push(b);
+        }
+    }
+}
+
+/// Parse the first `;`-separated decimal parameter of a CSI body.
+fn ascii_num(params: &[u8], default: u16) -> u16 {
+    let end = params
+        .iter()
+        .position(|&b| b == b';')
+        .unwrap_or(params.len());
+    std::str::from_utf8(&params[..end])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Parse the second `;`-separated decimal parameter of a CSI body (for CUP col).
+fn ascii_semi_second(params: &[u8]) -> Option<u16> {
+    let rest = params.split(|&b| b == b';').nth(1)?;
+    std::str::from_utf8(rest).ok()?.parse().ok()
+}
+
+/// One-shot VS16 widening for a complete buffer (the `capture-pane` seed).
+fn widen_vs16_oneshot(input: &[u8], cols: u16) -> Vec<u8> {
+    Vs16Widener::new(cols).process(input)
+}
+
 /// (Re)build `parser` from tmux's authoritative `capture-pane` at `cols`x`rows`,
 /// resetting any prior content. `pipe-pane` carries only the app's incremental
 /// output, never tmux's reflow, so on a resize a grid that merely `set_size`d
@@ -239,7 +435,7 @@ fn seed_parser(
         if !prefix.is_empty() {
             p.process(&prefix);
         }
-        p.process(&lf_to_crlf(body));
+        p.process(&widen_vs16_oneshot(&lf_to_crlf(body), cols));
         app_cursor.store(p.screen().application_cursor(), Ordering::Relaxed);
     }
 }
@@ -419,12 +615,20 @@ fn row_to_ansi(screen: &vt100::Screen, row: u16, cols: u16) -> String {
             out.push_str(&sgr);
             cur_sgr = Some(sgr);
         }
+        let mut advance = if cell.is_wide() { 2 } else { 1 };
         if cell.has_contents() {
             out.push_str(cell.contents());
+            // `widen_vs16` reserves a trailing blank column for a base+VS16
+            // emoji (width 1 to vt100, two cells on a real terminal). Own both
+            // columns so that reserved blank is not serialised as a stray space
+            // and the following cell keeps its column.
+            if advance == 1 && cell.contents().ends_with('\u{fe0f}') {
+                advance = 2;
+            }
         } else {
             out.push(' ');
         }
-        col += if cell.is_wide() { 2 } else { 1 };
+        col += advance;
     }
     out
 }
@@ -605,6 +809,8 @@ impl VtChannel {
                 let mut conn = conn;
                 let _ = conn.set_read_timeout(Some(Duration::from_millis(200)));
                 let mut buf = [0u8; 8192];
+                // Cross-chunk state for VS16 widening (see `Vs16Widener`).
+                let mut vs16 = Vs16Widener::new(cols);
                 while !stop.load(Ordering::Relaxed) {
                     match conn.read(&mut buf) {
                         Ok(0) => break,
@@ -614,8 +820,9 @@ impl VtChannel {
                             while !seeded.load(Ordering::Relaxed) && !stop.load(Ordering::Relaxed) {
                                 std::thread::sleep(Duration::from_millis(1));
                             }
+                            let widened = vs16.process(&buf[..n]);
                             if let Ok(mut p) = parser.lock() {
-                                p.process(&buf[..n]);
+                                p.process(&widened);
                                 app_cursor
                                     .store(p.screen().application_cursor(), Ordering::Relaxed);
                             }
@@ -856,6 +1063,89 @@ mod tests {
         assert!(
             !content.contains("\x1b[10C") && !content.contains("\x1b[C"),
             "cursor-forward escape leaked:\n{content:?}"
+        );
+    }
+
+    #[test]
+    fn vs16_reserves_second_column() {
+        // "[A]" heart+vs16 "[B]": the emoji must occupy two columns so the
+        // trailing bracket keeps its position (issue #2590).
+        let mut p = vt100::Parser::new(3, 20, 0);
+        p.process(&widen_vs16_oneshot("[A]\u{2764}\u{fe0f}[B]".as_bytes(), 20));
+        let s = p.screen();
+        assert_eq!(s.cell(0, 3).map(|c| c.contents()), Some("\u{2764}\u{fe0f}"));
+        assert!(
+            s.cell(0, 4).is_some_and(|c| !c.has_contents()),
+            "column after the emoji must be the reserved blank"
+        );
+        assert_eq!(s.cell(0, 5).map(|c| c.contents()), Some("["));
+        // The serialised row glues the emoji to the next cell, no stray space.
+        let (content, _) = grid_content(&mut p, 3, 20, 3);
+        assert!(
+            content.contains("[A]\u{2764}\u{fe0f}[B]"),
+            "row: {content:?}"
+        );
+        assert!(
+            !content.contains("\u{2764}\u{fe0f} ["),
+            "reserved blank leaked as a space: {content:?}"
+        );
+    }
+
+    #[test]
+    fn vs16_relative_write_does_not_shift_left() {
+        // A redrawing app advances two columns past the emoji, then writes the
+        // next run relatively. Pre-fix, vt100 advanced one and the run
+        // overwrote the emoji's second column, shifting the row left; the nudge
+        // prevents it (the "flip" in issue #2590).
+        let mut p = vt100::Parser::new(3, 20, 0);
+        p.process(&widen_vs16_oneshot("\u{2764}\u{fe0f}[B]".as_bytes(), 20));
+        let s = p.screen();
+        assert_eq!(s.cell(0, 0).map(|c| c.contents()), Some("\u{2764}\u{fe0f}"));
+        assert_eq!(
+            s.cell(0, 2).map(|c| c.contents()),
+            Some("["),
+            "bracket must sit at column 2, not column 1"
+        );
+    }
+
+    #[test]
+    fn vs16_pairs_across_chunk_boundary() {
+        // base in one read, VS16 in the next: carried state still pairs them,
+        // so the widening never intermittently misses.
+        let mut p = vt100::Parser::new(3, 20, 0);
+        let mut w = Vs16Widener::new(20);
+        p.process(&w.process("[A]\u{2764}".as_bytes()));
+        p.process(&w.process("\u{fe0f}[B]".as_bytes()));
+        let s = p.screen();
+        assert_eq!(s.cell(0, 3).map(|c| c.contents()), Some("\u{2764}\u{fe0f}"));
+        assert_eq!(
+            s.cell(0, 5).map(|c| c.contents()),
+            Some("["),
+            "bracket must sit at column 5 across the split"
+        );
+    }
+
+    #[test]
+    fn vs16_already_wide_base_is_not_nudged() {
+        // A width-2 base carrying a redundant VS16 must not gain a third
+        // column: only width-1 bases are nudged.
+        let mut p = vt100::Parser::new(3, 20, 0);
+        p.process(&widen_vs16_oneshot("\u{1f600}\u{fe0f}[B]".as_bytes(), 20));
+        let s = p.screen();
+        // 😀 occupies cols 0-1 (wide), the bracket follows at col 2.
+        assert_eq!(s.cell(0, 2).map(|c| c.contents()), Some("["));
+    }
+
+    #[test]
+    fn vs16_at_right_margin_does_not_corrupt() {
+        // base+VS16 as the last content of a narrow row: no panic, nothing lost.
+        let mut p = vt100::Parser::new(3, 6, 0);
+        p.process(&widen_vs16_oneshot("ABCDE\u{2764}\u{fe0f}X".as_bytes(), 6));
+        let (content, _) = grid_content(&mut p, 3, 6, 3);
+        assert!(content.contains('X'), "trailing char lost: {content:?}");
+        assert!(
+            content.contains("\u{2764}\u{fe0f}"),
+            "emoji lost: {content:?}"
         );
     }
 

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -75,6 +75,20 @@ describe("wrapLine", () => {
     expect(rows.length).toBe(2);
   });
 
+  it("counts a base + VS16 emoji as two cells and never splits the pair", () => {
+    // heart U+2764 + VS16 U+FE0F renders in emoji presentation, width 2
+    // (aoe #2590); like a wide char it wraps whole at cols=2.
+    const rows = wrapLine([seg("a\u2764\uFE0F\u2764\uFE0F")], 2);
+    expect(rows.map((r) => lineText(r))).toEqual(["a", "\u2764\uFE0F", "\u2764\uFE0F"]);
+  });
+
+  it("leaves a bare width-1 symbol as one cell without VS16", () => {
+    // Without VS16 the heart is text-presentation width 1, so "a\u2764b" fits 3
+    // columns and must not be over-widened.
+    const line = [seg("a\u2764b")];
+    expect(wrapLine(line, 3)).toEqual([line]);
+  });
+
   it("keeps combining marks attached to their base character", () => {
     // e + combining acute (zero cells) + "x" is 2 cells; at cols=2 the
     // line is identity, and at cols=1 the mark stays with the e.

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -46,10 +46,19 @@ function cellWidth(codePoint: string): number {
   return WIDE.test(codePoint) ? 2 : 1;
 }
 
+// A width-1 base followed by U+FE0F (VS16) renders in emoji presentation and
+// takes two cells, matching tmux and the pane grid (aoe issue #2590). VS16
+// itself stays zero-width; the second cell is folded onto the base.
+function cellWidthWithNext(ch: string, next: string | undefined): number {
+  const w = cellWidth(ch);
+  return w === 1 && next === "\uFE0F" ? 2 : w;
+}
+
 function textWidth(text: string): number {
   if (ASCII_PRINTABLE_ONLY.test(text)) return text.length;
+  const cps = [...text];
   let width = 0;
-  for (const ch of text) width += cellWidth(ch);
+  for (let i = 0; i < cps.length; i++) width += cellWidthWithNext(cps[i]!, cps[i + 1]);
   return width;
 }
 
@@ -76,8 +85,10 @@ export function wrapLine(line: AnsiSegment[], cols: number): AnsiSegment[][] {
         chunk = "";
       }
     };
-    for (const ch of seg.text) {
-      const w = cellWidth(ch);
+    const cps = [...seg.text];
+    for (let i = 0; i < cps.length; i++) {
+      const ch = cps[i]!;
+      const w = cellWidthWithNext(ch, cps[i + 1]);
       // A wide char that doesn't fit wraps whole (terminals leave the
       // last cell empty); zero-width marks stay with their base char.
       if (used + w > cols && used > 0) {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Emoji formed by a base codepoint plus U+FE0F (VS16), such as ❤️ (U+2764 U+FE0F) and ⚠️ (U+26A0 U+FE0F), rendered one cell too narrow in aoe's control-mode pane renderer, shifting the following cell left and flipping between correct and broken under redraw pressure (issue #2590).

Root cause: the pane byte stream feeds a `vt100::Parser` grid, and vt100 measures width per codepoint. The base is width 1 and VS16 is a width-0 combining mark, so the grapheme occupies a single grid cell and the cursor ends one column short of what tmux and the producing app assume (both treat it as width 2). Under relative redraws the app then overwrites the trailing column and the row shifts left; absolute repositioning avoids the overwrite, which is why it flips. vt100's per-codepoint width cannot be hooked, and a dependency fork/vendor was out of scope.

Fix, entirely first-party, no dependency changed:

- `src/tmux/vt.rs`: a byte-stream widener (alongside the existing `lf_to_crlf` preprocessing) injects a cursor-forward after a VS16 that follows a width-1 base, so vt100 reserves the second column and relative writes land correctly. It tracks the cursor column across CR/BS/HT and CUP/CHA/CUF/CUB to skip the last-column case, where vt100 already wraps the next char like a real wide char and a nudge would let it overwrite the emoji. `row_to_ansi` owns the reserved blank so it is not serialised as a stray space.
- `web/src/lib/liveTermLines.ts`: the mobile/web live terminal measured widths per codepoint too, so its wrap and cursor math undercounted VS16 emoji; it now folds the second cell onto the base via one-codepoint lookahead.

The native TUI needed no change: ratatui measures each grapheme with `UnicodeWidthStr::width`, which already handles VS16 as width 2.

Closes #2590

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In an aoe-attached tmux pane, run `printf '[가][😀][❤️][⚠️][✅][🇰🇷]\n'` and confirm every bracket pair stays aligned.
- [ ] Open a heavily-redrawing TUI (e.g. Claude Code) in an aoe pane, exercise redraws, and confirm the cell after ❤️ / ⚠️ no longer flips between correct and shifted.
- [ ] View the same session in the web/mobile live terminal and confirm VS16 emoji render two cells wide with the following text aligned.
- [ ] Confirm plain (text-presentation) symbols without VS16, e.g. a bare `❤`, still render one cell wide.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a Playwright test, because: the change is pure cell-width logic in `liveTermLines`, covered by the Vitest unit spec `web/src/lib/liveTermLines.test.ts` (already mapped in `web/tests/coverage-matrix.json`), which is the right altitude for width math.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped an e2e test, because: the grid/serialisation path is covered by deterministic unit tests in `src/tmux/vt.rs` (`vs16_*`) that feed bytes through `vt100::Parser` + `row_to_ansi` and assert exact columns; a tmux-driven e2e would depend on the terminal font's emoji width and be nondeterministic.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the width-provider debate, and implementation were drafted by Claude under my direction. I made the design calls (first-party byte-stream fix over a vt100 fork or vendor) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785489023&installation_id=139138837&pr_number=2597&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2597&signature=1412f0aff3d0986f58381347754bb2e6fe1d0f5e49cc77b93283dcd06e1cf08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
- Fixed tmux control-mode pane rendering so emoji made from a width-1 base character followed by VS16 (e.g., ❤️, ⚠️) reserve **two terminal cells** instead of one.
- Prevented the reserved second cell from being emitted as an actual visible character/blank in the serialized output.
- Updated the web client’s live terminal width + wrapping logic to measure VS16 sequences consistently (one-codepoint lookahead).
- Added/expanded unit tests to cover VS16 width, wrapping behavior, and redraw/margin edge cases (including resync after seeding/resizing).

## Benefit
- VS16 emoji stay aligned and do not cause the following cell to shift left.
- Rendering stays stable under repeated redraws, keeping aoe panes consistent with direct `tmux attach`.

## Technical notes
- `src/tmux/vt.rs`: introduced a byte-stream “VS16 widener” that tracks cursor/columns across chunks and injects a cursor-forward nudge when VS16 needs a reserved second cell; `row_to_ansi` ensures the reserved blank is only owned/emitted when truly empty/unmodified.
- `web/src/lib/liveTermLines.ts`: adjusted width/wrapping to look ahead by code point so VS16 presentation sequences are treated as width-2 units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->