### PR TITLE
fix(session): preserve sandboxed opencode.db across launches; only skip_entries needed for host-drift protection (closes #2605)

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -54,8 +54,10 @@ struct AgentConfigMount {
     /// authentication from being overwritten by stale host copies.
     preserve_files: &'static [&'static str],
     /// Files to delete from the sandbox dir before each launch. Prevents stale state
-    /// (e.g. SQLite databases from a previous opencode version) from causing failures
-    /// when the container image is updated.
+    /// (e.g. leftover lock/cache files) from causing failures when the container image
+    /// is updated. Do NOT use this for sandbox-owned session state (e.g. opencode's
+    /// SQLite DB, see #2605): that must survive relaunches, so it is kept out of
+    /// `clean_files` and instead protected from host drift via `skip_entries`.
     clean_files: &'static [&'static str],
 }
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -92,10 +92,13 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         tool_name: "opencode",
         host_rel: ".local/share/opencode",
         container_suffix: ".local/share/opencode",
-        // Never copy or keep the SQLite database in the sandbox. Opencode must
-        // create its own fresh database on each launch -- a stale db from a
-        // previous opencode version (or copied from the host) causes drizzle
-        // migration failures.
+        // `skip_entries` prevents copying the host DB into the sandbox; a
+        // schema-drifted host DB would trigger drizzle migration failures
+        // against the sandboxed opencode. The sandbox creates its own DB
+        // in-container on first launch, which is always schema-consistent
+        // with that opencode. Do NOT wipe it on subsequent launches: it
+        // holds `ses_*` session identity and is the resume source of truth.
+        // See #2605.
         skip_entries: &[
             "sandbox",
             "opencode.db",
@@ -107,7 +110,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],
-        clean_files: &["opencode.db", "opencode.db-wal", "opencode.db-shm"],
+        clean_files: &[],
     },
     AgentConfigMount {
         tool_name: "opencode",
@@ -2173,6 +2176,82 @@ mod tests {
             );
         }
         assert!(!sandbox.join("state.db").exists());
