### PR TITLE
chore(deps): bump ACP Rust crate to 0.15 and TS SDK to 0.28.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
+checksum = "eb5232c1162bcff4eafe378cc88a1ccaee2d49cedd9fe3d2517c5742bb748ced"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -55,7 +55,6 @@ dependencies = [
  "blocking",
  "futures",
  "futures-concurrency",
- "jsonrpcmsg",
  "rustc-hash",
  "schemars 1.2.1",
  "serde",
@@ -63,13 +62,14 @@ dependencies = [
  "shell-words",
  "tracing",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
+checksum = "7cb3131da850c922c348b36a9b96684d69779c3a776e83a948ba0b10e77766bb"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
+checksum = "b4e7eb6f1e554741f621ae4abb046d4fbb3cb88541bc599693ae7f9aa30b72eb"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2150,16 +2150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpcmsg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,6 +3791,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"], optional = true }
 getrandom = { version = "0.4", optional = true }
 
 # Agent Client Protocol — drives the structured view surface bundled with `serve`.
-agent-client-protocol = { version = "0.14", optional = true, features = ["unstable_end_turn_token_usage", "unstable_elicitation", "unstable_session_fork"] }
+agent-client-protocol = { version = "0.15", optional = true, features = ["unstable_end_turn_token_usage", "unstable_elicitation", "unstable_session_fork"] }
 
 # Semver parsing for ACP adapter compatibility checks (see src/acp/agent_compat.rs).
 semver = { version = "1", optional = true }

--- a/acp-worker/aoe-agent/package-lock.json
+++ b/acp-worker/aoe-agent/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.25.1",
+        "@agentclientprotocol/sdk": "^0.28.1",
         "@ai-sdk/anthropic": "^3.0.89",
         "@ai-sdk/google": "^3.0.86",
         "@ai-sdk/openai": "^3.0.77",
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz",
-      "integrity": "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.28.1.tgz",
+      "integrity": "sha512-Z2Frs6YtPhnZZ+XwFXyQkRDXY0fn8FjCalEs0W4yUhQnY4TztmNq0/RnfzWdFN3vqT3h0jTz5klzYbZHGxCDyQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/acp-worker/aoe-agent/package.json
+++ b/acp-worker/aoe-agent/package.json
@@ -16,7 +16,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.25.1",
+    "@agentclientprotocol/sdk": "^0.28.1",
     "@ai-sdk/anthropic": "^3.0.89",
     "@ai-sdk/openai": "^3.0.77",
     "@ai-sdk/google": "^3.0.86",

--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -29,264 +29,221 @@ interface SessionState {
   messages: ModelMessage[];
 }
 
-class AoeAgent implements acp.Agent {
-  private connection: acp.AgentSideConnection;
-  private sessions: Map<string, SessionState>;
+// ponytail: one Node process serves exactly one ACP connection, so a
+// module-level session map is equivalent to the old per-connection instance
+// state; no need to thread state through the connect handler.
+const sessions = new Map<string, SessionState>();
 
-  constructor(connection: acp.AgentSideConnection) {
-    this.connection = connection;
-    this.sessions = new Map();
+async function handlePrompt(
+  params: acp.PromptRequest,
+  client: acp.AgentContext,
+): Promise<acp.PromptResponse> {
+  const session = sessions.get(params.sessionId);
+  if (!session) {
+    throw new Error(`Session ${params.sessionId} not found`);
   }
 
-  async initialize(
-    params: acp.InitializeRequest,
-  ): Promise<acp.InitializeResponse> {
-    return {
-      protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
-      agentCapabilities: {
-        loadSession: false,
-        promptCapabilities: {
-          image: false,
-          audio: false,
-        },
-      },
-    };
-  }
+  session.pendingPrompt?.abort();
+  session.pendingPrompt = new AbortController();
+  const abortSignal = session.pendingPrompt.signal;
 
-  async authenticate(
-    _params: acp.AuthenticateRequest,
-  ): Promise<acp.AuthenticateResponse | void> {
-    return {};
-  }
+  const userText = params.prompt
+    .filter((c): c is acp.TextContent & { type: "text" } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
 
-  async newSession(
-    _params: acp.NewSessionRequest,
-  ): Promise<acp.NewSessionResponse> {
-    const sessionId = randomHexId();
-    const modelId = process.env.AOE_AGENT_MODEL ?? "claude-opus-4-7";
-    this.sessions.set(sessionId, {
-      pendingPrompt: null,
-      modelId,
-      messages: [],
+  session.messages.push({ role: "user", content: userText });
+
+  const tools = buildTools(params.sessionId, client);
+
+  try {
+    const model = pickModel(session.modelId);
+    const result = streamText({
+      model,
+      messages: session.messages,
+      tools,
+      // Allow up to ~16 tool-call rounds in a single user turn so the
+      // agent can compose multiple Read/Write/Bash steps before
+      // returning to the user.
+      stopWhen: stepCountIs(16),
+      abortSignal,
     });
-    return { sessionId };
-  }
 
-  async setSessionMode(
-    _params: acp.SetSessionModeRequest,
-  ): Promise<acp.SetSessionModeResponse> {
-    return {};
-  }
-
-  async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
-    const session = this.sessions.get(params.sessionId);
-    if (!session) {
-      throw new Error(`Session ${params.sessionId} not found`);
-    }
-
-    session.pendingPrompt?.abort();
-    session.pendingPrompt = new AbortController();
-    const abortSignal = session.pendingPrompt.signal;
-
-    const userText = params.prompt
-      .filter((c): c is acp.TextContentBlock => c.type === "text")
-      .map((c) => c.text)
-      .join("\n");
-
-    session.messages.push({ role: "user", content: userText });
-
-    const tools = this.buildTools(params.sessionId);
-
-    try {
-      const model = pickModel(session.modelId);
-      const result = streamText({
-        model,
-        messages: session.messages,
-        tools,
-        // Allow up to ~16 tool-call rounds in a single user turn so the
-        // agent can compose multiple Read/Write/Bash steps before
-        // returning to the user.
-        stopWhen: stepCountIs(16),
-        abortSignal,
-      });
-
-      let assistantBuffer = "";
-      const toolCallTitles = new Map<string, string>();
-      for await (const part of result.fullStream) {
-        if (abortSignal.aborted) break;
-        switch (part.type) {
-          case "text-delta": {
-            const delta =
-              (part as { text?: string }).text ??
-              (part as { textDelta?: string }).textDelta ??
-              "";
-            if (!delta) break;
-            assistantBuffer += delta;
-            await this.connection.sessionUpdate({
-              sessionId: params.sessionId,
-              update: {
-                sessionUpdate: "agent_message_chunk",
-                content: { type: "text", text: delta },
-              },
-            });
-            break;
-          }
-          case "tool-call": {
-            const id = part.toolCallId;
-            const name = part.toolName;
-            toolCallTitles.set(id, name);
-            await this.connection.sessionUpdate({
-              sessionId: params.sessionId,
-              update: {
-                sessionUpdate: "tool_call",
-                toolCallId: id,
-                title: name,
-                kind: classifyKind(name),
-                status: "pending",
-                rawInput: part.input as Record<string, unknown>,
-              },
-            });
-            break;
-          }
-          case "tool-result": {
-            const id = part.toolCallId;
-            await this.connection.sessionUpdate({
-              sessionId: params.sessionId,
-              update: {
-                sessionUpdate: "tool_call_update",
-                toolCallId: id,
-                status: "completed",
-                rawOutput: serialiseToolOutput(part.output),
-              },
-            });
-            break;
-          }
-          case "tool-error": {
-            const id = part.toolCallId;
-            await this.connection.sessionUpdate({
-              sessionId: params.sessionId,
-              update: {
-                sessionUpdate: "tool_call_update",
-                toolCallId: id,
-                status: "failed",
-                rawOutput: { error: String(part.error) },
-              },
-            });
-            break;
-          }
-          case "error": {
-            const err = (part as { error: unknown }).error;
-            throw err instanceof Error ? err : new Error(String(err));
-          }
-          default:
-            break;
-        }
-      }
-
-      session.messages.push({ role: "assistant", content: assistantBuffer });
-
-      if (abortSignal.aborted) {
-        return { stopReason: "cancelled" };
-      }
-      session.pendingPrompt = null;
-      return { stopReason: "end_turn" };
-    } catch (err) {
-      session.pendingPrompt = null;
-      if (abortSignal.aborted) {
-        return { stopReason: "cancelled" };
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      await this.connection
-        .sessionUpdate({
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: {
-              type: "text",
-              text: `\n[aoe-agent error] ${message}\n`,
+    let assistantBuffer = "";
+    const toolCallTitles = new Map<string, string>();
+    for await (const part of result.fullStream) {
+      if (abortSignal.aborted) break;
+      switch (part.type) {
+        case "text-delta": {
+          const delta =
+            (part as { text?: string }).text ??
+            (part as { textDelta?: string }).textDelta ??
+            "";
+          if (!delta) break;
+          assistantBuffer += delta;
+          await client.notify("session/update", {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: delta },
             },
-          },
-        })
-        .catch(() => undefined);
-      throw err;
+          });
+          break;
+        }
+        case "tool-call": {
+          const id = part.toolCallId;
+          const name = part.toolName;
+          toolCallTitles.set(id, name);
+          await client.notify("session/update", {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: id,
+              title: name,
+              kind: classifyKind(name),
+              status: "pending",
+              rawInput: part.input as Record<string, unknown>,
+            },
+          });
+          break;
+        }
+        case "tool-result": {
+          const id = part.toolCallId;
+          await client.notify("session/update", {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: id,
+              status: "completed",
+              rawOutput: serialiseToolOutput(part.output),
+            },
+          });
+          break;
+        }
+        case "tool-error": {
+          const id = part.toolCallId;
+          await client.notify("session/update", {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: id,
+              status: "failed",
+              rawOutput: { error: String(part.error) },
+            },
+          });
+          break;
+        }
+        case "error": {
+          const err = (part as { error: unknown }).error;
+          throw err instanceof Error ? err : new Error(String(err));
+        }
+        default:
+          break;
+      }
     }
-  }
 
-  async cancel(params: acp.CancelNotification): Promise<void> {
-    this.sessions.get(params.sessionId)?.pendingPrompt?.abort();
-  }
+    session.messages.push({ role: "assistant", content: assistantBuffer });
 
-  /**
-   * Tool palette: Read, Write, Bash. Each tool's execute() body issues
-   * an ACP request back to aoe and returns the result. The model never
-   * sees the file system or shell directly.
-   */
-  private buildTools(sessionId: string) {
-    return {
-      Read: tool({
-        description:
-          "Read a text file from the session's working directory.",
-        inputSchema: z.object({
-          path: z.string().describe("Absolute path to the file to read."),
-        }),
-        execute: async ({ path }) => {
-          const result = await this.connection.readTextFile({
-            sessionId,
-            path,
-          });
-          return { content: result.content };
+    if (abortSignal.aborted) {
+      return { stopReason: "cancelled" };
+    }
+    session.pendingPrompt = null;
+    return { stopReason: "end_turn" };
+  } catch (err) {
+    session.pendingPrompt = null;
+    if (abortSignal.aborted) {
+      return { stopReason: "cancelled" };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    await client
+      .notify("session/update", {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: `\n[aoe-agent error] ${message}\n`,
+          },
         },
-      }),
-      Write: tool({
-        description:
-          "Write text contents to a file in the session's working directory.",
-        inputSchema: z.object({
-          path: z.string().describe("Absolute path of the file to write."),
-          content: z.string().describe("Full text content to write."),
-        }),
-        execute: async ({ path, content }) => {
-          await this.connection.writeTextFile({
-            sessionId,
-            path,
-            content,
-          });
-          return { ok: true };
-        },
-      }),
-      Bash: tool({
-        description:
-          "Run a shell command and capture its output. Used for one-shot tasks; long-running processes are not supported.",
-        inputSchema: z.object({
-          command: z.string().describe("Shell command to run."),
-          args: z
-            .array(z.string())
-            .optional()
-            .describe("Arguments passed to the command."),
-        }),
-        execute: async ({ command, args }) => {
-          const term = await this.connection.createTerminal({
-            sessionId,
-            command,
-            args: args ?? [],
-          });
-          try {
-            const exit = await term.waitForExit();
-            const out = await term.currentOutput();
-            const code =
-              (exit as { exitCode?: number }).exitCode ??
-              (exit as { exit_code?: number }).exit_code ??
-              null;
-            return {
-              stdout: out.output,
-              exitCode: code,
-            };
-          } finally {
-            await term.release().catch(() => undefined);
-          }
-        },
-      }),
-    };
+      })
+      .catch(() => undefined);
+    throw err;
   }
+}
+
+/**
+ * Tool palette: Read, Write, Bash. Each tool's execute() body issues
+ * an ACP request back to aoe and returns the result. The model never
+ * sees the file system or shell directly.
+ */
+function buildTools(sessionId: string, client: acp.AgentContext) {
+  return {
+    Read: tool({
+      description: "Read a text file from the session's working directory.",
+      inputSchema: z.object({
+        path: z.string().describe("Absolute path to the file to read."),
+      }),
+      execute: async ({ path }) => {
+        const result = await client.request("fs/read_text_file", {
+          sessionId,
+          path,
+        });
+        return { content: result.content };
+      },
+    }),
+    Write: tool({
+      description:
+        "Write text contents to a file in the session's working directory.",
+      inputSchema: z.object({
+        path: z.string().describe("Absolute path of the file to write."),
+        content: z.string().describe("Full text content to write."),
+      }),
+      execute: async ({ path, content }) => {
+        await client.request("fs/write_text_file", {
+          sessionId,
+          path,
+          content,
+        });
+        return { ok: true };
+      },
+    }),
+    Bash: tool({
+      description:
+        "Run a shell command and capture its output. Used for one-shot tasks; long-running processes are not supported.",
+      inputSchema: z.object({
+        command: z.string().describe("Shell command to run."),
+        args: z
+          .array(z.string())
+          .optional()
+          .describe("Arguments passed to the command."),
+      }),
+      execute: async ({ command, args }) => {
+        const { terminalId } = await client.request("terminal/create", {
+          sessionId,
+          command,
+          args: args ?? [],
+        });
+        try {
+          const exit = await client.request("terminal/wait_for_exit", {
+            sessionId,
+            terminalId,
+          });
+          const out = await client.request("terminal/output", {
+            sessionId,
+            terminalId,
+          });
+          return {
+            stdout: out.output,
+            exitCode: exit.exitCode ?? null,
+          };
+        } finally {
+          await client
+            .request("terminal/release", { sessionId, terminalId })
+            .catch(() => undefined);
+        }
+      },
+    }),
+  };
 }
 
 function classifyKind(toolName: string): acp.ToolKind {
@@ -332,7 +289,38 @@ function main() {
   const input = Writable.toWeb(process.stdout);
   const output = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
   const stream = acp.ndJsonStream(input, output);
-  new acp.AgentSideConnection((conn) => new AoeAgent(conn), stream);
+
+  acp
+    .agent({ name: "aoe-agent" })
+    .onRequest("initialize", ({ params }) => ({
+      protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: false,
+        promptCapabilities: {
+          image: false,
+          audio: false,
+        },
+      },
+    }))
+    .onRequest("authenticate", () => ({}))
+    .onRequest("session/new", () => {
+      const sessionId = randomHexId();
+      const modelId = process.env.AOE_AGENT_MODEL ?? "claude-opus-4-7";
+      sessions.set(sessionId, {
+        pendingPrompt: null,
+        modelId,
+        messages: [],
+      });
+      return { sessionId };
+    })
+    .onRequest("session/set_mode", () => ({}))
+    .onRequest("session/prompt", ({ params, client }) =>
+      handlePrompt(params, client),
+    )
+    .onNotification("session/cancel", ({ params }) => {
+      sessions.get(params.sessionId)?.pendingPrompt?.abort();
+    })
+    .connect(stream);
 
   process.stdin.on("end", () => process.exit(0));
   process.on("SIGTERM", () => process.exit(0));

--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -142,7 +142,12 @@ async function handlePrompt(
       }
     }
 
-    session.messages.push({ role: "assistant", content: assistantBuffer });
+    // Anthropic rejects an assistant message with empty content, so skip
+    // persisting blank turns (tool-only rounds and cancellations both leave
+    // the buffer empty) to keep the next prompt's history valid.
+    if (assistantBuffer) {
+      session.messages.push({ role: "assistant", content: assistantBuffer });
+    }
 
     if (abortSignal.aborted) {
       return { stopReason: "cancelled" };

--- a/acp-worker/test-shim/package-lock.json
+++ b/acp-worker/test-shim/package-lock.json
@@ -8,13 +8,13 @@
       "name": "aoe-acp-test-shim",
       "version": "0.0.1",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.25.1"
+        "@agentclientprotocol/sdk": "^0.28.1"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz",
-      "integrity": "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.28.1.tgz",
+      "integrity": "sha512-Z2Frs6YtPhnZZ+XwFXyQkRDXY0fn8FjCalEs0W4yUhQnY4TztmNq0/RnfzWdFN3vqT3h0jTz5klzYbZHGxCDyQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/acp-worker/test-shim/package.json
+++ b/acp-worker/test-shim/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.25.1"
+    "@agentclientprotocol/sdk": "^0.28.1"
   }
 }

--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -133,7 +133,7 @@ async function handleNewSession(params) {
     const fs = await import("node:fs/promises");
     await fs.writeFile(recordFile, JSON.stringify(params?.mcpServers ?? []));
   }
-  const sessionId = "shim-" + Math.random().toString(36).slice(2, 10);
+  const sessionId = "shim-" + crypto.randomUUID();
   sessions.set(sessionId, {});
   return { sessionId };
 }

--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -17,545 +17,535 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { Readable, Writable } from "node:stream";
 
-class ShimAgent {
-  constructor(connection) {
-    this.connection = connection;
-    this.sessions = new Map();
-    // SHIM_PRESEED_SESSION_ID lets a test attach to the shim via the
-    // socket transport with `ConnectMode::Resume` (which skips
-    // `session/new`) and still get a working `prompt`. Without it,
-    // the shim's prompt handler rejects unknown session ids.
-    const preseed = process.env.SHIM_PRESEED_SESSION_ID;
-    if (preseed) {
-      this.sessions.set(preseed, {});
-    }
-    // Resolver used by the SILENT_ORPHAN test mode: prompt() parks on
-    // a Promise that the cancel() handler resolves so the test can
-    // assert the watchdog without waiting for CANCEL_ESCALATION_GRACE
-    // to elapse.
-    this._silentOrphanResolve = null;
-    this._installDeleteHandlerIfRequested();
-    this._emitUnsolicitedNotifIfRequested();
-  }
+// ponytail: one shim process serves exactly one ACP connection, so
+// module-level state is equivalent to the old per-connection instance state.
+const sessions = new Map();
+// Resolver used by the SILENT_ORPHAN test mode: prompt() parks on a Promise
+// that the session/cancel handler resolves so the test can assert the
+// watchdog without waiting for CANCEL_ESCALATION_GRACE to elapse.
+let silentOrphanResolve = null;
 
-  // SHIM_EMIT_UNSOLICITED_NOTIF reproduces a still-alive runner
-  // forwarding a single mid-turn notification shortly after the daemon
-  // reattaches in Resume mode, with no prompt issued. Used by the #1216
-  // test to confirm the resume-idle watchdog disarms on the first
-  // inbound notification (instead of firing after normal mid-turn
-  // silence). The value is the delay in ms before the emit (default
-  // 150); after this one notification the shim stays silent so the test
-  // can assert no synthetic Stopped follows. Requires
-  // SHIM_PRESEED_SESSION_ID so the notification carries a known session.
-  _emitUnsolicitedNotifIfRequested() {
-    const raw = process.env.SHIM_EMIT_UNSOLICITED_NOTIF;
-    if (raw === undefined) return;
-    const sessionId = process.env.SHIM_PRESEED_SESSION_ID;
-    if (!sessionId) return;
-    const delayMs = Number.parseInt(raw, 10);
-    setTimeout(
-      () => {
-        this.connection
-          .sessionUpdate({
-            sessionId,
-            update: {
-              sessionUpdate: "agent_message_chunk",
-              content: { type: "text", text: "mid-turn chunk after reattach" },
-            },
-          })
-          .catch(() => {});
-      },
-      Number.isFinite(delayMs) ? delayMs : 150,
+// SHIM_PRESEED_SESSION_ID lets a test attach to the shim via the socket
+// transport with `ConnectMode::Resume` (which skips `session/new`) and still
+// get a working `prompt`. Without it, the shim's prompt handler rejects
+// unknown session ids.
+const preseed = process.env.SHIM_PRESEED_SESSION_ID;
+if (preseed) {
+  sessions.set(preseed, {});
+}
+
+// SHIM_EMIT_UNSOLICITED_NOTIF reproduces a still-alive runner forwarding a
+// single mid-turn notification shortly after the daemon reattaches in Resume
+// mode, with no prompt issued. Used by the #1216 test to confirm the
+// resume-idle watchdog disarms on the first inbound notification (instead of
+// firing after normal mid-turn silence). The value is the delay in ms before
+// the emit (default 150); after this one notification the shim stays silent so
+// the test can assert no synthetic Stopped follows. Requires
+// SHIM_PRESEED_SESSION_ID so the notification carries a known session.
+function emitUnsolicitedNotifIfRequested(client) {
+  const raw = process.env.SHIM_EMIT_UNSOLICITED_NOTIF;
+  if (raw === undefined) return;
+  const sessionId = process.env.SHIM_PRESEED_SESSION_ID;
+  if (!sessionId) return;
+  const delayMs = Number.parseInt(raw, 10);
+  setTimeout(
+    () => {
+      client
+        .notify("session/update", {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "mid-turn chunk after reattach" },
+          },
+        })
+        .catch(() => {});
+    },
+    Number.isFinite(delayMs) ? delayMs : 150,
+  );
+}
+
+function handleInitialize(params) {
+  const agentCapabilities = {
+    loadSession: false,
+  };
+  // SHIM_DELETE_CAPABILITY=1 advertises sessionCapabilities.delete
+  // so the Rust client's session/delete dispatch path can be
+  // exercised end-to-end. Tests for #1404 toggle this; default off
+  // mirrors the negative-path adapters (aoe-agent, codex, opencode).
+  if (process.env.SHIM_DELETE_CAPABILITY === "1") {
+    agentCapabilities.sessionCapabilities = { delete: {} };
+  }
+  // SHIM_MCP_CAPABILITY advertises mcpCapabilities so the Rust client's
+  // http/sse capability gating can be exercised. Comma list, e.g. "http",
+  // "sse", or "http,sse". Absent => neither advertised (stdio only).
+  if (process.env.SHIM_MCP_CAPABILITY) {
+    const caps = process.env.SHIM_MCP_CAPABILITY.split(",").map((s) =>
+      s.trim(),
     );
-  }
-
-  async initialize(params) {
-    const agentCapabilities = {
-      loadSession: false,
-    };
-    // SHIM_DELETE_CAPABILITY=1 advertises sessionCapabilities.delete
-    // so the Rust client's session/delete dispatch path can be
-    // exercised end-to-end. Tests for #1404 toggle this; default off
-    // mirrors the negative-path adapters (aoe-agent, codex, opencode).
-    if (process.env.SHIM_DELETE_CAPABILITY === "1") {
-      agentCapabilities.sessionCapabilities = { delete: {} };
-    }
-    // SHIM_MCP_CAPABILITY advertises mcpCapabilities so the Rust client's
-    // http/sse capability gating can be exercised. Comma list, e.g. "http",
-    // "sse", or "http,sse". Absent => neither advertised (stdio only).
-    if (process.env.SHIM_MCP_CAPABILITY) {
-      const caps = process.env.SHIM_MCP_CAPABILITY.split(",").map((s) =>
-        s.trim(),
-      );
-      agentCapabilities.mcpCapabilities = {
-        http: caps.includes("http"),
-        sse: caps.includes("sse"),
-      };
-    }
-    return {
-      protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
-      agentCapabilities,
-      agentInfo: {
-        name: "@agentclientprotocol/claude-agent-acp",
-        // Keep at (or above) the agent_compat floor in
-        // src/acp/agent_compat.rs, or the gate rejects the shim's handshake.
-        version: "0.55.0",
-      },
+    agentCapabilities.mcpCapabilities = {
+      http: caps.includes("http"),
+      sse: caps.includes("sse"),
     };
   }
+  return {
+    protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
+    agentCapabilities,
+    agentInfo: {
+      name: "@agentclientprotocol/claude-agent-acp",
+      // Keep at (or above) the agent_compat floor in
+      // src/acp/agent_compat.rs, or the gate rejects the shim's handshake.
+      version: "0.55.0",
+    },
+  };
+}
 
-  // session/delete handler installed only when
-  // SHIM_DELETE_CAPABILITY=1. Without the install, the SDK's request
-  // dispatcher returns -32601 method_not_found, which is the
-  // negative-path expectation aoe needs to test against (matches
-  // aoe-agent, codex, opencode behavior).
-  _installDeleteHandlerIfRequested() {
-    if (process.env.SHIM_DELETE_CAPABILITY !== "1") return;
-    // SHIM_DELETE_MODE controls the response shape so tests can drive
-    // the success / timeout / failure branches without spinning up
-    // distinct shim binaries. SHIM_DELETE_RECORD_FILE, when set,
-    // appends one line per call with the requested sessionId so tests
-    // assert the RPC actually fired.
-    this.deleteSession = async (params) => {
-      const mode = process.env.SHIM_DELETE_MODE ?? "success";
-      const recordFile = process.env.SHIM_DELETE_RECORD_FILE;
-      if (recordFile) {
-        const fs = await import("node:fs/promises");
-        await fs.appendFile(recordFile, `${params.sessionId}\n`);
-      }
-      if (mode === "slow") {
-        await new Promise((r) => setTimeout(r, 3000));
-        return {};
-      }
-      if (mode === "error") {
-        throw acp.RequestError.internalError({}, "shim deliberate failure");
-      }
-      return {};
-    };
+// session/delete handler registered only when SHIM_DELETE_CAPABILITY=1.
+// Without the registration, the SDK's request dispatcher returns -32601
+// method_not_found, which is the negative-path expectation aoe needs to test
+// against (matches aoe-agent, codex, opencode behavior).
+//
+// SHIM_DELETE_MODE controls the response shape so tests can drive the success
+// / timeout / failure branches without spinning up distinct shim binaries.
+// SHIM_DELETE_RECORD_FILE, when set, appends one line per call with the
+// requested sessionId so tests assert the RPC actually fired.
+async function handleDeleteSession(params) {
+  const mode = process.env.SHIM_DELETE_MODE ?? "success";
+  const recordFile = process.env.SHIM_DELETE_RECORD_FILE;
+  if (recordFile) {
+    const fs = await import("node:fs/promises");
+    await fs.appendFile(recordFile, `${params.sessionId}\n`);
   }
-
-  async authenticate(_params) {
+  if (mode === "slow") {
+    await new Promise((r) => setTimeout(r, 3000));
     return {};
   }
-
-  async newSession(params) {
-    // SHIM_MCP_RECORD_FILE, when set, captures the mcp_servers the client
-    // forwarded on session/new so tests assert MCP forwarding end to end.
-    const recordFile = process.env.SHIM_MCP_RECORD_FILE;
-    if (recordFile) {
-      const fs = await import("node:fs/promises");
-      await fs.writeFile(recordFile, JSON.stringify(params?.mcpServers ?? []));
-    }
-    const sessionId = "shim-" + Math.random().toString(36).slice(2, 10);
-    this.sessions.set(sessionId, {});
-    return { sessionId };
+  if (mode === "error") {
+    throw acp.RequestError.internalError({}, "shim deliberate failure");
   }
+  return {};
+}
 
-  async setSessionMode(_params) {
-    return {};
+async function handleNewSession(params) {
+  // SHIM_MCP_RECORD_FILE, when set, captures the mcp_servers the client
+  // forwarded on session/new so tests assert MCP forwarding end to end.
+  const recordFile = process.env.SHIM_MCP_RECORD_FILE;
+  if (recordFile) {
+    const fs = await import("node:fs/promises");
+    await fs.writeFile(recordFile, JSON.stringify(params?.mcpServers ?? []));
   }
+  const sessionId = "shim-" + Math.random().toString(36).slice(2, 10);
+  sessions.set(sessionId, {});
+  return { sessionId };
+}
 
-  async prompt(params) {
-    if (!this.sessions.has(params.sessionId)) {
-      throw new Error("unknown session");
-    }
-    const userText = params.prompt
-      .filter((c) => c.type === "text")
-      .map((c) => c.text)
-      .join("\n");
+async function handlePrompt(params, client) {
+  if (!sessions.has(params.sessionId)) {
+    throw new Error("unknown session");
+  }
+  const userText = params.prompt
+    .filter((c) => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
 
-    // SILENT_ORPHAN reproduces the upstream
-    // `agentclientprotocol/claude-agent-acp#688` failure mode for the
-    // silent-orphan watchdog test in
-    // tests/acp_silent_orphan.rs. Sequence:
-    //   1. emit one assistant chunk
-    //   2. emit a cost-populated usage_update (claude-agent-acp's
-    //      "wrap up accounting" marker the daemon uses as a
-    //      terminal-candidate signal)
-    //   3. park until cancel() resolves the promise
-    // Without the cancel handler we'd hang the test for the full
-    // CANCEL_ESCALATION_GRACE; the explicit resolve keeps the test
-    // under a second while still exercising the watchdog. See #1240.
-    if (userText.includes("SILENT_ORPHAN")) {
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: "wedged response complete" },
-        },
-      });
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "usage_update",
-          input_tokens: 100,
-          output_tokens: 200,
-          cost: { amount: 0.01, currency: "USD" },
-        },
-      });
-      await new Promise((resolve) => {
-        this._silentOrphanResolve = resolve;
-      });
-      return { stopReason: "cancelled" };
-    }
-
-    // ASYNC_AGENT_ORPHAN reproduces the Claude SDK async-agent shape
-    // for the #1360 watchdog suppression test. Sequence:
-    //   1. emit tool_call for an Agent invocation
-    //   2. emit tool_call_update with status=completed and content text
-    //      "Async agent launched successfully. agentId: ..." (the marker
-    //      the Rust classifier looks for to flip async_agent_running)
-    //   3. park until cancel() resolves the promise
-    // The Rust test then drains for longer than the base watchdog grace
-    // and asserts NO `prompt_orphaned` Stopped frame arrived. Without
-    // the async detection, the watchdog would fire ~300ms after the
-    // completion; with it, the effective grace is lifted to 30 minutes
-    // so the test window stays silent.
-    if (userText.includes("ASYNC_AGENT_ORPHAN")) {
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call",
-          toolCallId: "tc-async-agent-1",
-          title: "Research async target",
-          kind: "other",
-          status: "pending",
-          rawInput: { description: "Research target", prompt: "..." },
-        },
-      });
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: "tc-async-agent-1",
-          status: "completed",
-          content: [
-            {
-              type: "content",
-              content: {
-                type: "text",
-                text: "Async agent launched successfully.\nagentId: async-test-1 (internal ID)",
-              },
-            },
-          ],
-        },
-      });
-      await new Promise((resolve) => {
-        this._silentOrphanResolve = resolve;
-      });
-      return { stopReason: "cancelled" };
-    }
-
-    // BACKGROUND_BASH_ORPHAN reproduces the #1401 shape: the Claude SDK
-    // `Bash` tool fired with `run_in_background: true`. The visible
-    // ToolCall completes immediately with the marker
-    // "Command running in background with ID: <id>", then the prompt
-    // also receives a cost-populated usage_update (the production
-    // false-positive's trigger). The Rust watchdog must observe the
-    // off-protocol marker and stay suppressed past the fast grace.
-    if (userText.includes("BACKGROUND_BASH_ORPHAN")) {
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call",
-          toolCallId: "tc-bg-orphan-1",
-          title: "Bash",
-          kind: "execute",
-          status: "pending",
-          rawInput: { command: "sleep 600", run_in_background: true },
-        },
-      });
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: "tc-bg-orphan-1",
-          status: "completed",
-          content: [
-            {
-              type: "content",
-              content: {
-                type: "text",
-                text: "Command running in background with ID: btest-orphan-1. Output is being written to: /tmp/x",
-              },
-            },
-          ],
-        },
-      });
-      // Force the daemon down the fast-grace path; if off-protocol
-      // suppression is wired correctly, the watchdog should still
-      // stay quiet for the full test window.
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "usage_update",
-          input_tokens: 10,
-          output_tokens: 10,
-          cost: { amount: 0.01, currency: "USD" },
-        },
-      });
-      await new Promise((resolve) => {
-        this._silentOrphanResolve = resolve;
-      });
-      return { stopReason: "cancelled" };
-    }
-
-    // WAKEUP_ORPHAN reproduces the ScheduleWakeup path from #1401: the
-    // agent registers an absolute wake-at, then idles intentionally
-    // waiting for the scheduled prompt to fire. A cost-populated
-    // usage_update follows so the daemon would otherwise switch to the
-    // fast grace; the wakeup suppression must override it until
-    // `at + base_grace` passes.
-    if (userText.includes("WAKEUP_ORPHAN")) {
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call",
-          toolCallId: "tc-wakeup-1",
-          title: "ScheduleWakeup",
-          kind: "other",
-          status: "pending",
-          rawInput: {
-            delaySeconds: 60,
-            reason: "test scheduled wakeup",
-            prompt: "continue",
-          },
-        },
-      });
-      // Real claude-agent-acp lands `raw_input` on an interim
-      // `tool_call_update` BEFORE the final completed frame; the
-      // watchdog now requires this carrier to fire `WakeupPending`
-      // (so a Failed completion doesn't blindly suppress for the
-      // delay window). Mirror the real shape: emit one in-progress
-      // update with raw_input.delaySeconds, then a final completed
-      // update.
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: "tc-wakeup-1",
-          status: "in_progress",
-          title: "ScheduleWakeup",
-          rawInput: {
-            delaySeconds: 60,
-            reason: "test scheduled wakeup",
-            prompt: "continue",
-          },
-        },
-      });
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: "tc-wakeup-1",
-          status: "completed",
-          content: [
-            {
-              type: "content",
-              content: {
-                type: "text",
-                text: "Next wakeup scheduled.",
-              },
-            },
-          ],
-        },
-      });
-      await this.connection.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "usage_update",
-          input_tokens: 10,
-          output_tokens: 10,
-          cost: { amount: 0.01, currency: "USD" },
-        },
-      });
-      await new Promise((resolve) => {
-        this._silentOrphanResolve = resolve;
-      });
-      return { stopReason: "cancelled" };
-    }
-
-    // Optional slow path: tests that need to observe mid-turn UI
-    // (e.g. the working spinner) include "SLOW" in the prompt so the
-    // shim adds a configurable delay between events.
-    const slow = userText.includes("SLOW");
-    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-    // Optional rate-limit path: tests for #1281 include "RATE_LIMIT"
-    // in the prompt so the shim returns the same JSON-RPC error shape
-    // claude-agent-acp emits when the Anthropic API rejects a request
-    // for quota reasons. Uses the SDK's RequestError so the structured
-    // `data` field reaches the wire (a plain `throw new Error(...)`
-    // would be stringified into the message). The Rust ACP client
-    // must classify this as RateLimit + Stopped{rate_limited} instead
-    // of treating it as a worker crash.
-    if (userText.includes("RATE_LIMIT")) {
-      throw acp.RequestError.internalError(
-        { errorKind: "rate_limit" },
-        "You've hit your limit · resets 12:10pm (Europe/Paris)",
-      );
-    }
-
-    await this.connection.sessionUpdate({
+  // SILENT_ORPHAN reproduces the upstream
+  // `agentclientprotocol/claude-agent-acp#688` failure mode for the
+  // silent-orphan watchdog test in
+  // tests/acp_silent_orphan.rs. Sequence:
+  //   1. emit one assistant chunk
+  //   2. emit a cost-populated usage_update (claude-agent-acp's
+  //      "wrap up accounting" marker the daemon uses as a
+  //      terminal-candidate signal)
+  //   3. park until cancel() resolves the promise
+  // Without the cancel handler we'd hang the test for the full
+  // CANCEL_ESCALATION_GRACE; the explicit resolve keeps the test
+  // under a second while still exercising the watchdog. See #1240.
+  if (userText.includes("SILENT_ORPHAN")) {
+    await client.notify("session/update", {
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "agent_message_chunk",
-        content: { type: "text", text: `received: ${userText}` },
+        content: { type: "text", text: "wedged response complete" },
       },
     });
-    if (slow) await sleep(800);
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        input_tokens: 100,
+        output_tokens: 200,
+        cost: { amount: 0.01, currency: "USD" },
+      },
+    });
+    await new Promise((resolve) => {
+      silentOrphanResolve = resolve;
+    });
+    return { stopReason: "cancelled" };
+  }
 
