### PR TITLE
feat(session): add auto-resume toggle and fix resume-probe retry loop

### DIFF
--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -815,7 +815,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     }
     if !fresh_after_failed_resume.is_empty() {
         println!(
-            "ℹ {} started fresh (prior resume probe failed for the stored sid; run `aoe session set-session-id` to retry it):",
+            "ℹ {} started fresh (a prior resume attempt failed for the stored sid; the old conversation is still reachable via the agent's own resume/history picker):",
             fresh_after_failed_resume.len()
         );
         for (title, sid) in &fresh_after_failed_resume {
@@ -947,7 +947,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
         StartOutcome::FreshAfterFailedResume { sid } => {
             println!(
-                "✓ Restarted session: {} (started fresh; prior resume probe failed for sid {sid}, run `aoe session set-session-id` to retry it)",
+                "✓ Restarted session: {} (started fresh; a prior resume attempt failed for sid {sid}, the old conversation is still reachable via the agent's own resume/history picker)",
                 title
             );
         }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -761,6 +761,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, String)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
+    let mut fresh_after_failed_resume: Vec<(String, String)> = Vec::new();
     let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
         let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
@@ -773,6 +774,10 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                 title,
                 format!("resume failed for sid {sid}; preserved for explicit retry"),
             )),
+            Ok(StartOutcome::FreshAfterFailedResume { sid }) => {
+                fresh_after_failed_resume.push((title.clone(), sid));
+                succeeded.push((id, title));
+            }
             Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((id, title)),
             Err(e) => failed.push((title, e.to_string())),
         }
