### PR TITLE
fix(session): honor repo-local overrides in smart-rename indicator + gate (closes #2351)

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -618,12 +618,17 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
         }
     }
 
-    // Overlay the smart-rename indicator. `running` comes from the live
-    // in-flight set; `pending` from the shared eligibility predicate, so the
-    // chip cannot drift from the runtime gate. Config resolved once per profile.
+    // Overlay the smart-rename indicator. `Running` comes from the live
+    // in-flight set; `Pending` from the shared eligibility predicate, so the
+    // indicator cannot drift from the runtime gate. Config resolved once per
+    // (profile, project_path) so repo-local overrides are honored.
     {
-        use crate::session::smart_rename::{check_eligible_resolved, SmartRenameState};
+        use crate::session::smart_rename::{
+            check_eligible_resolved, resolve_smart_rename_config, SmartRenameConfig,
+            SmartRenameState,
+        };
         use std::collections::{HashMap, HashSet};
+        use std::path::Path;
         let inflight: HashSet<String> = state
             .smart_rename_inflight
             .lock()
@@ -634,8 +639,7 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default();
-        let mut cfg_cache: HashMap<String, (bool, String, HashMap<String, String>)> =
-            HashMap::new();
+        let mut cfg_cache: HashMap<(String, String), SmartRenameConfig> = HashMap::new();
         for (resp, inst) in sessions.iter_mut().zip(instances.iter()) {
             resp.default_name = crate::session::civilizations::is_default_civ_name(&inst.title);
             if inflight.contains(&inst.id) {
@@ -647,28 +651,19 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<SessionsE
             if attempted.contains(&inst.id) {
                 continue;
             }
-            let (setting_on, rename_agent, overrides) = cfg_cache
-                .entry(inst.source_profile.clone())
-                .or_insert_with(|| {
-                    let cfg = crate::session::profile_config::resolve_config_or_warn(
-                        &inst.source_profile,
-                    )
-                    .session;
-                    (
-                        cfg.smart_rename,
-                        cfg.smart_rename_agent,
-                        cfg.agent_command_override,
-                    )
-                });
+            let key = (inst.source_profile.clone(), inst.project_path.clone());
+            let cfg = cfg_cache.entry(key).or_insert_with(|| {
+                resolve_smart_rename_config(&inst.source_profile, Path::new(&inst.project_path))
+            });
             let eligible = check_eligible_resolved(
                 inst.is_structured(),
-                *setting_on,
+                cfg.setting_on,
                 &inst.title,
                 &inst.tool,
-                rename_agent,
+                &cfg.rename_agent,
                 inst.is_sandboxed(),
                 &inst.command,
-                overrides,
+                &cfg.overrides,
             )
             .is_ok();
             if eligible {

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -17,6 +17,7 @@ use crate::agents;
 use crate::session::civilizations::is_default_civ_name;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::path::Path;
 
 /// Per-session smart-rename state surfaced to the dashboard so the sidebar can
 /// show that a session will be (or is being) auto-named. `Inactive` for
@@ -148,6 +149,32 @@ pub fn check_eligible_resolved(
         command_override_in_cfg,
     )?;
     Ok(agent.expect("check_eligible Ok implies a built-in agent"))
+}
+
+/// Config fields the smart-rename indicator and runtime gate both consume.
+/// Named fields (rather than a tuple) prevent the sidebar `cfg_cache` and
+/// `try_smart_rename` from drifting on positional order.
+#[derive(Debug, Clone)]
+pub struct SmartRenameConfig {
+    pub setting_on: bool,
+    pub rename_agent: String,
+    pub overrides: HashMap<String, String>,
+}
+
+/// Resolve smart-rename config for a session, honoring repo-local overrides
+/// in `<project_path>/.agent-of-empires/config.toml`. Shared helper so
+/// `try_smart_rename` and the sidebar indicator overlay in
+/// `src/server/api/sessions.rs` cannot drift. Falls back to the
+/// profile-only config (with a warning) on a missing or malformed repo
+/// config, matching [`crate::session::repo_config::resolve_config_with_repo_or_warn`].
+pub fn resolve_smart_rename_config(profile: &str, project_path: &Path) -> SmartRenameConfig {
+    let cfg = crate::session::repo_config::resolve_config_with_repo_or_warn(profile, project_path)
+        .session;
+    SmartRenameConfig {
+        setting_on: cfg.smart_rename,
+        rename_agent: cfg.smart_rename_agent,
+        overrides: cfg.agent_command_override,
+    }
 }
 
 /// Hard cap on how much of the user's first message is handed to the one-shot
@@ -372,16 +399,16 @@ mod serve {
             return;
         };
 
-        let config = crate::session::profile_config::resolve_config_or_warn(&profile);
+        let cfg = resolve_smart_rename_config(&profile, Path::new(&project_path));
         let agent = match check_eligible_resolved(
             structured,
-            config.session.smart_rename,
+            cfg.setting_on,
             &title,
             &tool,
-            &config.session.smart_rename_agent,
+            &cfg.rename_agent,
             sandboxed,
             &command,
-            &config.session.agent_command_override,
+            &cfg.overrides,
         ) {
             Ok(agent) => agent,
             Err(reason) => {
@@ -873,5 +900,57 @@ mod tests {
         assert!(sanitize_title(&"z".repeat(80), "x").is_none());
         // Numeric-only is not a title.
         assert!(sanitize_title("12345", "x").is_none());
+    }
+
+    // Regression for #2351: pins the shared helper that both `try_smart_rename`
+    // and the sidebar indicator overlay in `src/server/api/sessions.rs` route
+    // through. The helper is verified in isolation here; call-site coverage is
+    // design-level (reverting either site to bypass the helper is visible in
+    // review because both explicitly name `resolve_smart_rename_config`).
+    #[test]
+    #[serial_test::serial]
+    fn resolve_smart_rename_config_honors_repo_local_overrides() {
+        let home = tempfile::tempdir().expect("tempdir HOME");
+        // SAFETY: serialized by `#[serial]`; matches `set_tmp_home` in
+        // `src/session/mcp_state.rs`.
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
+        }
+
+        let repo = tempfile::tempdir().expect("tempdir repo");
+        let cfg_dir = repo.path().join(".agent-of-empires");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        std::fs::write(
+            cfg_dir.join("config.toml"),
+            r#"
+[session]
+smart_rename_agent = "opencode"
+
+[session.agent_command_override]
+claude = "my-wrapper"
+"#,
+        )
+        .unwrap();
+
+        let cfg = resolve_smart_rename_config("default", repo.path());
+        assert_eq!(cfg.rename_agent, "opencode");
+        assert_eq!(
+            cfg.overrides.get("claude").map(String::as_str),
+            Some("my-wrapper"),
+        );
+
+        let agent = check_eligible_resolved(
+            true,
+            cfg.setting_on,
+            "Vikings",
+            "claude",
+            &cfg.rename_agent,
+            false,
+            "",
+            &cfg.overrides,
+        )
+        .expect("eligible");
+        assert_eq!(agent.binary, "opencode");
     }
 }


### PR DESCRIPTION
## Description

Two smart-rename call sites resolved config via `profile_config::resolve_config_or_warn`, so a repo-local `.agent-of-empires/config.toml` overriding `smart_rename_agent` or `agent_command_override` was silently ignored on both:

- Runtime gate: [`try_smart_rename`](src/session/smart_rename.rs) in `src/session/smart_rename.rs`
- Sidebar indicator overlay: [`cfg_cache`](src/server/api/sessions.rs) in `list_sessions` (was keyed on `inst.source_profile` only)

Fix extracts a shared helper:

```rust
// src/session/smart_rename.rs
#[derive(Debug, Clone)]
pub struct SmartRenameConfig { pub setting_on: bool, pub rename_agent: String, pub overrides: HashMap<String, String> }
pub fn resolve_smart_rename_config(profile: &str, project_path: &Path) -> SmartRenameConfig
```

Both call sites route through the helper, resolving via `repo_config::resolve_config_with_repo_or_warn`. The sidebar `cfg_cache` is re-keyed on `(profile, project_path)` to match the adjacent [`acp_cmd_cache`](src/server/api/sessions.rs:551) pattern, so runtime gate and indicator resolve identically against the same repo-aware config and cannot drift.

Closes #2351. Follow-up to the profile-only resolver limitation surfaced in the #2350 walkthrough.

### What changed

- `src/session/smart_rename.rs`: new `SmartRenameConfig` struct + `resolve_smart_rename_config` function at unconditional module level, next to `check_eligible_resolved` (its natural peer). Both are `pub` and documented. Struct derives `Debug`, `Clone` for parity with `SmartRenameState` and `SkipReason`.
- `src/session/smart_rename.rs`: `try_smart_rename` calls the helper.
- `src/server/api/sessions.rs`: sidebar overlay imports `SmartRenameConfig` + `resolve_smart_rename_config`, drops the previous local tuple alias, calls the helper. Named fields on the cached value prevent a future edit from swapping positional slots silently.
- `check_eligible_resolved` is unchanged: it was already the shared entry point.

### Test

`resolve_smart_rename_config_honors_repo_local_overrides` in `src/session/smart_rename.rs`:

- Isolates `HOME` and `XDG_CONFIG_HOME` under a tempdir (`#[serial_test::serial]` + `unsafe { set_var }` matching [`set_tmp_home`](src/session/mcp_state.rs:338) in `mcp_state.rs`).
- Writes a real `.agent-of-empires/config.toml` with `[session] smart_rename_agent = "opencode"` and `[session.agent_command_override] claude = "my-wrapper"`.
- Calls `resolve_smart_rename_config("default", repo.path())` and asserts the repo overrides land on the returned struct.
- Feeds the resolved fields into `check_eligible_resolved` and asserts the eligibility gate resolves to `opencode`, not the session's `claude` binary.

Existing coverage remains green: 22 tests in `session::smart_rename` and 92 tests in `server::api::sessions` all pass.

### Known limitation and follow-up

- **Test scope, honest disclosure.** The regression test pins the shared helper in isolation. A revert of either call site to `profile_config::resolve_config_or_warn` would leave the test green (the helper stays correct). Call-site protection is design-level: both sites now name `resolve_smart_rename_config` explicitly, so a revert renames the function at both sites and is visible in code review. A live-serve integration test that stands up a fixture `AppState` and asserts `list_sessions` reports `SmartRenameState::Pending` for a repo-overridden session is queued as follow-up.
- **Per-request I/O.** The sidebar's [`acp_cmd_cache`](src/server/api/sessions.rs:551) and this PR's `cfg_cache` both call `resolve_config_with_repo_or_warn` for the same `(profile, project_path)`, so one `list_sessions` poll (3s cadence per `web/src/hooks/useSessions.ts`) reads `.agent-of-empires/config.toml` twice per unique key. This mirrors the pre-existing pattern and is not a regression this PR introduces. Unifying both overlays under a single per-request `Config` cache is a natural follow-up but out of scope for this fix.

### How tested

- `cargo fmt --check`
- `cargo clippy --features serve --all-targets -- -D warnings`
- `cargo test --features serve --lib session::smart_rename` (22 pass, incl. new regression)
- `cargo test --features serve --lib server::api::sessions` (92 pass)

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR does not change a user-facing dashboard flow. The sidebar indicator value is now correct for repos with `.agent-of-empires/config.toml` overrides, but there is no new UI surface and no behavior change for repos without repo-local overrides.
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR does not change TUI rendering, a CLI subcommand, or session lifecycle. The runtime gate now honors repo overrides; a unit test on the shared helper plus the eligibility gate pins the contract with no need for a tmux-driven fixture.
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7 (Sisyphus via OhMyOpenCode)

**Any Additional AI Details you'd like to share:**

Diff drafted and iterated through three Oracle cross-validation rounds (code quality + content/terminology) before submission. All prose above authored by the AI agent; the maintainer of this fork reviewed before opening.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change makes smart rename respect repo-specific config overrides instead of only using profile-level settings.

- Smart rename now reads configuration from the repository-aware config path, so `.agent-of-empires/config.toml` overrides are applied correctly.
- The runtime rename gate and the sidebar “pending” indicator now use the same shared config lookup, keeping them in sync.
- The sidebar cache is now keyed by both profile and project path, so different repos can have different smart rename behavior without конфликт.
- A regression test was added to confirm repo-local overrides for the rename agent and command settings are honored.

Benefits:
- Fixes incorrect smart rename behavior in repos with local overrides
- Prevents the sidebar badge from disagreeing with actual rename eligibility
- Makes config handling more consistent and reliable across the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->