### PR TITLE
fix(server): stop rejecting session title/group on shell metacharacters

### DIFF
--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -90,6 +90,22 @@ pub(super) fn validate_no_shell_injection(value: &str, field_name: &str) -> Resu
     Ok(())
 }
 
+/// Validate a pure display label (session title, group path): these are
+/// never passed to a shell or interpreted as a path (#2624), so unlike
+/// `validate_no_shell_injection` this allows apostrophes, punctuation, and
+/// most metacharacters. It still rejects control characters, since a
+/// literal newline or NUL corrupts single-line UI rendering and storage
+/// regardless of shell context.
+pub(super) fn validate_display_label(value: &str, field_name: &str) -> Result<(), String> {
+    if let Some(c) = value.chars().find(|c| c.is_control()) {
+        return Err(format!(
+            "Invalid control character U+{:04X} in {}.",
+            c as u32, field_name
+        ));
+    }
+    Ok(())
+}
+
 // The settings PATCH write surface (which sections/fields the web may write,
 // which need elevation, which are host-only) is no longer a hand-kept list
 // here: it is derived from the settings schema in
@@ -558,6 +574,44 @@ mod tests {
                 "validate_no_shell_injection should reject {:?} but accepted {:?}",
                 c,
                 input
+            );
+        }
+    }
+
+    /// #2624: real-world session titles/groups (imported from Claude Code
+    /// summaries) routinely contain apostrophes, question marks, and other
+    /// shell metacharacters that are harmless for a display label.
+    #[test]
+    fn display_label_accepts_common_punctuation() {
+        for value in [
+            "I've read @filename?",
+            "I'm testing this out",
+            "Goal: fix the parser",
+            "What's next?",
+            "Fix [draft] (wip) ~ #123",
+            "work/claude/imports",
+        ] {
+            assert!(
+                validate_display_label(value, "title").is_ok(),
+                "should accept {:?}",
+                value
+            );
+        }
+    }
+
+    #[test]
+    fn display_label_rejects_control_characters() {
+        for value in [
+            "bad\nname",
+            "bad\rname",
+            "bad\tname",
+            "bad\u{1b}name",
+            "bad\0name",
+        ] {
+            assert!(
+                validate_display_label(value, "title").is_err(),
+                "should reject {:?}",
+                value
             );
         }
     }

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -90,14 +90,29 @@ pub(super) fn validate_no_shell_injection(value: &str, field_name: &str) -> Resu
     Ok(())
 }
 
+/// Unicode bidirectional-format characters (category Cf): `char::is_control()`
+/// only covers Cc, so these pass through unblocked otherwise. Left in a
+/// display label, they let the rendered text reorder relative to what's
+/// stored (Trojan-Source-style spoofing, e.g. CVE-2021-42574) in shared UI
+/// surfaces. This is the same set rustc's own bidi lint blocks in source
+/// literals.
+const BIDI_CONTROL_CHARS: &[char] = &[
+    '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', // LRE RLE PDF LRO RLO
+    '\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}', // LRI RLI FSI PDI
+];
+
 /// Validate a pure display label (session title, group path): these are
 /// never passed to a shell or interpreted as a path (#2624), so unlike
 /// `validate_no_shell_injection` this allows apostrophes, punctuation, and