+    }
+
+    #[test]
+    fn test_opencode_mount_clean_files_does_not_touch_sqlite_db() {
+        // Drift guard for #2605. The opencode data-dir mount's SQLite DB holds
+        // `ses_*` session identity and is the resume source of truth;
+        // `skip_entries` handles host-to-sandbox pollution, so `clean_files`
+        // must not list `opencode.db*` (that regressed resume across every
+        // kill/restart).
+        let mount = AGENT_CONFIG_MOUNTS
+            .iter()
+            .find(|m| m.tool_name == "opencode" && m.host_rel == ".local/share/opencode")
+            .expect("opencode data-dir mount");
+        assert!(
+            !mount
+                .clean_files
+                .iter()
+                .any(|f| f.starts_with("opencode.db")),
+            "opencode.db* must not appear in clean_files (regression of #2605); clean_files = {:?}",
+            mount.clean_files,
+        );
+        assert!(
+            mount.skip_entries.contains(&"opencode.db"),
+            "opencode.db must remain in skip_entries to block host schema drift",
+        );
+        assert!(mount.skip_entries.contains(&"opencode.db-wal"));
+        assert!(mount.skip_entries.contains(&"opencode.db-shm"));
+    }
+
+    #[test]
+    fn test_opencode_mount_preserves_sqlite_db_across_prepares() {
+        // Regression for #2605. Before the fix, `prepare_sandbox_dir` walked
+        // `clean_files` on every invocation and wiped the sandbox-owned
+        // opencode SQLite DB, so `aoe resume` hit "Session not found". This
+        // test plants a DB in the sandbox subdir, invokes `prepare_sandbox_dir`
+        // (which fires at container_config.rs:987 and :1436), and asserts the
+        // DB survives byte-for-byte.
+        let dir = TempDir::new().unwrap();
+        let host = dir.path().join(".local/share/opencode");
+        let sandbox = host.join(SANDBOX_SUBDIR);
+        fs::create_dir_all(&sandbox).unwrap();
+
+        let db_bytes = b"SQLite format 3\0-opencode-session-state";
+        fs::write(sandbox.join("opencode.db"), db_bytes).unwrap();
+        fs::write(sandbox.join("opencode.db-wal"), b"wal-frames").unwrap();
+        fs::write(sandbox.join("opencode.db-shm"), b"shm-index").unwrap();
+
+        // Host config so `sync_agent_config` has real work to do; without a
+        // non-empty host_dir the sync short-circuits and we would not exercise
+        // the code path that used to wipe the DB.
+        fs::write(host.join("config.json"), "{}").unwrap();
+
+        let mount = AGENT_CONFIG_MOUNTS
+            .iter()
+            .find(|m| m.tool_name == "opencode" && m.host_rel == ".local/share/opencode")
+            .expect("opencode data-dir mount");
+        let out = prepare_sandbox_dir(mount, dir.path()).unwrap();
+        assert_eq!(out, sandbox);
+
+        assert!(
+            out.join("opencode.db").exists(),
+            "opencode.db must survive prepare_sandbox_dir (regression of #2605)",
+        );
+        assert_eq!(
+            fs::read(out.join("opencode.db")).unwrap(),
+            db_bytes,
+            "opencode.db content must be untouched",
+        );
+        assert!(
+            out.join("opencode.db-wal").exists(),
+            "opencode.db-wal must survive",
+        );
+        assert!(
+            out.join("opencode.db-shm").exists(),
+            "opencode.db-shm must survive",
+        );
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2201,8 +2201,14 @@ mod tests {
             mount.skip_entries.contains(&"opencode.db"),
             "opencode.db must remain in skip_entries to block host schema drift",
         );
-        assert!(mount.skip_entries.contains(&"opencode.db-wal"));
-        assert!(mount.skip_entries.contains(&"opencode.db-shm"));
+        assert!(
+            mount.skip_entries.contains(&"opencode.db-wal"),
+            "opencode.db-wal must remain in skip_entries to block host schema drift",
+        );
+        assert!(
+            mount.skip_entries.contains(&"opencode.db-shm"),
+            "opencode.db-shm must remain in skip_entries to block host schema drift",
+        );
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -94,8 +94,8 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         container_suffix: ".local/share/opencode",
         // `skip_entries` prevents copying the host DB into the sandbox; a
         // schema-drifted host DB would trigger drizzle migration failures
-        // against the sandboxed opencode. The sandbox creates its own DB
-        // in-container on first launch, which is always schema-consistent
+        // against the sandboxed opencode. The sandboxed opencode creates its
+        // own DB in-container on first launch, which is always schema-consistent
         // with that opencode. Do NOT wipe it on subsequent launches: it
         // holds `ses_*` session identity and is the resume source of truth.
         // See #2605.

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -39,6 +39,7 @@ mod intro;
 mod kiro_launch;
 mod logs;
 mod new_session;
+mod opencode_sandbox_resume;
 mod plugins;
 mod profile_picker;
 mod project_registry;

--- a/tests/e2e/opencode_sandbox_resume.rs
+++ b/tests/e2e/opencode_sandbox_resume.rs
@@ -20,7 +20,7 @@ use crate::harness::TuiTestHarness;
 #[serial]
 #[ignore = "requires Docker daemon"]
 fn sandboxed_opencode_db_survives_prepare_sandbox_cycle() {
-    let mut h = TuiTestHarness::new_in_tmp("opencode_sandbox_resume");
+    let mut h = TuiTestHarness::new("opencode_sandbox_resume");
     // Install an `opencode` PATH shim so `aoe add --cmd opencode` resolves
     // during tool discovery. The container has its own opencode binary; the
     // shim only needs to make `which opencode` succeed on the host.

--- a/tests/e2e/opencode_sandbox_resume.rs
+++ b/tests/e2e/opencode_sandbox_resume.rs
@@ -1,0 +1,101 @@
+//! Regression test for #2605: sandboxed opencode's SQLite database (which
+//! holds `ses_*` session identity) must survive `prepare_sandbox_dir` cycles.
+//!
+//! Before the fix, the opencode `AgentConfigMount` listed `opencode.db*` in
+//! `clean_files`; `prepare_sandbox_dir` walked that list unconditionally on
+//! every agent-config refresh and per-tool sandbox setup, meaning every
+//! kill/restart destroyed the DB. `aoe resume` then invoked
+//! `opencode --session <id>` against an empty DB and opencode exited 1 with
+//! "Session not found". `skip_entries` already blocks host-to-sandbox copy,
+//! so removing the entries from `clean_files` is safe.
+//!
+//! Requires a running Docker daemon; marked `#[ignore]` for CI per the
+//! sandbox e2e convention (see `tests/e2e/sandbox.rs`).
+
+use serial_test::serial;
+
+use crate::harness::TuiTestHarness;
+
+#[test]
+#[serial]
+#[ignore = "requires Docker daemon"]
+fn sandboxed_opencode_db_survives_prepare_sandbox_cycle() {
+    let mut h = TuiTestHarness::new_in_tmp("opencode_sandbox_resume");
+    // Install an `opencode` PATH shim so `aoe add --cmd opencode` resolves
+    // during tool discovery. The container has its own opencode binary; the
+    // shim only needs to make `which opencode` succeed on the host.
+    h.install_path_command("opencode");
+    let project = h.project_path();
+
+    // First `aoe add --sandbox --cmd opencode`: with `config_tool == "opencode"`
+    // the filter at container_config.rs:1432 selects the opencode mounts, so
+    // `prepare_sandbox_dir` runs against the data-dir mount. This is the exact
+    // code path #2605 lives in.
+    let add1 = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "--sandbox",
+        "--cmd",
+        "opencode",
+        "-t",
+        "OpencodeResumeFirst",
+    ]);
+    assert!(
+        add1.status.success(),
+        "first aoe add --sandbox --cmd opencode failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&add1.stdout),
+        String::from_utf8_lossy(&add1.stderr),
+    );
+
+    // Simulate what an opencode-in-container run leaves behind: a SQLite DB
+    // holding a `ses_*` session row. The regression in #2605 fired inside
+    // `prepare_sandbox_dir`, which wiped these files on every subsequent
+    // invocation.
+    let sandbox_dir = h.home_path().join(".local/share/opencode/sandbox");
+    std::fs::create_dir_all(&sandbox_dir).expect("create opencode sandbox dir");
+    let db_bytes = b"SQLite format 3\0-ses_regression_2605";
+    std::fs::write(sandbox_dir.join("opencode.db"), db_bytes).unwrap();
+    std::fs::write(sandbox_dir.join("opencode.db-wal"), b"wal-frames").unwrap();
+    std::fs::write(sandbox_dir.join("opencode.db-shm"), b"shm-index").unwrap();
+
+    // A second `aoe add --sandbox --cmd opencode` re-runs the same filtered
+    // walk and re-invokes `prepare_sandbox_dir` for the opencode mounts.
+    // Before the fix, this cycle destroyed the DB planted above; after the
+    // fix, `clean_files` is empty for the opencode data-dir mount and the DB
+    // must survive intact.
+    let add2 = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "--sandbox",
+        "--cmd",
+        "opencode",
+        "-t",
+        "OpencodeResumeSecond",
+    ]);
+    assert!(
+        add2.status.success(),
+        "second aoe add --sandbox --cmd opencode failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&add2.stdout),
+        String::from_utf8_lossy(&add2.stderr),
+    );
+
+    let db_path = sandbox_dir.join("opencode.db");
+    assert!(
+        db_path.exists(),
+        "opencode.db must survive prepare_sandbox_dir cycles (regression of #2605); \
+         wiping this file is what breaks `aoe resume` for sandboxed opencode",
+    );
+    assert_eq!(
+        std::fs::read(&db_path).unwrap(),
+        db_bytes,
+        "opencode.db content must be untouched across CLI cycles (regression of #2605)",
+    );
+    assert!(
+        sandbox_dir.join("opencode.db-wal").exists(),
+        "opencode.db-wal must survive (regression of #2605)",
+    );
+    assert!(
+        sandbox_dir.join("opencode.db-shm").exists(),
+        "opencode.db-shm must survive (regression of #2605)",
+    );
+}


