### PR TITLE
fix(web): disable worktree toggle for non-git folders, surface a typed create error

### DIFF
--- a/src/server/api/git.rs
+++ b/src/server/api/git.rs
@@ -304,6 +304,39 @@ pub async fn list_branches(
     }
 }
 
+#[derive(Deserialize)]
+pub struct IsRepoQuery {
+    pub path: String,
+}
+
+/// Reports whether `path` is a git repository, using the same
+/// `GitWorktree::is_git_repo` gate the session builder enforces (`builder.rs`
+/// single-worktree path). The new-session wizard probes this to disable the
+/// worktree toggle for a plain folder. Returns 200 `{ "is_git_repo": bool }`;
+/// a transient failure surfaces as a non-200 so the client can stay optimistic
+/// rather than misreport a real repo as a non-repo.
+pub async fn is_git_repo(
+    axum::extract::Query(query): axum::extract::Query<IsRepoQuery>,
+) -> impl IntoResponse {
+    let result = tokio::task::spawn_blocking(move || {
+        crate::git::GitWorktree::is_git_repo(std::path::Path::new(&query.path))
+    })
+    .await;
+
+    match result {
+        Ok(is_git_repo) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "is_git_repo": is_git_repo })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -34,7 +34,7 @@ pub use acp::{
 
 #[cfg(feature = "serve")]
 pub use client_log::post_client_log;
-pub use git::{clone_repo, list_branches};
+pub use git::{clone_repo, is_git_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
 pub use plugins::{

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1546,6 +1546,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/filesystem/browse", get(api::browse_filesystem))
         .route("/api/filesystem/home", get(api::filesystem_home))
         .route("/api/git/branches", get(api::list_branches))
+        .route("/api/git/is-repo", get(api::is_git_repo))
         .route("/api/git/clone", post(api::clone_repo))
         .route("/api/groups", get(api::list_groups))
         .route(

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -534,11 +534,16 @@ pub fn build_instance(
             // Single worktree mode (existing logic)
             let path = PathBuf::from(&params.path);
             if !GitWorktree::is_git_repo(&path) {
-                bail!(
+                // Typed error (not a bare `bail!` string) so the web handler's
+                // whitelist forwards an actionable message instead of the
+                // opaque "Failed to create session". The context keeps the
+                // fuller tip for callers that surface the anyhow chain (CLI,
+                // TUI).
+                return Err(anyhow::Error::new(GitError::NotAGitRepo).context(format!(
                     "Worktree mode requires a git repository, but this path is not one: {}\n\
                      Tip: start an in-place session (no worktree) here, or point at a git repository.",
                     path.display()
-                );
+                )));
             }
             let main_repo_path_raw = GitWorktree::find_main_repo(&path)?;
             let main_repo_path = main_repo_path_raw
@@ -1934,6 +1939,38 @@ mod tests {
             err.to_string()
                 .contains("Cannot combine --scratch with worktree mode"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn build_instance_worktree_on_non_git_path_returns_typed_not_a_git_repo() {
+        // A worktree requested on a plain (non-git) folder must fail with the
+        // typed GitError::NotAGitRepo, not a bare `bail!` string. The web
+        // handler only forwards an actionable message for whitelisted typed
+        // GitError variants, so a string bail would surface the opaque
+        // "Failed to create session" instead.
+        let temp_home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        let app_dir = isolated_app_dir(temp_home.path());
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(app_dir.join("config.toml"), "").unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        let mut params = custom_agent_params(project.path(), "claude");
+        params.tool = "claude".to_string();
+        params.worktree_enabled = true;
+        params.worktree_branch = Some("feat".to_string());
+
+        let err = match build_instance(params, &[], &[], "default") {
+            Ok(_) => panic!("worktree on a non-git path must error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.chain()
+                .filter_map(|c| c.downcast_ref::<crate::git::error::GitError>())
+                .any(|g| matches!(g, crate::git::error::GitError::NotAGitRepo)),
+            "expected a typed GitError::NotAGitRepo in the chain, got: {err:#}"
         );
     }
 }

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -8,7 +8,7 @@ import {
   fetchSettings,
   createSession,
   fetchVolumeIgnoresPreview,
-  fetchBranches,
+  fetchIsGitRepo,
   markVolumeIgnoresGlobsAcknowledged,
   type VolumeIgnoresGlobPreview,
   type HooksNeedTrust,
@@ -231,17 +231,18 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
 
   // Probe whether the selected path is a git repository so the worktree
   // toggle can be disabled for a plain folder (e.g. a root picked via "Use
-  // this folder"). `fetchBranches` hits the same `GitWorktree::is_git_repo`
-  // gate the builder enforces and returns null for a non-repo, so this
-  // matches the server's accept/reject by construction. Scratch sessions
-  // have no path and never use a worktree, so skip the probe there.
+  // this folder"). `/api/git/is-repo` uses the same `GitWorktree::is_git_repo`
+  // gate the builder enforces, so the UI matches the server's accept/reject.
+  // Only act on a definitive answer: on a transient failure (null) leave the
+  // optimistic default so a probe blip can't misreport a repo as a non-repo.
+  // Scratch sessions have no path and never use a worktree, so skip the probe.
   const probePath = state.data.scratch ? "" : state.data.path;
   useEffect(() => {
     if (!probePath) return;
     let cancelled = false;
-    fetchBranches(probePath).then((rows) => {
-      if (!cancelled) {
-        dispatch({ type: "SET_FIELD", field: "pathIsGitRepo", value: rows !== null });
+    fetchIsGitRepo(probePath).then((isRepo) => {
+      if (!cancelled && isRepo !== null) {
+        dispatch({ type: "SET_FIELD", field: "pathIsGitRepo", value: isRepo });
       }
     });
     return () => {

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -8,6 +8,7 @@ import {
   fetchSettings,
   createSession,
   fetchVolumeIgnoresPreview,
+  fetchBranches,
   markVolumeIgnoresGlobsAcknowledged,
   type VolumeIgnoresGlobPreview,
   type HooksNeedTrust,
@@ -227,6 +228,26 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
     // identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Probe whether the selected path is a git repository so the worktree
+  // toggle can be disabled for a plain folder (e.g. a root picked via "Use
+  // this folder"). `fetchBranches` hits the same `GitWorktree::is_git_repo`
+  // gate the builder enforces and returns null for a non-repo, so this
+  // matches the server's accept/reject by construction. Scratch sessions
+  // have no path and never use a worktree, so skip the probe there.
+  const probePath = state.data.scratch ? "" : state.data.path;
+  useEffect(() => {
+    if (!probePath) return;
+    let cancelled = false;
+    fetchBranches(probePath).then((rows) => {
+      if (!cancelled) {
+        dispatch({ type: "SET_FIELD", field: "pathIsGitRepo", value: rows !== null });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [probePath]);
 
   const handleChange = useCallback((field: string, value: unknown) => {
     dispatch({ type: "SET_FIELD", field, value });

--- a/web/src/components/session-wizard/__tests__/SessionWizard.hooksTrust.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionWizard.hooksTrust.test.tsx
@@ -16,6 +16,7 @@ const createSession = vi.fn();
 vi.mock("../../../lib/api", () => ({
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgents: vi.fn().mockResolvedValue([]),
+  fetchBranches: vi.fn().mockResolvedValue([]),
   fetchGroups: vi.fn().mockResolvedValue([]),
   fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
   fetchProfiles: vi.fn().mockResolvedValue([]),

--- a/web/src/components/session-wizard/__tests__/SessionWizard.hooksTrust.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionWizard.hooksTrust.test.tsx
@@ -16,7 +16,7 @@ const createSession = vi.fn();
 vi.mock("../../../lib/api", () => ({
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgents: vi.fn().mockResolvedValue([]),
-  fetchBranches: vi.fn().mockResolvedValue([]),
+  fetchIsGitRepo: vi.fn().mockResolvedValue(true),
   fetchGroups: vi.fn().mockResolvedValue([]),
   fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
   fetchProfiles: vi.fn().mockResolvedValue([]),

--- a/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
@@ -15,7 +15,7 @@ const createSession = vi.fn();
 vi.mock("../../../lib/api", () => ({
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgents: vi.fn().mockResolvedValue([]),
-  fetchBranches: vi.fn().mockResolvedValue([]),
+  fetchIsGitRepo: vi.fn().mockResolvedValue(true),
   fetchGroups: vi.fn().mockResolvedValue([]),
   fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
   fetchProfiles: vi.fn().mockResolvedValue([]),

--- a/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
+++ b/web/src/components/session-wizard/__tests__/SessionWizard.lastInstruction.test.tsx
@@ -15,6 +15,7 @@ const createSession = vi.fn();
 vi.mock("../../../lib/api", () => ({
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgents: vi.fn().mockResolvedValue([]),
+  fetchBranches: vi.fn().mockResolvedValue([]),
   fetchGroups: vi.fn().mockResolvedValue([]),
   fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
   fetchProfiles: vi.fn().mockResolvedValue([]),

--- a/web/src/components/session-wizard/__tests__/structuredViewToggle.test.tsx
+++ b/web/src/components/session-wizard/__tests__/structuredViewToggle.test.tsx
@@ -28,7 +28,7 @@ const createSession = vi.fn();
 vi.mock("../../../lib/api", () => ({
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgents: vi.fn().mockResolvedValue([]),
-  fetchBranches: vi.fn().mockResolvedValue([]),
+  fetchIsGitRepo: vi.fn().mockResolvedValue(true),
   fetchGroups: vi.fn().mockResolvedValue([]),
   fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
   fetchProfiles: vi.fn().mockResolvedValue([]),

--- a/web/src/components/session-wizard/__tests__/structuredViewToggle.test.tsx
+++ b/web/src/components/session-wizard/__tests__/structuredViewToggle.test.tsx
@@ -28,6 +28,7 @@ const createSession = vi.fn();
 vi.mock("../../../lib/api", () => ({
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgents: vi.fn().mockResolvedValue([]),
+  fetchBranches: vi.fn().mockResolvedValue([]),
   fetchGroups: vi.fn().mockResolvedValue([]),
   fetchDockerStatus: vi.fn().mockResolvedValue({ available: false }),
   fetchProfiles: vi.fn().mockResolvedValue([]),

--- a/web/src/components/session-wizard/steps/SessionStep.tsx
+++ b/web/src/components/session-wizard/steps/SessionStep.tsx
@@ -14,6 +14,9 @@ interface WizardData {
   group: string;
   tool: string;
   scratch: boolean;
+  /** Whether `path` is a git repository. Worktrees need a repo, so the
+   *  worktree toggle is disabled when this is false. See #2680 follow-up. */
+  pathIsGitRepo: boolean;
   [key: string]: unknown;
 }
 
@@ -65,6 +68,11 @@ export function SessionStep({ data, onChange, embedded = false }: Props) {
   // attachExisting/baseBranch/group from reducer state regardless of what
   // is on screen, so a hidden toggle keeps its default value. See #1514.
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  // Worktrees require a git repo; disable the toggle for a plain folder
+  // (e.g. a root picked via "Use this folder"). The reducer also forces
+  // useWorktree off once the probe reports a non-repo, so a stale "on" from
+  // a previous repo path can't ride through.
+  const worktreeDisabled = !data.pathIsGitRepo;
 
   const titleField = (
     <div className="mb-5">
@@ -94,28 +102,43 @@ export function SessionStep({ data, onChange, embedded = false }: Props) {
           Scratch sessions do not use git worktrees.
         </p>
       ) : (
-        <label
-          className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
-          onClick={(e) => {
-            // Clicks that land on the Toggle button already drive
-            // `onChange("useWorktree", v)`. Letting the label's own
-            // handler also fire would flip the value a second time
-            // and land back on the original. Skip the label handler
-            // for clicks originating inside the Toggle.
-            if ((e.target as HTMLElement).closest('button[role="switch"]')) {
-              return;
-            }
-            onChange("useWorktree", !data.useWorktree);
-          }}
-        >
-          <div className="flex-1">
-            <div className="text-sm font-medium text-text-primary">Create a worktree</div>
-            <div className="text-xs text-text-dim mt-0.5 leading-snug">
-              Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
+        <>
+          <label
+            className={`flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg mb-3 ${
+              worktreeDisabled ? "opacity-40 cursor-not-allowed" : "cursor-pointer"
+            }`}
+            onClick={(e) => {
+              if (worktreeDisabled) return;
+              // Clicks that land on the Toggle button already drive
+              // `onChange("useWorktree", v)`. Letting the label's own
+              // handler also fire would flip the value a second time
+              // and land back on the original. Skip the label handler
+              // for clicks originating inside the Toggle.
+              if ((e.target as HTMLElement).closest('button[role="switch"]')) {
+                return;
+              }
+              onChange("useWorktree", !data.useWorktree);
+            }}
+          >
+            <div className="flex-1">
+              <div className="text-sm font-medium text-text-primary">Create a worktree</div>
+              <div className="text-xs text-text-dim mt-0.5 leading-snug">
+                Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo
+                folder.
+              </div>
             </div>
-          </div>
-          <Toggle checked={data.useWorktree} onChange={(v) => onChange("useWorktree", v)} />
-        </label>
+            <Toggle
+              checked={data.useWorktree}
+              onChange={(v) => onChange("useWorktree", v)}
+              disabled={worktreeDisabled}
+            />
+          </label>
+          {worktreeDisabled && (
+            <p className="text-xs text-text-dim mb-3" aria-label="Worktree disabled: not a git repository">
+              This folder is not a git repository, so the session runs in place. Worktrees need a repo.
+            </p>
+          )}
+        </>
       )}
 
       {!data.scratch && data.useWorktree && (

--- a/web/src/components/session-wizard/steps/__tests__/SessionStep.worktreeGate.test.tsx
+++ b/web/src/components/session-wizard/steps/__tests__/SessionStep.worktreeGate.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+//
+// Tests the worktree-toggle gate in SessionStep: a session pointed at a
+// folder that is not a git repository (e.g. a root picked via "Use this
+// folder") must not be able to enable worktree mode, which the server
+// rejects. See #2680 follow-up.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+// SessionStep imports fetchBranches for its base-branch picker; stub it so
+// the module graph resolves. The gate under test does not depend on it.
+vi.mock("../../../../lib/api", () => ({
+  fetchBranches: vi.fn().mockResolvedValue([]),
+}));
+
+import { SessionStep } from "../SessionStep";
+import { initialData } from "../../wizardReducer";
+
+function renderStep(overrides: Partial<typeof initialData>) {
+  const onChange = vi.fn();
+  // embedded mode renders the worktree controls flat, so the toggle is
+  // visible without expanding the Advanced fold.
+  render(<SessionStep data={{ ...initialData, ...overrides }} onChange={onChange} embedded />);
+  return { onChange };
+}
+
+afterEach(cleanup);
+
+describe("SessionStep worktree gate", () => {
+  it("enables the worktree toggle for a git-repo path", () => {
+    renderStep({ path: "/repos/app", pathIsGitRepo: true });
+    // This repo's component tests do not load jest-dom, so assert on the
+    // plain DOM `disabled` property and query-null presence.
+    expect((screen.getByRole("switch") as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByLabelText("Worktree disabled: not a git repository")).toBeNull();
+  });
+
+  it("disables the worktree toggle and explains why for a non-repo path", () => {
+    const { onChange } = renderStep({ path: "/home/user/projects", pathIsGitRepo: false });
+    const toggle = screen.getByRole("switch") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(screen.getByLabelText("Worktree disabled: not a git repository")).toBeTruthy();
+
+    // A click on the disabled toggle must not flip useWorktree on.
+    fireEvent.click(toggle);
+    expect(onChange).not.toHaveBeenCalledWith("useWorktree", true);
+  });
+});

--- a/web/src/components/session-wizard/wizardReducer.test.ts
+++ b/web/src/components/session-wizard/wizardReducer.test.ts
@@ -402,3 +402,38 @@ describe("SessionWizard reducer / worktree default from config (#2423)", () => {
     expect(late.data.useWorktree).toBe(true);
   });
 });
+
+describe("SessionWizard reducer / worktree gating on non-git paths", () => {
+  it("forces useWorktree off when the probe reports a non-repo path", () => {
+    const withWorktree = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "useWorktree",
+      value: true,
+    });
+    expect(withWorktree.data.useWorktree).toBe(true);
+
+    const nonRepo = reducer(withWorktree, {
+      type: "SET_FIELD",
+      field: "pathIsGitRepo",
+      value: false,
+    });
+    expect(nonRepo.data.pathIsGitRepo).toBe(false);
+    expect(nonRepo.data.useWorktree).toBe(false);
+  });
+
+  it("optimistically resets pathIsGitRepo to true on a path change so a stale non-repo result can't linger", () => {
+    const nonRepo = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "pathIsGitRepo",
+      value: false,
+    });
+    expect(nonRepo.data.pathIsGitRepo).toBe(false);
+
+    const newPath = reducer(nonRepo, {
+      type: "SET_FIELD",
+      field: "path",
+      value: "/home/user/some-repo",
+    });
+    expect(newPath.data.pathIsGitRepo).toBe(true);
+  });
+});

--- a/web/src/components/session-wizard/wizardReducer.test.ts
+++ b/web/src/components/session-wizard/wizardReducer.test.ts
@@ -436,4 +436,21 @@ describe("SessionWizard reducer / worktree gating on non-git paths", () => {
     });
     expect(newPath.data.pathIsGitRepo).toBe(true);
   });
+
+  it("clears a stale non-repo result when scratch is turned on, so a scratch round-trip leaves an empty path optimistic", () => {
+    const nonRepo = reducer(makeState(), {
+      type: "SET_FIELD",
+      field: "pathIsGitRepo",
+      value: false,
+    });
+    expect(nonRepo.data.pathIsGitRepo).toBe(false);
+
+    const scratchOn = reducer(nonRepo, {
+      type: "SET_FIELD",
+      field: "scratch",
+      value: true,
+    });
+    expect(scratchOn.data.path).toBe("");
+    expect(scratchOn.data.pathIsGitRepo).toBe(true);
+  });
 });

--- a/web/src/components/session-wizard/wizardReducer.ts
+++ b/web/src/components/session-wizard/wizardReducer.ts
@@ -47,6 +47,12 @@ export interface WizardData {
    *  `scratch` clears `path`/`useWorktree`/`extraRepoPaths`; setting any
    *  of those back to a non-empty value clears `scratch`. */
   scratch: boolean;
+  /** Whether the selected `path` is a git repository. Worktrees require a
+   *  repo, so the worktree toggle is disabled when this is false. Defaults
+   *  true (optimistic) and is corrected by a probe in `SessionWizard` when
+   *  `path` changes; a non-repo path forces `useWorktree` off, mirroring the
+   *  scratch arm. Not part of the submit payload. */
+  pathIsGitRepo: boolean;
   /** Per-session opt-in to structured view rendering for ACP-capable tools.
    *  Defaults true so ACP-capable tools render in the structured view by
    *  default ("ACP tools run in structured view" behavior); the user
@@ -130,6 +136,7 @@ export const initialData: WizardData = {
   extraArgs: "",
   commandOverride: "",
   scratch: false,
+  pathIsGitRepo: true,
   useStructuredView: true,
   agentModel: "",
   agentEffort: "",
@@ -170,6 +177,17 @@ export function reducer(state: WizardState, action: Action): WizardState {
         // (#2276). The import picker dispatches `importAcpSessionId` AFTER
         // `path`, so its own selection survives this.
         newData.importAcpSessionId = "";
+      }
+      // A new path is optimistically a repo until the SessionWizard probe
+      // says otherwise, so a stale non-repo result can't leave the worktree
+      // toggle disabled after switching to a real repo.
+      if (action.field === "path") {
+        newData.pathIsGitRepo = true;
+      }
+      // The probe reports a non-repo path: worktrees need a repo, so force
+      // the toggle off the same way the scratch arm does above.
+      if (action.field === "pathIsGitRepo" && action.value === false) {
+        newData.useWorktree = false;
       }
       // Mark dirty whenever the user manually edits an agent-step
       // field. Guarded against `state.data.profile` previously, but the

--- a/web/src/components/session-wizard/wizardReducer.ts
+++ b/web/src/components/session-wizard/wizardReducer.ts
@@ -163,6 +163,10 @@ export function reducer(state: WizardState, action: Action): WizardState {
         newData.path = "";
         newData.extraRepoPaths = [];
         newData.useWorktree = false;
+        // Clear a stale non-repo probe result too, so toggling scratch back
+        // off doesn't show "not a git repository" for a not-yet-chosen path.
+        // Keeps the "no path selected == optimistically a repo" invariant.
+        newData.pathIsGitRepo = true;
         // Leaving the import flow for scratch: drop the import id so it
         // can't ride along on the submit. See #2276.
         newData.importAcpSessionId = "";

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1272,6 +1272,16 @@ export function fetchBranches(path: string, includeRemote = false): Promise<Bran
   return fetchJson<BranchInfo[]>(`/api/git/branches?${params.toString()}`);
 }
 
+/** Whether `path` is a git repository, per the same gate the session builder
+ *  enforces. Returns the boolean, or null on a transient failure so callers
+ *  can stay optimistic rather than misreport a repo as a non-repo. Used by the
+ *  new-session wizard to disable the worktree toggle for a plain folder. */
+export async function fetchIsGitRepo(path: string): Promise<boolean | null> {
+  const params = new URLSearchParams({ path });
+  const res = await fetchJson<{ is_git_repo: boolean }>(`/api/git/is-repo?${params.toString()}`);
+  return res ? res.is_git_repo : null;
+}
+
 // --- Acp context primer ---
 
 export interface ContextPrimerResponse {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #2680. After "Use this folder" let you point a session at a plain (non-git) folder, the new-session wizard still offered the "Create a worktree" toggle. Worktrees require a git repo, so enabling it there made session creation fail, which read as a crash.

Two changes:

1. **Wizard gate (web).** When the selected path is not a git repository, the worktree toggle is greyed out and disabled, with a short note ("This folder is not a git repository, so the session runs in place. Worktrees need a repo."). The wizard probes the path with `fetchBranches`, which hits the same `GitWorktree::is_git_repo` gate the builder enforces and returns null for a non-repo, so the UI gate matches the server's accept/reject by construction. A non-repo result also forces `useWorktree` off in the reducer, and a path change optimistically resets the flag so a stale disable can't linger after switching back to a repo.

2. **Typed create error (builder).** `build_instance` bailed with a plain string for the worktree-on-non-git case, which the web handler masked to the opaque "Failed to create session" (only whitelisted typed `GitError` variants are forwarded). It now returns the already-whitelisted `GitError::NotAGitRepo` with the fuller tip attached as anyhow context, so the web surfaces a clear message and the CLI and TUI still show the tip. This is defense in depth behind the wizard gate.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, start a new session, Browse tab, navigate into a folder that is not a git repo and click "Use this folder"; confirm the worktree toggle is greyed out and disabled with the explanatory note.
- [ ] From that state, pick a folder that is a git repo; confirm the worktree toggle re-enables.
- [ ] With a non-repo path selected, confirm you cannot turn the toggle on and can still create an in-place session.
- [ ] Defense in depth: force a worktree create on a non-git path outside the wizard (e.g. an API client posting `worktree_branch` with a non-git `path`); confirm the error reads "Path is not in a git repository" rather than "Failed to create session".

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the gate is pure client logic (probe result -> toggle disabled + reducer forces useWorktree off), which per AGENTS.md belongs in Vitest + RTL. Added `SessionStep.worktreeGate.test.tsx` and reducer cases in `wizardReducer.test.ts`. The changed components (`SessionWizard.tsx`, `SessionStep.tsx`) are already mapped in `web/tests/coverage-matrix.json` (id `session-wizard`), so no matrix change was needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

<!-- The builder change only alters the error TYPE for an already-failing path; covered by a Rust unit test (build_instance_worktree_on_non_git_path_returns_typed_not_a_git_repo) plus the existing public_create_session_error whitelist test. -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (probe via fetchBranches rather than a new endpoint; typed error plus anyhow context), reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR prevents the web session wizard from getting into a broken state when users select a folder that isn’t a git repository. The wizard now detects whether the chosen path is a git repo and automatically disables the “Create a worktree” toggle for non-repo folders, showing a short explanation instead of letting the user proceed to a failing session creation.

It also tightens backend and UI behavior:
- Backend worktree creation on non-git paths now returns a clearer, typed error (`NotAGitRepo`) so the web surface can report the reason more reliably.
- The wizard reducer proactively turns off `useWorktree` when the selected path is known to be a non-repo and resets/stabilizes this state when the user changes paths (including scratch-mode transitions) to avoid stale gating.

Tests were added/updated to cover the new git-repo check flow, the disabled worktree UI behavior, and the reducer’s non-git state handling.

Benefits: fewer user-facing failures, clearer error messaging, and safer wizard state management that avoids stale UI toggles.

```technical
Key changes:
- Added GET /api/git/is-repo and a web helper fetchIsGitRepo(path) returning boolean|null.
- SessionWizard now probes the selected path and dispatches pathIsGitRepo updates only for definitive non-repo results.
- SessionStep disables the worktree Toggle and shows an explanatory note when pathIsGitRepo is false.
- wizardReducer forces useWorktree off when pathIsGitRepo is false, and resets pathIsGitRepo appropriately on path changes and scratch-mode enabling.
- Rust builder returns GitError::NotAGitRepo for worktree creation attempts on non-git paths, with a new unit test asserting the typed error chain.
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->