### PR TITLE
feat(cli): add `aoe session import` to bulk-import Claude Code sessions

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -628,7 +628,7 @@ Import existing Claude Code sessions from disk. Scans the given path(s) (default
 
 ###### **Arguments:**
 
-* `<PATHS>` — Directories to scan. Only Claude sessions whose recorded working directory is at or under one of these are imported. Defaults to the current directory. Ignored with `--all`
+* `<PATHS>` — Directories to scan. Only Claude sessions whose recorded working directory is at or under one of these are imported. Defaults to the current directory. Cannot be combined with `--all`
 
 ###### **Options:**
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -34,6 +34,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe session archive`↴](#aoe-session-archive)
 * [`aoe session unarchive`↴](#aoe-session-unarchive)
 * [`aoe session restore`↴](#aoe-session-restore)
+* [`aoe session import`↴](#aoe-session-import)
 * [`aoe session list-trash`↴](#aoe-session-list-trash)
 * [`aoe session empty-trash`↴](#aoe-session-empty-trash)
 * [`aoe group`↴](#aoe-group)
@@ -352,6 +353,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `archive` — Archive a session: sink it in the Attention sort and tear down its tmux sessions. Worktree, branch, container preserved. `--no-kill` skips tmux teardown. See #1868
 * `unarchive` — Unarchive a session (restores it to its tier in the Attention sort)
 * `restore` — Restore a trashed session, returning it to its prior bucket with its transcript and metadata intact. See #2489
+* `import` — Import existing Claude Code sessions from disk. Scans the given path(s) (default: current directory) for Claude Code conversations whose working directory is at or under a path, and creates an AoE session for each: a terminal/tmux session that resumes the conversation with `claude --resume <id>` (default), or a structured-view session with `--structured`
 * `list-trash` — List the sessions currently in the trash
 * `empty-trash` — Permanently purge every trashed session in the profile (irreversible)
 
@@ -615,6 +617,27 @@ Restore a trashed session, returning it to its prior bucket with its transcript 
 ###### **Arguments:**
 
 * `<IDENTIFIER>` — Session ID or title
+
+
+
+## `aoe session import`
+
+Import existing Claude Code sessions from disk. Scans the given path(s) (default: current directory) for Claude Code conversations whose working directory is at or under a path, and creates an AoE session for each: a terminal/tmux session that resumes the conversation with `claude --resume <id>` (default), or a structured-view session with `--structured`
+
+**Usage:** `aoe session import [OPTIONS] [PATHS]...`
+
+###### **Arguments:**
+
+* `<PATHS>` — Directories to scan. Only Claude sessions whose recorded working directory is at or under one of these are imported. Defaults to the current directory. Ignored with `--all`
+
+###### **Options:**
+
+* `--all` — Import every discoverable Claude session, ignoring the path filter
+* `--structured` — Import as structured-view sessions (rendered in the web dashboard and the structured TUI view) instead of terminal/tmux sessions. Structured sessions replay their transcript under `aoe serve`
+* `--group <GROUP>` — Place imported sessions under this session group
+* `--launch` — Start terminal sessions immediately after importing (spawns the tmux pane running `claude --resume <id>`). Ignored for structured imports
+* `--dry-run` — List what would be imported without creating anything
+* `-y`, `--yes` — Skip the confirmation prompt when importing more than one session
 
 
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -19,8 +19,6 @@ pub mod agent_profiles;
 pub mod agent_registry;
 pub mod approvals;
 pub mod background_agent;
-#[cfg(feature = "serve")]
-pub mod claude_import;
 pub mod client;
 pub mod context_primer;
 pub mod elicitations;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -2123,3 +2123,66 @@ mod acp_reject_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod import_tests {
+    use super::*;
+    use crate::session::claude_import::ClaudeSessionSummary;
+
+    fn summary(id: &str, cwd: &str, title: Option<&str>) -> ClaudeSessionSummary {
+        ClaudeSessionSummary {
+            session_id: id.to_string(),
+            cwd: cwd.to_string(),
+            title: title.map(str::to_string),
+            last_modified_ms: 0,
+            cwd_exists: true,
+        }
+    }
+
+    #[test]
+    fn terminal_import_pins_resume_target() {
+        let s = summary("abc123-def456", "/home/me/proj", Some("Fix bug"));
+        let inst = build_import_instance(&s, false, "");
+        assert_eq!(inst.tool, "claude");
+        assert_eq!(inst.project_path, "/home/me/proj");
+        assert_eq!(inst.title, "Fix bug");
+        assert_eq!(
+            inst.resume_intent,
+            ResumeIntent::Use("abc123-def456".to_string())
+        );
+    }
+
+    #[test]
+    fn title_falls_back_to_short_id() {
+        let s = summary("abcdef12-3456-7890", "/home/me/proj", None);
+        let inst = build_import_instance(&s, false, "team/imports");
+        assert_eq!(inst.title, "Claude import abcdef12");
+        assert_eq!(inst.group_path, "team/imports");
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn structured_import_seeds_replay_fields() {
+        let s = summary("sid-1", "/home/me/proj", Some("x"));
+        let inst = build_import_instance(&s, true, "");
+        assert!(inst.is_structured());
+        assert_eq!(inst.acp_session_id.as_deref(), Some("sid-1"));
+        assert_eq!(inst.import_pending, Some(true));
+        // Structured imports do not pin a terminal resume target.
+        assert_eq!(inst.resume_intent, ResumeIntent::Default);
+    }
+
+    #[test]
+    fn already_imported_matches_resume_and_observed_ids() {
+        let mut by_resume = Instance::new("a", "/p");
+        by_resume.resume_intent = ResumeIntent::Use("id-1".to_string());
+        let mut by_observed = Instance::new("b", "/p");
+        by_observed.agent_session_id = Some("id-2".to_string());
+        let fresh = Instance::new("c", "/p");
+        let instances = vec![by_resume, by_observed, fresh];
+
+        assert!(already_imported(&instances, "id-1"));
+        assert!(already_imported(&instances, "id-2"));
+        assert!(!already_imported(&instances, "id-3"));
+    }
+}

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -94,7 +94,7 @@ pub enum SessionCommands {
 pub struct ImportArgs {
     /// Directories to scan. Only Claude sessions whose recorded working
     /// directory is at or under one of these are imported. Defaults to the
-    /// current directory. Ignored with `--all`.
+    /// current directory. Cannot be combined with `--all`.
     pub paths: Vec<String>,
 
     /// Import every discoverable Claude session, ignoring the path filter.

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -5,7 +5,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::collections::HashSet;
 
-use crate::session::{GroupTree, StartOutcome, Storage};
+use crate::session::{GroupTree, Instance, ResumeIntent, StartOutcome, Storage};
 
 #[derive(Subcommand)]
 pub enum SessionCommands {
@@ -75,11 +75,55 @@ pub enum SessionCommands {
     /// transcript and metadata intact. See #2489.
     Restore(SessionIdArgs),
 
+    /// Import existing Claude Code sessions from disk. Scans the given
+    /// path(s) (default: current directory) for Claude Code conversations
+    /// whose working directory is at or under a path, and creates an AoE
+    /// session for each: a terminal/tmux session that resumes the
+    /// conversation with `claude --resume <id>` (default), or a
+    /// structured-view session with `--structured`.
+    Import(ImportArgs),
+
     /// List the sessions currently in the trash.
     ListTrash,
 
     /// Permanently purge every trashed session in the profile (irreversible).
     EmptyTrash,
+}
+
+#[derive(Args)]
+pub struct ImportArgs {
+    /// Directories to scan. Only Claude sessions whose recorded working
+    /// directory is at or under one of these are imported. Defaults to the
+    /// current directory. Ignored with `--all`.
+    pub paths: Vec<String>,
+
+    /// Import every discoverable Claude session, ignoring the path filter.
+    #[arg(long, conflicts_with = "paths")]
+    pub all: bool,
+
+    /// Import as structured-view sessions (rendered in the web dashboard and
+    /// the structured TUI view) instead of terminal/tmux sessions. Structured
+    /// sessions replay their transcript under `aoe serve`.
+    #[cfg(feature = "serve")]
+    #[arg(long)]
+    pub structured: bool,
+
+    /// Place imported sessions under this session group.
+    #[arg(long)]
+    pub group: Option<String>,
+
+    /// Start terminal sessions immediately after importing (spawns the tmux
+    /// pane running `claude --resume <id>`). Ignored for structured imports.
+    #[arg(long)]
+    pub launch: bool,
+
+    /// List what would be imported without creating anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip the confirmation prompt when importing more than one session.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
 }
 
 #[derive(Args)]
@@ -270,6 +314,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
         SessionCommands::Archive(args) => archive_session(profile, args).await,
         SessionCommands::Unarchive(args) => unarchive_session(profile, args).await,
         SessionCommands::Restore(args) => restore_session(profile, args).await,
+        SessionCommands::Import(args) => import_sessions(profile, args).await,
         SessionCommands::ListTrash => list_trash(profile).await,
         SessionCommands::EmptyTrash => empty_trash(profile).await,
     }
@@ -632,6 +677,243 @@ fn bail_if_acp(inst: &crate::session::Instance, verb: &str) -> Result<()> {
 
 #[cfg(not(feature = "serve"))]
 fn bail_if_acp(_inst: &crate::session::Instance, _verb: &str) -> Result<()> {
+    Ok(())
+}
+
+/// Resolve the scan roots for `aoe session import`. Empty input means the
+/// current directory. Each root is canonicalized (falling back to the path as
+/// given if it does not resolve) so the component-aware filter compares against
+/// absolute paths.
+fn resolve_import_roots(paths: &[String]) -> Result<Vec<std::path::PathBuf>> {
+    let raw: Vec<std::path::PathBuf> = if paths.is_empty() {
+        vec![std::env::current_dir()?]
+    } else {
+        paths.iter().map(std::path::PathBuf::from).collect()
+    };
+    Ok(raw
+        .into_iter()
+        .map(|p| p.canonicalize().unwrap_or(p))
+        .collect())
+}
+
+/// True when `id` is already imported by some instance, so a re-run does not
+/// create duplicates. Checks the terminal resume target, the poller-observed
+/// id, and (serve builds) the structured-view id.
+fn already_imported(instances: &[Instance], id: &str) -> bool {
+    instances.iter().any(|inst| {
+        if inst.agent_session_id.as_deref() == Some(id) {
+            return true;
+        }
+        if matches!(&inst.resume_intent, ResumeIntent::Use(s) if s == id) {
+            return true;
+        }
+        #[cfg(feature = "serve")]
+        if inst.acp_session_id.as_deref() == Some(id) {
+            return true;
+        }
+        false
+    })
+}
+
+/// Build the AoE `Instance` for one discovered Claude session. Terminal imports
+/// pin `resume_intent` so the first launch emits `claude --resume <id>`;
+/// structured imports (serve only) seed the fields the reconciler reads to
+/// replay the transcript.
+fn build_import_instance(
+    s: &crate::session::claude_import::ClaudeSessionSummary,
+    structured: bool,
+    group: &str,
+) -> Instance {
+    let title = s.title.clone().unwrap_or_else(|| {
+        let short = s.session_id.get(..8).unwrap_or(s.session_id.as_str());
+        format!("Claude import {short}")
+    });
+    let mut inst = Instance::new(&title, &s.cwd);
+    inst.tool = "claude".to_string();
+    if !group.is_empty() {
+        inst.group_path = group.to_string();
+    }
+    apply_import_mode(&mut inst, s, structured);
+    inst
+}
+
+#[cfg(feature = "serve")]
+fn apply_import_mode(
+    inst: &mut Instance,
+    s: &crate::session::claude_import::ClaudeSessionSummary,
+    structured: bool,
+) {
+    if structured {
+        inst.view = crate::session::View::Structured;
+        inst.acp_session_id = Some(s.session_id.clone());
+        inst.import_pending = Some(true);
+    } else {
+        inst.resume_intent = ResumeIntent::Use(s.session_id.clone());
+    }
+}
+
+#[cfg(not(feature = "serve"))]
+fn apply_import_mode(
+    inst: &mut Instance,
+    s: &crate::session::claude_import::ClaudeSessionSummary,
+    _structured: bool,
+) {
+    inst.resume_intent = ResumeIntent::Use(s.session_id.clone());
+}
+
+async fn import_sessions(profile: &str, args: ImportArgs) -> Result<()> {
+    use crate::session::claude_import::{scan_sessions, sessions_under_paths, MAX_SESSIONS};
+
+    #[cfg(feature = "serve")]
+    let structured = args.structured;
+    #[cfg(not(feature = "serve"))]
+    let structured = false;
+
+    // Discover, then narrow to the requested paths unless --all.
+    let mut discovered = scan_sessions();
+    if !args.all {
+        let roots = resolve_import_roots(&args.paths)?;
+        discovered = sessions_under_paths(discovered, &roots);
+    }
+
+    // A session whose recorded cwd no longer exists cannot be resumed:
+    // `claude --resume` resolves the transcript by cwd, so a dead cwd would
+    // silently start a fresh conversation. Skip and report those.
+    let (candidates, missing_cwd): (Vec<_>, Vec<_>) =
+        discovered.into_iter().partition(|s| s.cwd_exists);
+
+    // Dedupe against sessions already imported into this profile.
+    let (existing, _groups) = Storage::new_unwatched(profile)?.load_with_groups()?;
+    let candidate_count = candidates.len();
+    let mut to_import: Vec<_> = candidates
+        .into_iter()
+        .filter(|s| !already_imported(&existing, &s.session_id))
+        .collect();
+    let already = candidate_count - to_import.len();
+
+    // Bulk safety backstop; the picker cap also applies to the CLI.
+    let capped = to_import.len() > MAX_SESSIONS;
+    if capped {
+        to_import.truncate(MAX_SESSIONS);
+    }
+
+    let report_skipped = || {
+        if already > 0 {
+            println!("  ({already} already imported, skipped)");
+        }
+        if !missing_cwd.is_empty() {
+            println!(
+                "  ({} skipped: working directory no longer exists)",
+                missing_cwd.len()
+            );
+        }
+        if capped {
+            println!("  (capped at {MAX_SESSIONS}; narrow the path(s) to import the rest)");
+        }
+    };
+
+    if to_import.is_empty() {
+        println!("No new Claude Code sessions to import.");
+        report_skipped();
+        return Ok(());
+    }
+
+    let kind = if structured { "structured" } else { "terminal" };
+    println!(
+        "Found {} Claude Code session(s) to import as {kind} sessions:",
+        to_import.len()
+    );
+    for s in &to_import {
+        let short = s.session_id.get(..8).unwrap_or(s.session_id.as_str());
+        let title = s.title.as_deref().unwrap_or("(no title)");
+        println!("  {short}  {title}  [{}]", s.cwd);
+    }
+    report_skipped();
+
+    if args.dry_run {
+        println!("Dry run: nothing created.");
+        return Ok(());
+    }
+
+    if to_import.len() > 1 && !args.yes {
+        use std::io::Write;
+        print!("Import {} session(s)? [y/N] ", to_import.len());
+        std::io::stdout().flush().ok();
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !matches!(input.trim().to_lowercase().as_str(), "y" | "yes") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let group = args.group.clone().unwrap_or_default();
+    let storage = Storage::new_unwatched(profile)?;
+    let created_ids = storage.update(|all_instances, groups| {
+        let mut ids = Vec::new();
+        for s in &to_import {
+            // Re-check under the lock so a concurrent import does not duplicate.
+            if already_imported(all_instances, &s.session_id) {
+                continue;
+            }
+            let inst = build_import_instance(s, structured, &group);
+            ids.push(inst.id.clone());
+            all_instances.push(inst.clone());
+            if !inst.group_path.is_empty() {
+                let mut tree = GroupTree::new_with_groups(all_instances, groups);
+                tree.create_group(&inst.group_path);
+                *groups = tree.get_all_groups();
+            }
+        }
+        Ok(ids)
+    })?;
+
+    println!("✓ Imported {} session(s).", created_ids.len());
+
+    if structured {
+        if args.launch {
+            println!("Note: --launch is ignored for structured imports.");
+        }
+        println!(
+            "Structured sessions replay their transcript on the next `aoe serve` \
+             (auto-spawned within ~2s while serve is running)."
+        );
+        return Ok(());
+    }
+
+    if args.launch {
+        launch_imported(profile, &created_ids)?;
+    } else if !created_ids.is_empty() {
+        println!("Start them with `aoe session start <id>` (or launch on import with --launch).");
+    }
+    Ok(())
+}
+
+/// Start freshly imported terminal sessions, spawning each tmux pane. Mirrors
+/// `start_session`'s three-phase pattern; failures are reported per session and
+/// do not abort the rest.
+fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
+    let storage = Storage::new_unwatched(profile)?;
+    for id in ids {
+        let (instances, _groups) = storage.load_with_groups()?;
+        let Some(inst) = instances.iter().find(|i| &i.id == id) else {
+            continue;
+        };
+        let mut working = inst.clone();
+        working.source_profile = profile.to_string();
+        if let Err(e) = working.start_with_size(crate::terminal::get_size()) {
+            eprintln!("Warning: failed to start {}: {e}", working.title);
+            continue;
+        }
+        let wid = working.id.clone();
+        storage.update(|instances, _groups| {
+            if let Some(stored) = instances.iter_mut().find(|i| i.id == wid) {
+                stored.merge_post_start(&working);
+            }
+            Ok(())
+        })?;
+        println!("✓ Started {}", working.title);
+    }
     Ok(())
 }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2218,7 +2218,7 @@ pub async fn list_claude_sessions(State(state): State<Arc<AppState>>) -> impl In
     if let Some(resp) = read_only_block(&state) {
         return resp;
     }
-    let mut sessions = tokio::task::spawn_blocking(crate::acp::claude_import::scan_sessions)
+    let mut sessions = tokio::task::spawn_blocking(crate::session::claude_import::scan_sessions)
         .await
         .unwrap_or_default();
     // Drop sessions AoE owns: importing one is a no-op and they are noise in
@@ -2264,7 +2264,7 @@ pub async fn list_claude_sessions(State(state): State<Arc<AppState>>) -> impl In
     });
     // Cap AFTER ownership filtering so a burst of AoE-managed sessions can't
     // push real imports off the (newest-first) list. See #2276.
-    sessions.truncate(crate::acp::claude_import::MAX_SESSIONS);
+    sessions.truncate(crate::session::claude_import::MAX_SESSIONS);
     Json(sessions).into_response()
 }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4205,7 +4205,7 @@ pub async fn create_session(
         let import_cwd = body.path.trim().to_string();
         let import_id_owned = import_id.to_string();
         let belongs = tokio::task::spawn_blocking(move || {
-            crate::acp::claude_import::scan_sessions()
+            crate::session::claude_import::scan_sessions()
                 .into_iter()
                 .any(|s| s.session_id == import_id_owned && s.cwd == import_cwd)
         })

--- a/src/session/claude_import.rs
+++ b/src/session/claude_import.rs
@@ -139,9 +139,18 @@ fn cwd_under_worktree(cwd: &str, markers: &[String]) -> bool {
 /// are filtered separately by the endpoint, which has the instance list.
 /// See #2276.
 pub fn scan_sessions() -> Vec<ClaudeSessionSummary> {
-    let Some(projects) = claude_config_dir().map(|d| d.join("projects")) else {
+    let Some(config_dir) = claude_config_dir() else {
         return Vec::new();
     };
+    scan_sessions_in(&config_dir)
+}
+
+/// Scan the `projects/` tree under `config_dir` (the resolved Claude config
+/// directory). Split out from [`scan_sessions`] so tests can point at a temp
+/// config tree without mutating the global `CLAUDE_CONFIG_DIR` env (which would
+/// race the parallel test runner). See [`scan_sessions`] for filtering rules.
+pub fn scan_sessions_in(config_dir: &Path) -> Vec<ClaudeSessionSummary> {
+    let projects = config_dir.join("projects");
     let Ok(project_dirs) = fs::read_dir(&projects) else {
         return Vec::new();
     };
@@ -182,6 +191,24 @@ pub fn scan_sessions() -> Vec<ClaudeSessionSummary> {
 
     out.sort_by_key(|s| std::cmp::Reverse(s.last_modified_ms));
     out
+}
+
+/// Retain sessions whose recorded `cwd` is at or under one of `roots`.
+/// Component-aware via [`Path::starts_with`], so a root of `/a/app` does not
+/// match a cwd of `/a/app-v2`. Comparison is lexical on the paths as given;
+/// callers wanting symlink-robust matching should canonicalize `roots` (and the
+/// cwds) first.
+pub fn sessions_under_paths(
+    sessions: Vec<ClaudeSessionSummary>,
+    roots: &[PathBuf],
+) -> Vec<ClaudeSessionSummary> {
+    sessions
+        .into_iter()
+        .filter(|s| {
+            let cwd = Path::new(&s.cwd);
+            roots.iter().any(|r| cwd.starts_with(r))
+        })
+        .collect()
 }
 
 /// Build a summary for one `.jsonl` file. Returns `None` when the file has no
@@ -422,5 +449,72 @@ mod tests {
             &[r#"{"type":"last-prompt","sessionId":"nocwd"}"#],
         );
         assert!(summarize_file(&path).is_none());
+    }
+
+    fn summary(id: &str, cwd: &str) -> ClaudeSessionSummary {
+        ClaudeSessionSummary {
+            session_id: id.to_string(),
+            cwd: cwd.to_string(),
+            title: None,
+            last_modified_ms: 0,
+            cwd_exists: true,
+        }
+    }
+
+    #[test]
+    fn sessions_under_paths_is_component_aware() {
+        let sessions = vec![
+            summary("a", "/home/me/app"),
+            summary("b", "/home/me/app/sub/deep"),
+            summary("c", "/home/me/app-v2"),
+            summary("d", "/home/me/other"),
+        ];
+        let roots = vec![PathBuf::from("/home/me/app")];
+        let kept: Vec<_> = sessions_under_paths(sessions, &roots)
+            .into_iter()
+            .map(|s| s.session_id)
+            .collect();
+        // Root itself and descendants match; the sibling `app-v2` does NOT
+        // (component-aware, not a string prefix), nor does an unrelated dir.
+        assert_eq!(kept, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn sessions_under_paths_matches_any_root() {
+        let sessions = vec![
+            summary("a", "/p/one/x"),
+            summary("b", "/p/two/y"),
+            summary("c", "/p/three/z"),
+        ];
+        let roots = vec![PathBuf::from("/p/one"), PathBuf::from("/p/three")];
+        let kept: Vec<_> = sessions_under_paths(sessions, &roots)
+            .into_iter()
+            .map(|s| s.session_id)
+            .collect();
+        assert_eq!(kept, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn scan_sessions_in_reads_temp_config_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("projects").join("-encoded-cwd");
+        fs::create_dir_all(&project).unwrap();
+        let work = tmp.path().join("work");
+        fs::create_dir(&work).unwrap();
+        let cwd_str = work.to_str().unwrap();
+        write_jsonl(
+            &project,
+            "713b7f46-d0f2-454e-91be-a3305d35660c",
+            &[&format!(
+                r#"{{"type":"user","cwd":"{cwd_str}","message":{{"role":"user","content":"hello"}}}}"#
+            )],
+        );
+
+        let found = scan_sessions_in(tmp.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].session_id, "713b7f46-d0f2-454e-91be-a3305d35660c");
+        assert_eq!(found[0].cwd, cwd_str);
+        // Absent projects dir yields an empty scan, never an error.
+        assert!(scan_sessions_in(&tmp.path().join("nope")).is_empty());
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -4,6 +4,10 @@ pub mod artifacts;
 pub mod builder;
 pub(crate) mod capture;
 pub mod civilizations;
+// Discovery of on-disk Claude Code sessions. Lives here (not under the
+// serve-gated `acp` module) because terminal/tmux import via the CLI works in
+// every build; only the structured-view import path needs `serve`.
+pub mod claude_import;
 pub mod config;
 pub(crate) mod container_config;
 pub mod deletion;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds `aoe session import`, a CLI entry point for bulk-importing existing Claude Code sessions into AoE. This is the CLI half of #2466 (the TUI picker, proposal A, is intentionally left for a follow-up).

Given one or more paths (default: the current directory), the command scans on-disk Claude Code conversations and imports each whose recorded working directory is at or under a path:

- **Terminal / tmux (default, every build):** creates a session pinned to resume the conversation, so its first launch runs `claude --resume <id>` in a tmux pane. This reuses the same `resume_intent = ResumeIntent::Use(id)` mechanism that the already-shipped `aoe session set-session-id` uses, so the resume path is unchanged and already tested.
- **Structured view (`--structured`, serve builds):** seeds `view = Structured`, `acp_session_id`, and `import_pending` so `aoe serve` replays the transcript, matching what the web import wizard does today.

Safety and ergonomics: skips sessions already imported (idempotent re-runs), skips sessions whose working directory no longer exists (`claude --resume` resolves the transcript by cwd, so a dead cwd would silently start fresh), previews with `--dry-run`, confirms multi-session imports unless `-y/--yes`, supports `--group` and `--all`, and can `--launch` terminal panes right after import.

One structural change worth calling out: the discovery core (`scan_sessions`, `ClaudeSessionSummary`) previously lived under the `acp` module, which is gated behind the `serve` feature. Terminal import must work in every build, so it moved to `session::claude_import` (its dependencies are only `session::Config` + std, no ACP). The web dashboard endpoints follow the new path; the structured-view Instance fields stay serve-gated.

Partial of #2466

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With at least one real Claude Code conversation on disk, `cd` into that project and run `aoe session import --dry-run`; confirm it lists the session (id, title, cwd) and creates nothing.
- [ ] Run `aoe session import` in that directory; confirm a new terminal session appears in `aoe` / `aoe session` list, then start it and confirm the tmux pane resumes the prior conversation (`claude --resume`).
- [ ] Run the same import again; confirm it reports the session as already imported and creates no duplicate.
- [ ] Run `aoe session import /path/that/has/no/claude/sessions`; confirm "No new Claude Code sessions to import."
- [ ] Import more than one session at once and confirm the `[y/N]` confirmation prompt appears (and `-y` skips it).
- [ ] On a `--features serve` build with `aoe serve` running, run `aoe session import --structured`; confirm the imported session shows in the dashboard and replays its transcript.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the command's logic is covered by focused unit tests (path filtering, temp-config-tree discovery, instance construction with resume pinning, title fallback, structured replay-seed fields, and the dedupe predicate); the handler itself is thin wiring over these tested units and the already-tested `resume_intent` launch path.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. A `/debate` consult (Gemini + GPT) pressure-tested the design (command placement, component-aware path matching, cwd-missing handling, bulk-import safety). I reviewed each commit and made the design calls.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a new `aoe session import` command to bulk-import existing Claude Code sessions saved on disk into AoE.

What changed:
- Introduced a CLI workflow that scans one or more paths (default: current directory) for saved Claude Code conversations and imports matching sessions.
- Default import mode creates terminal/tmux-ready AoE sessions pinned to resume with `claude --resume <id>`.
- `--structured` mode (available only in serve builds) seeds AoE session fields so the transcript can be replayed via `aoe serve`, matching the existing web import flow.
- Added safety and usability features:
  - Skips sessions that are already imported.
  - Skips sessions whose recorded working directory no longer exists.
  - Supports `--dry-run`.
  - Caps the number of imported sessions (via `MAX_SESSIONS`).
  - Requires confirmation for multi-session imports (bypassed with `-y/--yes`).
  - Supports `--group` and `--launch` (terminal launch; structured mode gives replay guidance for `aoe serve`).
  - Adds `--all` to ignore path filtering (and disallows combining `--all` with scoped `PATHS`).
- Refactored Claude session discovery into a shared, session-level module so CLI/terminal imports work in all builds (not only the web/serve path).
- Updated server endpoints to use the same shared discovery logic.
- Expanded documentation and added tests for path/root filtering and structured import field seeding/dedupe behavior.

Benefits:
- Enables migrating existing Claude Code history from the CLI (not just the web dashboard), supporting scripted and terminal-based workflows.
- Keeps CLI and web imports consistent by reusing the same discovery and structured import seeding logic.
- Makes bulk imports safer and more predictable by avoiding duplicates and invalid/mismatched session candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->