### PR TITLE
feat(web): make agent-output URLs clickable in the terminal view

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
-import { ansiToLines, findCursorCharIndex, textWidth, wrapLine } from "../lib/liveTermLines";
+import { ansiToLines, findCursorCharIndex, splitUrls, textWidth, wrapLine } from "../lib/liveTermLines";
 import { wheelNotches } from "../lib/liveMouse";
 import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
@@ -153,6 +153,23 @@ const CURSOR_CELL_STYLE: CSSProperties = {
   outlineOffset: "-1px",
 };
 
+// Wrap http(s) URLs in a segment's text as clickable anchors, so agent output
+// (PR links, localhost dev servers, docs) opens in one tap instead of a
+// manual select-copy-paste (#2685). Plain text returns as-is.
+function linkify(text: string): ReactNode {
+  const parts = splitUrls(text);
+  if (parts.length === 1 && parts[0]!.url == null) return text;
+  return parts.map((p, i) =>
+    p.url ? (
+      <a key={i} href={p.url} target="_blank" rel="noopener noreferrer" className="underline cursor-pointer">
+        {p.text}
+      </a>
+    ) : (
+      p.text
+    ),
+  );
+}
+
 export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[]; cursorCol: number | null }) {
   if (cursorCol == null) {
     if (segs.length === 0) return <div> </div>; // keep empty rows at full height
@@ -160,12 +177,14 @@ export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[];
       <div>
         {segs.map((seg, i) => (
           <span key={i} style={segStyle(seg.style)}>
-            {seg.text}
+            {linkify(seg.text)}
           </span>
         ))}
       </div>
     );
   }
+  // The cursor row (live input line) keeps the delicate cell-split logic below
+  // and is not linkified; agent-output URLs live in the cursorCol == null rows.
   // Render the row with the single cell at `cursorCol` boxed. Walk segments by
   // terminal cell width, not UTF-16 code units, since `cursorCol` is a real
   // cell count from tmux and CJK/wide glyphs take two cells but one code

