### PR TITLE
test(tui): refresh opencode status_detection fixtures against 1.17.12 (closes #2606)

### DIFF
--- a/scripts/capture-fixtures.sh
+++ b/scripts/capture-fixtures.sh
@@ -130,7 +130,19 @@ get_version() {
 }
 
 VERSION=$(get_version)
+VERSION="${VERSION:-unknown}"
 DATE=$(date +%Y-%m-%d)
+
+# Coarse "1.17.x"-style range from the captured version, so reviewers can
+# spot fixture drift at a glance. Returns the input unchanged on unknown shapes.
+verified_range() {
+    if [[ "${1#v}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.x"
+    else
+        echo "$1"
+    fi
+}
+VERIFIED_AGAINST=$(verified_range "$VERSION")
 
 # Capture pane content (last 50 lines to match detection logic)
 CONTENT=$(tmux capture-pane -t "$SESSION" -p -S -50)
@@ -143,6 +155,7 @@ cat > "$OUTPUT_FILE" << EOF
 # FIXTURE: $TOOL_DISPLAY - $STATE_DISPLAY State
 # Captured from: $VERSION
 # Capture date: $DATE
+# Verified against: $VERIFIED_AGAINST (last check: $DATE)
 # To add more: scripts/capture-fixtures.sh $TOOL $STATE <tmux_session> [description]
 #
 # Expected status: $(echo "$STATE" | sed 's/waiting.*/Waiting/; s/running/Running/; s/idle/Idle/')

--- a/tests/fixtures/opencode/idle/001_startup.txt
+++ b/tests/fixtures/opencode/idle/001_startup.txt
@@ -1,28 +1,58 @@
 # FIXTURE: OpenCode - Idle State
-# Captured from: 1.1.8
-# Capture date: 2026-01-10
+# Captured from: 1.17.12+6697cf3
+# Capture date: 2026-07-02
+# Verified against: 1.17.x (last check: 2026-07-02)
 # To add more: scripts/capture-fixtures.sh opencode idle <tmux_session> [description]
 #
 # Expected status: Idle
-# Key indicators: "Ask anything..." prompt with empty input
+# Key indicators: "Ask anything..." prompt, no "esc interrupt", no spinner
 
 
 
 
-                                                                                   ▄
-                                                  █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
-                                                  █░░█ █░░█ █▀▀▀ █░░█ █░░░ █░░█ █░░█ █▀▀▀
-                                                  ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀
-
-
-                                ┃
-                                ┃  Ask anything... "What is the tech stack of this project?"
-                                ┃
-                                ┃  Build  Nemotron 3 Nano LM Studio (local)
-                                ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-                                                                          tab switch agent  ctrl+p commands
 
 
 
 
-  ~/scm/agent-of-empires:main                                                                                                       1.1.8
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                                  ▄
+                                                                                 █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
+                                                                                 █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀
+                                                                                 ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀
+
+
+                                                               ┃
+                                                               ┃  Ask anything... "What is the tech stack of this project?"
+                                                               ┃
+                                                               ┃  Sisyphus - Ultraworker · Claude Opus 4.7 HAI Anthropic · max
+                                                               ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+                                                                                                               tab agents  ctrl+p commands
+
+
+
+                                                               ● Tip Use backticks in commands to inject shell output (e.g., `git status`)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  ~/SAPDevelop/agent-of-empires-git-worktrees/opencode-status_detection-fixtures:fix/2606-opencode-fixtures-refresh  ⊙ 7 MCP /status                                                   1.17.12+6697cf3

--- a/tests/fixtures/opencode/idle/002_mini.txt
+++ b/tests/fixtures/opencode/idle/002_mini.txt
@@ -1,0 +1,17 @@
+# FIXTURE: OpenCode - Idle State
+# Captured from: 1.17.12+6697cf3
+# Capture date: 2026-07-02
+# Verified against: 1.17.x (last check: 2026-07-02)
+# To add more: scripts/capture-fixtures.sh opencode idle <tmux_session> [description]
+#
+# Expected status: Idle
+# Key indicators: mini split-footer, "Ask anything..." prompt, plain "BUILD" footer, no "esc interrupt", no spinner
+
+
+█▀▀█  OpenCode
+█  █  /private/tmp/opencode-fixture-home
+▀▀▀▀
+
+Ask anything... "Fix a TODO in the codebase"
+
+ BUILD                                                                                                                                                                                       ctrl+p cmd

--- a/tests/fixtures/opencode/running/001_generating.txt
+++ b/tests/fixtures/opencode/running/001_generating.txt
@@ -1,45 +1,58 @@
 # FIXTURE: OpenCode - Running State
-# Captured from: 1.1.8
-# Capture date: 2026-01-10
+# Captured from: 1.17.12+6697cf3
+# Capture date: 2026-07-02
+# Verified against: 1.17.x (last check: 2026-07-02)
 # To add more: scripts/capture-fixtures.sh opencode running <tmux_session> [description]
 #
 # Expected status: Running
-# Key indicators: "esc interrupt" shown at bottom, spinner animation
+# Key indicators: "esc interrupt" hint and spinner chars in the footer
 
+
+  ┃                                                                                                                                                             New session - 2026-07-02T14:57:02.
+  ┃  write me a 2000 word detailed essay about the history of computer science, covering ada lovelace, alan turing, von neumann, dijkstra, knuth and be         771Z
+  ┃  thorough                                                                                                                                                   ses_0dcaaaaccffeHbSNYBYVg2jsMq
   ┃
-  ┃  # Write 'hi' to /tmp file                                                                                        12,138  6% ($0.00)
-  ┃
+                                                                                                                                                                Context
+     The History of Computer Science: From Analytical Engines to Algorithmic Foundations                                                                        0 tokens
+                                                                                                                                                                0% used
+     The history of computer science is not a linear progression from primitive counting devices to modern silicon chips, but rather a rich tapestry of         $0.00 spent
+     mathematical insight, engineering ambition, and philosophical inquiry stretching across nearly two centuries. It is a discipline that emerged from the
+     confluence of mathematics, logic, electrical engineering, and linguistics, shaped by extraordinary individuals whose intellectual contributions            ▼ MCP
+     continue to define how we think about computation itself. To understand computer science, one must trace the arc of thought from the visionary poetry      • codegraph Connected
+     of Ada Lovelace, through the profound abstractions of Alan Turing, the pragmatic architectures of John von Neumann, the disciplined rigor of Edsger        • context7 Connected
+     Dijkstra, and finally to the encyclopedic scholarship of Donald Knuth. Each of these figures represents not merely a chapter, but a paradigm shift in      • github Connected
+     how humanity understood the possibilities of mechanical and later electronic thought.                                                                      • grep_app Connected
+                                                                                                                                                                • lsp Connected
+     Ada Lovelace: The First Programmer                                                                                                                         • markitdown Disabled
+                                                                                                                                                                • perplexity Disabled
+     Augusta Ada King, Countess of Lovelace, born in 1815, occupies a unique and often mythologized position in the history of computing. The                   • serena Connected
+                                                                                                                                                                • websearch Connected
+     ▣  Sisyphus - Ultraworker · Claude Opus 4.7
+                                                                                                                                                                LSP
+                                                                                                                                                                LSPs are disabled
 
-     ▣  Build · minimax-m2.1-free · 23.8s
+                                                                                                                                                                ┌───────────────────────────────────┐
+                                                                                                                                                                │                                   │
+                                                                                                                                                                │ Models                            │
+                                                                                                                                                                │ artistry gemini-2.5-pro           │
+                                                                                                                                                                │ atlas claude-sonnet-4-6           │
+                                                                                                                                                                │ deep claude-opus-4-7              │
+                                                                                                                                                                │ explore claude-sonnet-4-6         │
+                                                                                                                                                                │ hephaestus gpt-5.5                │
+                                                                                                                                                                │ librarian claude-sonnet-4-6       │
+                                                                                                                                                                │ metis claude-opus-4-7             │
+                                                                                                                                                                │ momus claude-opus-4-7             │
+                                                                                                                                                                │ multimodal-looker gemini-2.5-     │
+                                                                                                                                                                │ flash                             │
+                                                                                                                                                                │ oracle claude-opus-4-7            │
+                                                                                                                                                                │ prometheus claude-opus-4-7        │
+                                                                                                                                                                │ quick claude-sonnet-4-6           │
+                                                                                                                                                                │                                   │
+                                                                                                                                                                └───────────────────────────────────┘
 
-  ┃
-  ┃  use the bash tool
-  ┃
-
-  ┃  Thinking: The user wants me to use the bash tool to write 'hi' to a file in /tmp. Let me use echo with bash to accomplish this.
-
-     $ echo 'hi' > /tmp/hi.txt
-
-  ┃
-  ┃  Never mind, please write me a 2000 word story
-  ┃
-
-  ┃  Thinking: The user is asking me to write a 2000 word story. This is a creative writing task, not a coding task. Let me write an
-  ┃  engaging story of approximately 2000 words.
-
-     The lighthouse keeper's daughter had been watching the storm for three days. From her bedroom window high in the tower, she could
-     see the sea churn like a massive animal restless in its cage, white-capped waves crashing against rocks that had stood unmoving
-     since before anyone could remember.
-
-     Elara had memorized every grain of that view—the way the lighthouse beam swept across the darkness every thirty seconds, the cry of
-     gulls that grew hoarse from shouting at the wind, the distant shape of the village nestled in the cove below, its windows glowing
-     like earthbound stars. She knew
-
-     ▣  Build · minimax-m2.1-free
-
-  ┃
-  ┃
-  ┃
-  ┃  Build  MiniMax M2.1 OpenCode Zen
-  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-   ⬝⬝⬝⬝⬝⬝⬝⬝  esc interrupt                                                                              tab switch agent  ctrl+p commands
+  ┃                                                                                                                                                             ~/SAPDevelop/agent-of-empires-git-
+  ┃                                                                                                                                                             worktrees/opencode-status_detection-
+  ┃                                                                                                                                                             fixtures:fix/2606-opencode-fixtures-
+  ┃  Sisyphus - Ultraworker · Claude Opus 4.7 HAI Anthropic · max                                                                                               refresh
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   ⬝⬝⬝⬝⬝⬝⬝⬝  esc interrupt                                                                                                       tab agents  ctrl+p commands    • OpenCode 1.17.12+6697cf3

--- a/tests/fixtures/opencode/running/002_mini.txt
+++ b/tests/fixtures/opencode/running/002_mini.txt
@@ -1,0 +1,19 @@
+# FIXTURE: OpenCode - Running State
+# Captured from: 1.17.12+6697cf3
+# Capture date: 2026-07-02
+# Verified against: 1.17.x (last check: 2026-07-02)
+# To add more: scripts/capture-fixtures.sh opencode running <tmux_session> [description]
+#
+# Expected status: Running
+# Key indicators: mini split-footer, "BUILD  ⬝⬝⬝⬝⬝⬝⬝⬝ esc interrupt" in the footer
+
+
+█▀▀█  OpenCode
+█  █  /private/tmp/opencode-fixture-home
+▀▀▀▀
+
+› write me a 2000 word detailed essay about the history of computer science, covering ada lovelace, alan turing, von neumann, dijkstra, knuth and be thorough
+
+
+
+ BUILD  ⬝⬝⬝⬝⬝⬝⬝⬝ esc interrupt                                                                                                                                                               ctrl+p cmd

--- a/tests/fixtures/opencode/waiting_permission/001_bash_command.txt
+++ b/tests/fixtures/opencode/waiting_permission/001_bash_command.txt
@@ -1,45 +1,58 @@
 # FIXTURE: OpenCode - Waiting_permission State
-# Captured from: 1.1.8
-# Capture date: 2026-01-10
+# Captured from: 1.17.12+6697cf3
+# Capture date: 2026-07-02
+# Verified against: 1.17.x (last check: 2026-07-02)
 # To add more: scripts/capture-fixtures.sh opencode waiting_permission <tmux_session> [description]
 #
 # Expected status: Waiting
-# Key indicators: "Permission required" and "Allow once / Allow always / Reject" options
+# Key indicators: "△ Permission required" dialog with "Allow once / Allow always / Reject" options
 
+
+  ┃                                                                                                                                                             Running ls -la /
+  ┃  run 'ls -la /' using the bash tool                                                                                                                         ses_0dca27d24ffeLaK881bo7vmGLP
   ┃
-  ┃  # Write 'hi' to /tmp file                                                                                        12,123  6% ($0.00)
-  ┃
+                                                                                                                                                                Context
+     $ ls -la /                                                                                                                                                 0 tokens
+                                                                                                                                                                0% used
+     ▣  Build · gpt-5.5                                                                                                                                         $0.00 spent
+
+                                                                                                                                                                LSP
+                                                                                                                                                                LSPs are disabled
 
 
-  ┃
-  ┃  # Wrote ../../../../tmp/hi.txt
-  ┃
-  ┃   1 hi
-  ┃
 
-  ┃  Thinking: The write tool was successful. I've written 'hi' to /tmp/hi.txt. The task is complete.
 
-     Done. Wrote "hi" to /tmp/hi.txt.
 
-     ▣  Build · minimax-m2.1-free · 23.8s
 
-  ┃
-  ┃  use the bash tool
-  ┃
 
-  ┃  Thinking: The user wants me to use the bash tool to write 'hi' to a file in /tmp. Let me use echo with bash to accomplish this.
 
-     $ echo 'hi' > /tmp/hi.txt
 
-     ▣  Build · minimax-m2.1-free
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   ┃
   ┃  △ Permission required
+  ┃    # Shell command
   ┃
-  ┃  # Write 'hi' to /tmp/hi.txt using bash
+  ┃  $ ls -la /
   ┃
-  ┃  $ echo 'hi' > /tmp/hi.txt
-  ┃
-  ┃
-  ┃   Allow once   Allow always   Reject                                                                       ⇆ select  enter confirm
-  ┃
+  ┃                                                                                                                                                             /private/tmp/opencode-fixture-home
+  ┃   Allow once   Allow always   Reject                                                                       ctrl+f fullscreen  ⇆ select  enter confirm
+  ┃                                                                                                                                                             • OpenCode 1.17.12+6697cf3

--- a/tests/fixtures/opencode/waiting_permission/002_mini.txt
+++ b/tests/fixtures/opencode/waiting_permission/002_mini.txt
@@ -1,0 +1,33 @@
+# FIXTURE: OpenCode - Waiting_permission State
+# Captured from: 1.17.12+6697cf3
+# Capture date: 2026-07-02
+# Verified against: 1.17.x (last check: 2026-07-02)
+# To add more: scripts/capture-fixtures.sh opencode waiting_permission <tmux_session> [description]
+#
+# Expected status: Waiting
+# Key indicators: mini split-footer, "△ Permission required" dialog with "Allow once / Allow always / Reject" options
+
+
+█▀▀█  OpenCode
+█  █  /private/tmp/opencode-fixture-home
+▀▀▀▀
+
+› run 'ls -la /' using the bash tool
+
+# Running in /
+$ ls -la /
+
+
+
+  △ Permission required
+
+   # Shell command
+
+  $ ls -la /
+
+
+
+
+
+
+   Allow once   Allow always   Reject                                                                                                                             ⇆ select  enter confirm  esc reject


### PR DESCRIPTION
## Description

Closes #2606.

`src/tmux/status_detection.rs::detect_opencode_status` (line 304) was exercised in CI against fixtures captured from opencode 1.1.8 (Jan 2026). Installed opencode is now 1.17.12+6697cf3, 16 minor versions ahead. v1.17.10 introduced the `--mini` split-footer TUI mode that was entirely uncaptured. Detection had not been validated against shipping opencode for five months, so any regression on real opencode passed CI silently.

**What**

- Recapture `tests/fixtures/opencode/{idle,running,waiting_permission}/001_*.txt` against opencode 1.17.12+6697cf3 (full TUI mode, isolated HOME with `permission: "ask"`).
- Add `tests/fixtures/opencode/{idle,running,waiting_permission}/002_mini.txt` covering the new `--mini` split-footer surface (added in v1.17.10).
- Add `# Verified against: 1.17.x (last check: 2026-07-02)` header discipline to every fixture, and teach `scripts/capture-fixtures.sh` to emit it automatically. A small `verified_range()` helper extracts the major.minor prefix from the captured version (`1.17.12+6697cf3` → `1.17.x`) so the field stays honest without a manual step.
- Guard the `get_version` fallback so an absent tool no longer renders an empty `Verified against:` field.
- Backfill the per-fixture `# Key indicators:` line so each fixture states the concrete TUI strings the detector anchors on (e.g. `"esc interrupt" hint and spinner chars in the footer`).

**Why**

- Fixtures were 16 minor versions stale.
- The `--mini` split-footer mode had zero coverage, so any pattern that only appears there (short header, single-line footer with `BUILD` and `ctrl+p cmd`) could not be regression-caught.
- The `Verified against:` field makes future drift visible at a glance in review.

**How tested**

- `cargo test --features serve --lib tmux::status_detection`: 107 passed, 0 failed.
- `cargo test --features serve --test integration status_detection`: 3 passed (each test iterates every `.txt` in its state directory, so all 6 fixtures are exercised).
- `cargo fmt --check` clean, `cargo clippy --features serve --all-targets -- -D warnings` clean, pre-commit hook (cargo-husky) clean.
- One pre-existing lib test failure (`session::instance::tests::update_status_reconciles_running_hook_to_waiting_on_claude_approval_prompt`, refs #1913) reproduces on `main` before this branch is applied. Unrelated to opencode fixtures.
- Manual capture verified: opencode 1.17.12 idle prompt, generating response with `esc interrupt`, and permission dialog (`△ Permission required` + `Allow once / Allow always / Reject`) all detected correctly on both full and `--mini` modes.

`detect_opencode_status` was NOT modified: the existing patterns handle the fresh 1.17.12 output on both surfaces. Existing 1.1.8-compatible patterns remain untouched, preserving backward compatibility for users on older opencode.

**Follow-up**

#436 (open) proposes replacing pane-content detection with hook-based status. This PR is orthogonal short-term hygiene; the wider design in #436 remains the right long-term direction.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (fixture header discipline)
- [x] For UI changes: included screenshot or recording (N/A, fixture text captures)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. It refreshes ground-truth fixtures already consumed by `tests/integration/status_detection.rs`; those existing tests exercise every fixture in each state directory, so the new `--mini` fixtures are covered without new test scaffolding.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7 (Sisyphus, OhMyOpenCode)

**Any Additional AI Details you'd like to share:**

Fixture capture was scripted through tmux with an isolated `HOME` and a project-local `opencode.json` forcing `permission: "ask"` so the default Build agent surfaced the real permission dialog. Detection patterns were left untouched after confirming the fresh captures matched existing match arms.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Refreshed the OpenCode status-detection fixtures to match a current `1.17.12` capture instead of the old `1.1.8` snapshots.

- Updated the existing idle, running, and waiting-permission fixtures with new captures and metadata.
- Added new `--mini` fixtures for the split-footer TUI mode in idle, running, and waiting-permission states.
- Added `Verified against:` header information to fixtures so future drift is easier to spot.
- Improved the fixture capture script so it writes that verification info automatically and falls back safely when version detection is unavailable.
- Added clearer key-indicator lines to the fixture headers.

The detection logic itself was left unchanged.

Benefit: fixture coverage is now current, includes the newer UI mode, and should be easier to keep from drifting again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->