-/// most metacharacters. It still rejects control characters, since a
-/// literal newline or NUL corrupts single-line UI rendering and storage
-/// regardless of shell context.
+/// most metacharacters. It still rejects control characters and bidi
+/// override/isolate characters, since a literal newline, NUL, or bidi
+/// override corrupts single-line UI rendering, storage, or the displayed
+/// text's actual order regardless of shell context.
 pub(super) fn validate_display_label(value: &str, field_name: &str) -> Result<(), String> {
-    if let Some(c) = value.chars().find(|c| c.is_control()) {
+    if let Some(c) = value
+        .chars()
+        .find(|c| c.is_control() || BIDI_CONTROL_CHARS.contains(c))
+    {
         return Err(format!(
             "Invalid control character U+{:04X} in {}.",
             c as u32, field_name
@@ -610,6 +625,21 @@ mod tests {
         ] {
             assert!(
                 validate_display_label(value, "title").is_err(),
+                "should reject {:?}",
+                value
+            );
+        }
+    }
+
+    /// `is_control()` alone misses Cf-category bidi override/isolate chars;
+    /// unblocked, they let a title's rendered order differ from what's
+    /// stored (Trojan-Source-style spoofing).
+    #[test]
+    fn display_label_rejects_bidi_control_characters() {
+        for &c in BIDI_CONTROL_CHARS {
+            let value = format!("bad{}name", c);
+            assert!(
+                validate_display_label(&value, "title").is_err(),
                 "should reject {:?}",
                 value
             );

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::git::error::GitError;
 use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Status, Storage};
 
+use super::validate_display_label;
 use super::validate_no_shell_injection;
 use super::AppState;
 
@@ -997,7 +998,7 @@ pub async fn rename_session(
         )
             .into_response();
     }
-    if let Err(msg) = validate_no_shell_injection(&title, "title") {
+    if let Err(msg) = validate_display_label(&title, "title") {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({ "message": msg })),
@@ -1289,13 +1290,10 @@ pub async fn set_worktree_name(
         )
             .into_response();
     }
-    if let Err(msg) = validate_no_shell_injection(&name, "name") {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "message": msg })),
-        )
-            .into_response();
-    }
+    // #2624: no shell-injection check here. `name` becomes a git branch and
+    // filesystem leaf via `edit_worktree_workdir`, which already runs it
+    // through `git_sanitize_branch_name` + `sanitize_branch_name` before
+    // either ever sees a raw byte (src/session/worktree_edit.rs).
 
     // Serialize against other mutations on this session (start, delete,
     // another rename) so the git ops and the metadata write don't race.
@@ -1543,11 +1541,11 @@ pub async fn update_session_group(
         Err(rej) => return rej.into_response(),
     };
     let group = body.group;
-    // Match `create_session`'s group handling exactly: shell-injection
+    // Match `create_session`'s group handling exactly: display-label
     // check on a non-empty path, no trimming or slash normalization. The
     // empty string is the ungroup sentinel and skips validation.
     if !group.is_empty() {
-        if let Err(msg) = validate_no_shell_injection(&group, "group") {
+        if let Err(msg) = validate_display_label(&group, "group") {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({ "message": msg })),
@@ -4039,11 +4037,7 @@ pub async fn create_session(
     // Validate user inputs for shell injection. For scratch sessions the
     // `path` field is server-provisioned (and clients typically send an
     // empty string), so skip the path entry in that case.
-    let mut shell_checks: Vec<(&str, &str)> = vec![
-        (body.extra_args.as_str(), "extra_args"),
-        (body.tool.as_str(), "tool"),
-        (body.group.as_str(), "group"),
-    ];
+    let mut shell_checks: Vec<(&str, &str)> = vec![(body.extra_args.as_str(), "extra_args")];
     if !body.scratch {
         shell_checks.push((body.path.as_str(), "path"));
     }
@@ -4056,17 +4050,22 @@ pub async fn create_session(
                 .into_response();
         }
     }
-    if let Some(ref title) = body.title {
-        if let Err(msg) = validate_no_shell_injection(title, "title") {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "validation_failed", "message": msg})),
-            )
-                .into_response();
-        }
+    // #2624: `title`/`group` are display labels, not shell input, so they
+    // go through `validate_display_label` (control characters only)
+    // instead. `tool` is checked against the agent registry below
+    // (`validate_session_tool_identity`); `worktree_branch` is re-sanitized
+    // for git-ref safety in the builder; `profile` is checked against
+    // `list_profiles()` right below. None of the four ever reach a shell,
+    // so `validate_no_shell_injection` no longer runs on them.
+    if let Err(msg) = validate_display_label(&body.group, "group") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": msg})),
+        )
+            .into_response();
     }
