### PR TITLE
feat(plugin): add manifest identity icons (icon, icon_asset) and a discovery source avatar

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -18,9 +18,10 @@ mod manifest;
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
-    screenshot_path_ok, BuildStep, ClientAction, CommandContribution, KeybindContribution,
-    ManifestError, PluginManifest, RuntimeSpec, Screenshot, SettingContribution, SettingType,
-    StatusContribution, ThemeContribution, UiContribution, UiSlot, MAX_SCREENSHOTS,
+    lucide_icon_name_ok, screenshot_path_ok, BuildStep, ClientAction, CommandContribution,
+    KeybindContribution, ManifestError, PluginManifest, RuntimeSpec, Screenshot,
+    SettingContribution, SettingType, StatusContribution, ThemeContribution, UiContribution,
+    UiSlot, MAX_SCREENSHOTS,
 };
 
 /// Version of the manifest schema and host API this crate describes.
@@ -32,5 +33,6 @@ pub use manifest::{
 /// `default_location`); 4 when the `status` contribution section and the
 /// `aoe_version` host-compatibility field were added; 5 when the `screenshots`
 /// presentation metadata was added; 6 when a command could declare a
-/// client-executed `action` (`ClientAction`).
-pub const API_VERSION: u32 = 6;
+/// client-executed `action` (`ClientAction`); 7 when `icon` and `icon_asset`
+/// identity metadata were added.
+pub const API_VERSION: u32 = 7;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -31,6 +31,21 @@ pub struct PluginManifest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub screenshots: Vec<Screenshot>,
 
+    /// Lucide kebab-case icon name (e.g. `"git-branch"`) used as the plugin's
+    /// identity glyph where a raster asset isn't available or hasn't loaded.
+    /// Only syntax-checked here; an unknown name resolves to the host's
+    /// generic fallback icon client-side rather than failing to parse.
+    /// Requires `api_version >= 7`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+
+    /// Repository-relative raster image used as the plugin's identity icon,
+    /// shown in place of `icon` wherever the surface can render an image.
+    /// Same path rules as `screenshots` (see [`screenshot_path_ok`]).
+    /// Requires `api_version >= 7`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_asset: Option<String>,
+
     /// Resource/effect capabilities the plugin requests. Static contributions
     /// below are NOT listed here; only runtime resource access is. The user
     /// grants these once at install (community plugins); builtins are
@@ -260,6 +275,24 @@ pub fn screenshot_path_ok(path: &str) -> bool {
         // No extension (or a leading-dot dotfile with no extension).
         _ => false,
     }
+}
+
+/// Whether `name` is a syntactically valid lucide icon name: lowercase
+/// ASCII kebab-case, non-empty segments, bounded length. Checked here so a
+/// malformed name fails at parse time with an actionable message; whether the
+/// name actually exists in lucide's icon set is the client's problem alone
+/// (an unknown name degrades to the host's generic fallback icon rather than
+/// failing to parse), so this crate does not depend on lucide's registry.
+pub fn lucide_icon_name_ok(name: &str) -> bool {
+    if name.is_empty() || name.len() > 80 {
+        return false;
+    }
+    name.split('-').all(|seg| {
+        !seg.is_empty()
+            && seg
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    })
 }
 
 /// A host-rendered UI slot a plugin may push state into (#2366). A closed set,
@@ -734,6 +767,21 @@ impl PluginManifest {
                 format!("screenshots[{i}].alt must not be empty"),
             );
         }
+        if let Some(icon) = &self.icon {
+            check(
+                lucide_icon_name_ok(icon),
+                format!("icon {icon:?} must be a lucide kebab-case icon name"),
+            );
+        }
+        if let Some(path) = &self.icon_asset {
+            check(
+                screenshot_path_ok(path),
+                format!(
+                    "icon_asset {path:?} must be a repository-relative image path \
+                     (png/jpg/jpeg/gif/webp), not a URL or an absolute/traversing path"
+                ),
+            );
+        }
         // `aoe_version` is the host-app compatibility range, gated by the host
         // at install and load; reject a malformed requirement at parse so the
         // author learns of it before publishing rather than at a user's install.
