### PR TITLE
fix(tui): sort storages.keys() before feeding rewire helpers (closes #2584)

### DIFF
--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2271,7 +2271,8 @@ impl HomeView {
         // single-profile mode (`aoe --profile X`) the user opted into
         // exactly that profile's instance state, so we don't watch
         // sessions.json/groups.json for unrelated profiles.
-        let initial_disk_profiles: Vec<String> = view.storages.keys().cloned().collect();
+        let mut initial_disk_profiles: Vec<String> = view.storages.keys().cloned().collect();
+        initial_disk_profiles.sort();
         view.rewire_disk_subscriptions(&initial_disk_profiles);
         // Config subscriptions are intentionally asymmetric: even in
         // single-profile mode, peer edits to ANY profile's config.toml
@@ -2324,7 +2325,9 @@ impl HomeView {
                     error = %error,
                     "list_profiles failed during reload_storage_only; reusing loaded storages for watcher rewires"
                 );
-                self.storages.keys().cloned().collect()
+                let mut keys: Vec<String> = self.storages.keys().cloned().collect();
+                keys.sort();
+                keys
             }
         };
 
@@ -2339,7 +2342,8 @@ impl HomeView {
         // so the unconditional call is a no-op on a stable profile set.
         self.rewire_config_subscriptions(&current_profiles);
         if self.active_profile.is_some() {
-            let active_only: Vec<String> = self.storages.keys().cloned().collect();
+            let mut active_only: Vec<String> = self.storages.keys().cloned().collect();
+            active_only.sort();
             self.rewire_disk_subscriptions(&active_only);
         } else {
             self.rewire_disk_subscriptions(&current_profiles);
@@ -2490,7 +2494,9 @@ impl HomeView {
         match crate::session::list_profiles() {
             Ok(profiles) => {
                 let disk_targets: Vec<String> = if self.active_profile.is_some() {
-                    self.storages.keys().cloned().collect()
+                    let mut keys: Vec<String> = self.storages.keys().cloned().collect();
+                    keys.sort();
+                    keys
                 } else {
                     profiles.clone()
                 };
@@ -4290,7 +4296,9 @@ impl HomeView {
                     error = %e,
                     "list_profiles failed during switch_profile; reusing loaded storages for config rewire"
                 );
-                self.storages.keys().cloned().collect()
+                let mut keys: Vec<String> = self.storages.keys().cloned().collect();
+                keys.sort();
+                keys
             }
         };
         self.rewire_config_subscriptions(&config_targets);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2270,9 +2270,9 @@ impl HomeView {
         // Disk subscriptions stay scoped to the loaded storages: in
         // single-profile mode (`aoe --profile X`) the user opted into
         // exactly that profile's instance state, so we don't watch
-        // sessions.json/groups.json for unrelated profiles. Sorted
-        // so the rewire install-loop ack identity stays stable across
-        // HashMap rehash between ticks (see #2584).
+        // sessions.json/groups.json for unrelated profiles. Sorted so
+        // the install-loop's last-write-wins target stays stable across
+        // HashMap rehash between rewire ticks (see #2584).
         let mut initial_disk_profiles: Vec<String> = view.storages.keys().cloned().collect();
         initial_disk_profiles.sort();
         view.rewire_disk_subscriptions(&initial_disk_profiles);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2270,7 +2270,9 @@ impl HomeView {
         // Disk subscriptions stay scoped to the loaded storages: in
         // single-profile mode (`aoe --profile X`) the user opted into
         // exactly that profile's instance state, so we don't watch
-        // sessions.json/groups.json for unrelated profiles.
+        // sessions.json/groups.json for unrelated profiles. Sorted
+        // so the rewire install-loop ack identity stays stable across
+        // HashMap rehash between ticks (see #2584).
         let mut initial_disk_profiles: Vec<String> = view.storages.keys().cloned().collect();
         initial_disk_profiles.sort();
         view.rewire_disk_subscriptions(&initial_disk_profiles);


### PR DESCRIPTION
## Description

Closes #2584 (CodeRabbit-flagged follow-up on #2578, which closed #2112).

### What

Five `self.storages.keys().cloned().collect()` fallbacks that feed the rewire helpers' `current` slice now sort before hand-off. Mirrors `list_profiles()`'s sorted contract on the happy path (`src/session/mod.rs:400`, `list_profile_names_in` calls `.sort()`).

### Why

`HashMap` iteration is stable for an unmutated map but randomized per-instance and reshuffled by rehash on profile add/remove between rewire ticks. When every `to_add` entry fails `subscribe_channel` with the same `WatchErrorKind`, the install loop's last-write-wins pick lands on whichever profile hashes last after rehash. That flips the `(profile, kind)` ack identity even though the underlying failure identity is unchanged, re-arming the "Reload Failed" dialog.

Sorting the fallback keys gives the install loop a deterministic last-write-wins target across churn events, so the ack identity is stable when the failure identity is.

### Sites touched (all rewire-adjacent)

The issue named three; audit revealed two additional call sites on the same rewire codepath. All five are inside `src/tui/home/mod.rs`:

| Site | Function | Feeds |
|---|---|---|
| `HomeView::new` initial | `view.storages.keys()` for `initial_disk_profiles` | `rewire_disk_subscriptions` |
| `reload_storage_only` `list_profiles` Err arm | `self.storages.keys()` fallback for `current_profiles` | both rewire helpers |
| `reload_storage_only` `active_profile.is_some()` branch | `self.storages.keys()` for `active_only` | `rewire_disk_subscriptions` |
| `rewire_after_profile_delete` `active_profile.is_some()` branch (audit) | `self.storages.keys()` for `disk_targets` | `rewire_disk_subscriptions` |
| `switch_profile` `list_profiles` Err arm (audit) | `self.storages.keys()` fallback for `config_targets` | `rewire_config_subscriptions` |

Pattern is identical at each site: change `let` → `let mut`, add `.sort()`. Bare-expression arms (`match`/`if`) are wrapped in a three-line block returning the sorted `Vec`.

### Sites audited and left as-is (not rewire-adjacent)

Both use the `keys()` collection in an order-agnostic way, so sorting them would be a no-op for the bug at hand and would slightly widen this PR's blast radius:

- `reload_storage_only` `group_trees.retain(|k, _| storage_keys.contains(k))` — `Vec::contains` is set-membership.
- `refresh_registered_projects` — feeds the project-view renderer via `self.registered_projects`; there is no downstream last-write-wins ack pick, so the failure-identity determinism concern this PR addresses does not extend here.

### Diff size

+13 / -5 = 8 net LOC across 5 sites, all in `src/tui/home/mod.rs`. Well under the review-friendly ceiling.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (see Test Coverage Analysis below on why no new test is added in this PR)
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (N/A, no visible UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the natural home for a regression test is `src/tui/home/file_watch_tests.rs`, which is currently flaky under #2600 (global `HOME` env race). A follow-up PR will land the test once #2600 is resolved. The deterministic property added here is code-verifiable via `Vec::sort` semantics, and all 666 existing `tui::home` unit tests pass on this diff.

### How I tested

Local, on this diff:

- `cargo fmt --check` — clean
- `cargo clippy --features serve --all-targets -- -D warnings` — clean
- `cargo test --features serve --lib tui::home` — 666 passed, 0 failed, 0 ignored
- Pre-commit hook — clean

### Out of scope

- `ReloadFailureState` ack semantics
- `apply_*_init_pass` behavior
- Rewire helper internals (`DiskWatchState::rewire`, `ConfigWatchState::rewire`)
- `list_profiles()` sorted contract in `src/session/mod.rs`
- Fixing #2600 (the `HOME` env race that makes `file_watch_tests` flaky) — prerequisite for the deferred regression test, not this PR

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** `claude-opus-4-7`

**Any Additional AI Details you'd like to share:** Fix pattern (`.sort()` after `.collect()`) and rationale were prescribed verbatim by the reporter in the issue body. AI executed the audit (identifying two additional rewire-adjacent call sites beyond the three named), applied the mechanical edit, and ran the gates.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This update makes the TUI’s profile rewire paths more consistent by sorting fallback profile lists before they’re used. In practice, that means startup and several reload/switch/delete fallback flows now process profiles in a stable order instead of relying on whatever order the storage map happens to return.

Benefits:
- Removes nondeterministic behavior during profile rewire handling
- Makes repeated reload and switch flows more stable after storage churn
- Helps prevent the reload-failed dialog from being re-triggered by ordering differences

Technical note:
- The change only affects how fallback `storages.keys()` collections are ordered before being passed to the disk/config rewire helpers.
- No public APIs or data structures were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->