### PR TITLE
feat(plugin): filter sessions.list and bound UI-state quota per session

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -576,9 +576,18 @@ session reload (eventual consistency, not a live push).
 `sessions.list` returns one entry per session with `id`, `title`,
 `project_path`, `tool`, `status` (the run-state), and two inactivity flags:
 `archived` (the session is archived) and `snoozed` (it has a snooze deadline
-still in the future; a past deadline reports `false`). The call never filters
-server-side, so a worker that should ignore dormant sessions, for example to
-avoid spending API quota on them, checks these flags itself.
+still in the future; a past deadline reports `false`). A worker that should
+ignore dormant sessions, for example to avoid spending API quota on them, can
+check these flags itself.
+
+The call also takes an optional `exclude` param: an array of state names to
+drop server-side, from `archived`, `snoozed`, and `trashed`. A missing or empty
+`exclude` returns every session (so an older worker is unaffected); a value
+outside that set, or a non-string entry, is an `INVALID_PARAMS` error rather
+than a silently ignored filter. This lets a worker skip trashed sessions
+(pending deletion, never surfaced to the user) without enumerating them, which
+matters because a workspace with many trashed sessions would otherwise push
+per-session UI state for all of them.
 
 `config.get { key }` returns the value at `plugins.<plugin-id>.settings.<key>`
 for the calling plugin's own id, so a worker reads back the settings the user

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -482,9 +482,9 @@ fn sessions_list(state: &HostApiState, params: &Value) -> Result<Value, Dispatch
     let sessions: Vec<Value> = instances
         .iter()
         .filter(|i| {
-            !(exclude.archived && i.is_archived())
-                && !(exclude.snoozed && i.is_snoozed())
-                && !(exclude.trashed && i.is_trashed())
+            !((exclude.archived && i.is_archived())
+                || (exclude.snoozed && i.is_snoozed())
+                || (exclude.trashed && i.is_trashed()))
         })
         .map(|i| {
             json!({

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -217,7 +217,7 @@ pub fn dispatch(
         }
         "sessions.list" => {
             ctx.require(CAP_SESSION_READ)?;
-            sessions_list(state)
+            sessions_list(state, params)
         }
         "config.get" => {
             ctx.require(CAP_WORKER)?;
@@ -427,7 +427,52 @@ fn session_meta_cas(
     Ok(json!({ "swapped": swapped, "current": current }))
 }
 
-fn sessions_list(state: &HostApiState) -> Result<Value, DispatchError> {
+/// The set of inactivity states a `sessions.list` caller wants dropped from the
+/// result. Each maps to an `is_*` predicate on the instance. Absent/empty means
+/// return everything, so an old caller that passes no `exclude` is unaffected.
+#[derive(Default)]
+struct SessionListExclude {
+    archived: bool,
+    snoozed: bool,
+    trashed: bool,
+}
+
+/// Parse the optional `exclude` param: an array of state names to drop, from
+/// `archived` / `snoozed` / `trashed`. A missing or null `exclude` excludes
+/// nothing. A non-array, a non-string entry, or an unknown name is caller error
+/// (INVALID_PARAMS) rather than a silently-ignored typo, so a worker learns its
+/// filter did not apply instead of assuming it did.
+fn parse_sessions_exclude(params: &Value) -> Result<SessionListExclude, DispatchError> {
+    let mut out = SessionListExclude::default();
+    let raw = match params.get("exclude") {
+        None | Some(Value::Null) => return Ok(out),
+        Some(v) => v,
+    };
+    let arr = raw
+        .as_array()
+        .ok_or_else(|| DispatchError::invalid_params("param \"exclude\" must be an array"))?;
+    for item in arr {
+        match item.as_str() {
+            Some("archived") => out.archived = true,
+            Some("snoozed") => out.snoozed = true,
+            Some("trashed") => out.trashed = true,
+            Some(other) => {
+                return Err(DispatchError::invalid_params(format!(
+                    "unknown sessions.list exclude value {other:?}"
+                )))
+            }
+            None => {
+                return Err(DispatchError::invalid_params(
+                    "\"exclude\" entries must be strings",
+                ))
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn sessions_list(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let exclude = parse_sessions_exclude(params)?;
     let storage = state
         .storage()
         .map_err(|e| DispatchError::internal(e.to_string()))?;
@@ -436,6 +481,11 @@ fn sessions_list(state: &HostApiState) -> Result<Value, DispatchError> {
         .map_err(|e| DispatchError::internal(e.to_string()))?;
     let sessions: Vec<Value> = instances
         .iter()
+        .filter(|i| {
+            !(exclude.archived && i.is_archived())
+                && !(exclude.snoozed && i.is_snoozed())
+                && !(exclude.trashed && i.is_trashed())
+        })
         .map(|i| {
             json!({
                 "id": i.id,
@@ -846,6 +896,151 @@ mod tests {
         // A snooze deadline in the past is inactive.
         assert_eq!(by_id(&past_id)["snoozed"], json!(false));
         assert_eq!(by_id(&past_id)["archived"], json!(false));
+    }
+
+    /// `sessions.list` drops the states named in `exclude` server-side, so a
+    /// worker that only cares about live sessions never enumerates dormant or
+    /// trashed ones. Each state filters independently and the flags on the
+    /// returned entries are unaffected.
+    #[test]
+    #[serial_test::serial]
+    fn sessions_list_exclude_filters_server_side() {
+        use crate::session::{Instance, Storage};
+
+        struct XdgGuard(Option<std::ffi::OsString>);
+        impl Drop for XdgGuard {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let _xdg = XdgGuard(std::env::var_os("XDG_CONFIG_HOME"));
+        std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+
+        let storage = Storage::new_unwatched("default").unwrap();
+        let (active_id, archived_id, snoozed_id, trashed_id) = storage
+            .update(|instances, _groups| {
+                let active = Instance::new("active", "/tmp/plugin-host-test");
+                let active_id = active.id.clone();
+
+                let mut archived = Instance::new("archived", "/tmp/plugin-host-test");
+                archived.archived_at = Some(chrono::Utc::now());
+                let archived_id = archived.id.clone();
+
+                let mut snoozed = Instance::new("snoozed", "/tmp/plugin-host-test");
+                snoozed.snoozed_until = Some(chrono::Utc::now() + chrono::Duration::hours(1));
+                let snoozed_id = snoozed.id.clone();
+
+                let mut trashed = Instance::new("trashed", "/tmp/plugin-host-test");
+                trashed.trashed_at = Some(chrono::Utc::now());
+                let trashed_id = trashed.id.clone();
+
+                instances.push(active);
+                instances.push(archived);
+                instances.push(snoozed);
+                instances.push(trashed);
+                Ok((active_id, archived_id, snoozed_id, trashed_id))
+            })
+            .unwrap();
+
+        let state =
+            HostApiState::open(&tmp.path().join("plugin_events.db"), "default", 100).unwrap();
+        let a = ctx(&[CAP_SESSION_READ]);
+        // Assert on the ids this test seeded rather than on totals: the store is
+        // the profile's real storage (an existing app dir wins over the test's
+        // XDG override on macOS), so ambient sessions may be present.
+        let ids = |v: &Value| -> Vec<String> {
+            v["sessions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|s| s["id"].as_str().unwrap().to_string())
+                .collect()
+        };
+
+        // No exclude: all four seeded sessions come back.
+        let all = ids(&dispatch(&state, &a, "sessions.list", &json!({})).unwrap());
+        for id in [&active_id, &archived_id, &snoozed_id, &trashed_id] {
+            assert!(all.contains(id), "no-exclude list missing {id}");
+        }
+
+        // Each exclude drops exactly its state and leaves the others.
+        let no_trash = dispatch(
+            &state,
+            &a,
+            "sessions.list",
+            &json!({ "exclude": ["trashed"] }),
+        )
+        .unwrap();
+        let no_trash_ids = ids(&no_trash);
+        assert!(!no_trash_ids.contains(&trashed_id));
+        assert!(no_trash_ids.contains(&archived_id));
+        assert!(no_trash_ids.contains(&active_id));
+        // Flags on returned entries are unaffected by filtering.
+        let archived_entry = no_trash["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["id"] == json!(archived_id))
+            .unwrap();
+        assert_eq!(archived_entry["archived"], json!(true));
+
+        let no_archived = ids(&dispatch(
+            &state,
+            &a,
+            "sessions.list",
+            &json!({ "exclude": ["archived"] }),
+        )
+        .unwrap());
+        assert!(!no_archived.contains(&archived_id));
+        assert!(no_archived.contains(&trashed_id));
+
+        // Excluding every dormant state drops all three, keeps the active one.
+        let live = ids(&dispatch(
+            &state,
+            &a,
+            "sessions.list",
+            &json!({ "exclude": ["archived", "snoozed", "trashed"] }),
+        )
+        .unwrap());
+        assert!(live.contains(&active_id));
+        for id in [&archived_id, &snoozed_id, &trashed_id] {
+            assert!(!live.contains(id), "dormant {id} should be excluded");
+        }
+
+        // Drop exactly the ids this test seeded so it leaves no residue in the
+        // profile store, matching the deterministic-and-self-cleaning rule.
+        let seeded = [&active_id, &archived_id, &snoozed_id, &trashed_id];
+        storage
+            .update(|instances, _groups| {
+                instances.retain(|i| !seeded.iter().any(|id| **id == i.id));
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    /// A malformed `exclude` is caller error (INVALID_PARAMS), not a silently
+    /// ignored no-op, so a worker's typo cannot masquerade as an applied filter.
+    #[test]
+    #[serial_test::serial]
+    fn sessions_list_rejects_bad_exclude() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state =
+            HostApiState::open(&tmp.path().join("plugin_events.db"), "default", 100).unwrap();
+        let a = ctx(&[CAP_SESSION_READ]);
+
+        for bad in [
+            json!({ "exclude": "trashed" }),
+            json!({ "exclude": ["deleted"] }),
+            json!({ "exclude": [1] }),
+        ] {
+            let err = dispatch(&state, &a, "sessions.list", &bad).unwrap_err();
+            assert_eq!(err.code, codes::INVALID_PARAMS);
+        }
     }
 
     /// `config.get` reads the calling plugin's own persisted settings, gated by

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -23,10 +23,20 @@ use aoe_plugin_api::UiSlot;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// Most entries one plugin may hold at once across all slots. A cooperative
-/// bound (the model is honest, not adversarial), enough to keep a buggy plugin
-/// from growing host memory without limit.
-const MAX_ENTRIES_PER_PLUGIN: usize = 256;
+/// Most entries one plugin may hold in a single revision scope (one session id,
+/// or "" for global slots). Sized well above any real per-session slot count so
+/// one session's panes are never starved by another session's entries. The old
+/// flat per-plugin cap did exactly that: once a plugin touched enough sessions,
+/// early-created entries filled the bucket and later sessions' new keys were
+/// rejected forever.
+const MAX_ENTRIES_PER_SCOPE: usize = 32;
+/// Absolute backstop across all of one plugin's scopes. `session_id` is not
+/// validated against real sessions in `ui.state.set`, so without a global cap a
+/// buggy plugin could fabricate unbounded session ids and stay under the
+/// per-scope cap forever. A cooperative bound (the model is honest, not
+/// adversarial), sized to keep worst-case pane-payload memory bounded (1024
+/// entries against the 64 KiB pane ceiling is roughly 64 MiB per plugin).
+const MAX_ENTRIES_PER_PLUGIN: usize = 1024;
 /// Largest normalized payload accepted for one entry, in bytes of JSON. The
 /// pane slot gets a much larger budget than the small badge/column slots: a
 /// pane can carry a full PR comment list, where a badge is a few words.
@@ -230,7 +240,9 @@ pub enum UiError {
     /// newer worker replaced it). The write is dropped rather than resurrecting
     /// stale state.
     StaleWorker,
-    /// The plugin already holds `MAX_ENTRIES_PER_PLUGIN` entries.
+    /// Adding this key would exceed either the per-scope cap
+    /// (`MAX_ENTRIES_PER_SCOPE`) or the per-plugin backstop
+    /// (`MAX_ENTRIES_PER_PLUGIN`). Updating an existing key is never blocked.
     QuotaExceeded,
     /// The payload did not match the slot's typed shape, or a scope rule
     /// (per-session slot needs a `session_id`; a global slot must not have one).
@@ -307,7 +319,11 @@ struct Inner {
     /// entry change to that scope. `scope` is the entry's session id, or `""`
     /// for a global slot. Daemon-local: it resets when the daemon restarts, so
     /// the client treats any change off its baseline (including a reset to a
-    /// lower value) as "state moved".
+    /// lower value) as "state moved". Not covered by the entry quota: a scope's
+    /// counter is retained after its entries are removed (the client must still
+    /// observe the bump that cleared them), so a plugin that churns many
+    /// fabricated session ids leaves revision keys behind. Acceptable under the
+    /// cooperative model; bounded revision retention is a separate follow-up.
     revisions: HashMap<(String, String), u64>,
 }
 
@@ -418,15 +434,22 @@ impl UiStore {
         if inner.active.get(plugin_id) != Some(&generation) {
             return Err(UiError::StaleWorker);
         }
-        if !inner.entries.contains_key(&key)
-            && inner
-                .entries
-                .keys()
-                .filter(|k| k.plugin_id == plugin_id)
-                .count()
-                >= MAX_ENTRIES_PER_PLUGIN
-        {
-            return Err(UiError::QuotaExceeded);
+        if !inner.entries.contains_key(&key) {
+            let scope = scope_of(session_id);
+            let mut plugin_entries = 0usize;
+            let mut scope_entries = 0usize;
+            for existing in inner.entries.keys().filter(|k| k.plugin_id == plugin_id) {
+                plugin_entries += 1;
+                if scope_of(existing.session_id.as_deref()) == scope {
+                    scope_entries += 1;
+                }
+            }
+            // Per-scope cap stops one session (or the global scope) from starving
+            // the others; the per-plugin backstop still bounds total memory when
+            // session ids are fabricated.
+            if scope_entries >= MAX_ENTRIES_PER_SCOPE || plugin_entries >= MAX_ENTRIES_PER_PLUGIN {
+                return Err(UiError::QuotaExceeded);
+            }
         }
         inner.entries.insert(key, normalized);
         inner.bump_revision(plugin_id, scope_of(session_id));
@@ -970,17 +993,69 @@ mod tests {
     }
 
     #[test]
-    fn per_plugin_quota_enforced() {
+    fn per_scope_quota_blocks_only_that_scope() {
         let s = store();
         let g = s.begin_generation("acme.kit");
+        // Fill session s1's scope to the per-scope cap.
+        for i in 0..MAX_ENTRIES_PER_SCOPE {
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                &format!("b{i}"),
+                Some("s1"),
+                &json!({"text": "x"}),
+            )
+            .unwrap();
+        }
+        // A new key in s1 is now rejected.
+        assert_eq!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                "overflow",
+                Some("s1"),
+                &json!({"text": "x"})
+            ),
+            Err(UiError::QuotaExceeded)
+        );
+        // A different session's scope still has room: no cross-session starving.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::RowBadge,
+            "b0",
+            Some("s2"),
+            &json!({"text": "x"}),
+        )
+        .unwrap();
+        // Updating an existing key in the full scope is never blocked.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::RowBadge,
+            "b0",
+            Some("s1"),
+            &json!({"text": "y"}),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn per_plugin_backstop_bounds_fabricated_scopes() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // One entry per distinct session scope, so the per-scope cap never trips;
+        // only the global backstop can stop this.
         for i in 0..MAX_ENTRIES_PER_PLUGIN {
             s.set(
                 "acme.kit",
                 g,
-                UiSlot::Card,
-                &format!("c{i}"),
-                None,
-                &json!({"title": "x"}),
+                UiSlot::RowBadge,
+                "b",
+                Some(&format!("s{i}")),
+                &json!({"text": "x"}),
             )
             .unwrap();
         }
@@ -988,21 +1063,40 @@ mod tests {
             s.set(
                 "acme.kit",
                 g,
-                UiSlot::Card,
-                "overflow",
-                None,
-                &json!({"title": "x"})
+                UiSlot::RowBadge,
+                "b",
+                Some("overflow"),
+                &json!({"text": "x"})
             ),
             Err(UiError::QuotaExceeded)
         );
-        // Updating an existing entry is not blocked by the quota.
+    }
+
+    #[test]
+    fn removing_entry_frees_scope_capacity() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        for i in 0..MAX_ENTRIES_PER_SCOPE {
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::RowBadge,
+                &format!("b{i}"),
+                Some("s1"),
+                &json!({"text": "x"}),
+            )
+            .unwrap();
+        }
+        s.remove("acme.kit", g, UiSlot::RowBadge, "b0", Some("s1"))
+            .unwrap();
+        // The freed slot lets a new key in.
         s.set(
             "acme.kit",
             g,
-            UiSlot::Card,
-            "c0",
-            None,
-            &json!({"title": "y"}),
+            UiSlot::RowBadge,
+            "replacement",
+            Some("s1"),
+            &json!({"text": "x"}),
         )
         .unwrap();
     }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Per-session plugin panes (for example the GitHub plugin's right-dock pane) silently vanish for most sessions once a user accumulates many trashed sessions. Root cause: the `sessions.list` host RPC returns every session including trashed ones, so a worker enumerates all of them and pushes per-session UI state (badge, column, pane) for each. That exhausts the plugin's UI-state entry quota, and because the quota only blocks new keys, a never-created pane key stays rejected forever while already-created keys keep updating. The pane is dropped with no user-facing error.

This PR fixes the host side of that in two parts:

1. `sessions.list` gains an optional `exclude` param, an array of state names from `archived`, `snoozed`, and `trashed`. A missing or empty `exclude` returns everything, so existing workers are unaffected; an unknown or non-string entry is `INVALID_PARAMS` rather than a silently ignored filter. A worker can now drop trashed sessions server-side instead of enumerating them. The response shape is unchanged (no new field); the existing `archived` / `snoozed` flags stay.

2. The flat per-plugin UI-state cap (`MAX_ENTRIES_PER_PLUGIN = 256`, which counted every slot in one bucket) is replaced with a per-`(plugin, scope)` cap (`MAX_ENTRIES_PER_SCOPE = 32`, scope being the session id or `""` for global slots) plus a per-plugin backstop (`MAX_ENTRIES_PER_PLUGIN = 1024`). One session can no longer starve another's panes; the backstop still bounds memory when a plugin fabricates session ids (which `ui.state.set` does not validate). Updates to existing keys are never blocked.

The companion worker change lands separately in `agent-of-empires/plugin-github` (it will pass `exclude: ["trashed", ...]`); this PR is the enabling host side. Design was reviewed via a two-model debate (filter shape and quota constants).

Covered by new Rust unit tests in `src/plugin/host_api.rs` (exclude filtering, partial exclude, bad-value rejection) and `src/plugin/ui_state.rs` (per-scope cap, per-plugin backstop, remove-frees-capacity). The `revisions` map is documented as intentionally outside the entry quota (bounded revision retention is a separate follow-up).

Closes #2693

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] A plugin worker calling `sessions.list` with `{ "exclude": ["trashed"] }` no longer receives trashed sessions, and passing an unknown value like `["deleted"]` returns an INVALID_PARAMS error (exercised by `cargo test --features serve --lib sessions_list_exclude_filters_server_side` and `sessions_list_rejects_bad_exclude`).
- [ ] A plugin that fills one session's per-scope UI-state quota can still publish entries for other sessions, and updates to existing keys are never blocked (exercised by `per_scope_quota_blocks_only_that_scope`).
- [ ] End to end, after the companion `plugin-github` worker update ships: with a workspace holding many trashed sessions plus a handful of active ones, every active session with an open PR shows its GitHub pane, not just the first session.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (host-side plugin RPC and quota only; the rendering path is unchanged)
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (covered instead by Rust unit tests on the plugin host RPC and UI-state store)
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:** Investigation, the design debate, and the implementation were driven by Claude under my direction. I made the design calls (drop the standalone trashed flag in favor of a general `exclude` filter, per-scope quota plus backstop, defer revision-map pruning), reviewed each commit, and ran the tests.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated session listing so plugins can filter out archived, snoozed, and trashed sessions server-side, with invalid filter values now rejected instead of ignored. This helps prevent plugins from wasting quota on sessions they don’t need.

Reworked UI-state quota handling to be more balanced: limits are now enforced per plugin and per session/global scope, with a higher overall plugin cap as a backstop. This lets active sessions keep receiving new pane entries even when many other sessions exist, while still protecting memory use.

Added documentation and tests covering session filtering, invalid parameter handling, per-scope quota limits, and recovery after entries are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->