-    await this.connection.sessionUpdate({
+  // ASYNC_AGENT_ORPHAN reproduces the Claude SDK async-agent shape
+  // for the #1360 watchdog suppression test. Sequence:
+  //   1. emit tool_call for an Agent invocation
+  //   2. emit tool_call_update with status=completed and content text
+  //      "Async agent launched successfully. agentId: ..." (the marker
+  //      the Rust classifier looks for to flip async_agent_running)
+  //   3. park until cancel() resolves the promise
+  // The Rust test then drains for longer than the base watchdog grace
+  // and asserts NO `prompt_orphaned` Stopped frame arrived. Without
+  // the async detection, the watchdog would fire ~300ms after the
+  // completion; with it, the effective grace is lifted to 30 minutes
+  // so the test window stays silent.
+  if (userText.includes("ASYNC_AGENT_ORPHAN")) {
+    await client.notify("session/update", {
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "tool_call",
-        toolCallId: "tc-1",
-        title: "Reading shim file",
-        kind: "read",
+        toolCallId: "tc-async-agent-1",
+        title: "Research async target",
+        kind: "other",
         status: "pending",
-        locations: [{ path: "/tmp/shim.txt" }],
-        rawInput: { path: "/tmp/shim.txt" },
+        rawInput: { description: "Research target", prompt: "..." },
       },
     });
-    if (slow) await sleep(800);
-
-    await this.connection.sessionUpdate({
+    await client.notify("session/update", {
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "tool_call_update",
-        toolCallId: "tc-1",
+        toolCallId: "tc-async-agent-1",
         status: "completed",
-        rawOutput: { content: "shim file contents" },
-      },
-    });
-    if (slow) await sleep(800);
-
-    // Optional fs round-trip exercised by tests via prompt keywords.
-    if (userText.includes("FS_READ_WRITE")) {
-      try {
-        // Write a fresh file inside the session cwd.
-        await this.connection.writeTextFile({
-          sessionId: params.sessionId,
-          path: process.cwd() + "/shim-roundtrip.txt",
-          content: "hello from shim",
-        });
-        // Read it back.
-        const read = await this.connection.readTextFile({
-          sessionId: params.sessionId,
-          path: process.cwd() + "/shim-roundtrip.txt",
-        });
-        await this.connection.sessionUpdate({
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `fs_read=${read.content}` },
-          },
-        });
-      } catch (err) {
-        await this.connection.sessionUpdate({
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `fs_error=${err.message ?? err}` },
-          },
-        });
-      }
-    }
-
-    // Optional terminal round-trip exercised by tests.
-    if (userText.includes("TERMINAL_RUN")) {
-      try {
-        const term = await this.connection.createTerminal({
-          sessionId: params.sessionId,
-          command: "echo",
-          args: ["terminal-roundtrip-ok"],
-        });
-        const exit = await term.waitForExit();
-        const out = await term.currentOutput();
-        // WaitForTerminalExitResponse flattens TerminalExitStatus, so
-        // exitCode is at the top level. Fall back to nested in case the
-        // SDK wraps it differently in a future version.
-        const code =
-          exit.exitCode ??
-          exit.exit_code ??
-          exit.exitStatus?.exitCode ??
-          "?";
-        await this.connection.sessionUpdate({
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
+        content: [
+          {
+            type: "content",
             content: {
               type: "text",
-              text: `terminal_output=${out.output.trim()};exit=${code}`,
+              text: "Async agent launched successfully.\nagentId: async-test-1 (internal ID)",
             },
           },
-        });
-        await term.release();
-      } catch (err) {
-        await this.connection.sessionUpdate({
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `terminal_error=${err.message ?? err}` },
-          },
-        });
-      }
-    }
-
-    // Optional permission request, controlled by prompt content so tests
-    // can opt into exercising the approval round-trip.
-    if (userText.includes("REQUEST_PERMISSION")) {
-      const response = await this.connection.requestPermission({
-        sessionId: params.sessionId,
-        toolCall: {
-          toolCallId: "tc-2",
-          title: "Modify shim config",
-          kind: "edit",
-          status: "pending",
-          locations: [{ path: "/tmp/shim-config.json" }],
-          rawInput: {
-            path: "/tmp/shim-config.json",
-            content: '{"x":1}',
-          },
-        },
-        options: [
-          { kind: "allow_once", name: "Allow once", optionId: "yes" },
-          { kind: "reject_once", name: "Reject", optionId: "no" },
         ],
+      },
+    });
+    await new Promise((resolve) => {
+      silentOrphanResolve = resolve;
+    });
+    return { stopReason: "cancelled" };
+  }
+
+  // BACKGROUND_BASH_ORPHAN reproduces the #1401 shape: the Claude SDK
+  // `Bash` tool fired with `run_in_background: true`. The visible
+  // ToolCall completes immediately with the marker
+  // "Command running in background with ID: <id>", then the prompt
+  // also receives a cost-populated usage_update (the production
+  // false-positive's trigger). The Rust watchdog must observe the
+  // off-protocol marker and stay suppressed past the fast grace.
+  if (userText.includes("BACKGROUND_BASH_ORPHAN")) {
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-bg-orphan-1",
+        title: "Bash",
+        kind: "execute",
+        status: "pending",
+        rawInput: { command: "sleep 600", run_in_background: true },
+      },
+    });
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-bg-orphan-1",
+        status: "completed",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "Command running in background with ID: btest-orphan-1. Output is being written to: /tmp/x",
+            },
+          },
+        ],
+      },
+    });
+    // Force the daemon down the fast-grace path; if off-protocol
+    // suppression is wired correctly, the watchdog should still
+    // stay quiet for the full test window.
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        input_tokens: 10,
+        output_tokens: 10,
+        cost: { amount: 0.01, currency: "USD" },
+      },
+    });
+    await new Promise((resolve) => {
+      silentOrphanResolve = resolve;
+    });
+    return { stopReason: "cancelled" };
+  }
+
+  // WAKEUP_ORPHAN reproduces the ScheduleWakeup path from #1401: the
+  // agent registers an absolute wake-at, then idles intentionally
+  // waiting for the scheduled prompt to fire. A cost-populated
+  // usage_update follows so the daemon would otherwise switch to the
+  // fast grace; the wakeup suppression must override it until
+  // `at + base_grace` passes.
+  if (userText.includes("WAKEUP_ORPHAN")) {
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-wakeup-1",
+        title: "ScheduleWakeup",
+        kind: "other",
+        status: "pending",
+        rawInput: {
+          delaySeconds: 60,
+          reason: "test scheduled wakeup",
+          prompt: "continue",
+        },
+      },
+    });
+    // Real claude-agent-acp lands `raw_input` on an interim
+    // `tool_call_update` BEFORE the final completed frame; the
+    // watchdog now requires this carrier to fire `WakeupPending`
+    // (so a Failed completion doesn't blindly suppress for the
+    // delay window). Mirror the real shape: emit one in-progress
+    // update with raw_input.delaySeconds, then a final completed
+    // update.
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-wakeup-1",
+        status: "in_progress",
+        title: "ScheduleWakeup",
+        rawInput: {
+          delaySeconds: 60,
+          reason: "test scheduled wakeup",
+          prompt: "continue",
+        },
+      },
+    });
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-wakeup-1",
+        status: "completed",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "Next wakeup scheduled.",
+            },
+          },
+        ],
+      },
+    });
+    await client.notify("session/update", {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        input_tokens: 10,
+        output_tokens: 10,
+        cost: { amount: 0.01, currency: "USD" },
+      },
+    });
+    await new Promise((resolve) => {
+      silentOrphanResolve = resolve;
+    });
+    return { stopReason: "cancelled" };
+  }
+
+  // Optional slow path: tests that need to observe mid-turn UI
+  // (e.g. the working spinner) include "SLOW" in the prompt so the
+  // shim adds a configurable delay between events.
+  const slow = userText.includes("SLOW");
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  // Optional rate-limit path: tests for #1281 include "RATE_LIMIT"
+  // in the prompt so the shim returns the same JSON-RPC error shape
+  // claude-agent-acp emits when the Anthropic API rejects a request
+  // for quota reasons. Uses the SDK's RequestError so the structured
+  // `data` field reaches the wire (a plain `throw new Error(...)`
+  // would be stringified into the message). The Rust ACP client
+  // must classify this as RateLimit + Stopped{rate_limited} instead
+  // of treating it as a worker crash.
+  if (userText.includes("RATE_LIMIT")) {
+    throw acp.RequestError.internalError(
+      { errorKind: "rate_limit" },
+      "You've hit your limit · resets 12:10pm (Europe/Paris)",
+    );
+  }
+
+  await client.notify("session/update", {
+    sessionId: params.sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: `received: ${userText}` },
+    },
+  });
+  if (slow) await sleep(800);
+
+  await client.notify("session/update", {
+    sessionId: params.sessionId,
+    update: {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-1",
+      title: "Reading shim file",
+      kind: "read",
+      status: "pending",
+      locations: [{ path: "/tmp/shim.txt" }],
+      rawInput: { path: "/tmp/shim.txt" },
+    },
+  });
+  if (slow) await sleep(800);
+
+  await client.notify("session/update", {
+    sessionId: params.sessionId,
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-1",
+      status: "completed",
+      rawOutput: { content: "shim file contents" },
+    },
+  });
+  if (slow) await sleep(800);
+
+  // Optional fs round-trip exercised by tests via prompt keywords.
+  if (userText.includes("FS_READ_WRITE")) {
+    try {
+      // Write a fresh file inside the session cwd.
+      await client.request("fs/write_text_file", {
+        sessionId: params.sessionId,
+        path: process.cwd() + "/shim-roundtrip.txt",
+        content: "hello from shim",
       });
-      const verdict =
-        response.outcome.outcome === "selected"
-          ? response.outcome.optionId
-          : "cancelled";
-      await this.connection.sessionUpdate({
+      // Read it back.
+      const read = await client.request("fs/read_text_file", {
+        sessionId: params.sessionId,
+        path: process.cwd() + "/shim-roundtrip.txt",
+      });
+      await client.notify("session/update", {
         sessionId: params.sessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: `permission_outcome=${verdict}` },
+          content: { type: "text", text: `fs_read=${read.content}` },
+        },
+      });
+    } catch (err) {
+      await client.notify("session/update", {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: `fs_error=${err.message ?? err}` },
         },
       });
     }
