### PR TITLE
feat: extend first-run tour to open Settings for worktree and plugins

### DIFF
--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -36,7 +36,7 @@ Individual settings also appear in the palette under `Settings`. A writable togg
 
 The first time you open the dashboard in a browser, a **Choose your theme** card appears before anything else. Picking a theme applies it live and saves it to your default profile; you can switch freely, then click **Continue**. Change it later in Settings > Appearance. The card is skipped in read-only mode and for anyone who already finished the tutorial.
 
-After the theme card, an interactive walkthrough highlights the major regions (command bar, sidebar, starting a session, settings, and inside a session the diff panel and composer). Each step lists its keyboard shortcuts and has a **Skip** button.
+After the theme card, an interactive walkthrough highlights the major regions (command bar, sidebar, starting a session, settings, and inside a session the diff panel and composer). Two of its steps open Settings for you: the Worktree tab, explaining the per-session path templates, and the Plugins tab, explaining how to find, install, and trust plugins. Each step lists its keyboard shortcuts and has a **Skip** button.
 
 Completing or skipping the tour records `app_state.has_seen_web_tour` on the server, so it does not relaunch on reload or on another device pointed at the same server. To replay it, open the overflow menu and choose **Show tutorial**; re-triggering adapts to where you are (dashboard regions, or composer / mode picker / send controls inside a session). It does not auto-launch on touch devices, where it is menu-only.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,11 +51,11 @@ first-party plugins land as each piece is verified.
 
 ## Installing external plugins
 
