### PR TITLE
fix(acp): seed sidebar status from post-Stopped agent activity

### DIFF
--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -968,12 +968,9 @@ impl EventStore {
         collected
     }
 
-    /// Latest event for `session_id` that the sidebar status derivation
-    /// cares about. Used at daemon startup to seed `Instance.status`
-    /// from history: the in-memory status writes that fire on live
-    /// structured view events don't survive restart, so without this scan a
-    /// session that was mid-turn when the previous daemon died would
-    /// render Idle until the next lifecycle event arrived. See #1103.
+    /// Latest terminal-lifecycle event for `session_id`, used by the
+    /// rate-limit park callers to detect a `Stopped{rate_limited}` and
+    /// decide whether to auto-resume or hold the session parked.
     ///
     /// `RateLimitAutoResumed` is included deliberately: the rate-limit
     /// auto-resume reconciler pass publishes it to supersede the terminal
@@ -982,6 +979,12 @@ impl EventStore {
     /// re-parking. A new status event added here also participates in
     /// park supersession; keep that in mind before extending the set. See
     /// #1722.
+    ///
+    /// This set intentionally EXCLUDES agent-transcript activity events
+    /// (`ThinkingStarted` / `AgentMessageChunk` / `ToolCallStarted`) so an
+    /// activity event that lands after a `Stopped{rate_limited}` cannot hide
+    /// the park from the resume logic. Status seeding wants the opposite and
+    /// uses `latest_seed_status_event` instead. See #2625.
     pub fn latest_status_event(&self, session_id: &str) -> Option<Event> {
         let conn = match self.conn.lock() {
             Ok(g) => g,
@@ -1009,6 +1012,62 @@ impl EventStore {
                 warn!(
                     target: "acp.event_store",
                     "latest_status_event query for {session_id}: {e}"
+                );
+                None
+            });
+        json.and_then(|s| serde_json::from_str(&s).ok())
+    }
+
+    /// Latest event for `session_id` that the sidebar status derivation
+    /// cares about. Used at daemon startup (`seed_acp_statuses`) and on
+    /// reattach to seed `Instance.status` from history: the in-memory status
+    /// writes that fire on live structured view events don't survive restart,
+    /// so without this scan a session that was mid-turn when the previous
+    /// daemon died would render Idle until the next lifecycle event arrived.
+    /// See #1103.
+    ///
+    /// Unlike [`Self::latest_status_event`] this set ALSO matches the
+    /// agent-transcript activity events (`ThinkingStarted` /
+    /// `AgentMessageChunk` / `ToolCallStarted`). The live status path
+    /// (`derive_acp_status`) maps those to `Running`, so a turn that the
+    /// agent resumed on its own after a `Stopped{prompt_complete}` (no new
+    /// `UserPromptSent`, e.g. a fired wakeup or a background job) keeps its
+    /// green dot across a restart instead of collapsing to a stale Idle from
+    /// the earlier `Stopped`. This query must stay in sync with the
+    /// `Set(Running)` / `Set(Waiting)` arms of `derive_acp_status`. See #2625.
+    pub fn latest_seed_status_event(&self, session_id: &str) -> Option<Event> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let json: Option<String> = conn
+            .query_row(
+                "SELECT event_json FROM acp_events
+                 WHERE session_id = ?1
+                   AND (json_extract(event_json, '$.UserPromptSent') IS NOT NULL
+                     OR json_extract(event_json, '$.ApprovalRequested') IS NOT NULL
+                     OR json_extract(event_json, '$.ApprovalResolved') IS NOT NULL
+                     OR json_extract(event_json, '$.ElicitationRequested') IS NOT NULL
+                     OR json_extract(event_json, '$.ElicitationResolved') IS NOT NULL
+                     OR json_extract(event_json, '$.Stopped') IS NOT NULL
+                     OR json_extract(event_json, '$.RateLimitAutoResumed') IS NOT NULL
+                     OR json_extract(event_json, '$.AgentStartupError') IS NOT NULL
+                     OR json_extract(event_json, '$.AgentMessageChunk') IS NOT NULL
+                     OR json_extract(event_json, '$.ToolCallStarted') IS NOT NULL
+                     -- ThinkingStarted is a unit enum variant, serialized as
+                     -- the bare JSON string \"ThinkingStarted\" rather than an
+                     -- object, so it needs an equality match, not json_extract.
+                     OR event_json = '\"ThinkingStarted\"')
+                 ORDER BY seq DESC
+                 LIMIT 1",
+                params![session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(
+                    target: "acp.event_store",
+                    "latest_seed_status_event query for {session_id}: {e}"
                 );
                 None
             });
@@ -2868,6 +2927,104 @@ mod tests {
 
         // Unknown session → None.
         assert!(store.latest_status_event("nope").is_none());
+    }
+
+    /// `latest_seed_status_event` also matches agent-transcript activity
+    /// events, so a turn the agent resumed on its own after a terminal
+    /// `Stopped{prompt_complete}` (no new `UserPromptSent`) seeds Running,
+    /// not a stale Idle, across a daemon restart. `latest_status_event`
+    /// keeps ignoring those activity events so rate-limit park detection is
+    /// unaffected. See #2625.
+    #[test]
+    fn latest_seed_status_event_sees_activity_after_stopped() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "go".into(),
+                    attachments: Vec::new(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .unwrap();
+        // Agent resumes on its own: streams more output with no new prompt.
+        store
+            .record(
+                "s-1",
+                3,
+                &Event::AgentMessageChunk {
+                    text: "build done".into(),
+                },
+            )
+            .unwrap();
+
+        // Seed derivation follows the activity: the newest status-relevant
+        // event is the AgentMessageChunk, which the live path maps to Running.
+        assert!(matches!(
+            store.latest_seed_status_event("s-1"),
+            Some(Event::AgentMessageChunk { text }) if text == "build done"
+        ));
+        // Park detection still sees only the terminal Stopped.
+        assert!(matches!(
+            store.latest_status_event("s-1"),
+            Some(Event::Stopped { reason }) if reason == "prompt_complete"
+        ));
+
+        // A `ThinkingStarted` alone (no other lifecycle event) seeds via the
+        // activity set, whereas the narrow query returns None.
+        store.record("s-2", 1, &Event::ThinkingStarted).unwrap();
+        assert!(matches!(
+            store.latest_seed_status_event("s-2"),
+            Some(Event::ThinkingStarted)
+        ));
+        assert!(store.latest_status_event("s-2").is_none());
+    }
+
+    /// A rate-limit park must not be hidden from `latest_status_event` by a
+    /// trailing activity event, or the auto-resume logic would try to resume
+    /// a quota-blocked session. `latest_seed_status_event` is free to move on
+    /// (the sidebar shows the resumed work), but the park query stays put.
+    /// See #1722, #2625.
+    #[test]
+    fn latest_status_event_ignores_activity_after_rate_limit_park() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::Stopped {
+                    reason: "rate_limited".into(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::AgentMessageChunk {
+                    text: "trailing".into(),
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(
+            store.latest_status_event("s-1"),
+            Some(Event::Stopped { reason }) if reason == "rate_limited"
+        ));
+        assert!(matches!(
+            store.latest_seed_status_event("s-1"),
+            Some(Event::AgentMessageChunk { text }) if text == "trailing"
+        ));
     }
 
     /// `unresolved_approval_nonces` finds `ApprovalRequested` rows whose

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1045,7 +1045,7 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
                     // away. Re-derive from history here too so the
                     // dot turns green immediately. See #1103 (A).
                     if in_flight_turn {
-                        if let Some(event) = state.acp_event_store.latest_status_event(&id) {
+                        if let Some(event) = state.acp_event_store.latest_seed_status_event(&id) {
                             if let Some(intent) = crate::server::derive_acp_status(&event) {
                                 let mut instances = state.instances.write().await;
                                 if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3860,7 +3860,7 @@ pub(crate) async fn seed_acp_statuses(state: Arc<AppState>) {
         return;
     }
     for id in acp_ids {
-        let Some(event) = state.acp_event_store.latest_status_event(&id) else {
+        let Some(event) = state.acp_event_store.latest_seed_status_event(&id) else {
             continue;
         };
         let Some(intent) = derive_acp_status(&event) else {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A structured-view session showed as Idle (gray) in the web sidebar while the agent was actually still working. It happened when the agent resumed a turn on its own after emitting a terminal `Stopped{reason:"prompt_complete"}` with no new `UserPromptSent` (for example: it kicked off a background build, said "I'll pick this back up when it finishes", emitted `prompt_complete`, then streamed more output and went quiet waiting on the build).

The sidebar status is server-derived (`SessionResponse.status`). The live status path is already correct: `derive_acp_status` maps `AgentMessageChunk` / `ToolCallStarted` / `ThinkingStarted` to `Running`, and the per-frame listener applies it, so a resumed turn goes green in real time. The gap is the seed and reattach paths. On daemon restart (and on reattach to an in-flight runner), status is re-derived from `EventStore::latest_status_event`, whose SQL only matches lifecycle events and excludes the three agent-activity events. So the newest matched event is the stale `Stopped`, the dot seeds `Idle`, and because the agent is quietly waiting on its background job no further live event arrives to flip it back to green.

This adds `EventStore::latest_seed_status_event`, which matches the same lifecycle set plus `AgentMessageChunk`, `ToolCallStarted`, and `ThinkingStarted`, and points the two status-seed callers (`seed_acp_statuses` and the reattach re-derive in the reconciler) at it. `latest_status_event` is left untouched so the three rate-limit park callers keep detecting `Stopped{rate_limited}` without a trailing activity event hiding the park (see #1722). The seed and live paths now agree: a session with agent-initiated activity after a `Stopped` seeds `Running`, matching what the user sees while the daemon is live.

Note on the linked issue: #2625 was filed with the root cause pinned on the frontend reducer (`turnActive`). Deeper investigation showed the reported sidebar-gray symptom is the server seed path described above, not the reducer. I will update the issue body to match.

Closes #2625

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start `aoe serve`, open a structured-view session, and have the agent finish a turn (`prompt_complete`) then resume on its own without a new prompt (e.g. a `/loop` or a fired `ScheduleWakeup`, or any turn that streams more output after finishing). While that resumed work is live, confirm the sidebar dot is green (Running).
- [ ] With the session in that resumed state, restart the daemon (`aoe serve --stop` then `aoe serve`, or `aoe update`). Reload the dashboard and confirm the session seeds green (Running), not gray (Idle).
- [ ] Confirm a session that ended cleanly (`prompt_complete`, no later activity) still seeds gray (Idle) after a restart.
- [ ] Confirm a rate-limit parked session (`Stopped{rate_limited}`) still shows gray after a restart and is not auto-resumed.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

The sidebar already renders `SessionResponse.status`; this fixes how the server derives that value at seed time. The behavior is covered by Rust unit tests on the event-store queries (`latest_seed_status_event_sees_activity_after_stopped`, `latest_status_event_ignores_activity_after_rate_limit_park`), which is where the defect lived.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, `/debate` design consultation, and implementation drafted by Claude under my direction. I made the design calls (server-side seed fix over the frontend-reducer path the issue first proposed, keeping the rate-limit park query narrow) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785679771&installation_id=139138837&pr_number=2627&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2627&signature=b263b8dbba544d40a6da79819ff07640630b68aec4307d88853b46b90b672726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes sidebar status seeding for ACP sessions that keep working after `Stopped{reason:"prompt_complete"}`.

- It updates the server-side status lookup used during startup and reattach so resumed activity is treated as **Running**, not stale **Idle**.
- It keeps the separate rate-limit parking path intact, so `Stopped{reason:"rate_limited"}` sessions are still detected correctly.
- It adds tests to cover both cases: resumed work after prompt completion, and clean terminal/rate-limited sessions.

Technical note: the change introduces a seed-specific event query that includes post-stop agent activity events, while leaving the existing latest-status query unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->