### PR TITLE
feat(web): render a plugin's icon_asset in the activity bar and dock tab

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -49,8 +49,8 @@ render; local plugins do not support screenshots yet (future work beyond
 ### Identity icon
 
 A plugin may declare a static identity icon, shown in the installed Settings >
-Plugins list, the detail modal, and (as a fallback) its activity-bar pane
-button (requires `api_version >= 7`):
+Plugins list, the detail modal, and its activity-bar button / dock tab
+(requires `api_version >= 7`):
 
 ```toml
 icon = "git-branch"                 # a lucide kebab-case icon name
@@ -65,6 +65,17 @@ exact same path rules as `screenshots.path`; lucide ships no brand/logo icons
 `icon` alone), so `icon_asset` is how a plugin ships one. When both are set,
 `icon_asset` wins wherever an image can render, falling back to `icon` if the
 asset fails to load.
+
+`icon_asset` wins unconditionally in the activity bar / dock tab too, even
+over a pane's own per-pane runtime icon (the `icon` field a plugin's worker
+pushes on its `pane` UI-state payload, see below): a plugin's real logo is a
+stronger identity signal than a lucide glyph a worker chose before this field
+existed. Below `icon_asset`, the precedence is per-pane runtime icon, then the
+manifest `icon`, then the host's generic fallback. `PaneIcon`
+(`web/src/components/PaneIcon.tsx`) and `PluginIdentityIcon`
+(`web/src/components/settings/PluginIdentityIcon.tsx`) share the same
+reset-on-URL-change fallback behavior via `useAssetFailed`
+(`web/src/lib/pluginUi.ts`).
 
 For an installed (not-yet-uninstalled) plugin, `icon_asset` is served from its
 own install directory via `GET /api/plugins/{id}/icon`, which re-validates the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -453,18 +453,24 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     syncPlugins(pluginPanes.map((p) => ({ id: p.id, defaultDock: p.defaultDock })));
   }, [pluginPanes, syncPlugins]);
 
-  // One-shot lookup from plugin id to its manifest identity icon, so a pane
-  // that doesn't set its own per-pane icon still gets something more
-  // distinctive than the generic Puzzle fallback. Fetched once on mount
-  // rather than polled: the installed-plugin list itself has no live sync
-  // anywhere else in the app today (Settings > Plugins only reloads on
+  // One-shot lookup from plugin id to its manifest identity (icon name +
+  // icon_asset URL), so a pane gets a real identity glyph, up to the plugin's
+  // actual logo, even when it doesn't set its own per-pane icon. Fetched once
+  // on mount rather than polled: the installed-plugin list itself has no live
+  // sync anywhere else in the app today (Settings > Plugins only reloads on
   // mount and after its own mutations), so this matches existing staleness
   // tolerance rather than introducing a new one.
-  const [pluginIconNameById, setPluginIconNameById] = useState<Record<string, string | undefined>>({});
+  const [pluginIdentityById, setPluginIdentityById] = useState<
+    Record<string, { icon?: string; iconAssetUrl?: string }>
+  >({});
   useEffect(() => {
     void fetchPlugins().then((res) => {
       if (!res) return;
-      setPluginIconNameById(Object.fromEntries(res.plugins.map((p) => [p.id, p.icon ?? undefined])));
+      setPluginIdentityById(
+        Object.fromEntries(
+          res.plugins.map((p) => [p.id, { icon: p.icon ?? undefined, iconAssetUrl: p.icon_asset_url ?? undefined }]),
+        ),
+      );
     });
   }, []);
 
@@ -472,8 +478,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     (id: string): PaneDisplay => {
       const plugin = pluginPaneById.get(id);
       if (plugin) {
-        const icon = resolvePaneIcon(plugin.icon, pluginIconNameById[plugin.entry.plugin_id]) ?? Puzzle;
-        return { title: plugin.title, icon };
+        const identity = pluginIdentityById[plugin.entry.plugin_id];
+        const icon = resolvePaneIcon(plugin.icon, identity?.icon) ?? Puzzle;
+        // A plugin's real logo outranks any lucide glyph, including a
+        // per-pane runtime icon a worker chose before icon_asset existed.
+        return { title: plugin.title, icon, iconAssetUrl: identity?.iconAssetUrl };
       }
       if (isTerminalTabId(id)) {
         const idx = terminalIndexOf(id);
@@ -483,7 +492,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       const d = BUILTIN_PANES.find((p) => p.id === id)!;
       return { title: d.title, icon: d.icon };
     },
-    [pluginPaneById, pluginIconNameById],
+    [pluginPaneById, pluginIdentityById],
   );
 
   // A persisted tab is visible only if its backing pane currently exists: diff

--- a/web/src/components/ActivityBar.tsx
+++ b/web/src/components/ActivityBar.tsx
@@ -1,6 +1,5 @@
-import { createElement } from "react";
-
 import type { PaneDisplay } from "./Dock";
+import { PaneIcon } from "./PaneIcon";
 
 interface Props {
   paneIds: string[];
@@ -33,7 +32,7 @@ export function ActivityBar({ paneIds, descriptorFor, isOpen, onToggle }: Props)
             title={`${open ? "Hide" : "Show"} ${name} pane`}
             aria-label={`Toggle ${name} pane`}
           >
-            {createElement(desc.icon, { className: "size-4", "aria-hidden": true })}
+            <PaneIcon icon={desc.icon} iconAssetUrl={desc.iconAssetUrl} className="size-4" />
           </button>
         );
       })}

--- a/web/src/components/Dock.tsx
+++ b/web/src/components/Dock.tsx
@@ -1,4 +1,4 @@
-import { createElement, Fragment, type ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { PanelBottom, PanelRight, Plus, X, type LucideIcon } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
@@ -6,10 +6,14 @@ import { CSS } from "@dnd-kit/utilities";
 
 import type { DockLocation } from "../lib/panes";
 import { usePaneDnd, type PaneTabData, type SplitDropData } from "./paneDnd";
+import { PaneIcon } from "./PaneIcon";
 
 export interface PaneDisplay {
   title: string;
   icon: LucideIcon;
+  /** A plugin's manifest `icon_asset`, resolved to a fetchable URL. See
+   *  `PaneIcon` for the precedence over `icon`. */
+  iconAssetUrl?: string;
 }
 
 interface Props {
@@ -89,7 +93,7 @@ function SortableTab({ id, location, groupIndex, isActive, desc, onActivate, onC
         {...listeners}
         className="flex items-center gap-1 pl-2 pr-1 cursor-pointer min-w-0 touch-none"
       >
-        {createElement(desc.icon, { className: "size-3.5 shrink-0", "aria-hidden": true })}
+        <PaneIcon icon={desc.icon} iconAssetUrl={desc.iconAssetUrl} className="size-3.5 shrink-0" />
         <span className="text-[11px] font-medium truncate max-w-[10rem]">{desc.title}</span>
       </button>
       <button

--- a/web/src/components/PaneIcon.tsx
+++ b/web/src/components/PaneIcon.tsx
@@ -1,0 +1,49 @@
+import { createElement, type ComponentType } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { useAssetFailed } from "../lib/pluginUi";
+
+interface Props {
+  /** Already-resolved fallback: a built-in pane's own icon, or a plugin
+   *  pane's per-pane runtime icon / manifest icon / generic Puzzle, per
+   *  `resolvePaneIcon`'s chain. Used when `iconAssetUrl` is absent or fails. */
+  icon: LucideIcon;
+  /** A plugin's manifest `icon_asset`, resolved to a fetchable URL. Wins over
+   *  `icon` unconditionally when present and loading: a plugin's own real
+   *  logo is a stronger identity signal than any lucide glyph, including one
+   *  a plugin's worker deliberately chose for a specific pane before this
+   *  field existed. */
+  iconAssetUrl?: string;
+  className: string;
+  testId?: string;
+}
+
+/** The activity-bar/dock-tab icon for one pane. Mirrors
+ *  `PluginIdentityIcon`'s precedence and reset-on-URL-change behavior via the
+ *  shared `useAssetFailed` hook, but takes an already-resolved fallback
+ *  component instead of a lucide name, since built-in panes pass a concrete
+ *  icon (`FileDiff`, `SquareTerminal`, ...) rather than a manifest string. */
+export function PaneIcon({ icon, iconAssetUrl, className, testId }: Props) {
+  const [assetFailed, markFailed] = useAssetFailed(iconAssetUrl);
+
+  if (iconAssetUrl && !assetFailed) {
+    return (
+      <img
+        src={iconAssetUrl}
+        alt=""
+        aria-hidden="true"
+        data-testid={testId}
+        className={`${className} rounded-sm object-contain`}
+        onError={markFailed}
+      />
+    );
+  }
+
+  // `data-testid` isn't in LucideProps; widen to a generic component type
+  // rather than dropping the attribute.
+  return createElement(icon as ComponentType<Record<string, unknown>>, {
+    className,
+    "aria-hidden": true,
+    "data-testid": testId,
+  });
+}

--- a/web/src/components/__tests__/PaneIcon.test.tsx
+++ b/web/src/components/__tests__/PaneIcon.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from "@testing-library/react";
+import { GitBranch } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import { PaneIcon } from "../PaneIcon";
+
+describe("PaneIcon", () => {
+  it("renders the icon_asset image, outranking the resolved fallback icon", async () => {
+    const { findByTestId } = render(
+      <PaneIcon icon={GitBranch} iconAssetUrl="/api/plugins/acme.widget/icon" className="size-4" testId="icon" />,
+    );
+    const icon = await findByTestId("icon");
+    expect(icon.tagName).toBe("IMG");
+    expect(icon.getAttribute("src")).toBe("/api/plugins/acme.widget/icon");
+  });
+
+  it("falls back to the resolved icon component when there is no icon_asset", () => {
+    const { getByTestId } = render(<PaneIcon icon={GitBranch} className="size-4" testId="icon" />);
+    expect(getByTestId("icon").tagName).toBe("svg");
+  });
+
+  it("falls back to the icon on load failure, then retries a later working URL", async () => {
+    const { findByTestId, getByTestId, rerender } = render(
+      <PaneIcon icon={GitBranch} iconAssetUrl="/first.png" className="size-4" testId="icon" />,
+    );
+    fireEvent.error(getByTestId("icon"));
+    expect(getByTestId("icon").tagName).toBe("svg");
+
+    rerender(<PaneIcon icon={GitBranch} iconAssetUrl="/second.png" className="size-4" testId="icon" />);
+    const icon = await findByTestId("icon");
+    expect(icon.tagName).toBe("IMG");
+    expect(icon.getAttribute("src")).toBe("/second.png");
+  });
+});

--- a/web/src/components/settings/PluginIdentityIcon.tsx
+++ b/web/src/components/settings/PluginIdentityIcon.tsx
@@ -1,7 +1,7 @@
-import { createElement, useState, type ComponentType } from "react";
+import { createElement, type ComponentType } from "react";
 import { Puzzle } from "lucide-react";
 
-import { lucideIcon } from "../../lib/pluginUi";
+import { lucideIcon, useAssetFailed } from "../../lib/pluginUi";
 
 interface Props {
   /** Manifest `icon`: a lucide kebab-case name, or null/undefined if unset. */
@@ -18,16 +18,7 @@ interface Props {
  *  surface that uses it, so the icon itself is decorative (`alt=""
  *  aria-hidden`) rather than needing author-supplied alt text. */
 export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4", testId }: Props) {
-  const [assetFailed, setAssetFailed] = useState(false);
-  // Reset the failure flag whenever a new URL is supplied (e.g. the detail
-  // modal swaps the local fallback route for the resolved manifest URL once
-  // its gh fetch lands), so a transient failure on the first URL doesn't
-  // permanently hide a later working one.
-  const [trackedUrl, setTrackedUrl] = useState(iconAssetUrl);
-  if (iconAssetUrl !== trackedUrl) {
-    setTrackedUrl(iconAssetUrl);
-    setAssetFailed(false);
-  }
+  const [assetFailed, markFailed] = useAssetFailed(iconAssetUrl);
 
   if (iconAssetUrl && !assetFailed) {
     return (
@@ -37,7 +28,7 @@ export function PluginIdentityIcon({ icon, iconAssetUrl, className = "size-4", t
         aria-hidden="true"
         data-testid={testId}
         className={`${className} shrink-0 rounded-sm object-contain`}
-        onError={() => setAssetFailed(true)}
+        onError={markFailed}
       />
     );
   }

--- a/web/src/lib/pluginUi.ts
+++ b/web/src/lib/pluginUi.ts
@@ -2,7 +2,7 @@
 // slots through these so the filtering rules (and the per-session tearing
 // guard) live in one tested place rather than scattered across the UI.
 
-import { createElement, forwardRef, type ComponentType, type CSSProperties } from "react";
+import { createElement, forwardRef, useState, type ComponentType, type CSSProperties } from "react";
 import type { LucideIcon, LucideProps } from "lucide-react";
 import { DynamicIcon, iconNames } from "lucide-react/dynamic";
 
@@ -33,6 +33,22 @@ export function lucideIcon(name: string | undefined): LucideIcon | undefined {
   ) as LucideIcon;
   cache.set(name, Icon);
   return Icon;
+}
+
+/** Tracks whether an image URL has failed to load, resetting automatically
+ *  when the URL itself changes (e.g. a fallback route getting replaced by a
+ *  resolved manifest URL once a fetch lands), so a transient failure on one
+ *  URL doesn't permanently hide a later working one. Shared by every
+ *  identity-icon renderer (`PluginIdentityIcon`, the activity-bar/dock pane
+ *  icon) so the reset-on-change logic lives in one tested place. */
+export function useAssetFailed(url: string | null | undefined): [boolean, () => void] {
+  const [failed, setFailed] = useState(false);
+  const [trackedUrl, setTrackedUrl] = useState(url);
+  if (url !== trackedUrl) {
+    setTrackedUrl(url);
+    setFailed(false);
+  }
+  return [failed, () => setFailed(true)];
 }
 
 /** Theme-backed classes per tone, shared by every slot renderer so a plugin's

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -493,8 +493,8 @@
       "id": "app-shell.activity-bar",
       "kind": "vitest",
       "risk": "low",
-      "specs": ["src/components/__tests__/ActivityBar.test.tsx"],
-      "components": ["web/src/components/ActivityBar.tsx"]
+      "specs": ["src/components/__tests__/ActivityBar.test.tsx", "src/components/__tests__/PaneIcon.test.tsx"],
+      "components": ["web/src/components/ActivityBar.tsx", "web/src/components/PaneIcon.tsx"]
     },
     {
       "id": "app-shell.tips-badge",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #2636. That PR added `icon`/`icon_asset` to plugin manifests and rendered them in Settings > Plugins and the detail modal, but explicitly scoped the activity bar and dock tab strip to lucide-only rendering (a plugin's own per-pane runtime icon, then the manifest `icon`, then a generic fallback). Verified live against the real GitHub plugin (rebuilt with `icon_asset` set) via Playwright: the activity-bar toggle button and the dock tab both rendered the plugin's pre-existing per-pane icon, never the manifest fallback and never the real logo, since a per-pane icon set by a worker always shadowed everything else in that chain.

This closes that gap: `icon_asset` now renders directly in the activity bar and dock tab, taking precedence over even a plugin's own per-pane runtime icon. A plugin's real logo is a stronger identity signal than a lucide glyph a worker chose for pane content before this field existed.

## What changed

- `web/src/components/PaneIcon.tsx` (new): the activity-bar/dock-tab icon renderer. Takes an already-resolved fallback icon component (matches how built-in panes already pass concrete `LucideIcon`s) plus an optional `icon_asset` URL, rendering the image when present and falling back on load failure.
- `web/src/lib/pluginUi.ts`: extracted `useAssetFailed`, the reset-on-URL-change hook `PluginIdentityIcon` already used, so `PaneIcon` doesn't duplicate it. `PluginIdentityIcon` now uses the same shared hook.
- `web/src/components/Dock.tsx`, `web/src/components/ActivityBar.tsx`: render via `PaneIcon` instead of a raw `createElement(desc.icon, ...)`. `PaneDisplay` gets a new optional `iconAssetUrl` field.
- `web/src/App.tsx`: the one-shot plugin-identity lookup now carries both the manifest `icon` name and `icon_asset_url`, not just the name.
- `docs/development/internals/plugin-system.md`: documents the precedence.

## How to test

- [ ] Install a plugin declaring `icon_asset` (e.g. the GitHub plugin at 1.7.0+) and confirm its activity-bar toggle button and dock tab show the real image, not a lucide glyph.
- [ ] Confirm this holds even if the plugin's own pane payload still sets a per-pane `icon` (older plugin versions): the manifest `icon_asset` should win.
- [ ] Temporarily break the `icon_asset` URL (e.g. rename the asset file) and confirm the activity bar/dock tab gracefully falls back to the manifest `icon` (or `Puzzle`) instead of a broken image.
- [ ] A plugin with only a manifest `icon` (no `icon_asset`) still shows the lucide fallback as before (no regression).
- [ ] A plugin with neither still falls back to `Puzzle` (no regression).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is rendering-precedence logic (Vitest + RTL territory per `AGENTS.md`), not a Playwright-mandated flow. Added `web/src/components/__tests__/PaneIcon.test.tsx` (asset renders and outranks the fallback, falls back on error, falls back to the resolved icon with no asset, resets on URL change) and updated `web/tests/coverage-matrix.json`'s `app-shell.activity-bar` entry for the new component file.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code)

**Any Additional AI Details you'd like to share:**
I verified the root cause live with Playwright against a real running dashboard before scoping this fix (confirmed via SVG path inspection that the activity bar and dock tab were rendering the plugin's old per-pane icon, not the new manifest fields). Claude implemented the fix and tests under my direction; I made the precedence call (icon_asset wins unconditionally, even over a per-pane runtime icon).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR extends plugin icon support so activity-bar buttons and dock tabs can show a plugin’s image asset, not just a built-in icon. It also improves fallback behavior when an image cannot load, so the UI can gracefully switch to a default icon instead of breaking.

Key changes:
- Added a new shared icon component for pane tabs and activity-bar items.
- Passed plugin identity data through the app so panes can access icon asset URLs.
- Updated the activity bar and dock to use the new icon rendering path.
- Reused the same asset-failure handling for plugin identity icons.
- Clarified the plugin-system docs to explain icon precedence.
- Added tests for image rendering, fallback handling, and refresh-on-URL-change behavior.

Benefit:
- Plugins can now display their intended branding more consistently across the UI.
- Icon fallbacks are more reliable and easier to maintain because the logic is shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->