### PR TITLE
fix: remove Blacksmith CI runner fallback vars

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,9 @@ jobs:
     # between the sequential legs is gone and the legs run in parallel. The
     # required-check context is the fan-in `cargo-linux-ok` job below (named
     # "Cargo Test (linux)"), NOT these shard jobs; keep that in sync with the
-    # branch ruleset if the leg set changes. The runner comes from a repo
-    # Actions variable so Blacksmith can be dropped without a commit when the
-    # monthly credit pool runs dry: clearing RUNNER_CARGO_LINUX in Settings ->
-    # Actions -> Variables falls back to the free GitHub-hosted runner on the
-    # next run. Jobs already queued for Blacksmith sit "queued" forever (GitHub
-    # has no runner fallback primitive), so flip the variable, then re-run the
-    # stuck workflow.
+    # branch ruleset if the leg set changes.
     name: Cargo Test (linux, ${{ matrix.leg }})
-    runs-on: ${{ vars.RUNNER_CARGO_LINUX || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -122,11 +116,9 @@ jobs:
     # container_config.rs; the integration and e2e crates exercise OS-portable
     # code the Linux legs already cover, so macOS only runs --lib --bins.
     # `--features serve` is a strict superset of the default suite, so a single
-    # run covers both feature gates. The runner comes from a repo Actions
-    # variable (clear RUNNER_CARGO_MACOS to fall back to the GitHub-hosted
-    # runner on the next run).
+    # run covers both feature gates.
     name: Cargo Test (macos)
-    runs-on: ${{ vars.RUNNER_CARGO_MACOS || 'macos-latest' }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -279,9 +271,7 @@ jobs:
 
   playwright:
     name: Playwright (mocked)
-    # Same Blacksmith-with-fallback scheme as the cargo job: clear
-    # RUNNER_PLAYWRIGHT_MOCKED to drop to the free GitHub runner.
-    runs-on: ${{ vars.RUNNER_PLAYWRIGHT_MOCKED || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Description
Blacksmith is being removed, so drop the custom-runner fallback wiring in CI. The `cargo-linux`, `cargo-macos`, and `playwright` (mocked) jobs in `.github/workflows/tests.yml` read `runs-on` from repo Actions variables (`RUNNER_CARGO_LINUX`, `RUNNER_CARGO_MACOS`, `RUNNER_PLAYWRIGHT_MOCKED`) that pointed at Blacksmith runners, falling back to GitHub-hosted runners. Reverted all three to plain `ubuntu-latest` / `macos-latest` and removed the now-stale explanatory comments.

Note: the repo Actions variables themselves (`RUNNER_CARGO_LINUX`, `RUNNER_CARGO_MACOS`, `RUNNER_PLAYWRIGHT_MOCKED`) should also be cleared from Settings -> Actions -> Variables; this PR only removes the code-side reference.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Sonnet 5 (Claude Code)

**Any Additional AI Details you'd like to share:** Used to locate the Blacksmith runner references and edit the workflow file.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR simplifies the test workflow by removing Blacksmith-specific runner fallback logic and reverting the affected jobs to standard GitHub-hosted runners.

What changed:
- `cargo-linux` now always uses `ubuntu-latest`
- `cargo-macos` now always uses `macos-latest`
- `playwright` (mocked) now always uses `ubuntu-latest`
- Removed the related fallback comments and workflow wiring

Benefits:
- Makes CI behavior more predictable
- Reduces reliance on repository-level runner overrides
- Easier to maintain and understand

The workflow still mentions that the matching repository variables should be cleared in GitHub settings, but this PR does not remove them there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->