### PR TITLE
fix(web): restore clipboard image paste in the live terminal

### DIFF
--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -59,7 +59,7 @@ fn mime_allowed(kind: PromptAttachmentKind, mime: &str) -> bool {
 /// True if `bytes` start with a magic-number signature for a supported
 /// raster image. Guards against a client mislabeling arbitrary bytes as
 /// `image/png` to smuggle them past the allowlist.
-fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
+pub(crate) fn sniff_image_mime(bytes: &[u8]) -> Option<&'static str> {
     if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
         Some("image/png")
     } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -46,7 +46,7 @@ pub use plugins::{
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
-    force_smart_rename, get_recent_projects, kill_terminal, list_sessions,
+    force_smart_rename, get_recent_projects, kill_terminal, list_sessions, paste_image,
     preview_volume_ignores_globs, read_output, rename_session, restore_session, search_sessions,
     send_message, serve_session_artifact, session_diff_file, session_diff_files, set_worktree_name,
     start_session, stop_session, trash_session, update_session_archive, update_session_diff_base,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -8248,6 +8248,192 @@ pub async fn send_message(
     }
 }
 
+/// Max decoded size of a pasted image (5 MiB). Claude Code caps image
+/// attachments around this size; the route body limit in `build_router`
+/// leaves headroom for base64's ~33% overhead plus JSON framing.
+const MAX_PASTE_IMAGE_BYTES: usize = 5 * 1024 * 1024;
+
+/// Directory, relative to the session worktree, holding images pasted into
+/// the live terminal. It lives inside the worktree so a Docker-sandboxed
+/// pane, which mounts the worktree but cannot see the host temp dir, can
+/// still read the file. A self-ignoring `.gitignore` keeps the blobs out of
+/// git. See #2678.
+const PASTE_IMAGE_DIR: &str = ".aoe-pasted-images";
+
+#[derive(Deserialize)]
+pub struct PasteImageRequest {
+    /// Client-declared MIME. Advisory only: the extension and the
+    /// accept/reject decision come from magic-byte sniffing, never this field.
+    #[serde(default)]
+    pub mime_type: String,
+    /// Standard-base64 image bytes.
+    pub data: String,
+}
+
+fn paste_image_extension(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        _ => "bin",
+    }
+}
+
+/// Write the decoded blob into the worktree's paste-image dir and return the
+/// host path plus the generated file name. Sync (filesystem I/O); call from a
+/// blocking pool.
+fn write_paste_image(
+    project_path: &str,
+    bytes: &[u8],
+    ext: &str,
+) -> std::io::Result<(std::path::PathBuf, String)> {
+    let dir = std::path::Path::new(project_path).join(PASTE_IMAGE_DIR);
+    std::fs::create_dir_all(&dir)?;
+    // A `.gitignore` of `*` also ignores itself, so the whole directory stays
+    // invisible to `git add` with no git subprocess.
+    let gitignore = dir.join(".gitignore");
+    if !gitignore.exists() {
+        std::fs::write(&gitignore, "*\n")?;
+    }
+    let file_name = format!("aoe-paste-{}.{}", uuid::Uuid::new_v4(), ext);
+    let path = dir.join(&file_name);
+    // create_new: uuid names never collide; fail loud if the impossible happens.
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    std::io::Write::write_all(&mut f, bytes)?;
+    Ok((path, file_name))
+}
+
+/// Map the host paste-image file to the path the tmux pane reads. Non-sandboxed
+/// panes share the host filesystem, so the absolute host path is correct. A
+/// sandboxed pane mounts the worktree under a container path (`/workspace/...`);
+/// reuse `compute_volume_paths` so the pasted path matches that mount.
+fn pane_visible_paste_path(project_path: &str, is_sandboxed: bool, file_name: &str) -> String {
+    if is_sandboxed {
+        if let Ok((_, working_dir)) = crate::session::container_config::compute_volume_paths(
+            std::path::Path::new(project_path),
+            project_path,
+        ) {
+            return format!("{working_dir}/{PASTE_IMAGE_DIR}/{file_name}");
+        }
+    }
+    std::path::Path::new(project_path)
+        .join(PASTE_IMAGE_DIR)
+        .join(file_name)
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Save a clipboard image pasted into the live terminal and return the path
+/// the tmux pane can read, so the CLI agent (e.g. Claude Code) attaches it.
+/// See #2678.
+pub async fn paste_image(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    req: Result<Json<PasteImageRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    use base64::Engine as _;
+
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "read_only"})),
+        )
+            .into_response();
+    }
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(rej) => return rej.into_response(),
+    };
+
+    let instances = state.instances.read().await;
+    let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found"})),
+        )
+            .into_response();
+    };
+    drop(instances);
+
+    let bytes = match base64::engine::general_purpose::STANDARD.decode(req.data.as_bytes()) {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid_base64"})),
+            )
+                .into_response();
+        }
+    };
+    if bytes.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "empty"})),
+        )
+            .into_response();
+    }
+    if bytes.len() > MAX_PASTE_IMAGE_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({"error": "too_large"})),
+        )
+            .into_response();
+    }
+    let Some(mime) = super::acp::sniff_image_mime(&bytes) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "not_an_image"})),
+        )
+            .into_response();
+    };
+    let ext = paste_image_extension(mime);
+
+    let project_path = instance.project_path.clone();
+    let is_sandboxed = instance.is_sandboxed();
+    let write_project = project_path.clone();
+    let (host_path, file_name) =
+        match tokio::task::spawn_blocking(move || write_paste_image(&write_project, &bytes, ext))
+            .await
+        {
+            Ok(Ok(res)) => res,
+            Ok(Err(e)) => {
+                tracing::warn!(target: "http.api.sessions", "paste_image: write failed: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "write_failed"})),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::warn!(target: "http.api.sessions", "paste_image: join failed: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "write_failed"})),
+                )
+                    .into_response();
+            }
+        };
+
+    // Best-effort TTL cleanup: the file only needs to outlive the agent
+    // reading it. A detached task keeps the worktree from accumulating blobs
+    // without any teardown bookkeeping.
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        let _ = tokio::fs::remove_file(&host_path).await;
+    });
+
+    let pane_path = pane_visible_paste_path(&project_path, is_sandboxed, &file_name);
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "path": pane_path })),
+    )
+        .into_response()
+}
+
 #[derive(Deserialize)]
 pub struct OutputQuery {
     #[serde(default = "default_output_lines")]
@@ -8629,5 +8815,84 @@ mod send_output_tests {
     fn send_message_request_accepts_message() {
         let r: SendMessageRequest = serde_json::from_str("{\"message\":\"hello\"}").unwrap();
         assert_eq!(r.message, "hello");
+    }
+}
+
+#[cfg(test)]
+mod paste_image_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    const PNG_1PX: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89,
+    ];
+
+    #[test]
+    fn extension_from_sniffed_mime() {
+        assert_eq!(paste_image_extension("image/png"), "png");
+        assert_eq!(paste_image_extension("image/jpeg"), "jpg");
+        assert_eq!(paste_image_extension("image/gif"), "gif");
+        assert_eq!(paste_image_extension("image/webp"), "webp");
+    }
+
+    #[test]
+    fn write_paste_image_lands_in_worktree_and_ignores_itself() {
+        let dir = tempdir().unwrap();
+        let project = dir.path().to_string_lossy().to_string();
+
+        let (path, name) = write_paste_image(&project, PNG_1PX, "png").unwrap();
+
+        assert!(path.exists(), "image file must be written");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            PNG_1PX,
+            "bytes must round-trip"
+        );
+        assert!(name.starts_with("aoe-paste-") && name.ends_with(".png"));
+        let gitignore = dir.path().join(PASTE_IMAGE_DIR).join(".gitignore");
+        assert_eq!(
+            std::fs::read_to_string(gitignore).unwrap(),
+            "*\n",
+            "dir must self-ignore so pasted blobs never reach git"
+        );
+    }
+
+    #[test]
+    fn non_sandboxed_pane_path_is_absolute_host_path() {
+        let dir = tempdir().unwrap();
+        let project = dir.path().to_string_lossy().to_string();
+
+        let pane = pane_visible_paste_path(&project, false, "aoe-paste-x.png");
+
+        let expected = dir
+            .path()
+            .join(PASTE_IMAGE_DIR)
+            .join("aoe-paste-x.png")
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(pane, expected);
+    }
+
+    #[test]
+    fn sandboxed_pane_path_uses_container_mount() {
+        let dir = tempdir().unwrap();
+        let project = dir.path().to_string_lossy().to_string();
+        let dir_name = dir
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        let pane = pane_visible_paste_path(&project, true, "aoe-paste-x.png");
+
+        // A non-git worktree mounts under /workspace/<dir-name>; the pasted
+        // path must be the container-visible path, not the host path.
+        assert_eq!(
+            pane,
+            format!("/workspace/{dir_name}/{PASTE_IMAGE_DIR}/aoe-paste-x.png")
+        );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1487,6 +1487,13 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/sessions/{id}/ensure", post(api::ensure_session))
         .route("/api/sessions/{id}/send", post(api::send_message))
+        .route(
+            "/api/sessions/{id}/paste-image",
+            // A base64 screenshot blows past the global 1 MiB cap. 8 MiB
+            // leaves headroom for the 5 MiB decoded cap (enforced in the
+            // handler) plus base64's ~33% overhead and JSON framing.
+            post(api::paste_image).layer(axum::extract::DefaultBodyLimit::max(8 * 1024 * 1024)),
+        )
         .route("/api/sessions/{id}/output", get(api::read_output))
         .route(
             "/api/sessions/{id}/notifications",

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -6,7 +6,7 @@ import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
 import { MobileLiveTerminal } from "./MobileLiveTerminal";
 import { KeyboardFab } from "./KeyboardFab";
 import { TerminalConnectionBanners } from "./TerminalConnectionBanners";
-import { ensureSession, ensureTerminal } from "../lib/api";
+import { ensureSession, ensureTerminal, pasteImage } from "../lib/api";
 import type { SessionResponse } from "../lib/types";
 import {
   FOCUS_TERMINAL_EVENT,
@@ -81,6 +81,8 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
     setEnsureError(null);
   }
   const lastEnsuredSessionIdRef = useRef<string | null>(null);
+
+  const uploadPastedImage = useCallback((file: File) => pasteImage(session.id, file), [session.id]);
 
   const focusSelf = useCallback(() => {
     const ta = inputRef.current;
@@ -279,6 +281,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
           enterReading={live.enterReading}
           returnToLive={live.returnToLive}
           sendData={live.sendData}
+          uploadPastedImage={uploadPastedImage}
           forwardWheel={live.forwardWheel}
           forwardButton={live.forwardButton}
           ctrlActiveRef={ctrlActiveRef}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -78,6 +78,10 @@ export interface MobileLiveTerminalProps {
   enterReading: (rows: number) => void;
   returnToLive: (rows: number) => void;
   sendData: (data: string) => void;
+  /** Upload a clipboard image pasted into the pane and resolve to the path
+   *  the tmux pane can read (host path, or the container mount for sandboxed
+   *  sessions), or null on failure. See #2678. */
+  uploadPastedImage: (file: File) => Promise<string | null>;
   /** Forward a wheel notch to a full-screen mouse app (alternate screen).
    *  Used instead of capture-window scrolling when the frame reports the
    *  pane is such an app. */
@@ -107,6 +111,13 @@ export interface MobileLiveTerminalProps {
    *  prompt sits just above the keyboard. The paired host/container shells are
    *  ordinary terminals, so they top-align like a normal bash window. */
   bottomAlign: boolean;
+}
+
+// Backslash-escape whitespace and backslashes in a pasted image path, matching
+// what terminal drag-and-drop produces, so a path under a directory with spaces
+// (e.g. "Agent of Empires") is parsed as a single token by the CLI agent.
+function escapePastePath(p: string): string {
+  return p.replace(/[\\ \t]/g, (c) => `\\${c}`);
 }
 
 function segStyle(style: AnsiStyle): CSSProperties | undefined {
@@ -221,6 +232,7 @@ export function MobileLiveTerminal({
   enterReading,
   returnToLive,
   sendData,
+  uploadPastedImage,
   forwardWheel,
   forwardButton,
   ctrlActiveRef,
@@ -1046,11 +1058,37 @@ export function MobileLiveTerminal({
 
   const onPaste = useCallback(
     (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      e.preventDefault();
+      // Read clipboard data synchronously: `clipboardData` is not guaranteed
+      // to survive an await in every browser.
       const text = e.clipboardData.getData("text/plain");
-      if (text) sendData(`\x1b[200~${text}\x1b[201~`);
+      const imageFiles = Array.from(e.clipboardData.items ?? [])
+        .filter((it) => it.kind === "file")
+        .map((it) => it.getAsFile())
+        .filter((f): f is File => f != null && f.type.startsWith("image/"));
+
+      e.preventDefault();
+
+      if (imageFiles.length === 0) {
+        // Bracketed paste so agents treat embedded newlines as pasted text.
+        if (text) sendData(`\x1b[200~${text}\x1b[201~`);
+        return;
+      }
+
+      // The browser drops non-text clipboard payloads, so an image cannot be
+      // typed into the pane. Upload each blob to the host, then paste the
+      // file path(s) the CLI agent reads to attach them. See #2678.
+      void (async () => {
+        const paths = (await Promise.all(imageFiles.map((f) => uploadPastedImage(f)))).filter(
+          (p): p is string => p != null,
+        );
+        const parts = [text.trim(), ...paths.map(escapePastePath)].filter((s) => s.length > 0);
+        if (parts.length === 0) return;
+        // Leading and trailing spaces keep the path from gluing onto queued
+        // text or the user's next keystroke. No newline: never auto-submit.
+        sendData(`\x1b[200~ ${parts.join(" ")} \x1b[201~`);
+      })();
     },
-    [sendData],
+    [sendData, uploadPastedImage],
   );
 
   const onCompositionStart = useCallback(() => {

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -42,7 +42,7 @@ const frame: LiveFrame = {
   mouseSgr: false,
 };
 
-function renderTerm() {
+function renderTerm(uploadPastedImage = vi.fn().mockResolvedValue(null)) {
   const inputRef = createRef<HTMLTextAreaElement>();
   const sendData = vi.fn();
   render(
@@ -57,6 +57,7 @@ function renderTerm() {
       enterReading={vi.fn()}
       returnToLive={vi.fn()}
       sendData={sendData}
+      uploadPastedImage={uploadPastedImage}
       forwardWheel={vi.fn()}
       forwardButton={vi.fn()}
       ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
@@ -66,7 +67,16 @@ function renderTerm() {
       bottomAlign
     />,
   );
-  return { input: inputRef.current!, sendData };
+  return { input: inputRef.current!, sendData, uploadPastedImage };
+}
+
+// A clipboard item wrapping a File, as clipboardData.items exposes it.
+function imageItem(file: File): DataTransferItem {
+  return {
+    kind: "file",
+    type: file.type,
+    getAsFile: () => file,
+  } as unknown as DataTransferItem;
 }
 
 describe("MobileLiveTerminal paste", () => {
@@ -84,6 +94,61 @@ describe("MobileLiveTerminal paste", () => {
       clipboardData: { getData: (t: string) => (t === "text/plain" ? "hello world" : "") },
     });
     expect(sendData).toHaveBeenCalledWith("\x1b[200~hello world\x1b[201~");
+  });
+
+  it("uploads a pasted image and bracketed-pastes the returned host path (#2678)", async () => {
+    const upload = vi.fn().mockResolvedValue("/repo/.aoe-pasted-images/aoe-paste-x.png");
+    const { input, sendData } = renderTerm(upload);
+
+    const file = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => "", items: [imageItem(file)] },
+    });
+
+    expect(upload).toHaveBeenCalledWith(file);
+    // Path resolves on a microtask; flush before asserting the send.
+    await vi.waitFor(() =>
+      expect(sendData).toHaveBeenCalledWith("\x1b[200~ /repo/.aoe-pasted-images/aoe-paste-x.png \x1b[201~"),
+    );
+  });
+
+  it("escapes spaces in the pasted path so a dir like 'Agent of Empires' stays one token", async () => {
+    const upload = vi.fn().mockResolvedValue("/Users/me/Agent of Empires/.aoe-pasted-images/x.png");
+    const { input, sendData } = renderTerm(upload);
+
+    const file = new File([new Uint8Array([1])], "s.png", { type: "image/png" });
+    fireEvent.paste(input, { clipboardData: { getData: () => "", items: [imageItem(file)] } });
+
+    await vi.waitFor(() =>
+      expect(sendData).toHaveBeenCalledWith(
+        "\x1b[200~ /Users/me/Agent\\ of\\ Empires/.aoe-pasted-images/x.png \x1b[201~",
+      ),
+    );
+  });
+
+  it("keeps clipboard text alongside a pasted image", async () => {
+    const upload = vi.fn().mockResolvedValue("/repo/.aoe-pasted-images/x.png");
+    const { input, sendData } = renderTerm(upload);
+
+    const file = new File([new Uint8Array([1])], "s.png", { type: "image/png" });
+    fireEvent.paste(input, {
+      clipboardData: { getData: (t: string) => (t === "text/plain" ? "look at" : ""), items: [imageItem(file)] },
+    });
+
+    await vi.waitFor(() =>
+      expect(sendData).toHaveBeenCalledWith("\x1b[200~ look at /repo/.aoe-pasted-images/x.png \x1b[201~"),
+    );
+  });
+
+  it("a failed image upload sends nothing (no crash, no partial paste)", async () => {
+    const upload = vi.fn().mockResolvedValue(null);
+    const { input, sendData } = renderTerm(upload);
+
+    const file = new File([new Uint8Array([1])], "s.png", { type: "image/png" });
+    fireEvent.paste(input, { clipboardData: { getData: () => "", items: [imageItem(file)] } });
+
+    await vi.waitFor(() => expect(upload).toHaveBeenCalled());
+    expect(sendData).not.toHaveBeenCalled();
   });
 
   it("still sends Ctrl+C as SIGINT (other chords unchanged)", () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -142,6 +142,42 @@ export async function ensureTerminal(id: string, index = 0, container = false): 
   }
 }
 
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Drop the `data:<mime>;base64,` prefix; the server wants raw base64.
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Upload a clipboard image pasted into the live terminal. The host writes it
+ * into the session worktree and returns the path the tmux pane can read, so
+ * the CLI agent (e.g. Claude Code) attaches it. Returns null on any failure.
+ * See #2678.
+ */
+export async function pasteImage(id: string, file: File): Promise<string | null> {
+  try {
+    const data = await fileToBase64(file);
+    const res = await fetch(`/api/sessions/${id}/paste-image`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mime_type: file.type, data }),
+    });
+    if (!res.ok) return null;
+    const body = await res.json().catch(() => ({}));
+    return typeof body.path === "string" ? body.path : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Kill an extra terminal tab's host + container shells (index >= 1). Index 0
  *  is the primary terminal shared with the native TUI and cannot be killed
  *  from the web UI (the server rejects it); closing that tab only hides it. */


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Since the v1.11.1 live-terminal renderer swap, pasting a clipboard image into the web live view did nothing: the `onPaste` handler read only `text/plain` and wrapped it in a bracketed paste, so any image blob was discarded at the browser layer before the daemon ever saw it. On v1.11.0 (the xterm.js view) a pasted screenshot reached Claude Code as an attachment.

This restores it. The client now detects image items on the clipboard, uploads each blob to the host over a new `POST /api/sessions/{id}/paste-image` endpoint, and bracketed-pastes the returned file path into the pane so the CLI agent (e.g. Claude Code, which attaches an image when an absolute path appears in its input) picks it up. The server base64-decodes the blob, sniffs the image type via the existing magic-byte helper (rejecting non-images), caps it at 5 MiB, and writes it into a self-ignoring `.aoe-pasted-images/` directory in the session worktree. A detached task deletes the file after an hour.

The file lives in the worktree, not the host temp dir, so a Docker-sandboxed pane (which mounts the worktree but cannot see host `/tmp`) can still read it. For sandboxed sessions the returned path is the container mount (`/workspace/...`), computed from the same `compute_volume_paths` mapping the container launch uses; otherwise it is the absolute host path. Spaces in the path are backslash-escaped (matching terminal drag-and-drop), so a directory like "Agent of Empires" stays a single token. Plain text paste is unchanged, and text is preserved when pasted alongside an image.

Closes #2678

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a Claude Code session in the web live view, focus the terminal, copy a screenshot to the clipboard, press Ctrl+V. The image reaches the agent as an attachment (a file lands in `<worktree>/.aoe-pasted-images/` and its path is pasted into the pane).
- [ ] Paste plain text with Ctrl+V: it still bracketed-pastes the text unchanged.
- [ ] Type some text, then paste an image: both the text and the image path arrive in one paste, nothing auto-submits.
- [ ] Run the same paste in a Docker-sandboxed session: the pasted path is a `/workspace/...` container path and the agent still attaches the image.
- [ ] Confirm `.aoe-pasted-images/` does not show up under `git status` in the worktree.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec (`web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx`, mapped by the existing `terminal.clipboard-chords` coverage-matrix entry) covering image upload, path escaping, text-plus-image, and upload-failure. Server helpers are unit-tested in `src/server/api/sessions.rs`. Per AGENTS.md, request-payload behavior belongs in Vitest rather than Playwright.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design (with a two-model debate on storage location and wire format), and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change restores image paste support in the web live terminal. Clipboard images are now detected, uploaded, and inserted into the terminal as file paths so the agent can attach them again, while normal text paste still works as before.

On the backend, a new session paste-image endpoint was added with image validation, size limits, temporary storage, and cleanup. On the frontend, the live terminal now sends image clipboard items to that endpoint and preserves mixed text + image paste behavior. Tests were updated to cover image uploads, path escaping, and fallback behavior.

Benefits:
- Fixes dropped image pastes in the web terminal
- Keeps plain-text paste behavior intact
- Adds safer handling for uploaded pasted images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->