### PR TITLE
docs(sandbox): document opencode.db image-upgrade remediation

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -275,7 +275,7 @@ Git worktrees need the bare repo pattern so the container can reach the repo's g
 **Fix:** Delete the sandboxed OpenCode DB and restart the session. Only the sandboxed OpenCode chat history is lost; host OpenCode state (outside the `sandbox/` subdir) is untouched.
 
 ```bash
-rm -f ~/.local/share/opencode/sandbox/opencode.db{,-wal,-shm}
+rm -f ~/.local/share/opencode/sandbox/opencode.db*
 ```
 
-**Note:** This is a rare event tied to breaking schema changes in OpenCode releases; most upgrades migrate cleanly. If you hit it repeatedly on the same image bump, please file an issue upstream at `anomalyco/opencode` with the migration error output.
+**Note:** This is a rare event tied to breaking schema changes in OpenCode releases; most upgrades migrate cleanly. If you hit it repeatedly on the same image bump, please file an issue upstream at [anomalyco/opencode](https://github.com/anomalyco/opencode) with the migration error output.

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -265,3 +265,17 @@ Git worktrees need the bare repo pattern so the container can reach the repo's g
    The `MEM LIMIT` column should reflect your configured value.
 
 **Note:** On Linux, Docker runs natively without a VM, so the memory ceiling is your host's physical RAM. You typically only need `memory_limit` on Linux to prevent a single container from consuming all system memory.
+
+### Sandboxed OpenCode fails to start after a container-image upgrade
+
+**Symptoms:** After bumping the sandbox container image, launching or resuming a sandboxed OpenCode session fails on boot with a drizzle or SQLite migration error (e.g. `no such column`, `CREATE TABLE ... already exists`, `Failed to run the query`). Non-sandboxed OpenCode sessions on the same host are unaffected.
+
+**Cause:** The sandboxed OpenCode SQLite database at `~/.local/share/opencode/sandbox/opencode.db{,-wal,-shm}` persists across sessions so that `aoe resume` keeps `ses_*` identity working across kills and daemon restarts (see #2605). OpenCode manages its schema with drizzle, and drizzle migrations are forward-only. If the new image ships an OpenCode release whose forward migrations are not compatible with the pre-existing DB, OpenCode aborts on boot. This is the same failure class users hit on standalone OpenCode CLI upgrades (see upstream anomalyco/opencode#31119 and anomalyco/opencode#16678); the sandbox-image bump is just another version-change vector.
+
+**Fix:** Delete the sandboxed OpenCode DB and restart the session. Only the sandboxed OpenCode chat history is lost; host OpenCode state (outside the `sandbox/` subdir) is untouched.
+
+```bash
+rm -f ~/.local/share/opencode/sandbox/opencode.db{,-wal,-shm}
+```
+
+**Note:** This is a rare event tied to breaking schema changes in OpenCode releases; most upgrades migrate cleanly. If you hit it repeatedly on the same image bump, please file an issue upstream at `anomalyco/opencode` with the migration error output.


### PR DESCRIPTION
## Description

Follow-up to #2650 (which fixed #2605). Adds a Troubleshooting entry to `docs/guides/sandbox.md` documenting how to recover when a sandbox container-image upgrade ships an OpenCode release with a schema change that is not forward-compatible with the persisted sandbox DB.

### Context

Reviewer @Seluj78 flagged this as an acknowledged trade-off on #2650:

> Emptying `clean_files` also drops the container-image-update reset the struct doc originally described. If a future container bumps opencode past a non-forward-migratable schema, an old sandbox DB could hit a drizzle migration failure instead of being wiped. The PR leans on drizzle forward-migration owning that path, which is the designed behavior and the lesser evil versus destroying session identity on every kill. Acknowledged in the issue thread; accept as-is.

This PR does not change the trade-off; it just makes the recovery path discoverable in the docs.

### Cross-validation

Before writing, I ran an Oracle cross-validation pass on the claim (opencode uses drizzle → drizzle migrations forward-only → sandbox DB path is `~/.local/share/opencode/sandbox/opencode.db*` → failure mode is real). All six substantive points came back VALID, including that the exact same failure class is **already observed upstream on standalone OpenCode CLI upgrades** (anomalyco/opencode#31119 documents remediation via `rm ~/.local/share/opencode/opencode.db`; anomalyco/opencode#16678 documents the drizzle name-vs-hash migration cutover breaking pre-existing DBs). The sandbox-image bump is mechanically the same migrator hitting the same problem, just via a different version-change vector.

### Shape

New Troubleshooting subsection follows the existing `Symptoms / Cause / Fix` layout of the OOM entry directly above it:

- **Symptoms**: concrete error strings a user will actually see (`no such column`, `CREATE TABLE ... already exists`, `Failed to run the query`).
- **Cause**: `~/.local/share/opencode/sandbox/opencode.db*` persists post-#2605 for `ses_*` resume identity → drizzle is forward-only → incompatible new migrations abort boot. Upstream issue refs for evidence.
- **Fix**: one-line `rm -f` on the three DB files. Scoped to the sandbox subdir, host OpenCode state untouched.
- **Note**: reactive framing — rare, most upgrades migrate cleanly, escalate upstream if repeated.

### PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

### Checklist

- [x] New and existing tests pass (docs-only, no code impact)
- [x] Documentation was updated where necessary (this PR)
- [ ] For UI changes: included screenshot or recording (n/a)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** claude-opus-4-7

**Any Additional AI Details you'd like to share:**

Drafting, cross-validation, and wording were assisted by claude-opus-4-7. The follow-up direction (docs vs. code change) was proposed by @Seluj78's review of #2650 explicitly acknowledging the trade-off as-is. An Oracle cross-validation pass verified six substantive points (opencode uses drizzle-orm/bun-sqlite, drizzle migrations are forward-only, the sandbox DB path is correct, the failure class is observed upstream, no pre-fix behavior would have handled schema bumps more gracefully than auto-wipe, and this codebase's docs style supports documenting observed failures reactively) before any file was written.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new troubleshooting entry to `docs/guides/sandbox.md` for a rare sandbox startup failure after an OpenCode container image upgrade.

The update:
- explains the visible error symptoms and root cause
- documents that sandbox OpenCode database files now persist between sessions
- gives a targeted recovery step to delete only the sandbox OpenCode DB files
- clarifies that host OpenCode data is unaffected

Benefit: this helps users quickly recover from upgrade-related schema incompatibilities without losing their main OpenCode state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->