### PR TITLE
fix(web): fill and blink the live terminal cursor while focused

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -254,7 +254,7 @@ The web dashboard (`web/`) is a utility that sits between a developer and a term
 
 - Row heights: 28-32px. Buttons: 32-40px. The dashboard is denser than the marketing site on purpose.
 - Border radii: `rounded-md` (6px) for inline affordances, `rounded-lg` (8px) for panels and dialogs. No `rounded-xl` or larger in the dashboard.
-- Motion: `animate-fade-in` and `animate-slide-up` are the only named transitions. Prefer `transition-colors` for hover/focus. Avoid scaling, parallax, or layered motion.
+- Motion: `animate-fade-in`, `animate-slide-up`, and `animate-term-cursor-blink` (the live terminal's focused-cursor blink, a terminal convention rather than decorative motion) are the only named transitions. Prefer `transition-colors` for hover/focus. Avoid scaling, parallax, or layered motion.
 
 ### What stays per-surface
 

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -142,13 +142,19 @@ function segStyle(style: AnsiStyle): CSSProperties | undefined {
 // Screenshot-friendly; no behavior changes.
 const LIVE_DEBUG = typeof location !== "undefined" && new URLSearchParams(location.search).has("livedebug");
 
-// Hollow-box cursor drawn AS A CELL inside the text flow, the way a real
-// terminal (and the desktop xterm view) renders it, rather than a separate
-// absolutely-positioned block whose pixel row we reconstruct from cursor.y and
-// line-height. Tying it to the actual rendered cell means it cannot drift off
-// its row (wrapping, row-height, offset assumptions). `outline` instead of
-// `border` so the box does not reflow the line by a pixel.
-const CURSOR_CELL_STYLE: CSSProperties = {
+// Cursor drawn AS A CELL inside the text flow, the way a real terminal
+// renders it, rather than a separate absolutely-positioned block whose pixel
+// row we reconstruct from cursor.y and line-height. Tying it to the actual
+// rendered cell means it cannot drift off its row (wrapping, row-height,
+// offset assumptions). Filled (solid background, inverted text) while the
+// hidden input has focus, matching every terminal's focused-cursor
+// convention; hollow `outline` while blurred so the box does not reflow the
+// line by a pixel.
+const CURSOR_CELL_STYLE_FOCUSED: CSSProperties = {
+  backgroundColor: "var(--term-cursor, #f59e0b)",
+  color: "var(--term-bg, #1c1c1f)",
+};
+const CURSOR_CELL_STYLE_BLURRED: CSSProperties = {
   outline: "1px solid var(--term-cursor, #f59e0b)",
   outlineOffset: "-1px",
 };
@@ -170,7 +176,16 @@ function linkify(text: string): ReactNode {
   );
 }
 
-export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[]; cursorCol: number | null }) {
+export const Row = memo(function Row({
+  segs,
+  cursorCol,
+  focused = false,
+}: {
+  segs: AnsiSegment[];
+  cursorCol: number | null;
+  focused?: boolean;
+}) {
+  const cursorStyle = focused ? CURSOR_CELL_STYLE_FOCUSED : CURSOR_CELL_STYLE_BLURRED;
   if (cursorCol == null) {
     if (segs.length === 0) return <div> </div>; // keep empty rows at full height
     return (
@@ -206,7 +221,7 @@ export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[];
         );
       }
       out.push(
-        <span key={key++} data-live-cursor style={{ ...segStyle(seg.style), ...CURSOR_CELL_STYLE }}>
+        <span key={key++} data-live-cursor style={{ ...segStyle(seg.style), ...cursorStyle }}>
           {chars[idx]}
         </span>,
       );
@@ -232,7 +247,7 @@ export const Row = memo(function Row({ segs, cursorCol }: { segs: AnsiSegment[];
     // and box a space.
     if (cursorCol > col) out.push(<span key="pad">{" ".repeat(cursorCol - col)}</span>);
     out.push(
-      <span key="cursor" data-live-cursor style={CURSOR_CELL_STYLE}>
+      <span key="cursor" data-live-cursor style={cursorStyle}>
         {" "}
       </span>,
     );
@@ -274,6 +289,10 @@ export function MobileLiveTerminal({
   // ignored) font-family value.
   const termFontFamily = (settings.terminalFontFamily ?? "").trim().replace(/"/g, "");
   const fontFamily = termFontFamily ? `"${termFontFamily}", var(--font-mono)` : undefined;
+  // Drives the cursor cell's filled-vs-hollow style; separate from the
+  // `onInputFocusChange` bubble-up, which only drives the parent's chrome
+  // ring (see LiveTerminalView).
+  const [focused, setFocused] = useState(false);
   const [fontSize, setFontSize] = useState(() => configuredFontSize);
   // Adopt the persisted setting when it changes (settings panel, or the
   // pointer class flipping which font key applies) via the adjust-state-
@@ -1227,7 +1246,7 @@ export function MobileLiveTerminal({
           {topPadLines > 0 && <div style={{ height: `${topPadLines * lineH}px` }} aria-hidden="true" />}
           {visual.rows.slice(winStart, winEnd).map((segs, j) => {
             const i = winStart + j;
-            return <Row key={i} segs={segs} cursorCol={i === cursorRow ? live.col : null} />;
+            return <Row key={i} segs={segs} cursorCol={i === cursorRow ? live.col : null} focused={focused} />;
           })}
           {bottomPadLines > 0 && <div style={{ height: `${bottomPadLines * lineH}px` }} aria-hidden="true" />}
         </div>
@@ -1280,8 +1299,14 @@ export function MobileLiveTerminal({
         // a ghost caret floating over the terminal. caret-color is the
         // documented off switch; color guards select-all artifacts.
         style={{ fontSize: "16px", caretColor: "transparent", color: "transparent" }}
-        onFocus={() => onInputFocusChange(true)}
-        onBlur={() => onInputFocusChange(false)}
+        onFocus={() => {
+          setFocused(true);
+          onInputFocusChange(true);
+        }}
+        onBlur={() => {
+          setFocused(false);
+          onInputFocusChange(false);
+        }}
         autoCapitalize="off"
         autoCorrect="off"
         autoComplete="off"

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1256,7 +1256,14 @@ export function MobileLiveTerminal({
           {topPadLines > 0 && <div style={{ height: `${topPadLines * lineH}px` }} aria-hidden="true" />}
           {visual.rows.slice(winStart, winEnd).map((segs, j) => {
             const i = winStart + j;
-            return <Row key={i} segs={segs} cursorCol={i === cursorRow ? live.col : null} focused={focused} />;
+            return (
+              <Row
+                key={i}
+                segs={segs}
+                cursorCol={i === cursorRow ? live.col : null}
+                focused={i === cursorRow && focused}
+              />
+            );
           })}
           {bottomPadLines > 0 && <div style={{ height: `${bottomPadLines * lineH}px` }} aria-hidden="true" />}
         </div>

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -221,7 +221,12 @@ export const Row = memo(function Row({
         );
       }
       out.push(
-        <span key={key++} data-live-cursor style={{ ...segStyle(seg.style), ...cursorStyle }}>
+        <span
+          key={key++}
+          data-live-cursor
+          className={focused ? "animate-term-cursor-blink" : undefined}
+          style={{ ...segStyle(seg.style), ...cursorStyle }}
+        >
           {chars[idx]}
         </span>,
       );
@@ -247,7 +252,12 @@ export const Row = memo(function Row({
     // and box a space.
     if (cursorCol > col) out.push(<span key="pad">{" ".repeat(cursorCol - col)}</span>);
     out.push(
-      <span key="cursor" data-live-cursor style={cursorStyle}>
+      <span
+        key="cursor"
+        data-live-cursor
+        className={focused ? "animate-term-cursor-blink" : undefined}
+        style={cursorStyle}
+      >
         {" "}
       </span>,
     );

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
@@ -5,6 +5,8 @@
 // and picks a filled style (solid background, inverted text) when true,
 // keeping the hollow outline for the default/blurred case so existing
 // placement tests (MobileLiveTerminal.cjkCursor.test.tsx) need no changes.
+// Focused also gets the blink animation class; jsdom doesn't run the CSS
+// animation itself, but the class presence is what drives it in a browser.
 
 import { describe, expect, it } from "vitest";
 import { render } from "@testing-library/react";
@@ -20,35 +22,39 @@ function cursorCell(container: HTMLElement) {
 }
 
 describe("Row cursor fill state", () => {
-  it("renders a hollow outline, no fill, when unfocused (default)", () => {
+  it("renders a hollow outline, no fill, no blink, when unfocused (default)", () => {
     const { container } = render(<Row segs={[seg("hi")]} cursorCol={2} />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
     expect(cell!.style.outline).toContain("var(--term-cursor");
     expect(cell!.style.backgroundColor).toBe("");
+    expect(cell!.className).toBe("");
   });
 
-  it("renders a hollow outline, no fill, when focused=false", () => {
+  it("renders a hollow outline, no fill, no blink, when focused=false", () => {
     const { container } = render(<Row segs={[seg("hi")]} cursorCol={2} focused={false} />);
     const cell = cursorCell(container);
     expect(cell!.style.outline).toContain("var(--term-cursor");
     expect(cell!.style.backgroundColor).toBe("");
+    expect(cell!.className).toBe("");
   });
 
-  it("fills solid with inverted text color when focused=true", () => {
+  it("fills solid with inverted text color and blinks when focused=true", () => {
     const { container } = render(<Row segs={[seg("hi")]} cursorCol={2} focused />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
     expect(cell!.style.backgroundColor).toContain("var(--term-cursor");
     expect(cell!.style.color).toContain("var(--term-bg");
     expect(cell!.style.outline).toBe("");
+    expect(cell!.className).toContain("animate-term-cursor-blink");
   });
 
-  it("fills the blank-cell cursor (cursor past row text) when focused", () => {
+  it("fills and blinks the blank-cell cursor (cursor past row text) when focused", () => {
     const { container } = render(<Row segs={[seg("hi")]} cursorCol={5} focused />);
     const cell = cursorCell(container);
     expect(cell).not.toBeNull();
     expect(cell!.style.backgroundColor).toContain("var(--term-cursor");
     expect(cell!.style.outline).toBe("");
+    expect(cell!.className).toContain("animate-term-cursor-blink");
   });
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+//
+// The cursor cell always rendered as a hollow outline, with no path for the
+// input's focus state to reach it (#2684). `Row` now takes a `focused` prop
+// and picks a filled style (solid background, inverted text) when true,
+// keeping the hollow outline for the default/blurred case so existing
+// placement tests (MobileLiveTerminal.cjkCursor.test.tsx) need no changes.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Row } from "../MobileLiveTerminal";
+import type { AnsiSegment } from "../../lib/ansi";
+
+function seg(text: string): AnsiSegment {
+  return { text, style: {} };
+}
+
+function cursorCell(container: HTMLElement) {
+  return container.querySelector("[data-live-cursor]") as HTMLElement | null;
+}
+
+describe("Row cursor fill state", () => {
+  it("renders a hollow outline, no fill, when unfocused (default)", () => {
+    const { container } = render(<Row segs={[seg("hi")]} cursorCol={2} />);
+    const cell = cursorCell(container);
+    expect(cell).not.toBeNull();
+    expect(cell!.style.outline).toContain("var(--term-cursor");
+    expect(cell!.style.backgroundColor).toBe("");
+  });
+
+  it("renders a hollow outline, no fill, when focused=false", () => {
+    const { container } = render(<Row segs={[seg("hi")]} cursorCol={2} focused={false} />);
+    const cell = cursorCell(container);
+    expect(cell!.style.outline).toContain("var(--term-cursor");
+    expect(cell!.style.backgroundColor).toBe("");
+  });
+
+  it("fills solid with inverted text color when focused=true", () => {
+    const { container } = render(<Row segs={[seg("hi")]} cursorCol={2} focused />);
+    const cell = cursorCell(container);
+    expect(cell).not.toBeNull();
+    expect(cell!.style.backgroundColor).toContain("var(--term-cursor");
+    expect(cell!.style.color).toContain("var(--term-bg");
+    expect(cell!.style.outline).toBe("");
+  });
+
+  it("fills the blank-cell cursor (cursor past row text) when focused", () => {
+    const { container } = render(<Row segs={[seg("hi")]} cursorCol={5} focused />);
+    const cell = cursorCell(container);
+    expect(cell).not.toBeNull();
+    expect(cell!.style.backgroundColor).toContain("var(--term-cursor");
+    expect(cell!.style.outline).toBe("");
+  });
+});

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
@@ -62,17 +62,20 @@ function renderTerm() {
 }
 
 describe("MobileLiveTerminal cursor fill on focus", () => {
-  it("starts hollow, fills on focus, reverts to hollow on blur", () => {
+  it("starts hollow, fills and blinks on focus, reverts to hollow (no blink) on blur", () => {
     const { inputRef, cursorCell } = renderTerm();
     expect(cursorCell()!.style.backgroundColor).toBe("");
     expect(cursorCell()!.style.outline).toContain("var(--term-cursor");
+    expect(cursorCell()!.className).toBe("");
 
     fireEvent.focus(inputRef.current!);
     expect(cursorCell()!.style.backgroundColor).toContain("var(--term-cursor");
     expect(cursorCell()!.style.outline).toBe("");
+    expect(cursorCell()!.className).toContain("animate-term-cursor-blink");
 
     fireEvent.blur(inputRef.current!);
     expect(cursorCell()!.style.backgroundColor).toBe("");
     expect(cursorCell()!.style.outline).toContain("var(--term-cursor");
+    expect(cursorCell()!.className).toBe("");
   });
 });

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// End-to-end within MobileLiveTerminal: focusing/blurring the hidden input
+// must flip the rendered cursor cell's style, not just the parent's chrome
+// ring (#2684). The cell has to survive being focused, blurred, and
+// re-focused without drifting into a stuck state either way.
+
+import { createRef } from "react";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+import type { LiveFrame } from "../../hooks/useLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const frame: LiveFrame = {
+  content: "$ \n",
+  rows: 3,
+  history: 1000,
+  cursor: { x: 2, y: 0 },
+  altScreen: false,
+  mouse: false,
+  mouseSgr: false,
+};
+
+function renderTerm() {
+  const inputRef = createRef<HTMLTextAreaElement>();
+  const utils = render(
+    <MobileLiveTerminal
+      frame={frame}
+      connected
+      active
+      reading={false}
+      sendResize={vi.fn()}
+      setWindow={vi.fn()}
+      setCadence={vi.fn()}
+      enterReading={vi.fn()}
+      returnToLive={vi.fn()}
+      sendData={vi.fn()}
+      uploadPastedImage={vi.fn()}
+      forwardWheel={vi.fn()}
+      forwardButton={vi.fn()}
+      ctrlActiveRef={createRef<boolean>() as React.RefObject<boolean>}
+      clearCtrl={vi.fn()}
+      inputRef={inputRef}
+      onInputFocusChange={vi.fn()}
+      bottomAlign
+    />,
+  );
+  const cursorCell = () => utils.container.querySelector("[data-live-cursor]") as HTMLElement | null;
+  return { inputRef, cursorCell };
+}
+
+describe("MobileLiveTerminal cursor fill on focus", () => {
+  it("starts hollow, fills on focus, reverts to hollow on blur", () => {
+    const { inputRef, cursorCell } = renderTerm();
+    expect(cursorCell()!.style.backgroundColor).toBe("");
+    expect(cursorCell()!.style.outline).toContain("var(--term-cursor");
+
+    fireEvent.focus(inputRef.current!);
+    expect(cursorCell()!.style.backgroundColor).toContain("var(--term-cursor");
+    expect(cursorCell()!.style.outline).toBe("");
+
+    fireEvent.blur(inputRef.current!);
+    expect(cursorCell()!.style.backgroundColor).toBe("");
+    expect(cursorCell()!.style.outline).toContain("var(--term-cursor");
+  });
+});

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -419,6 +419,33 @@ body {
   animation: slide-in-right 0.2s ease-out;
 }
 
+/* Live terminal cursor blink while its input is focused (MobileLiveTerminal's
+   `Row`). Only oscillates the filled-cursor colors set by the inline style;
+   the almost-equal keyframe percentages make the swap an instant cut instead
+   of a fade. `color: inherit` on the off phase approximates the original
+   glyph color rather than reproducing it exactly, good enough since the
+   cursor sits on the input line, which is normally default-colored text. */
+@keyframes term-cursor-blink {
+  0%,
+  50% {
+    background-color: var(--term-cursor, #f59e0b);
+    color: var(--term-bg, #1c1c1f);
+  }
+  50.001%,
+  100% {
+    background-color: transparent;
+    color: inherit;
+  }
+}
+.animate-term-cursor-blink {
+  animation: term-cursor-blink 1.06s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-term-cursor-blink {
+    animation: none;
+  }
+}
+
 /* One-shot flash for the field a settings-search jump lands on. The target
    wrapper remounts on each jump (SettingsView keys the content subtree on the
    focus nonce), so the animation replays without any JS timer or state. */

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -122,6 +122,16 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx"]
     },
     {
+      "id": "terminal.live-cursor-focus-fill",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/MobileLiveTerminal.cursorFocus.test.tsx",
+        "src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx"
+      ],
+      "components": ["web/src/components/MobileLiveTerminal.tsx"]
+    },
+    {
       "id": "terminal.clipboard-chords",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The live terminal's cursor cell (agent pane, both paired-shell surfaces, every device) always rendered as a hollow outline box. It never filled solid when the pane's hidden input had focus, so a live, ready-for-input pane looked identical to a blurred one. Every terminal app, including the xterm.js view this renderer replaced, fills the cursor while focused and hollows it on blur; that behavior never carried over when `MobileLiveTerminal` became the shared renderer for desktop and mobile alike.

`Row` (`web/src/components/MobileLiveTerminal.tsx`) drew the cursor cell but had no `focused` prop at all, and the hidden input's `onFocus`/`onBlur` only bubbled a boolean up to the parent for the pane's chrome ring, never back down to the cursor. This PR adds a local `focused` state in `MobileLiveTerminal`, threads it into `Row`, and gives `Row` two cursor styles instead of one: a filled background with inverted text while focused, the existing hollow outline while blurred.

While in there, the cursor also now blinks while focused (a CSS animation class applied only when `focused`), matching the blink convention most terminals have alongside the focused fill. It respects `prefers-reduced-motion` and stays static while blurred. It does not reset the blink phase to solid on every keystroke the way some terminals do; that refinement is left for later if anyone asks.

Closes #2684

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a session's terminal pane in the web dashboard (desktop), click into it to focus, confirm the cursor cell fills solid instead of staying a hollow outline, and blinks.
- [ ] Click away (blur the pane), confirm the cursor reverts to the static hollow outline (no blink).
- [ ] On a touch device (or the browser's mobile emulation), tap the terminal to open the soft keyboard, confirm the cursor fills and blinks the same way as desktop.
- [ ] Switch between the agent pane and a paired host/container shell, confirm both surfaces show the same focused/blurred cursor behavior.
- [ ] With the OS "reduce motion" setting on, focus the pane and confirm the cursor fills solid without blinking.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a Playwright spec, because: the bug and the fix are pure component-render logic (a CSS style/class branching on a focus boolean), fully reproducible and verifiable in jsdom via Vitest + RTL, the same layer `MobileLiveTerminal.tapFocus.test.tsx` already uses for this component's focus behavior. No backend, WS, or tmux state is involved, and jsdom doesn't execute CSS animations anyway so a browser-driven spec wouldn't add signal over asserting the class is present. Added `MobileLiveTerminal.cursorFocus.test.tsx` (unit tests on `Row`'s style/class output) and `MobileLiveTerminal.cursorFocusIntegration.test.tsx` (fires focus/blur on the real hidden input, asserts the rendered cursor cell's style and blink class), both mapped in `web/tests/coverage-matrix.json` under `terminal.live-cursor-focus-fill`. The fill-state assertions fail on the pre-fix tree (verified in an ephemeral detached worktree at the parent commit) and pass after the fix.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation (filed as #2684), plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (including asking for the blink addition after the initial fix), and ran the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the web live terminal cursor to feel like a typical terminal: when the terminal is focused, the cursor becomes a filled “solid cell” with inverted text and blinks; when blurred, it returns to the existing hollow outline.

### What changed
- **Cursor styling now has two states**: **unfocused = hollow/outlined**, **focused = filled with inverted text**.
- **Focus behavior is now tracked locally** in `MobileLiveTerminal` and used to drive cursor rendering.
- The blink effect was added via a new CSS animation class and **is disabled automatically under `prefers-reduced-motion`**.
- **Performance improvement**: only the **active cursor row** receives the “focused” styling input, avoiding unnecessary re-renders of other rows.
- **Tests added** (unit + integration) to verify cursor fill/outline and blink/anti-blink behavior on focus/blur.
- **Coverage and documentation updated** to include the new cursor blink animation.

### Benefits
- Clearer, more familiar “typing position” feedback when the terminal is focused.
- Better accessibility by respecting reduced-motion settings.
- Smoother rendering by limiting focus-driven updates to the cursor row.

### Potential follow-up
- If coverage doesn’t already verify cursor focus/blink on all shared surfaces (e.g., agent pane / paired shell surfaces) end-to-end, consider adding targeted assertions there.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->