-External plugins are community code that you install at your own risk. Install
-and uninstall are CLI-only (`aoe plugin` is reserved for management); the TUI
-and web surfaces show the result but do not install. Updating an already
-installed plugin can be done from the CLI or approved in-app (see Trust and
-capabilities below).
+External plugins are community code that you install at your own risk. Install,
+update, and uninstall from the CLI (`aoe plugin`) or from the web dashboard's
+Plugins settings (Marketplace searches the `aoe-plugin` GitHub topic; each
+mutating action confirms the plugin's capabilities first). See Trust and
+capabilities below.
 
 ```sh
 aoe plugin install gh:owner/repo          # latest release (the audited default)

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -82,8 +82,8 @@ pub struct DiscoveryResult {
     /// `badge`: an installed-and-featured repo shows the `Installed` badge but
     /// must still rank as featured (the badge is one-of, ranking is not).
     pub featured: bool,
-    /// The exact command to install this plugin (web has no install path, so it
-    /// shows this for the user to copy into a terminal).
+    /// The exact `aoe plugin install` command for this plugin, shown alongside
+    /// the in-app Install button for users who prefer the terminal.
     pub install_command: String,
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1730,6 +1730,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     seen: tourSeen,
     seenKnown: tourSeenKnown,
     onSeen: handleTourSeen,
+    onNavigate: (tab) => (tab ? navigate(`/settings/${tab}`) : handleCloseSettings()),
   });
 
   // Auto-pop the tip-of-the-day once per load, after onboarding settles, like

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -480,16 +480,15 @@ export function SettingsView({
 
       case "worktree":
         return (
-          <div {...tourAnchor(TOUR_ANCHORS.settingsWorktree)}>
-            <SchemaSection
-              section="worktree"
-              schema={schema}
-              focusRequest={focusRequest}
-              values={worktree}
-              onSaveField={saveSubField}
-              advancedSubtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
-            />
-          </div>
+          <SchemaSection
+            section="worktree"
+            schema={schema}
+            focusRequest={focusRequest}
+            values={worktree}
+            onSaveField={saveSubField}
+            advancedSubtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
+            fieldAnchor={{ field: "path_template", anchor: TOUR_ANCHORS.settingsWorktree }}
+          />
         );
 
       case "theme":

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -20,6 +20,7 @@ import { SelectField } from "./settings/FormFields";
 import { DiffSettings } from "./settings/DiffSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { PluginsSettings } from "./settings/PluginsSettings";
+import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import { PluginSettingsSections } from "./settings/PluginSettingsSections";
 import { SettingsHeader } from "./settings/SettingsHeader";
 import { ProfilesSection } from "./profiles/ProfilesSection";
@@ -479,14 +480,16 @@ export function SettingsView({
 
       case "worktree":
         return (
-          <SchemaSection
-            section="worktree"
-            schema={schema}
-            focusRequest={focusRequest}
-            values={worktree}
-            onSaveField={saveSubField}
-            advancedSubtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
-          />
+          <div {...tourAnchor(TOUR_ANCHORS.settingsWorktree)}>
+            <SchemaSection
+              section="worktree"
+              schema={schema}
+              focusRequest={focusRequest}
+              values={worktree}
+              onSaveField={saveSubField}
+              advancedSubtitle="Bare-repo and workspace path templates, branch cleanup, and submodules."
+            />
+          </div>
         );
 
       case "theme":
@@ -547,7 +550,7 @@ export function SettingsView({
 
       case "plugins":
         return (
-          <div className="space-y-6">
+          <div className="space-y-6" {...tourAnchor(TOUR_ANCHORS.settingsPlugins)}>
             <PluginsSettings />
             {schemaGuard() ?? <PluginSettingsSections schema={schema} settings={settings} onSaved={loadSettings} />}
           </div>

--- a/web/src/components/settings/SchemaSection.tsx
+++ b/web/src/components/settings/SchemaSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { SettingsFieldDescriptor, SettingsValidation } from "../../lib/types";
+import { type TourAnchorId, tourAnchor } from "../../lib/tourSteps";
 import {
   CollapsibleSection,
   ListField,
@@ -35,6 +36,10 @@ interface Props {
    *  participates in the SettingsView remount key; this component reacts to the
    *  fresh mount. */
   focusRequest?: { section: string; field: string; nonce: number } | null;
+  /** Attach a tour anchor to one specific field's wrapper, so the first-run tour
+   *  can spotlight a single control (e.g. the worktree path template) rather
+   *  than the whole section. */
+  fieldAnchor?: { field: string; anchor: TourAnchorId };
 }
 
 /** Client-side list-entry validator derived from the server's validation rule,
@@ -191,6 +196,7 @@ export function SchemaSection({
   advancedSubtitle,
   onAfterSave,
   focusRequest,
+  fieldAnchor,
 }: Props) {
   const fields = schema.filter((d) => d.section === section && d.web_write.policy !== "local_only");
   const primary = fields.filter((d) => !d.advanced);
@@ -216,12 +222,14 @@ export function SchemaSection({
 
   const wrap = (d: SettingsFieldDescriptor, node: React.ReactNode) => {
     const isTarget = d.field === targetField;
+    const anchorProps = fieldAnchor && d.field === fieldAnchor.field ? tourAnchor(fieldAnchor.anchor) : {};
     return (
       <div
         key={d.field}
         ref={isTarget ? targetRef : undefined}
         data-settings-field={`${d.section}.${d.field}`}
         className={isTarget ? "animate-settings-highlight" : undefined}
+        {...anchorProps}
       >
         {node}
       </div>

--- a/web/src/components/tour/TourRunner.transition.test.tsx
+++ b/web/src/components/tour/TourRunner.transition.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// TourRunner drives react-joyride in controlled mode so the settings-modal
+// steps (whose anchors live behind a route transition) never hand the engine a
+// missing target. These tests mock react-joyride down to a prop sink so we can
+// assert the transition contract directly: navigate on the crossing, suspend
+// (unmount) while the DOM mutates, poll for the anchor, remount at the new
+// index. See TourRunner.tsx and issue #2633.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import TourRunner from "./TourRunner";
+import { TOUR_ANCHORS, type TourStep } from "../../lib/tourSteps";
+
+vi.mock("react-joyride", async () => {
+  const { createElement } = await import("react");
+  let latestOnEvent: ((data: unknown) => void) | null = null;
+  const Joyride = (props: { stepIndex: number; run: boolean; onEvent: (data: unknown) => void }) => {
+    latestOnEvent = props.onEvent;
+    return createElement("div", {
+      "data-testid": "joyride",
+      "data-step-index": props.stepIndex,
+      "data-run": String(props.run),
+    });
+  };
+  return {
+    Joyride,
+    EVENTS: { STEP_AFTER: "step:after", TOUR_END: "tour:end", TARGET_NOT_FOUND: "error:target_not_found" },
+    ACTIONS: { PREV: "prev", NEXT: "next" },
+    STATUS: { FINISHED: "finished", SKIPPED: "skipped" },
+    __getOnEvent: () => latestOnEvent,
+  };
+});
+
+import * as joyrideMock from "react-joyride";
+
+const fire = (data: Record<string, unknown>) => {
+  const onEvent = (joyrideMock as unknown as { __getOnEvent: () => (d: unknown) => void }).__getOnEvent();
+  act(() => onEvent(data));
+};
+
+function addAnchor(value: string) {
+  const el = document.createElement("div");
+  el.setAttribute("data-tour", value);
+  document.body.appendChild(el);
+  return el;
+}
+
+const dashStep: TourStep = {
+  id: "topbar",
+  anchor: TOUR_ANCHORS.topbar,
+  scopes: ["dashboard"],
+  title: "t",
+  body: "b",
+};
+const dashStep2: TourStep = {
+  id: "new-session",
+  anchor: TOUR_ANCHORS.dashboardNewSession,
+  scopes: ["dashboard"],
+  title: "t2",
+  body: "b2",
+};
+const worktreeStep: TourStep = {
+  id: "settings-worktree",
+  anchor: TOUR_ANCHORS.settingsWorktree,
+  settingsTab: "worktree",
+  scopes: ["dashboard"],
+  title: "wt",
+  body: "wt body",
+};
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+describe("TourRunner controlled transitions", () => {
+  it("navigates, suspends, and remounts at the new index when crossing into a settings step", async () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    const onNavigate = vi.fn();
+    const onFinish = vi.fn();
+    const { queryByTestId, getByTestId } = render(
+      <TourRunner run steps={[dashStep, worktreeStep]} onFinish={onFinish} onNavigate={onNavigate} />,
+    );
+    expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("0");
+
+    // Advance from the dashboard step into the worktree settings step.
+    fire({ type: "step:after", index: 0, action: "next", status: "" });
+
+    // Host is told to open the worktree tab, and Joyride unmounts (suspended)
+    // so it cannot fault on the not-yet-painted anchor.
+    expect(onNavigate).toHaveBeenCalledWith("worktree");
+    expect(queryByTestId("joyride")).toBeNull();
+
+    // The tab paints its anchor; the poll lifts the suspension and remounts at 1.
+    addAnchor(TOUR_ANCHORS.settingsWorktree);
+    await waitFor(() => expect(queryByTestId("joyride")).not.toBeNull());
+    expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("1");
+  });
+
+  it("does not navigate or suspend between two dashboard steps", () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    addAnchor(TOUR_ANCHORS.dashboardNewSession);
+    const onNavigate = vi.fn();
+    const { getByTestId } = render(
+      <TourRunner run steps={[dashStep, dashStep2]} onFinish={vi.fn()} onNavigate={onNavigate} />,
+    );
+    fire({ type: "step:after", index: 0, action: "next", status: "" });
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("1");
+  });
+
+  it("closes settings and marks seen when the tour ends on a settings step", () => {
+    addAnchor(TOUR_ANCHORS.settingsWorktree);
+    const onNavigate = vi.fn();
+    const onFinish = vi.fn();
+    render(<TourRunner run steps={[worktreeStep]} onFinish={onFinish} onNavigate={onNavigate} />);
+    fire({ type: "tour:end", index: 0, action: "skip", status: "skipped" });
+    expect(onNavigate).toHaveBeenCalledWith(null);
+    expect(onFinish).toHaveBeenCalledWith(true);
+  });
+});

--- a/web/src/components/tour/TourRunner.transition.test.tsx
+++ b/web/src/components/tour/TourRunner.transition.test.tsx
@@ -109,6 +109,25 @@ describe("TourRunner controlled transitions", () => {
     expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("1");
   });
 
+  it("closes settings on Back out of a settings step and resumes at the prior index", async () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    const onNavigate = vi.fn();
+    const { queryByTestId, getByTestId } = render(
+      <TourRunner run steps={[dashStep, worktreeStep]} onFinish={vi.fn()} onNavigate={onNavigate} />,
+    );
+    // Forward into the worktree settings step.
+    fire({ type: "step:after", index: 0, action: "next", status: "" });
+    addAnchor(TOUR_ANCHORS.settingsWorktree);
+    await waitFor(() => expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("1"));
+
+    // Back out: host is told to close Settings, tour suspends, then remounts at 0.
+    fire({ type: "step:after", index: 1, action: "prev", status: "" });
+    expect(onNavigate).toHaveBeenLastCalledWith(null);
+    expect(queryByTestId("joyride")).toBeNull();
+    await waitFor(() => expect(queryByTestId("joyride")).not.toBeNull());
+    expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("0");
+  });
+
   it("closes settings and marks seen when the tour ends on a settings step", () => {
     addAnchor(TOUR_ANCHORS.settingsWorktree);
     const onNavigate = vi.fn();

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -98,6 +98,7 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
         // ponytail: end the tour rather than hang; it re-triggers from the menu.
         // Upgrade to skip-the-step-in-direction if a feature-flagged (droppable)
         // settings tab is ever added as a target.
+        if (step.settingsTab) onNavigate(null); // don't strand the user in Settings
         onFinish(false);
         return;
       }
@@ -105,7 +106,7 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
     };
     frame = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(frame);
-  }, [suspended, stepIndex, steps, onFinish]);
+  }, [suspended, stepIndex, steps, onFinish, onNavigate]);
 
   const handleEvent = useCallback(
     (data: EventData) => {
@@ -139,7 +140,8 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
 
       if (data.type === EVENTS.TARGET_NOT_FOUND) {
         // Should not happen given the suspend/poll, but never leave the user
-        // stuck on a spotlight with no tooltip.
+        // stuck on a spotlight with no tooltip, or stranded in Settings.
+        if (steps[data.index]?.settingsTab) onNavigate(null);
         onFinish(false);
       }
     },

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -4,11 +4,24 @@
 // specific (the component, its event/action constants, theming) lives here;
 // TourProvider stays engine-agnostic and deals only in TourStep data. Swapping
 // the engine later means rewriting this file alone.
-import { useCallback, useMemo } from "react";
-import { Joyride, EVENTS, STATUS, type EventData, type Step } from "react-joyride";
+//
+// Controlled mode (`stepIndex`) is load-bearing for the settings-modal steps. A
+// step with `settingsTab` lives behind the route-driven Settings modal, so its
+// anchor only exists after we navigate there. If react-joyride ran uncontrolled
+// it would query the target the instant it advanced, before React committed the
+// new route, and fire TARGET_NOT_FOUND. Instead we own the index: on every
+// transition we ask the host to navigate, unmount Joyride while the DOM mutates,
+// poll for the target anchor, and only then remount at the new index. Same path
+// serves Next and Back, so cross-modal navigation can never hand Joyride a
+// missing target.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ACTIONS, Joyride, EVENTS, STATUS, type EventData, type Step } from "react-joyride";
 import { type TourShortcutHint, type TourStep, tourSelector } from "../../lib/tourSteps";
 import { SHORTCUTS_BY_ID, formatTourShortcut } from "../../lib/shortcuts";
 import { TOUR_RUNNER_OPTIONS, TOUR_RUNNER_STYLES } from "./tourRunnerStyles";
+
+/** Settings tab a step opens, or null to close settings and return to base. */
+export type TourSettingsTab = NonNullable<TourStep["settingsTab"]>;
 
 export interface TourRunnerProps {
   run: boolean;
@@ -16,9 +29,16 @@ export interface TourRunnerProps {
   /** Called once when the tour ends. `markSeen` is false for our own programmatic
    *  stop (scope change / unmount), true for a user finish, skip, or close. */
   onFinish: (markSeen: boolean) => void;
+  /** Open the given Settings tab, or close Settings when passed null. Drives the
+   *  route so the deferred anchor of a settingsTab step mounts before its step. */
+  onNavigate: (tab: TourSettingsTab | null) => void;
 }
 
 const LOCALE = { skip: "Skip", last: "Done", next: "Next", back: "Back" };
+
+// Safety net for the poll: settings tabs are core, always-present UI, so a
+// missing anchor here means a route crash or a removed tab, not a normal state.
+const ANCHOR_WAIT_MS = 3000;
 
 function hintLine(hint: TourShortcutHint): string {
   return `${formatTourShortcut(SHORTCUTS_BY_ID[hint.id].chord)} ${hint.verb}`;
@@ -51,26 +71,87 @@ function toJoyrideStep(step: TourStep): Step {
   };
 }
 
-export default function TourRunner({ run, steps, onFinish }: TourRunnerProps) {
+export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRunnerProps) {
   const joyrideSteps = useMemo(() => steps.map(toJoyrideStep), [steps]);
+  const [stepIndex, setStepIndex] = useState(0);
+  // While suspended we unmount Joyride so it neither fires TARGET_NOT_FOUND nor
+  // paints a tooltip against a node that is mid-unmount (e.g. the sidebar going
+  // away as Settings opens). The poll below lifts it once the next anchor lands.
+  const [suspended, setSuspended] = useState(false);
+
+  useEffect(() => {
+    if (!suspended) return;
+    // stepIndex is always in-bounds here: suspension is only ever set alongside
+    // setStepIndex(next) after the STEP_AFTER handler bounds-checks `next`. The
+    // guard is a plain return (no setState) purely to satisfy the type checker.
+    const step = steps[stepIndex];
+    if (!step) return;
+    const selector = tourSelector(step.anchor);
+    const start = performance.now();
+    let frame = 0;
+    const tick = () => {
+      if (document.querySelector(selector)) {
+        setSuspended(false);
+        return;
+      }
+      if (performance.now() - start > ANCHOR_WAIT_MS) {
+        // ponytail: end the tour rather than hang; it re-triggers from the menu.
+        // Upgrade to skip-the-step-in-direction if a feature-flagged (droppable)
+        // settings tab is ever added as a target.
+        onFinish(false);
+        return;
+      }
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [suspended, stepIndex, steps, onFinish]);
 
   const handleEvent = useCallback(
     (data: EventData) => {
-      if (data.type !== EVENTS.TOUR_END) return;
-      // Gate on the terminal status, not the action: a programmatic stop
-      // (run -> false on scope change / unmount) ends with a non-terminal
-      // status and may carry `action: null`, which an action allowlist would
-      // misread as a user finish and silently opt the user out. Only an
-      // actual finish or skip marks the tour seen.
-      const markSeen = data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED;
-      onFinish(markSeen);
+      if (data.type === EVENTS.TOUR_END) {
+        // Gate on the terminal status, not the action: a programmatic stop
+        // (unmount) ends with a non-terminal status and may carry `action:
+        // null`, which an action allowlist would misread as a user finish.
+        const markSeen = data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED;
+        // If the tour ends while parked on a settings step (Skip/Done inside the
+        // modal), return to the dashboard so the user does not land in Settings.
+        if (steps[data.index]?.settingsTab) onNavigate(null);
+        onFinish(markSeen);
+        return;
+      }
+
+      if (data.type === EVENTS.STEP_AFTER) {
+        const direction = data.action === ACTIONS.PREV ? -1 : 1;
+        const next = data.index + direction;
+        if (next < 0 || next >= steps.length) return;
+        const currentTab = steps[data.index]?.settingsTab ?? null;
+        const nextTab = steps[next]?.settingsTab ?? null;
+        setStepIndex(next);
+        // Only the crossings that change the settings route need a navigate +
+        // suspend; dashboard-to-dashboard steps advance with no extra work.
+        if (currentTab !== nextTab) {
+          onNavigate(nextTab);
+          setSuspended(true);
+        }
+        return;
+      }
+
+      if (data.type === EVENTS.TARGET_NOT_FOUND) {
+        // Should not happen given the suspend/poll, but never leave the user
+        // stuck on a spotlight with no tooltip.
+        onFinish(false);
+      }
     },