@@ -765,6 +813,15 @@ impl PluginManifest {
             check(
                 self.screenshots.is_empty(),
                 "screenshots require api_version >= 5".into(),
+            );
+        }
+        // `icon` and `icon_asset` are api_version 7 fields; same reasoning as
+        // the gates above.
+        if self.api_version < 7 {
+            check(self.icon.is_none(), "icon requires api_version >= 7".into());
+            check(
+                self.icon_asset.is_none(),
+                "icon_asset requires api_version >= 7".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -905,3 +905,106 @@ fn screenshot_path_ok_rejects_backslash_and_bad_shapes() {
         assert!(!screenshot_path_ok(bad), "{bad:?} should be rejected");
     }
 }
+
+#[test]
+fn icon_parses_and_round_trips() {
+    let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 7
+icon = "git-branch"
+icon_asset = "assets/icon.png"
+"#;
+    let manifest = PluginManifest::from_toml_str(toml).expect("icon parses");
+    assert_eq!(manifest.icon.as_deref(), Some("git-branch"));
+    assert_eq!(manifest.icon_asset.as_deref(), Some("assets/icon.png"));
+}
+
+#[test]
+fn icon_requires_api_version_7() {
+    let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 6
+icon = "git-branch"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("icon requires api_version >= 7"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn icon_asset_requires_api_version_7() {
+    let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 6
+icon_asset = "assets/icon.png"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("icon_asset requires api_version >= 7"))),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn icon_asset_rejects_bad_paths() {
+    for bad in [
+        "https://tracker.example.com/x.png",
+        "/etc/passwd.png",
+        "../secrets.png",
+        "evil.svg",
+        "noext",
+    ] {
+        let toml = format!(
+            r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 7
+icon_asset = "{bad}"
+"#
+        );
+        let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+        assert!(
+            matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("icon_asset") && e.contains("must be a repository-relative image path"))),
+            "path {bad:?} should be rejected, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn icon_rejects_bad_names() {
+    for bad in ["GitHub", "git_branch", "-git", "git--branch", ""] {
+        let toml = format!(
+            r#"
+id = "acme.widget"
+name = "Widget"
+version = "0.1.0"
+api_version = 7
+icon = "{bad}"
+"#
+        );
+        let err = PluginManifest::from_toml_str(&toml).unwrap_err();
+        assert!(
+            matches!(&err, ManifestError::Invalid(errs) if errs.iter().any(|e| e.contains("must be a lucide kebab-case icon name"))),
+            "icon {bad:?} should be rejected, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn lucide_icon_name_ok_rejects_bad_shapes() {
+    use aoe_plugin_api::lucide_icon_name_ok;
+    assert!(lucide_icon_name_ok("git-branch"));
+    assert!(lucide_icon_name_ok("puzzle"));
+    for bad in ["GitHub", "git_branch", "-git", "git-", "git--branch", ""] {
+        assert!(!lucide_icon_name_ok(bad), "{bad:?} should be rejected");
+    }
+}

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -46,6 +46,35 @@ image. The assets must be committed and pushed to the source repo before they
 render; local plugins do not support screenshots yet (future work beyond
 #2484).
 
+### Identity icon
+
+A plugin may declare a static identity icon, shown in the installed Settings >
+Plugins list, the detail modal, and (as a fallback) its activity-bar pane
+button (requires `api_version >= 7`):
+
+```toml
+icon = "git-branch"                 # a lucide kebab-case icon name
+icon_asset = "assets/icon.png"      # repository-relative raster image
+```
+
+`icon` is only syntax-checked (lowercase kebab-case); whether the name exists
+in lucide's icon set is the web client's problem, and an unknown name falls
+back to a generic icon rather than failing to parse. `icon_asset` follows the
+exact same path rules as `screenshots.path`; lucide ships no brand/logo icons
+(the motivating case: the GitHub plugin cannot render its own mark through
+`icon` alone), so `icon_asset` is how a plugin ships one. When both are set,
+`icon_asset` wins wherever an image can render, falling back to `icon` if the
+asset fails to load.
+
+For an installed (not-yet-uninstalled) plugin, `icon_asset` is served from its
+own install directory via `GET /api/plugins/{id}/icon`, which re-validates the
+path and canonicalizes it against the install directory before reading, so a
+plugin cannot declare a path that escapes its own tree. For a `gh:` source not
+yet installed, the plugin detail endpoint resolves it to
+`raw.githubusercontent.com` exactly like screenshots. A builtin (no install
+directory) or a plugin with no `icon_asset` renders `icon` or the generic
+fallback instead.
+
 ## Registry
 
 `src/plugin/registry.rs` owns the in-process registry.
@@ -720,6 +749,13 @@ means "a curated source slug", not "the current tree matches the pin". Results
 rank featured-first then by stars (#2105 will add popularity ranking). Install
 stays the trust boundary: `aoe plugin install` fetches the manifest, prompts for
 capabilities, and enforces the featured pin.
+
+Each result also carries `source_avatar_url`, the repo owner's GitHub avatar
+(`github.com/{owner}.png`), derived from the search response's `full_name` with
+no extra request. This is a source-identity affordance, not the plugin's own
+`icon`/`icon_asset` (unknown until a manifest fetch, which discovery
+deliberately never does); the dashboard renders it as a separate, distinctly
+styled avatar rather than through the plugin identity icon component.
 
 Surfaces: `aoe plugin discover [query]`, the TUI plugin manager `d` key, and the
 dashboard "Search GitHub" button (`GET /api/plugins/discover?q=`). The dashboard

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -13,7 +13,7 @@
 use std::time::Duration;
 
 use anyhow::{bail, Result};
-use aoe_plugin_api::{screenshot_path_ok, MAX_SCREENSHOTS};
+use aoe_plugin_api::{lucide_icon_name_ok, screenshot_path_ok, MAX_SCREENSHOTS};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use serde::{Deserialize, Serialize};
 
@@ -85,6 +85,15 @@ pub struct DiscoveryResult {
     /// The exact command to install this plugin (web has no install path, so it
     /// shows this for the user to copy into a terminal).
     pub install_command: String,
+    /// The repo owner's GitHub avatar (`github.com/{owner}.png`), shown as a
+    /// source-identity affordance. This is NOT the plugin's own identity icon
+    /// (`aoe-plugin.toml`'s `icon`/`icon_asset`, only known after a manifest
+    /// fetch): discovery is deliberately repo-level and never fetches each
+    /// result's manifest (see the module doc), so the owner avatar is the only
+    /// zero-cost visual identity available at search time. Always resolvable
+    /// from `full_name` with no extra request; GitHub serves this path for any
+    /// owner.
+    pub source_avatar_url: String,
 }
 
 /// Search the `aoe-plugin` topic and badge each result. `query` is an optional
@@ -148,6 +157,8 @@ fn badge_repos(
             } else {
                 DiscoveryBadge::Unvetted
             };
+            // Already validated as exactly two non-empty segments above.
+            let owner = repo.full_name.split('/').next().unwrap_or_default();
             Some(DiscoveryResult {
                 install_command: format!("aoe plugin install {slug}"),
                 slug,
@@ -156,6 +167,7 @@ fn badge_repos(
                 description: repo.description.filter(|d| !d.is_empty()),
                 stars: repo.stargazers_count,
                 badge,
+                source_avatar_url: format!("https://github.com/{owner}.png?size=64"),
             })
         })
         .collect()
@@ -202,6 +214,12 @@ pub struct DetailManifest {
     /// `raw.githubusercontent.com`. Author-declared paths that fail validation
     /// are dropped here rather than failing the whole detail.
     pub screenshots: Vec<ScreenshotView>,
+    /// Lucide kebab-case identity icon name, straight from the manifest.
+    pub icon: Option<String>,
+    /// The manifest's `icon_asset`, resolved to a `raw.githubusercontent.com`
+    /// URL exactly like screenshots. `None` below `api_version >= 7` or when
+    /// the declared path fails validation.
+    pub icon_asset_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -244,6 +262,23 @@ fn resolve_screenshots(
             caption: s.caption,
         })
         .collect()
+}
+
+/// Resolve a manifest's raw `icon_asset` into a browser-fetchable URL. Gated
+/// on `api_version >= 7` to mirror [`aoe_plugin_api::PluginManifest::validate`],
+/// and dropped on an invalid path, exactly like [`resolve_screenshots`].
+fn resolve_icon_asset(
+    api_version: u32,
+    path: Option<String>,
+    owner: &str,
+    repo: &str,
+    reference: Option<&str>,
+) -> Option<String> {
+    if api_version < 7 {
+        return None;
+    }
+    let path = path?;
+    screenshot_path_ok(&path).then(|| raw_url(owner, repo, reference, &path))
 }
 
 /// Build the `raw.githubusercontent.com` URL for a repository-relative path.
@@ -290,6 +325,10 @@ struct RawManifest {
     ui: Vec<RawUi>,
     #[serde(default)]
     screenshots: Vec<RawScreenshot>,
+    #[serde(default)]
+    icon: Option<String>,
+    #[serde(default)]
+    icon_asset: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -345,6 +384,17 @@ pub async fn details(source: &str) -> Result<PluginDetail> {
                 screenshots: resolve_screenshots(
                     m.api_version,
                     m.screenshots,
+                    owner,
+                    repo,
+                    reference,
+                ),
+                icon: (m.api_version >= 7)
+                    .then_some(m.icon)
+                    .flatten()
+                    .filter(|i| lucide_icon_name_ok(i)),
+                icon_asset_url: resolve_icon_asset(
+                    m.api_version,
+                    m.icon_asset,
                     owner,
                     repo,
                     reference,
@@ -541,5 +591,61 @@ alt = "good"
     fn install_command_uses_the_slug() {
         let out = badge_repos(vec![repo("acme/widget", 1)], &FeaturedIndex::default(), &[]);
         assert_eq!(out[0].install_command, "aoe plugin install gh:acme/widget");
+    }
+
+    #[test]
+    fn source_avatar_url_derives_from_the_owner_with_no_extra_request() {
+        let out = badge_repos(vec![repo("acme/widget", 1)], &FeaturedIndex::default(), &[]);
+        assert_eq!(
+            out[0].source_avatar_url,
+            "https://github.com/acme.png?size=64"
+        );
+    }
+
+    #[test]
+    fn detail_manifest_parses_icon_and_resolves_icon_asset() {
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 7
+icon = "git-branch"
+icon_asset = "assets/icon.png"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        assert_eq!(m.icon.as_deref(), Some("git-branch"));
+        let url = resolve_icon_asset(m.api_version, m.icon_asset, "acme", "widget", None);
+        assert_eq!(
+            url.as_deref(),
+            Some("https://raw.githubusercontent.com/acme/widget/HEAD/assets/icon.png")
+        );
+    }
+
+    #[test]
+    fn icon_asset_gated_out_below_api_version_7() {
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 6
+icon_asset = "assets/icon.png"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        let url = resolve_icon_asset(m.api_version, m.icon_asset, "acme", "widget", None);
+        assert!(url.is_none(), "v6 must not expose icon_asset");
+    }
+
+    #[test]
+    fn icon_asset_drops_an_invalid_path() {
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 7
+icon_asset = "https://tracker.example.com/x.png"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        let url = resolve_icon_asset(m.api_version, m.icon_asset, "acme", "widget", None);
+        assert!(url.is_none(), "an absolute URL path must be dropped");
     }
 }

--- a/src/plugin/discover.rs
+++ b/src/plugin/discover.rs
@@ -264,6 +264,18 @@ fn resolve_screenshots(
         .collect()
 }
 
+/// Resolve a manifest's raw `icon` name, gated on `api_version >= 7` and
+/// syntax-checked via [`lucide_icon_name_ok`], so a malformed or pre-7 name
+/// from attacker-influenced remote manifest content never reaches the client.
+/// Extracted from the `details()` call site so this filter is independently
+/// testable without a network-backed `details()` call.
+fn resolve_icon_name(api_version: u32, icon: Option<String>) -> Option<String> {
+    if api_version < 7 {
+        return None;
+    }
+    icon.filter(|i| lucide_icon_name_ok(i))
+}
+
 /// Resolve a manifest's raw `icon_asset` into a browser-fetchable URL. Gated
 /// on `api_version >= 7` to mirror [`aoe_plugin_api::PluginManifest::validate`],
 /// and dropped on an invalid path, exactly like [`resolve_screenshots`].
@@ -388,10 +400,7 @@ pub async fn details(source: &str) -> Result<PluginDetail> {
                     repo,
                     reference,
                 ),
-                icon: (m.api_version >= 7)
-                    .then_some(m.icon)
-                    .flatten()
-                    .filter(|i| lucide_icon_name_ok(i)),
+                icon: resolve_icon_name(m.api_version, m.icon),
                 icon_asset_url: resolve_icon_asset(
                     m.api_version,
                     m.icon_asset,
@@ -613,11 +622,46 @@ icon = "git-branch"
 icon_asset = "assets/icon.png"
 "#;
         let m: RawManifest = toml::from_str(toml).expect("lenient parse");
-        assert_eq!(m.icon.as_deref(), Some("git-branch"));
+        assert_eq!(
+            resolve_icon_name(m.api_version, m.icon.clone()).as_deref(),
+            Some("git-branch")
+        );
         let url = resolve_icon_asset(m.api_version, m.icon_asset, "acme", "widget", None);
         assert_eq!(
             url.as_deref(),
             Some("https://raw.githubusercontent.com/acme/widget/HEAD/assets/icon.png")
+        );
+    }
+
+    #[test]
+    fn icon_name_gated_out_below_api_version_7() {
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 6
+icon = "git-branch"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        assert!(
+            resolve_icon_name(m.api_version, m.icon).is_none(),
+            "v6 must not expose icon"
+        );
+    }
+
+    #[test]
+    fn icon_name_drops_an_invalid_name() {
+        let toml = r#"
+id = "acme.widget"
+name = "Widget"
+version = "1.0.0"
+api_version = 7
+icon = "GitHub"
+"#;
+        let m: RawManifest = toml::from_str(toml).expect("lenient parse");
+        assert!(
+            resolve_icon_name(m.api_version, m.icon).is_none(),
+            "a non-kebab-case name must be dropped, not surfaced to the client"
         );
     }
 

--- a/src/plugin/view.rs
+++ b/src/plugin/view.rs
@@ -15,6 +15,13 @@ pub struct PluginView {
     pub name: String,
     pub version: String,
     pub description: String,
+    /// Lucide kebab-case identity icon name, straight from the manifest.
+    pub icon: Option<String>,
+    /// Resolved URL for the manifest's `icon_asset`, only set when the plugin
+    /// has both an on-disk install directory (not a builtin) and an
+    /// `icon_asset` path: `GET /api/plugins/{id}/icon` streams it from the
+    /// install directory.
+    pub icon_asset_url: Option<String>,
     pub enabled: bool,
     /// First-party builtin (compiled in) versus an externally installed plugin.
     pub builtin: bool,
@@ -51,6 +58,9 @@ impl LoadedPlugin {
             name: self.manifest.name.clone(),
             version: self.manifest.version.clone(),
             description: self.manifest.description.clone(),
+            icon: self.manifest.icon.clone(),
+            icon_asset_url: (self.manifest.icon_asset.is_some() && self.dir.is_some())
+                .then(|| format!("/api/plugins/{}/icon", self.id())),
             enabled: self.enabled,
             builtin: self.builtin(),
             validation: self.validation.as_str().to_string(),

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -39,8 +39,8 @@ pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_con
 pub use plugins::{
     apply_plugin_update, dismiss_plugin_update, invoke_plugin_action, list_plugins,
     plugin_commands, plugin_details, plugin_discover, plugin_job_status, plugin_ui_state,
-    plugin_update_preview, plugin_updates, preview_plugin_install, set_plugin_enabled,
-    start_plugin_install, start_plugin_uninstall,
+    plugin_update_preview, plugin_updates, preview_plugin_install, serve_plugin_icon,
+    set_plugin_enabled, start_plugin_install, start_plugin_uninstall,
 };
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -61,6 +61,77 @@ pub async fn list_plugins() -> Json<serde_json::Value> {
     }))
 }
 
+/// Resolve a plugin's declared `icon_asset` (repository-relative, already
+/// `screenshot_path_ok`-checked) against its install directory, refusing to
+/// serve anything outside that directory. Both `dir` and the joined path are
+/// canonicalized so a symlink or `..` segment cannot escape containment; the
+/// caller passes the already-loaded `dir`/`rel` rather than this function
+/// touching the registry, so it is plain path logic and testable without a
+/// running plugin host.
+fn resolve_plugin_icon_path(dir: &std::path::Path, rel: &str) -> Option<PathBuf> {
+    if !aoe_plugin_api::screenshot_path_ok(rel) {
+        return None;
+    }
+    let root = dir.canonicalize().ok()?;
+    let target = root.join(rel).canonicalize().ok()?;
+    target.starts_with(&root).then_some(target)
+}
+
+fn content_type_for_icon(path: &std::path::Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => Some("image/png"),
+        Some("jpg") | Some("jpeg") => Some("image/jpeg"),
+        Some("gif") => Some("image/gif"),
+        Some("webp") => Some("image/webp"),
+        _ => None,
+    }
+}
+
+/// `GET /api/plugins/{id}/icon`: stream an installed plugin's `icon_asset`
+/// from its install directory. Mirrors `serve_sound_file`'s allowlist-then-read
+/// shape: the manifest path is re-validated and re-joined against the
+/// plugin's own directory rather than trusted from a cached URL. A builtin
+/// (no install directory) or a plugin with no `icon_asset` 404s.
+pub async fn serve_plugin_icon(Path(id): Path<String>) -> Response {
+    let registry = plugin::registry();
+    let Some(plugin) = registry.all().iter().find(|p| p.id() == id) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let (Some(dir), Some(rel)) = (plugin.dir.clone(), plugin.manifest.icon_asset.clone()) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let resolved = tokio::task::spawn_blocking(move || resolve_plugin_icon_path(&dir, &rel)).await;
+    let path = match resolved {
+        Ok(Some(p)) => p,
+        _ => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let Some(content_type) = content_type_for_icon(&path) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    (
+        StatusCode::OK,
+        [
+            (axum::http::header::CONTENT_TYPE, content_type),
+            (axum::http::header::CACHE_CONTROL, "private, max-age=3600"),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
 /// One active plugin command, normalized for the dashboard command palette and
 /// keymap: the namespaced `fqid`, its declared keybind chords, and its optional
 /// client-executed `action`. The web binds and renders these without parsing
@@ -713,5 +784,62 @@ mod tests {
             PluginJobStatus::Failed { error } => assert!(error.contains("boom"), "{error}"),
             other => panic!("expected Failed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_plugin_icon_path_serves_a_file_inside_the_install_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("icon.png"), b"fake png bytes").unwrap();
+        let resolved = resolve_plugin_icon_path(dir.path(), "icon.png").expect("resolves");
+        assert_eq!(
+            resolved,
+            dir.path().canonicalize().unwrap().join("icon.png")
+        );
+    }
+
+    #[test]
+    fn resolve_plugin_icon_path_rejects_traversal_and_absolute_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("icon.png"), b"x").unwrap();
+        // "../secret.png" is rejected by screenshot_path_ok's shape check
+        // alone, before any filesystem access, so no sibling file is needed
+        // to prove containment holds.
+        for bad in [
+            "../secret.png",
+            "/etc/passwd.png",
+            "icon.svg",
+            "missing.png",
+        ] {
+            assert!(
+                resolve_plugin_icon_path(dir.path(), bad).is_none(),
+                "{bad:?} should not resolve"
+            );
+        }
+    }
+
+    #[test]
+    fn content_type_for_icon_covers_raster_extensions_only() {
+        assert_eq!(
+            content_type_for_icon(std::path::Path::new("a.png")),
+            Some("image/png")
+        );
+        assert_eq!(
+            content_type_for_icon(std::path::Path::new("a.jpg")),
+            Some("image/jpeg")
+        );
+        assert_eq!(
+            content_type_for_icon(std::path::Path::new("a.jpeg")),
+            Some("image/jpeg")
+        );
+        assert_eq!(
+            content_type_for_icon(std::path::Path::new("a.gif")),
+            Some("image/gif")
+        );
+        assert_eq!(
+            content_type_for_icon(std::path::Path::new("a.webp")),
+            Some("image/webp")
+        );
+        assert_eq!(content_type_for_icon(std::path::Path::new("a.svg")), None);
+        assert_eq!(content_type_for_icon(std::path::Path::new("a")), None);
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1562,6 +1562,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Plugin management. The enable/disable toggle gates on read-only +
         // elevation inside the handler.
         .route("/api/plugins", get(api::list_plugins))
+        .route("/api/plugins/{id}/icon", get(api::serve_plugin_icon))
         .route("/api/plugins/commands", get(api::plugin_commands))
         .route("/api/plugins/ui-state", get(api::plugin_ui_state))
         .route("/api/plugins/updates", get(api::plugin_updates))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,7 +37,7 @@ import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
 import { useIsWideViewport } from "./hooks/useIsWideViewport";
 import type { RightPanelView } from "./lib/rightPanelView";
 import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab } from "./lib/paneLayout";
-import { isPluginPaneId, usePluginPanes, type PluginPane } from "./lib/pluginPanes";
+import { isPluginPaneId, resolvePaneIcon, usePluginPanes, type PluginPane } from "./lib/pluginPanes";
 import { PluginPaneBody } from "./components/plugin/PluginSlots";
 import { TOUR_ANCHORS, tourAnchor } from "./lib/tourSteps";
 import {
@@ -69,6 +69,7 @@ import {
   setSessionSnooze,
   trashSession,
   restoreSession,
+  fetchPlugins,
 } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { normalizeProjectPathKey } from "./lib/registeredProjects";
@@ -452,10 +453,28 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     syncPlugins(pluginPanes.map((p) => ({ id: p.id, defaultDock: p.defaultDock })));
   }, [pluginPanes, syncPlugins]);
 
+  // One-shot lookup from plugin id to its manifest identity icon, so a pane
+  // that doesn't set its own per-pane icon still gets something more
+  // distinctive than the generic Puzzle fallback. Fetched once on mount
+  // rather than polled: the installed-plugin list itself has no live sync
+  // anywhere else in the app today (Settings > Plugins only reloads on
+  // mount and after its own mutations), so this matches existing staleness
+  // tolerance rather than introducing a new one.
+  const [pluginIconNameById, setPluginIconNameById] = useState<Record<string, string | undefined>>({});
+  useEffect(() => {
+    void fetchPlugins().then((res) => {
+      if (!res) return;
+      setPluginIconNameById(Object.fromEntries(res.plugins.map((p) => [p.id, p.icon ?? undefined])));
+    });
+  }, []);
+
   const paneDescriptor = useCallback(
     (id: string): PaneDisplay => {
       const plugin = pluginPaneById.get(id);
-      if (plugin) return { title: plugin.title, icon: plugin.icon ?? Puzzle };
+      if (plugin) {
+        const icon = resolvePaneIcon(plugin.icon, pluginIconNameById[plugin.entry.plugin_id]) ?? Puzzle;
+        return { title: plugin.title, icon };
+      }
       if (isTerminalTabId(id)) {
         const idx = terminalIndexOf(id);
         const term = BUILTIN_PANES.find((p) => p.id === "terminal")!;
@@ -464,7 +483,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       const d = BUILTIN_PANES.find((p) => p.id === id)!;
       return { title: d.title, icon: d.icon };
     },
-    [pluginPaneById],
+    [pluginPaneById, pluginIconNameById],
   );
 
   // A persisted tab is visible only if its backing pane currently exists: diff

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -95,7 +95,12 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
       >
         <div className="mb-3 flex items-start justify-between gap-3">
           <div className="flex items-start gap-2">
-            <PluginIdentityIcon icon={icon} iconAssetUrl={iconAssetUrl} className="mt-0.5 size-5" />
+            <PluginIdentityIcon
+              icon={icon}
+              iconAssetUrl={iconAssetUrl}
+              className="mt-0.5 size-5"
+              testId="plugin-detail-icon"
+            />
             <div>
               <h2 className="font-semibold">{title}</h2>
               {version && <p className="text-xs text-text-dim">v{version}</p>}

--- a/web/src/components/settings/PluginDetailModal.tsx
+++ b/web/src/components/settings/PluginDetailModal.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
 
 import { fetchPluginDetails, type PluginDetail } from "../../lib/api";
+import { PluginIdentityIcon } from "./PluginIdentityIcon";
 
 interface Fallback {
   version?: string;
   description?: string;
   capabilities?: string[];
   ui_contributions?: { slot: string; id: string }[];
+  icon?: string | null;
+  icon_asset_url?: string | null;
 }
 
 interface PluginDetailModalProps {
@@ -71,6 +74,8 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
   const description = manifest?.description ?? fallback?.description ?? null;
   const capabilities = manifest?.capabilities ?? fallback?.capabilities ?? [];
   const ui = manifest?.ui_contributions ?? fallback?.ui_contributions ?? [];
+  const icon = manifest?.icon ?? fallback?.icon ?? null;
+  const iconAssetUrl = manifest?.icon_asset_url ?? fallback?.icon_asset_url ?? null;
   // Screenshots come only from the fetched gh manifest; a no-media plugin
   // yields an empty list and renders no gallery chrome.
   const screenshots = manifest?.screenshots ?? [];
@@ -89,10 +94,13 @@ export function PluginDetailModal({ source, title, fallback, installCommand, onC
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-3 flex items-start justify-between gap-3">
-          <div>
-            <h2 className="font-semibold">{title}</h2>
-            {version && <p className="text-xs text-text-dim">v{version}</p>}
-            <p className="text-[11px] text-text-dim">{source}</p>
+          <div className="flex items-start gap-2">
+            <PluginIdentityIcon icon={icon} iconAssetUrl={iconAssetUrl} className="mt-0.5 size-5" />
+            <div>
+              <h2 className="font-semibold">{title}</h2>
+              {version && <p className="text-xs text-text-dim">v{version}</p>}
+              <p className="text-[11px] text-text-dim">{source}</p>
+            </div>
           </div>
           <button
             type="button"

--- a/web/src/components/settings/PluginIdentityIcon.tsx
+++ b/web/src/components/settings/PluginIdentityIcon.tsx
@@ -1,0 +1,36 @@
+import { createElement, useState } from "react";
+import { Puzzle } from "lucide-react";
+
+import { lucideIcon } from "../../lib/pluginUi";
+
+interface Props {
+  /** Manifest `icon`: a lucide kebab-case name, or null/undefined if unset. */
+  icon?: string | null;
+  /** Manifest `icon_asset` resolved to a fetchable URL, or null/undefined. */
+  iconAssetUrl?: string | null;
+  className?: string;
+}
+
+/** A plugin's identity glyph: `icon_asset_url` if present (falls back to
+ *  `icon` if the image 404s), else the manifest's lucide `icon`, else the
+ *  generic `Puzzle` icon. Always rendered next to the plugin's name on every
+ *  surface that uses it, so the icon itself is decorative (`alt=""
+ *  aria-hidden`) rather than needing author-supplied alt text. */
+export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4" }: Props) {
+  const [assetFailed, setAssetFailed] = useState(false);
+
+  if (iconAssetUrl && !assetFailed) {
+    return (
+      <img
+        src={iconAssetUrl}
+        alt=""
+        aria-hidden="true"
+        className={`${className} shrink-0 rounded-sm object-contain`}
+        onError={() => setAssetFailed(true)}
+      />
+    );
+  }
+
+  const Icon = (icon && lucideIcon(icon)) || Puzzle;
+  return createElement(Icon, { className: `${className} shrink-0`, "aria-hidden": true });
+}

--- a/web/src/components/settings/PluginIdentityIcon.tsx
+++ b/web/src/components/settings/PluginIdentityIcon.tsx
@@ -19,6 +19,15 @@ interface Props {
  *  aria-hidden`) rather than needing author-supplied alt text. */
 export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4", testId }: Props) {
   const [assetFailed, setAssetFailed] = useState(false);
+  // Reset the failure flag whenever a new URL is supplied (e.g. the detail
+  // modal swaps the local fallback route for the resolved manifest URL once
+  // its gh fetch lands), so a transient failure on the first URL doesn't
+  // permanently hide a later working one.
+  const [trackedUrl, setTrackedUrl] = useState(iconAssetUrl);
+  if (iconAssetUrl !== trackedUrl) {
+    setTrackedUrl(iconAssetUrl);
+    setAssetFailed(false);
+  }
 
   if (iconAssetUrl && !assetFailed) {
     return (

--- a/web/src/components/settings/PluginIdentityIcon.tsx
+++ b/web/src/components/settings/PluginIdentityIcon.tsx
@@ -1,4 +1,4 @@
-import { createElement, useState } from "react";
+import { createElement, useState, type ComponentType } from "react";
 import { Puzzle } from "lucide-react";
 
 import { lucideIcon } from "../../lib/pluginUi";
@@ -34,5 +34,12 @@ export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4", t
   }
 
   const Icon = (icon && lucideIcon(icon)) || Puzzle;
-  return createElement(Icon, { className: `${className} shrink-0`, "aria-hidden": true, "data-testid": testId });
+  // `data-testid` isn't in LucideProps; widen to a generic component type
+  // rather than dropping the attribute, since assertions need to reach the
+  // rendered svg itself, not a wrapping element.
+  return createElement(Icon as ComponentType<Record<string, unknown>>, {
+    className: `${className} shrink-0`,
+    "aria-hidden": true,
+    "data-testid": testId,
+  });
 }

--- a/web/src/components/settings/PluginIdentityIcon.tsx
+++ b/web/src/components/settings/PluginIdentityIcon.tsx
@@ -9,6 +9,7 @@ interface Props {
   /** Manifest `icon_asset` resolved to a fetchable URL, or null/undefined. */
   iconAssetUrl?: string | null;
   className?: string;
+  testId?: string;
 }
 
 /** A plugin's identity glyph: `icon_asset_url` if present (falls back to
@@ -16,7 +17,7 @@ interface Props {
  *  generic `Puzzle` icon. Always rendered next to the plugin's name on every
  *  surface that uses it, so the icon itself is decorative (`alt=""
  *  aria-hidden`) rather than needing author-supplied alt text. */
-export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4" }: Props) {
+export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4", testId }: Props) {
   const [assetFailed, setAssetFailed] = useState(false);
 
   if (iconAssetUrl && !assetFailed) {
@@ -25,6 +26,7 @@ export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4" }:
         src={iconAssetUrl}
         alt=""
         aria-hidden="true"
+        data-testid={testId}
         className={`${className} shrink-0 rounded-sm object-contain`}
         onError={() => setAssetFailed(true)}
       />
@@ -32,5 +34,5 @@ export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4" }:
   }
 
   const Icon = (icon && lucideIcon(icon)) || Puzzle;
-  return createElement(Icon, { className: `${className} shrink-0`, "aria-hidden": true });
+  return createElement(Icon, { className: `${className} shrink-0`, "aria-hidden": true, "data-testid": testId });
 }

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -494,7 +494,11 @@ export function PluginsSettings() {
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <PluginIdentityIcon icon={plugin.icon} iconAssetUrl={plugin.icon_asset_url} />
+                      <PluginIdentityIcon
+                        icon={plugin.icon}
+                        iconAssetUrl={plugin.icon_asset_url}
+                        testId={`plugin-icon-${plugin.id}`}
+                      />
                       <button
                         type="button"
                         className="font-medium hover:underline"

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../lib/api";
 import { reportInfo } from "../../lib/toastBus";
 import { PluginDetailModal } from "./PluginDetailModal";
+import { PluginIdentityIcon } from "./PluginIdentityIcon";
 import { PluginInstallConsentModal } from "./PluginInstallConsentModal";
 import { PluginJobProgressModal } from "./PluginJobProgressModal";
 import { PluginUpdateConsentModal } from "./PluginUpdateConsentModal";
@@ -33,6 +34,8 @@ interface DetailTarget {
     description?: string;
     capabilities?: string[];
     ui_contributions?: { slot: string; id: string }[];
+    icon?: string | null;
+    icon_asset_url?: string | null;
   };
   installCommand?: string;
 }
@@ -396,6 +399,18 @@ export function PluginsSettings() {
                     data-testid={`plugins-discover-result-${r.slug}`}
                   >
                     <div className="flex flex-wrap items-center gap-2">
+                      <img
+                        src={r.source_avatar_url}
+                        alt=""
+                        aria-hidden="true"
+                        className="size-4 shrink-0 rounded-full"
+                        data-testid={`plugins-discover-avatar-${r.slug}`}
+                        // A deleted or renamed GitHub account 404s; hide the
+                        // avatar rather than leave a broken-image icon.
+                        onError={(e) => {
+                          e.currentTarget.classList.add("hidden");
+                        }}
+                      />
                       <button
                         type="button"
                         className="font-medium text-accent-500 hover:underline"
@@ -479,6 +494,7 @@ export function PluginsSettings() {
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
+                      <PluginIdentityIcon icon={plugin.icon} iconAssetUrl={plugin.icon_asset_url} />
                       <button
                         type="button"
                         className="font-medium hover:underline"
@@ -491,6 +507,8 @@ export function PluginsSettings() {
                               description: plugin.description,
                               capabilities: plugin.capabilities,
                               ui_contributions: plugin.ui_contributions,
+                              icon: plugin.icon,
+                              icon_asset_url: plugin.icon_asset_url,
                             },
                           })
                         }

--- a/web/src/components/settings/__tests__/PluginIdentityIcon.test.tsx
+++ b/web/src/components/settings/__tests__/PluginIdentityIcon.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PluginIdentityIcon } from "../PluginIdentityIcon";
+
+describe("PluginIdentityIcon", () => {
+  it("falls back to the lucide icon, then retries a later working URL instead of staying stuck", async () => {
+    const { findByTestId, getByTestId, rerender } = render(
+      <PluginIdentityIcon icon="git-branch" iconAssetUrl="/first.png" testId="icon" />,
+    );
+    // The asset fails to load; the component falls back to the lucide icon
+    // (a dynamically-loaded lucide component, hence findByTestId to await it).
+    fireEvent.error(getByTestId("icon"));
+    expect((await findByTestId("icon")).tagName).toBe("svg");
+
+    // A later render swaps in a different (working) URL, e.g. the detail
+    // modal's fallback route getting replaced by the resolved manifest URL.
+    // The prior failure must not stick to the new URL.
+    rerender(<PluginIdentityIcon icon="git-branch" iconAssetUrl="/second.png" testId="icon" />);
+    const icon = await findByTestId("icon");
+    expect(icon.tagName).toBe("IMG");
+    expect(icon.getAttribute("src")).toBe("/second.png");
+  });
+});

--- a/web/src/components/settings/__tests__/PluginsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PluginsSettings.test.tsx
@@ -528,6 +528,93 @@ describe("PluginsSettings", () => {
     await waitFor(() => expect(queryByTestId("plugin-detail-modal")).toBeNull());
   });
 
+  it("renders an installed plugin's icon_asset as an image", async () => {
+    fetchPlugins.mockResolvedValue(
+      listResponse({
+        plugins: [
+          {
+            id: "agent-of-empires.github",
+            name: "GitHub",
+            version: "1.0.0",
+            description: "GitHub integration.",
+            enabled: true,
+            builtin: false,
+            validation: "featured",
+            source: "gh:agent-of-empires/plugin-github",
+            capabilities: [],
+            ui_contributions: [],
+            granted: true,
+            needs_reapproval: false,
+            icon: "github",
+            icon_asset_url: "/api/plugins/agent-of-empires.github/icon",
+          },
+        ],
+      }),
+    );
+    const { findByTestId } = render(<PluginsSettings />);
+    const icon = await findByTestId("plugin-icon-agent-of-empires.github");
+    expect(icon.tagName).toBe("IMG");
+    expect(icon.getAttribute("src")).toBe("/api/plugins/agent-of-empires.github/icon");
+  });
+
+  it("falls back to the lucide icon when a plugin has no icon_asset_url", async () => {
+    fetchPlugins.mockResolvedValue(
+      listResponse({
+        plugins: [
+          {
+            id: "acme.widget",
+            name: "Widget",
+            version: "1.0.0",
+            description: "A widget.",
+            enabled: true,
+            builtin: false,
+            validation: "community",
+            source: "gh:acme/widget",
+            capabilities: [],
+            ui_contributions: [],
+            granted: true,
+            needs_reapproval: false,
+            icon: "git-branch",
+            icon_asset_url: null,
+          },
+        ],
+      }),
+    );
+    const { findByTestId } = render(<PluginsSettings />);
+    const icon = await findByTestId("plugin-icon-acme.widget");
+    expect(icon.tagName).toBe("svg");
+  });
+
+  it("shows the plugin's icon in the detail modal header", async () => {
+    fetchPlugins.mockResolvedValue(
+      listResponse({
+        plugins: [
+          {
+            id: "agent-of-empires.github",
+            name: "GitHub",
+            version: "1.0.0",
+            description: "GitHub integration.",
+            enabled: true,
+            builtin: false,
+            validation: "featured",
+            source: "gh:agent-of-empires/plugin-github",
+            capabilities: [],
+            ui_contributions: [],
+            granted: true,
+            needs_reapproval: false,
+            icon: "github",
+            icon_asset_url: "/api/plugins/agent-of-empires.github/icon",
+          },
+        ],
+      }),
+    );
+    const { findByTestId } = render(<PluginsSettings />);
+    fireEvent.click(await findByTestId("plugin-open-agent-of-empires.github"));
+    const icon = await findByTestId("plugin-detail-icon");
+    expect(icon.tagName).toBe("IMG");
+    expect(icon.getAttribute("src")).toBe("/api/plugins/agent-of-empires.github/icon");
+  });
+
   it("Escape closes the detail modal when no lightbox is open", async () => {
     const { findByTestId, queryByTestId } = render(<PluginsSettings />);
     fireEvent.click(await findByTestId("plugin-open-example.plugin"));

--- a/web/src/lib/__tests__/pluginPanes.test.tsx
+++ b/web/src/lib/__tests__/pluginPanes.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
+import { GitBranch } from "lucide-react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PluginUiEntry } from "../api";
-import { isPluginPaneId, usePluginPanes } from "../pluginPanes";
+import { isPluginPaneId, resolvePaneIcon, usePluginPanes } from "../pluginPanes";
 
 const { entriesRef } = vi.hoisted(() => ({ entriesRef: { current: [] as PluginUiEntry[] } }));
 vi.mock("../pluginUiContext", () => ({ usePluginUiEntries: () => entriesRef.current }));
@@ -40,5 +41,23 @@ describe("usePluginPanes", () => {
   it("returns nothing without a session", () => {
     set([{ plugin_id: "gh", slot: "pane", id: "main", session_id: "s1", payload: {} }]);
     expect(renderHook(() => usePluginPanes(null)).result.current).toEqual([]);
+  });
+});
+
+describe("resolvePaneIcon", () => {
+  it("prefers the pane's own runtime icon over the manifest icon", () => {
+    expect(resolvePaneIcon(GitBranch, "puzzle")).toBe(GitBranch);
+  });
+
+  it("falls back to the manifest identity icon when the pane sets none", () => {
+    expect(resolvePaneIcon(undefined, "git-branch")).toBeDefined();
+  });
+
+  it("falls through to undefined for an unknown manifest icon name", () => {
+    expect(resolvePaneIcon(undefined, "not-a-real-lucide-icon-name")).toBeUndefined();
+  });
+
+  it("falls through to undefined when neither is set", () => {
+    expect(resolvePaneIcon(undefined, undefined)).toBeUndefined();
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -222,6 +222,11 @@ export interface PluginView {
   name: string;
   version: string;
   description: string;
+  /** Lucide kebab-case identity icon name, straight from the manifest. */
+  icon: string | null;
+  /** Resolved URL for the manifest's `icon_asset` (served from the plugin's
+   *  install directory), null for a builtin or a plugin with no icon_asset. */
+  icon_asset_url: string | null;
   enabled: boolean;
   builtin: boolean;
   /** Validation provenance: "builtin" | "featured" | "community" | "local". */
@@ -327,6 +332,10 @@ export interface PluginDiscoveryResult {
   stars: number;
   badge: "installed" | "featured" | "unvetted";
   install_command: string;
+  /** The repo owner's GitHub avatar; a source-identity affordance, NOT the
+   *  plugin's own icon (unknown until a manifest fetch, which discovery
+   *  results never do). */
+  source_avatar_url: string;
 }
 
 export type DiscoverResult = { kind: "ok"; results: PluginDiscoveryResult[] } | { kind: "error"; message: string };
@@ -364,6 +373,10 @@ export interface PluginDetailManifest {
   ui_contributions: { slot: string; id: string }[];
   /** Screenshot/GIF previews, each resolved server-side to a raw.githubusercontent.com URL. */
   screenshots: { src: string; alt: string; caption: string }[];
+  /** Lucide kebab-case identity icon name. */
+  icon: string | null;
+  /** The manifest's `icon_asset`, resolved server-side to a raw.githubusercontent.com URL. */
+  icon_asset_url: string | null;
 }
 
 /** On-demand detail for one plugin source (`GET /api/plugins/details`): manifest

--- a/web/src/lib/pluginPanes.ts
+++ b/web/src/lib/pluginPanes.ts
@@ -33,6 +33,20 @@ function defaultDock(entry: PluginUiEntry): DockLocation {
   return entry.payload["default_location"] === "bottom" ? "bottom" : "right";
 }
 
+/** Fallback chain for a plugin pane's activity-bar/tab icon: the pane's own
+ *  runtime payload icon (set by the plugin's worker for this specific pane),
+ *  else the plugin's manifest identity icon (a static, per-plugin lucide
+ *  name), else undefined so the caller applies its own generic fallback
+ *  (the host's `Puzzle` icon). Kept as a pure function, separate from
+ *  `usePluginPanes`, so the fallback chain is unit-testable without mounting
+ *  the app or the plugin UI-state context. */
+export function resolvePaneIcon(
+  paneIcon: LucideIcon | undefined,
+  manifestIconName: string | undefined,
+): LucideIcon | undefined {
+  return paneIcon ?? lucideIcon(manifestIconName);
+}
+
 /** Plugin panes for the given session, in stable (plugin_id, entry id) order. */
 export function usePluginPanes(sessionId: string | null): PluginPane[] {
   const entries = usePluginUiEntries();

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2940,7 +2940,8 @@
         "web/src/components/settings/PluginDetailModal.tsx",
         "web/src/components/settings/PluginUpdateConsentModal.tsx",
         "web/src/components/settings/PluginInstallConsentModal.tsx",
-        "web/src/components/settings/PluginJobProgressModal.tsx"
+        "web/src/components/settings/PluginJobProgressModal.tsx",
+        "web/src/components/settings/PluginIdentityIcon.tsx"
       ]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2934,7 +2934,10 @@
       "id": "settings.plugins",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/settings/__tests__/PluginsSettings.test.tsx"],
+      "specs": [
+        "src/components/settings/__tests__/PluginsSettings.test.tsx",
+        "src/components/settings/__tests__/PluginIdentityIcon.test.tsx"
+      ],
       "components": [
         "web/src/components/settings/PluginsSettings.tsx",
         "web/src/components/settings/PluginDetailModal.tsx",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Plugins had no visual identity anywhere: the installed Settings > Plugins list and the detail modal showed plain text, and the only icon mechanism that existed (a per-widget lucide name on runtime panes/badges) falls back to a generic `Puzzle` glyph for every plugin that omits it. Worse, lucide ships no brand/logo icons at all, so even a well-configured plugin (the motivating case: the GitHub plugin) had no way to render its actual mark.

This adds two manifest fields, `icon` (a lucide kebab-case name) and `icon_asset` (a repository-relative raster image), gated behind a new `api_version >= 7`, following the exact validation-gating precedent already used for `screenshots` (>= 5) and `status` (>= 4). `icon_asset` reuses `screenshot_path_ok` directly and, for an installed plugin, is served from its own install directory via a new `GET /api/plugins/{id}/icon` route (mirroring `serve_sound_file`'s allowlist-then-read shape, with canonicalize + containment checks so a plugin cannot declare a path that escapes its own install tree). For a not-yet-installed `gh:` source, it resolves to `raw.githubusercontent.com` exactly like screenshots do today.

The installed list and the detail modal now render this through a shared `PluginIdentityIcon` component (precedence: `icon_asset` with graceful `onError` fallback, then `icon`, then the generic `Puzzle`). The activity bar's pane fallback also consults the plugin's manifest icon before falling back to `Puzzle`, so two plugins that both omit a per-pane icon no longer render identically. As an additional, cheap improvement, marketplace discovery rows now show the repo owner's GitHub avatar as a separate source-identity affordance (never conflated with the plugin's own icon, since discovery deliberately never fetches each result's manifest to stay under GitHub's unauthenticated search rate limit).

Investigated and planned via `/aoe-investigate` and `/aoe-implement`; the plan was debated between two independent LLMs before implementation (two-field vs. a single polymorphic field, whether the installed list needed real local asset serving, and the activity-bar polling question), and I made the final calls on scope from that debate.

Closes #2632

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cd web && npm run dev` alongside `cargo run --features serve -- serve` (or `cargo xtask dev`); open the dashboard's Settings > Plugins panel and confirm every installed plugin row shows a `Puzzle` icon (no manifest declares `icon`/`icon_asset` yet, so this is the no-regression baseline).
- [ ] Add a local test plugin with `api_version = 7` and `icon = "git-branch"` in its `aoe-plugin.toml`; reload Settings > Plugins and confirm the installed row shows the git-branch glyph instead of `Puzzle`.
- [ ] Give the same plugin an `icon_asset = "some/relative/path.png"` pointing at a real PNG in its install directory; confirm the row now shows that image, and that `curl <dashboard-origin>/api/plugins/<id>/icon` returns the PNG bytes with `Content-Type: image/png`.
- [ ] Click the plugin's row to open the detail modal; confirm the same icon renders in the header.
- [ ] Try `icon_asset` pointing outside the plugin's directory (e.g. `../../etc/hosts`) or at a non-raster extension; confirm the manifest fails to load (`aoe plugin` load error) rather than serving anything, and `GET /api/plugins/<id>/icon` 404s.
- [ ] Open Settings > Plugins > marketplace tab and search; confirm each result row now shows the repo owner's GitHub avatar next to the slug.
- [ ] Set the pane/badge payload `icon` on a running plugin's pane (unrelated to the manifest field) and confirm it still takes precedence over the manifest icon in the activity bar, per the existing runtime-icon mechanism.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this flow's existing coverage-matrix entry (`settings.plugins`) is `kind: "vitest"`, not Playwright (per `AGENTS.md`, request-payload/rendering permutations like this belong in Vitest + RTL). Extended `web/src/components/settings/__tests__/PluginsSettings.test.tsx` (installed-row icon, detail-modal icon) and `web/src/lib/__tests__/pluginPanes.test.tsx` (`resolvePaneIcon` fallback chain), and added the new `PluginIdentityIcon.tsx` to the matrix entry's `components[]`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-investigate` + `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**
Investigation, the two-LLM design debate, the plan, and the implementation were drafted by Claude under my direction. I reviewed each commit, made the scope calls the debate surfaced (keeping the local icon-serving endpoint, adding the discovery avatar, keeping the `API_VERSION` bump), and ran the manual test steps above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agent-of-empires/codesmith/agent-of-empires/pr/2636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785700463&installation_id=139138837&pr_number=2636&repository=agent-of-empires%2Fagent-of-empires&return_to=https%3A%2F%2Fgithub.com%2Fagent-of-empires%2Fagent-of-empires%2Fpull%2F2636&signature=9159d1acb2399dde5eca0cb9ce584f5e541213c09ee89138725272a93d2f4e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a stable visual identity for plugins across the app.

- Introduces two new optional manifest fields for identity icons:
  - a built-in lucide icon name (`icon`)
  - a repository-relative raster image asset (`icon_asset`)
- Bumps the plugin `api_version` to gate these fields (older manifests can’t use them).
- Adds a server route to securely serve installed plugin icon assets (`/api/plugins/{id}/icon`), with safe path containment and content-type checks.
- Extends marketplace/discovery plumbing to derive a source avatar and to resolve plugin identity assets when available.
- Updates the web UI to use a shared `PluginIdentityIcon` component in:
  - Settings → Plugins
  - the plugin detail modal
  - plugin activity/pane icon fallback
  - with the intended fallback order: `icon_asset` → `icon` → generic `Puzzle`.
- Improves marketplace cards by showing the repository owner’s GitHub avatar as a source identity indicator.
- Adds/updates tests and internal docs to cover manifest validation, asset serving, and UI rendering/fallback behavior (including recovery after icon load failures).

Benefit: plugins are easier to recognize and consistently branded across discovery, settings, detail views, and runtime panes—making the dashboard feel more trustworthy and polished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->