+  }
 
-    await this.connection.sessionUpdate({
+  // Optional terminal round-trip exercised by tests.
+  if (userText.includes("TERMINAL_RUN")) {
+    try {
+      const { terminalId } = await client.request("terminal/create", {
+        sessionId: params.sessionId,
+        command: "echo",
+        args: ["terminal-roundtrip-ok"],
+      });
+      const exit = await client.request("terminal/wait_for_exit", {
+        sessionId: params.sessionId,
+        terminalId,
+      });
+      const out = await client.request("terminal/output", {
+        sessionId: params.sessionId,
+        terminalId,
+      });
+      // WaitForTerminalExitResponse flattens TerminalExitStatus, so
+      // exitCode is at the top level. Fall back to nested in case the
+      // SDK wraps it differently in a future version.
+      const code =
+        exit.exitCode ?? exit.exit_code ?? exit.exitStatus?.exitCode ?? "?";
+      await client.notify("session/update", {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: `terminal_output=${out.output.trim()};exit=${code}`,
+          },
+        },
+      });
+      await client
+        .request("terminal/release", {
+          sessionId: params.sessionId,
+          terminalId,
+        })
+        .catch(() => {});
+    } catch (err) {
+      await client.notify("session/update", {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: `terminal_error=${err.message ?? err}` },
+        },
+      });
+    }
+  }
+
+  // Optional permission request, controlled by prompt content so tests
+  // can opt into exercising the approval round-trip.
+  if (userText.includes("REQUEST_PERMISSION")) {
+    const response = await client.request("session/request_permission", {
+      sessionId: params.sessionId,
+      toolCall: {
+        toolCallId: "tc-2",
+        title: "Modify shim config",
+        kind: "edit",
+        status: "pending",
+        locations: [{ path: "/tmp/shim-config.json" }],
+        rawInput: {
+          path: "/tmp/shim-config.json",
+          content: '{"x":1}',
+        },
+      },
+      options: [
+        { kind: "allow_once", name: "Allow once", optionId: "yes" },
+        { kind: "reject_once", name: "Reject", optionId: "no" },
+      ],
+    });
+    const verdict =
+      response.outcome.outcome === "selected"
+        ? response.outcome.optionId
+        : "cancelled";
+    await client.notify("session/update", {
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "agent_message_chunk",
-        content: { type: "text", text: "done" },
+        content: { type: "text", text: `permission_outcome=${verdict}` },
       },
     });
