### PR TITLE
fix(web): compute live-terminal cursor column by cell width, not code units

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -142,7 +142,7 @@ const CURSOR_CELL_STYLE: CSSProperties = {
   outlineOffset: "-1px",
 };
 
-const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[]; cursorCol: number | null }) {
+export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[]; cursorCol: number | null }) {
   if (cursorCol == null) {
     if (segs.length === 0) return <div> </div>; // keep empty rows at full height
     return (

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
-import { ansiToLines, wrapLine } from "../lib/liveTermLines";
+import { ansiToLines, findCursorCharIndex, textWidth, wrapLine } from "../lib/liveTermLines";
 import { wheelNotches } from "../lib/liveMouse";
 import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
@@ -156,31 +156,34 @@ export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[];
     );
   }
   // Render the row with the single cell at `cursorCol` boxed. Walk segments by
-  // column; split the one that straddles the cursor.
+  // terminal cell width, not UTF-16 code units, since `cursorCol` is a real
+  // cell count from tmux and CJK/wide glyphs take two cells but one code
+  // unit (#2665); split the segment that straddles the cursor.
   const out: ReactNode[] = [];
   let col = 0;
   let placed = false;
   let key = 0;
   for (const seg of segs) {
     const t = seg.text;
-    if (!placed && cursorCol >= col && cursorCol < col + t.length) {
-      const off = cursorCol - col;
-      if (off > 0) {
+    const idx = placed ? null : findCursorCharIndex(t, cursorCol - col);
+    if (idx != null) {
+      const chars = [...t];
+      if (idx > 0) {
         out.push(
           <span key={key++} style={segStyle(seg.style)}>
-            {t.slice(0, off)}
+            {chars.slice(0, idx).join("")}
           </span>,
         );
       }
       out.push(
         <span key={key++} data-live-cursor style={{ ...segStyle(seg.style), ...CURSOR_CELL_STYLE }}>
-          {t[off]}
+          {chars[idx]}
         </span>,
       );
-      if (off + 1 < t.length) {
+      if (idx + 1 < chars.length) {
         out.push(
           <span key={key++} style={segStyle(seg.style)}>
-            {t.slice(off + 1)}
+            {chars.slice(idx + 1).join("")}
           </span>,
         );
       }
@@ -192,7 +195,7 @@ export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[];
         </span>,
       );
     }
-    col += t.length;
+    col += textWidth(t);
   }
   if (!placed) {
     // Cursor sits past the row's text (blank input cell): pad to the column

--- a/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// Row boxes the live cursor cell by walking segment text and comparing a
+// UTF-16-index-based running column against `cursorCol`, which is a real
+// terminal cell count from tmux (issue #2665). Every CJK/wide character
+// contributes 2 cells but only 1 UTF-16 code unit, so the running column
+// under-counts and the boxed cell drifts right of the actual cursor.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Row } from "../MobileLiveTerminal";
+import type { AnsiSegment } from "../../lib/ansi";
+
+function seg(text: string): AnsiSegment {
+  return { text, style: {} };
+}
+
+function cursorCell(container: HTMLElement) {
+  return container.querySelector("[data-live-cursor]");
+}
+
+describe("Row cursor placement with CJK (wide) characters", () => {
+  it("boxes the cell immediately after CJK text with no drift", () => {
+    // 7 Korean chars (2 cells each) + 3 digits (1 cell each) = 17 cells.
+    // The cursor sits right after the last typed character.
+    const text = "한글정렬테스트123";
+    const { container } = render(<Row segs={[seg(text)]} cursorCol={17} />);
+    const cell = cursorCell(container);
+    expect(cell).not.toBeNull();
+    // No padding spaces should precede the boxed cell; it must sit right
+    // after the text, not drifted further right.
+    expect(cell!.previousSibling).toBeNull();
+    expect(cell!.textContent).toBe(" ");
+  });
+
+  it("boxes the correct character in a mixed ASCII+CJK line", () => {
+    // "hello " is 6 cells; then CJK chars are 2 cells each: 한(6-8) 글(8-10)
+    // 정(10-12) 렬(12-14). Column 8 must land on "글", not "정".
+    const segs = [seg("hello "), seg("한글정렬")];
+    const { container } = render(<Row segs={segs} cursorCol={8} />);
+    const cell = cursorCell(container);
+    expect(cell).not.toBeNull();
+    expect(cell!.textContent).toBe("글"); // 글
+  });
+});

--- a/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx
@@ -27,9 +27,10 @@ describe("Row cursor placement with CJK (wide) characters", () => {
     const { container } = render(<Row segs={[seg(text)]} cursorCol={17} />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
-    // No padding spaces should precede the boxed cell; it must sit right
-    // after the text, not drifted further right.
-    expect(cell!.previousSibling).toBeNull();
+    // The row is [text span, cursor span]. No pad span should be inserted
+    // between them; drift shows up as a pad span full of spaces.
+    expect(container.querySelectorAll("span")).toHaveLength(2);
+    expect(cell!.previousSibling!.textContent).toBe(text);
     expect(cell!.textContent).toBe(" ");
   });
 

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { ansiToLines, lineText, wrapLine } from "./liveTermLines";
+import { ansiToLines, findCursorCharIndex, lineText, wrapLine } from "./liveTermLines";
 
 describe("ansiToLines", () => {
   it("splits plain text into lines and drops the capture trailing terminator", () => {
@@ -82,5 +82,42 @@ describe("wrapLine", () => {
     expect(wrapLine(line, 2)).toEqual([line]);
     const rows = wrapLine(line, 1);
     expect(rows.map((r) => lineText(r))).toEqual(["e\u0301", "x"]);
+  });
+});
+
+describe("findCursorCharIndex", () => {
+  it("is a plain code-unit index for ASCII text", () => {
+    expect(findCursorCharIndex("hello", 0)).toBe(0);
+    expect(findCursorCharIndex("hello", 4)).toBe(4);
+    expect(findCursorCharIndex("hello", 5)).toBeNull(); // past the end
+  });
+
+  it("returns null when the column falls past the end of the text", () => {
+    expect(findCursorCharIndex("\u4f60\u597d", 4)).toBeNull(); // "\u4f60\u597d" is 4 cells
+  });
+
+  it("counts CJK as two cells so the column maps to the right character", () => {
+    // "\u4f60\u597d\u4e16\u754c": \u4f60(0-2) \u597d(2-4) \u4e16(4-6) \u754c(6-8).
+    const text = "\u4f60\u597d\u4e16\u754c";
+    expect(findCursorCharIndex(text, 0)).toBe(0); // \u4f60
+    expect(findCursorCharIndex(text, 2)).toBe(1); // \u597d
+    expect(findCursorCharIndex(text, 4)).toBe(2); // \u4e16
+    expect(findCursorCharIndex(text, 6)).toBe(3); // \u754c
+  });
+
+  it("never splits an emoji's surrogate pair", () => {
+    // "a" (1 cell) + grinning face U+1F600 (2 cells): column 1 must land
+    // on the whole emoji, not one half of its surrogate pair.
+    const text = "a\u{1F600}";
+    expect(findCursorCharIndex(text, 0)).toBe(0);
+    expect(findCursorCharIndex(text, 1)).toBe(1);
+    expect(findCursorCharIndex(text, 2)).toBe(1);
+  });
+
+  it("skips zero-width combining marks", () => {
+    // e + combining acute (zero cells) + "x": column 1 is "x", not the mark.
+    const text = "e\u0301x";
+    expect(findCursorCharIndex(text, 0)).toBe(0); // e
+    expect(findCursorCharIndex(text, 1)).toBe(2); // x (index 1 is the mark)
   });
 });

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -41,16 +41,37 @@ const WIDE =
   /[\u1100-\u115F\u2E80-\u303E\u3041-\u33FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE30-\uFE4F\uFF00-\uFF60\uFFE0-\uFFE6\u{1F300}-\u{1FAFF}]|\p{Emoji_Presentation}/u;
 const ASCII_PRINTABLE_ONLY = /^[\x20-\x7E]*$/;
 
-function cellWidth(codePoint: string): number {
+export function cellWidth(codePoint: string): number {
   if (ZERO_WIDTH.test(codePoint)) return 0;
   return WIDE.test(codePoint) ? 2 : 1;
 }
 
-function textWidth(text: string): number {
+export function textWidth(text: string): number {
   if (ASCII_PRINTABLE_ONLY.test(text)) return text.length;
   let width = 0;
   for (const ch of text) width += cellWidth(ch);
   return width;
+}
+
+/** Find the code point in `text` whose terminal cell range contains `col`
+ *  (cell units from the start of `text`), or null if `col` falls at or
+ *  past the end. Iterates code points (an emoji's surrogate pair never
+ *  splits) and counts cells the same way `textWidth`/`wrapLine` do, so a
+ *  cursor column from tmux (already cell-based) lands on the right glyph
+ *  even when wide CJK or zero-width characters precede it. */
+export function findCursorCharIndex(text: string, col: number): number | null {
+  if (ASCII_PRINTABLE_ONLY.test(text)) {
+    return col >= 0 && col < text.length ? col : null;
+  }
+  let c = 0;
+  let i = 0;
+  for (const ch of text) {
+    const w = cellWidth(ch);
+    if (col >= c && col < c + w) return i;
+    c += w;
+    i++;
+  }
+  return null;
 }
 
 /** Hard-wrap one styled line at `cols` terminal cells, preserving

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -108,6 +108,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.live-cursor-wide-chars",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx", "src/lib/liveTermLines.test.ts"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.clipboard-chords",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web live view's cursor drifted right of the actual end of typed text when CJK (wide) characters were typed into an agent's composer (#2665). Root cause: `Row` in `MobileLiveTerminal.tsx` walked its cursor-placement column by JS string `.length` (UTF-16 code units), while `cursorCol` comes straight from tmux as a real terminal cell count. Every CJK/wide glyph takes two cells but one code unit, so the running column under-counted and the boxed cursor landed past the real end of the text, drifting further with each wide character typed. Since the desktop PTY-relay view (xterm.js) was removed in v1.11.1, `MobileLiveTerminal` now renders on every device, so the bug hit desktop Chrome/Edge, not just mobile.

The fix reuses the wcwidth-style cell-width table `liveTermLines.ts` already uses for line wrapping (`wrapLine`), extracting a new pure `findCursorCharIndex(text, col)` helper and rewiring `Row` to walk by cell width instead of code-unit length.

Closes #2665

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: the bug is pure column-width math (no touch, WS-shape, or reconnect behavior involved), so a Vitest unit/component test on the extracted `findCursorCharIndex` and on `Row` directly reproduces and proves the fix more precisely than a Playwright spec would. Added `web/src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx` (fails on the pre-fix code, passes after) and extended `web/src/lib/liveTermLines.test.ts` with CJK, emoji-surrogate-pair, and zero-width-combining-mark cases. Added a `coverage-matrix.json` entry (`terminal.live-cursor-wide-chars`) mapping both specs to `MobileLiveTerminal.tsx`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How to test

- [ ] Open a session in the web live view (desktop or mobile), focus the terminal, type Korean/Japanese/Chinese text into the agent's composer (e.g. `한글정렬테스트123`) and confirm the block cursor sits immediately after the last typed character, not drifted right.
- [ ] Type a mix of ASCII and CJK text (e.g. `hello 한글정렬`) and confirm the cursor lands on the correct character as you move through the line.
- [ ] `cd web && npx vitest run src/components/__tests__/MobileLiveTerminal.cjkCursor.test.tsx src/lib/liveTermLines.test.ts` passes.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-investigate` + `/aoe-implement` skills)

**Any Additional AI Details you'd like to share:**
Investigation, root cause, plan, and implementation drafted by Claude under my direction (via `/aoe-investigate` then `/aoe-implement`). I reviewed the root cause and the diff, and confirmed the reproduce-then-fix test evidence (fails pre-fix, passes post-fix).

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This update fixes the live terminal cursor drifting to the right when users type wide characters like CJK text.

What changed:
- Cursor placement now follows terminal cell width instead of plain string length.
- The mobile live terminal row rendering was updated to split text at the correct visible character boundary.
- Shared width logic was extracted and reused so cursor positioning and line rendering stay consistent.
- New tests were added to cover CJK text, mixed ASCII/CJK input, emoji, and combining characters.
- Coverage tracking was updated for the new cursor-width behavior.

Benefits:
- Cursor now matches the real typing position more accurately.
- Wide characters and mixed-language input render correctly.
- The fix is backed by regression tests to prevent the bug from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->