-    [onFinish],
+    [steps, onFinish, onNavigate],
   );
+
+  if (suspended) return null;
 
   return (
     <Joyride
       run={run}
+      stepIndex={stepIndex}
       steps={joyrideSteps}
       continuous
       options={TOUR_RUNNER_OPTIONS}

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -10,6 +10,7 @@
 // is a plain hook returning the element to render rather than a context.
 import { lazy, Suspense, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { resolveTourSteps, type TourScope, type TourStep } from "../lib/tourSteps";
+import type { TourSettingsTab } from "../components/tour/TourRunner";
 import { isAutomatedSession } from "../lib/onboarding";
 
 const TourRunner = lazy(() => import("../components/tour/TourRunner"));
@@ -33,6 +34,9 @@ export interface UseTourOptions {
   /** Called when the user finishes or skips the tour, so App can persist the
    *  seen flag to the backend. */
   onSeen: () => void;
+  /** Open a Settings tab (or close Settings when passed null) so the tour can
+   *  walk through settings-modal steps. App implements it via the router. */
+  onNavigate: (tab: TourSettingsTab | null) => void;
 }
 
 /**
@@ -78,6 +82,7 @@ export function useTour({
   seen,
   seenKnown,
   onSeen,
+  onNavigate,
 }: UseTourOptions): UseTourResult {
   const [run, setRun] = useState(false);
   const [steps, setSteps] = useState<TourStep[]>([]);
@@ -168,7 +173,7 @@ export function useTour({
 
   const tourElement = run ? (
     <Suspense fallback={null}>
-      <TourRunner run={run} steps={steps} onFinish={handleFinish} />
+      <TourRunner run={run} steps={steps} onFinish={handleFinish} onNavigate={onNavigate} />
     </Suspense>
   ) : null;
 

--- a/web/src/lib/__tests__/tourSteps.test.ts
+++ b/web/src/lib/__tests__/tourSteps.test.ts
@@ -129,14 +129,31 @@ describe("resolveTourSteps", () => {
     expect(steps.map((s) => s.id)).not.toContain("right-panel");
   });
 
-  it("drops steps whose anchor is absent from the DOM", () => {
+  it("drops steps whose anchor is absent from the DOM, except deferred settings steps", () => {
     const steps = resolveTourSteps({
       scope: "dashboard",
       readOnly: false,
       isDesktop: true,
       hasAnchor: () => false,
     });
-    expect(steps).toEqual([]);
+    // settingsTab steps mount their anchor only after the tour navigates into
+    // Settings, so they bypass the launch-time DOM probe; everything else drops.
+    expect(steps.map((s) => s.id)).toEqual(["settings-worktree", "settings-plugins"]);
+    expect(steps.every((s) => s.settingsTab)).toBe(true);
+  });
+
+  it("still requires present anchors for non-settings steps when a settings step is eligible", () => {
+    const present = new Set<TourAnchorId>([TOUR_ANCHORS.topbar]);
+    const steps = resolveTourSteps({
+      scope: "dashboard",
+      readOnly: false,
+      isDesktop: true,
+      hasAnchor: (a) => present.has(a),
+    });
+    const ids = steps.map((s) => s.id);
+    expect(ids).toContain("topbar"); // present anchor -> kept
+    expect(ids).toContain("settings-worktree"); // deferred -> kept regardless
+    expect(ids).not.toContain("sidebar"); // absent non-deferred anchor -> dropped
   });
 
   it("preserves TOUR_STEPS order", () => {

--- a/web/src/lib/tourSteps.ts
+++ b/web/src/lib/tourSteps.ts
@@ -20,6 +20,8 @@ export const TOUR_ANCHORS = {
   sidebar: "sidebar",
   sidebarSettings: "sidebar-settings",
   dashboardNewSession: "dashboard-new-session",
+  settingsWorktree: "settings-worktree",
+  settingsPlugins: "settings-plugins",
   rightPanel: "right-panel",
   composer: "acp-composer",
   modePicker: "acp-mode-picker",
@@ -59,6 +61,15 @@ export interface TourStep {
   writableOnly?: boolean;
   /** Drop the step on coarse-pointer / non-desktop layouts (region not shown). */
   desktopOnly?: boolean;
+  /**
+   * The step lives inside the route-driven Settings modal. Presence means two
+   * things: the anchor is deferred (it only mounts once the tour navigates to
+   * this tab, so resolveTourSteps skips the launch-time DOM probe), and the
+   * runner must navigate to `/settings/<tab>` before showing the step and close
+   * settings when leaving it. TourRunner drives this in controlled mode so the
+   * target is mounted before react-joyride evaluates it (never a race).
+   */
+  settingsTab?: "worktree" | "plugins";
 }
 
 /** The CSS selector that resolves a given anchor in the DOM. */
@@ -113,6 +124,25 @@ export const TOUR_STEPS: readonly TourStep[] = [
     title: "Settings and profiles",
     body: "Tune sandboxing, worktrees, sounds, devices, and per-profile overrides here.",
     shortcutHints: [{ id: "settings", verb: "opens settings" }],
+  },
+  {
+    id: "settings-worktree",
+    anchor: TOUR_ANCHORS.settingsWorktree,
+    settingsTab: "worktree",
+    scopes: ["dashboard"],
+    writableOnly: true,
+    desktopOnly: true,
+    title: "Worktrees keep sessions isolated",
+    body: "Worktrees give each session its own branch checkout, so agents never step on each other. They are off by default; enable them here. The path template decides where each checkout lands: {repo-name}, {branch}, and {session-id} expand per session (default ../{repo-name}-worktrees/{branch}). A separate bare-repo template sits under Advanced.",
+  },
+  {
+    id: "settings-plugins",
+    anchor: TOUR_ANCHORS.settingsPlugins,
+    settingsTab: "plugins",
+    scopes: ["dashboard"],
+    desktopOnly: true,
+    title: "Extend AoE with plugins",
+    body: "Browse and manage plugins here. Marketplace searches the aoe-plugin GitHub topic; click Install on a result to add it (you confirm its capabilities first). A featured badge means the maintainers reviewed and pinned that release; unvetted means a matching repo nobody has audited, so install at your own risk.",
   },
   {
     id: "right-panel",
@@ -191,5 +221,12 @@ function defaultHasAnchor(anchor: TourAnchorId): boolean {
  */
 export function resolveTourSteps(ctx: ResolveTourContext): TourStep[] {
   const hasAnchor = ctx.hasAnchor ?? defaultHasAnchor;
-  return TOUR_STEPS.filter((step) => isStepEligible(step, ctx) && hasAnchor(step.anchor));
+  return TOUR_STEPS.filter((step) => {
+    if (!isStepEligible(step, ctx)) return false;
+    // settingsTab steps live behind the Settings route; their anchor only mounts
+    // once the runner navigates there mid-tour, so the launch-time DOM probe
+    // would wrongly drop them. Eligibility (scope/read-only/desktop) still gates.
+    if (step.settingsTab) return true;
+    return hasAnchor(step.anchor);
+  });
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2870,7 +2870,8 @@
         "web/src/components/Dashboard.tsx",
         "web/src/components/WorkspaceSidebar.tsx",
         "web/src/components/Dock.tsx",
-        "web/src/components/acp/Composer.tsx"
+        "web/src/components/acp/Composer.tsx",
+        "web/src/components/SettingsView.tsx"
       ]
     },
     {
@@ -2881,7 +2882,8 @@
         "src/lib/__tests__/tourSteps.test.ts",
         "src/hooks/__tests__/useTour.test.ts",
         "src/components/__tests__/Dashboard.tour.test.tsx",
-        "src/components/tour/TourRunner.theme.test.tsx"
+        "src/components/tour/TourRunner.theme.test.tsx",
+        "src/components/tour/TourRunner.transition.test.tsx"
       ],
       "components": [
         "web/src/components/Dashboard.tsx",

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -95,23 +95,28 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     // Story (issue #2633): the tour opens Settings mid-walk. The controlled
     // runner navigates into the Worktree then Plugins tab, mounting each anchor
     // before showing its step, and closes Settings when it moves on.
-    const next = page.getByRole("button", { name: "Next" });
-    for (let i = 0; i < 6; i++) {
-      if (await page.getByText("Worktrees keep sessions isolated").isVisible()) break;
+    // Joyride labels the advance button "Next (N of M)", so match on the prefix.
+    // Walk step by step, waiting for each tooltip before advancing: the crossing
+    // into Settings is async (navigate, suspend, poll for the anchor, remount),
+    // so a tight click loop would race past the worktree step before it paints.
+    const next = page.getByRole("button", { name: /^Next/ });
+    const step = async (heading: string) => {
       await next.click();
-    }
-    await expect(page.getByText("Worktrees keep sessions isolated")).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText(heading)).toBeVisible({ timeout: 10_000 });
+    };
+    await step("Workspaces and sessions"); // sidebar
+    await step("Start a session"); // new-session
+    await step("Settings and profiles"); // settings entry
+    await step("Worktrees keep sessions isolated"); // opens Settings > Worktree
     await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/worktree");
 
-    await next.click();
-    await expect(page.getByText("Extend AoE with plugins")).toBeVisible({ timeout: 10_000 });
+    await step("Extend AoE with plugins"); // switches to Settings > Plugins
     await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/plugins");
 
     // Moving past the plugins step closes Settings and lands back on the dashboard.
-    await next.click();
-    await expect(page.getByText("Replay this tour any time")).toBeVisible({ timeout: 10_000 });
+    await step("Replay this tour any time");
     await expect.poll(() => new URL(page.url()).pathname).toBe("/");
-    await page.getByRole("button", { name: "Done" }).click();
+    await page.getByRole("button", { name: /^Done/ }).click();
     await expect(page.getByText("Replay this tour any time")).toBeHidden();
 
     // The flag stays set after a manual re-trigger, so the next reload is quiet.

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -92,6 +92,28 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     await page.getByRole("menuitem", { name: "Show tutorial" }).click();
     await expect(page.getByText(FIRST_STEP)).toBeVisible({ timeout: 10_000 });
 
+    // Story (issue #2633): the tour opens Settings mid-walk. The controlled
+    // runner navigates into the Worktree then Plugins tab, mounting each anchor
+    // before showing its step, and closes Settings when it moves on.
+    const next = page.getByRole("button", { name: "Next" });
+    for (let i = 0; i < 6; i++) {
+      if (await page.getByText("Worktrees keep sessions isolated").isVisible()) break;
+      await next.click();
+    }
+    await expect(page.getByText("Worktrees keep sessions isolated")).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/worktree");
+
+    await next.click();
+    await expect(page.getByText("Extend AoE with plugins")).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/plugins");
+
+    // Moving past the plugins step closes Settings and lands back on the dashboard.
+    await next.click();
+    await expect(page.getByText("Replay this tour any time")).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/");
+    await page.getByRole("button", { name: "Done" }).click();
+    await expect(page.getByText("Replay this tour any time")).toBeHidden();
+
     // The flag stays set after a manual re-trigger, so the next reload is quiet.
     expect(
       await page.evaluate(async () => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web dashboard first-run tour walked users past the Settings entry but never opened it, so the two least-discoverable surfaces, worktree path templates and the Plugins page, stayed hidden. This extends the tour with two dashboard-scope steps that open the Settings modal for you: the Worktree tab (explaining that worktrees isolate each session and how the `{repo-name}` / `{branch}` / `{session-id}` path templates expand) and the Plugins tab (explaining the `aoe-plugin` GitHub-topic search, the in-app Install flow, and what featured vs unvetted means).

The load-bearing piece is how the tour crosses a route transition without flaking. Settings is route-driven, so a settings step's anchor does not exist until the tour navigates there. Handing react-joyride a not-yet-painted target makes it fire `TARGET_NOT_FOUND` and stick. Following a two-model design debate (gpt-5.5 + gemini-3.1-pro, unanimous), `TourRunner` now drives react-joyride in controlled mode: on each step crossing it navigates via a router-backed callback, unmounts Joyride while the DOM mutates, polls (rAF) for the next anchor, then remounts at the new index. The same path serves Next and Back, and a 3s timeout ends the tour rather than hanging. Non-settings steps and the rest of the tour are unchanged.

This also corrects a stale claim in `docs/plugins.md` and a `discover.rs` comment that said plugin install was CLI-only; the dashboard has had a working install path.

Closes #2633

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Fresh dashboard on desktop: the tour auto-launches; step Next until "Worktrees keep sessions isolated" and confirm Settings opens to the Worktree tab with the tooltip on the path-template section.
- [ ] Next again: Settings switches to the Plugins tab and the tooltip explains marketplace search plus featured vs unvetted.
- [ ] Next past Plugins: Settings closes and the final "Replay this tour any time" step shows on the dashboard.
- [ ] Click Back from the Plugins step back through Worktree to the Settings step: navigation reverses without the tour getting stuck.
- [ ] Skip or Done while parked on a settings step: the modal closes and you land on the dashboard.
- [ ] Replay via More, then "Show tutorial": the settings steps behave the same.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Live spec `web/tests/live/tutorial.spec.ts` now walks the tour into both settings tabs and asserts the route opens and closes. A new `web/src/components/tour/TourRunner.transition.test.tsx` unit-tests the controlled navigate/suspend/poll/remount contract, and `web/src/lib/__tests__/tourSteps.test.ts` covers the deferred-anchor resolver bypass.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill), with a design debate consult to gpt-5.5 and gemini-3.1-pro on the react-joyride route-transition mechanism.

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (controlled-mode over navigate-on-event, point the plugins step at the page rather than force the marketplace sub-tab, worktree step always shown) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785698636&installation_id=139138837&pr_number=2634&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2634&signature=93c26186d27ad57d72f601bf4fbcea34758b758ecf656b59669c0168df66518c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR expands the first-run web dashboard tour so it can actively open Settings and walk users through the **Worktree** and **Plugins** areas (instead of only pointing at existing elements on the dashboard).

Key changes:
- Added two new first-run tour steps:
  - **Settings → Worktree** (targets the Path Template field; explains the default template and how `{repo-name}`, `{branch}`, and `{session-id}` expand)
  - **Settings → Plugins** (targets the marketplace search; explains plugin discovery via the `aoe-plugin` topic, in-app installation, and featured vs unvetted trust)
- Updated the tour to handle Settings navigation reliably:
  - The tour can transition into Settings, wait for the next target to mount, then resume
  - It supports both **Next** and **Back** across the dashboard↔Settings boundary
  - It prevents hangs by timing out/ending the tour when a step target never appears
  - It ensures Settings closes when the tour ends or is skipped
- Adjusted tour step resolution so Settings-scoped steps are scheduled even if their anchors aren’t present until after navigation.
- Updated and expanded tests (unit + Playwright) to cover the new Settings flow and regressions around “Back” navigation.
- Updated documentation to correct stale guidance: plugin installation is **not** CLI-only anymore.

Benefits:
- New users get a guided, end-to-end setup experience for Worktree + Plugins
- The tour remains stable and predictable across route/tab changes
- Documentation matches the current in-app plugin experience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->