--- a/web/src/components/__tests__/MobileLiveTerminal.linkify.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.linkify.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+//
+// Row renders http(s) URLs in agent output as clickable anchors so they open
+// in one tap instead of a manual select-copy-paste (#2685). Only non-cursor
+// rows are linkified; the cursor (live input) row keeps its cell-split path.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Row } from "../MobileLiveTerminal";
+import type { AnsiSegment } from "../../lib/ansi";
+
+function seg(text: string): AnsiSegment {
+  return { text, style: {} };
+}
+
+describe("Row URL linkification", () => {
+  it("renders a URL in output as a new-tab anchor", () => {
+    const { container } = render(<Row segs={[seg("PR: https://github.com/o/r/pull/1")]} cursorCol={null} />);
+    const a = container.querySelector("a");
+    expect(a).not.toBeNull();
+    expect(a!.getAttribute("href")).toBe("https://github.com/o/r/pull/1");
+    expect(a!.getAttribute("target")).toBe("_blank");
+    expect(a!.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(a!.textContent).toBe("https://github.com/o/r/pull/1");
+  });
+
+  it("leaves plain output without anchors", () => {
+    const { container } = render(<Row segs={[seg("no links here")]} cursorCol={null} />);
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe("no links here");
+  });
+
+  it("does not linkify the cursor row", () => {
+    const { container } = render(<Row segs={[seg("https://example.com")]} cursorCol={0} />);
+    expect(container.querySelector("a")).toBeNull();
+  });
+});

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { ansiToLines, findCursorCharIndex, lineText, wrapLine } from "./liveTermLines";
+import { ansiToLines, findCursorCharIndex, lineText, splitUrls, wrapLine } from "./liveTermLines";
 
 describe("ansiToLines", () => {
   it("splits plain text into lines and drops the capture trailing terminator", () => {
@@ -119,5 +119,42 @@ describe("findCursorCharIndex", () => {
     const text = "e\u0301x";
     expect(findCursorCharIndex(text, 0)).toBe(0); // e
     expect(findCursorCharIndex(text, 1)).toBe(2); // x (index 1 is the mark)
+  });
+});
+
+describe("splitUrls", () => {
+  it("returns a single non-link part for plain text", () => {
+    expect(splitUrls("no links here")).toEqual([{ text: "no links here", url: null }]);
+  });
+
+  it("linkifies a lone URL", () => {
+    expect(splitUrls("https://github.com/o/r/pull/1")).toEqual([
+      { text: "https://github.com/o/r/pull/1", url: "https://github.com/o/r/pull/1" },
+    ]);
+  });
+
+  it("splits a URL embedded mid-text", () => {
+    expect(splitUrls("open http://localhost:3000 now")).toEqual([
+      { text: "open ", url: null },
+      { text: "http://localhost:3000", url: "http://localhost:3000" },
+      { text: " now", url: null },
+    ]);
+  });
+
+  it("trims trailing sentence punctuation out of the href", () => {
+    expect(splitUrls("see https://example.com/a).")).toEqual([
+      { text: "see ", url: null },
+      { text: "https://example.com/a", url: "https://example.com/a" },
+      { text: ").", url: null },
+    ]);
+  });
+
+  it("handles multiple URLs on one line", () => {
+    const parts = splitUrls("https://a.com and https://b.com");
+    expect(parts.filter((p) => p.url).map((p) => p.url)).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("does not linkify a bare host:port without a scheme", () => {
+    expect(splitUrls("localhost:3000 is up")).toEqual([{ text: "localhost:3000 is up", url: null }]);
   });
 });

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -32,6 +32,42 @@ export function lineText(line: AnsiSegment[]): string {
   return line.map((s) => s.text).join("");
 }
 
+// Match http(s) URLs so agent output in the terminal view can be linkified.
+// ponytail: plain per-line regex, no OSC 8 / reflow tracking (there is no
+// xterm here). A URL split across wrapped visual rows linkifies only its
+// first part; upgrade to reflow-aware matching only if that proves painful.
+const URL_RE = /https?:\/\/\S+/g;
+// Trailing punctuation that is usually sentence/wrapping syntax, not the URL
+// (e.g. `see https://x.com/a).`). Stripped from the match; re-emitted as text.
+const URL_TRAILING = /[.,;:!?)\]}'">]+$/;
+
+export interface UrlPart {
+  text: string;
+  /** The href when this part is a link, else null. */
+  url: string | null;
+}
+
+/** Split one line of plain text into link and non-link parts. Returns a
+ *  single non-link part when there are no URLs. */
+export function splitUrls(text: string): UrlPart[] {
+  const parts: UrlPart[] = [];
+  let last = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    const start = m.index;
+    const raw = m[0];
+    const trimmed = raw.replace(URL_TRAILING, "");
+    // Keep the trimmed form only if a host character survives; otherwise the
+    // match was scheme + punctuation and the original stands.
+    const url = /^https?:\/\/\S/.test(trimmed) ? trimmed : raw;
+    if (start > last) parts.push({ text: text.slice(last, start), url: null });
+    parts.push({ text: url, url });
+    last = start + url.length;
+  }
+  if (parts.length === 0) return [{ text, url: null }];
+  if (last < text.length) parts.push({ text: text.slice(last), url: null });
+  return parts;
+}
+
 // Terminal cell widths, wcwidth-style: combining marks and zero-width
 // joiners take no cell; East Asian Wide/Fullwidth and emoji take two.
 // tmux wraps by cells, so wrapping (and the cursor math built on it)

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -108,6 +108,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.live-clickable-urls",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/liveTermLines.test.ts", "src/components/__tests__/MobileLiveTerminal.linkify.test.tsx"],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.live-cursor-wide-chars",
       "kind": "vitest",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

URLs that an agent prints in the web terminal view rendered as plain text, so there was no way to tap or click them. On mobile this meant a manual select, copy, paste for every PR link, staging URL, or localhost dev server, which is 4 to 5 fiddly steps for something that should be one tap.

The live terminal renders each ANSI segment as a plain `<span>` (`MobileLiveTerminal.tsx` `Row`); nothing turned URL substrings into links. This adds a small pure `splitUrls` helper in `liveTermLines.ts` that detects `http(s)://` URLs per rendered line, and wires it into `Row` so output rows wrap those URLs in `<a target="_blank" rel="noopener noreferrer">` anchors. Trailing sentence punctuation is kept out of the href (`see https://example.com).` links `https://example.com`).

Scope is deliberately tight, matching the issue and the maintainer comment that the structured view is already fine (its prose is markdown-linkified):

- Only `http(s)://` URLs are linkified. A bare `localhost:PORT` with no scheme is left alone; dev servers print `http://localhost:PORT`, which is covered.
- Only non-cursor rows are linkified, so the live input line keeps its delicate cursor-cell split path untouched. Agent-output URLs live in the non-cursor rows.
- Detection is a plain per-line regex. Without xterm there is no OSC 8 or reflow tracking, so a URL split across wrapped visual rows linkifies its first part only. This is an inherent terminal-grid limitation, noted rather than solved.

Closes #2685

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a session in the web dashboard terminal view and have the agent print an `https://` URL (e.g. a PR link); confirm it renders underlined and clickable.
- [ ] Click the link on desktop; confirm it opens in a new tab.
- [ ] Tap the link on mobile; confirm it opens in the browser.
- [ ] Print `see https://example.com).` and confirm the trailing `).` is not part of the opened URL.
- [ ] Confirm plain non-URL output and the active input line render unchanged.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec and updated `web/tests/coverage-matrix.json` (`terminal.live-clickable-urls`). Pure render/parse logic is covered by RTL + unit tests: `splitUrls` unit tests in `liveTermLines.test.ts` and a `Row` render test in `MobileLiveTerminal.linkify.test.tsx`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the scope calls, reviewed the commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added clickable URL support in the web terminal output so links printed by agents can be opened directly instead of copied manually.

Key changes:
- Terminal lines now detect `http://` and `https://` links and split them into link/plain-text parts.
- Mobile live terminal rows render detected links as clickable anchors that open in a new tab.
- Cursor/input rows stay unchanged and are not linkified.
- Added tests covering normal URLs, multiple links, punctuation trimming, plain text, and non-linkified cursor rows.
- Updated coverage metadata for the new terminal link behavior.

Benefit:
- Makes URLs in terminal output much easier to use, especially on mobile, without changing non-link text or broader terminal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->