### PR TITLE
fix(plugin): peel annotated tags in ls_remote to stop phantom update loop

### DIFF
--- a/src/plugin/fetch.rs
+++ b/src/plugin/fetch.rs
@@ -186,7 +186,13 @@ pub fn ls_remote(url: &str, reference: Option<&str>) -> Result<String> {
         }
     }
     let target = reference.unwrap_or("HEAD");
-    let out = run_git(&["ls-remote", url, target], None)?;
+    // An annotated tag's peeled `^{}` commit is only emitted when the refspec
+    // asks for it; without it ls-remote returns the tag object, which never
+    // equals the commit the install checked out (a phantom "update available",
+    // #2646). Request both so parse_ls_remote can prefer the peeled commit. A
+    // branch or HEAD has no `^{}` to match, so the extra pattern is a no-op.
+    let peeled = format!("{target}^{{}}");
+    let out = run_git(&["ls-remote", url, target, &peeled], None)?;
     parse_ls_remote(&out, target)
 }
 
@@ -531,6 +537,56 @@ mod tests {
     fn ls_remote_returns_pinned_sha_as_is() {
         let sha = "abcdef0123456789abcdef0123456789abcdef01";
         assert_eq!(ls_remote("unused://", Some(sha)).unwrap(), sha);
+    }
+
+    #[test]
+    fn ls_remote_peels_annotated_tag_to_commit() {
+        // `git ls-remote <url> v1` returns the annotated tag object, but the
+        // install checks out the peeled commit. ls_remote must resolve to the
+        // commit so the update check does not report a phantom update (#2646).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .expect("run git")
+        };
+        // git absent: nothing to test, skip rather than fail.
+        if !git(&["init", "-q"]).status.success() {
+            return;
+        }
+        std::fs::write(path.join("f"), b"x").unwrap();
+        git(&["add", "f"]);
+        git(&["commit", "-qm", "c"]);
+        git(&["tag", "-a", "v1", "-m", "release"]);
+
+        let sha_of = |rev: &str| {
+            String::from_utf8(git(&["rev-parse", rev]).stdout)
+                .unwrap()
+                .trim()
+                .to_string()
+        };
+        let commit = sha_of("HEAD");
+        let tag_object = sha_of("v1");
+        // An annotated tag's object is distinct from the commit it points at;
+        // without that, this test would not distinguish the bug from the fix.
+        assert_ne!(
+            commit, tag_object,
+            "annotated tag object should differ from the commit"
+        );
+
+        let resolved = ls_remote(path.to_str().unwrap(), Some("v1")).unwrap();
+        assert_eq!(
+            resolved, commit,
+            "ls_remote should return the peeled commit, not the tag object"
+        );
+        assert_ne!(resolved, tag_object);
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A plugin that tracks an annotated git tag showed a permanent phantom "update available" that never cleared: "Check for updates" reported an update, but clicking "Update" said "already up to date". Not a restart issue; it repeated on every check.

Root cause: `ls_remote` (`src/plugin/fetch.rs`) ran `git ls-remote <url> <tag>` with the bare tag name. For an annotated tag, git returns only the tag-object SHA, never the peeled `^{}` commit. `parse_ls_remote` is written to prefer the peeled line, but that line was never in the output, so it returned the tag object. The lockfile records the peeled commit (what `git_clone_checkout` checks out), so `update_check::outdated` compared the tag object against the commit and they never matched, reporting a phantom update forever. "Update" (`preview_update`) compares source tree hashes instead, so it correctly saw no change, hence the contradiction.

The fix requests the `<tag>^{}` refspec alongside the tag so the peeled commit is present and `parse_ls_remote`'s existing preference logic resolves to it. A branch or `HEAD` has no `^{}` to match, so that path is unchanged. This corrects the check on every surface that shares `outdated`: the web "Check for updates" button, the TUI `c` check, `aoe plugin outdated`, and the auto-update sweep.

Ships with a regression test that builds a repo with an annotated tag and asserts `ls_remote` returns the peeled commit, not the tag object. Verified red on the pre-fix tree, green after.

Closes #2646

## How to test

- [ ] With a plugin tracking an annotated-tag release (e.g. the GitHub plugin at its latest release), open Settings > Plugins, click "Check for updates", and confirm no "update available" badge appears.
- [ ] Run `aoe plugin outdated` and confirm the annotated-tag plugin is not reported as needing an update.
- [ ] Confirm the two paths agree: "Check for updates" and the "Update" button no longer contradict each other.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The bug is surfaced in the dashboard but the defect and fix live entirely in the Rust `ls_remote` git-resolution path; no dashboard code changed. The regression is covered by a Rust unit test (`ls_remote_peels_annotated_tag_to_commit`) that reproduces it against a real annotated tag.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No TUI rendering, subcommand, or lifecycle change; only the commit `aoe plugin outdated` resolves. Covered by the Rust unit test above.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and confirmed the regression test goes red before the fix and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### What changed
- Fixed plugin update checks for annotated git tags so they now resolve to the actual commit being installed, not the tag object itself.
- Updated the shared remote tag lookup logic so annotated tags are checked in the same way across update-related flows.
- Added a regression test to confirm annotated tags return the peeled commit SHA and do not show as outdated when already current.

### Benefit
- Prevents plugins from being stuck in a false “update available” state.
- Makes “Check for updates,” “Update,” and auto-update behavior agree with each other for tagged releases.
- Adds coverage to guard against the issue coming back.

### Technical note
- `ls_remote` now queries both `tag` and `tag^{}` so parsing can select the peeled commit for annotated tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->