### PR DESCRIPTION
## Description

Closes #2605.

### What

`opencode.db{,-wal,-shm}` removed from the opencode `AgentConfigMount.clean_files` at [src/session/container_config.rs](src/session/container_config.rs). Entries remain in `skip_entries` so a schema-drifted host DB is still never copied into the sandbox. The comment above the mount block is rewritten to explain the invariant: `skip_entries` handles pollution, the sandbox owns its DB, subsequent launches must not wipe it.

### Why

`clean_files` was defense-in-depth that turned destructive in practice. `prepare_sandbox_dir` walks `clean_files` unconditionally on every invocation, called at both `container_config.rs:987` (agent-config refresh) and `:1436` (per-tool sandbox setup), meaning every kill/restart of a sandboxed opencode session destroys the SQLite DB that holds session identity. `aoe resume` then calls `opencode --session <id>` against an empty DB, opencode exits 1 with `Session not found`, and session context is lost with no recovery path.

The original justifying comment mentioned drizzle migration failures against a schema-drifted host DB, but `skip_entries` already blocks host-to-sandbox copy for those three files. The sandbox creates its own DB in-container on first launch, which is always schema-consistent with the sandboxed opencode binary that wrote it. Wiping on subsequent launches was never necessary for drift protection and destroyed the resume source of truth.

