### PR TITLE
fix(acp): peer_pid_from_socket bounds connect() with non-blocking + poll(POLLOUT, 100ms) (closes #2621)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ percent-encoding = "2"
 tokio-util = { version = "0.7", features = ["codec", "compat"] }
 
 # Process handling
-nix = { version = "0.31", features = ["signal", "process", "net", "fs", "resource", "dir", "user"] }
+nix = { version = "0.31", features = ["signal", "process", "net", "fs", "resource", "dir", "user", "poll"] }
 
 # Unicode width + normalization (NFKD used to fold accents in title-derived branch names)
 unicode-normalization = "0.1"

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -37,8 +37,8 @@ pub fn is_pid_alive(_pid: u32) -> bool {
 /// Ask the kernel which process is listening on this Unix domain socket
 /// by connecting and reading the peer's credentials. Returns `Some(pid)`
 /// if the path resolves to a live UDS with a valid peer, `None` otherwise
-/// (path missing, wrong file type, peer already gone, or a target other
-/// than Linux/macOS).
+/// (path missing, wrong file type, peer already gone, connect timeout,
+/// or a target other than Linux/macOS).
 ///
 /// Callers (`worker_registry::terminate`, `shutdown_and_wait`) use this
 /// as the fallback source of the runner PID when the on-disk record is
@@ -51,9 +51,9 @@ pub fn is_pid_alive(_pid: u32) -> bool {
 /// Timeout: connect is bounded at 100ms via non-blocking `connect(2)`
 /// plus `poll(POLLOUT)`. Prevents a wedged runner (D-state kernel
 /// thread, accept loop hung, kernel memory pressure) from stalling the
-/// calling tokio worker thread. On timeout or a completed-but-failed
-/// connect (`SO_ERROR != 0`) the function returns `None`, same silent
-/// fail semantics as any other failure mode.
+/// calling tokio worker thread. Timeouts and completed-but-failed
+/// connects (`SO_ERROR != 0`) fall into the same `None` bucket as any
+/// other failure.
 ///
 /// See #2102, #2621.
 #[cfg(target_os = "linux")]
@@ -67,23 +67,10 @@ pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
 
 #[cfg(target_os = "macos")]
 pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
-    use std::os::fd::AsRawFd;
+    use nix::sys::socket::{getsockopt, sockopt::LocalPeerPid};
     let stream = connect_with_timeout(path)?;
-    let mut pid: libc::pid_t = 0;
-    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
-    // SAFETY: `stream` keeps the fd valid for the duration of the syscall.
-    // `pid` is aligned and sized for `pid_t`; `len` is initialized to
-    // `sizeof(pid_t)`, which is what LOCAL_PEERPID writes on success.
-    let rc = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_LOCAL,
-            libc::LOCAL_PEERPID,
-            std::ptr::addr_of_mut!(pid).cast::<libc::c_void>(),
-            &mut len,
-        )
-    };
-    (rc == 0 && pid > 0).then_some(pid as u32)
+    let pid = getsockopt(&stream, LocalPeerPid).ok()?;
+    (pid > 0).then_some(pid as u32)
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -99,13 +86,13 @@ pub fn peer_pid_from_socket(_path: &Path) -> Option<u32> {
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
     use nix::errno::Errno;
-    use nix::fcntl::{fcntl, FcntlArg, OFlag};
+    use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
     use nix::poll::{poll, PollFd, PollFlags};
     use nix::sys::socket::{
         connect, getsockopt, socket, sockopt::SocketError, AddressFamily, SockFlag, SockType,
         UnixAddr,
     };
-    use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+    use std::os::fd::{AsFd, AsRawFd, OwnedFd};
     use std::os::unix::net::UnixStream;
 
     let addr = UnixAddr::new(path).ok()?;
@@ -116,8 +103,12 @@ fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
         None,
     )
     .ok()?;
-    // `SockFlag::SOCK_NONBLOCK` is gated to linux_android/BSD in nix 0.31,
-    // so set `O_NONBLOCK` via fcntl for portability with macOS.
+    // `SockFlag::SOCK_NONBLOCK` and `SOCK_CLOEXEC` are gated to
+    // linux_android/BSD in nix 0.31, so set `FD_CLOEXEC` and
+    // `O_NONBLOCK` via fcntl for portability with macOS. Matches
+    // `std::os::unix::net::UnixStream::connect`, which sets
+    // `FD_CLOEXEC` on the returned fd.
+    fcntl(fd.as_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).ok()?;
     fcntl(fd.as_fd(), FcntlArg::F_SETFL(OFlag::O_NONBLOCK)).ok()?;
 
     match connect(fd.as_raw_fd(), &addr) {
@@ -140,10 +131,7 @@ fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
         Err(_) => return None,
     }
 
-    // SAFETY: `fd` is a validly-connected AF_UNIX stream socket we own;
-    // `into_raw_fd` transfers ownership to `UnixStream::from_raw_fd`, so
-    // only the returned stream will close the fd on drop.
-    Some(unsafe { UnixStream::from_raw_fd(fd.into_raw_fd()) })
+    Some(UnixStream::from(fd))
 }
 
 /// Signal a worker's entire process group, then the worker pid itself.
