### PR TITLE
fix(tmux): fix poisoned paired-terminal shell and isolate the dev tmux socket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes `debug.log` in app data dir).
 - Running from source needs `tmux` installed.
 - Debug builds use an isolated namespace so they don't collide with an installed release `aoe`: app data dir is `~/.agent-of-empires-dev` (macOS/Windows) or `~/.config/agent-of-empires-dev` (Linux), tmux session prefix is `aoe_dev_`, and `aoe serve` defaults to port `8081`. Release builds keep the original `agent-of-empires` paths, `aoe_` prefix, and port `8080`.
+- Debug builds also run tmux on their own socket (`<app_dir>/tmux.sock`) rather than tmux's shared default, so a `cargo run` / e2e build can never poison an installed release build's tmux server (default-shell, base env); release builds keep the default socket. Set `AOE_TMUX_SOCKET=<path>` to force a specific socket (the e2e harness uses this to isolate each test).
 
 ### Web Dashboard
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,6 +1,5 @@
 //! Process utilities for tmux session management
 
-use std::process::Command;
 use std::time::Duration;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -29,7 +28,7 @@ pub fn get_pane_pid(session_name: &str) -> Option<u32> {
     // pane even when the user has created additional tmux windows or split
     // panes.  See #435, #488.
     let target = format!("{session_name}:^.0");
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["display-message", "-t", &target, "-p", "#{pane_pid}"])
         .output()
         .ok()?;

