### PR TITLE
fix(containers): per-runtime permission_denied_markers

### DIFF
--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn probe_err_is_unknown() {
-        let r = Err(error::DockerError::RemoveFailed("inspect exit 1".into()));
+        let r = Err(error::DockerError::InspectFailed("inspect exit 1".into()));
         assert!(matches!(classify_running_probe(r), Probe::Unknown(_)));
     }
 

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -105,11 +105,15 @@ pub(crate) struct RuntimeBase {
     /// Case-insensitive stderr substrings that identify a "permission
     /// denied" error (typically Linux docker/podman socket without
     /// docker-group membership). Structural parallel to `not_found_markers`
-    /// and `daemon_down_markers` (#2656 follow-up to #2596), so each runtime
-    /// only matches its own wording and cross-runtime bleed is impossible
-    /// by construction. Case sensitivity mirrors [`Self::is_not_found`]:
-    /// OS-emitted "permission denied" strings vary in capitalization across
-    /// kernel versions and locales, so case-fold matching is safest.
+    /// and `daemon_down_markers` (#2656 follow-up to #2596). Isolation is
+    /// intentionally asymmetric: Docker's marker is tightly scoped to the
+    /// canonical "docker daemon socket" wording, so cross-runtime bleed is
+    /// prevented by construction there; Podman and Apple use the broad
+    /// "permission denied" placeholder pending real-fixture capture, which
+    /// does bleed across runtimes but preserves pre-#2656 behavior. Case
+    /// handling mirrors [`Self::is_not_found`]: OS-emitted "permission
+    /// denied" strings vary in capitalization across kernel versions and
+    /// locales, so case-fold matching is safest.
     pub permission_denied_markers: &'static [&'static str],
 }
 