-    if let Some(ref branch) = body.worktree_branch {
-        if let Err(msg) = validate_no_shell_injection(branch, "worktree_branch") {
+    if let Some(ref title) = body.title {
+        if let Err(msg) = validate_display_label(title, "title") {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({"error": "validation_failed", "message": msg})),
@@ -4075,13 +4074,6 @@ pub async fn create_session(
         }
     }
     if let Some(ref profile_name) = body.profile {
-        if let Err(msg) = validate_no_shell_injection(profile_name, "profile") {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "validation_failed", "message": msg})),
-            )
-                .into_response();
-        }
         // Verify the profile exists. Every profile is a real directory under
         // profiles/; there is no implicitly-valid profile name. Distinguish
         // an enumeration failure (I/O, permissions) from a missing profile

--- a/web/tests/live/session-group-edit.spec.ts
+++ b/web/tests/live/session-group-edit.spec.ts
@@ -135,4 +135,52 @@ base.describe("session group edit via sidebar context menu (#1726)", () => {
       await serve.stop();
     }
   });
+
+  base("a group path containing an apostrophe is accepted (#2624)", async ({ page }, testInfo) => {
+    const title = "group-edit-shell-chars";
+    const newGroup = "Sam's Team/imports";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId = sessions[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
+
+      await row.click({ button: "right" });
+      const menu = page.locator("[data-testid='sidebar-context-menu']");
+      await expect(menu).toBeVisible();
+
+      const patchPromise = page.waitForResponse(
+        (res) => res.url().endsWith(`/api/sessions/${sessionId}/group`) && res.request().method() === "PATCH",
+      );
+
+      await menu.locator("[data-testid='sidebar-context-menu-edit-group']").click();
+      const modal = page.locator("[data-testid='session-group-modal']");
+      await expect(modal).toBeVisible();
+      const input = modal.locator("[data-testid='session-group-modal-input']");
+      await input.fill(newGroup);
+      await modal.locator("[data-testid='session-group-modal-save']").click();
+
+      const patchRes = await patchPromise;
+      expect(patchRes.ok(), `group save should succeed, got ${patchRes.status()}`).toBe(true);
+      await expect(modal).toBeHidden();
+
+      await expect
+        .poll(async () => (await listSessions(serve.baseUrl))[0]?.group_path, {
+          timeout: 5_000,
+        })
+        .toBe(newGroup);
+    } finally {
+      await serve.stop();
+    }
+  });
 });

--- a/web/tests/live/session-rename.spec.ts
+++ b/web/tests/live/session-rename.spec.ts
@@ -147,4 +147,52 @@ base.describe("session rename via sidebar context menu (#1220)", () => {
       await serve.stop();
     }
   });
+
+  base("a title with an apostrophe, question mark, and colon is accepted (#2624)", async ({ page }, testInfo) => {
+    const original = "shell-chars-source";
+    // Mirrors real Claude Code session titles that broke import: an
+    // apostrophe, a trailing question mark, and a "Goal:" prefix.
+    const updated = "Goal: I've fixed the parser, right?";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: original }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId = sessions[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(original, { timeout: 10_000 });
+
+      await row.click({ button: "right" });
+      const menu = page.locator("[data-testid='sidebar-context-menu']");
+      await expect(menu).toBeVisible();
+
+      const patchPromise = page.waitForResponse(
+        (res) => res.url().endsWith(`/api/sessions/${sessionId}`) && res.request().method() === "PATCH",
+      );
+
+      await menu.locator("[data-testid='sidebar-context-menu-rename']").click();
+      const input = page.locator("[data-testid='sidebar-rename-input']");
+      await expect(input).toBeVisible();
+      await input.fill(updated);
+      await input.press("Enter");
+
+      const patchRes = await patchPromise;
+      expect(patchRes.ok(), `rename should succeed, got ${patchRes.status()}`).toBe(true);
+
+      await expect
+        .poll(async () => (await listSessions(serve.baseUrl))[0]?.title, {
+          timeout: 5_000,
+        })
+        .toBe(updated);
+    } finally {
+      await serve.stop();
+    }
+  });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