-
-    return { stopReason: "end_turn" };
   }
 
-  async cancel(_params) {
-    // Unstick the SILENT_ORPHAN park so prompt() returns and the
-    // daemon's prompt_fut resolves. Other prompt branches finish
-    // synchronously so this is a no-op for them.
-    if (this._silentOrphanResolve) {
-      const resolve = this._silentOrphanResolve;
-      this._silentOrphanResolve = null;
-      resolve();
-    }
+  await client.notify("session/update", {
+    sessionId: params.sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "done" },
+    },
+  });
+
+  return { stopReason: "end_turn" };
+}
+
+function handleCancel() {
+  // Unstick the SILENT_ORPHAN park so prompt() returns and the
+  // daemon's prompt_fut resolves. Other prompt branches finish
+  // synchronously so this is a no-op for them.
+  if (silentOrphanResolve) {
+    const resolve = silentOrphanResolve;
+    silentOrphanResolve = null;
+    resolve();
   }
 }
 
@@ -587,7 +577,22 @@ async function bootstrap() {
     outputWeb = Readable.toWeb(process.stdin);
   }
   const stream = acp.ndJsonStream(inputWeb, outputWeb);
-  new acp.AgentSideConnection((conn) => new ShimAgent(conn), stream);
+
+  const app = acp
+    .agent({ name: "aoe-acp-test-shim" })
+    .onRequest("initialize", ({ params }) => handleInitialize(params))
+    .onRequest("authenticate", () => ({}))
+    .onRequest("session/new", ({ params }) => handleNewSession(params))
+    .onRequest("session/set_mode", () => ({}))
+    .onRequest("session/prompt", ({ params, client }) =>
+      handlePrompt(params, client),
+    )
+    .onNotification("session/cancel", () => handleCancel())
+    .onConnect((connection) => emitUnsolicitedNotifIfRequested(connection.client));
+  if (process.env.SHIM_DELETE_CAPABILITY === "1") {
+    app.onRequest("session/delete", ({ params }) => handleDeleteSession(params));
+  }
+  app.connect(stream);
 
   process.stdin.on("end", () => process.exit(0));
   process.on("SIGTERM", () => process.exit(0));

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -17,15 +17,15 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
-use agent_client_protocol::schema::ErrorCode;
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::ErrorCode;
+use agent_client_protocol::schema::v1::{
     AudioContent, BlobResourceContents, CancelNotification, ClientCapabilities, ContentBlock,
     CreateElicitationRequest, CreateElicitationResponse, CreateTerminalRequest,
     CreateTerminalResponse, ElicitationAction, ElicitationCapabilities,
     ElicitationFormCapabilities, EmbeddedResource, EmbeddedResourceResource,
     FileSystemCapabilities, ForkSessionRequest, ImageContent, InitializeRequest,
     KillTerminalRequest, KillTerminalResponse, LoadSessionRequest, McpServer, MessageId,
-    NewSessionRequest, PermissionOptionKind, PromptRequest, ProtocolVersion, ReadTextFileRequest,
+    NewSessionRequest, PermissionOptionKind, PromptRequest, ReadTextFileRequest,
     ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
     RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
     SelectedPermissionOutcome, SessionConfigId, SessionConfigValueId, SessionId,
@@ -34,6 +34,7 @@ use agent_client_protocol::schema::{
     WaitForTerminalExitRequest, WaitForTerminalExitResponse, WriteTextFileRequest,
     WriteTextFileResponse,
 };
+use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, JsonRpcRequest, JsonRpcResponse, Responder,
 };
