### PR TITLE
fix(serve): skip .git probe for protected $HOME folders to avoid macOS TCC prompts

### DIFF
--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -1055,6 +1055,28 @@ pub async fn filesystem_home() -> impl IntoResponse {
     }
 }
 
+/// Standard system folders that live directly under $HOME. On macOS several
+/// of these (Downloads, Desktop, Pictures/Photos, Music) are TCC-protected:
+/// opening them triggers a permission prompt. None is ever a git repo, so the
+/// directory browser skips its `.git` probe for them and avoids the prompt.
+const HOME_SYSTEM_DIRS: &[&str] = &[
+    "Desktop",
+    "Documents",
+    "Downloads",
+    "Movies",
+    "Music",
+    "Pictures",
+    "Public",
+    "Library",
+];
+
+fn skip_git_probe(parent: &std::path::Path, name: &str, home: Option<&std::path::Path>) -> bool {
+    match home {
+        Some(home) => parent == home && HOME_SYSTEM_DIRS.contains(&name),
+        None => false,
+    }
+}
+
 pub async fn browse_filesystem(
     axum::extract::Query(query): axum::extract::Query<BrowseQuery>,
 ) -> impl IntoResponse {
@@ -1068,9 +1090,10 @@ pub async fn browse_filesystem(
             return Err("Path is not a directory");
         }
 
+        let home = dirs::home_dir();
         // Security: restrict browsing to the user's home directory
-        if let Some(home) = dirs::home_dir() {
-            if !canonical.starts_with(&home) {
+        if let Some(home) = &home {
+            if !canonical.starts_with(home) {
                 return Err("Path is outside the home directory");
             }
         }
@@ -1093,7 +1116,15 @@ pub async fn browse_filesystem(
                     continue;
                 }
             }
-            let is_git_repo = entry_path.join(".git").exists();
+            // Probing `.git` inside a directory opens it, which on macOS
+            // triggers a TCC permission prompt. Skip the probe for the
+            // standard system folders directly under $HOME (Downloads,
+            // Desktop, Music, Pictures, etc.); none of them is ever a repo.
+            let is_git_repo = if skip_git_probe(&canonical, &name, home.as_deref()) {
+                false
+            } else {
+                entry_path.join(".git").exists()
+            };
             entries.push(DirEntry {
                 name,
                 path: entry_path.to_string_lossy().to_string(),
@@ -1827,6 +1858,32 @@ mod tests {
     use super::*;
     use axum::body::to_bytes;
     use std::collections::HashMap;
+
+    #[test]
+    fn skip_git_probe_avoids_protected_home_folders() {
+        let home = std::path::Path::new("/Users/alice");
+
+        // Protected/system folders directly under $HOME: never probe .git,
+        // so macOS never prompts for Downloads/Desktop/Music/Pictures.
+        for name in ["Downloads", "Desktop", "Music", "Pictures", "Documents"] {
+            assert!(
+                skip_git_probe(home, name, Some(home)),
+                "expected to skip .git probe for ~/{name}"
+            );
+        }
+
+        // A real project directly under $HOME still gets probed, so its git
+        // badge is preserved.
+        assert!(!skip_git_probe(home, "myproject", Some(home)));
+
+        // A folder named like a system dir but NOT directly under $HOME is
+        // probed normally (only the direct-$HOME set is protected).
+        let sub = std::path::Path::new("/Users/alice/code");
+        assert!(!skip_git_probe(sub, "Downloads", Some(home)));
+
+        // No home resolved: never skip (falls back to normal probing).
+        assert!(!skip_git_probe(home, "Downloads", None));
+    }
 
     fn custom_agents(entries: &[(&str, &str)]) -> HashMap<String, String> {
         entries

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -1070,7 +1070,12 @@ const HOME_SYSTEM_DIRS: &[&str] = &[
     "Library",
 ];
 
+/// The TCC prompt only exists on macOS, so gate the skip there. On other
+/// platforms these folders are probed normally and keep their git badge.
 fn skip_git_probe(parent: &std::path::Path, name: &str, home: Option<&std::path::Path>) -> bool {
+    if !cfg!(target_os = "macos") {
+        return false;
+    }
     match home {
         Some(home) => parent == home && HOME_SYSTEM_DIRS.contains(&name),
         None => false,
@@ -1863,12 +1868,17 @@ mod tests {
     fn skip_git_probe_avoids_protected_home_folders() {
         let home = std::path::Path::new("/Users/alice");
 
-        // Protected/system folders directly under $HOME: never probe .git,
-        // so macOS never prompts for Downloads/Desktop/Music/Pictures.
+        // The skip is macOS-only: the TCC prompt does not exist elsewhere,
+        // so other platforms probe normally and keep the git badge.
+        let macos = cfg!(target_os = "macos");
+
+        // Protected/system folders directly under $HOME: skipped on macOS so
+        // it never prompts for Downloads/Desktop/Music/Pictures.
         for name in ["Downloads", "Desktop", "Music", "Pictures", "Documents"] {
-            assert!(
+            assert_eq!(
                 skip_git_probe(home, name, Some(home)),
-                "expected to skip .git probe for ~/{name}"
+                macos,
+                "unexpected probe decision for ~/{name}"
             );
         }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On macOS, the web dashboard directory browser triggered a Transparency, Consent, and Control (TCC) permission prompt for Downloads, Desktop, Photos, and Music. When it listed `$HOME`, it probed for a `.git` directory inside every child, including those protected system folders. Resolving `~/Downloads/.git` forces macOS to open `~/Downloads`, which is exactly what pops the per-category permission prompt.

None of the standard system folders directly under `$HOME` (Desktop, Documents, Downloads, Movies, Music, Pictures, Public, Library) is ever a git repository, so this change skips the `.git` probe for them. The prompts stop, and the git badge is preserved for real repositories directly under `$HOME`. The fix is a pure predicate (`skip_git_probe`) wired into `browse_filesystem`, so it is unit-tested without touching the filesystem.

This is Layer A of #2641. The remaining half, giving the binary a stable code-signing identity so grants persist across rebuilds and releases, needs an Apple Developer account plus repo secrets and cannot be verified in a normal PR; it is tracked separately in #2643.

Closes #2641

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the change is a backend predicate with no user-facing UI change (the git badge behavior is unchanged for real repos). It is covered by a Rust unit test on `skip_git_probe`; a Playwright test cannot observe whether a macOS TCC prompt fired.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] On macOS, reset the relevant grants (`tccutil reset SystemPolicyDownloadsFolder`, `SystemPolicyDesktopFolder`, `Photos`), start `aoe serve`, open the session wizard, and select the Browse tab at `$HOME`; confirm no Downloads/Desktop/Photos/Music permission prompt appears.
- [ ] With a git repo directly under `$HOME` (e.g. `~/somerepo`), open the Browse tab at `$HOME` and confirm that repo still shows its git badge.
- [ ] Navigate into a non-protected folder under `$HOME` that contains a git repo and confirm the badge still appears there.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the scope call (ship Layer A now, track signing/notarization as #2643), reviewed the commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change fixes macOS folder browsing by not doing extra “.git probing” inside certain protected folders that sit directly under your home directory (like Downloads, Desktop, Music, Pictures, Documents, plus Movies, Public, and Library). That avoids macOS permission prompts while keeping the git indicator working for real project folders.

What changed:
- Added a macOS-only rule to skip checking for `.git` inside a curated set of home subfolders.
- Wired that rule into the filesystem browse endpoint so it decides per-entry whether to probe.
- Reused the resolved `$HOME` value during browsing to keep the “stay in home” and “skip probing” logic consistent.
- Added a Rust unit test that verifies the skip behavior (including non-matching “similarly named” folders and the “no home resolved” case) without touching the filesystem.

Benefits:
- Fewer unnecessary macOS re-permission prompts when browsing common home folders
- Git badges remain accurate for actual repositories

Follow-ups (from the broader work this addresses):
- Apply the same “don’t traverse protected folders unnecessarily” approach to the TUI directory picker and path autocomplete
- Complete the remaining macOS signing/notarization work tracked elsewhere
<!-- end of auto-generated comment: release notes by coderabbit.ai -->