"Import from Claude" prefills the session title from the real Claude Code session summary, so titles routinely contain apostrophes (`I've`, `I'm`), question marks, colons (`Goal:`), and other punctuation. `validate_no_shell_injection` rejected all of these as "shell metacharacters", so nearly every real-world import failed with a 400.

Tracing every call site showed `title` and `group` never reach a shell: every real consumer (the tmux session name, the derived git branch, the worktree directory leaf) already re-sanitizes independently before touching tmux, git, or the filesystem. `worktree_branch`, the workdir-rename `name`, `tool`, and `profile` are the same story: each is either re-sanitized downstream (git ref safety) or checked against a real allowlist (the agent registry, `list_profiles()`) a few lines later. None of the six ever needed a shell-metacharacter blocklist.

This PR:
- Adds `validate_display_label`, a narrower helper that only rejects control characters (a literal newline/NUL still corrupts single-line UI rendering and storage), and uses it for `title` and `group`, the two fields that are genuinely free-text display labels.
- Drops the shell-metacharacter check entirely for `worktree_branch`, the workdir-rename `name`, `tool`, and `profile`, relying on their existing downstream sanitizers/allowlists.
- Leaves `extra_args` and `path` unchanged: `extra_args` is genuinely interpolated into a shell command line before being typed into the session's tmux pane, so it keeps the strict blocklist.
- Leaves `validate_no_shell_injection` itself, its `SHELL_METACHARACTERS` list, and its pinned regression tests untouched.

Closes #2624

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the web dashboard, import a Claude Code session whose title contains an apostrophe or question mark; import succeeds instead of 400ing.
- [ ] Right-click a session row, Rename, type a title like `Goal: I've fixed the parser, right?`, press Enter; the rename succeeds and the title displays verbatim.
- [ ] Right-click a session row, Edit group, type a group path like `Sam's Team/imports`, save; the save succeeds and the session shows under that group.
- [ ] Renaming a session's workdir, setting an explicit worktree branch, or picking a tool/profile with a stray apostrophe still behaves sanely (sanitized to a safe git/fs name rather than 400ing).
- [ ] Creating a session with shell metacharacters in `extra_args` (e.g. `; rm -rf /`) is still rejected with a 400, unchanged from before.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added a shell-metacharacter regression case to `web/tests/live/session-rename.spec.ts` and `web/tests/live/session-group-edit.spec.ts`; both existing entries already map these two flows in `web/tests/coverage-matrix.json`, so no new entry was needed. Confirmed red (400) on the pre-fix tree via an ephemeral detached worktree, green on the fixed tree. Also added Rust unit tests for the new `validate_display_label` helper in `src/server/api/mod.rs`, alongside the existing pinned `validate_no_shell_injection` tests.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, including a `/debate` consult between two independent LLMs on validation scope before implementing. I reviewed each commit, made the design calls, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785678428&installation_id=139138837&pr_number=2626&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2626&signature=4157eab2d255758d19d059acd2cd1c781f889bdf1dbd571578f3b66038d779f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change relaxes overly strict “shell-like” validation for session display text so importing and editing sessions with normal punctuation now works.

- Added a dedicated `validate_display_label` check for session title/group display inputs, which only rejects control characters (and specific Unicode bidi override/isolate characters).
- Removed the prior shell-metacharacter blocking for several fields that don’t need shell-injection-style validation, including worktree branch/workdir rename `name`, and other session creation/edit fields like `tool` and `profile` (relying on existing downstream sanitization/allowlists).
- Kept `validate_no_shell_injection` for fields that still require stronger protection (e.g., where values can actually reach shell/tmux/git/filesystem contexts); `extra_args` and `path` behavior remains unchanged.

Benefits: Session import and rename/group edit no longer fail with values like `I've`, `I'm`, `Goal:`, `read `@filename``, `?`, and strings containing apostrophes—while still preventing problematic control/bidi characters.

Tests:
- Added/updated server-side validation coverage for accepted punctuation and rejected control/bidi characters.
- Added live UI tests for renaming and editing session groups containing apostrophes/special punctuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->