### PR TITLE
feat(web): let users pick the terminal font family

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -234,6 +234,10 @@ export function MobileLiveTerminal({
   const coarse = useIsCoarsePointer();
   const fontKey = coarse ? "mobileFontSize" : "desktopFontSize";
   const configuredFontSize = settings[fontKey];
+  // A user-chosen terminal font, falling back to the bundled `--font-mono` so a
+  // missing/mistyped family degrades gracefully instead of blanking the grid.
+  const termFontFamily = settings.terminalFontFamily.trim();
+  const fontFamily = termFontFamily ? `"${termFontFamily}", var(--font-mono)` : undefined;
   const [fontSize, setFontSize] = useState(() => configuredFontSize);
   // Adopt the persisted setting when it changes (settings panel, or the
   // pointer class flipping which font key applies) via the adjust-state-
@@ -266,7 +270,7 @@ export function MobileLiveTerminal({
   }, []);
   useLayoutEffect(() => {
     remeasure();
-  }, [remeasure, fontSize]);
+  }, [remeasure, fontSize, fontFamily]);
   useEffect(() => {
     const fonts = (document as Document & { fonts?: { ready: Promise<unknown> } }).fonts;
     fonts?.ready
@@ -1117,6 +1121,8 @@ export function MobileLiveTerminal({
         }`}
         style={{
           fontSize: `${fontSize}px`,
+          // Undefined leaves the `font-mono` class to supply the default family.
+          fontFamily,
           lineHeight: `${lineH}px`,
           background: "var(--term-bg, #1c1c1f)",
           color: "var(--term-fg, #e4e4e7)",

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -236,7 +236,9 @@ export function MobileLiveTerminal({
   const configuredFontSize = settings[fontKey];
   // A user-chosen terminal font, falling back to the bundled `--font-mono` so a
   // missing/mistyped family degrades gracefully instead of blanking the grid.
-  const termFontFamily = settings.terminalFontFamily.trim();
+  // Strip quotes so a stray `"` can't produce a malformed (and silently
+  // ignored) font-family value.
+  const termFontFamily = (settings.terminalFontFamily ?? "").trim().replace(/"/g, "");
   const fontFamily = termFontFamily ? `"${termFontFamily}", var(--font-mono)` : undefined;
   const [fontSize, setFontSize] = useState(() => configuredFontSize);
   // Adopt the persisted setting when it changes (settings panel, or the

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -1,4 +1,7 @@
+import { useMemo } from "react";
+
 import { useWebSettings } from "../hooks/useWebSettings";
+import { detectInstalledFonts } from "../lib/fontDetect";
 import {
   MAX_PERSISTENT_TERMINALS,
   MIN_PERSISTENT_TERMINALS,
@@ -10,6 +13,9 @@ const FONT_SIZES = Array.from({ length: 23 }, (_, i) => i + 6); // 6..28
 export function TerminalSettings() {
   const { settings, update } = useWebSettings();
   const maxPersistentTerminals = normalizePersistentTerminalLimit(settings.maxPersistentTerminals);
+  // Probe once per mount; the set of installed fonts doesn't change while the
+  // panel is open.
+  const detectedFonts = useMemo(() => detectInstalledFonts(), []);
 
   return (
     <div>
@@ -73,6 +79,30 @@ export function TerminalSettings() {
           <p className="text-[11px] text-text-muted mt-1">
             Font size for web terminal sessions on desktop, including tmux-backed sessions. Hold Ctrl and scroll over
             the terminal (or pinch on a trackpad) to zoom; the new size is saved here.
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="terminal-font-family" className="block text-[13px] text-text-secondary mb-2">
+            Font family
+          </label>
+          <input
+            id="terminal-font-family"
+            type="text"
+            list="terminal-font-options"
+            value={settings.terminalFontFamily}
+            placeholder="Default (Geist Mono)"
+            onChange={(e) => update({ terminalFontFamily: e.target.value })}
+            className="w-full bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono"
+          />
+          <datalist id="terminal-font-options">
+            {detectedFonts.map((f) => (
+              <option key={f} value={f} />
+            ))}
+          </datalist>
+          <p className="text-[11px] text-text-muted mt-1">
+            Font for web terminal sessions. Pick a detected font or type any font name; it must be installed on this
+            device. Leave blank for the bundled default. Use a Nerd Font to render powerline and icon glyphs.
           </p>
         </div>
 

--- a/web/src/components/__tests__/TerminalSettings.test.tsx
+++ b/web/src/components/__tests__/TerminalSettings.test.tsx
@@ -5,9 +5,13 @@
 // (key `aoe-web-settings`) rather than PATCH /api/settings. The contract
 // here is the JSON shape written to that key. Part of #1217.
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import { TerminalSettings } from "../TerminalSettings";
+
+vi.mock("../../lib/fontDetect", () => ({
+  detectInstalledFonts: () => ["JetBrains Mono", "MesloLGS NF"],
+}));
 
 const KEY = "aoe-web-settings";
 
@@ -54,6 +58,28 @@ describe("TerminalSettings localStorage contract", () => {
     const select = container.querySelectorAll("select")[1] as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "20" } });
     expect(readStored().desktopFontSize).toBe(20);
+  });
+
+  it("font family input writes terminalFontFamily", () => {
+    const { container } = render(<TerminalSettings />);
+    const input = container.querySelector("#terminal-font-family") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "MesloLGS NF" } });
+    expect(readStored().terminalFontFamily).toBe("MesloLGS NF");
+  });
+
+  it("lists detected fonts as datalist suggestions", () => {
+    const { container } = render(<TerminalSettings />);
+    const options = Array.from(container.querySelectorAll("#terminal-font-options option")).map(
+      (o) => (o as HTMLOptionElement).value,
+    );
+    expect(options).toEqual(["JetBrains Mono", "MesloLGS NF"]);
+  });
+
+  it("reflects a stored terminalFontFamily on mount", () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ terminalFontFamily: "Fira Code" }));
+    const { container } = render(<TerminalSettings />);
+    const input = container.querySelector("#terminal-font-family") as HTMLInputElement;
+    expect(input.value).toBe("Fira Code");
   });
 
   it("autoOpenKeyboard checkbox writes the boolean flag", () => {

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -8,6 +8,7 @@ const STORAGE_KEY = "aoe-web-settings";
 export interface WebSettings {
   mobileFontSize: number;
   desktopFontSize: number;
+  terminalFontFamily: string;
   autoOpenKeyboard: boolean;
   persistentTerminals: boolean;
   maxPersistentTerminals: number;
@@ -20,6 +21,7 @@ function getDefaults(): WebSettings {
   return {
     mobileFontSize: 8,
     desktopFontSize: 14,
+    terminalFontFamily: "",
     autoOpenKeyboard: true,
     persistentTerminals: false,
     maxPersistentTerminals: DEFAULT_PERSISTENT_TERMINALS,

--- a/web/src/lib/__tests__/fontDetect.test.ts
+++ b/web/src/lib/__tests__/fontDetect.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+//
+// The width-probe detector: a candidate is "installed" iff its measured width
+// differs from the baseline generic. jsdom has no real font metrics, so we
+// stub the canvas 2d context to model an installed set.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { detectInstalledFonts } from "../fontDetect";
+
+const BASE: Record<string, number> = { monospace: 100, serif: 110, "sans-serif": 120 };
+
+function stubCanvas(installed: Set<string>) {
+  const ctx = {
+    font: "",
+    measureText() {
+      // font looks like `48px monospace` or `48px "Name", monospace`.
+      const m = this.font.match(/^\d+px (?:"([^"]+)", )?(\S+)$/);
+      const name = m?.[1];
+      const baseline = m?.[2] ?? "monospace";
+      const base = BASE[baseline] ?? 100;
+      return { width: name && installed.has(name) ? base + 7 : base };
+    },
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("detectInstalledFonts", () => {
+  it("returns only candidates whose metrics differ from the baseline", () => {
+    stubCanvas(new Set(["Menlo", "Hack"]));
+    expect(detectInstalledFonts(["Menlo", "Hack", "Nonexistent Font"])).toEqual(["Menlo", "Hack"]);
+  });
+
+  it("returns [] when no 2d context is available", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    expect(detectInstalledFonts(["Menlo"])).toEqual([]);
+  });
+});

--- a/web/src/lib/fontDetect.ts
+++ b/web/src/lib/fontDetect.ts
@@ -1,0 +1,62 @@
+// Client-side detection of installed monospace fonts, so the Terminal
+// settings can list fonts the viewer actually has (e.g. a Nerd Font with the
+// powerline/icon glyphs the bundled Geist Mono lacks). Uses the permission-
+// free, cross-browser width-probe: a candidate font is installed iff a test
+// string measured in `"<candidate>", <baseline>` differs from the baseline
+// generic alone. queryLocalFonts() would enumerate everything, but it is
+// Chromium-only and needs a permission prompt.
+//
+// ponytail: probe only finds fonts on this curated list; the settings combobox
+// stays free-text so any other installed font is still selectable by name.
+
+const BASELINES = ["monospace", "serif", "sans-serif"] as const;
+// Mixed glyphs so a font with different metrics than the baseline shows a
+// measurable width delta.
+const PROBE = "mmmmmmmmmmlliWQ0Ogq{}[]#@";
+
+// Common developer + Nerd Font families. Nerd Font variants are listed under
+// the names their installers register (e.g. "MesloLGS NF").
+export const MONOSPACE_FONT_CANDIDATES = [
+  "JetBrains Mono",
+  "JetBrainsMono Nerd Font",
+  "Fira Code",
+  "FiraCode Nerd Font",
+  "MesloLGS NF",
+  "MesloLGL Nerd Font",
+  "Hack",
+  "Hack Nerd Font",
+  "Cascadia Code",
+  "CaskaydiaCove Nerd Font",
+  "Source Code Pro",
+  "SauceCodePro Nerd Font",
+  "IBM Plex Mono",
+  "Roboto Mono",
+  "Ubuntu Mono",
+  "DejaVu Sans Mono",
+  "Menlo",
+  "Monaco",
+  "SF Mono",
+  "Consolas",
+  "Courier New",
+  "Liberation Mono",
+  "Inconsolata",
+  "Anonymous Pro",
+  "Victor Mono",
+];
+
+export function detectInstalledFonts(candidates: string[] = MONOSPACE_FONT_CANDIDATES): string[] {
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) return [];
+  const size = 48;
+  const base: Record<string, number> = {};
+  for (const b of BASELINES) {
+    ctx.font = `${size}px ${b}`;
+    base[b] = ctx.measureText(PROBE).width;
+  }
+  return candidates.filter((name) =>
+    BASELINES.some((b) => {
+      ctx.font = `${size}px "${name}", ${b}`;
+      return ctx.measureText(PROBE).width !== base[b];
+    }),
+  );
+}

--- a/web/src/lib/fontDetect.ts
+++ b/web/src/lib/fontDetect.ts
@@ -6,7 +6,7 @@
 // generic alone. queryLocalFonts() would enumerate everything, but it is
 // Chromium-only and needs a permission prompt.
 //
-// ponytail: probe only finds fonts on this curated list; the settings combobox
+// caveat: probe only finds fonts on this curated list; the settings combobox
 // stays free-text so any other installed font is still selectable by name.
 
 const BASELINES = ["monospace", "serif", "sans-serif"] as const;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -462,8 +462,12 @@
       "id": "settings.terminal-localstorage",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/__tests__/TerminalSettings.test.tsx"],
-      "components": ["web/src/components/TerminalSettings.tsx", "web/src/components/TerminalSessionStack.tsx"]
+      "specs": ["src/components/__tests__/TerminalSettings.test.tsx", "src/lib/__tests__/fontDetect.test.ts"],
+      "components": [
+        "web/src/components/TerminalSettings.tsx",
+        "web/src/components/TerminalSessionStack.tsx",
+        "web/src/lib/fontDetect.ts"
+      ]
     },
     {
       "id": "app-shell.topbar-dev-badge",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web dashboard terminal (a custom DOM renderer since xterm.js was removed) had its font family hardcoded to the bundled `--font-mono` ("Geist Mono"). Geist Mono lacks powerline and Nerd Font icon glyphs, so those characters rendered incorrectly, which is what #2613 reports.

This adds a client-local "Font family" preference to Settings, Terminal (stored in `localStorage` under `aoe-web-settings`, the same mechanism as the existing font-size and diff-view preferences, not backend config). The field is a native combobox: it lists monospace and Nerd fonts detected as installed on the viewing device as datalist suggestions, and also accepts any font name typed by hand for a font not on the probe list. Leaving it blank keeps the bundled default.

Font detection uses the permission-free, cross-browser width-probe technique: a candidate font is installed if a test string measured in that font differs from the baseline generic. `queryLocalFonts()` was avoided because it is Chromium-only and requires a permission prompt.

The chosen family is applied inline on the terminal renderer with the bundled `--font-mono` as a fallback, so a missing or mistyped name degrades gracefully instead of blanking the grid. The renderer re-measures its character advance when the font changes, keeping the cursor overlay and the tmux column count aligned to the new metrics.

Closes #2613

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, go to Settings, Terminal, and confirm a "Font family" field appears with detected fonts offered as suggestions.
- [ ] Type an installed monospace or Nerd font (for example `MesloLGS NF`), open a terminal session, and confirm the terminal text renders in that font and icon/powerline glyphs display correctly.
- [ ] Clear the field and confirm the terminal reverts to the default (Geist Mono).
- [ ] Reload the page and confirm the chosen font persists.
- [ ] Type a bogus font name and confirm the terminal falls back to the default rather than breaking the layout or cursor alignment.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Note: per AGENTS.md, a settings-input permutation like this belongs in Vitest, not Playwright. Coverage is added there: `web/src/components/__tests__/TerminalSettings.test.tsx` (font-family write/read contract) and `web/src/lib/__tests__/fontDetect.test.ts` (detector), both mapped in `web/tests/coverage-matrix.json`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I made the design calls (client-local setting, font detection over a fixed dropdown) and will run the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785598917&installation_id=139138837&pr_number=2619&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2619&signature=93e75de53ed1d51994afbe7e47e5db73ddf5064fd3cdac537a6614d0c6f3752d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a “Font family” setting to the web dashboard terminal so users can pick a monospace font that better supports required icon glyphs (e.g., powerline/Nerd Font icons). The value is stored in localStorage with other web settings, shown in the Terminal Settings UI with detected installed-font suggestions (via a permission-free detection method), and still allows free-text entry for any font name. When left blank or invalid, the terminal falls back to the bundled monospace font.

The live terminal applies the selected font immediately and re-measures character sizing when the font changes, helping keep cursor alignment and column counts accurate (including tmux-related layout). Added font detection and unit tests for both font detection and the new settings persistence; also updated test coverage mapping. Additional robustness fixes ensure the saved font value is cleaned up and the settings field is safely handled when missing.

Benefits:
- Fixes incorrectly rendered glyphs/icons in the web terminal by letting users choose a compatible font
- Improves terminal customization flexibility
- Maintains correct terminal layout when switching fonts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->