Reviewer @hiSandog raised this scoping direction in the issue thread: "*cleanup should probably target only volatile subdirectories, not the SQLite DB that holds session identity*". This PR implements that scope.

### PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

### Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (comment above the mount block explains the new invariant)
- [ ] For UI changes: included screenshot or recording (n/a)

### How Tested

- **Drift-guard unit test** `test_opencode_mount_clean_files_does_not_touch_sqlite_db`: asserts `opencode.db*` stays out of `clean_files` and remains in `skip_entries`. Fails immediately if a future contributor re-adds the destructive entries.
- **Behavioral unit test** `test_opencode_mount_preserves_sqlite_db_across_prepares`: plants `opencode.db{,-wal,-shm}` in the sandbox subdir, invokes `prepare_sandbox_dir(mount, home)`, and asserts byte-level survival.
- **E2e test** `sandboxed_opencode_db_survives_prepare_sandbox_cycle` at [tests/e2e/opencode_sandbox_resume.rs](tests/e2e/opencode_sandbox_resume.rs): Docker-gated `#[ignore]` per the sandbox e2e convention. Installs an `opencode` PATH shim and runs `aoe add --sandbox --cmd opencode` twice with a fake DB planted between calls; passing `--cmd opencode` makes `config_tool == "opencode"` so the filter at `container_config.rs:1432` selects the opencode mounts and the test actually exercises the code path #2605 lives in.

Gates:
- `cargo fmt --check` clean
- `cargo clippy --features serve --all-targets -- -D warnings` clean
- `cargo test --lib --features serve session::container_config`: 88 passed / 0 failed (both new tests included)
- `cargo check --features serve,e2e-tests --tests --test e2e` clean

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (`tests/e2e/opencode_sandbox_resume.rs`, Docker-gated `#[ignore]`)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7

**Any Additional AI Details you'd like to share:**

Diagnosis, scoping, and implementation were assisted by claude-opus-4-7 driven by a human plan. The direction fork (β: remove `opencode.db*` from `clean_files` vs. α: version-gate wipe on schema mismatch) was resolved by @hiSandog's community design guidance on the issue thread; the AI implemented β and did not invent the direction. An Oracle cross-validation pass surfaced that the e2e test would only exercise the pre-fix bug when `config_tool == "opencode"`, which was addressed by installing an `opencode` PATH shim and passing `--cmd opencode`.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change preserves `opencode`’s sandbox-owned SQLite session database (`opencode.db` plus its `-wal`/`-shm` files) across sandbox refreshes, so resumed sessions keep working after a kill or daemon restart. Sandbox setup no longer deletes these DB files on every launch, while still preventing a potentially schema-drifted host DB from being copied into the sandbox. Related mount/config comments and `clean_files` documentation were updated to make the “never use cleanup for sandbox-owned session state” rule explicit.

It adds regression coverage:
- a unit “drift guard” checking that the `opencode` mount does *not* include the DB files in `clean_files` and instead protects them via `skip_entries`,
- a unit behavior test confirming the DB files and their contents survive `prepare_sandbox_dir`/refresh,
- and a Docker-gated end-to-end resume test (currently ignored) that exercises the session resume flow.

Benefits:
- fixes broken `opencode` session resume after restart,
- keeps valid sandbox session history intact across launches,
- reduces the risk of accidentally wiping a working local session state due to host/sandbox differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->