@@ -790,6 +794,9 @@ mod tests {
 
         // Apple placeholder: no captured wording, but the broad marker still
         // routes generic Linux socket permission errors to PermissionDenied.
+        // TODO: replace with captured Apple `container` CLI permission
+        // stderr once a real macOS 26 fixture is available (cf. #2655 for
+        // the parallel Apple daemon-down fixture follow-up).
         let apple_stderr = "Error: permission denied accessing container socket";
         assert!(matches!(
             RuntimeBase::APPLE_CONTAINER.classify_inspect_failure(apple_stderr),
@@ -798,14 +805,14 @@ mod tests {
     }
 
     #[test]
-    fn is_permission_denied_is_cross_runtime_isolated() {
-        // Regression guard parallel to is_daemon_down_is_cross_runtime_isolated:
-        // Docker's specific "permission denied while trying to connect to the
-        // docker daemon socket" MUST NOT match Podman or Apple runtimes, which
-        // use the broader "permission denied" placeholder marker. The
-        // asymmetry is intentional: Docker's marker is tightened as far as
-        // its canonical wording allows, Podman/Apple stay permissive until
-        // real fixtures land.
+    fn is_permission_denied_cross_runtime_isolation_is_asymmetric() {
+        // Companion to is_daemon_down_is_cross_runtime_isolated, but the
+        // invariant tested here is asymmetric by design: Docker's marker is
+        // tightened to the canonical "docker daemon socket" clause, so it
+        // isolates cleanly; Podman and Apple use the broad "permission
+        // denied" placeholder pending real-fixture capture and thus stay
+        // permissive. The asymmetric name flags that this test does NOT
+        // assert full three-way isolation like its daemon-down sibling.
         let docker_pd = "Got permission denied while trying to connect to the Docker daemon socket";
         assert!(RuntimeBase::DOCKER.is_permission_denied(docker_pd));
         // Podman and Apple ALSO match "permission denied" (their broader
@@ -818,6 +825,14 @@ mod tests {
         let podman_only = "Error: unable to connect to Podman socket: connect: permission denied";
         assert!(!RuntimeBase::DOCKER.is_permission_denied(podman_only));
         assert!(RuntimeBase::PODMAN.is_permission_denied(podman_only));
+
+        // Docker's tightening promise: unrelated "permission denied" errors
+        // (image policy, registry auth, volume mount) that a broad substring
+        // match would misclassify MUST be rejected. Locks the tightening
+        // against future regressions ("just one more case, it will be fine").
+        let policy_denied =
+            "docker: Error response from daemon: pull access denied: permission denied by policy";
+        assert!(!RuntimeBase::DOCKER.is_permission_denied(policy_denied));
     }
 
     #[test]

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -102,6 +102,15 @@ pub(crate) struct RuntimeBase {
     /// sites (#2596 follow-up). Case sensitivity is intentional; every
     /// runtime's daemon-down message has stable capitalization at the source.
     pub daemon_down_markers: &'static [&'static str],
+    /// Case-insensitive stderr substrings that identify a "permission
+    /// denied" error (typically Linux docker/podman socket without
+    /// docker-group membership). Structural parallel to `not_found_markers`
+    /// and `daemon_down_markers` (#2656 follow-up to #2596), so each runtime
+    /// only matches its own wording and cross-runtime bleed is impossible
+    /// by construction. Case sensitivity mirrors [`Self::is_not_found`]:
+    /// OS-emitted "permission denied" strings vary in capitalization across
+    /// kernel versions and locales, so case-fold matching is safest.
+    pub permission_denied_markers: &'static [&'static str],
 }
 
 impl RuntimeBase {
@@ -120,6 +129,15 @@ impl RuntimeBase {
         // of this message across every Docker OS variant (macOS Desktop, Linux
         // CE, Windows Desktop).
         daemon_down_markers: &["Cannot connect to the Docker daemon"],
+        // Docker's canonical Linux socket-permission wording, per the
+        // post-install docs: "Got permission denied while trying to connect
+        // to the Docker daemon socket at unix:///var/run/docker.sock ...".
+        // The "docker daemon socket" clause is specific enough to exclude
+        // unrelated permission errors (image policy, volume mount, registry
+        // auth) that a broad "permission denied" match would misclassify.
+        permission_denied_markers: &[
+            "permission denied while trying to connect to the docker daemon socket",
+        ],
     };
 
     pub const APPLE_CONTAINER: Self = Self {
@@ -146,6 +164,12 @@ impl RuntimeBase {
         // log actionability, not correctness. Replace with a captured
         // fixture when available.
         daemon_down_markers: &["connect to container daemon"],
+        // Placeholder: Apple's `container` CLI permission-denied wording is
+        // not captured in this repo. The bare "permission denied" match
+        // preserves the pre-#2656 broad-inline-substring behavior for this
+        // runtime; tighten to an Apple-specific pattern once captured to
+        // prevent future cross-runtime substring bleed.
+        permission_denied_markers: &["permission denied"],
     };
 
     pub const PODMAN: Self = Self {
@@ -169,6 +193,13 @@ impl RuntimeBase {
         // - "Cannot connect to Podman." fires on Podman Desktop / machine
         //   mode (macOS / Windows), when the VM is stopped.
         daemon_down_markers: &["connect to Podman socket", "Cannot connect to Podman."],
+        // Placeholder: Podman's socket-permission wording is not captured
+        // in this repo. In practice Podman surfaces the underlying Linux
+        // socket permission error, which contains "permission denied" (e.g.
+        // "unable to connect to Podman socket: dial unix ...: connect:
+        // permission denied"). Matches the pre-#2656 broad-inline-substring
+        // behavior; tighten to a Podman-specific pattern once captured.
+        permission_denied_markers: &["permission denied"],
     };
 
     /// Whether `stderr` from a container inspect indicates the runtime's
@@ -176,6 +207,17 @@ impl RuntimeBase {
     /// per-runtime; see [`Self::daemon_down_markers`] rationale.
     pub fn is_daemon_down(&self, stderr: &str) -> bool {
         self.daemon_down_markers.iter().any(|m| stderr.contains(m))
+    }
+
+    /// Whether `stderr` indicates a permission-denied error for this
+    /// runtime's socket / daemon. Case-insensitive to tolerate wording
+    /// drift across kernel versions and locales, per
+    /// [`Self::permission_denied_markers`] rationale.
+    pub fn is_permission_denied(&self, stderr: &str) -> bool {
+        let lower = stderr.to_lowercase();
+        self.permission_denied_markers
+            .iter()
+            .any(|m| lower.contains(m))
     }
 
     /// Whether `stderr` from a remove/stop indicates the container did not
@@ -206,15 +248,22 @@ impl RuntimeBase {
         // Mirror run_create's daemon-down / permission-denied sniff so the
         // Probe::Unknown(e) warn logs at gate sites show the actionable
         // DaemonNotRunning / PermissionDenied Display messages rather than
-        // a raw stderr wrapped in InspectFailed. Daemon-down markers live
-        // per-runtime on Self (parallel to `not_found_markers`) so each
-        // runtime only matches its own wording and cross-runtime bleed is
-        // impossible by construction.
+        // a raw stderr wrapped in InspectFailed. Markers live per-runtime on
+        // Self (parallel to `not_found_markers`) so each runtime only matches
+        // its own wording and cross-runtime bleed is impossible by
+        // construction.
+        //
+        // Order matters: permission-denied is checked BEFORE daemon-down
+        // because Podman's socket-permission stderr ("unable to connect to
+        // Podman socket: ... connect: permission denied") also matches
+        // Podman's daemon_down_markers ("connect to Podman socket"). The
+        // permission-denied path is the more specific classification, so it
+        // must win when both markers match the same stderr.
+        if self.is_permission_denied(stderr) {
+            return Err(DockerError::PermissionDenied);
+        }
         if self.is_daemon_down(stderr) {
             return Err(DockerError::DaemonNotRunning);
-        }
-        if stderr.to_lowercase().contains("permission denied") {
-            return Err(DockerError::PermissionDenied);
         }
         Err(DockerError::InspectFailed(sanitize_stderr(stderr)))
     }
@@ -439,10 +488,10 @@ impl RuntimeBase {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             tracing::debug!(target: "containers.runtime", "stderr: {}", stderr);
-            if stderr.contains("permission denied") {
+            if self.is_permission_denied(&stderr) {
                 return Err(DockerError::PermissionDenied);
             }
-            if stderr.contains("Cannot connect to the Docker daemon") {
+            if self.is_daemon_down(&stderr) {
                 return Err(DockerError::DaemonNotRunning);
             }
             if stderr.contains("No such image") || stderr.contains("Unable to find image") {
@@ -718,16 +767,57 @@ mod tests {
 
     #[test]
     fn inspect_permission_denied_stderr_maps_to_permission_denied() {
-        // Docker's "Got permission denied while trying to connect to the
-        // Docker daemon socket" (typical on Linux without docker-group
-        // membership) surfaces the actionable PermissionDenied variant
-        // rather than opaque InspectFailed. Matches run_create's sniff.
-        let stderr = "Got permission denied while trying to connect to the Docker daemon socket \
-                      at unix:///var/run/docker.sock";
+        // Docker's canonical Linux socket-permission wording ("Got permission
+        // denied while trying to connect to the Docker daemon socket") surfaces
+        // the actionable PermissionDenied variant on all three runtimes via
+        // per-runtime `permission_denied_markers`. Podman and Apple use the
+        // broader "permission denied" placeholder pending real-fixture capture,
+        // so the OS-level socket error text matches on those runtimes too.
+        let docker_stderr =
+            "Got permission denied while trying to connect to the Docker daemon socket \
+                             at unix:///var/run/docker.sock";
         assert!(matches!(
-            RuntimeBase::DOCKER.classify_inspect_failure(stderr),
+            RuntimeBase::DOCKER.classify_inspect_failure(docker_stderr),
             Err(DockerError::PermissionDenied)
         ));
+
+        let podman_stderr = "Error: unable to connect to Podman socket: dial unix \
+                             /run/user/1000/podman/podman.sock: connect: permission denied";
+        assert!(matches!(
+            RuntimeBase::PODMAN.classify_inspect_failure(podman_stderr),
+            Err(DockerError::PermissionDenied)
+        ));
+
+        // Apple placeholder: no captured wording, but the broad marker still
+        // routes generic Linux socket permission errors to PermissionDenied.
+        let apple_stderr = "Error: permission denied accessing container socket";
+        assert!(matches!(
+            RuntimeBase::APPLE_CONTAINER.classify_inspect_failure(apple_stderr),
+            Err(DockerError::PermissionDenied)
+        ));
+    }
+
+    #[test]
+    fn is_permission_denied_is_cross_runtime_isolated() {
+        // Regression guard parallel to is_daemon_down_is_cross_runtime_isolated:
+        // Docker's specific "permission denied while trying to connect to the
+        // docker daemon socket" MUST NOT match Podman or Apple runtimes, which
+        // use the broader "permission denied" placeholder marker. The
+        // asymmetry is intentional: Docker's marker is tightened as far as
+        // its canonical wording allows, Podman/Apple stay permissive until
+        // real fixtures land.
+        let docker_pd = "Got permission denied while trying to connect to the Docker daemon socket";
+        assert!(RuntimeBase::DOCKER.is_permission_denied(docker_pd));
+        // Podman and Apple ALSO match "permission denied" (their broader
+        // placeholders): this is the pre-#2656 behavior preserved intentionally.
+        assert!(RuntimeBase::PODMAN.is_permission_denied(docker_pd));
+        assert!(RuntimeBase::APPLE_CONTAINER.is_permission_denied(docker_pd));
+
+        // Conversely, a Podman-only wording that lacks Docker's specific
+        // clause MUST NOT match Docker's tight marker.
+        let podman_only = "Error: unable to connect to Podman socket: connect: permission denied";
+        assert!(!RuntimeBase::DOCKER.is_permission_denied(podman_only));
+        assert!(RuntimeBase::PODMAN.is_permission_denied(podman_only));
     }
 
     #[test]

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -253,9 +253,10 @@ impl RuntimeBase {
         // Probe::Unknown(e) warn logs at gate sites show the actionable
         // DaemonNotRunning / PermissionDenied Display messages rather than
         // a raw stderr wrapped in InspectFailed. Markers live per-runtime on
-        // Self (parallel to `not_found_markers`) so each runtime only matches
-        // its own wording and cross-runtime bleed is impossible by
-        // construction.
+        // Self (parallel to `not_found_markers`): daemon-down is fully
+        // isolated across runtimes by construction, permission-denied is
+        // asymmetric because Podman and Apple placeholders intentionally
+        // bleed pending real-fixture capture (see field docs for details).
         //
         // Order matters: permission-denied is checked BEFORE daemon-down
         // because Podman's socket-permission stderr ("unable to connect to


### PR DESCRIPTION
## Description

Closes #2656. Post-merge cleanup on #2652 (fix for #2596).

`classify_inspect_failure` had the `permission_denied` sniff as the one inline substring the marker refactor of #2652 left behind — `not_found_markers` and `daemon_down_markers` are per-runtime fields on `RuntimeBase`, but permission-denied stayed as `stderr.to_lowercase().contains("permission denied")` inline in the function body. Same asymmetry existed in `run_create`. The inline substring is broad enough that a future runtime's unrelated error (image policy `"permission denied by policy"`, registry auth, volume mount permissions) could misclassify as socket permission-denied, emit the wrong `DaemonError::PermissionDenied` Display (`"On Linux: add your user to the docker group..."`), and mislead the operator.

**Structural change:** third `RuntimeBase` marker field parallel to the two existing ones.

- New `pub permission_denied_markers: &'static [&'static str]` field on `RuntimeBase`.
- New `pub fn RuntimeBase::is_permission_denied(&self, stderr: &str) -> bool` method (case-insensitive, matching `is_not_found`; OS-emitted `"permission denied"` strings vary in caps across kernels/locales).
- Docker marker: `"permission denied while trying to connect to the docker daemon socket"` — Docker's canonical [post-install docs](https://docs.docker.com/engine/install/linux-postinstall/) wording, specific enough to exclude unrelated `"permission denied"` errors.
- Podman marker: `"permission denied"` — placeholder pending real-fixture capture (Podman socket-perm errors in the wild contain this via the Linux socket() syscall error text). Preserves pre-#2656 broad-inline-substring behavior for this runtime.
- Apple marker: `"permission denied"` — same placeholder rationale; Apple's `container` CLI permission wording not captured in this repo.
- `classify_inspect_failure` and `run_create` both migrate their inline substring checks to `self.is_permission_denied(...)` / `self.is_daemon_down(...)`. Zero hardcoded strings remain in the daemon-down / permission-denied classification path (image-not-found is a 4th marker family — `"No such image"` / `"Unable to find image"` still inline in `run_create` — deliberately out of scope for #2656).

**Isolation is asymmetric by design.** Docker's marker is tightly scoped to the canonical "docker daemon socket" clause, so cross-runtime bleed is prevented by construction there. Podman and Apple use the broad `"permission denied"` placeholder pending real-fixture capture; they do bleed across runtimes but preserve pre-#2656 behavior. The paired test `is_permission_denied_cross_runtime_isolation_is_asymmetric` locks both halves of the invariant, including a false-positive rejection assertion that Docker's tight marker rejects unrelated `"permission denied by policy"` (image policy) stderr.

**Ordering fix.** `classify_inspect_failure` now checks `is_permission_denied` BEFORE `is_daemon_down`. Podman's socket-permission stderr `"unable to connect to Podman socket: ... connect: permission denied"` contains BOTH the `"connect to Podman socket"` daemon-down marker AND the `"permission denied"` permission-denied marker. Without the reorder, Podman permission-denied errors misclassified as `DaemonNotRunning`. Inline comment documents the invariant so a future reorder cannot silently regress this.

**Bundled maintainer nit** from Seluj78's merge review of #2652: `probe_err_is_unknown` test (`src/containers/mod.rs:324`) seeded the running-probe classifier with `DockerError::RemoveFailed("inspect exit 1")`. A running-probe path never yields a removal error; `InspectFailed` models the real `Err` path. Cosmetic — the `Err(_) → Probe::Unknown` mapping remains exercised — but corrected for semantic accuracy. Grouped here because both fixes touch the same `containers::` test surface.

**Follow-up commit `bc56bf37` (Round-1 self-review)** addresses semantic findings on the initial `b493c91f` push: (i) reworded the `permission_denied_markers` doc comment which had incorrectly claimed cross-runtime bleed was "impossible by construction" (that guarantee holds only for Docker's tight marker); (ii) renamed the isolation test to `is_permission_denied_cross_runtime_isolation_is_asymmetric` so the name matches the actual invariant; (iii) added the Docker false-positive rejection assertion; (iv) added an explicit `TODO` on the synthetic Apple fixture referencing #2655 (the parallel Apple daemon-down fixture follow-up).

**Follow-up commit `571a0f99` (Round-2 self-review)** applies a doc-only correction: the umbrella comment inside `classify_inspect_failure` retained the pre-`bc56bf37` "cross-runtime bleed is impossible by construction" phrasing at function level, chapeauting both `is_daemon_down` (fully isolated) and `is_permission_denied` (asymmetric). Reworded to encode the two-tier reality and point to the field doc as the single source of truth for the nuance.

Diff: **+123 / -17** across 2 files (`src/containers/runtime_base.rs`, `src/containers/mod.rs`), 3 commits.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording <!-- N/A: no UI change -->

## Test Coverage Analysis

Two tests added / extended in `containers::runtime_base::tests`:

- `inspect_permission_denied_stderr_maps_to_permission_denied` extended from Docker-only to full three-runtime matrix (Docker canonical socket-permission, Podman socket-permission with the `dial unix ... connect:` clause, Apple placeholder with an explicit `TODO` calling for the real macOS 26 fixture per #2655). Locks the classifier's per-runtime routing on real-shape fixtures.
- `is_permission_denied_cross_runtime_isolation_is_asymmetric` regression guard parallel to `is_daemon_down_is_cross_runtime_isolated`, but the asymmetric name is intentional — Docker's marker is tightened as far as its canonical wording allows and isolates cleanly, while Podman and Apple stay permissive on the broad placeholder. Documents (a) Docker's tight marker rejects Podman-only stderr, (b) Docker's tight marker rejects unrelated `"permission denied by policy"` (image policy path — the concrete tightening promise from the PR body), (c) Podman/Apple placeholders accept Docker's specific wording (pre-#2656 behavior preserved intentionally).

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: pure server-side classifier refactor
- [ ] Added or updated a Playwright spec under `web/tests/`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: function signatures and observable behavior unchanged on the happy path
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Rationale: the refactor changes classifier internals; the observable surface (`DockerError` variant returned) stays identical for the happy path on all three runtimes. The Podman permission-denied case gains correctness (previously would have misclassified as `DaemonNotRunning`), but that requires a live Podman daemon with a permission-denied socket to demonstrate — not deterministically reproducible in e2e without runtime mocking. Unit-level classifier coverage is the right granularity.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (Sisyphus, via OhMyOpenCode)

**Any Additional AI Details you'd like to share:** Refactor completes the marker pattern established across three prior review rounds on #2652 (Round 6 tightened Apple `not_found_markers`, Round 8 introduced per-runtime `daemon_down_markers`, this PR adds per-runtime `permission_denied_markers`). The ordering-invariant bug (Podman socket-perm matches both daemon-down and permission-denied markers) surfaced immediately via the extended cross-runtime test and was locked with an inline comment before commit. Two post-push self-review rounds surfaced (R1) two doc-comment inaccuracies plus a missing false-positive assertion, corrected in `bc56bf37`, and (R2) one surviving instance of the same doc-drift at function-level umbrella comment, corrected in `571a0f99`; a Round-3 pass came back with zero findings. Final local verification at HEAD `571a0f99`: `cargo fmt --check`, `cargo clippy --lib --tests -- -D warnings`, `cargo test --lib -- containers` (**71/71 passed, 2 ignored**).

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)