@@ -233,7 +234,7 @@ pub(crate) fn classify_rate_limit_from_message(message: &str) -> Option<RateLimi
 #[request(method = "session/delete", response = DeleteSessionResponse)]
 #[serde(rename_all = "camelCase")]
 struct DeleteSessionRequest {
-    session_id: agent_client_protocol::schema::SessionId,
+    session_id: agent_client_protocol::schema::v1::SessionId,
     /// Emit `_meta: {}` so adapters that validate against the strict
     /// `unstable_session_delete` schema accept the request. Optional
     /// in the TS schema, but a defensive default avoids `-32602
@@ -694,9 +695,9 @@ pub(crate) enum LifecycleSignal {
 /// or after final accounting, and treating those as progress would
 /// mask the exact wedge the watchdog is designed to detect. See #1240.
 fn classify_lifecycle_signal(
-    update: &agent_client_protocol::schema::SessionUpdate,
+    update: &agent_client_protocol::schema::v1::SessionUpdate,
 ) -> Option<LifecycleSignal> {
-    use agent_client_protocol::schema::{SessionUpdate, ToolCallStatus};
+    use agent_client_protocol::schema::v1::{SessionUpdate, ToolCallStatus};
     match update {
         SessionUpdate::UsageUpdate(u) if u.cost.is_some() => Some(LifecycleSignal::TerminalUsage),
         SessionUpdate::AgentMessageChunk(_)
@@ -1316,9 +1317,9 @@ async fn send_lifecycle_signal(
 /// ID: ...` would otherwise trip the watchdog to its 30-minute floor.
 /// See CodeRabbit review on PR #1406.
 fn detect_off_protocol_work_completed(
-    content: &Option<Vec<agent_client_protocol::schema::ToolCallContent>>,
+    content: &Option<Vec<agent_client_protocol::schema::v1::ToolCallContent>>,
 ) -> Option<OffProtocolWorkKind> {
-    use agent_client_protocol::schema::ToolCallContent;
+    use agent_client_protocol::schema::v1::ToolCallContent;
     let blocks = content.as_ref()?;
     for block in blocks {
         let ToolCallContent::Content(c) = block else {
@@ -3251,9 +3252,9 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
 /// list the agent offered. Falls back gracefully if the agent didn't
 /// offer the preferred kind.
 fn pick_option_id(
-    options: &[agent_client_protocol::schema::PermissionOption],
+    options: &[agent_client_protocol::schema::v1::PermissionOption],
     decision: ApprovalDecision,
-) -> Option<agent_client_protocol::schema::PermissionOptionId> {
+) -> Option<agent_client_protocol::schema::v1::PermissionOptionId> {
     let preferred_kinds = match decision {
         ApprovalDecision::Allow => &[
             PermissionOptionKind::AllowOnce,
@@ -3433,10 +3434,10 @@ fn monitor_event_from_raw(raw_input: &serde_json::Value) -> Option<Event> {
 /// behavior so the sidebar countdown lights up immediately. See
 /// CodeRabbit review on PR #1406.
 fn wakeup_lifecycle_signal_from_update(
-    update: &agent_client_protocol::schema::SessionUpdate,
+    update: &agent_client_protocol::schema::v1::SessionUpdate,
     profile: &agent_profiles::AgentProfile,
 ) -> Option<LifecycleSignal> {
-    use agent_client_protocol::schema::{SessionUpdate, ToolCallStatus};
+    use agent_client_protocol::schema::v1::{SessionUpdate, ToolCallStatus};
     if !profile.supports_wakeup_tools {
         return None;
     }
@@ -3463,7 +3464,7 @@ fn wakeup_lifecycle_signal_from_update(
 /// signal, so stale replay frames cannot suppress or disarm watchdogs for a
 /// new prompt epoch.
 fn classify_watchdog_notification_signals(
-    update: &agent_client_protocol::schema::SessionUpdate,
+    update: &agent_client_protocol::schema::v1::SessionUpdate,
     profile: &agent_profiles::AgentProfile,
     suppressing_history_replay: bool,
 ) -> (Option<LifecycleSignal>, Option<LifecycleSignal>) {
@@ -3772,7 +3773,10 @@ fn map_update_to_events(
             // #1059. Gated on the agent's profile so codex / opencode /
             // gemini mode switches don't spuriously emit empty Plans.
             if profile.supports_exit_plan_mode
-                && matches!(tc.kind, agent_client_protocol::schema::ToolKind::SwitchMode)
+                && matches!(
+                    tc.kind,
+                    agent_client_protocol::schema::v1::ToolKind::SwitchMode
+                )
             {
                 if let Some(plan) = extract_plan_from_switch_mode(&raw_args) {
                     events.push(Event::PlanUpdated { plan });
@@ -3797,12 +3801,12 @@ fn map_update_to_events(
             let id = update.tool_call_id.0.to_string();
             let is_error = matches!(
                 update.fields.status,
-                Some(agent_client_protocol::schema::ToolCallStatus::Failed)
+                Some(agent_client_protocol::schema::v1::ToolCallStatus::Failed)
             );
             let completed = matches!(
                 update.fields.status,
-                Some(agent_client_protocol::schema::ToolCallStatus::Completed)
-                    | Some(agent_client_protocol::schema::ToolCallStatus::Failed)
+                Some(agent_client_protocol::schema::v1::ToolCallStatus::Completed)
+                    | Some(agent_client_protocol::schema::v1::ToolCallStatus::Failed)
             );
             // claude-agent-acp emits the initial `tool_call` frame
             // eagerly, often well before the underlying bash / read /
@@ -3813,7 +3817,7 @@ fn map_update_to_events(
             // See #1060.
             let in_progress = matches!(
                 update.fields.status,
-                Some(agent_client_protocol::schema::ToolCallStatus::InProgress)
+                Some(agent_client_protocol::schema::v1::ToolCallStatus::InProgress)
             );
             let content_text = update
                 .fields
@@ -4064,7 +4068,7 @@ fn map_update_to_events(
             vec![Event::UsageUpdated { usage }]
         }
         SessionUpdate::AvailableCommandsUpdate(u) => {
-            use agent_client_protocol::schema::AvailableCommandInput;
+            use agent_client_protocol::schema::v1::AvailableCommandInput;
             let commands: Vec<AvailableCommand> = u
                 .available_commands
                 .into_iter()
@@ -4155,7 +4159,7 @@ fn background_agent_launched_from_value(v: &serde_json::Value) -> Option<Event> 
 /// favor of session config options, so there is no longer a second
 /// channel to normalize. See #1403, #1820.
 fn config_options_event(
-    raw: Option<Vec<agent_client_protocol::schema::SessionConfigOption>>,
+    raw: Option<Vec<agent_client_protocol::schema::v1::SessionConfigOption>>,
 ) -> Option<Event> {
     raw.map(|raw| Event::ConfigOptionsUpdated {
         options: raw.into_iter().filter_map(map_acp_config_option).collect(),
@@ -4212,9 +4216,9 @@ fn dispatch_set_config_option(
 }
 
 fn thought_level_config_id(
-    options: &[agent_client_protocol::schema::SessionConfigOption],
-) -> Option<agent_client_protocol::schema::SessionConfigId> {
-    use agent_client_protocol::schema::{SessionConfigKind, SessionConfigOptionCategory};
+    options: &[agent_client_protocol::schema::v1::SessionConfigOption],
+) -> Option<agent_client_protocol::schema::v1::SessionConfigId> {
+    use agent_client_protocol::schema::v1::{SessionConfigKind, SessionConfigOptionCategory};
 
     options.iter().find_map(|option| {
         if !matches!(
@@ -4234,9 +4238,9 @@ fn thought_level_config_id(
 /// Mirrors `thought_level_config_id`; non-`Select` kinds are skipped because
 /// they carry no selectable value the default-application path can set.
 fn mode_config_id(
-    options: &[agent_client_protocol::schema::SessionConfigOption],
-) -> Option<agent_client_protocol::schema::SessionConfigId> {
-    use agent_client_protocol::schema::{SessionConfigKind, SessionConfigOptionCategory};
+    options: &[agent_client_protocol::schema::v1::SessionConfigOption],
+) -> Option<agent_client_protocol::schema::v1::SessionConfigId> {
+    use agent_client_protocol::schema::v1::{SessionConfigKind, SessionConfigOptionCategory};
 
     options.iter().find_map(|option| {
         if !matches!(option.category, Some(SessionConfigOptionCategory::Mode)) {
@@ -4263,9 +4267,9 @@ pub(crate) fn should_fork(fork_from: Option<&str>, agent_advertises_fork: bool) 
 /// the structured view does not yet render (today everything except `Select`).
 /// See #1403.
 fn map_acp_config_option(
-    option: agent_client_protocol::schema::SessionConfigOption,
+    option: agent_client_protocol::schema::v1::SessionConfigOption,
 ) -> Option<ConfigOptionDescriptor> {
-    use agent_client_protocol::schema::{
+    use agent_client_protocol::schema::v1::{
         SessionConfigKind, SessionConfigOptionCategory, SessionConfigSelectOptions,
     };
 
@@ -4333,8 +4337,8 @@ fn map_acp_config_option(
     })
 }
 
-fn map_plan_status(status: agent_client_protocol::schema::PlanEntryStatus) -> PlanStepStatus {
-    use agent_client_protocol::schema::PlanEntryStatus;
+fn map_plan_status(status: agent_client_protocol::schema::v1::PlanEntryStatus) -> PlanStepStatus {
+    use agent_client_protocol::schema::v1::PlanEntryStatus;
     match status {
         PlanEntryStatus::Pending => PlanStepStatus::Pending,
         PlanEntryStatus::InProgress => PlanStepStatus::InProgress,
@@ -4348,8 +4352,8 @@ fn map_plan_status(status: agent_client_protocol::schema::PlanEntryStatus) -> Pl
 /// TodoWrite args payload. Matches the values
 /// `web/src/components/acp/ToolCards.tsx::normaliseTodoStatus`
 /// accepts so the TodoUpdateCard renders the right glyph.
-fn plan_status_to_str(status: &agent_client_protocol::schema::PlanEntryStatus) -> &'static str {
-    use agent_client_protocol::schema::PlanEntryStatus;
+fn plan_status_to_str(status: &agent_client_protocol::schema::v1::PlanEntryStatus) -> &'static str {
+    use agent_client_protocol::schema::v1::PlanEntryStatus;
     match status {
         PlanEntryStatus::Pending => "pending",
         PlanEntryStatus::InProgress => "in_progress",
@@ -4366,8 +4370,8 @@ fn raw_event<T: serde::Serialize>(value: &T) -> Event {
 
 /// Stable lowercased string form of an ACP `ToolKind`. Used to drive the
 /// per-tool renderer dispatch on the web side.
-fn tool_kind_str(kind: &agent_client_protocol::schema::ToolKind) -> String {
-    use agent_client_protocol::schema::ToolKind;
+fn tool_kind_str(kind: &agent_client_protocol::schema::v1::ToolKind) -> String {
+    use agent_client_protocol::schema::v1::ToolKind;
     match kind {
         ToolKind::Read => "read",
         ToolKind::Edit => "edit",
@@ -4434,8 +4438,10 @@ async fn emit_permission_denied(event_tx: &mpsc::Sender<Event>, tool_call_id: &s
 /// non-text content blocks (images, resources, embedded terminals); the
 /// per-tool renderer fall-back path only knows how to display text. Diff
 /// blocks are bridged separately by `extract_diffs_from_content`.
-fn extract_tool_content_text(blocks: &[agent_client_protocol::schema::ToolCallContent]) -> String {
-    use agent_client_protocol::schema::ToolCallContent;
+fn extract_tool_content_text(
+    blocks: &[agent_client_protocol::schema::v1::ToolCallContent],
+) -> String {
+    use agent_client_protocol::schema::v1::ToolCallContent;
     let mut out = String::new();
     for block in blocks {
         if let ToolCallContent::Content(c) = block {
@@ -4467,9 +4473,9 @@ const MAX_INLINE_MEDIA_B64: usize = 4 * 1024 * 1024;
 /// so the structured list only carries weight when real media is present.
 /// See #1818.
 fn extract_tool_output_blocks(
-    blocks: &[agent_client_protocol::schema::ToolCallContent],
+    blocks: &[agent_client_protocol::schema::v1::ToolCallContent],
 ) -> Vec<ToolOutputBlock> {
-    use agent_client_protocol::schema::{EmbeddedResourceResource, ToolCallContent};
+    use agent_client_protocol::schema::v1::{EmbeddedResourceResource, ToolCallContent};
     let mut out: Vec<ToolOutputBlock> = Vec::new();
     let mut has_media = false;
     let cap =
@@ -4560,8 +4566,8 @@ fn extract_tool_output_blocks(
 /// the classifier.
 fn extract_memory_recall(
     meta: &Option<serde_json::Map<String, serde_json::Value>>,
-    locations: &[agent_client_protocol::schema::ToolCallLocation],
-    content: &[agent_client_protocol::schema::ToolCallContent],
+    locations: &[agent_client_protocol::schema::v1::ToolCallLocation],
+    content: &[agent_client_protocol::schema::v1::ToolCallContent],
 ) -> Option<MemoryRecall> {
     let map = meta.as_ref()?;
     let claude_code = map.get("claudeCode")?;
@@ -4632,9 +4638,9 @@ fn cap_diff_text(text: &str) -> String {
 /// is `#[non_exhaustive]`, so the wildcard arm keeps this compiling as the
 /// schema grows. Per-side text is capped and the list bounded. See #1721.
 fn extract_diffs_from_content(
-    blocks: &[agent_client_protocol::schema::ToolCallContent],
+    blocks: &[agent_client_protocol::schema::v1::ToolCallContent],
 ) -> Vec<DiffPreview> {
-    use agent_client_protocol::schema::ToolCallContent;
+    use agent_client_protocol::schema::v1::ToolCallContent;
     let created_at = chrono::Utc::now();
     blocks
         .iter()
@@ -4663,7 +4669,7 @@ fn handle_delete_session_cmd(
     acp_session_id: String,
     respond_to: oneshot::Sender<DeleteSessionOutcome>,
 ) {
-    let target = agent_client_protocol::schema::SessionId::from(acp_session_id);
+    let target = agent_client_protocol::schema::v1::SessionId::from(acp_session_id);
     // `block_task()` is documented as safe to await from a spawned
     // task: it waits on the per-request oneshot the main connection
     // task feeds via its inbound pump, so the dispatch loop keeps
@@ -5486,7 +5492,7 @@ async fn run_connection_task<W, R>(
                                     opts.iter().any(|o| {
                                         o.category
                                             == Some(
-                                                agent_client_protocol::schema::
+                                                agent_client_protocol::schema::v1::
                                                     SessionConfigOptionCategory::Mode,
                                             )
                                     })
@@ -5621,7 +5627,7 @@ async fn run_connection_task<W, R>(
                                             opts.iter().any(|o| {
                                                 o.category
                                                     == Some(
-                                                        agent_client_protocol::schema::
+                                                        agent_client_protocol::schema::v1::
                                                             SessionConfigOptionCategory::Mode,
                                                     )
                                             })
@@ -5729,7 +5735,7 @@ async fn run_connection_task<W, R>(
                                 opts.iter().any(|o| {
                                     o.category
                                         == Some(
-                                            agent_client_protocol::schema::
+                                            agent_client_protocol::schema::v1::
                                                 SessionConfigOptionCategory::Mode,
                                         )
                                 })
@@ -7132,8 +7138,10 @@ async fn handle_create_terminal(
     result
 }
 
-fn build_exit_status(exit_code: Option<i32>) -> agent_client_protocol::schema::TerminalExitStatus {
-    use agent_client_protocol::schema::TerminalExitStatus;
+fn build_exit_status(
+    exit_code: Option<i32>,
+) -> agent_client_protocol::schema::v1::TerminalExitStatus {
+    use agent_client_protocol::schema::v1::TerminalExitStatus;
     let cast = exit_code.and_then(|c| u32::try_from(c).ok());
     TerminalExitStatus::new().exit_code(cast)
 }
@@ -7552,7 +7560,7 @@ mod tests {
     /// would otherwise mask. See PR review.
     #[test]
     fn acp_fork_capability_and_response_wire_keys_are_stable() {
-        use agent_client_protocol::schema::{ForkSessionResponse, SessionCapabilities};
+        use agent_client_protocol::schema::v1::{ForkSessionResponse, SessionCapabilities};
 
         // The fork capability is advertised as a `"fork": {}` object nested in
         // the session capabilities the agent returns from `initialize`.
@@ -9206,7 +9214,7 @@ mod tests {
 
     #[test]
     fn map_update_to_events_threads_parent_tool_call_id() {
-        use agent_client_protocol::schema::{SessionUpdate, ToolCall as AcpToolCall};
+        use agent_client_protocol::schema::v1::{SessionUpdate, ToolCall as AcpToolCall};
         let mut meta = serde_json::Map::new();
         meta.insert(
             "claudeCode".to_string(),
@@ -9226,7 +9234,7 @@ mod tests {
 
     #[test]
     fn map_update_to_events_leaves_parent_none_when_meta_missing() {
-        use agent_client_protocol::schema::{SessionUpdate, ToolCall as AcpToolCall};
+        use agent_client_protocol::schema::v1::{SessionUpdate, ToolCall as AcpToolCall};
         let mut tc = AcpToolCall::new("tc-1", "Read");
         tc.raw_input = Some(serde_json::json!({"path": "x"}));
         let events = map_update_to_events(SessionUpdate::ToolCall(tc), &agent_profiles::CLAUDE);
@@ -9238,7 +9246,7 @@ mod tests {
     }
 
     fn text_chunk(text: &str, id: Option<&str>) -> SessionUpdate {
-        use agent_client_protocol::schema::{ContentBlock, ContentChunk, TextContent};
+        use agent_client_protocol::schema::v1::{ContentBlock, ContentChunk, TextContent};
         let mut chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(text)));
         if let Some(id) = id {
             chunk = chunk.message_id(id);
@@ -9247,7 +9255,7 @@ mod tests {
     }
 
     fn tool_update() -> SessionUpdate {
-        use agent_client_protocol::schema::ToolCall as AcpToolCall;
+        use agent_client_protocol::schema::v1::ToolCall as AcpToolCall;
         SessionUpdate::ToolCall(AcpToolCall::new("t-dedup", "Read"))
     }
 
@@ -9341,7 +9349,7 @@ mod tests {
 
     #[test]
     fn map_update_to_events_does_not_link_parent_for_unverified_agents() {
-        use agent_client_protocol::schema::{SessionUpdate, ToolCall as AcpToolCall};
+        use agent_client_protocol::schema::v1::{SessionUpdate, ToolCall as AcpToolCall};
         let mut meta = serde_json::Map::new();
         meta.insert(
             "claudeCode".to_string(),
@@ -9479,7 +9487,7 @@ mod tests {
 
     #[test]
     fn pick_option_id_finds_allow_once() {
-        use agent_client_protocol::schema::{PermissionOption, PermissionOptionId};
+        use agent_client_protocol::schema::v1::{PermissionOption, PermissionOptionId};
         let options = vec![
             PermissionOption::new(
                 PermissionOptionId::new("yes"),
@@ -9498,7 +9506,7 @@ mod tests {
 
     #[test]
     fn pick_option_id_falls_back() {
-        use agent_client_protocol::schema::{PermissionOption, PermissionOptionId};
+        use agent_client_protocol::schema::v1::{PermissionOption, PermissionOptionId};
         let options = vec![PermissionOption::new(
             PermissionOptionId::new("always"),
             "Always",
@@ -9617,7 +9625,7 @@ mod tests {
 
     #[test]
     fn extract_tool_content_text_concats_text_blocks() {
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         let blocks = vec![
             ToolCallContent::Content(Content::new("stdout line 1")),
             ToolCallContent::Content(Content::new("stdout line 2")),
@@ -9636,7 +9644,7 @@ mod tests {
 
     #[test]
     fn detect_off_protocol_work_completed_matches_async_agent_prefix() {
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         let blocks = vec![ToolCallContent::Content(Content::new(
             "Async agent launched successfully.\nagentId: af2a6a5d46bc21f91 (internal ID)",
         ))];
@@ -9648,7 +9656,7 @@ mod tests {
 
     #[test]
     fn detect_off_protocol_work_completed_matches_background_command_prefix() {
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         let blocks = vec![ToolCallContent::Content(Content::new(
             "Command running in background with ID: bgxe33hwb. Output is being written to: /tmp/x",
         ))];
@@ -9660,7 +9668,7 @@ mod tests {
 
     #[test]
     fn detect_off_protocol_work_completed_none_on_regular_completion() {
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         let blocks = vec![ToolCallContent::Content(Content::new(
             "abc1234 first commit\nabc1235 second commit",
         ))];
@@ -9684,7 +9692,7 @@ mod tests {
         // an echo or grep that includes the phrase) must NOT trip
         // off-protocol suppression. Match anchors at the start of a
         // line, not anywhere in the content.
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         let blocks = vec![ToolCallContent::Content(Content::new(
             "user typed: Command running in background with ID: pretend\nbye",
         ))];
@@ -9701,7 +9709,7 @@ mod tests {
         // The marker may not be the first character of the block;
         // a leading newline or whitespace must not break detection
         // as long as the marker starts the (trimmed) line.
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         let blocks = vec![ToolCallContent::Content(Content::new(
             "\n  Command running in background with ID: btest. log: /tmp/x",
         ))];
@@ -9713,7 +9721,9 @@ mod tests {
 
     #[test]
     fn wakeup_lifecycle_signal_from_completed_tool_call_update() {
-        use agent_client_protocol::schema::{ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{
+            ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
         let fields = ToolCallUpdateFields::new()
             .status(ToolCallStatus::Completed)
             .title("ScheduleWakeup".to_string())
@@ -9732,7 +9742,7 @@ mod tests {
         // tool could still fail. Watchdog suppression must wait until
         // a successful ToolCallUpdate { Completed }. See CodeRabbit
         // review on PR #1406.
-        use agent_client_protocol::schema::ToolCall;
+        use agent_client_protocol::schema::v1::ToolCall;
         let mut tc = ToolCall::new("tc-wake-2", "ScheduleWakeup");
         tc.raw_input = Some(serde_json::json!({ "delaySeconds": 60 }));
         let sig = wakeup_lifecycle_signal_from_update(
@@ -9747,7 +9757,9 @@ mod tests {
         // A failed ScheduleWakeup means no wakeup was actually
         // registered; suppressing for `delay + base_grace` would
         // hide a real adapter wedge.
-        use agent_client_protocol::schema::{ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{
+            ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
         let fields = ToolCallUpdateFields::new()
             .status(ToolCallStatus::Failed)
             .title("ScheduleWakeup".to_string())
@@ -9767,7 +9779,9 @@ mod tests {
         // it from the final `Completed` frame. Requiring strictly
         // Completed status would lose the wakeup; we gate only on
         // not-Failed.
-        use agent_client_protocol::schema::{ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{
+            ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
         let fields = ToolCallUpdateFields::new()
             .status(ToolCallStatus::InProgress)
             .title("ScheduleWakeup".to_string())
@@ -9782,7 +9796,7 @@ mod tests {
 
     #[test]
     fn classify_watchdog_notification_signals_ignores_ambient_updates() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             AvailableCommand as AcpAvailableCommand, AvailableCommandsUpdate,
         };
         let update = SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(vec![
@@ -9798,7 +9812,7 @@ mod tests {
 
     #[test]
     fn classify_watchdog_notification_signals_marks_lifecycle_updates() {
-        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
         let update = SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
             "tc-lifecycle-1",
             ToolCallUpdateFields::new(),
@@ -9813,7 +9827,7 @@ mod tests {
 
     #[test]
     fn classify_watchdog_notification_signals_suppresses_during_history_replay() {
-        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
         let update = SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
             "tc-suppressed-1",
             ToolCallUpdateFields::new(),
@@ -9828,7 +9842,7 @@ mod tests {
 
     #[test]
     fn classify_lifecycle_signal_marks_async_agent_completion() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -9855,7 +9869,7 @@ mod tests {
 
     #[test]
     fn classify_lifecycle_signal_marks_background_command_completion() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -9885,7 +9899,7 @@ mod tests {
 
     #[test]
     fn classify_lifecycle_signal_clears_off_protocol_on_regular_completion() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -9910,7 +9924,7 @@ mod tests {
 
     #[test]
     fn classify_lifecycle_signal_failed_ignores_off_protocol_marker() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10044,7 +10058,7 @@ mod tests {
 
     #[test]
     fn classify_lifecycle_signal_tool_call_carries_run_in_background_flag() {
-        use agent_client_protocol::schema::ToolCall;
+        use agent_client_protocol::schema::v1::ToolCall;
         let mut tc = ToolCall::new("tc-bg-2", "Bash");
         tc.raw_input = Some(serde_json::json!({
             "command": "npm install",
@@ -10107,7 +10121,9 @@ mod tests {
         // payload under `_meta.claudeCode`. It must map to a typed
         // BackgroundAgentLaunched, not a raw passthrough. This is the
         // path the unit test on the helper alone did not cover.
-        use agent_client_protocol::schema::{SessionUpdate, ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{
+            SessionUpdate, ToolCallUpdate, ToolCallUpdateFields,
+        };
         let mut meta = serde_json::Map::new();
         meta.insert(
             "claudeCode".to_string(),
@@ -10173,7 +10189,7 @@ mod tests {
 
     #[test]
     fn classify_lifecycle_signal_tool_call_defaults_run_in_background_false() {
-        use agent_client_protocol::schema::ToolCall;
+        use agent_client_protocol::schema::v1::ToolCall;
         let mut tc = ToolCall::new("tc-fg-1", "Bash");
         tc.raw_input = Some(serde_json::json!({ "command": "ls" }));
         match classify_lifecycle_signal(&SessionUpdate::ToolCall(tc)) {
@@ -10186,7 +10202,7 @@ mod tests {
 
     #[test]
     fn map_tool_call_update_completed_carries_content() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10222,7 +10238,7 @@ mod tests {
         // marker while the sub-agent runs off-protocol. The completion
         // event must carry async_subagent so renderers draw a background
         // card and drop the marker body (it leaks an internal agent id).
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10246,7 +10262,7 @@ mod tests {
 
     #[test]
     fn map_tool_call_update_normal_completion_is_not_async_subagent() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10271,7 +10287,7 @@ mod tests {
         // Imported sessions replay prior user turns as user_message_chunk
         // (#2276); they must map to UserPromptSent so the user's bubbles
         // render, not get dropped to a raw event.
-        use agent_client_protocol::schema::{ContentBlock, ContentChunk, TextContent};
+        use agent_client_protocol::schema::v1::{ContentBlock, ContentChunk, TextContent};
         let chunk = ContentChunk::new(ContentBlock::Text(TextContent::new("hello from the past")));
         let events = map_update_to_events(
             SessionUpdate::UserMessageChunk(chunk),
@@ -10288,7 +10304,7 @@ mod tests {
     }
 
     fn mode_from_current_mode_update(id: &str) -> SessionMode {
-        use agent_client_protocol::schema::CurrentModeUpdate;
+        use agent_client_protocol::schema::v1::CurrentModeUpdate;
         let events = map_update_to_events(
             SessionUpdate::CurrentModeUpdate(CurrentModeUpdate::new(id.to_string())),
             &agent_profiles::CLAUDE,
@@ -10410,7 +10426,7 @@ mod tests {
 
     #[test]
     fn map_tool_call_update_in_progress_with_content_emits_streaming_event() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10451,7 +10467,9 @@ mod tests {
 
     #[test]
     fn map_tool_call_update_in_progress_restamps_started_at() {
-        use agent_client_protocol::schema::{ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{
+            ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
         let fields = ToolCallUpdateFields::new().status(ToolCallStatus::InProgress);
         let update = ToolCallUpdate::new("tc-3", fields);
         let events = map_update_to_events(
@@ -10482,7 +10500,7 @@ mod tests {
 
     #[test]
     fn extract_diffs_from_content_bridges_diff_blocks_and_ignores_others() {
-        use agent_client_protocol::schema::{Content, Diff, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, Diff, ToolCallContent};
         let blocks = vec![
             ToolCallContent::Content(Content::new("some text")),
             ToolCallContent::Diff(Diff::new("src/foo.rs", "new body").old_text("old body")),
@@ -10501,7 +10519,7 @@ mod tests {
 
     #[test]
     fn extract_diffs_from_content_caps_per_side_text() {
-        use agent_client_protocol::schema::{Diff, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Diff, ToolCallContent};
         let huge = "x".repeat(MAX_DIFF_TEXT_BYTES + 4096);
         let blocks = vec![ToolCallContent::Diff(
             Diff::new("src/big.rs", huge.clone()).old_text(huge),
@@ -10527,7 +10545,7 @@ mod tests {
 
     #[test]
     fn extract_tool_output_blocks_empty_for_text_only() {
-        use agent_client_protocol::schema::{Content, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Content, ToolCallContent};
         // Pure text completion: the `content` string path renders it, so the
         // structured list stays empty and the existing path is untouched.
         let blocks = vec![ToolCallContent::Content(Content::new("just text"))];
@@ -10536,7 +10554,7 @@ mod tests {
 
     #[test]
     fn extract_tool_output_blocks_preserves_media_and_resources() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             AudioContent, Content, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
             ImageContent, ResourceLink, TextResourceContents, ToolCallContent,
         };
@@ -10589,7 +10607,7 @@ mod tests {
     fn extract_tool_output_blocks_keeps_blob_resource_payload() {
         // #1818 review: a binary (blob) embedded resource must keep its
         // inline bytes so it stays recoverable as a download.
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             BlobResourceContents, Content, ContentBlock, EmbeddedResource,
             EmbeddedResourceResource, ToolCallContent,
         };
@@ -10621,7 +10639,9 @@ mod tests {
 
     #[test]
     fn extract_tool_output_blocks_drops_oversized_inline_media() {
-        use agent_client_protocol::schema::{Content, ContentBlock, ImageContent, ToolCallContent};
+        use agent_client_protocol::schema::v1::{
+            Content, ContentBlock, ImageContent, ToolCallContent,
+        };
         let huge = "A".repeat(MAX_INLINE_MEDIA_B64 + 1);
         let blocks = vec![ToolCallContent::Content(Content::new(ContentBlock::Image(
             ImageContent::new(huge, "image/png"),
@@ -10642,7 +10662,7 @@ mod tests {
 
     #[test]
     fn extract_diffs_from_content_caps_diff_count() {
-        use agent_client_protocol::schema::{Diff, ToolCallContent};
+        use agent_client_protocol::schema::v1::{Diff, ToolCallContent};
         let blocks: Vec<ToolCallContent> = (0..MAX_TOOL_DIFFS + 8)
             .map(|i| ToolCallContent::Diff(Diff::new(format!("f{i}.rs"), "x")))
             .collect();
@@ -10655,7 +10675,7 @@ mod tests {
         // Codex attaches the apply_patch diff to the initial `tool_call`
         // frame as ToolCallContent::Diff. The edit card reads path + preview
         // from ToolCall.diffs, so it must survive ingest. See #1721.
-        use agent_client_protocol::schema::{Diff, ToolCall, ToolCallContent, ToolKind};
+        use agent_client_protocol::schema::v1::{Diff, ToolCall, ToolCallContent, ToolKind};
         let mut tc = ToolCall::new("tc-edit-1", "Edit src/foo.rs");
         tc.kind = ToolKind::Edit;
         tc.content = vec![ToolCallContent::Diff(
@@ -10677,7 +10697,7 @@ mod tests {
         // Codex also re-sends the diff on the in-progress and completion
         // updates; those must reach the reducer via ToolCallUpdated.diffs so
         // a late-arriving diff still lands on the card. See #1721.
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Diff, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10706,7 +10726,7 @@ mod tests {
     fn map_tool_call_update_text_only_leaves_diffs_none() {
         // A text-only update must not carry Some([]) (which would wipe an
         // earlier frame's diffs in the reducer). See #1721.
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             Content, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
         };
         let fields = ToolCallUpdateFields::new()
@@ -10734,7 +10754,7 @@ mod tests {
         // the slack so `Event::WakeupScheduled` lands in the store
         // (sidebar `⏰ in Nm` chip + structured view "Asleep until…" banner
         // depend on it). Regression for #1091.
-        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
         let fields = ToolCallUpdateFields::new()
             .title("ScheduleWakeup".to_string())
             .raw_input(serde_json::json!({
@@ -10774,7 +10794,7 @@ mod tests {
         // Title-only update (the initial frame's mirror, before
         // raw_input arrives) must NOT emit a WakeupScheduled, otherwise
         // we'd publish a "wakeup at epoch zero" placeholder.
-        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
         let fields = ToolCallUpdateFields::new().title("ScheduleWakeup".to_string());
         let update = ToolCallUpdate::new("toolu_test", fields);
         let events = map_update_to_events(
@@ -10796,7 +10816,7 @@ mod tests {
         // `description` arrive on a follow-up `ToolCallUpdate`. That update
         // must emit MonitorArmed so the sidebar shows a "monitoring" badge
         // instead of a plain grey idle dot.
-        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
         let fields = ToolCallUpdateFields::new()
             .title("Monitor".to_string())
             .raw_input(serde_json::json!({
@@ -10826,7 +10846,7 @@ mod tests {
     fn map_tool_call_update_skips_monitor_when_args_empty() {
         // The initial title-only / empty-args frame must NOT arm the badge;
         // only the populated follow-up update does.
-        use agent_client_protocol::schema::{ToolCallUpdate, ToolCallUpdateFields};
+        use agent_client_protocol::schema::v1::{ToolCallUpdate, ToolCallUpdateFields};
         let fields = ToolCallUpdateFields::new()
             .title("Monitor".to_string())
             .raw_input(serde_json::json!({}));
@@ -10845,7 +10865,7 @@ mod tests {
 
     #[test]
     fn map_session_info_update_ignores_pushed_title() {
-        use agent_client_protocol::schema::SessionInfoUpdate;
+        use agent_client_protocol::schema::v1::SessionInfoUpdate;
         let info = SessionInfoUpdate::new().title("Fix the flaky test".to_string());
         let events = map_update_to_events(
             SessionUpdate::SessionInfoUpdate(info),
@@ -10856,7 +10876,7 @@ mod tests {
 
     #[test]
     fn map_session_info_update_without_title_emits_nothing() {
-        use agent_client_protocol::schema::SessionInfoUpdate;
+        use agent_client_protocol::schema::v1::SessionInfoUpdate;
         // Null/undefined title (e.g. a timestamp-only update) yields no event.
         let info = SessionInfoUpdate::new().updated_at("2026-06-25T00:00:00Z".to_string());
         let events = map_update_to_events(
@@ -10868,7 +10888,7 @@ mod tests {
 
     #[test]
     fn map_usage_update_emits_typed_usage_event() {
-        use agent_client_protocol::schema::{Cost, UsageUpdate};
+        use agent_client_protocol::schema::v1::{Cost, UsageUpdate};
         let u = UsageUpdate::new(12_345, 200_000).cost(Cost::new(0.42, "USD"));
         let events = map_update_to_events(SessionUpdate::UsageUpdate(u), &agent_profiles::CLAUDE);
         assert_eq!(events.len(), 1);
@@ -10886,7 +10906,7 @@ mod tests {
 
     #[test]
     fn map_available_commands_update_emits_typed_event() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             AvailableCommand as AcpAvailableCommand, AvailableCommandInput,
             AvailableCommandsUpdate, UnstructuredCommandInput,
         };
@@ -10916,7 +10936,7 @@ mod tests {
 
     #[test]
     fn map_config_option_update_emits_typed_event_with_categories() {
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             ConfigOptionUpdate, SessionConfigKind, SessionConfigOption,
             SessionConfigOptionCategory, SessionConfigSelect, SessionConfigSelectOption,
             SessionConfigSelectOptions,
@@ -10989,7 +11009,7 @@ mod tests {
         // upstream variant, which cannot be constructed against the
         // current `#[non_exhaustive]` schema, so it is verified by
         // inspection rather than a unit test.)
-        use agent_client_protocol::schema::{
+        use agent_client_protocol::schema::v1::{
             ConfigOptionUpdate, SessionConfigKind, SessionConfigOption,
             SessionConfigOptionCategory, SessionConfigSelect, SessionConfigSelectOption,
             SessionConfigSelectOptions,

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -26,7 +26,8 @@
 //! adapters are passed through. The supervisor's known spawn intent is
 //! the gate, not the self-reported `agent_info.name` on the wire.
 
-use agent_client_protocol::schema::{InitializeResponse, ProtocolVersion};
+use agent_client_protocol::schema::v1::InitializeResponse;
+use agent_client_protocol::schema::ProtocolVersion;
 
 use super::state::StartupErrorDetail;
 
@@ -446,7 +447,7 @@ fn auto_install_for(expected: ExpectedAgent) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_client_protocol::schema::Implementation;
+    use agent_client_protocol::schema::v1::Implementation;
 
     fn make_init(name: &str, version: &str) -> InitializeResponse {
         InitializeResponse::new(ProtocolVersion::V1).agent_info(Implementation::new(name, version))

--- a/src/acp/elicitations.rs
+++ b/src/acp/elicitations.rs
@@ -27,7 +27,7 @@
 
 use std::collections::BTreeMap;
 
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     CreateElicitationRequest, CreateElicitationResponse, ElicitationAcceptAction,
     ElicitationAction, ElicitationContentValue, ElicitationMode, ElicitationPropertySchema,
     ElicitationSchema, ElicitationScope, MultiSelectItems, StringFormat, StringPropertySchema,
@@ -801,7 +801,7 @@ pub fn build_response(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_client_protocol::schema::{
+    use agent_client_protocol::schema::v1::{
         BooleanPropertySchema, ElicitationFormMode, ElicitationSessionScope, EnumOption,
         IntegerPropertySchema, MultiSelectPropertySchema, NumberPropertySchema,
         StringPropertySchema,

--- a/src/acp/mcp_config.rs
+++ b/src/acp/mcp_config.rs
@@ -8,7 +8,7 @@
 //! resolver across forwarding and display guarantees what the user sees equals
 //! what the agent receives.
 
-use agent_client_protocol::schema::{
+use agent_client_protocol::schema::v1::{
     EnvVariable, HttpHeader, McpCapabilities, McpServer, McpServerHttp, McpServerSse,
     McpServerStdio,
 };

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -543,7 +543,7 @@ fn resolve_mcp_layers(
     session_id: &str,
     profile: Option<&str>,
     cwd: &std::path::Path,
-) -> Vec<agent_client_protocol::schema::McpServer> {
+) -> Vec<agent_client_protocol::schema::v1::McpServer> {
     use crate::session::mcp_model::{resolve_effective, summarize};
 
     // One resolver for forwarding and the management surfaces (#1996): assemble


### PR DESCRIPTION
## Description

Takes over three dependabot bumps that could not merge as-is because each new version required source changes. Supersedes #2668, #2672, #2674.

**Rust `agent-client-protocol` 0.14 → 0.15** (#2668)
0.15 replaced the vendored `jsonrpcmsg` crate with shared schema types and moved every message type from `schema::` into the versioned `schema::v1::` module (`ProtocolVersion` / `MaybeUndefined` stay at the schema root). Rewrote all `agent_client_protocol::schema::` references across `src/acp/` to `schema::v1::`, keeping `ProtocolVersion` on its own root-level import.

**TS `@agentclientprotocol/sdk` 0.25.1 → 0.28.1** in `acp-worker/aoe-agent` (#2674) and `acp-worker/test-shim` (#2672)
0.27 rewrote the SDK around an `agent({ name }).onRequest(...).connect(stream)` builder and deprecated `AgentSideConnection` + the `acp.Agent` interface. Migrated both worker packages fully off the deprecated surface rather than pinning to it:
- Class handlers → builder chain keyed by ACP method literal.
- New `AgentContext` exposes generic `request` / `notify`: `sessionUpdate` → `notify("session/update")`, `readTextFile`/`writeTextFile` → `request("fs/*")`, `requestPermission` → `request("session/request_permission")`, terminals via raw `terminal/create` + `wait_for_exit` + `output` + `release` (no more `TerminalHandle`).
- Per-instance session state → module-level map (one worker process serves one connection).
- shim: conditional `session/delete` registration; unsolicited-notif timer moved to `.onConnect`.
- `TextContentBlock` type removed → `TextContent & { type: "text" }`.
- Kept `ndJsonStream`, `PROTOCOL_VERSION`, `RequestError` (not deprecated).

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed; no user-facing surface change)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Dependency-only change with no new behavior; validated against the existing ACP integration suite that spawns the Node shim end-to-end.

- `cargo fmt --check`, `cargo clippy --features serve`, `cargo build --features serve` clean.
- `cargo test --features serve --test integration acp` → 22 passed, covering every scripted shim path: silent_orphan (SILENT_ORPHAN / ASYNC_AGENT_ORPHAN / BACKGROUND_BASH_ORPHAN / WAKEUP_ORPHAN + cancel), session_delete (delete handler + error/slow modes), midturn (socket transport + `onConnect` unsolicited notif), mcp (capability + forwarding), smoke (FS_READ_WRITE / TERMINAL_RUN / REQUEST_PERMISSION / RATE_LIMIT round-trips).
- `aoe-agent`: `tsc --noEmit` clean; manual stdio smoke returns correct `initialize` + `session/new` results.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:** Investigated the three dependabot bumps, mapped the breaking/deprecated API surfaces, and applied the migrations.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the project to newer ACP protocol/SDK versions and migrates off deprecated/breaking APIs.

Main changes:
- Upgraded `agent-client-protocol` (Rust) from `0.14` → `0.15` and `@agentclientprotocol/sdk` (TypeScript) from `0.25.1` → `0.28.1`.
- Updated Rust schema usage to match the new namespacing (`schema::v1`), including wider `src/acp/` type-import adjustments.
- Reworked both ACP worker packages to use the SDK’s new builder-style connection flow (moving away from the deprecated class-based `AgentSideConnection` / `acp.Agent` interface).
- Refreshed worker runtime behavior around sessions and requests: new session state handling, updated request/notification wiring, improved cancellation handling, and updated tool/terminal interaction surfaces.
- Added/adjusted small correctness and security fixes:
  - Skip persisting empty assistant turns to avoid prompt-breaking behavior after tool-only/cancelled turns.
  - Use `crypto.randomUUID()` for `test-shim` session IDs to resolve insecure randomness warnings.
- Kept the existing ACP integration behavior aligned, while validating through formatting, linting, builds, TypeScript checks, and the existing integration suite.

Benefit:
- Brings the codebase onto the current ACP API contracts, lowering deprecation risk and making future protocol upgrades more straightforward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->