### PR TITLE
perf(session): fast-path smart-rename listener gate on Event variant

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3820,10 +3820,16 @@ async fn acp_event_listener(state: Arc<AppState>) {
 
         // Smart-rename defer: fire the one-shot only on a clean
         // `prompt_complete` `Event::Stopped`, so it never races the live worker
-        // for the same provider API. The reason-allowlist plus the two sync
-        // mutex `contains()` checks drop non-matching events before we touch
-        // the event store or spawn a task. See #2348.
-        let should_rename = {
+        // for the same provider API. Fast-path on the event variant BEFORE
+        // touching the two sync mutexes so high-volume streaming-delta frames
+        // (`AgentMessageChunk`, `ToolCallStarted`, `ThinkingStarted`, ...) skip
+        // the locks entirely; the pure predicate then applies the reason
+        // allowlist + the two per-session `contains()` checks. See #2348 and
+        // the post-merge review nit on #2651.
+        let should_rename = matches!(
+            frame.event.as_ref(),
+            crate::acp::state::Event::Stopped { .. }
+        ) && {
             let attempted = state
                 .smart_rename_attempted
                 .lock()


### PR DESCRIPTION
## Description

Follow-up on the post-merge review nit for #2651. In that PR's approval, @Seluj78 flagged:

> `src/server/mod.rs` ~324-339: the listener locks both `smart_rename` mutexes on every ACP broadcast frame before the event-variant check. Only a `prompt_complete Event::Stopped` can pass. Gating on `matches!(event, Event::Stopped { .. })` first would skip both locks on the high-volume streaming-delta path. Micro cost: two uncontended lock/unlock per frame.

## What changed

Fast-path on the event variant BEFORE entering the two-sync-mutex block in [`acp_event_listener`](src/server/mod.rs): a `matches!(event, Event::Stopped { .. })` short-circuits before either `Mutex::lock()`. During an active turn the ACP frame stream is dominated by `AgentMessageChunk`, `ToolCallStarted`, `ThinkingStarted`, none of which can ever be a smart-rename trigger, so the two mutex acquisitions now happen only on the rare `Stopped` frame. Zero behavior change: the pure predicate `should_trigger_smart_rename` already rejects non-`Stopped` events via its internal `matches!(event, Event::Stopped { reason } if reason == "prompt_complete")` allowlist, so the outer `matches!` is a strict optimization guard.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (in-source comment cites #2348 and this review nit)
- [ ] For UI changes: included screenshot or recording (N/A: backend micro-optimization)

## Test Coverage Analysis

- [x] Playwright: N/A (no user-facing dashboard flow).
- [x] TUI/CLI e2e: N/A (no TUI, CLI, or session lifecycle change).

Existing `should_trigger_smart_rename_only_on_clean_prompt_complete_stop` (predicate table over every `Event::Stopped` reason + non-`Stopped` events + both gate short-circuits) already covers the semantic equivalence; a listener-level test would duplicate it since the outer `matches!` is a strict superset of the predicate's internal check.

**Gates locally**: `cargo fmt --check`, `cargo clippy --features serve --all-targets -- -D warnings`, `cargo test --features serve --lib session::smart_rename` (27/27) — all clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7 (Anthropic)

**Any Additional AI Details you'd like to share:**

Post-merge review nit implementation was direct: single-hunk edit, one file. Two orthogonal review passes (design + Rust idiom + harmonization ; docs + terminology + concision) landed 0 must-fix.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change makes the smart-rename listener skip unnecessary work for most ACP events by checking the event type first. Only stop events can trigger smart-rename, so the code now avoids taking locks and doing extra checks for common streaming frames that will never use that path.

Benefits:
- Reduces lock contention and overhead on high-volume event traffic
- Keeps behavior the same while improving performance
- Clarifies the intent with an updated in-source comment

Technical note:
The new guard short-circuits on `Event::Stopped` before consulting the existing smart-rename predicates and mutex-backed tracking state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->