### PR TITLE
fix(session): defer smart-rename to turn-complete + bound global concurrency (closes #2348)

### DIFF
--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1107,14 +1107,11 @@ pub async fn acp_prompt(
         .acp_supervisor
         .publish_user_prompt_with_attachments(&id, req.text.clone(), &attachments)
         .await;
-    // Best-effort: auto-rename a still-default-named session from this first
-    // message via AoE's one-shot mode. Detached so it never blocks or fails the
-    // prompt; all gating lives inside. See session::smart_rename.
-    tokio::spawn(crate::session::smart_rename::try_smart_rename(
-        state.clone(),
-        id.clone(),
-        req.text.clone(),
-    ));
+    // Smart-rename now fires from `acp_event_listener` on the first clean
+    // `prompt_complete` `Event::Stopped` for this session, so the one-shot
+    // never races this handler's live worker for the same provider API.
+    // The event-store lookup of the first prompt happens in the listener.
+    // See `session::smart_rename` and #2348.
     match state
         .acp_supervisor
         .send_prompt(&id, &req.text, &attachments)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -306,6 +306,11 @@ pub struct AppState {
     /// respawn a one-shot agent; one attempt per session bounds that cost and
     /// clears the `pending` sidebar chip once an attempt has run.
     pub smart_rename_attempted: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Global cap on concurrent smart-rename one-shots so a burst of new
+    /// sessions cannot fan out into N host processes each holding a slot for
+    /// up to `ONESHOT_TIMEOUT`. Held only across the child spawn + wait. See
+    /// `session::smart_rename` and #2348.
+    pub smart_rename_semaphore: tokio::sync::Semaphore,
     /// Suppression set for the startup-recovery cascade. While an entry is
     /// present and younger than `recovery::RECENTLY_RESTARTED_TTL`, the
     /// `status_poll_loop` skips `update_status_with_metadata` for that
@@ -993,6 +998,9 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         instance_locks: RwLock::new(std::collections::HashMap::new()),
         smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
+        smart_rename_semaphore: tokio::sync::Semaphore::new(
+            crate::session::smart_rename::MAX_CONCURRENT,
+        ),
         recently_restarted: crate::session::recovery::new_recently_restarted(),
         recovery_pending: crate::session::recovery::new_recovery_pending(),
         cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
@@ -3810,6 +3818,43 @@ async fn acp_event_listener(state: Arc<AppState>) {
             }
         }
 
+        // Smart-rename defer: fire the one-shot only on a clean
+        // `prompt_complete` `Event::Stopped`, so it never races the live worker
+        // for the same provider API. Two sync mutex `contains()` checks and
+        // the reason-allowlist drop the 99% of events that need no action
+        // before we touch the event store or spawn a task. See #2348.
+        let should_rename = {
+            let attempted = state
+                .smart_rename_attempted
+                .lock()
+                .expect("smart_rename_attempted poisoned");
+            let inflight = state
+                .smart_rename_inflight
+                .lock()
+                .expect("smart_rename_inflight poisoned");
+            crate::session::smart_rename::should_trigger_smart_rename(
+                frame.event.as_ref(),
+                &frame.session_id,
+                &attempted,
+                &inflight,
+            )
+        };
+        if should_rename {
+            if let Some(first_message) = state.acp_event_store.first_user_prompt(&frame.session_id)
+            {
+                let state_for_rename = state.clone();
+                let session_id = frame.session_id.clone();
+                tokio::spawn(async move {
+                    crate::session::smart_rename::try_smart_rename(
+                        state_for_rename,
+                        session_id,
+                        first_message,
+                    )
+                    .await;
+                });
+            }
+        }
+
         let status_intent = derive_acp_status(frame.event.as_ref());
         let acp_change = derive_acp_session_change(frame.event.as_ref());
         if status_intent.is_none() && acp_change.is_none() {
@@ -4198,6 +4243,9 @@ pub mod test_support {
             instance_locks: RwLock::new(HashMap::new()),
             smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
             smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
+            smart_rename_semaphore: tokio::sync::Semaphore::new(
+                crate::session::smart_rename::MAX_CONCURRENT,
+            ),
             recently_restarted: crate::session::recovery::new_recently_restarted(),
             recovery_pending: crate::session::recovery::new_recovery_pending(),
             cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3820,9 +3820,9 @@ async fn acp_event_listener(state: Arc<AppState>) {
 
         // Smart-rename defer: fire the one-shot only on a clean
         // `prompt_complete` `Event::Stopped`, so it never races the live worker
-        // for the same provider API. Two sync mutex `contains()` checks and
-        // the reason-allowlist drop the 99% of events that need no action
-        // before we touch the event store or spawn a task. See #2348.
+        // for the same provider API. The reason-allowlist plus the two sync
+        // mutex `contains()` checks drop non-matching events before we touch
+        // the event store or spawn a task. See #2348.
         let should_rename = {
             let attempted = state
                 .smart_rename_attempted

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3852,6 +3852,19 @@ async fn acp_event_listener(state: Arc<AppState>) {
                     )
                     .await;
                 });
+            } else {
+                // A `prompt_complete` Stopped without any persisted UserPromptSent
+                // is unexpected: `publish_user_prompt_with_attachments` runs
+                // strictly before `send_prompt` in the ACP handler, so by the
+                // time the turn ends the first prompt should be durable in the
+                // event store. A silent skip would hide a plumbing bug (attachment
+                // rollback, pruning of an old session, race with SessionCleared);
+                // surface it at debug so operators can trace it.
+                tracing::debug!(
+                    target: "smart_rename",
+                    session = %frame.session_id,
+                    "trigger fired but event store has no first_user_prompt; skipping"
+                );
             }
         }
 

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -771,7 +771,7 @@ mod serve {
             // `force_smart_rename` at sessions.rs:2582-2587 clears the
             // attempted gate before spawning `try_smart_rename`, and does NOT
             // wait for an `Event::Stopped`: the manual retry path stays
-            // reactive. The bounding is delegated to the shared semaphore
+            // on-demand. The bounding is delegated to the shared semaphore
             // acquired inside `try_smart_rename`. This test emulates the
             // clear step and asserts the predicate would fire again for the
             // same session (which the listener uses; force_smart_rename itself

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -19,6 +19,11 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Cap on concurrent smart-rename one-shots across the process. Two slots keep
+/// steady-state throughput on multi-core hosts without letting N stuck
+/// sessions each hold a slot for up to `ONESHOT_TIMEOUT`. See #2348.
+pub const MAX_CONCURRENT: usize = 2;
+
 /// Per-session smart-rename state surfaced to the dashboard so the sidebar can
 /// show that a session will be (or is being) auto-named. `Inactive` for
 /// sessions that are not eligible or already renamed.
@@ -331,7 +336,7 @@ fn truncate_bytes(s: &str, max: usize) -> &str {
 }
 
 #[cfg(feature = "serve")]
-pub use serve::try_smart_rename;
+pub use serve::{should_trigger_smart_rename, try_smart_rename};
 
 #[cfg(feature = "serve")]
 mod serve {
@@ -341,14 +346,34 @@ mod serve {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    // The one-shot is spawned from the prompt handler at the same instant the
-    // session's own worker starts its first heavy turn, so the two contend for
-    // CPU and the same provider API. Standalone the call finishes well under
-    // 12s; under that contention it can run far longer. 120s absorbs the
-    // contention without a deeper scheduling change (deferring the one-shot
-    // until the live turn settles is tracked as a follow-up). The child is
-    // killed on drop, so a timed-out call leaves no orphan.
-    const ONESHOT_TIMEOUT: Duration = Duration::from_secs(120);
+    // Since #2348 the one-shot is deferred to the first `prompt_complete`
+    // `Event::Stopped`, so it no longer races the live worker for the same
+    // provider API. Standalone the call finishes well under 12s; 60s is a
+    // conservative ceiling that leaves headroom for cold agent starts without
+    // holding a global-semaphore slot as long as #2347's 120s band-aid did.
+    // The child is killed on drop, so a timed-out call leaves no orphan.
+    const ONESHOT_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// Should this ACP broadcast event trigger a smart-rename one-shot for its
+    /// session? Cheap sync predicate: reason-allowlists `prompt_complete` (all
+    /// other `Stopped` reasons like `user_stopped`, `rate_limited`,
+    /// `agent_unresponsive`, `reattach_idle` are either not turn boundaries or
+    /// states where auto-renaming would be intrusive), and short-circuits on
+    /// the two per-session gates so the listener drops the 99% of events that
+    /// need no action before touching the event store or spawning a task.
+    /// See #2348.
+    pub fn should_trigger_smart_rename(
+        event: &crate::acp::state::Event,
+        session_id: &str,
+        attempted: &HashSet<String>,
+        inflight: &HashSet<String>,
+    ) -> bool {
+        let is_clean_stop = matches!(
+            event,
+            crate::acp::state::Event::Stopped { reason } if reason == "prompt_complete"
+        );
+        is_clean_stop && !attempted.contains(session_id) && !inflight.contains(session_id)
+    }
 
     /// Marks a session as having an in-flight one-shot rename so a burst of
     /// rapid first prompts cannot spawn concurrent title generators. Removed on
@@ -437,7 +462,19 @@ mod serve {
         // session attempted in that case: a transient slow first prompt (cold
         // agent start) must not permanently disable naming. A later prompt
         // retries. The inflight guard above already prevents concurrent spawns.
-        let Some(raw) = run_oneshot(&argv, &project_path).await else {
+        //
+        // The permit is scoped tightly around `run_oneshot` so ineligible /
+        // early-return paths above never consume a slot. Same-session duplicates
+        // are already rejected by the InflightGuard, so this permit only gates
+        // cross-session concurrency (#2348).
+        let raw = {
+            let _permit = match state.smart_rename_semaphore.acquire().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            run_oneshot(&argv, &project_path).await
+        };
+        let Some(raw) = raw else {
             return;
         };
 
@@ -627,6 +664,133 @@ mod serve {
             legacy.title = "Hand-picked name".to_string();
             legacy.last_auto_title = None;
             assert!(!title_is_auto_overwritable(&legacy));
+        }
+
+        #[test]
+        fn oneshot_timeout_is_60s() {
+            // Drift-guard against future bump-back: #2347 raised this to 120s
+            // to absorb the prompt-handler race; #2348 removed the race at
+            // source, so this should stay at the deferred-trigger ceiling.
+            assert_eq!(ONESHOT_TIMEOUT, Duration::from_secs(60));
+        }
+
+        #[test]
+        fn should_trigger_smart_rename_only_on_clean_prompt_complete_stop() {
+            use crate::acp::state::Event;
+            let id = "s-1";
+            let empty: HashSet<String> = HashSet::new();
+
+            let clean = Event::Stopped {
+                reason: "prompt_complete".into(),
+            };
+            assert!(should_trigger_smart_rename(&clean, id, &empty, &empty));
+
+            for reason in [
+                "rate_limited",
+                "user_stopped",
+                "user_forced",
+                "agent_unresponsive",
+                "prompt_orphaned",
+                "reattach_idle",
+                "approval_cancelled_on_restart",
+                "restart_pending",
+            ] {
+                let ev = Event::Stopped {
+                    reason: reason.into(),
+                };
+                assert!(
+                    !should_trigger_smart_rename(&ev, id, &empty, &empty),
+                    "reason={reason} should not fire smart-rename"
+                );
+            }
+
+            let non_stop = Event::UserPromptSent {
+                text: "hi".into(),
+                attachments: vec![],
+            };
+            assert!(!should_trigger_smart_rename(&non_stop, id, &empty, &empty));
+
+            let mut attempted = HashSet::new();
+            attempted.insert(id.to_string());
+            assert!(
+                !should_trigger_smart_rename(&clean, id, &attempted, &empty),
+                "attempted-gate must short-circuit even for prompt_complete"
+            );
+
+            let mut inflight = HashSet::new();
+            inflight.insert(id.to_string());
+            assert!(
+                !should_trigger_smart_rename(&clean, id, &empty, &inflight),
+                "inflight-gate must short-circuit even for prompt_complete"
+            );
+
+            assert!(
+                should_trigger_smart_rename(&clean, "other-session", &attempted, &empty),
+                "gates must be per-session, not global"
+            );
+        }
+
+        #[tokio::test]
+        async fn smart_rename_semaphore_bounds_concurrent_permits_to_max() {
+            // A burst of would-be one-shots must see peak concurrency capped
+            // at MAX_CONCURRENT, so N stuck sessions cannot fan out into N
+            // host processes each holding a slot for `ONESHOT_TIMEOUT`.
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            use tokio::sync::Semaphore;
+
+            let sem = Arc::new(Semaphore::new(MAX_CONCURRENT));
+            let live = Arc::new(AtomicUsize::new(0));
+            let peak = Arc::new(AtomicUsize::new(0));
+
+            let mut handles = Vec::new();
+            for _ in 0..5 {
+                let sem = sem.clone();
+                let live = live.clone();
+                let peak = peak.clone();
+                handles.push(tokio::spawn(async move {
+                    let _permit = sem.acquire().await.expect("semaphore closed");
+                    let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(80)).await;
+                    live.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+            for h in handles {
+                h.await.expect("permit task panicked");
+            }
+
+            let seen = peak.load(Ordering::SeqCst);
+            assert!(
+                seen <= MAX_CONCURRENT,
+                "peak concurrency {seen} exceeded cap {MAX_CONCURRENT}"
+            );
+            assert!(
+                seen >= 2,
+                "expected the burst to actually saturate the pool (seen={seen})"
+            );
+        }
+
+        #[test]
+        fn force_smart_rename_attempted_clear_re_enables_retry() {
+            // `force_smart_rename` at sessions.rs:2582-2587 clears the
+            // attempted gate before spawning `try_smart_rename`, and does NOT
+            // wait for an `Event::Stopped`: the manual retry path stays
+            // reactive. The bounding is delegated to the shared semaphore
+            // acquired inside `try_smart_rename`. This test emulates the
+            // clear step and asserts the predicate would fire again for the
+            // same session (which the listener uses; force_smart_rename itself
+            // skips the predicate and spawns directly).
+            use crate::acp::state::Event;
+            let id = "s-1";
+            let mut attempted = HashSet::new();
+            attempted.insert(id.to_string());
+            let inflight = HashSet::new();
+            let ev = Event::Stopped {
+                reason: "prompt_complete".into(),
+            };
+            assert!(!should_trigger_smart_rename(&ev, id, &attempted, &inflight));
+            attempted.remove(id);
+            assert!(should_trigger_smart_rename(&ev, id, &attempted, &inflight));
         }
     }
 }

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -359,9 +359,8 @@ mod serve {
     /// other `Stopped` reasons like `user_stopped`, `rate_limited`,
     /// `agent_unresponsive`, `reattach_idle` are either not turn boundaries or
     /// states where auto-renaming would be intrusive), and short-circuits on
-    /// the two per-session gates so the listener drops the 99% of events that
-    /// need no action before touching the event store or spawning a task.
-    /// See #2348.
+    /// the two per-session gates so the listener drops non-matching events
+    /// before touching the event store or spawning a task. See #2348.
     pub fn should_trigger_smart_rename(
         event: &crate::acp::state::Event,
         session_id: &str,
@@ -386,13 +385,11 @@ mod serve {
     impl<'a> InflightGuard<'a> {
         fn acquire(set: &'a Mutex<HashSet<String>>, id: &str) -> Option<Self> {
             let mut guard = set.lock().expect("smart_rename_inflight poisoned");
-            if !guard.insert(id.to_string()) {
+            let id = id.to_string();
+            if !guard.insert(id.clone()) {
                 return None;
             }
-            Some(Self {
-                set,
-                id: id.to_string(),
-            })
+            Some(Self { set, id })
         }
     }
 
@@ -468,9 +465,8 @@ mod serve {
         // are already rejected by the InflightGuard, so this permit only gates
         // cross-session concurrency (#2348).
         let raw = {
-            let _permit = match state.smart_rename_semaphore.acquire().await {
-                Ok(p) => p,
-                Err(_) => return,
+            let Ok(_permit) = state.smart_rename_semaphore.acquire().await else {
+                return;
             };
             run_oneshot(&argv, &project_path).await
         };

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -468,7 +468,7 @@ mod serve {
             let Ok(_permit) = state.smart_rename_semaphore.acquire().await else {
                 return;
             };
-            run_oneshot(&argv, &project_path).await
+            run_oneshot(&session_id, &argv, &project_path).await
         };
         let Some(raw) = raw else {
             return;
@@ -499,7 +499,7 @@ mod serve {
     /// Run the agent one-shot in the session's working directory, capturing
     /// stdout. Returns `None` on spawn error, non-zero exit, or timeout. The
     /// child is killed on drop, so a timed-out call leaves no orphan.
-    async fn run_oneshot(argv: &[String], cwd: &str) -> Option<String> {
+    async fn run_oneshot(session_id: &str, argv: &[String], cwd: &str) -> Option<String> {
         use tokio::process::Command;
         let mut cmd = Command::new(&argv[0]);
         cmd.args(&argv[1..])
@@ -516,7 +516,7 @@ mod serve {
         let child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!(target: "smart_rename", "one-shot spawn failed: {e}");
+                tracing::debug!(target: "smart_rename", session = %session_id, "one-shot spawn failed: {e}");
                 return None;
             }
         };
@@ -535,15 +535,15 @@ mod serve {
                     .into_iter()
                     .rev()
                     .collect();
-                tracing::debug!(target: "smart_rename", code = ?out.status.code(), stderr = %tail, "one-shot exited non-zero");
+                tracing::debug!(target: "smart_rename", session = %session_id, code = ?out.status.code(), stderr = %tail, "one-shot exited non-zero");
                 None
             }
             Ok(Err(e)) => {
-                tracing::debug!(target: "smart_rename", "one-shot io error: {e}");
+                tracing::debug!(target: "smart_rename", session = %session_id, "one-shot io error: {e}");
                 None
             }
             Err(_) => {
-                tracing::debug!(target: "smart_rename", "one-shot timed out");
+                tracing::debug!(target: "smart_rename", session = %session_id, "one-shot timed out");
                 None
             }
         }
@@ -637,7 +637,7 @@ mod serve {
                 "-p".to_string(),
                 "title this".to_string(),
             ];
-            assert!(run_oneshot(&argv, "").await.is_none());
+            assert!(run_oneshot("test-session", &argv, "").await.is_none());
         }
 
         #[test]


### PR DESCRIPTION
## Description

Closes #2348.

The smart-rename one-shot was spawned from the ACP prompt handler at the same instant the session's own worker started its first heavy turn, so the two contended for CPU and the same provider API. PR #2347 band-aided the resulting failures by raising `ONESHOT_TIMEOUT` from 45s to 120s; the race continued for longer, and N stuck sessions could hold N host one-shot processes for up to 120s each (unbounded fanout under burst).

**What changed**

- **Trigger moved from the prompt handler to a turn-complete listener.** The `tokio::spawn(try_smart_rename(...))` at [`src/server/api/acp.rs`](src/server/api/acp.rs) previously placed at line 1101 is removed. The one-shot now fires from the existing [`acp_event_listener`](src/server/mod.rs) at the first clean `Event::Stopped { reason: "prompt_complete" }` for the session. This reuses the single-listener pattern already spawned at process init, so no new subscription task is added.
- **Reason allowlist.** Only `"prompt_complete"` fires the rename. Every other `Event::Stopped` reason (`rate_limited`, `user_stopped`, `user_forced`, `agent_unresponsive`, `prompt_orphaned`, `reattach_idle`, `approval_cancelled_on_restart`, `restart_pending`) is either not a real turn boundary or a state where auto-renaming would be intrusive or wasteful.
- **First-turn gate.** The listener does two cheap sync `HashSet::contains()` checks against the existing `smart_rename_attempted` and `smart_rename_inflight` state on `AppState` BEFORE spawning, so non-matching `Stopped` events (already-renamed sessions, multi-turn sessions on turn 2+) drop before the event-store lookup or the spawn.
- **Global concurrency bound.** New `smart_rename_semaphore: tokio::sync::Semaphore` field on `AppState` (cap = `MAX_CONCURRENT = 2`, giving ~2 renames/min steady-state under saturation on multi-core hosts). The permit is acquired inside `try_smart_rename` in a scoped block that spans only the `run_oneshot` I/O, so ineligible calls and same-session duplicates (already rejected by `InflightGuard`) never consume a slot. `force_smart_rename` at [`src/server/api/sessions.rs`](src/server/api/sessions.rs) is unchanged: it still spawns `try_smart_rename` directly (manual retry stays on-demand), and its call automatically routes through the same semaphore.
- **`ONESHOT_TIMEOUT` returns to 60s.** Conservative middle of #2348's suggested 60-90s range; standalone the one-shot finishes well under 12s, and 60s leaves headroom for cold agent starts without holding a semaphore slot as long as #2347's 120s band-aid did. Metric-driven fine tuning is a follow-up.
- **`should_trigger_smart_rename` extracted as a pure sync predicate.** Takes `(&Event, &session_id, &attempted, &inflight)` and returns `bool`; the acp listener holds the two sync `Mutex` guards only across this predicate call and never spans an `await` under lock.

**Why (race at source rather than absorbing it)**

Bumping the timeout absorbed the contention window but did nothing about the underlying race: the one-shot process still competed with the live worker for the same provider tokens, and each stuck session could hold a host process for up to 120s. This PR removes the race so the one-shot only runs when the worker is idle, which means the timeout can come back down AND the number of concurrent one-shots can be capped without hurting the happy path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A: backend-only race fix)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [x] N/A: this PR doesn't change a user-facing dashboard flow (the visible behavior after a first prompt is unchanged; the timing of the auto-rename shifts from "during the first turn" to "just after the first turn ends", which is the intended fix, not a UX change).

**TUI / CLI (e2e test)**

- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. Session status, tmux, and structured view are untouched.

Regression coverage lives with the code:

- `oneshot_timeout_is_60s` (drift-guard against a future well-meaning bump-back to absorb a symptom instead of finding its cause).
- `should_trigger_smart_rename_only_on_clean_prompt_complete_stop` (predicate table: every documented `Event::Stopped` reason variant, non-`Stopped` events, and both per-session gate short-circuits).
- `smart_rename_semaphore_bounds_concurrent_permits_to_max` (5-task burst; asserts peak concurrency <= `MAX_CONCURRENT` AND >= 2 so a future silent size drop does not go unnoticed).
- `force_smart_rename_attempted_clear_re_enables_retry` (structural check: force-rename's attempted-clear step at [`sessions.rs`](src/server/api/sessions.rs) 2582-2587 re-enables the predicate for the same session).

Existing 23 smart_rename tests unchanged and passing; 15 acp handler tests unchanged and passing (regression check for the removed prompt-handler spawn).

**Gates run locally:**

- `cargo fmt --check`: clean
- `cargo clippy --features serve --all-targets -- -D warnings`: clean
- `cargo test --features serve --lib session::smart_rename`: 27/27 pass
- `cargo test --features serve --lib server::api::acp`: 15/15 pass

## Out of scope

- Persisting smart-rename state across restarts (tracked separately as #2349 per the issue body).
- Replacing the CLI one-shot with a direct HTTP title model.
- Metric-driven tuning of `ONESHOT_TIMEOUT` or `MAX_CONCURRENT` beyond the conservative values chosen here.
- Making `MAX_CONCURRENT` configurable via `ProfileConfig`.
- Any change to `try_smart_rename`'s config-resolution logic (merged as #2602 for #2351).
- Any change to `force_smart_rename` semantic beyond routing through the shared semaphore (which happens automatically because it spawns `try_smart_rename`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7 (Anthropic)

**Any Additional AI Details you'd like to share:**

Design fork (WHERE to hook the turn-complete trigger: session status transition vs first-message-persisted vs ACP `Event::Stopped` broadcast vs a pre-existing lifecycle hook) was resolved with a read-only oracle consultation grounded in seven code citations before implementation.

The verdict picked the `Event::Stopped { reason: "prompt_complete" }` listener because smart-rename is already gated to ACP structured-view sessions by `SkipReason::NotStructured`, so hooking the ACP broadcast has zero coverage gap for terminal-tool sessions.

Implementation, tests, and cross-validation followed. The final diff was cross-validated by a second oracle pass against a 16-item checklist covering the removed spawn, the new listener hook, semaphore semantics, sync-lock-across-await hazards, race between listener and force path, and AGENTS.md compliance. Subsequent review cycles (three-lens post-review on design + Rust idioms + harmonization + terminology, then a fresh algorithmic + docs pass, then a security + reliability + observability + merge-readiness pass) returned zero MUST-FIX findings; each surfaced nitpick was applied as a small follow-up commit before the branch was rebased onto current main.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
- Moved smart-rename from starting during the live prompt handler to running after the first turn fully completes.
- Added a global limit so only a small number of smart-rename jobs can run at once.
- Reduced the smart-rename timeout back to a shorter, safer value.
- Kept manual “force smart rename” support, but routed it through the same limit.
- Added and updated tests around trigger timing, concurrency limits, timeout, and retry behavior.

## Benefits
- Reduces contention and startup races for new sessions.
- Prevents smart-rename jobs from piling up during bursts of activity.
- Makes the rename flow more predictable and less prone to hanging.

## Technical notes
- The trigger logic was split into a pure check that only allows a clean turn-complete stop event and blocks duplicate/in-flight runs.
- Session-level logging was improved for failures, skipped runs, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->