### PR TITLE
feat(web): remember last agent instruction in session wizard

### DIFF
--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -42,8 +42,10 @@ const MORE_OPTIONS_OPEN_KEY = "aoe-new-session-more-options-open";
 /** localStorage key remembering the last agent-instruction text the user
  *  submitted. Per-browser, so someone who reuses the same instruction on
  *  every session does not retype it. Free text, so no validation on read
- *  unlike the tool key. See #2614. */
-const LAST_USED_INSTRUCTION_KEY = "aoe-acp-last-instruction";
+ *  unlike the tool key. Not ACP-scoped (custom_instruction ships for
+ *  tmux-passthrough sessions too), so it uses the new-session prefix. See
+ *  #2614. */
+const LAST_USED_INSTRUCTION_KEY = "aoe-new-session-last-instruction";
 
 function loadLastUsedTool(): string {
   const stored = safeGetItem(LAST_USED_TOOL_KEY);

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -39,6 +39,12 @@ const LAST_USED_TOOL_KEY = "aoe-acp-last-tool";
  *  every time. See #2210. */
 const MORE_OPTIONS_OPEN_KEY = "aoe-new-session-more-options-open";
 
+/** localStorage key remembering the last agent-instruction text the user
+ *  submitted. Per-browser, so someone who reuses the same instruction on
+ *  every session does not retype it. Free text, so no validation on read
+ *  unlike the tool key. See #2614. */
+const LAST_USED_INSTRUCTION_KEY = "aoe-acp-last-instruction";
+
 function loadLastUsedTool(): string {
   const stored = safeGetItem(LAST_USED_TOOL_KEY);
   if (stored && ACP_CAPABLE_TOOLS.has(stored)) {
@@ -50,6 +56,14 @@ function loadLastUsedTool(): string {
 function saveLastUsedTool(tool: string): void {
   if (!ACP_CAPABLE_TOOLS.has(tool)) return;
   safeSetItem(LAST_USED_TOOL_KEY, tool);
+}
+
+function loadLastUsedInstruction(): string {
+  return safeGetItem(LAST_USED_INSTRUCTION_KEY) ?? "";
+}
+
+function saveLastUsedInstruction(instruction: string): void {
+  safeSetItem(LAST_USED_INSTRUCTION_KEY, instruction);
 }
 
 function loadMoreOptionsOpen(): boolean {
@@ -64,7 +78,7 @@ function saveMoreOptionsOpen(open: boolean): void {
  *  fresh wizard opens default to whatever the user picked last. The
  *  prefill path overrides this when `prefill.tool` is set. */
 function buildInitialData(): WizardData {
-  return { ...initialData, tool: loadLastUsedTool() };
+  return { ...initialData, tool: loadLastUsedTool(), customInstruction: loadLastUsedInstruction() };
 }
 
 function acpDefaultsFor(session: Record<string, unknown> | undefined, tool: string): { model: string; effort: string } {
@@ -297,6 +311,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
     if (result.ok) {
       dispatch({ type: "SUBMIT_SUCCESS" });
       saveLastUsedTool(tool);
+      saveLastUsedInstruction(body.custom_instruction ?? "");
       const warnings = result.session?.warnings;
       if (warnings && warnings.length > 0) {
         for (const w of warnings) toastBus.handler?.error(w);

--- a/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
@@ -28,7 +28,7 @@ vi.mock("../../../lib/api", () => ({
   createSession: (...args: unknown[]) => createSession(...args),
 }));
 
-const INSTRUCTION_KEY = "aoe-acp-last-instruction";
+const INSTRUCTION_KEY = "aoe-new-session-last-instruction";
 const MORE_OPTIONS_KEY = "aoe-new-session-more-options-open";
 
 afterEach(() => {

--- a/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+//
+// Wizard remembers the last agent-instruction across opens (#2614), the same
+// per-browser way it already remembers the last tool. A submitted instruction
+// is written to localStorage and prefilled into the next wizard open, so a
+// user who reuses the same instruction on every session stops retyping it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, fireEvent, waitFor } from "@testing-library/react";
+
+import { SessionWizard } from "../SessionWizard";
+
+const createSession = vi.fn();
+
+vi.mock("../../../lib/api", () => ({
+  fetchSettings: vi.fn().mockResolvedValue({}),
+  fetchAgents: vi.fn().mockResolvedValue([]),
+  fetchGroups: vi.fn().mockResolvedValue([]),
+  fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
+  fetchProfiles: vi.fn().mockResolvedValue([]),
+  fetchVolumeIgnoresPreview: vi.fn().mockResolvedValue([]),
+  markVolumeIgnoresGlobsAcknowledged: vi.fn().mockResolvedValue(undefined),
+  fetchSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+  fetchRecentProjects: vi.fn().mockResolvedValue({
+    projects: [{ path: "/tmp/proj", display_name: "proj", tool: "claude", last_used_at: "2026-01-01T00:00:00Z" }],
+  }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
+  createSession: (...args: unknown[]) => createSession(...args),
+}));
+
+const INSTRUCTION_KEY = "aoe-acp-last-instruction";
+const MORE_OPTIONS_KEY = "aoe-new-session-more-options-open";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+function renderWizard(onCreated: (session: unknown) => void = () => {}) {
+  return render(
+    <SessionWizard onClose={() => {}} onCreated={onCreated} prefill={{ path: "/tmp/proj", tool: "claude" }} />,
+  );
+}
+
+describe("SessionWizard last-instruction memory (#2614)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    createSession.mockResolvedValue({ ok: true, session: { id: "s1" } });
+  });
+
+  it("prefills the stored instruction into the create payload", async () => {
+    localStorage.setItem(INSTRUCTION_KEY, "always be terse");
+    const onCreated = vi.fn();
+    const { getByText } = renderWizard(onCreated);
+
+    fireEvent.click(getByText(/Launch session/));
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1));
+    expect(createSession.mock.calls[0][0]).toMatchObject({ custom_instruction: "always be terse" });
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith({ id: "s1" }));
+  });
+
+  it("writes the submitted instruction back to localStorage", async () => {
+    // Fold open so AgentOptions (and the instruction textarea) render.
+    localStorage.setItem(MORE_OPTIONS_KEY, "true");
+    const { getByText, getByPlaceholderText } = renderWizard();
+
+    fireEvent.change(getByPlaceholderText("Custom instructions for this session..."), {
+      target: { value: "review for security" },
+    });
+    fireEvent.click(getByText(/Launch session/));
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1));
+    expect(createSession.mock.calls[0][0]).toMatchObject({ custom_instruction: "review for security" });
+    await waitFor(() => expect(localStorage.getItem(INSTRUCTION_KEY)).toBe("review for security"));
+  });
+
+  it("clears the stored instruction when submitted empty", async () => {
+    localStorage.setItem(INSTRUCTION_KEY, "stale text");
+    localStorage.setItem(MORE_OPTIONS_KEY, "true");
+    const { getByText, getByPlaceholderText } = renderWizard();
+
+    fireEvent.change(getByPlaceholderText("Custom instructions for this session..."), {
+      target: { value: "" },
+    });
+    fireEvent.click(getByText(/Launch session/));
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(localStorage.getItem(INSTRUCTION_KEY)).toBe(""));
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The session wizard reset the "Agent instructions" field to empty on every open, so anyone who reuses the same instruction on each session had to retype it every time (#2614).

This persists the last submitted instruction to `localStorage` and prefills it on the next wizard open, mirroring the existing last-used-tool memory (`aoe-acp-last-tool`). It is per-browser and client-local, matching the wizard's two other memory knobs (last tool, "More options" fold state). An empty value round-trips, so clearing the field also clears the stored value rather than leaving stale text behind.

No Rust, config, or on-disk-format changes; this is not a new setting, so there is no TUI parity to add (the TUI new-session form has no instruction field). The change is contained to `web/src/components/session-wizard/SessionWizard.tsx`.

Closes #2614

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, start a new session, type an agent instruction, and launch it.
- [ ] Open the new-session wizard again in the same browser; confirm the "Agent instructions" field is prefilled with the text you last used.
- [ ] Clear the "Agent instructions" field, launch a session, reopen the wizard; confirm the field is now empty (no stale text).

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test for this flow (Vitest + RTL: `web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx`, covering prefill-into-payload, write-back, and empty-clear round-trips). Per AGENTS.md this localStorage round-trip fits the Vitest suite; `SessionWizard.tsx` is already mapped by the `wizard` entry in `web/tests/coverage-matrix.json`, so no matrix change was needed.
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (localStorage over server-side, scope to the instruction only) and reviewed each change.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785598921&installation_id=139138837&pr_number=2620&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2620&signature=8b19e01652e4b5738c4370e33fdd24036b9fb53425539de6f26e79ca2ca7e6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change updates the web session wizard to remember the last “Agent instructions” text a user submitted, and restore it the next time they open the wizard to start a new session in the same browser. If the user clears the field and then launches a session, that cleared value is also persisted so old text doesn’t reappear later.

A focused test suite was added to verify saving, restoring, and clearing behavior by checking the contents sent in the session creation request and ensuring `localStorage` is reset between tests.

Benefits:
- Reduces repeated retyping during frequent session creation
- Makes the wizard feel more convenient and stateful
- Prevents stale instruction text from coming back after the user intentionally clears it
<!-- end of auto-generated comment: release notes by coderabbit.ai -->