### PR TITLE
fix(tui): remove doubled border seam in stacked mode (closes #2301)

### DIFF
--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -61,7 +61,7 @@ fn compose_list_title(
 /// Source of truth for the pane-arrangement passed to `render_list` /
 /// `render_preview`, so their border masks honor DESIGN.md's single-shared-
 /// separator invariant.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum PaneLayout {
     Collapsed,
     Stacked,
@@ -69,13 +69,16 @@ enum PaneLayout {
 }
 
 impl PaneLayout {
-    /// Border mask for the list block. Stacked (and defensively Collapsed)
-    /// drop BOTTOM so the preview's TOP becomes the single shared seam;
-    /// SideBySide keeps the full box because the shared seam runs vertically
-    /// (list has no RIGHT, preview's LEFT is the divider).
+    /// Border mask for the list block, per DESIGN.md's single-shared-separator
+    /// invariant. Stacked (and defensively Collapsed) drop BOTTOM because the
+    /// preview's TOP is the shared horizontal seam, but keep RIGHT since the
+    /// pane spans full width. SideBySide keeps BOTTOM and drops RIGHT because
+    /// the preview's LEFT is the shared vertical seam.
     fn list_borders(self) -> Borders {
         match self {
-            PaneLayout::Stacked | PaneLayout::Collapsed => Borders::TOP | Borders::LEFT,
+            PaneLayout::Stacked | PaneLayout::Collapsed => {
+                Borders::TOP | Borders::LEFT | Borders::RIGHT
+            }
             PaneLayout::SideBySide => Borders::TOP | Borders::LEFT | Borders::BOTTOM,
         }
     }
@@ -3731,6 +3734,25 @@ mod tests {
         assert!(PaneLayout::SideBySide
             .list_borders()
             .contains(Borders::BOTTOM));
+    }
+
+    #[test]
+    fn stacked_list_keeps_right_border() {
+        assert!(PaneLayout::Stacked.list_borders().contains(Borders::RIGHT));
+    }
+
+    #[test]
+    fn collapsed_list_keeps_right_border() {
+        assert!(PaneLayout::Collapsed
+            .list_borders()
+            .contains(Borders::RIGHT));
+    }
+
+    #[test]
+    fn side_by_side_list_drops_right_border() {
+        assert!(!PaneLayout::SideBySide
+            .list_borders()
+            .contains(Borders::RIGHT));
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -61,7 +61,7 @@ fn compose_list_title(
 /// Source of truth for the pane-arrangement passed to `render_list` /
 /// `render_preview`, so their border masks honor DESIGN.md's single-shared-
 /// separator invariant.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum PaneLayout {
     Collapsed,
     Stacked,
@@ -804,8 +804,8 @@ impl HomeView {
         };
         // Stacked drops BOTTOM so the preview's TOP is the single shared seam
         // (DESIGN.md). Collapsed is unreachable here today (render_collapsed_strip
-        // owns that path) but matches Stacked so a future re-plumbing can't
-        // spring a doubled seam.
+        // owns that path) but matches Stacked so a future re-plumbing cannot
+        // introduce a doubled seam.
         let borders = match layout {
             PaneLayout::Stacked | PaneLayout::Collapsed => Borders::TOP | Borders::LEFT,
             PaneLayout::SideBySide => Borders::TOP | Borders::LEFT | Borders::BOTTOM,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -68,6 +68,29 @@ enum PaneLayout {
     SideBySide,
 }
 
+impl PaneLayout {
+    /// Border mask for the list block. Stacked (and defensively Collapsed)
+    /// drop BOTTOM so the preview's TOP becomes the single shared seam;
+    /// SideBySide keeps the full box because the shared seam runs vertically
+    /// (list has no RIGHT, preview's LEFT is the divider).
+    fn list_borders(self) -> Borders {
+        match self {
+            PaneLayout::Stacked | PaneLayout::Collapsed => Borders::TOP | Borders::LEFT,
+            PaneLayout::SideBySide => Borders::TOP | Borders::LEFT | Borders::BOTTOM,
+        }
+    }
+
+    /// Border mask for the preview block. All arms yield `Borders::ALL` today
+    /// because the preview always owns the full box; the match is kept
+    /// exhaustive so a future asymmetric change stays type-checked instead of
+    /// silently regressing.
+    fn preview_borders(self) -> Borders {
+        match self {
+            PaneLayout::Collapsed | PaneLayout::Stacked | PaneLayout::SideBySide => Borders::ALL,
+        }
+    }
+}
+
 /// Extra rows captured beyond the visible window so moderate scrolls don't
 /// force a fresh capture on every wheel tick. Cache invalidation uses the same
 /// reserve to decide when the captured window can no longer cover the
@@ -802,14 +825,7 @@ impl HomeView {
                 (theme.terminal_border, theme.terminal_border)
             }
         };
-        // Stacked drops BOTTOM so the preview's TOP is the single shared seam
-        // (DESIGN.md). Collapsed is unreachable here today (render_collapsed_strip
-        // owns that path) but matches Stacked so a future re-plumbing cannot
-        // introduce a doubled seam.
-        let borders = match layout {
-            PaneLayout::Stacked | PaneLayout::Collapsed => Borders::TOP | Borders::LEFT,
-            PaneLayout::SideBySide => Borders::TOP | Borders::LEFT | Borders::BOTTOM,
-        };
+        let borders = layout.list_borders();
         // Sort indicator rides `title_bottom`; ratatui only renders it when the
         // BOTTOM border exists, so it yields in stacked mode (still reachable via `s`).
         let sort_indicator = format!(" sort: {} ", self.sort_order.label());
@@ -1970,14 +1986,8 @@ impl HomeView {
             (border_color, title_color)
         };
 
-        // All arms `Borders::ALL` today: in Stacked the preview's TOP is the
-        // shared seam. Match kept exhaustive so asymmetric changes stay grep-visible.
-        let borders = match layout {
-            PaneLayout::Collapsed | PaneLayout::Stacked | PaneLayout::SideBySide => Borders::ALL,
-        };
-
         let mut block = Block::default()
-            .borders(borders)
+            .borders(layout.preview_borders())
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(border_color))
             .padding(Padding::horizontal(1));
@@ -3702,5 +3712,35 @@ mod tests {
         // Defensive: prefix near usize::MAX must not wrap. The checked_add
         // returns None which we map to "doesn't fit".
         assert_eq!(activity_column_padding(usize::MAX, 1000, 0), None);
+    }
+
+    #[test]
+    fn stacked_list_drops_bottom_border() {
+        assert!(!PaneLayout::Stacked.list_borders().contains(Borders::BOTTOM));
+    }
+
+    #[test]
+    fn collapsed_list_drops_bottom_border() {
+        assert!(!PaneLayout::Collapsed
+            .list_borders()
+            .contains(Borders::BOTTOM));
+    }
+
+    #[test]
+    fn side_by_side_list_keeps_bottom_border() {
+        assert!(PaneLayout::SideBySide
+            .list_borders()
+            .contains(Borders::BOTTOM));
+    }
+
+    #[test]
+    fn preview_always_owns_full_box() {
+        for layout in [
+            PaneLayout::Collapsed,
+            PaneLayout::Stacked,
+            PaneLayout::SideBySide,
+        ] {
+            assert_eq!(layout.preview_borders(), Borders::ALL);
+        }
     }
 }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -58,6 +58,16 @@ fn compose_list_title(
     format!(" {}{}{} ", prefix, profile_tag, suffix)
 }
 
+/// Source of truth for the pane-arrangement passed to `render_list` /
+/// `render_preview`, so their border masks honor DESIGN.md's single-shared-
+/// separator invariant.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum PaneLayout {
+    Collapsed,
+    Stacked,
+    SideBySide,
+}
+
 /// Extra rows captured beyond the visible window so moderate scrolls don't
 /// force a fresh capture on every wheel tick. Cache invalidation uses the same
 /// reserve to decide when the captured window can no longer cover the
@@ -573,7 +583,7 @@ impl HomeView {
             self.list_area = Rect::default();
             self.list_inner_area = Rect::default();
             self.render_collapsed_strip(frame, chunks[0], theme);
-            self.render_preview(frame, chunks[1], theme);
+            self.render_preview(frame, chunks[1], theme, PaneLayout::Collapsed);
         } else if available_width < responsive::STACKED_BREAKPOINT {
             let main_height = main_chunks[0].height;
             let list_height = responsive::stacked_list_height(main_height);
@@ -589,8 +599,8 @@ impl HomeView {
             // path exposes the resize-by-drag affordance.
             self.divider_col = None;
 
-            self.render_list(frame, chunks[0], theme);
-            self.render_preview(frame, chunks[1], theme);
+            self.render_list(frame, chunks[0], theme, PaneLayout::Stacked);
+            self.render_preview(frame, chunks[1], theme, PaneLayout::Stacked);
         } else {
             // Side-by-side: cap list width so the preview pane keeps its
             // usability floor (PREVIEW_MIN_WIDTH).
@@ -612,8 +622,8 @@ impl HomeView {
             // list's y-range (matches preview's y-range in side-by-side).
             self.divider_col = Some(chunks[1].x);
 
-            self.render_list(frame, chunks[0], theme);
-            self.render_preview(frame, chunks[1], theme);
+            self.render_list(frame, chunks[0], theme, PaneLayout::SideBySide);
+            self.render_preview(frame, chunks[1], theme, PaneLayout::SideBySide);
         }
         self.render_status_bar(frame, main_chunks[1], theme);
 
@@ -769,7 +779,7 @@ impl HomeView {
         frame.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
     }
 
-    fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, layout: PaneLayout) {
         self.list_area = area;
         let profile = self.active_profile_display();
         let title = match &self.view_mode {
@@ -792,24 +802,33 @@ impl HomeView {
                 (theme.terminal_border, theme.terminal_border)
             }
         };
-        // Current sort indicator on the bottom-right of the list block. Uses
-        // ratatui's `title_bottom` so it renders on the existing border and
-        // never intersects row content.
+        // Stacked drops BOTTOM so the preview's TOP is the single shared seam
+        // (DESIGN.md). Collapsed is unreachable here today (render_collapsed_strip
+        // owns that path) but matches Stacked so a future re-plumbing can't
+        // spring a doubled seam.
+        let borders = match layout {
+            PaneLayout::Stacked | PaneLayout::Collapsed => Borders::TOP | Borders::LEFT,
+            PaneLayout::SideBySide => Borders::TOP | Borders::LEFT | Borders::BOTTOM,
+        };
+        // Sort indicator rides `title_bottom`; ratatui only renders it when the
+        // BOTTOM border exists, so it yields in stacked mode (still reachable via `s`).
         let sort_indicator = format!(" sort: {} ", self.sort_order.label());
-        let block = Block::default()
-            .borders(Borders::TOP | Borders::LEFT | Borders::BOTTOM)
+        let mut block = Block::default()
+            .borders(borders)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(border_color))
             .title(title)
             .title_style(Style::default().fg(title_color).bold())
-            .title_bottom(
+            .padding(Padding::horizontal(1));
+        if borders.contains(Borders::BOTTOM) {
+            block = block.title_bottom(
                 Line::from(Span::styled(
                     sort_indicator,
                     Style::default().fg(theme.dimmed),
                 ))
                 .right_aligned(),
-            )
-            .padding(Padding::horizontal(1));
+            );
+        }
 
         let inner = block.inner(area);
         self.list_inner_area = inner;
@@ -1928,7 +1947,7 @@ impl HomeView {
         self.active_preview_cache().captured_lines
     }
 
-    fn render_preview(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_preview(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, layout: PaneLayout) {
         let compact = area.width < responsive::STACKED_BREAKPOINT;
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Structured => (theme.border, theme.title),
@@ -1951,8 +1970,14 @@ impl HomeView {
             (border_color, title_color)
         };
 
+        // All arms `Borders::ALL` today: in Stacked the preview's TOP is the
+        // shared seam. Match kept exhaustive so asymmetric changes stay grep-visible.
+        let borders = match layout {
+            PaneLayout::Collapsed | PaneLayout::Stacked | PaneLayout::SideBySide => Borders::ALL,
+        };
+
         let mut block = Block::default()
-            .borders(Borders::ALL)
+            .borders(borders)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(border_color))
             .padding(Padding::horizontal(1));

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14890,7 +14890,7 @@ mod live_send_boot_size_tests {
 }
 
 mod stacked_single_seam {
-    //! Regression coverage for #2301: the list and preview panels must meet
+    //! Regression coverage for #2301: the list and preview panes must meet
     //! on a single shared border in every layout (DESIGN.md invariant). The
     //! stacked layout used to draw the list's BOTTOM and preview's TOP as
     //! two adjacent horizontal borders, producing a visible doubled seam.
@@ -14903,7 +14903,7 @@ mod stacked_single_seam {
 
     /// Rows whose glyphs are dominated by the horizontal box-drawing char
     /// used by ratatui's `BorderType::Rounded`. Used to locate the shared
-    /// seam between the list and preview panels.
+    /// seam between the list and preview panes.
     fn horizontal_border_row_indices(buf: &ratatui::buffer::Buffer) -> Vec<u16> {
         const HORIZONTAL: &str = "─";
         let mut rows = Vec::new();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14901,10 +14901,12 @@ mod stacked_single_seam {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
-    /// Rows whose glyphs are dominated by the horizontal box-drawing char
-    /// used by ratatui's `BorderType::Rounded`. Used to locate the shared
-    /// seam between the list and preview panes.
-    fn horizontal_border_row_indices(buf: &ratatui::buffer::Buffer) -> Vec<u16> {
+    /// Row indices whose glyphs are dominated by the horizontal box-drawing
+    /// char used by ratatui's `BorderType::Rounded`. Includes both outer box
+    /// borders and any internal horizontal dividers; the caller relies on
+    /// adjacency to detect a doubled seam, not on the rows being borders
+    /// exclusively.
+    fn horizontal_dense_rows(buf: &ratatui::buffer::Buffer) -> Vec<u16> {
         const HORIZONTAL: &str = "─";
         let mut rows = Vec::new();
         for y in 0..buf.area.height {
@@ -14944,7 +14946,7 @@ mod stacked_single_seam {
         const { assert!(60 < responsive::STACKED_BREAKPOINT) };
         let buf = render_home(&mut env, 60, 40);
 
-        let border_rows = horizontal_border_row_indices(&buf);
+        let border_rows = horizontal_dense_rows(&buf);
         assert!(
             border_rows.len() >= 3,
             "expected at least list-top, shared-seam, and preview-bottom rows; got {border_rows:?}"
@@ -14968,7 +14970,7 @@ mod stacked_single_seam {
         const { assert!(120 >= responsive::STACKED_BREAKPOINT) };
         let buf = render_home(&mut env, 120, 40);
 
-        let border_rows = horizontal_border_row_indices(&buf);
+        let border_rows = horizontal_dense_rows(&buf);
         assert!(
             !border_rows.is_empty(),
             "side-by-side must still draw horizontal borders; got {border_rows:?}"

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14888,3 +14888,103 @@ mod live_send_boot_size_tests {
         );
     }
 }
+
+mod stacked_single_seam {
+    //! Regression coverage for #2301: the list and preview panels must meet
+    //! on a single shared border in every layout (DESIGN.md invariant). The
+    //! stacked layout used to draw the list's BOTTOM and preview's TOP as
+    //! two adjacent horizontal borders, producing a visible doubled seam.
+
+    use super::*;
+    use crate::tui::responsive;
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Rows whose glyphs are dominated by the horizontal box-drawing char
+    /// used by ratatui's `BorderType::Rounded`. Used to locate the shared
+    /// seam between the list and preview panels.
+    fn horizontal_border_row_indices(buf: &ratatui::buffer::Buffer) -> Vec<u16> {
+        const HORIZONTAL: &str = "─";
+        let mut rows = Vec::new();
+        for y in 0..buf.area.height {
+            let mut count = 0u16;
+            for x in 0..buf.area.width {
+                if buf[(x, y)].symbol() == HORIZONTAL {
+                    count += 1;
+                }
+            }
+            // Half the row width is well above the noise floor (title text,
+            // status glyphs, sort indicator) yet still catches the sparse
+            // horizontal chars in a narrow preview.
+            if count >= buf.area.width / 2 {
+                rows.push(y);
+            }
+        }
+        rows
+    }
+
+    fn render_home(env: &mut TestEnv, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let theme = load_theme("empire");
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                env.view.render(f, area, &theme, None, None, None);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    #[serial]
+    fn stacked_layout_has_single_horizontal_seam() {
+        let mut env = create_test_env_with_sessions(2);
+        const { assert!(60 < responsive::STACKED_BREAKPOINT) };
+        let buf = render_home(&mut env, 60, 40);
+
+        let border_rows = horizontal_border_row_indices(&buf);
+        assert!(
+            border_rows.len() >= 3,
+            "expected at least list-top, shared-seam, and preview-bottom rows; got {border_rows:?}"
+        );
+        for pair in border_rows.windows(2) {
+            assert!(
+                pair[1] - pair[0] > 1,
+                "doubled seam detected: horizontal borders on adjacent rows {} and {} \
+                 (issue #2301). All horizontal-border rows: {:?}",
+                pair[0],
+                pair[1],
+                border_rows,
+            );
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn side_by_side_layout_preserves_horizontal_borders() {
+        let mut env = create_test_env_with_sessions(2);
+        const { assert!(120 >= responsive::STACKED_BREAKPOINT) };
+        let buf = render_home(&mut env, 120, 40);
+
+        let border_rows = horizontal_border_row_indices(&buf);
+        assert!(
+            !border_rows.is_empty(),
+            "side-by-side must still draw horizontal borders; got {border_rows:?}"
+        );
+        // The single-shared-separator invariant is a global rule, not a
+        // stacked-only rule: if the enum threading ever grows an asymmetric
+        // path that re-doubles a seam in side-by-side, this catches it.
+        for pair in border_rows.windows(2) {
+            assert!(
+                pair[1] - pair[0] > 1,
+                "unexpected horizontal seam doubling in side-by-side between rows {} and {}; \
+                 all border rows: {:?}",
+                pair[0],
+                pair[1],
+                border_rows,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #2301: in stacked mode (terminal narrower than `STACKED_BREAKPOINT = 80 cols`), the session list drew `Borders::TOP | Borders::LEFT | Borders::BOTTOM` and the preview underneath drew `Borders::ALL`, stacking two adjacent horizontal borders into a visible doubled seam. This violated `DESIGN.md`'s single-shared-separator invariant that side-by-side and the collapsed strip added in #2294 already honored.

**Approach (per @njbrake's direction on the issue):** thread a file-private `PaneLayout { Collapsed, Stacked, SideBySide }` enum through `render_list` and `render_preview` so each block derives its border mask from a single source of truth, rather than sprinkling geometry-based border conditionals across the render paths. The per-layout masks live as `PaneLayout::list_borders()` / `PaneLayout::preview_borders()` methods on the enum, with the invariant expressed inside an exhaustive `match self` in each — which also unlocks direct unit tests of the mask without a `TestBackend` fixture.

Per-layout mask:

| Layout | List borders | Preview borders | Shared seam |
|---|---|---|---|
| Stacked | `TOP \| LEFT \| RIGHT` | `ALL` | Preview's TOP (single row) |
| SideBySide | `TOP \| LEFT \| BOTTOM` | `ALL` | List's absent RIGHT / preview's LEFT (single column) |
| Collapsed | `TOP \| LEFT \| RIGHT` (defensive; `render_collapsed_strip` owns the path today) | `ALL` | N/A (strip renders its own block) |

### Trade-off: sort chip in stacked mode

The list's `title_bottom` sort indicator (`` ` sort: Newest ` `` and friends) rides the `BOTTOM` border, so ratatui silently omits it in stacked mode. Sort remains reachable via the `s` keybind. This was flagged and approved on the issue thread; the alternative (relocating the chip in stacked mode only) was rejected as gold-plating given the sort menu shortcut. Side-by-side is unchanged.

### Visual evidence

Rendered via `TestBackend::new(60, 25)` (stacked mode — post-fix, list panel now has proper LEFT + RIGHT + TOP borders with BOTTOM dropped in favor of the shared seam with the preview's TOP):

```
 0|╭ aoe [test] ──────────────────────────────────────────── « |
 1|│ ⠒ session1                                               │|
 2|│ ⠒ session0                                               │|
 3|│                                                          │|
 …|…                                                          │|
 7|│                                                          │|
 8|╭ ⠒ session1 ──────────────────────────────────────────────╮|   <- single shared seam
 9|│                    No output available                   │|
 …|…                                                          │|
23|╰──────────────────────────────────────────────────────────╯|
24| ↵  Attach · t View · m Msg · / · ^K Cmds · ?     💡  3 tips |
```

Rendered at `TestBackend::new(120, 30)` (side-by-side, control — unchanged):

```
 0|╭ aoe [test] ─────────────────── « ╭ Preview ────── … ─── ╮|
 …|│ …                                │ …                    │|
28|╰──────────────────── sort: Newest ╰────── … ──────────────╯|   <- sort chip preserved
```

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo fmt --check`, `cargo clippy --features serve --all-targets -- -D warnings`, and `cargo test --lib tui::home` all green; the one file-watch inode-race test that flaked under parallel scheduling passes both in isolation and with `--test-threads=1`, and is present on `main` too)
- [x] Documentation was updated where necessary (N/A: no user-facing surface, config key, or CLI flag changes; the invariant this restores is the one `DESIGN.md` already documents)
- [x] For UI changes: included screenshot or recording (buffer dump above; a real-terminal recording would only re-derive the same buffer state that the new unit tests already assert on deterministically)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is a pure rendering (border-mask) fix, and the two new unit tests in `src/tui/home/tests.rs::stacked_single_seam` render the real `HomeView` through `ratatui::backend::TestBackend` and inspect the frame buffer directly, which is stricter and more deterministic than an asciinema-based e2e would be. They assert `.windows(2)` no-adjacency across all rows dominated by ratatui's rounded-horizontal glyph, so the pre-fix doubled seam (adjacent list-BOTTOM + preview-TOP rows) would fail them, and the invariant is guarded in both stacked and side-by-side.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7 (via opencode)

**Any Additional AI Details you'd like to share:**
Approach decision (enum threading vs inline geometry-detect) was pre-validated by consulting the model against `DESIGN.md`, the maintainer's stated direction in the issue, the `compact` binding at `render_preview:1932` (which drives 6 downstream content-density sites and had to stay independent of `PaneLayout`), and the sort-chip-on-`title_bottom` side effect. The completed diff was then cross-validated against the same criteria before opening. All code was reviewed and each design trade-off (defensive `Collapsed` arm, exhaustive-but-uniform preview match, `title_bottom` gating, side-by-side control test) is documented inline.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Improved the stacked-mode TUI layout so the session list and preview no longer render a doubled horizontal border seam when the terminal is narrow (under 80 columns). The border rules for both panes were consolidated so they follow the same layout-specific “who owns which edges” logic, keeping the shared separator invariant intact.

The fix also documents and enforces a small trade-off: in stacked mode, the list’s bottom sort chip is not drawn because it would sit on the shared bottom border; sorting is still accessible via the `s` key. Side-by-side behavior remains unchanged.

Added regression tests that render the UI into a buffer and verify the exact border/seam pattern for both stacked and side-by-side layouts, preventing the doubled-seam regression from reappearing.

Technical details:
- Introduced a file-private `PaneLayout` enum (`Collapsed`, `Stacked`, `SideBySide`) with `list_borders()` / `preview_borders()` as the single source of truth.
- Threaded `PaneLayout` through `render_list` and `render_preview`, deriving `Block` border masks from the enum with exhaustive matches.
- `PaneLayout::Stacked`/`Collapsed` list borders drop `Borders::BOTTOM` (keeping the shared seam single) and conditionally render the bottom sort chip only when `Borders::BOTTOM` is present; preview borders use `Borders::ALL` for all layouts.
- Unit tests inspect the rendered ratatui frame buffer for horizontal box-drawing glyphs to detect adjacent doubled seam rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->