@@ -807,6 +812,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
     for (_id, title) in &succeeded {
         println!("  · {}", title);
+    }
+    if !fresh_after_failed_resume.is_empty() {
+        println!(
+            "ℹ {} started fresh (prior resume probe failed for the stored sid; run `aoe session set-session-id` to retry it):",
+            fresh_after_failed_resume.len()
+        );
+        for (title, sid) in &fresh_after_failed_resume {
+            println!("  · {}: sid {}", title, sid);
+        }
     }
     if !orphaned.is_empty() {
         println!(
@@ -930,6 +944,12 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     match outcome {
         StartOutcome::ResumeFailed { sid } => {
             bail!("Resume failed for sid {sid}; preserved for explicit retry");
+        }
+        StartOutcome::FreshAfterFailedResume { sid } => {
+            println!(
+                "✓ Restarted session: {} (started fresh; prior resume probe failed for sid {sid}, run `aoe session set-session-id` to retry it)",
+                title
+            );
         }
         StartOutcome::Resumed | StartOutcome::Fresh => {
             println!("✓ Restarted session: {}", title);

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2883,7 +2883,13 @@ pub async fn start_session(
             if let Err(e) = inst.kill_clean() {
                 return Err(Box::new((inst, e)));
             }
-            match inst.start_with_resume_fallback(None, false) {
+            // Explicit restart endpoint (web dashboard Restart button):
+            // honor auto_resume_on_restart, same as TUI `e`/`Enter`. See #2609.
+            match inst.start_with_resume_fallback(
+                None,
+                false,
+                crate::session::ResumeAttemptPolicy::HonorAutoResumeSetting,
+            ) {
                 Ok(outcome) => Ok((inst, outcome)),
                 Err(e) => Err(Box::new((inst, e))),
             }
@@ -4943,7 +4949,16 @@ pub async fn ensure_session(
             // live entry can retain stale marker/sid state until the next
             // `status_poll_loop` reload window (~2s). See
             // `apply_post_restart_sync`.
-            match inst.start_with_resume_fallback(None, false) {
+            //
+            // `ensure_session` respawns on-demand before a WS attach/send,
+            // the server-side analog of `ensure_pane_ready`: always `Allow`,
+            // ignoring `auto_resume_on_restart`, so attaching doesn't
+            // silently drop the agent's context. See #2609.
+            match inst.start_with_resume_fallback(
+                None,
+                false,
+                crate::session::ResumeAttemptPolicy::Allow,
+            ) {
                 Ok(outcome) => Ok((inst, outcome)),
                 Err(e) => Err(Box::new((inst, e))),
             }
@@ -4961,6 +4976,9 @@ pub async fn ensure_session(
                 crate::session::StartOutcome::Resumed => "resumed",
                 crate::session::StartOutcome::ResumeFailed { .. } => "resume_failed",
                 crate::session::StartOutcome::Fresh => "fresh",
+                crate::session::StartOutcome::FreshAfterFailedResume { .. } => {
+                    "fresh_after_failed_resume"
+                }
             };
             let mut body = serde_json::json!({
                 "status": "restarted",
@@ -4974,6 +4992,12 @@ pub async fn ensure_session(
                 ));
                 body["resume_session_id"] = serde_json::Value::String(sid.clone());
                 return (StatusCode::CONFLICT, Json(body)).into_response();
+            }
+            if let crate::session::StartOutcome::FreshAfterFailedResume { sid } = &outcome {
+                body["message"] = serde_json::Value::String(format!(
+                    "Started fresh; a prior resume probe failed for sid {sid}"
+                ));
+                body["resume_session_id"] = serde_json::Value::String(sid.clone());
             }
             (StatusCode::OK, Json(body)).into_response()
         }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4995,9 +4995,11 @@ pub async fn ensure_session(
             }
             if let crate::session::StartOutcome::FreshAfterFailedResume { sid } = &outcome {
                 body["message"] = serde_json::Value::String(format!(
-                    "Started fresh; a prior resume probe failed for sid {sid}"
+                    "Started fresh; a prior resume attempt failed for sid {sid}. \
+                     The old conversation is still reachable via the agent's own \
+                     resume/history picker."
                 ));
-                body["resume_session_id"] = serde_json::Value::String(sid.clone());
+                body["prior_session_id"] = serde_json::Value::String(sid.clone());
             }
             (StatusCode::OK, Json(body)).into_response()
         }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -934,6 +934,20 @@ pub struct SessionConfig {
     )]
     pub smart_rename_agent: String,
 
+    /// Pass `--resume <sid>` (or the agent's equivalent) when restarting (`e`)
+    /// or reattaching (`Enter`) a terminal-mode session with a stored session
+    /// id. Disable to always start these sessions fresh instead, e.g. to
+    /// resume manually via the agent's own `/resume` picker. Does not affect
+    /// Send Message or Live Send, which always try to preserve context when
+    /// respawning a dead pane. See #2609.
+    #[serde(default = "default_true")]
+    #[setting(
+        label = "Auto-resume on restart/reattach",
+        widget = "toggle",
+        category = "Agents"
+    )]
+    pub auto_resume_on_restart: bool,
+
     /// Request xterm mouse tracking so the TUI handles the scroll wheel
     /// (preview-pane scroll) and click-to-select rows. Disable to hand the
     /// wheel and text selection back to the terminal, e.g. iOS Mosh +
@@ -1339,6 +1353,7 @@ impl Default for SessionConfig {
             merge_hooks_into_selected_agent: true,
             smart_rename: true,
             smart_rename_agent: String::new(),
+            auto_resume_on_restart: true,
             mouse_capture: true,
             custom_agents: HashMap::new(),
             agent_detect_as: HashMap::new(),

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -112,6 +112,27 @@ pub enum StartOutcome {
     /// actually occurred this call depends on the caller having killed
     /// any pre-existing pane first.
     Fresh,
+    /// A resume was skipped, and the session started fresh instead, because
+    /// `sid` already failed a resume probe (`resume_probe_failed_sid ==
+    /// agent_session_id`). Distinct from `Fresh` so callers can tell the user
+    /// their conversation did not resume, instead of silently starting a
+    /// blank session. Retrying the same sid would only reproduce the
+    /// original `ResumeFailed`; `aoe session set-session-id` is the explicit
+    /// escape hatch. See #2609.
+    FreshAfterFailedResume { sid: String },
+}
+
+/// Governs whether `start_with_resume_fallback` may pass `--resume <sid>` at
+/// all, independent of the per-sid loop-breaker (`resume_probe_failed_sid`),
+/// which always applies regardless of policy. `HonorAutoResumeSetting` is
+/// used by explicit user restart/reattach (`e`, `Enter`); `Allow` is used by
+/// Send Message and Live Send, which must keep trying to preserve agent
+/// context even when the user has disabled auto-resume for manual restarts.
+/// See #2609.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResumeAttemptPolicy {
+    HonorAutoResumeSetting,
+    Allow,
 }
 
 /// What `start_with_size_opts` did with the agent's session id this call.
@@ -3415,16 +3436,36 @@ impl Instance {
     }
 
     /// Restart the session, optionally skipping on_launch hooks (e.g. when
-    /// they already ran in the background creation poller).
+    /// they already ran in the background creation poller). Honors
+    /// `SessionConfig::auto_resume_on_restart`; this is the explicit
+    /// user-initiated restart/reattach path (`e`, `Enter`, CLI `session
+    /// restart`, startup recovery). See #2609.
     pub fn restart_with_size_opts(
         &mut self,
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
     ) -> Result<StartOutcome> {
+        self.restart_with_resume_policy(
+            size,
+            skip_on_launch,
+            ResumeAttemptPolicy::HonorAutoResumeSetting,
+        )
+    }
+
+    /// Shared restart cascade behind `restart_with_size_opts`. Broken out so
+    /// `ensure_pane_ready_with_size`'s dead-pane respawn (Send Message / Live
+    /// Send) can pass `ResumeAttemptPolicy::Allow`, keeping those surfaces
+    /// unaffected by `auto_resume_on_restart`. See #2609.
+    fn restart_with_resume_policy(
+        &mut self,
+        size: Option<(u16, u16)>,
+        skip_on_launch: bool,
+        resume_policy: ResumeAttemptPolicy,
+    ) -> Result<StartOutcome> {
         self.stop_poller();
         self.session_id_poller = None;
         self.kill_clean()?;
-        self.start_with_resume_fallback(size, skip_on_launch)
+        self.start_with_resume_fallback(size, skip_on_launch, resume_policy)
     }
 
     /// Settle-based pane probe used by the resume-fallback cascade.
@@ -3491,6 +3532,14 @@ impl Instance {
     ///      `StartOutcome::ResumeFailed`. A dead pane is not proof that the
     ///      sid is invalid, so this path must not clear it or launch fresh.
     ///
+    /// `resume_policy` gates step 1: `HonorAutoResumeSetting` additionally
+    /// requires `SessionConfig::auto_resume_on_restart`; `Allow` always
+    /// permits an attempt (subject to `should_attempt_resume`). Independent
+    /// of policy, a sid that already equals `resume_probe_failed_sid` from a
+    /// prior call never re-attempts resume: it returns
+    /// `StartOutcome::FreshAfterFailedResume` instead of repeating the same
+    /// doomed probe. See #2609.
+    ///
     /// Latency: only fires the probe when `--resume <sid>` is being passed
     /// to a freshly-created tmux session. Healthy resumes on real agents
     /// pay `RESUME_PROBE_POST_SHELL_GRACE` (~2s) once on cold start;
@@ -3508,6 +3557,7 @@ impl Instance {
         &mut self,
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
+        resume_policy: ResumeAttemptPolicy,
     ) -> Result<StartOutcome> {
         // Clear `Status::Error` on entry so a successful relaunch from any
         // restart surface (REST `ensure_session`, TUI Enter/restart, CLI
@@ -3564,9 +3614,30 @@ impl Instance {
         // honestly report `Fresh`. Without this gate, every Claude launch
         // would probe (~2s) and return `Resumed` because acquire always
         // assigns a UUID, even when no `--resume` was passed.
+        let resume_allowed_by_policy = match resume_policy {
+            ResumeAttemptPolicy::Allow => true,
+            ResumeAttemptPolicy::HonorAutoResumeSetting => {
+                super::profile_config::resolve_config_or_warn(&self.effective_profile())
+                    .session
+                    .auto_resume_on_restart
+            }
+        };
+        // Loop-breaker: a sid that already failed a probe is never retried
+        // automatically, regardless of policy, mirroring the check
+        // `is_recovery_candidate` already applies to the passive startup
+        // sweep. Without it, `e`/`Enter` retries the identical doomed sid
+        // forever. See #2609.
+        let mut skipped_failed_resume_sid: Option<String> = None;
         let attempted_sid = match &outcome {
-            LaunchSidOutcome::Existing { sid } if should_attempt_resume(Some(sid), &self.tool) => {
-                Some(sid.clone())
+            LaunchSidOutcome::Existing { sid }
+                if resume_allowed_by_policy && should_attempt_resume(Some(sid), &self.tool) =>
+            {
+                if self.resume_probe_failed_sid.as_deref() == Some(sid.as_str()) {
+                    skipped_failed_resume_sid = Some(sid.clone());
+                    None
+                } else {
+                    Some(sid.clone())
+                }
             }
             _ => None,
         };
@@ -3605,7 +3676,10 @@ impl Instance {
         // `start_with_size_opts`'s internal `session.exists()` check, in
         // which case `outcome` could be `Existing` despite the snapshot.
         if !attempting_resume || pane_was_preexisting {
-            return Ok(StartOutcome::Fresh);
+            return Ok(match skipped_failed_resume_sid {
+                Some(sid) => StartOutcome::FreshAfterFailedResume { sid },
+                None => StartOutcome::Fresh,
+            });
         }
 
         // Tier-1 settle probe. On Err (rare: only when `tmux_session()`
@@ -3728,28 +3802,35 @@ impl Instance {
             // Route fresh starts through the resume probe so a sid loaded
             // from disk that crashes the agent on launch is detected and
             // preserved with a loop-breaker instead of being retried
-            // automatically.
+            // automatically. Always `Allow`: Send Message and Live Send must
+            // keep trying to preserve agent context regardless of
+            // `auto_resume_on_restart`, which only scopes explicit
+            // restart/reattach. See #2609.
             let outcome = self
-                .start_with_resume_fallback(size, false)
+                .start_with_resume_fallback(size, false, ResumeAttemptPolicy::Allow)
                 .map_err(EnsureReadyError::Tmux)?;
             match outcome {
                 StartOutcome::ResumeFailed { sid } => {
                     return Ok(EnsureReadyOutcome::ResumeFailed { sid });
                 }
-                StartOutcome::Resumed | StartOutcome::Fresh => {}
+                StartOutcome::Resumed
+                | StartOutcome::Fresh
+                | StartOutcome::FreshAfterFailedResume { .. } => {}
             }
             self.wait_for_pane_ready(&session);
             return Ok(EnsureReadyOutcome::Started);
         }
         if session.is_pane_dead() {
             let outcome = self
-                .restart_with_size(size)
+                .restart_with_resume_policy(size, false, ResumeAttemptPolicy::Allow)
                 .map_err(EnsureReadyError::Tmux)?;
             match outcome {
                 StartOutcome::ResumeFailed { sid } => {
                     return Ok(EnsureReadyOutcome::ResumeFailed { sid });
                 }
-                StartOutcome::Resumed | StartOutcome::Fresh => {}
+                StartOutcome::Resumed
+                | StartOutcome::Fresh
+                | StartOutcome::FreshAfterFailedResume { .. } => {}
             }
             self.wait_for_pane_ready(&session);
             return Ok(EnsureReadyOutcome::Respawned);
@@ -6956,7 +7037,8 @@ mod tests {
 
     mod resume_fallback {
         use super::super::{
-            should_attempt_resume, Instance, LaunchSidOutcome, ResumeIntent, StartOutcome, Status,
+            should_attempt_resume, Instance, LaunchSidOutcome, ResumeAttemptPolicy, ResumeIntent,
+            StartOutcome, Status,
         };
         use serial_test::serial;
         use tempfile::tempdir;
@@ -8588,7 +8670,9 @@ mod tests {
             inst.agent_session_id = Some("11111111-1111-1111-1111-111111111111".to_string());
             inst.tool = "claude".to_string();
 
-            let outcome = inst.start_with_resume_fallback(None, true).unwrap();
+            let outcome = inst
+                .start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow)
+                .unwrap();
             assert_eq!(outcome, StartOutcome::Fresh);
         }
 
@@ -8633,7 +8717,7 @@ mod tests {
                 })
                 .unwrap();
 
-            let outcome = inst.start_with_resume_fallback(None, true);
+            let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
             let _ = std::process::Command::new("tmux")
                 .args(["kill-session", "-t", &tmux_name])
@@ -8711,7 +8795,7 @@ mod tests {
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
-            let outcome = inst.start_with_resume_fallback(None, true);
+            let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
             let _ = std::process::Command::new("tmux")
                 .args(["kill-session", "-t", &tmux_name])
@@ -8780,7 +8864,7 @@ mod tests {
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
-            let outcome = inst.start_with_resume_fallback(None, true);
+            let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
             let _ = std::process::Command::new("tmux")
                 .args(["kill-session", "-t", &tmux_name])

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -113,12 +113,15 @@ pub enum StartOutcome {
     /// any pre-existing pane first.
     Fresh,
     /// A resume was skipped, and the session started fresh instead, because
-    /// `sid` already failed a resume probe (`resume_probe_failed_sid ==
-    /// agent_session_id`). Distinct from `Fresh` so callers can tell the user
-    /// their conversation did not resume, instead of silently starting a
-    /// blank session. Retrying the same sid would only reproduce the
-    /// original `ResumeFailed`; `aoe session set-session-id` is the explicit
-    /// escape hatch. See #2609.
+    /// `sid` already failed a resume probe once before. Retrying the
+    /// identical sid would only reproduce the original `ResumeFailed`
+    /// forever, so this launch routes through `ResumeIntent::Cleared`
+    /// instead (same as a manual `aoe session set-session-id ""`): a fresh
+    /// sid is assigned and `sid` is not carried forward. Distinct from
+    /// `Fresh` so callers can tell the user their conversation did not
+    /// resume, instead of silently starting a blank session; the prior
+    /// conversation is still reachable through the agent's own resume/
+    /// history picker. See #2609.
     FreshAfterFailedResume { sid: String },
 }
 
@@ -597,6 +600,17 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "ResumeIntent::is_default")]
     pub(crate) resume_intent: ResumeIntent,
 
+    /// Runtime-only, one-shot: set by `start_with_resume_fallback` right
+    /// before calling `start_with_size_opts` to force this single launch
+    /// through the `ResumeIntent::Cleared` path (no `--resume` flag, fresh
+    /// sid) without persisting a real `Cleared` write ahead of time. Not
+    /// serialized; `reconcile_from_disk` explicitly carries it across the
+    /// `*self = disk` reload since it otherwise has no disk representation.
+    /// Consumed (reset to `false`) at the top of `start_with_size_opts`. See
+    /// #2609.
+    #[serde(skip)]
+    pub(crate) force_fresh_next_launch: bool,
+
     /// Runtime-only: which profile this instance was loaded from. Not persisted to disk.
     #[serde(default, skip_serializing)]
     pub source_profile: String,
@@ -1026,6 +1040,7 @@ impl Instance {
             agent_session_id: None,
             resume_probe_failed_sid: None,
             resume_intent: ResumeIntent::Default,
+            force_fresh_next_launch: false,
             source_profile: String::new(),
             notify_on_waiting: None,
             notify_on_idle: None,
@@ -1217,6 +1232,7 @@ impl Instance {
         disk.session_id_poller = self.session_id_poller.take();
         disk.retroactive_capture_excludes = std::mem::take(&mut self.retroactive_capture_excludes);
         disk.pane_dead_observed = self.pane_dead_observed;
+        disk.force_fresh_next_launch = self.force_fresh_next_launch;
         disk.source_profile = std::mem::take(&mut self.source_profile);
         // `before_start_env` is `#[serde(skip)]`, so the disk snapshot always
         // has it empty. Carry the live value forward; otherwise this reload
@@ -2285,6 +2301,17 @@ impl Instance {
         // CAS baseline). Covers resume-probe launches and explicit fresh
         // launches since both call this function.
         self.reconcile_from_disk();
+
+        // Consume the one-shot override, if `start_with_resume_fallback` set
+        // it, now that `reconcile_from_disk`'s `*self = disk` reload can no
+        // longer clobber it. Forces this launch through the same
+        // `ResumeIntent::Cleared` path a manual `aoe session set-session-id
+        // ""` would take: no `--resume` flag, fresh sid, one-shot
+        // auto-promote back to `Default` on disk after this launch persists.
+        // See #2609.
+        if std::mem::take(&mut self.force_fresh_next_launch) {
+            self.resume_intent = ResumeIntent::Cleared;
+        }
 
         self.reconcile_sidecar_into_disk();
 
@@ -3601,43 +3628,55 @@ impl Instance {
         // attempted, the race is just kill_clean cache staleness).
         let pane_was_preexisting = self.tmux_session().is_ok_and(|s| s.exists());
 
+        // Decide BEFORE launching whether this call may pass `--resume`, since
+        // that flag is baked into the command by `acquire_session_id` inside
+        // `start_with_size_opts`, not by anything read afterward. Only
+        // intervenes on the ambient auto-resume path (`ResumeIntent::Default`):
+        // an explicit one-shot `Use`/`Fork`/`Cleared` intent (e.g. just set via
+        // `aoe session set-session-id`) is a deliberate user action and must
+        // not be silently overridden by the restart-time policy or
+        // loop-breaker. When it fires, `force_fresh_next_launch` routes the
+        // launch through the same `ResumeIntent::Cleared` path a manual
+        // `set-session-id ""` would take. See #2609.
+        let mut skipped_failed_resume_sid: Option<String> = None;
+        if self.resume_intent == ResumeIntent::Default {
+            if let Some(sid) = self.agent_session_id.clone() {
+                let resume_allowed_by_policy = match resume_policy {
+                    ResumeAttemptPolicy::Allow => true,
+                    ResumeAttemptPolicy::HonorAutoResumeSetting => {
+                        super::profile_config::resolve_config_or_warn(&self.effective_profile())
+                            .session
+                            .auto_resume_on_restart
+                    }
+                };
+                let resume_capable = should_attempt_resume(Some(&sid), &self.tool);
+                let probe_already_failed = self.resume_probe_failed_sid.as_deref() == Some(&sid);
+                if resume_capable && probe_already_failed {
+                    // Loop-breaker: a sid that already failed a probe is never
+                    // retried automatically, regardless of policy, mirroring
+                    // the check `is_recovery_candidate` already applies to
+                    // the passive startup sweep. Without it, `e`/`Enter`
+                    // retries the identical doomed sid forever.
+                    skipped_failed_resume_sid = Some(sid);
+                    self.force_fresh_next_launch = true;
+                } else if resume_capable && !resume_allowed_by_policy {
+                    self.force_fresh_next_launch = true;
+                }
+            }
+        }
+
         let outcome = self.start_with_size_opts(size, skip_on_launch)?;
 
-        // Computed post-`start_with_size_opts` so it reflects post-reconcile
-        // state. A pre-call read would miss a peer-CLI `Use(X)` write that
-        // landed since the daemon's last status_poll, causing the cascade
-        // to skip the very Use(X_dead) case Tier-1's downgrade is meant to
-        // handle.
-        //
         // Gated on `LaunchSidOutcome::Existing` so fresh launches (Cleared,
         // no observed sid + Claude UUID generation) skip the probe and
         // honestly report `Fresh`. Without this gate, every Claude launch
         // would probe (~2s) and return `Resumed` because acquire always
-        // assigns a UUID, even when no `--resume` was passed.
-        let resume_allowed_by_policy = match resume_policy {
-            ResumeAttemptPolicy::Allow => true,
-            ResumeAttemptPolicy::HonorAutoResumeSetting => {
-                super::profile_config::resolve_config_or_warn(&self.effective_profile())
-                    .session
-                    .auto_resume_on_restart
-            }
-        };
-        // Loop-breaker: a sid that already failed a probe is never retried
-        // automatically, regardless of policy, mirroring the check
-        // `is_recovery_candidate` already applies to the passive startup
-        // sweep. Without it, `e`/`Enter` retries the identical doomed sid
-        // forever. See #2609.
-        let mut skipped_failed_resume_sid: Option<String> = None;
+        // assigns a UUID, even when no `--resume` was passed. When the
+        // pre-launch decision above forced `Cleared`, `outcome` is already
+        // `LaunchSidOutcome::Fresh` here, so this naturally yields `None`.
         let attempted_sid = match &outcome {
-            LaunchSidOutcome::Existing { sid }
-                if resume_allowed_by_policy && should_attempt_resume(Some(sid), &self.tool) =>
-            {
-                if self.resume_probe_failed_sid.as_deref() == Some(sid.as_str()) {
-                    skipped_failed_resume_sid = Some(sid.clone());
-                    None
-                } else {
-                    Some(sid.clone())
-                }
+            LaunchSidOutcome::Existing { sid } if should_attempt_resume(Some(sid), &self.tool) => {
+                Some(sid.clone())
             }
             _ => None,
         };
@@ -8818,6 +8857,234 @@ mod tests {
             assert_eq!(
                 row.resume_probe_failed_sid.as_deref(),
                 Some(stale_sid.as_str())
+            );
+        }
+
+        // #2609: `auto_resume_on_restart = false` must stop `--resume <sid>`
+        // from ever reaching the launched command on the restart/reattach
+        // path (`HonorAutoResumeSetting`), while leaving Send Message / Live
+        // Send (`Allow`) unaffected.
+        #[test]
+        #[serial]
+        fn auto_resume_on_restart_false_skips_stored_sid_and_launches_fresh() {
+            if std::process::Command::new("tmux")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                eprintln!("tmux not available; skipping");
+                return;
+            }
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let mut cfg = crate::session::config::Config::default();
+            cfg.session.auto_resume_on_restart = false;
+            crate::session::config::save_config(&cfg).unwrap();
+
+            let storage = crate::session::storage::Storage::new_unwatched("fb-toggle-off").unwrap();
+
+            let stale_sid = "44444444-4444-4444-4444-444444444444".to_string();
+            let mut inst = Instance::new("fallback_toggle_off_test", "/tmp/x");
+            inst.tool = "claude".to_string();
+            inst.source_profile = "fb-toggle-off".to_string();
+            // Would die if (and only if) `--resume <stale_sid>` reached the
+            // command; with the toggle off it must never be passed, so this
+            // process lives.
+            inst.command = format!(
+                "/bin/sh -c 'case \"$*\" in *{stale}*) exit 1 ;; esac; exec sleep 30' --",
+                stale = stale_sid,
+            );
+            inst.agent_session_id = Some(stale_sid.clone());
+            inst.status = Status::Idle;
+
+            let xs = vec![inst.clone()];
+            storage
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            let outcome = inst.start_with_resume_fallback(
+                None,
+                true,
+                ResumeAttemptPolicy::HonorAutoResumeSetting,
+            );
+
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            assert_eq!(outcome.unwrap(), StartOutcome::Fresh);
+            assert_ne!(
+                inst.agent_session_id.as_deref(),
+                Some(stale_sid.as_str()),
+                "toggle off must generate a fresh sid, not reuse the stale one"
+            );
+        }
+
+        // #2609: Send Message / Live Send (`Allow`) must keep attempting resume
+        // regardless of `auto_resume_on_restart`, so a dead pane still surfaces
+        // `ResumeFailed` (proving `--resume <sid>` was passed) rather than
+        // silently starting fresh and losing agent context.
+        #[test]
+        #[serial]
+        fn allow_policy_still_attempts_resume_when_auto_resume_on_restart_is_false() {
+            if std::process::Command::new("tmux")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                eprintln!("tmux not available; skipping");
+                return;
+            }
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let mut cfg = crate::session::config::Config::default();
+            cfg.session.auto_resume_on_restart = false;
+            crate::session::config::save_config(&cfg).unwrap();
+
+            let storage =
+                crate::session::storage::Storage::new_unwatched("fb-allow-ignores").unwrap();
+
+            let stale_sid = "55555555-5555-5555-5555-555555555555".to_string();
+            let mut inst = Instance::new("fallback_allow_ignores_toggle_test", "/tmp/x");
+            inst.tool = "claude".to_string();
+            inst.source_profile = "fb-allow-ignores".to_string();
+            inst.command = "/bin/false".to_string();
+            inst.agent_session_id = Some(stale_sid.clone());
+            inst.status = Status::Idle;
+
+            let xs = vec![inst.clone()];
+            storage
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
+
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            assert_eq!(
+                outcome.unwrap(),
+                StartOutcome::ResumeFailed {
+                    sid: stale_sid.clone(),
+                },
+                "Allow must ignore auto_resume_on_restart=false and still attempt resume"
+            );
+        }
+
+        // #2609 core bug: a sid whose resume probe already failed once must
+        // never be retried automatically. Reproduces the reported infinite
+        // loop (two consecutive `e`/`Enter` presses against the same doomed
+        // sid) and proves the second attempt terminates it instead of
+        // repeating `ResumeFailed` forever.
+        #[test]
+        #[serial]
+        fn stale_probe_failed_sid_is_not_retried_on_next_attempt() {
+            if std::process::Command::new("tmux")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                eprintln!("tmux not available; skipping");
+                return;
+            }
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage = crate::session::storage::Storage::new_unwatched("fb-loop-break").unwrap();
+
+            let stale_sid = "66666666-6666-6666-6666-666666666666".to_string();
+            let mut inst = Instance::new("fallback_loop_break_test", "/tmp/x");
+            inst.tool = "claude".to_string();
+            inst.source_profile = "fb-loop-break".to_string();
+            inst.command = "/bin/false".to_string();
+            inst.agent_session_id = Some(stale_sid.clone());
+            inst.status = Status::Idle;
+
+            let xs = vec![inst.clone()];
+            storage
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            // First attempt: reproduces the pre-existing `ResumeFailed` path,
+            // exactly like `fallback_marks_resume_failed_and_preserves_sid_when_pane_dies`.
+            let first = inst
+                .start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow)
+                .unwrap();
+            assert_eq!(
+                first,
+                StartOutcome::ResumeFailed {
+                    sid: stale_sid.clone(),
+                }
+            );
+            assert_eq!(
+                inst.resume_probe_failed_sid.as_deref(),
+                Some(stale_sid.as_str())
+            );
+
+            // Second attempt, same sid, same doomed command: on the pre-fix
+            // tree this reproduces the reported bug (identical `ResumeFailed`
+            // forever). The fix must instead skip the resume attempt and
+            // start fresh.
+            inst.kill_clean().unwrap();
+            let second = inst
+                .start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow)
+                .unwrap();
+
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            assert_eq!(
+                second,
+                StartOutcome::FreshAfterFailedResume {
+                    sid: stale_sid.clone(),
+                },
+                "a sid that already failed a resume probe must not be retried automatically"
+            );
+            assert_ne!(
+                inst.agent_session_id.as_deref(),
+                Some(stale_sid.as_str()),
+                "loop-breaker must generate a fresh sid instead of repeating the doomed one"
+            );
+            assert_eq!(
+                inst.resume_probe_failed_sid, None,
+                "loop-breaker's fresh launch clears the stale marker, matching ResumeIntent::Cleared semantics"
             );
         }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -52,6 +52,8 @@ pub use groups::{
     is_within_archived_section, is_within_trash_section, Group, GroupTree, Item,
     ARCHIVED_SECTION_NAME, ARCHIVED_SECTION_PATH, TRASH_SECTION_NAME, TRASH_SECTION_PATH,
 };
+#[cfg(feature = "serve")]
+pub(crate) use instance::ResumeAttemptPolicy;
 pub(crate) use instance::{persist_session_to_storage, ResumeIntent, SidWrite};
 pub use instance::{
     EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo, SessionBucket,

--- a/src/session/restart.rs
+++ b/src/session/restart.rs
@@ -73,7 +73,12 @@ pub fn perform_restart(request: RestartRequest) -> RestartResult {
 }
 
 fn should_send_restart_wake(outcome: &Result<StartOutcome, String>) -> bool {
-    matches!(outcome, Ok(StartOutcome::Fresh | StartOutcome::Resumed))
+    matches!(
+        outcome,
+        Ok(StartOutcome::Fresh
+            | StartOutcome::Resumed
+            | StartOutcome::FreshAfterFailedResume { .. })
+    )
 }
 
 /// Wait for the restarted pane to become live and past its boot shell, then

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2843,6 +2843,11 @@ impl App {
                     )));
                     return Ok(());
                 }
+                Ok(crate::session::StartOutcome::FreshAfterFailedResume { sid }) => {
+                    self.update_status = Some(UpdateStatus::transient(format!(
+                        "Started fresh; resume previously failed for sid {sid}"
+                    )));
+                }
                 Ok(_) => {}
             }
             self.home.set_instance_error(session_id, None);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3073,8 +3073,9 @@ impl HomeView {
                             self.info_dialog = Some(InfoDialog::new(
                                 "Restarted",
                                 &format!(
-                                    "Started fresh; a prior resume probe failed for sid {sid}. \
-                                     Run `aoe session set-session-id` to retry it."
+                                    "Started fresh; a prior resume attempt failed for sid {sid}. \
+                                     The old conversation is still reachable via the agent's \
+                                     own resume/history picker."
                                 ),
                             ));
                         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2918,6 +2918,18 @@ impl HomeView {
                             );
                         }
                         Ok(crate::session::StartOutcome::Fresh) => {}
+                        Ok(crate::session::StartOutcome::FreshAfterFailedResume { sid }) => {
+                            // Defensive: `is_recovery_candidate` already excludes
+                            // sids equal to `resume_probe_failed_sid`, so this
+                            // should not normally fire here. See #2609.
+                            tracing::info!(
+                                target: "session.startup_recovery",
+                                id = %instance_id,
+                                %title,
+                                %sid,
+                                "started fresh; sid previously failed a resume probe",
+                            );
+                        }
                         Err(e) => {
                             tracing::warn!(
                                 target: "session.startup_recovery",
@@ -3048,6 +3060,21 @@ impl HomeView {
                                 "Restart Failed",
                                 &format!(
                                     "Resume failed for sid {sid}; preserved for explicit retry"
+                                ),
+                            ));
+                        }
+                        Ok(crate::session::StartOutcome::FreshAfterFailedResume { sid }) => {
+                            tracing::info!(
+                                target: "session.restart",
+                                id = %session_id,
+                                %sid,
+                                "started fresh; sid previously failed a resume probe",
+                            );
+                            self.info_dialog = Some(InfoDialog::new(
+                                "Restarted",
+                                &format!(
+                                    "Started fresh; a prior resume probe failed for sid {sid}. \
+                                     Run `aoe session set-session-id` to retry it."
                                 ),
                             ));
                         }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two related fixes for terminal-mode session restart/reattach, from #2609:

1. **New setting**: `Auto-resume on restart/reattach` (`session.auto_resume_on_restart`, default on) lets you disable automatic `--resume <sid>` on `e`/`Enter`/CLI `session restart`/web dashboard restart/startup recovery. Off by user request means these surfaces always start a fresh conversation instead, matching the reported workflow of resuming manually via the agent's own `/resume` picker when needed. Send Message and Live Send are unaffected either way, since losing agent context there would be a real regression, not the requested behavior.

2. **Bug fix**: when a resume attempt failed (the launched pane died during AoE's post-launch probe), the session showed `resume failed for sid <sid>; preserved for explicit retry` and every subsequent `e`/`Enter` press retried the identical doomed sid, reproducing the exact same failure forever. There was no automatic escape; only `aoe session set-session-id` broke the loop once, and only by retargeting to a different sid. The fix: a sid that already failed a probe is never retried automatically. The session starts fresh instead and reports `StartOutcome::FreshAfterFailedResume`, surfaced as an informational notice (not `Status::Error`) across the TUI, CLI, and server.

Both land in the same function, `Instance::start_with_resume_fallback`, since the toggle and the loop-breaker are two branches of the same resume-eligibility decision.

**Implementation note worth flagging for review**: the decision now has to happen *before* `start_with_size_opts` launches the pane, not after. `--resume <sid>` is baked into the launch command by `acquire_session_id` well before the post-launch probe gate runs, so an earlier version of this change that only gated the probe/outcome-reporting logic compiled fine but didn't actually stop `--resume` from reaching the agent. The fix routes the suppressed launch through the existing `ResumeIntent::Cleared` one-shot machinery (the same path a manual `aoe session set-session-id ""` already takes) via a new transient `Instance` field, `force_fresh_next_launch`, carried across `reconcile_from_disk`'s mid-launch disk reload so it isn't lost. One consequence: the loop-breaker case now discards the failed sid (matching what `set-session-id ""` already does) rather than preserving it for a manual retry, since the deeper "skip resume but keep the sid" mechanism `acquire_session_id`'s architecture would require is out of proportion to the bug. Messaging was updated accordingly to point at the agent's own resume/history picker instead of suggesting `set-session-id` as a retry.

Closes #2609

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Settings toggle is discoverable in-app (TUI settings screen + web dashboard settings panel, both derived automatically from the single-source `#[setting(...)]` annotation); no `docs/` change needed. No visual/layout change; only new toast/dialog text for an existing dialog pattern.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow. `src/server/api/sessions.rs`'s `ensure_session`/`start_session` JSON responses gained a `fresh_after_failed_resume` outcome value and a `prior_session_id` field, but no `web/` frontend code changed and no new UI surface was added.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the core resume-decision logic is covered by new real-tmux Rust tests in `src/session/instance.rs` (`resume_fallback` test module), including a reproduce-then-fix regression test confirmed red against the pre-fix commit in an ephemeral worktree. The TUI/CLI/server changes are outcome-display text for an existing dialog/toast/print pattern (no new rendering, no new keybinding, no new interaction flow), so a `tests/e2e/` scenario would duplicate that coverage without adding meaningful signal.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude (via Claude Code, agent-of-empires `/aoe-implement` skill), with a `/debate` consult between gemini-3.1-pro-preview and gpt-5.5 on the `StartOutcome` shape and toggle default.

**Any Additional AI Details you'd like to share:**

Investigation, plan, `/debate` consult, and implementation drafted by Claude under my direction. I reviewed each commit and the design calls, including the mid-implementation correction once the `--resume` flag construction was traced to `acquire_session_id` rather than the post-launch probe gate.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## How to test

- [ ] Open TUI settings, find "Auto-resume on restart/reattach" under the Agents category, confirm it's on by default and toggleable
- [ ] With the toggle on (default), start a session, exit the agent so the pane dies, press `e` to restart: confirm the agent resumes the prior conversation
- [ ] Turn the toggle off, repeat: confirm the agent starts a brand-new conversation instead (no `--resume` in the launched command)
- [ ] Confirm Send Message / Live Send still resume a dead pane's context normally even with the toggle off
- [ ] Reproduce a resume-probe failure (e.g. point `agent_session_id` at an invalid/dead sid), press `e`/`Enter` twice in a row: confirm the second press starts fresh with an informational "Restarted" dialog instead of repeating the "Restart Failed" error dialog forever
- [ ] Same scenario via `aoe session restart <id>` and `aoe session restart --all`: confirm the CLI prints an informational fresh-start line instead of erroring
- [ ] Same scenario via the web dashboard restart/ensure-session flow: confirm the JSON response reports `resume_outcome: "fresh_after_failed_resume"` with a `prior_session_id` field, HTTP 200 (not the 409 `resume_failed` conflict)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785580075&installation_id=139138837&pr_number=2612&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2612&signature=b14d10b2d2c3ce65c47270b9789118c2334e2eda6e25fa9f5aa7c3018f8e266b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### High-level summary
This PR adds a new setting to control whether restart/reattach actions should automatically resume the previous session, with the default staying enabled. It also improves restart behavior so that if a resume attempt fails during startup, the app no longer keeps retrying the same broken session ID on later restarts. Instead, it starts fresh and clearly tells the user what happened.

The update also aligns CLI, TUI, and server responses so they all report this new “started fresh after failed resume” case consistently. Restart-related flows now respect the new setting, while message-send flows still preserve context as before.

### Benefits
- Gives users control over auto-resume on restart/reattach
- Prevents repeated failed resume loops
- Makes restart outcomes clearer across CLI, TUI, and API
- Keeps context-preserving send flows unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->