--- a/src/server/pane.rs
+++ b/src/server/pane.rs
@@ -239,7 +239,7 @@ pub(crate) async fn wait_for_tmux_ready(tmux_name: &str) -> PaneReadiness {
 async fn probe_tmux_readiness(tmux_name: &str) -> PaneReadiness {
     let name = tmux_name.to_string();
     tokio::task::spawn_blocking(move || {
-        let has_session = std::process::Command::new("tmux")
+        let has_session = crate::tmux::tmux_command()
             .args(["has-session", "-t", &name])
             .output();
         let has_session_ok = match has_session {
@@ -249,7 +249,7 @@ async fn probe_tmux_readiness(tmux_name: &str) -> PaneReadiness {
         if !has_session_ok {
             return PaneReadiness::NotReady;
         }
-        let panes = std::process::Command::new("tmux")
+        let panes = crate::tmux::tmux_command()
             .args(["list-panes", "-t", &name, "-F", "#{pane_dead}"])
             .output();
         match panes {

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -811,7 +811,7 @@ pub(crate) fn compose_exclusion_with_stopped_peers(
 /// [`compose_exclusion`] instead, which composes this function with the
 /// per-instance exclusion list.
 fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
-    let output = match std::process::Command::new("tmux")
+    let output = match crate::tmux::tmux_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
     {

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -154,6 +154,29 @@ pub(crate) fn user_shell() -> String {
 /// Shells whose quoting rules are incompatible with POSIX `'\''` escaping.
 const NON_POSIX_SHELLS: &[&str] = &["fish", "nu", "nushell", "pwsh", "powershell"];
 
+/// Shells we can safely launch with a `-l` login flag. Others (nushell,
+/// PowerShell) are launched plain; they still source their own interactive
+/// config, and `-l` would either error or mean something different there.
+const LOGIN_FLAG_SHELLS: &[&str] = &["bash", "zsh", "sh", "ksh", "dash", "fish", "csh", "tcsh"];
+
+/// Build the tmux pane command that launches `shell` as a login+interactive
+/// shell, so it sources the user's profile and rc files (`~/.zprofile`,
+/// `~/.zshrc`, oh-my-zsh, Homebrew/nvm PATH setup) exactly as a native
+/// terminal would. Login-capable shells get `-l`; others launch plain. The
+/// path is shell-escaped for the tmux command parser.
+pub(crate) fn login_shell_command(shell: &str) -> String {
+    let basename = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(shell);
+    let escaped = shell_escape(shell);
+    if LOGIN_FLAG_SHELLS.contains(&basename) {
+        format!("{escaped} -l")
+    } else {
+        escaped
+    }
+}
+
 /// Like [`user_shell`], but falls back to `bash` when the user's shell is
 /// non-POSIX (e.g. fish, nushell, pwsh). Use this for command wrappers that
 /// rely on POSIX single-quote escaping (`'\''`).
@@ -681,6 +704,23 @@ pub(crate) fn build_docker_env_args(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_login_shell_command_adds_login_flag_for_known_shells() {
+        assert_eq!(login_shell_command("/bin/zsh"), "'/bin/zsh' -l");
+        assert_eq!(login_shell_command("/bin/bash"), "'/bin/bash' -l");
+        assert_eq!(
+            login_shell_command("/opt/homebrew/bin/fish"),
+            "'/opt/homebrew/bin/fish' -l"
+        );
+    }
+
+    #[test]
+    fn test_login_shell_command_plain_for_non_login_shells() {
+        // nu / pwsh do not take a POSIX `-l`; launch them plain.
+        assert_eq!(login_shell_command("/usr/bin/nu"), "'/usr/bin/nu'");
+        assert_eq!(login_shell_command("/usr/bin/pwsh"), "'/usr/bin/pwsh'");
+    }
 
     /// Regression test: when an instance is created under a non-default profile and
     /// has no per-session `extra_env` overrides, the docker env args must come from

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -957,7 +957,7 @@ fn override_if_distinct(stored: Option<&str>, fresh: String) -> Option<String> {
 
 fn tmux_env_session_name_for_instance_id(instance_id: &str) -> Option<String> {
     let suffix = format!("_{}", truncate_id(instance_id, 8));
-    let output = std::process::Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
         .ok()?;
@@ -5593,21 +5593,17 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_ensure_pane_ready_alive_pane_is_noop() {
-        if std::process::Command::new("tmux")
-            .arg("-V")
-            .output()
-            .is_err()
-        {
+        if crate::tmux::tmux_command().arg("-V").output().is_err() {
             eprintln!("tmux not available; skipping");
             return;
         }
 
         let mut inst = Instance::new("ensure_alive_test", "/tmp/test");
         let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-        let _ = std::process::Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["kill-session", "-t", &tmux_name])
             .output();
-        let created = std::process::Command::new("tmux")
+        let created = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -5636,7 +5632,7 @@ mod tests {
         assert_eq!(inst.last_start_time, prev_start);
         assert_eq!(inst.status, prev_status);
 
-        let _ = std::process::Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["kill-session", "-t", &tmux_name])
             .output();
     }
@@ -6980,10 +6976,9 @@ mod tests {
 
     mod kill_terminal_if_dead {
         use super::*;
-        use std::process::Command;
 
         fn tmux_available() -> bool {
-            Command::new("tmux")
+            crate::tmux::tmux_command()
                 .arg("-V")
                 .output()
                 .map(|o| o.status.success())
@@ -6995,7 +6990,7 @@ mod tests {
         /// the dead-pane state without going through `start_terminal`, which
         /// would also apply unrelated tmux options.
         fn spawn_remain_on_exit(name: &str, cmd: &str) {
-            let output = Command::new("tmux")
+            let output = crate::tmux::tmux_command()
                 .args([
                     "new-session",
                     "-d",
@@ -7025,7 +7020,7 @@ mod tests {
         }
 
         fn cleanup(name: &str) {
-            let _ = Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", name])
                 .output();
             crate::tmux::refresh_session_cache();
@@ -8748,11 +8743,7 @@ mod tests {
         #[test]
         #[serial]
         fn fallback_marks_resume_failed_and_preserves_sid_when_pane_dies() {
-            if std::process::Command::new("tmux")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("tmux not available; skipping");
                 return;
             }
@@ -8773,7 +8764,7 @@ mod tests {
             let id = inst.id.clone();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -8788,7 +8779,7 @@ mod tests {
 
             let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -8824,11 +8815,7 @@ mod tests {
         #[test]
         #[serial]
         fn fallback_does_not_launch_fresh_when_command_would_live_without_stale_sid() {
-            if std::process::Command::new("tmux")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("tmux not available; skipping");
                 return;
             }
@@ -8860,13 +8847,13 @@ mod tests {
                 .unwrap();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
             let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -8897,11 +8884,7 @@ mod tests {
         #[test]
         #[serial]
         fn auto_resume_on_restart_false_skips_stored_sid_and_launches_fresh() {
-            if std::process::Command::new("tmux")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("tmux not available; skipping");
                 return;
             }
@@ -8940,7 +8923,7 @@ mod tests {
                 .unwrap();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -8950,7 +8933,7 @@ mod tests {
                 ResumeAttemptPolicy::HonorAutoResumeSetting,
             );
 
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -8969,11 +8952,7 @@ mod tests {
         #[test]
         #[serial]
         fn allow_policy_still_attempts_resume_when_auto_resume_on_restart_is_false() {
-            if std::process::Command::new("tmux")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("tmux not available; skipping");
                 return;
             }
@@ -9007,13 +8986,13 @@ mod tests {
                 .unwrap();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
             let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -9034,11 +9013,7 @@ mod tests {
         #[test]
         #[serial]
         fn stale_probe_failed_sid_is_not_retried_on_next_attempt() {
-            if std::process::Command::new("tmux")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("tmux not available; skipping");
                 return;
             }
@@ -9067,7 +9042,7 @@ mod tests {
                 .unwrap();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -9096,7 +9071,7 @@ mod tests {
                 .start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow)
                 .unwrap();
 
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -9121,11 +9096,7 @@ mod tests {
         #[test]
         #[serial]
         fn resume_failed_fires_when_pane_dies_inside_post_shell_grace_window() {
-            if std::process::Command::new("tmux")
-                .arg("-V")
-                .output()
-                .is_err()
-            {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("tmux not available; skipping");
                 return;
             }
@@ -9157,13 +9128,13 @@ mod tests {
                 .unwrap();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
             let outcome = inst.start_with_resume_fallback(None, true, ResumeAttemptPolicy::Allow);
 
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
@@ -9191,7 +9162,6 @@ mod tests {
         use super::super::{publish_session_to_tmux_env, Instance, ResumeIntent};
         use serial_test::serial;
         use std::collections::HashSet;
-        use std::process::Command;
         use tempfile::{tempdir, TempDir};
 
         const VALID_SID: &str = "019342ab-1234-7def-8901-abcdef012345";
@@ -9209,10 +9179,10 @@ mod tests {
             }
 
             fn create_named(name: String) -> Self {
-                let _ = Command::new("tmux")
+                let _ = crate::tmux::tmux_command()
                     .args(["kill-session", "-t", &name])
                     .output();
-                let status = Command::new("tmux")
+                let status = crate::tmux::tmux_command()
                     .args(["new-session", "-d", "-s", &name])
                     .status()
                     .expect("failed to spawn tmux");
@@ -9227,14 +9197,14 @@ mod tests {
 
         impl Drop for TmuxSession {
             fn drop(&mut self) {
-                let _ = Command::new("tmux")
+                let _ = crate::tmux::tmux_command()
                     .args(["kill-session", "-t", &self.0])
                     .output();
             }
         }
 
         fn skip_if_no_tmux() -> bool {
-            if Command::new("tmux").arg("-V").output().is_err() {
+            if crate::tmux::tmux_command().arg("-V").output().is_err() {
                 eprintln!("Skipping: tmux not available");
                 return true;
             }
@@ -9546,14 +9516,14 @@ mod tests {
     struct KillTmuxOnDrop(String);
     impl Drop for KillTmuxOnDrop {
         fn drop(&mut self) {
-            let _ = std::process::Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &self.0])
                 .output();
         }
     }
 
     fn tmux_available() -> bool {
-        std::process::Command::new("tmux")
+        crate::tmux::tmux_command()
             .arg("-V")
             .output()
             .map(|o| o.status.success())
@@ -9601,7 +9571,7 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
         let quoted_pane_file =
             format!("'{}'", pane_file.to_string_lossy().replace('\'', r#"'\''"#));
         let launch = format!("cat {quoted_pane_file}; sleep 300");
-        let created = std::process::Command::new("tmux")
+        let created = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -9644,7 +9614,7 @@ Esc to cancel \u{b7} Tab to amend \u{b7} ctrl+e to explain\n\
         // authoritative read; a fixed sleep is flaky under parallel test load.
         let mut painted = false;
         for _ in 0..50 {
-            let cap = std::process::Command::new("tmux")
+            let cap = crate::tmux::tmux_command()
                 .args(["capture-pane", "-p", "-t", &session_name])
                 .output();
             if let Ok(out) = cap {

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -143,9 +143,7 @@ pub fn is_recovery_candidate(inst: &Instance) -> bool {
 /// Best-effort: `tmux start-server` is idempotent; if tmux is unavailable the
 /// caller will fail downstream with a more specific error.
 pub fn warm_tmux_server() {
-    let _ = std::process::Command::new("tmux")
-        .arg("start-server")
-        .status();
+    let _ = crate::tmux::tmux_command().arg("start-server").status();
 }
 
 /// Maximum number of recovery workers running concurrently. Sized to cover

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -6,7 +6,6 @@
 
 use anyhow::bail;
 use std::collections::HashMap;
-use std::process::Command;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
@@ -31,7 +30,7 @@ static ENV_CACHE: RwLock<EnvCache> = RwLock::new(EnvCache { entries: None });
 ///
 /// Hidden variables (set with `-h`) are not inherited by child processes.
 pub fn set_hidden_env(session_name: &str, key: &str, value: &str) -> anyhow::Result<()> {
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["set-environment", "-h", "-t", session_name, key, value])
         .output()?;
 
@@ -96,7 +95,7 @@ pub fn get_hidden_env(session_name: &str, key: &str) -> Option<String> {
 }
 
 fn fetch_hidden_env(session_name: &str, key: &str) -> Option<String> {
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["show-environment", "-h", "-t", session_name, key])
         .output()
         .ok()?;
@@ -122,7 +121,7 @@ fn fetch_hidden_env(session_name: &str, key: &str) -> Option<String> {
 
 /// Remove a hidden environment variable from a tmux session
 pub fn remove_hidden_env(session_name: &str, key: &str) -> anyhow::Result<()> {
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["set-environment", "-h", "-u", "-t", session_name, key])
         .output()?;
 
@@ -159,7 +158,7 @@ pub fn remove_hidden_env_batch(entries: &[(&str, &str)]) -> anyhow::Result<()> {
     }
 
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    let output = Command::new("tmux").args(&str_args).output();
+    let output = crate::tmux::tmux_command().args(&str_args).output();
 
     match output {
         Ok(out) if out.status.success() => {
@@ -224,7 +223,7 @@ pub fn set_hidden_env_batch(entries: &[(&str, &str, &str)]) -> anyhow::Result<()
     }
 
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    let output = Command::new("tmux").args(&str_args).output();
+    let output = crate::tmux::tmux_command().args(&str_args).output();
 
     match output {
         Ok(out) if out.status.success() => {
@@ -299,7 +298,7 @@ pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, O
     }
 
     let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    let output = Command::new("tmux").args(&str_args).output();
+    let output = crate::tmux::tmux_command().args(&str_args).output();
 
     let fallback = || {
         session_names

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -90,8 +90,10 @@ pub(crate) fn tmux_command() -> Command {
 }
 
 // Debug builds use `aoe_dev_*` prefixes so `cargo run` and an installed
-// release `aoe` can coexist on the same tmux server without seeing each
-// other's sessions.
+// release `aoe` never mistake each other's sessions. Debug builds also run on
+// their own tmux socket (see `tmux_socket_path`), so the two builds no longer
+// share a server at all; the prefix split is kept as defence in depth and to
+// keep dev/release session names visually distinct.
 pub const SESSION_PREFIX: &str = if cfg!(debug_assertions) {
     "aoe_dev_"
 } else {

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -30,9 +30,64 @@ pub mod test_support {
 }
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::process::Command;
-use std::sync::RwLock;
+use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
+
+/// Environment variable that overrides the tmux socket path. Set by the e2e
+/// harness (and available for opt-in isolation) so a spawned `aoe` routes all
+/// tmux calls to a known per-test socket instead of relying on `$TMUX`.
+pub const TMUX_SOCKET_ENV: &str = "AOE_TMUX_SOCKET";
+
+/// Resolve the tmux socket path this build talks to, or `None` to use tmux's
+/// default per-user socket. Cached: the process env does not change at runtime.
+///
+/// - `AOE_TMUX_SOCKET` set -> that path (e2e / opt-in isolation).
+/// - unit tests            -> a shared temp socket, so `cargo test` never
+///   touches the developer's real tmux server.
+/// - debug builds          -> `<app_dir>/tmux.sock`, giving `cargo run` and
+///   e2e their own tmux server so they can never poison an installed release
+///   build's shared server (#2608); the app dir is already namespaced
+///   (`~/.agent-of-empires-dev`).
+/// - release builds        -> `None`: keep tmux's default socket so upgrading
+///   does not orphan the release build's live sessions.
+fn tmux_socket_path() -> Option<PathBuf> {
+    static SOCKET: OnceLock<Option<PathBuf>> = OnceLock::new();
+    SOCKET
+        .get_or_init(|| {
+            if let Some(explicit) = std::env::var_os(TMUX_SOCKET_ENV) {
+                if !explicit.is_empty() {
+                    return Some(PathBuf::from(explicit));
+                }
+            }
+            #[cfg(test)]
+            {
+                return Some(std::env::temp_dir().join("aoe-unit-test-tmux.sock"));
+            }
+            #[cfg(all(not(test), debug_assertions))]
+            {
+                if let Ok(dir) = crate::session::get_app_dir() {
+                    return Some(dir.join("tmux.sock"));
+                }
+            }
+            #[allow(unreachable_code)]
+            None
+        })
+        .clone()
+}
+
+/// A `tmux` [`Command`] preconfigured with this build's socket flag (`-S`)
+/// when one applies. Every tmux invocation in aoe MUST go through this so all
+/// commands hit the same server; a raw `Command::new("tmux")` would fall back
+/// to the default socket and split state across two servers.
+pub(crate) fn tmux_command() -> Command {
+    let mut cmd = Command::new("tmux");
+    if let Some(sock) = tmux_socket_path() {
+        cmd.arg("-S").arg(sock);
+    }
+    cmd
+}
 
 // Debug builds use `aoe_dev_*` prefixes so `cargo run` and an installed
 // release `aoe` can coexist on the same tmux server without seeing each
@@ -85,7 +140,7 @@ const FIELD_SEP: char = '|';
 
 pub fn refresh_session_cache() {
     let start = Instant::now();
-    let output = Command::new("tmux")
+    let output = tmux_command()
         .args(["list-sessions", "-F", "#{session_name}|#{session_activity}"])
         .output();
 
@@ -156,7 +211,7 @@ fn is_aoe_session(name: &str) -> bool {
 /// for a panic button with a handful of sessions; if counts grow, batch the
 /// SIGTERM across all pids, wait once, then SIGKILL survivors.
 pub fn stop_all_sessions() -> anyhow::Result<usize> {
-    let output = Command::new("tmux")
+    let output = tmux_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
         .map_err(|e| anyhow::anyhow!("tmux list-sessions spawn failed: {e}"))?;
@@ -169,9 +224,7 @@ pub fn stop_all_sessions() -> anyhow::Result<usize> {
                 if let Some(pid) = crate::process::get_pane_pid(line) {
                     crate::process::kill_process_tree(pid);
                 }
-                let _ = Command::new("tmux")
-                    .args(["kill-session", "-t", line])
-                    .output();
+                let _ = tmux_command().args(["kill-session", "-t", line]).output();
                 killed += 1;
             }
         }
@@ -194,7 +247,7 @@ pub fn stop_all_sessions() -> anyhow::Result<usize> {
 /// `unwrap_or_default()` because their semantics are unchanged by an empty map.
 pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
     let start = Instant::now();
-    let output = Command::new("tmux")
+    let output = tmux_command()
         .args([
             "list-panes",
             "-a",
@@ -247,7 +300,7 @@ pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
 /// pass" rather than "nothing attached", so a transient tmux glitch cannot
 /// kill a pane the user is sitting in.
 pub fn attached_session_names() -> anyhow::Result<HashSet<String>> {
-    let output = Command::new("tmux")
+    let output = tmux_command()
         .args(["list-sessions", "-F", "#{session_name}|#{session_attached}"])
         .output();
 
@@ -359,7 +412,7 @@ pub fn session_exists_from_cache(name: &str) -> Option<bool> {
 }
 
 pub fn get_current_session_name() -> Option<String> {
-    let output = Command::new("tmux")
+    let output = tmux_command()
         .args(["display-message", "-p", "#{session_name}"])
         .output()
         .ok()?;
@@ -374,7 +427,7 @@ pub fn get_current_session_name() -> Option<String> {
 }
 
 pub fn is_tmux_available() -> bool {
-    Command::new("tmux").arg("-V").output().is_ok()
+    tmux_command().arg("-V").output().is_ok()
 }
 
 /// True when `binary` resolves on the user's PATH. An absolute or relative
@@ -485,6 +538,27 @@ mod tests {
     const P: &str = SESSION_PREFIX;
 
     #[test]
+    fn test_tmux_command_carries_socket_flag() {
+        // Under `cfg(test)` the socket resolves to a shared temp path, so the
+        // command must lead with `-S <path>` before any subcommand. This is
+        // the isolation mechanism (#2608): every tmux call routes through the
+        // same explicit socket instead of the default.
+        let cmd = tmux_command();
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_owned()).collect();
+        assert_eq!(args.first().map(|a| a.to_str().unwrap()), Some("-S"));
+        assert!(args.get(1).is_some(), "socket path arg present");
+        assert_eq!(cmd.get_program().to_str(), Some("tmux"));
+    }
+
+    #[test]
+    fn test_tmux_socket_path_resolves_under_test() {
+        assert!(
+            tmux_socket_path().is_some(),
+            "unit tests must not fall back to the default socket"
+        );
+    }
+
+    #[test]
     fn is_aoe_session_matches_every_kind_and_rejects_foreign() {
         assert!(is_aoe_session(&format!("{P}my_proj_abc12345")));
         assert!(is_aoe_session(&format!("{TERMINAL_PREFIX}x")));
@@ -586,7 +660,7 @@ mod tests {
     }
 
     fn tmux_available() -> bool {
-        Command::new("tmux")
+        tmux_command()
             .arg("-V")
             .output()
             .map(|o| o.status.success())
@@ -612,7 +686,7 @@ mod tests {
         // command string doesn't end up in the server process's argv.
         let dummy_guard = TmuxTestSession::new("aoe_test_compound_dummy");
         let dummy = dummy_guard.name().to_string();
-        let _ = Command::new("tmux")
+        let _ = tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -640,7 +714,7 @@ mod tests {
             marker
         );
 
-        let output = Command::new("tmux")
+        let output = tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -679,7 +753,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1000));
 
         // Capture pane output: should contain the secret value
-        let capture = Command::new("tmux")
+        let capture = tmux_command()
             .args([
                 "capture-pane",
                 "-t",
@@ -698,7 +772,7 @@ mod tests {
         );
 
         // Pane should be dead (exec replaced the shell, printenv exited)
-        let dead_check = Command::new("tmux")
+        let dead_check = tmux_command()
             .args(["display-message", "-t", &session_name, "-p", "#{pane_dead}"])
             .output()
             .expect("pane dead check");
@@ -729,7 +803,7 @@ mod tests {
         // command string doesn't end up in the server process's argv.
         let dummy_guard = TmuxTestSession::new("aoe_test_ps_dummy");
         let dummy = dummy_guard.name().to_string();
-        let _ = Command::new("tmux")
+        let _ = tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -753,7 +827,7 @@ mod tests {
         // replaced by sleep, whose argv is just "sleep 30" (no secret).
         let compound_cmd = format!("export AOE_PS_TEST='{}'; exec sleep 30", secret_value);
 
-        let output = Command::new("tmux")
+        let output = tmux_command()
             .args([
                 "new-session",
                 "-d",

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -67,8 +67,14 @@ fn tmux_socket_path() -> Option<PathBuf> {
             }
             #[cfg(all(not(test), debug_assertions))]
             {
-                if let Ok(dir) = crate::session::get_app_dir() {
-                    return Some(dir.join("tmux.sock"));
+                match crate::session::get_app_dir() {
+                    Ok(dir) => return Some(dir.join("tmux.sock")),
+                    Err(e) => tracing::warn!(
+                        target: "tmux.socket",
+                        error = %e,
+                        "get_app_dir() failed; debug build falling back to tmux's default socket, \
+                         which a dev build can share with (and poison for) release (#2608)"
+                    ),
                 }
             }
             #[allow(unreachable_code)]

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{bail, Result};
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -194,7 +194,7 @@ impl Session {
             return exists;
         }
 
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .args(["has-session", "-t", &self.name])
             .output()
             .map(|o| o.status.success())
@@ -224,7 +224,7 @@ impl Session {
             append_clipboard_passthrough_args(&mut args, &self.name);
         }
 
-        let output = Command::new("tmux").args(&args).output()?;
+        let output = crate::tmux::tmux_command().args(&args).output()?;
 
         // Note: With -d flag, tmux new-session returns 0 even if the shell command fails.
         // Log args at debug level for troubleshooting.
@@ -296,7 +296,7 @@ impl Session {
             args.push(cmd.to_string());
         }
 
-        let output = Command::new("tmux").args(&args).output()?;
+        let output = crate::tmux::tmux_command().args(&args).output()?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -331,7 +331,7 @@ impl Session {
             return Ok(());
         }
 
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["rename-session", "-t", &self.name, new_name])
             .output()?;
 
@@ -349,7 +349,7 @@ impl Session {
         }
 
         if std::env::var("TMUX").is_ok() {
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["switch-client", "-t", &self.name])
                 .status()?;
 
@@ -358,7 +358,7 @@ impl Session {
                 // This handles cases where TMUX env var is inherited but we're
                 // not actually inside a tmux client (e.g., terminal spawned
                 // from within tmux via `open -a Terminal`).
-                let status = Command::new("tmux")
+                let status = crate::tmux::tmux_command()
                     .args(["attach-session", "-t", &self.name])
                     .status()?;
 
@@ -373,7 +373,7 @@ impl Session {
                 }
             }
         } else {
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["attach-session", "-t", &self.name])
                 .status()?;
 
@@ -397,7 +397,7 @@ impl Session {
         info.push(format!("exists={}", self.exists()));
         info.push(format!("pane_dead={}", self.is_pane_dead()));
 
-        if let Ok(output) = Command::new("tmux")
+        if let Ok(output) = crate::tmux::tmux_command()
             .args([
                 "display-message",
                 "-t",
@@ -429,7 +429,7 @@ impl Session {
         // Use `^.0` to target the first window's first pane regardless of
         // base-index or which pane is active.  See #435, #488.
         let target = format!("{}:^.0", self.name);
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "capture-pane",
                 "-t",
@@ -475,7 +475,7 @@ impl Session {
         let start = format!("-{}", lines);
         const HEADER_FMT: &str =
             "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag}";
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "display-message",
                 "-p",
@@ -546,7 +546,7 @@ impl Session {
         // input land in a different pane than the one being captured.
         let target = format!("{}:^.0", self.name);
         for batch in raw_byte_batches(bytes) {
-            let output = Command::new("tmux")
+            let output = crate::tmux::tmux_command()
                 .args(["send-keys", "-t", &target, "-H"])
                 .args(&batch)
                 .output()?;
@@ -664,7 +664,7 @@ impl Session {
         if !self.exists() {
             return;
         }
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["set-option", "-t", &self.name, "window-size", "latest"])
             .output();
     }
@@ -687,7 +687,7 @@ impl Session {
         if cols == 0 || rows == 0 || !self.exists() {
             return;
         }
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args([
                 "resize-window",
                 "-t",
@@ -810,7 +810,7 @@ impl Session {
     }
 
     fn show_user_option(&self, opt: &str) -> Option<String> {
-        let out = Command::new("tmux")
+        let out = crate::tmux::tmux_command()
             .args(["show-options", "-v", "-t", &self.name, opt])
             .output()
             .ok()?;
@@ -826,13 +826,13 @@ impl Session {
     }
 
     fn set_user_option(&self, opt: &str, value: &str) {
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["set-option", "-t", &self.name, opt, value])
             .output();
     }
 
     fn unset_user_option(&self, opt: &str) {
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["set-option", "-u", "-t", &self.name, opt])
             .output();
     }
@@ -860,7 +860,7 @@ impl Session {
         let seq = SEND_COUNTER.fetch_add(1, Ordering::Relaxed);
         let buf_name = format!("aoe-send-{}-{}", std::process::id(), seq);
 
-        let mut child = Command::new("tmux")
+        let mut child = crate::tmux::tmux_command()
             .args(["load-buffer", "-b", &buf_name, "-"])
             .stdin(Stdio::piped())
             .stderr(Stdio::piped())
@@ -873,7 +873,7 @@ impl Session {
             bail!("tmux load-buffer failed (status={:?})", status.code());
         }
 
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["paste-buffer", "-d", "-p", "-b", &buf_name, "-t", target])
             .output()?;
         if !output.status.success() {
@@ -881,7 +881,7 @@ impl Session {
             // paste-buffer's `-d` only deletes on success; on failure the
             // buffer survives, so clean it up explicitly. Ignore errors
             // from the cleanup so the original failure isn't masked.
-            let _ = Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["delete-buffer", "-b", &buf_name])
                 .output();
             bail!("tmux paste-buffer failed: {}", stderr);
@@ -891,7 +891,7 @@ impl Session {
     }
 
     fn tmux_send(target: &str, args: &[&str]) -> Result<()> {
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .arg("send-keys")
             .args(["-t", target])
             .args(args)
@@ -984,7 +984,7 @@ mod tests {
 
     /// Helper: check if tmux is available for tests that need it
     fn tmux_available() -> bool {
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .arg("-V")
             .output()
             .map(|o| o.status.success())
@@ -1133,7 +1133,7 @@ mod tests {
         // A pane that scrolls as fast as tmux can ingest. The trailing
         // `set-option pane-base-index 0` chain mirrors `append_pane_base_index_args`
         // so `^.0` resolves on hosts with `pane-base-index 1` set globally (see #2231).
-        let out = Command::new("tmux")
+        let out = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1181,7 +1181,7 @@ mod tests {
             return;
         }
         let guard = TmuxTestSession::new("aoe_test_owner");
-        let out = Command::new("tmux")
+        let out = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1258,7 +1258,7 @@ mod tests {
         // parallel suite load can't outlive the pane before capturing.
         // Pin `pane-base-index 0` so `^.0` resolves on hosts with
         // `pane-base-index 1` set globally (see #488, #2231).
-        let status = Command::new("tmux")
+        let status = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1324,7 +1324,7 @@ mod tests {
         let guard = TmuxTestSession::new("aoe_test_remain");
         let session_name = guard.name().to_string();
         // Chain set-option -p with new-session to avoid race condition
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1351,7 +1351,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1500));
 
         // Session should still exist (remain-on-exit keeps it)
-        let exists = Command::new("tmux")
+        let exists = crate::tmux::tmux_command()
             .args(["has-session", "-t", &session_name])
             .output()
             .map(|o| o.status.success())
@@ -1359,7 +1359,7 @@ mod tests {
         assert!(exists, "Session should still exist due to remain-on-exit");
 
         // Pane should be dead (process exited)
-        let pane_dead = Command::new("tmux")
+        let pane_dead = crate::tmux::tmux_command()
             .args(["display-message", "-t", &session_name, "-p", "#{pane_dead}"])
             .output()
             .ok()
@@ -1381,7 +1381,7 @@ mod tests {
         let session_name = guard.name().to_string();
 
         // Create a session with a long-running command
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1407,7 +1407,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(200));
 
         // Pane should NOT be dead (sleep is still running)
-        let pane_dead = Command::new("tmux")
+        let pane_dead = crate::tmux::tmux_command()
             .args(["display-message", "-t", &session_name, "-p", "#{pane_dead}"])
             .output()
             .ok()
@@ -1432,7 +1432,7 @@ mod tests {
         let session_name = guard.name().to_string();
 
         // Create session with a long-running command in window 0
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1457,19 +1457,19 @@ mod tests {
 
         // Force base-index 1 and pane-base-index 1 to simulate users who
         // have both set in their tmux.conf.
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["set-option", "-t", &session_name, "base-index", "1"])
             .output()
             .expect("tmux set-option base-index");
         assert!(output.status.success());
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["set-option", "-t", &session_name, "pane-base-index", "1"])
             .output()
             .expect("tmux set-option pane-base-index");
         assert!(output.status.success());
 
         // Create a second window with a command that exits immediately
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-window",
                 "-t",
@@ -1505,7 +1505,7 @@ mod tests {
         let session_name = guard.name().to_string();
 
         // Create session running sleep in the first window
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1524,14 +1524,14 @@ mod tests {
         // Force base-index 1 to simulate users who have set base-index 1 in
         // their tmux.conf. With base-index 1, window 0 does not exist, so any
         // target using :0.0 silently fails.
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["set-option", "-t", &session_name, "base-index", "1"])
             .output()
             .expect("tmux set-option base-index");
         assert!(output.status.success());
 
         // Open a second window running a shell, and make it the active window
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["new-window", "-t", &session_name, "sh"])
             .output()
             .expect("tmux new-window");
@@ -1574,7 +1574,7 @@ mod tests {
         let session_name = guard.name().to_string();
 
         // Create session running sleep (not a shell) in the first window
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1593,14 +1593,14 @@ mod tests {
         // Force base-index 1 to simulate users who have set base-index 1 in
         // their tmux.conf. With base-index 1, window 0 does not exist, so any
         // target using :0.0 silently fails.
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["set-option", "-t", &session_name, "base-index", "1"])
             .output()
             .expect("tmux set-option base-index");
         assert!(output.status.success());
 
         // Open a second window running a shell and make it active
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["new-window", "-t", &session_name, "sh"])
             .output()
             .expect("tmux new-window");
@@ -1633,7 +1633,7 @@ mod tests {
         let session_name = guard.name().to_string();
 
         // Create session with a long-running command (the "agent")
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1657,14 +1657,14 @@ mod tests {
         assert!(output.status.success());
 
         // Split the window -- this creates a new pane running a shell
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["split-window", "-t", &session_name])
             .output()
             .expect("tmux split-window");
         assert!(output.status.success());
 
         // The split pane is now active. Select it explicitly to be sure.
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["select-pane", "-t", &format!("{session_name}:.1")])
             .output()
             .expect("tmux select-pane");
@@ -1699,7 +1699,7 @@ mod tests {
         let session_name = guard.name().to_string();
 
         // Create session with pane-base-index 0 pinned (as aoe does)
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1736,7 +1736,7 @@ mod tests {
         // verify our session-level override keeps pane 0 valid.
 
         // Split the window and make the new pane active
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args(["split-window", "-t", &session_name])
             .output()
             .expect("tmux split-window");
@@ -1861,7 +1861,7 @@ mod tests {
         let guard = TmuxTestSession::new("aoe_test_shell");
         let session_name = guard.name().to_string();
 
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1896,7 +1896,7 @@ mod tests {
         let guard = TmuxTestSession::new("aoe_test_noshell");
         let session_name = guard.name().to_string();
 
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -1940,7 +1940,7 @@ mod tests {
         // pane-base-index 0 to match what aoe does in production;
         // without this, users with `pane-base-index 1` in their
         // tmux.conf cause the `^.0` target to miss.
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -215,7 +215,7 @@ impl Session {
             return Ok(());
         }
 
-        let mut args = build_create_args(&self.name, working_dir, command, size);
+        let mut args = build_create_args(&self.name, working_dir, &[], command, size);
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
@@ -942,6 +942,7 @@ fn raw_byte_batches(bytes: &[u8]) -> Vec<Vec<String>> {
 pub(crate) fn build_create_args(
     session_name: &str,
     working_dir: &str,
+    env: &[(&str, &str)],
     command: Option<&str>,
     size: Option<(u16, u16)>,
 ) -> Vec<String> {
@@ -953,6 +954,14 @@ pub(crate) fn build_create_args(
         "-c".to_string(),
         working_dir.to_string(),
     ];
+
+    // Explicit per-session environment (`-e KEY=VAL`, tmux 3.0+). Set so a
+    // pane never inherits a stale value from the shared tmux server's frozen
+    // base environment. See the host-terminal call site for why this matters.
+    for (key, value) in env {
+        args.push("-e".to_string());
+        args.push(format!("{key}={value}"));
+    }
 
     if let Some((width, height)) = size {
         args.push("-x".to_string());
@@ -1763,7 +1772,7 @@ mod tests {
 
     #[test]
     fn test_build_create_args_without_size() {
-        let args = build_create_args("test_session", "/tmp/work", None, None);
+        let args = build_create_args("test_session", "/tmp/work", &[], None, None);
         assert_eq!(
             args,
             vec!["new-session", "-d", "-s", "test_session", "-c", "/tmp/work"]
@@ -1773,8 +1782,36 @@ mod tests {
     }
 
     #[test]
+    fn test_build_create_args_empty_env_adds_no_e_flag() {
+        // Byte-for-byte unchanged args when no env is supplied: the agent
+        // session and container terminals must not regress.
+        let args = build_create_args("s", "/tmp/work", &[], Some("claude"), None);
+        assert!(!args.contains(&"-e".to_string()));
+        assert_eq!(args.last().unwrap(), "claude");
+    }
+
+    #[test]
+    fn test_build_create_args_env_emits_e_flags_before_command() {
+        let args = build_create_args(
+            "s",
+            "/tmp/work",
+            &[("HOME", "/Users/me"), ("SHELL", "/bin/zsh")],
+            Some("'/bin/zsh' -l"),
+            None,
+        );
+        // Each pair becomes an adjacent `-e KEY=VAL`.
+        let e_idx = args.iter().position(|a| a == "-e").unwrap();
+        assert_eq!(args[e_idx + 1], "HOME=/Users/me");
+        assert_eq!(args[e_idx + 3], "SHELL=/bin/zsh");
+        // Env flags precede the trailing command.
+        assert!(e_idx < args.iter().position(|a| a == "'/bin/zsh' -l").unwrap());
+        // `-c` still precedes the env flags.
+        assert!(args.iter().position(|a| a == "-c").unwrap() < e_idx);
+    }
+
+    #[test]
     fn test_build_create_args_with_size() {
-        let args = build_create_args("test_session", "/tmp/work", None, Some((120, 40)));
+        let args = build_create_args("test_session", "/tmp/work", &[], None, Some((120, 40)));
         assert!(args.contains(&"-x".to_string()));
         assert!(args.contains(&"120".to_string()));
         assert!(args.contains(&"-y".to_string()));
@@ -1789,13 +1826,19 @@ mod tests {
 
     #[test]
     fn test_build_create_args_with_command() {
-        let args = build_create_args("test_session", "/tmp/work", Some("claude"), None);
+        let args = build_create_args("test_session", "/tmp/work", &[], Some("claude"), None);
         assert_eq!(args.last().unwrap(), "claude");
     }
 
     #[test]
     fn test_build_create_args_with_size_and_command() {
-        let args = build_create_args("test_session", "/tmp/work", Some("claude"), Some((80, 24)));
+        let args = build_create_args(
+            "test_session",
+            "/tmp/work",
+            &[],
+            Some("claude"),
+            Some((80, 24)),
+        );
 
         // Size args should be present
         assert!(args.contains(&"-x".to_string()));

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -955,9 +955,11 @@ pub(crate) fn build_create_args(
         working_dir.to_string(),
     ];
 
-    // Explicit per-session environment (`-e KEY=VAL`, tmux 3.0+). Set so a
-    // pane never inherits a stale value from the shared tmux server's frozen
-    // base environment. See the host-terminal call site for why this matters.
+    // Explicit per-session environment (`-e KEY=VAL`). `new-session -e`
+    // requires tmux 3.2+; aoe already assumes newer tmux elsewhere (clipboard
+    // passthrough needs 3.3, the VT channel 3.4), so no extra gate is added.
+    // Set so a pane never inherits a stale value from the shared tmux server's
+    // frozen base environment; see the host-terminal call site for why.
     for (key, value) in env {
         args.push("-e".to_string());
         args.push(format!("{key}={value}"));

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Result;
 use ratatui::style::Color;
-use std::process::Command;
 
 use crate::tui::styles::Theme;
 
@@ -84,7 +83,7 @@ pub fn apply_status_bar(
 /// Set a tmux option for a specific session.
 /// Remove a session-scoped option override so the global value applies.
 fn set_session_option_unset(session_name: &str, option: &str) -> Result<()> {
-    let output = std::process::Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["set-option", "-u", "-t", session_name, option])
         .output()?;
     if !output.status.success() {
@@ -98,7 +97,7 @@ fn set_session_option_unset(session_name: &str, option: &str) -> Result<()> {
 }
 
 fn set_session_option(session_name: &str, option: &str, value: &str) -> Result<()> {
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["set-option", "-t", session_name, option, value])
         .output()?;
 
@@ -230,7 +229,7 @@ pub fn get_status_for_current_session() -> Option<String> {
 
 /// Get a tmux option value for a session.
 fn get_session_option(session_name: &str, option: &str) -> Option<String> {
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["show-options", "-t", session_name, "-v", option])
         .output()
         .ok()?;

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -8,8 +8,9 @@ use anyhow::{bail, Result};
 use std::process::Command;
 
 use super::utils::{
-    append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
-    append_remain_on_exit_args, append_window_size_args, is_pane_dead, sanitize_session_name,
+    append_clipboard_passthrough_args, append_default_shell_args, append_mouse_on_args,
+    append_pane_base_index_args, append_remain_on_exit_args, append_window_size_args, is_pane_dead,
+    sanitize_session_name,
 };
 use super::{
     refresh_session_cache, session_exists_from_cache, CONTAINER_TERMINAL_PREFIX, TERMINAL_PREFIX,
@@ -17,6 +18,7 @@ use super::{
 use crate::cli::truncate_id;
 use crate::process;
 use crate::session::config::should_apply_tmux_clipboard;
+use crate::session::environment::{login_shell_command, user_shell};
 
 /// Classifies a paired terminal: adjusts the tmux session prefix and the
 /// human-readable label used in error messages.
@@ -40,6 +42,35 @@ impl TerminalKind {
             TerminalKind::Container => "container terminal session",
         }
     }
+}
+
+/// Pure computation of the host-terminal `-e` env pairs and the effective
+/// pane command, split out so the #2608 poisoning fix is unit-testable
+/// without spawning tmux. `shell` is `Some` only for host terminals; `home`
+/// and `path` are the resolved (possibly empty) host values, and empty
+/// entries are dropped. When no command is supplied, a host terminal
+/// defaults to the resolved login shell.
+fn host_pane_inputs(
+    shell: Option<&str>,
+    command: Option<&str>,
+    home: &str,
+    path: &str,
+) -> (Vec<(String, String)>, Option<String>) {
+    let Some(shell) = shell else {
+        return (Vec::new(), command.map(str::to_string));
+    };
+    let mut pairs = Vec::new();
+    if !home.is_empty() {
+        pairs.push(("HOME".to_string(), home.to_string()));
+    }
+    if !path.is_empty() {
+        pairs.push(("PATH".to_string(), path.to_string()));
+    }
+    pairs.push(("SHELL".to_string(), shell.to_string()));
+    let cmd = command
+        .map(str::to_string)
+        .or_else(|| Some(login_shell_command(shell)));
+    (pairs, cmd)
 }
 
 /// Shared implementation of the paired-terminal lifecycle. Not exposed; the
@@ -97,11 +128,37 @@ impl PairedTerminal {
             return Ok(());
         }
 
-        let mut args = super::session::build_create_args(&self.name, working_dir, command, size);
+        // Host terminals pin the pane's HOME/SHELL/PATH and launch the user's
+        // login shell explicitly, so they never inherit a stale value from the
+        // shared tmux server's frozen base environment: a dev build started
+        // with a sandboxed HOME/SHELL can win the race to start the shared
+        // server and poison `default-shell` + base env for every session,
+        // including release ones (#2608). Container terminals are excluded;
+        // their HOME/shell belong to the container, not the host.
+        let host_shell = matches!(self.kind, TerminalKind::Host).then(user_shell);
+        let home = std::env::var("HOME").unwrap_or_default();
+        let path = std::env::var("PATH").unwrap_or_default();
+        let (env_pairs, effective_cmd) =
+            host_pane_inputs(host_shell.as_deref(), command, &home, &path);
+        let env_refs: Vec<(&str, &str)> = env_pairs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        let mut args = super::session::build_create_args(
+            &self.name,
+            working_dir,
+            &env_refs,
+            effective_cmd.as_deref(),
+            size,
+        );
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
+        if let Some(shell) = &host_shell {
+            append_default_shell_args(&mut args, &self.name, shell);
+        }
         if should_apply_tmux_clipboard() {
             append_clipboard_passthrough_args(&mut args, &self.name);
         }
@@ -419,6 +476,50 @@ mod tests {
         assert_ne!(host_name, container_name);
         assert!(host_name.starts_with(TERMINAL_PREFIX));
         assert!(container_name.starts_with(CONTAINER_TERMINAL_PREFIX));
+    }
+
+    #[test]
+    fn test_host_pane_inputs_injects_env_and_login_shell() {
+        // Regression for #2608: a host terminal with no explicit command must
+        // pin HOME/PATH/SHELL and launch the user's login shell, so the pane
+        // no longer inherits the poisoned shared-server env / default-shell.
+        let (env, cmd) = host_pane_inputs(Some("/bin/zsh"), None, "/Users/me", "/usr/bin:/bin");
+        assert_eq!(
+            env,
+            vec![
+                ("HOME".to_string(), "/Users/me".to_string()),
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+                ("SHELL".to_string(), "/bin/zsh".to_string()),
+            ]
+        );
+        assert_eq!(cmd.as_deref(), Some("'/bin/zsh' -l"));
+    }
+
+    #[test]
+    fn test_host_pane_inputs_keeps_explicit_command() {
+        let (env, cmd) = host_pane_inputs(Some("/bin/zsh"), Some("htop"), "/Users/me", "/bin");
+        // Env is still pinned, but an explicit command is not overridden.
+        assert!(env.contains(&("SHELL".to_string(), "/bin/zsh".to_string())));
+        assert_eq!(cmd.as_deref(), Some("htop"));
+    }
+
+    #[test]
+    fn test_host_pane_inputs_drops_empty_home_path() {
+        let (env, _) = host_pane_inputs(Some("/bin/bash"), None, "", "");
+        assert_eq!(env, vec![("SHELL".to_string(), "/bin/bash".to_string())]);
+    }
+
+    #[test]
+    fn test_container_pane_inputs_unchanged() {
+        // Container terminals (shell = None) get no host env and keep their
+        // command verbatim; their HOME/shell belong to the container.
+        let (env, cmd) = host_pane_inputs(None, Some("bash -lc enter"), "/Users/me", "/bin");
+        assert!(env.is_empty());
+        assert_eq!(cmd.as_deref(), Some("bash -lc enter"));
+
+        let (env_none, cmd_none) = host_pane_inputs(None, None, "/Users/me", "/bin");
+        assert!(env_none.is_empty());
+        assert!(cmd_none.is_none());
     }
 
     fn tmux_available() -> bool {

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -5,7 +5,6 @@
 //! wrappers that fix the tmux name prefix and the log-message label.
 
 use anyhow::{bail, Result};
-use std::process::Command;
 
 use super::utils::{
     append_clipboard_passthrough_args, append_default_shell_args, append_mouse_on_args,
@@ -107,7 +106,7 @@ impl PairedTerminal {
             return exists;
         }
 
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .args(["has-session", "-t", &self.name])
             .output()
             .map(|o| o.status.success())
@@ -163,7 +162,7 @@ impl PairedTerminal {
             append_clipboard_passthrough_args(&mut args, &self.name);
         }
 
-        let output = Command::new("tmux").args(&args).output()?;
+        let output = crate::tmux::tmux_command().args(&args).output()?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -208,12 +207,12 @@ impl PairedTerminal {
         }
 
         if std::env::var("TMUX").is_ok() {
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["switch-client", "-t", &self.name])
                 .status()?;
 
             if !status.success() {
-                let status = Command::new("tmux")
+                let status = crate::tmux::tmux_command()
                     .args(["attach-session", "-t", &self.name])
                     .status()?;
 
@@ -222,7 +221,7 @@ impl PairedTerminal {
                 }
             }
         } else {
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["attach-session", "-t", &self.name])
                 .status()?;
 
@@ -377,7 +376,7 @@ impl ContainerTerminalSession {
 pub fn kill_all_terminals_for_id(id: &str) {
     let needle = format!("_{}", truncate_id(id, 8));
 
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output();
 
@@ -402,7 +401,7 @@ pub fn kill_all_terminals_for_id(id: &str) {
                 if let Some(pid) = process::get_pane_pid(line) {
                     process::kill_process_tree(pid);
                 }
-                let _ = Command::new("tmux")
+                let _ = crate::tmux::tmux_command()
                     .args(["kill-session", "-t", line])
                     .output();
             }
@@ -523,7 +522,7 @@ mod tests {
     }
 
     fn tmux_available() -> bool {
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .arg("-V")
             .output()
             .map(|o| o.status.success())
@@ -547,7 +546,7 @@ mod tests {
             },
         };
 
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",
@@ -595,7 +594,7 @@ mod tests {
             },
         };
 
-        let output = Command::new("tmux")
+        let output = crate::tmux::tmux_command()
             .args([
                 "new-session",
                 "-d",

--- a/src/tmux/test_helpers.rs
+++ b/src/tmux/test_helpers.rs
@@ -6,7 +6,6 @@
 //! `tmux new-session` themselves (they need their own `-x`/`-y`/command and
 //! occasionally compound argv), so the guard does not create the session.
 
-use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// RAII guard that runs `tmux kill-session -t <name>` on drop. The guard
@@ -37,7 +36,7 @@ impl Drop for TmuxTestSession {
     fn drop(&mut self) {
         // Best-effort, idempotent. Drop must not panic, so the Result is
         // discarded: a missing tmux server or already-dead session is fine.
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["kill-session", "-t", &self.name])
             .output();
     }
@@ -48,7 +47,7 @@ mod tests {
     use super::*;
 
     fn tmux_available() -> bool {
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .arg("-V")
             .output()
             .map(|o| o.status.success())
@@ -66,7 +65,7 @@ mod tests {
         {
             let guard = TmuxTestSession::new("aoe_test_guard_self");
             captured_name = guard.name().to_string();
-            let output = Command::new("tmux")
+            let output = crate::tmux::tmux_command()
                 .args([
                     "new-session",
                     "-d",
@@ -81,7 +80,7 @@ mod tests {
                 .output()
                 .expect("tmux new-session");
             assert!(output.status.success());
-            let exists = Command::new("tmux")
+            let exists = crate::tmux::tmux_command()
                 .args(["has-session", "-t", guard.name()])
                 .output()
                 .expect("tmux has-session")
@@ -89,7 +88,7 @@ mod tests {
                 .success();
             assert!(exists, "session should exist while guard is alive");
         }
-        let exists = Command::new("tmux")
+        let exists = crate::tmux::tmux_command()
             .args(["has-session", "-t", &captured_name])
             .output()
             .expect("tmux has-session")

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -2,7 +2,6 @@
 //! run in persistent tmux sessions tied to an agent session's working directory.
 
 use anyhow::{bail, Result};
-use std::process::Command;
 
 use super::utils::{
     append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
@@ -40,7 +39,7 @@ impl ToolSession {
             return exists;
         }
 
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .args(["has-session", "-t", &self.name])
             .output()
             .map(|o| o.status.success())
@@ -87,7 +86,7 @@ impl ToolSession {
             append_clipboard_passthrough_args(&mut args, &self.name);
         }
 
-        let output = Command::new("tmux").args(&args).output()?;
+        let output = crate::tmux::tmux_command().args(&args).output()?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -123,12 +122,12 @@ impl ToolSession {
         }
 
         if std::env::var("TMUX").is_ok() {
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["switch-client", "-t", &self.name])
                 .status()?;
 
             if !status.success() {
-                let status = Command::new("tmux")
+                let status = crate::tmux::tmux_command()
                     .args(["attach-session", "-t", &self.name])
                     .status()?;
 
@@ -137,7 +136,7 @@ impl ToolSession {
                 }
             }
         } else {
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["attach-session", "-t", &self.name])
                 .status()?;
 
@@ -164,7 +163,7 @@ impl ToolSession {
 pub fn kill_all_tool_sessions_for_id(session_id: &str) {
     let id_suffix = format!("_{}", truncate_id(session_id, 8));
 
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .args(["list-sessions", "-F", "#{session_name}"])
         .output();
 
@@ -176,7 +175,7 @@ pub fn kill_all_tool_sessions_for_id(session_id: &str) {
                     if let Some(pid) = process::get_pane_pid(line) {
                         process::kill_process_tree(pid);
                     }
-                    let _ = Command::new("tmux")
+                    let _ = crate::tmux::tmux_command()
                         .args(["kill-session", "-t", line])
                         .output();
                 }

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -1,7 +1,6 @@
 //! tmux utility functions
 
 use anyhow::{bail, Result};
-use std::process::Command;
 use std::sync::OnceLock;
 
 pub fn strip_ansi(content: &str) -> String {
@@ -207,7 +206,7 @@ pub fn is_pane_dead(session_name: &str) -> bool {
     // agent's pane even when the user has created additional tmux windows
     // or split panes.  See #435, #488.
     let target = format!("{session_name}:^.0");
-    Command::new("tmux")
+    crate::tmux::tmux_command()
         .args(["display-message", "-t", &target, "-p", "#{pane_dead}"])
         .output()
         .ok()
@@ -220,7 +219,7 @@ pub(crate) fn pane_current_command(session_name: &str) -> Option<String> {
     // Use `^.0` to target the first window's first pane regardless of
     // base-index or which pane is active.  See #435, #488.
     let target = format!("{session_name}:^.0");
-    Command::new("tmux")
+    crate::tmux::tmux_command()
         .args([
             "display-message",
             "-t",
@@ -260,7 +259,7 @@ pub fn is_pane_running_shell(session_name: &str) -> bool {
 pub fn tmux_prefix_display() -> &'static str {
     static CACHE: OnceLock<String> = OnceLock::new();
     CACHE.get_or_init(|| {
-        let raw = Command::new("tmux")
+        let raw = crate::tmux::tmux_command()
             .args(["show-option", "-gv", "prefix"])
             .output()
             .ok()
@@ -280,7 +279,7 @@ pub fn tmux_prefix_display() -> &'static str {
 /// `Err`. Caller is responsible for `refresh_session_cache` after a
 /// successful kill.
 pub(crate) fn kill_session_if_present(name: &str) -> Result<()> {
-    let output = Command::new("tmux")
+    let output = crate::tmux::tmux_command()
         .env("LC_ALL", "C")
         .args(["kill-session", "-t", name])
         .output()?;
@@ -536,7 +535,7 @@ mod tests {
     }
 
     fn tmux_available() -> bool {
-        Command::new("tmux")
+        crate::tmux::tmux_command()
             .arg("-V")
             .output()
             .map(|o| o.status.success())
@@ -555,7 +554,7 @@ mod tests {
             return;
         }
         let name = "aoe_test_kill_if_present_missing";
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["kill-session", "-t", name])
             .output();
         assert!(kill_session_if_present(name).is_ok());
@@ -568,17 +567,17 @@ mod tests {
             return;
         }
         let name = "aoe_test_kill_if_present_alive";
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["kill-session", "-t", name])
             .output();
-        let spawn = Command::new("tmux")
+        let spawn = crate::tmux::tmux_command()
             .args(["new-session", "-d", "-s", name])
             .status();
         if !spawn.map(|s| s.success()).unwrap_or(false) {
             return;
         }
         assert!(kill_session_if_present(name).is_ok());
-        let exists = Command::new("tmux")
+        let exists = crate::tmux::tmux_command()
             .args(["has-session", "-t", name])
             .status()
             .map(|s| s.success())

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -108,6 +108,23 @@ pub fn append_pane_base_index_args(args: &mut Vec<String>, target: &str) {
     ]);
 }
 
+/// Append `; set-option -t <target> default-shell <shell>` so panes the user
+/// later splits off this session use their real shell instead of the shared
+/// tmux server's frozen `default-shell` (which a dev build with a sandboxed
+/// env can poison; see #2608). The first pane is launched with an explicit
+/// login-shell command at create time because a `default-shell` set chained
+/// after `new-session` is too late for the already-spawned pane.
+pub fn append_default_shell_args(args: &mut Vec<String>, target: &str, shell: &str) {
+    args.extend([
+        ";".to_string(),
+        "set-option".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        "default-shell".to_string(),
+        shell.to_string(),
+    ]);
+}
+
 /// Append `; set-option -t <target> mouse on` to an in-flight tmux argument
 /// list so that mouse/wheel events are forwarded into tmux copy-mode.
 ///

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -534,6 +534,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_append_default_shell_args() {
+        let mut args: Vec<String> = vec!["new-session".into()];
+        append_default_shell_args(&mut args, "aoe_test", "/bin/zsh");
+        assert_eq!(
+            args,
+            vec![
+                "new-session",
+                ";",
+                "set-option",
+                "-t",
+                "aoe_test",
+                "default-shell",
+                "/bin/zsh",
+            ]
+        );
+    }
+
     fn tmux_available() -> bool {
         crate::tmux::tmux_command()
             .arg("-V")

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, Weak};
 use std::time::{Duration, Instant};
@@ -122,7 +121,7 @@ fn sh_quote(s: &str) -> String {
 }
 
 fn pane_size(target: &str) -> Option<(u16, u16)> {
-    let out = Command::new("tmux")
+    let out = crate::tmux::tmux_command()
         .args([
             "display-message",
             "-p",
@@ -147,7 +146,7 @@ fn pane_size(target: &str) -> Option<(u16, u16)> {
 /// off: `(alternate_on, mouse_tracking, mouse_sgr)`. Used once at arm to seed
 /// the grid's modes, which the rendered-content seed can't carry.
 fn pane_modes(target: &str) -> Option<(bool, bool, bool)> {
-    let out = Command::new("tmux")
+    let out = crate::tmux::tmux_command()
         .args([
             "display-message",
             "-p",
@@ -224,7 +223,7 @@ fn seed_parser(
     if !alt {
         seed_args.extend_from_slice(&["-S", &seed_start]);
     }
-    let Ok(out) = Command::new("tmux").args(&seed_args).output() else {
+    let Ok(out) = crate::tmux::tmux_command().args(&seed_args).output() else {
         return;
     };
     // Trim trailing blank rows: capture-pane pads the body out to the full pane
@@ -263,7 +262,7 @@ fn trim_trailing_blank_rows(raw: &[u8]) -> &[u8] {
 /// the server version doesn't change under a running aoe.
 fn tmux_supports_pipe_pane_io() -> bool {
     static SUPPORTED: LazyLock<bool> = LazyLock::new(|| {
-        let Ok(out) = Command::new("tmux").arg("-V").output() else {
+        let Ok(out) = crate::tmux::tmux_command().arg("-V").output() else {
             return false;
         };
         let v = String::from_utf8_lossy(&out.stdout);
@@ -649,7 +648,7 @@ impl VtChannel {
             sh_quote(&exe.to_string_lossy()),
             sh_quote(&sock_path.to_string_lossy())
         );
-        let armed = Command::new("tmux")
+        let armed = crate::tmux::tmux_command()
             .args(["pipe-pane", "-IO", "-t", &target, &pipe_cmd])
             .output()
             .ok();
@@ -673,7 +672,7 @@ impl VtChannel {
             if Instant::now() >= connect_deadline {
                 tracing::warn!(%target, "vt: forwarder did not connect; falling back to capture");
                 stop.store(true, Ordering::Relaxed);
-                let _ = Command::new("tmux")
+                let _ = crate::tmux::tmux_command()
                     .args(["pipe-pane", "-t", &target])
                     .output();
                 let _ = UnixStream::connect(&sock_path);
@@ -819,7 +818,7 @@ impl Drop for VtChannel {
             }
         }
         self.stop.store(true, Ordering::Relaxed);
-        let _ = Command::new("tmux")
+        let _ = crate::tmux::tmux_command()
             .args(["pipe-pane", "-t", &self.target])
             .output();
         // Unblock a reader still parked in accept().

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -942,7 +942,7 @@ fn dispatch_batch(tmux_name: &str, batch: Vec<WorkerMsg>) {
 /// level fn (rather than a method on the worker) so it stays callable
 /// from the spawned thread without holding a worker reference.
 fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()> {
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
 
     // Fast path (AOE_VT_LIVE): when a *live* input channel is armed for this
     // pane, ALL pane input goes through the socket, never `send-keys`. This is a
@@ -969,7 +969,7 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
     }
 
     let target = format!("{}:^.0", tmux_name);
-    let mut cmd = Command::new("tmux");
+    let mut cmd = crate::tmux::tmux_command();
     cmd.stderr(Stdio::null());
     match action {
         TmuxAction::Literal(s) => {
@@ -1378,8 +1378,8 @@ fn peel_trailing_semicolons(s: &str) -> (&str, usize) {
 /// Used for the head of a payload whose trailing semicolons were peeled
 /// off (see the `Literal` arm of [`dispatch_via_fork`]).
 fn send_literal(target: &str, s: &str) -> anyhow::Result<()> {
-    use std::process::{Command, Stdio};
-    let mut cmd = Command::new("tmux");
+    use std::process::Stdio;
+    let mut cmd = crate::tmux::tmux_command();
     cmd.stderr(Stdio::null());
     cmd.args(["send-keys", "-t", target, "-l", "--", s]);
     let status = cmd

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4850,7 +4850,7 @@ impl HomeView {
         if pane.width == 0 || pane.height == 0 {
             return;
         }
-        let resize_status = std::process::Command::new("tmux")
+        let resize_status = crate::tmux::tmux_command()
             .args([
                 "resize-window",
                 "-t",

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7400,11 +7400,7 @@ fn restart_selected_session_debounces_via_cooldown_map() {
 #[test]
 #[serial]
 fn restart_selected_session_surfaces_resume_failed_after_async_restart() {
-    if std::process::Command::new("tmux")
-        .arg("-V")
-        .output()
-        .is_err()
-    {
+    if crate::tmux::tmux_command().arg("-V").output().is_err() {
         eprintln!("Skipping: tmux not available");
         return;
     }
@@ -7422,7 +7418,7 @@ fn restart_selected_session_surfaces_resume_failed_after_async_restart() {
     inst.agent_session_id = Some(stale_sid.to_string());
     let id = inst.id.clone();
     let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-    let _ = std::process::Command::new("tmux")
+    let _ = crate::tmux::tmux_command()
         .args(["kill-session", "-t", &tmux_name])
         .output();
 
@@ -7456,7 +7452,7 @@ fn restart_selected_session_surfaces_resume_failed_after_async_restart() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
-    let _ = std::process::Command::new("tmux")
+    let _ = crate::tmux::tmux_command()
         .args(["kill-session", "-t", &tmux_name])
         .output();
 
@@ -14463,7 +14459,6 @@ mod apply_session_id_updates {
     use super::*;
     use crate::session::poller::SessionPoller;
     use crate::session::ResumeIntent;
-    use std::process::Command;
     use std::sync::{Arc, Mutex};
 
     const NEW_SID: &str = "019342ab-1111-7aaa-8bbb-cccdddeeefff";
@@ -14480,10 +14475,10 @@ mod apply_session_id_updates {
         }
 
         fn create_named(name: String) -> Self {
-            let _ = Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &name])
                 .output();
-            let status = Command::new("tmux")
+            let status = crate::tmux::tmux_command()
                 .args(["new-session", "-d", "-s", &name])
                 .status()
                 .expect("failed to spawn tmux");
@@ -14498,7 +14493,7 @@ mod apply_session_id_updates {
 
     impl Drop for TmuxSession {
         fn drop(&mut self) {
-            let _ = Command::new("tmux")
+            let _ = crate::tmux::tmux_command()
                 .args(["kill-session", "-t", &self.0])
                 .output();
             crate::tmux::refresh_session_cache();
@@ -14506,7 +14501,7 @@ mod apply_session_id_updates {
     }
 
     fn skip_if_no_tmux() -> bool {
-        if Command::new("tmux").arg("-V").output().is_err() {
+        if crate::tmux::tmux_command().arg("-V").output().is_err() {
             eprintln!("Skipping: tmux not available");
             return true;
         }

--- a/tests/e2e/archive_restore.rs
+++ b/tests/e2e/archive_restore.rs
@@ -14,14 +14,18 @@ fn read_sessions_json(h: &TuiTestHarness) -> serde_json::Value {
 }
 
 /// Best-effort cleanup so failures don't leak into the next `#[serial]` test.
-fn kill_tmux(name: &str) {
+fn kill_tmux(sock: &std::path::Path, name: &str) {
     let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(sock)
         .args(["kill-session", "-t", name])
         .output();
 }
 
-fn tmux_has_session(name: &str) -> bool {
+fn tmux_has_session(sock: &std::path::Path, name: &str) -> bool {
     Command::new("tmux")
+        .arg("-S")
+        .arg(sock)
         .args(["has-session", "-t", name])
         .output()
         .map(|o| o.status.success())
@@ -197,7 +201,10 @@ fn test_cli_archive_kills_agent_and_terminal_tmux_sessions() {
             .session_name()
             .to_string();
 
-    // Pre-create the four tmux kinds so archive can find and kill them.
+    // Pre-create the four tmux kinds so archive can find and kill them. Created
+    // on the harness's tmux socket (`AOE_TMUX_SOCKET`), the same one the CLI
+    // resolves (#2608), so archive's teardown sweeps them.
+    let sock = h.home_path().join("tmux.sock");
     let names = [
         &agent_tmux_name,
         &terminal_tmux_name,
@@ -206,6 +213,8 @@ fn test_cli_archive_kills_agent_and_terminal_tmux_sessions() {
     ];
     for name in names {
         let create = Command::new("tmux")
+            .arg("-S")
+            .arg(&sock)
             .args([
                 "new-session",
                 "-d",
@@ -235,13 +244,16 @@ fn test_cli_archive_kills_agent_and_terminal_tmux_sessions() {
         String::from_utf8_lossy(&archive_output.stderr)
     );
 
-    let alive: Vec<(&&String, bool)> = names.iter().map(|n| (n, tmux_has_session(n))).collect();
+    let alive: Vec<(&&String, bool)> = names
+        .iter()
+        .map(|n| (n, tmux_has_session(&sock, n)))
+        .collect();
 
     // Cleanup BEFORE asserting so a single failure cannot leak survivors
     // into the next serial test.
     for (name, is_alive) in &alive {
         if *is_alive {
-            kill_tmux(name);
+            kill_tmux(&sock, name);
         }
     }
 
@@ -294,6 +306,7 @@ fn test_cli_archive_no_kill_preserves_all_tmux_sessions() {
             .session_name()
             .to_string();
 
+    let sock = h.home_path().join("tmux.sock");
     let names = [
         &agent_tmux_name,
         &terminal_tmux_name,
@@ -302,6 +315,8 @@ fn test_cli_archive_no_kill_preserves_all_tmux_sessions() {
     ];
     for name in names {
         let create = Command::new("tmux")
+            .arg("-S")
+            .arg(&sock)
             .args([
                 "new-session",
                 "-d",
@@ -331,12 +346,15 @@ fn test_cli_archive_no_kill_preserves_all_tmux_sessions() {
         String::from_utf8_lossy(&archive_output.stderr)
     );
 
-    let alive: Vec<(&&String, bool)> = names.iter().map(|n| (n, tmux_has_session(n))).collect();
+    let alive: Vec<(&&String, bool)> = names
+        .iter()
+        .map(|n| (n, tmux_has_session(&sock, n)))
+        .collect();
 
     // Cleanup explicitly: --no-kill leaves the survivors so they would
     // pollute the next serial test.
     for name in &names {
-        kill_tmux(name);
+        kill_tmux(&sock, name);
     }
 
     for (name, is_alive) in &alive {

--- a/tests/e2e/archive_structured.rs
+++ b/tests/e2e/archive_structured.rs
@@ -119,30 +119,36 @@ fn wait_for_worker_gone(h: &TuiTestHarness, session_id: &str, timeout: Duration)
     }
 }
 
-fn tmux_has_session(name: &str) -> bool {
+fn tmux_has_session(sock: &std::path::Path, name: &str) -> bool {
     Command::new("tmux")
+        .arg("-S")
+        .arg(sock)
         .args(["has-session", "-t", name])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
-fn kill_tmux(name: &str) {
+fn kill_tmux(sock: &std::path::Path, name: &str) {
     let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(sock)
         .args(["kill-session", "-t", name])
         .output();
 }
 
 /// Pre-create a tool sub-session whose name matches what
 /// `kill_ancillary_tmux_sessions()` sweeps for `session_id` (by `_<id8>`
-/// suffix). Created on the default tmux server, the same one the daemon's
-/// teardown uses (it inherits the test process env). Mirrors the precedent in
-/// `archive_restore.rs`.
-fn create_tool_session(session_id: &str, title: &str) -> String {
+/// suffix). Created on the harness's tmux socket (`AOE_TMUX_SOCKET`), the same
+/// one the daemon resolves (#2608), so the daemon's teardown sweeps it.
+/// Mirrors the precedent in `archive_restore.rs`.
+fn create_tool_session(sock: &std::path::Path, session_id: &str, title: &str) -> String {
     let name = agent_of_empires::tmux::ToolSession::new(session_id, title, "tooltest")
         .session_name()
         .to_string();
     let create = Command::new("tmux")
+        .arg("-S")
+        .arg(sock)
         .args([
             "new-session",
             "-d",
@@ -279,7 +285,7 @@ fn setup(h: &mut TuiTestHarness, title: &str) -> (u16, String, String) {
     prompt_until_accepted(h, &session_id, Duration::from_secs(30));
     // Worker is live and registered. Pre-create the tool sub-session now so
     // archive's `kill_ancillary_tmux_sessions()` has something to find.
-    let tool_name = create_tool_session(&session_id, title);
+    let tool_name = create_tool_session(&h.home_path().join("tmux.sock"), &session_id, title);
 
     (port, session_id, tool_name)
 }
@@ -295,9 +301,10 @@ fn archive_kills_worker_and_tool_session() {
     let mut h = TuiTestHarness::new_in_tmp("archive_structured_kill");
     let title = "ArchiveStructKill";
     let (port, session_id, tool_name) = setup(&mut h, title);
+    let sock = h.home_path().join("tmux.sock");
 
     assert!(
-        tmux_has_session(&tool_name),
+        tmux_has_session(&sock, &tool_name),
         "precondition: tool session {tool_name} should exist before archive"
     );
 
@@ -305,10 +312,10 @@ fn archive_kills_worker_and_tool_session() {
 
     wait_for_worker_gone(&h, &session_id, Duration::from_secs(10));
 
-    let tool_alive = tmux_has_session(&tool_name);
+    let tool_alive = tmux_has_session(&sock, &tool_name);
     // Clean up before asserting so a failure can't leak into the next test.
     if tool_alive {
-        kill_tmux(&tool_name);
+        kill_tmux(&sock, &tool_name);
     }
     assert!(
         !tool_alive,
@@ -333,9 +340,10 @@ fn archive_no_kill_shuts_worker_but_keeps_tool_session() {
     let mut h = TuiTestHarness::new_in_tmp("archive_structured_nokill");
     let title = "ArchiveStructNoKill";
     let (port, session_id, tool_name) = setup(&mut h, title);
+    let sock = h.home_path().join("tmux.sock");
 
     assert!(
-        tmux_has_session(&tool_name),
+        tmux_has_session(&sock, &tool_name),
         "precondition: tool session {tool_name} should exist before archive"
     );
 
@@ -344,9 +352,9 @@ fn archive_no_kill_shuts_worker_but_keeps_tool_session() {
     // Worker shutdown is unconditional, so it must be gone even with kill_pane=false.
     wait_for_worker_gone(&h, &session_id, Duration::from_secs(10));
 
-    let tool_alive = tmux_has_session(&tool_name);
+    let tool_alive = tmux_has_session(&sock, &tool_name);
     // The survivor would pollute the next serial test; kill it before asserting.
-    kill_tmux(&tool_name);
+    kill_tmux(&sock, &tool_name);
     assert!(
         tool_alive,
         "tool sub-session {tool_name} must survive archive with kill_pane=false"

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -983,6 +983,7 @@ fn test_cli_rename_preserves_tmux_session() {
     require_tmux!();
 
     let h = TuiTestHarness::new("cli_rename_tmux");
+    let sock = h.home_path().join("tmux.sock");
     let project = h.project_path();
 
     // 1. Add a session
@@ -1007,6 +1008,8 @@ fn test_cli_rename_preserves_tmux_session() {
 
     // Create a real tmux session with that name (simulates a running session)
     let create = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args([
             "new-session",
             "-d",
@@ -1037,6 +1040,8 @@ fn test_cli_rename_preserves_tmux_session() {
 
     // 5. The old tmux session name should be gone
     let old_exists = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args(["has-session", "-t", &old_tmux_name])
         .output()
         .map(|o| o.status.success())
@@ -1054,6 +1059,8 @@ fn test_cli_rename_preserves_tmux_session() {
         truncated_id
     );
     let new_exists = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args(["has-session", "-t", &new_tmux_name])
         .output()
         .map(|o| o.status.success())
@@ -1066,6 +1073,8 @@ fn test_cli_rename_preserves_tmux_session() {
 
     // Cleanup
     let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args(["kill-session", "-t", &new_tmux_name])
         .output();
 }
@@ -1079,6 +1088,7 @@ fn test_cli_rm_kills_agent_tmux_session() {
     require_tmux!();
 
     let h = TuiTestHarness::new("cli_rm_tmux");
+    let sock = h.home_path().join("tmux.sock");
     let project = h.project_path();
 
     let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "RmTarget"]);
@@ -1099,6 +1109,8 @@ fn test_cli_rm_kills_agent_tmux_session() {
     );
 
     let create = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args([
             "new-session",
             "-d",
@@ -1127,6 +1139,8 @@ fn test_cli_rm_kills_agent_tmux_session() {
     );
 
     let still_alive = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args(["has-session", "-t", &tmux_name])
         .output()
         .map(|o| o.status.success())
@@ -1139,6 +1153,8 @@ fn test_cli_rm_kills_agent_tmux_session() {
 
     // Cleanup
     let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(&sock)
         .args(["kill-session", "-t", &tmux_name])
         .output();
 }

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -285,6 +285,8 @@ last_seen_version = "{}"
             eprintln!("RECORD_E2E is set but asciinema is not installed -- recording disabled");
         }
 
+        let tmux_socket_env = socket_path.display().to_string();
+
         Self {
             session_name,
             test_name: test_name.to_string(),
@@ -296,7 +298,12 @@ last_seen_version = "{}"
             spawned: false,
             recording,
             cast_path: None,
-            extra_env: Vec::new(),
+            // Pin the spawned aoe to the same tmux socket the harness drives
+            // and inspects. aoe now routes every tmux call through an explicit
+            // `-S <socket>` (#2608) instead of inheriting `$TMUX`, so without
+            // this it would land on its own app-dir socket and the harness
+            // would see none of its sessions.
+            extra_env: vec![("AOE_TMUX_SOCKET".to_string(), tmux_socket_env)],
             extra_path_dirs: Vec::new(),
             stop_daemon_on_drop: false,
             acp_fork_fail: false,

--- a/tests/e2e/kiro_launch.rs
+++ b/tests/e2e/kiro_launch.rs
@@ -28,14 +28,19 @@ use serial_test::serial;
 use std::process::Command;
 
 /// Kills its tmux session when dropped, so a panicking assertion in the test
-/// body still tears the real session down (the default tmux server is shared
-/// across runs, so a leak would accumulate stale sessions).
-struct TmuxSessionGuard(String);
+/// body still tears the real session down. Holds the socket aoe used
+/// (`AOE_TMUX_SOCKET`, #2608) so the kill targets the right server.
+struct TmuxSessionGuard {
+    socket: std::path::PathBuf,
+    name: String,
+}
 
 impl Drop for TmuxSessionGuard {
     fn drop(&mut self) {
         let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &self.0])
+            .arg("-S")
+            .arg(&self.socket)
+            .args(["kill-session", "-t", &self.name])
             .output();
     }
 }
@@ -70,8 +75,10 @@ fn launched_tmux_name(h: &TuiTestHarness, title: &str) -> String {
 
 /// The command tmux was told to run for the session's pane. This is the launch
 /// command aoe built, captured before (and independent of) execution.
-fn pane_start_command(session: &str) -> String {
+fn pane_start_command(sock: &std::path::Path, session: &str) -> String {
     let out = Command::new("tmux")
+        .arg("-S")
+        .arg(sock)
         .args(["list-panes", "-t", session, "-F", "#{pane_start_command}"])
         .output()
         .expect("tmux list-panes");
@@ -117,8 +124,12 @@ fn launch_kiro_and_read_command(
     let _ = h.run_cli(&args);
 
     let session = launched_tmux_name(h, title);
-    let guard = TmuxSessionGuard(session.clone());
-    let cmd = pane_start_command(&session);
+    let socket = h.home_path().join("tmux.sock");
+    let cmd = pane_start_command(&socket, &session);
+    let guard = TmuxSessionGuard {
+        socket,
+        name: session,
+    };
     (cmd, guard)
 }
 

--- a/tests/e2e/tool_sessions.rs
+++ b/tests/e2e/tool_sessions.rs
@@ -248,17 +248,16 @@ hotkey = "Alt+t"
 
     // Remove the agent session. `perform_deletion` invokes
     // `kill_all_tool_sessions_for_id`, which runs `tmux list-sessions` /
-    // `kill-session` against the tmux socket that the calling process
-    // sees. To exercise the sweep on the harness's per-test socket we
-    // point `TMUX` at it so the subprocess routes its tmux commands
-    // there instead of the system default.
-    let tmux_env = format!("{},0,0", harness_sock.display());
+    // `kill-session` against the tmux socket aoe resolves. aoe now routes
+    // every tmux call through an explicit `-S <socket>` (#2608), so point
+    // `AOE_TMUX_SOCKET` at the harness's per-test socket to exercise the
+    // sweep there instead of aoe's own app-dir socket.
     let aoe_binary = env!("CARGO_BIN_EXE_aoe");
     let remove = Command::new(aoe_binary)
         .args(["remove", &session_id, "--force"])
         .env("HOME", h.home_path())
         .env("XDG_CONFIG_HOME", h.home_path().join(".config"))
-        .env("TMUX", tmux_env)
+        .env("AOE_TMUX_SOCKET", &harness_sock)
         .env_remove("AGENT_OF_EMPIRES_DEBUG")
         .env_remove("AOE_LOG_LEVEL")
         .output()

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -3,8 +3,23 @@
 //! Declared once from `tests/integration/main.rs`; consumers import via
 //! `use crate::common::...`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+/// Stable per-process tmux socket for integration tests. aoe now resolves an
+/// explicit `-S <socket>` (#2608) and caches it once per process, so tests
+/// must (a) point aoe at a hermetic socket via `AOE_TMUX_SOCKET` and (b) make
+/// their own raw `tmux` calls target the same socket. The path is stable (not
+/// per-test-home) precisely because the lib caches it once; a per-home path
+/// would be dropped out from under a later test. Referencing it also sets
+/// `AOE_TMUX_SOCKET`, so any raw-tmux call site locks the lib onto the same
+/// socket before its first lib tmux call. `#[serial]` tests keep the env write
+/// single-threaded.
+pub fn tmux_socket() -> PathBuf {
+    let path = std::env::temp_dir().join("aoe-integration-tmux.sock");
+    std::env::set_var("AOE_TMUX_SOCKET", &path);
+    path
+}
 
 /// Path to the Node ACP test shim used by acp_* integration tests.
 ///
@@ -63,6 +78,9 @@ pub fn setup_temp_home() -> TempDir {
 /// Variant for tests that already own a `TempDir` (e.g. ones that also seed
 /// files under the same path before returning the guard).
 pub fn set_temp_home(path: &Path) {
+    // Establish the hermetic tmux socket before any lib tmux call so aoe's
+    // once-cached socket resolution locks onto it (#2608).
+    let _ = tmux_socket();
     std::env::set_var("HOME", path);
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     std::env::set_var("XDG_CONFIG_HOME", path.join(".config"));

--- a/tests/integration/parallel_capture.rs
+++ b/tests/integration/parallel_capture.rs
@@ -22,6 +22,8 @@ impl Drop for TmuxCleanup {
     fn drop(&mut self) {
         for name in &self.session_names {
             let _ = Command::new("tmux")
+                .arg("-S")
+                .arg(crate::common::tmux_socket())
                 .args(["kill-session", "-t", name])
                 .output();
         }
@@ -37,6 +39,8 @@ impl Drop for TmuxCleanup {
 /// sessions owned by other instances.
 fn build_exclusion_set_for_test(current_instance_id: &str) -> HashSet<String> {
     let output = match Command::new("tmux")
+        .arg("-S")
+        .arg(crate::common::tmux_socket())
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()
     {
@@ -85,12 +89,16 @@ fn skip_if_no_tmux() -> bool {
 fn create_test_sessions(session_names: &[String], instance_ids: &[String]) {
     for name in session_names {
         let _ = Command::new("tmux")
+            .arg("-S")
+            .arg(crate::common::tmux_socket())
             .args(["kill-session", "-t", name])
             .output();
     }
 
     for (name, instance_id) in session_names.iter().zip(instance_ids.iter()) {
         let status = Command::new("tmux")
+            .arg("-S")
+            .arg(crate::common::tmux_socket())
             .args(["new-session", "-d", "-s", name])
             .status()
             .expect("Failed to create tmux session");
@@ -249,6 +257,8 @@ fn test_cleanup_after_drop() {
     let session_name = "aoe_test_parallel_cleanup";
 
     let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(crate::common::tmux_socket())
         .args(["kill-session", "-t", session_name])
         .output();
 
@@ -258,12 +268,16 @@ fn test_cleanup_after_drop() {
         };
 
         let status = Command::new("tmux")
+            .arg("-S")
+            .arg(crate::common::tmux_socket())
             .args(["new-session", "-d", "-s", session_name])
             .status()
             .expect("Failed to create tmux session");
         assert!(status.success());
 
         let check = Command::new("tmux")
+            .arg("-S")
+            .arg(crate::common::tmux_socket())
             .args(["has-session", "-t", session_name])
             .status()
             .expect("Failed to check session");
@@ -271,6 +285,8 @@ fn test_cleanup_after_drop() {
     }
 
     let check = Command::new("tmux")
+        .arg("-S")
+        .arg(crate::common::tmux_socket())
         .args(["has-session", "-t", session_name])
         .status()
         .expect("Failed to check session");

--- a/tests/integration/session_id_acquisition.rs
+++ b/tests/integration/session_id_acquisition.rs
@@ -6,7 +6,7 @@ use agent_of_empires::tmux;
 use serial_test::serial;
 use std::process::Command;
 
-use crate::common::setup_temp_home;
+use crate::common::{setup_temp_home, tmux_socket};
 
 const VALID_CLAUDE_UUID: &str = "019342ab-1234-7def-8901-abcdef012345";
 
@@ -15,6 +15,8 @@ struct TmuxCleanup<'a>(&'a str);
 impl Drop for TmuxCleanup<'_> {
     fn drop(&mut self) {
         let _ = Command::new("tmux")
+            .arg("-S")
+            .arg(tmux_socket())
             .args(["kill-session", "-t", self.0])
             .output();
     }
@@ -44,6 +46,8 @@ fn start_with_size_opts_returns_skipped_when_pane_preexists() {
     let session_name = tmux::Session::generate_name(&inst.id, &inst.title);
 
     let status = Command::new("tmux")
+        .arg("-S")
+        .arg(tmux_socket())
         .args(["new-session", "-d", "-s", &session_name])
         .status()
         .expect("tmux new-session");

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -144,6 +144,12 @@ export interface ServeHandle {
    * with the session title rather than hard-coding `aoe_`.
    */
   tmuxPrefix: "aoe_" | "aoe_dev_";
+  /**
+   * The tmux socket the running binary uses (`AOE_TMUX_SOCKET`). Specs that
+   * inspect sessions with a raw `tmux` call MUST pass `-S <this>`; debug
+   * builds ignore `TMUX_TMPDIR` and route tmux through this socket (#2608).
+   */
+  tmuxSocket: string;
   stop(): Promise<void>;
   /**
    * Kill the running `aoe serve` proc and respawn it with the same args
@@ -237,6 +243,16 @@ export function resolveAoeBinary(): string {
  */
 export function tmuxPrefixFor(binaryPath: string): "aoe_" | "aoe_dev_" {
   return binaryPath.includes("/target/debug/") ? "aoe_dev_" : "aoe_";
+}
+
+/**
+ * The tmux socket path the harness pins via `AOE_TMUX_SOCKET`, under the
+ * test's isolated tmux tmpdir. The daemon and every spec that shells out to a
+ * raw `tmux` must agree on this: debug builds ignore `TMUX_TMPDIR` and route
+ * tmux through an explicit `-S <socket>` (#2608).
+ */
+export function tmuxSocketPath(home: string): string {
+  return join(home, "tmux", "aoe.sock");
 }
 
 /**
@@ -535,6 +551,12 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     // covered by the Vitest + RTL contract tests, not the live suite. A future
     // live spec that exercises the modal can unset this in its own env.
     DO_NOT_TRACK: process.env.DO_NOT_TRACK ?? "1",
+    // Pin the tmux socket explicitly. Debug builds otherwise route tmux
+    // through `<app_dir>/tmux.sock` and ignore TMUX_TMPDIR (#2608), so specs
+    // that inspect sessions with a raw `tmux` call must target this same
+    // socket (see `tmuxSocketPath`) rather than the default one under
+    // TMUX_TMPDIR.
+    AOE_TMUX_SOCKET: tmuxSocketPath(home),
   };
 
   if (authMode === "token") {
@@ -687,6 +709,7 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     authToken,
     tokenFile,
     tmuxPrefix: tmuxPrefixFor(aoeBinary),
+    tmuxSocket: tmuxSocketPath(home),
     async restart() {
       if (proc) await killProc(proc);
       const next = await spawnOnce(buildArgs(port), baseUrl);
@@ -722,7 +745,9 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
         // processes around that hold open file descriptors and trip
         // ENOTEMPTY on rmSync if not cleaned up first.
         try {
-          spawnSync("tmux", ["kill-server"], {
+          // aoe binds its own `-S <socket>` (#2608), not the default socket
+          // under TMUX_TMPDIR, so kill the server on that explicit socket.
+          spawnSync("tmux", ["-S", tmuxSocketPath(home), "kill-server"], {
             env: {
               ...process.env,
               HOME: home,

--- a/web/tests/live/ensure-session-restart.spec.ts
+++ b/web/tests/live/ensure-session-restart.spec.ts
@@ -12,14 +12,10 @@ import { join } from "node:path";
 import { test as base, expect } from "@playwright/test";
 import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
 
-function tmuxHasSession(home: string, name: string): boolean {
-  const res = spawnSync("tmux", ["has-session", "-t", name], {
-    env: {
-      ...process.env,
-      HOME: home,
-      TMUX_TMPDIR: join(home, "tmux"),
-    },
-  });
+// aoe (debug build) routes tmux through an explicit `-S <socket>` and ignores
+// TMUX_TMPDIR (#2608), so inspect sessions on the harness's pinned socket.
+function tmuxHasSession(socket: string, name: string): boolean {
+  const res = spawnSync("tmux", ["-S", socket, "has-session", "-t", name]);
   return res.status === 0;
 }
 
@@ -48,12 +44,12 @@ base.describe("ensure_session restart flow", () => {
           timeout: 10_000,
         })
         .toBe("Error");
-      expect(tmuxHasSession(serve.home, tmuxName)).toBe(false);
+      expect(tmuxHasSession(serve.tmuxSocket, tmuxName)).toBe(false);
 
       const r1 = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/ensure`, { method: "POST" });
       expect(r1.ok).toBeTruthy();
       expect((await r1.json()).status).toBe("restarted");
-      expect(tmuxHasSession(serve.home, tmuxName)).toBe(true);
+      expect(tmuxHasSession(serve.tmuxSocket, tmuxName)).toBe(true);
 
       const euid = process.getuid?.() ?? 0;
       const hookBase = `/tmp/aoe-hooks-${euid}`;
@@ -79,13 +75,7 @@ base.describe("ensure_session restart flow", () => {
       const r3 = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/ensure`, { method: "POST" });
       expect((await r3.json()).status).toBe("alive");
 
-      const kill = spawnSync("tmux", ["kill-session", "-t", tmuxName], {
-        env: {
-          ...process.env,
-          HOME: serve.home,
-          TMUX_TMPDIR: join(serve.home, "tmux"),
-        },
-      });
+      const kill = spawnSync("tmux", ["-S", serve.tmuxSocket, "kill-session", "-t", tmuxName]);
       expect(kill.status).toBe(0);
 
       const r4 = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/ensure`, { method: "POST" });
@@ -116,13 +106,7 @@ base.describe("ensure_session restart flow", () => {
       const sessionId: string = sessions[0]!.id;
       const tmuxName = `${serve.tmuxPrefix}${title}_${sessionId.slice(0, 8)}`;
 
-      spawnSync("tmux", ["kill-session", "-t", tmuxName], {
-        env: {
-          ...process.env,
-          HOME: serve.home,
-          TMUX_TMPDIR: join(serve.home, "tmux"),
-        },
-      });
+      spawnSync("tmux", ["-S", serve.tmuxSocket, "kill-session", "-t", tmuxName]);
 
       // Delay /ensure so Playwright reliably observes the "pending"
       // placeholder. Without this the live backend can resolve the

--- a/web/tests/live/triage-archive.spec.ts
+++ b/web/tests/live/triage-archive.spec.ts
@@ -56,7 +56,10 @@ base.describe("sidebar archive via context menu (#1581)", () => {
       await expect
         .poll(
           () => {
-            const result = spawnSync("tmux", ["ls"], {
+            // aoe routes tmux through an explicit `-S <socket>` (#2608), so
+            // list that socket rather than the default one under TMUX_TMPDIR;
+            // otherwise this lists an empty socket and passes trivially.
+            const result = spawnSync("tmux", ["-S", serve.tmuxSocket, "ls"], {
               env: serve.env,
               encoding: "utf8",
             });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes #2608, where a session's paired terminal (host shell tab) suddenly spawned raw `/bin/bash` with `$HOME` pointing at a temp dir instead of the user's `/bin/zsh` with the real `$HOME`, so `~/.zshrc` and oh-my-zsh never loaded. Root cause: aoe shares one tmux server across dev (`aoe_dev_*`) and release (`aoe_*`) builds, isolating only session names, not env. The server's `default-shell` and base env are process-global and frozen by whoever starts the server first, so a dev `cargo run` build launched with a sandboxed `HOME`/`SHELL` poisoned the server for release sessions too.

Two changes, matching the issue's proposals A and B (B in the safer asymmetric form):

**A. Pin the host terminal's env and shell on create.** Host paired terminals now pass `-e HOME`, `-e SHELL`, and `-e PATH` (resolved from the daemon's own correct env) to `tmux new-session`, launch the user's shell as a login shell so `~/.zprofile`/`~/.zshrc` load exactly as a native terminal would, and set the session `default-shell` so panes the user later splits also get the right shell. Agent sessions and container terminals are byte-for-byte unchanged. This makes the paired terminal correct regardless of which build froze the server.

**B. Give the debug build its own tmux socket.** All tmux invocations now route through a single `tmux_command()` helper that adds `-S <socket>`. Debug builds use `<app_dir>/tmux.sock` (namespaced, `~/.agent-of-empires-dev`), so a `cargo run` / e2e build can never poison an installed release build's server again. Release builds keep tmux's default socket, so upgrading does not orphan their live sessions. An `AOE_TMUX_SOCKET` env var overrides the socket (used by the test harnesses for hermetic isolation).

Closes #2608

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Start an installed release `aoe serve`, open a session's host terminal tab in the web dashboard, run `echo $SHELL; echo $HOME` and confirm they are your real shell and home (not `/bin/bash` and a temp dir), and that your prompt theme / oh-my-zsh loaded.
- [ ] With a release daemon already running, start a dev build (`cargo run`) that spawns a session, then open a release session's host terminal and confirm it is still your login shell (the dev build no longer shares the release tmux server).
- [ ] In a host terminal tab, split the pane (tmux prefix + `%` or `c`) and confirm the new pane also runs your login shell, not raw bash.
- [ ] Run `tmux -S ~/.agent-of-empires-dev/tmux.sock list-sessions` while a dev build has sessions, and confirm dev sessions live on that socket, separate from release sessions on the default socket.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Added unit coverage for the arg construction (`build_create_args` env flags, host env + login-shell resolution, `login_shell_command`, `tmux_command` socket flag) and reworked the e2e + integration harnesses to route their tmux calls through the same socket aoe now uses, keeping the full e2e suite green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a two-model design debate on the fix approach. I made the scoping call (asymmetric socket isolation over full symmetric to avoid breaking release session visibility on upgrade), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785598345&installation_id=139138837&pr_number=2617&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2617&signature=a53375394636c71a406871ef2eb4fb142ba5144b80a0451d7b2ab68be79bb281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes incorrect shell and `$HOME` being picked for host paired terminal tabs when tmux is shared between dev and release processes. It does this by explicitly passing `HOME`, `SHELL`, and `PATH` when creating host tmux sessions, starting the user’s shell as a login shell, and setting tmux `default-shell` so newly split panes use the correct shell.

It also improves tmux isolation for debug and tests by routing tmux through a shared helper that selects an appropriate tmux socket:
- Debug/test runs use a private socket under the dev app directory.
- Release builds keep tmux’s default socket.
- `AOE_TMUX_SOCKET` can override the socket for test harnesses.

On top of that, the PR refactors tmux invocations across the codebase to consistently use the shared socket-aware command builder, adds unit coverage for shell/login-shell argument construction and default-shell option generation, and updates unit/integration/e2e tests to operate against explicit `tmux -S <socket>` paths.

Benefits:
- Prevents dev/release tmux sessions from affecting each other
- Ensures host terminals consistently launch the right shell/environment (including login-shell behavior)
- Makes debug/test tmux behavior deterministic via per-test socket routing
- Improves test reliability by eliminating cross-test tmux state leakage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->