@@ -466,7 +454,7 @@ mod tests {
         let path = tmp.path().join("does-not-exist.sock");
         let start = std::time::Instant::now();
         assert_eq!(peer_pid_from_socket(&path), None);
-        assert!(start.elapsed() < std::time::Duration::from_millis(200));
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
     #[test]
@@ -476,7 +464,7 @@ mod tests {
         std::fs::write(&path, b"regular file").unwrap();
         let start = std::time::Instant::now();
         assert_eq!(peer_pid_from_socket(&path), None);
-        assert!(start.elapsed() < std::time::Duration::from_millis(200));
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -488,7 +476,7 @@ mod tests {
         let _listener = UnixListener::bind(&path).unwrap();
         let start = std::time::Instant::now();
         let pid = peer_pid_from_socket(&path);
-        assert!(start.elapsed() < std::time::Duration::from_millis(200));
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
         assert_eq!(pid, Some(std::process::id()));
     }
 }

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -38,7 +38,7 @@ pub fn is_pid_alive(_pid: u32) -> bool {
 /// by connecting and reading the peer's credentials. Returns `Some(pid)`
 /// if the path resolves to a live UDS with a valid peer, `None` otherwise
 /// (path missing, wrong file type, peer already gone, connect timeout,
-/// or a target other than Linux/macOS).
+/// or a target other than Linux/Android/macOS).
 ///
 /// Callers (`worker_registry::terminate`, `shutdown_and_wait`) use this
 /// as the fallback source of the runner PID when the on-disk record is
@@ -56,7 +56,7 @@ pub fn is_pid_alive(_pid: u32) -> bool {
 /// other failure.
 ///
 /// See #2102, #2621.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
     use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
     let stream = connect_with_timeout(path)?;
@@ -73,7 +73,7 @@ pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
     (pid > 0).then_some(pid as u32)
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
 pub fn peer_pid_from_socket(_path: &Path) -> Option<u32> {
     None
 }
@@ -83,8 +83,11 @@ pub fn peer_pid_from_socket(_path: &Path) -> Option<u32> {
 /// `None` on any failure (unreachable path, refused, timeout, syscall
 /// error), preserving the best-effort semantics of
 /// [`peer_pid_from_socket`]. See #2621.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
+    use std::os::fd::{AsFd, AsRawFd};
+    use std::os::unix::net::UnixStream;
+
     use nix::errno::Errno;
     use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
     use nix::poll::{poll, PollFd, PollFlags};
@@ -92,11 +95,9 @@ fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
         connect, getsockopt, socket, sockopt::SocketError, AddressFamily, SockFlag, SockType,
         UnixAddr,
     };
-    use std::os::fd::{AsFd, AsRawFd, OwnedFd};
-    use std::os::unix::net::UnixStream;
 
     let addr = UnixAddr::new(path).ok()?;
-    let fd: OwnedFd = socket(
+    let fd = socket(
         AddressFamily::Unix,
         SockType::Stream,
         SockFlag::empty(),
@@ -113,7 +114,10 @@ fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
 
     match connect(fd.as_raw_fd(), &addr) {
         Ok(()) => {}
-        Err(Errno::EINPROGRESS) => {
+        // `EAGAIN` is Linux AF_UNIX's variant of `EINPROGRESS`
+        // (`unix(7)`): connect cannot complete immediately; the
+        // same POLLOUT wait applies.
+        Err(Errno::EINPROGRESS | Errno::EAGAIN) => {
             let mut pfds = [PollFd::new(fd.as_fd(), PollFlags::POLLOUT)];
             // 100ms: same-host UDS connect completes in microseconds
             // against a healthy listener; this cap tolerates light
@@ -467,7 +471,7 @@ mod tests {
         assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
     #[test]
     fn peer_pid_from_socket_healthy_listener_returns_our_pid_bounded() {
         use std::os::unix::net::UnixListener;

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -48,19 +48,18 @@ pub fn is_pid_alive(_pid: u32) -> bool {
 /// `serde_json` parse errors to `Ok(None)`, so corrupt JSON stays in
 /// the "runner already gone" bucket and does not reach this fallback.
 ///
-/// Blocking-connect caveat: uses synchronous `UnixStream::connect`,
-/// which returns in microseconds against a healthy same-host listener.
-/// A wedged runner (D-state kernel thread, accept loop hung) could
-/// block the caller until the peer wakes or the kernel drops the
-/// listener. Callers today are the shutdown path where that runner is
-/// anyway the target of SIGTERM. A non-blocking `connect(2)` plus
-/// `poll(POLLOUT, timeout)` follow-up is tracked as #2621.
+/// Timeout: connect is bounded at 100ms via non-blocking `connect(2)`
+/// plus `poll(POLLOUT)`. Prevents a wedged runner (D-state kernel
+/// thread, accept loop hung, kernel memory pressure) from stalling the
+/// calling tokio worker thread. On timeout or a completed-but-failed
+/// connect (`SO_ERROR != 0`) the function returns `None`, same silent
+/// fail semantics as any other failure mode.
 ///
-/// See #2102.
+/// See #2102, #2621.
 #[cfg(target_os = "linux")]
 pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
     use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
-    let stream = std::os::unix::net::UnixStream::connect(path).ok()?;
+    let stream = connect_with_timeout(path)?;
     let creds = getsockopt(&stream, PeerCredentials).ok()?;
     let pid = creds.pid();
     (pid > 0).then_some(pid as u32)
@@ -69,7 +68,7 @@ pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
 #[cfg(target_os = "macos")]
 pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
     use std::os::fd::AsRawFd;
-    let stream = std::os::unix::net::UnixStream::connect(path).ok()?;
+    let stream = connect_with_timeout(path)?;
     let mut pid: libc::pid_t = 0;
     let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
     // SAFETY: `stream` keeps the fd valid for the duration of the syscall.
@@ -90,6 +89,61 @@ pub fn peer_pid_from_socket(path: &Path) -> Option<u32> {
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn peer_pid_from_socket(_path: &Path) -> Option<u32> {
     None
+}
+
+/// Non-blocking `connect(2)` to a Unix domain socket, capped at 100ms via
+/// `poll(POLLOUT)`. Returns the connected `UnixStream` on success, or
+/// `None` on any failure (unreachable path, refused, timeout, syscall
+/// error), preserving the best-effort semantics of
+/// [`peer_pid_from_socket`]. See #2621.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn connect_with_timeout(path: &Path) -> Option<std::os::unix::net::UnixStream> {
+    use nix::errno::Errno;
+    use nix::fcntl::{fcntl, FcntlArg, OFlag};
+    use nix::poll::{poll, PollFd, PollFlags};
+    use nix::sys::socket::{
+        connect, getsockopt, socket, sockopt::SocketError, AddressFamily, SockFlag, SockType,
+        UnixAddr,
+    };
+    use std::os::fd::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+    use std::os::unix::net::UnixStream;
+
+    let addr = UnixAddr::new(path).ok()?;
+    let fd: OwnedFd = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .ok()?;
+    // `SockFlag::SOCK_NONBLOCK` is gated to linux_android/BSD in nix 0.31,
+    // so set `O_NONBLOCK` via fcntl for portability with macOS.
+    fcntl(fd.as_fd(), FcntlArg::F_SETFL(OFlag::O_NONBLOCK)).ok()?;
+
+    match connect(fd.as_raw_fd(), &addr) {
+        Ok(()) => {}
+        Err(Errno::EINPROGRESS) => {
+            let mut pfds = [PollFd::new(fd.as_fd(), PollFlags::POLLOUT)];
+            // 100ms: same-host UDS connect completes in microseconds
+            // against a healthy listener; this cap tolerates light
+            // scheduler contention while bounding the pathological case
+            // (hung accept loop, kernel memory pressure).
+            if poll(&mut pfds, 100u16).ok()? == 0 {
+                return None;
+            }
+            // POLLOUT also fires on connect failure (ECONNREFUSED, etc.);
+            // check `SO_ERROR` before trusting the socket.
+            if getsockopt(&fd, SocketError).ok()? != 0 {
+                return None;
+            }
+        }
+        Err(_) => return None,
+    }
+
+    // SAFETY: `fd` is a validly-connected AF_UNIX stream socket we own;
+    // `into_raw_fd` transfers ownership to `UnixStream::from_raw_fd`, so
+    // only the returned stream will close the fd on drop.
+    Some(unsafe { UnixStream::from_raw_fd(fd.into_raw_fd()) })
 }
 
 /// Signal a worker's entire process group, then the worker pid itself.
@@ -404,5 +458,37 @@ mod tests {
             inspect_record_for_runner(&path, 42, extract),
             RunnerRecordState::Missing
         );
+    }
+
+    #[test]
+    fn peer_pid_from_socket_missing_path_returns_none_bounded() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.sock");
+        let start = std::time::Instant::now();
+        assert_eq!(peer_pid_from_socket(&path), None);
+        assert!(start.elapsed() < std::time::Duration::from_millis(200));
+    }
+
+    #[test]
+    fn peer_pid_from_socket_non_socket_file_returns_none_bounded() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("not-a-socket");
+        std::fs::write(&path, b"regular file").unwrap();
+        let start = std::time::Instant::now();
+        assert_eq!(peer_pid_from_socket(&path), None);
+        assert!(start.elapsed() < std::time::Duration::from_millis(200));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn peer_pid_from_socket_healthy_listener_returns_our_pid_bounded() {
+        use std::os::unix::net::UnixListener;
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("healthy.sock");
+        let _listener = UnixListener::bind(&path).unwrap();
+        let start = std::time::Instant::now();
+        let pid = peer_pid_from_socket(&path);
+        assert!(start.elapsed() < std::time::Duration::from_millis(200));
+        assert_eq!(pid, Some(std::process::id()));
     }
 }


### PR DESCRIPTION
## Description

Bounds `process::worker::peer_pid_from_socket` at 100ms by swapping the blocking `std::os::unix::net::UnixStream::connect(path)` for a non-blocking `connect(2)` plus `poll(POLLOUT, 100ms)` plus an `SO_ERROR` sanity check. The Linux/Android and macOS impls now delegate the connect to a shared `connect_with_timeout` helper.

**Why.** The peer-PID lookup is a fallback the shutdown path uses when the on-disk worker record is unreadable, and that population correlates with runners already in a degraded state (hung accept loop, D-state kernel thread, kernel memory pressure), exactly the case where a blocking `connect(2)` on a same-host UDS could stall a tokio worker thread for tens or hundreds of ms before `ECONNREFUSED` / `EAGAIN`. On the happy path (healthy listener) same-host UDS connect still completes in microseconds; behavior is equivalent for the peer-credentials lookup (including `FD_CLOEXEC` preservation, matched via `fcntl` for macOS portability since nix 0.31 gates `SockFlag::SOCK_CLOEXEC` to linux/BSD).

Flagged as M1 during review of #2618 (post-merge). No live user report; latent bug that manifests precisely in the scenarios that are already pathological.

Callers untouched: `worker_registry::terminate` and `AcpSupervisor::shutdown_and_wait` still call `peer_pid_from_socket` with the same signature and the same silent-fail-returns-`None` semantics on any error (timeout, syscall failure, `SO_ERROR != 0`).

Closes #2621.

### Notable design points

- The three platform arms (`linux`, `android`, `macos`) are **structurally symmetric**: all go through `connect_with_timeout` and then `nix::sys::socket::getsockopt` with the platform-specific sockopt (`PeerCredentials` on Linux/Android, `LocalPeerPid` on macOS). No hand-rolled `libc::getsockopt` calls remain; **zero `unsafe` blocks** anywhere in `src/process/worker.rs`.
- **`FD_CLOEXEC` + `O_NONBLOCK`** set via `fcntl` after `socket(2)` because nix 0.31 gates the `SockFlag::SOCK_*` variants to linux_android/BSD. Comment at the call site documents the portability quirk and the behavioral parity with `std::UnixStream::connect`.
- **Deferred-connect match arm folds `Errno::EAGAIN` alongside `EINPROGRESS`**. Linux `unix(7)` documents `EAGAIN` as the AF_UNIX variant of `EINPROGRESS` (connect cannot complete immediately); both take the same POLLOUT wait. `EWOULDBLOCK` is caught implicitly because nix 0.31 aliases it to `EAGAIN` on every target.
- **`SO_ERROR` post-poll check** — `POLLOUT` fires on completed-but-failed connects too (per Linux `poll(2)`), so relying on `POLLOUT` alone would misread `ECONNREFUSED` as success.
- **Docstring** rewrites the previous "Blocking-connect caveat" paragraph to state the new 100ms bound; extends the top-level `None`-cause enumeration to include "connect timeout".

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Three new unit tests in `src/process/worker.rs`, each timing-bounded to `Duration::from_secs(1)` (generous cushion above the 100ms `poll` cap to survive loaded GHA / ASan / TSan CI):

1. `peer_pid_from_socket_missing_path_returns_none_bounded` — path does not exist, returns `None`.
2. `peer_pid_from_socket_non_socket_file_returns_none_bounded` — path is a regular file, returns `None`.
3. `peer_pid_from_socket_healthy_listener_returns_our_pid_bounded` — bind a `UnixListener` in the test process, assert `Some(std::process::id())`.

All existing `process::worker` tests continue to pass (11/11 total).

Gates:

- `cargo fmt --check` clean.
- `cargo clippy --features serve --all-targets -- -D warnings` clean.
- `cargo test --features serve --lib -- process::worker` 11 passed, 0 failed.
- Pre-commit hook (clippy + fmt) green on all three commits.

Cumulative diff: +109 / -31, net **+78 LOC**.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The change is contained to `src/process/worker.rs::peer_pid_from_socket` (a leaf helper called from the shutdown path). No CLI surface, no session lifecycle change, no rendering change. Unit tests in the module cover the three behavioral branches; an e2e would only reach this code via a deliberately corrupted on-disk record, which is not a natural user-facing story.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7

**Any Additional AI Details you'd like to share:**

Direction (non-blocking connect + `poll(POLLOUT, 100ms)` + `SO_ERROR`) was prescribed verbatim in the issue body by @jerome-benoit. The AI implemented the plan across three commits: the initial fix, then two self-review follow-ups running an adversarial Oracle each pass against Rust idiom / harmonization / state-of-the-art / algorithmic-completeness criteria. Improvements folded in across the follow-ups: preserve `FD_CLOEXEC` to match `std::UnixStream::connect` on the resulting fd; drop the `unsafe FromRawFd`/`IntoRawFd` dance via `UnixStream::from(OwnedFd)` (stable since 1.63, MSRV is 1.85); replace the macOS raw `libc::getsockopt(LOCAL_PEERPID)` block with `nix::sockopt::LocalPeerPid` for structural symmetry with the Linux `PeerCredentials` path (eliminating the file's second `unsafe`); widen the test timing cushion to survive CI noise; fold `Errno::EAGAIN` into the deferred-connect arm (Linux AF_UNIX variant of `EINPROGRESS` per `unix(7)`); extend the platform gates to include `target_os = "android"` in line with the issue's own "Linux/Android via `SO_PEERCRED`" wording; harmonize import ordering with the module-level convention; drop a redundant `OwnedFd` type annotation; harmonize the docstring terminology with the file's existing tone.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR makes socket-based worker PID lookup more reliable by replacing a blocking connection attempt with a bounded timeout flow, so shutdown paths no longer hang when a worker is unresponsive.

It also broadens platform support and improves consistency:
- adds Android support
- aligns macOS handling with the Unix approach
- preserves socket close-on-exec behavior
- removes unsafe code from the worker lookup path

Tests were added for missing sockets, invalid socket paths, and a successful listener case, all with bounded runtime.

Benefit: faster, safer shutdown behavior with fewer chances of stalling on bad worker state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->