### PR TITLE
fix(session): activity age resets to <1m on TUI/daemon reload

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3000,14 +3000,9 @@ fn decide_passive_transition(
     inst: &Instance,
     old_status: Status,
     unread_enabled: bool,
-    now: chrono::DateTime<chrono::Utc>,
 ) -> PassiveTransitionDecision {
-    let patch = (!inst.is_structured()).then(|| crate::session::PassiveStatusPatch {
-        id: inst.id.clone(),
-        status: inst.status,
-        idle_entered_at: inst.idle_entered_at,
-        last_accessed_at: inst.last_accessed_at.unwrap_or(now),
-    });
+    let patch =
+        (!inst.is_structured()).then(|| crate::session::PassiveStatusPatch::from_instance(inst));
     let mark_unread = unread_enabled
         && old_status == Status::Running
         && inst.status == Status::Idle
@@ -3125,7 +3120,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     new: inst.status,
                     at: now,
                 });
-                let decision = decide_passive_transition(inst, *old, unread_enabled, now);
+                let decision = decide_passive_transition(inst, *old, unread_enabled);
                 if let Some(patch) = decision.patch {
                     patches_by_profile
                         .entry(inst.source_profile.clone())
@@ -4430,8 +4425,7 @@ mod tests {
         inst.view = crate::session::View::Structured;
         inst.status = Status::Idle;
 
-        let decision =
-            decide_passive_transition(&inst, Status::Starting, false, chrono::Utc::now());
+        let decision = decide_passive_transition(&inst, Status::Starting, false);
 
         assert!(
             decision.patch.is_none(),
@@ -4446,12 +4440,30 @@ mod tests {
         inst.idle_entered_at = Some(chrono::Utc::now());
         inst.last_accessed_at = Some(chrono::Utc::now());
 
-        let decision = decide_passive_transition(&inst, Status::Running, false, chrono::Utc::now());
+        let decision = decide_passive_transition(&inst, Status::Running, false);
 
         let patch = decision.patch.expect("plain tmux session must get a patch");
         assert_eq!(patch.id, inst.id);
         assert_eq!(patch.status, Status::Idle);
         assert_eq!(patch.idle_entered_at, inst.idle_entered_at);
+        assert_eq!(patch.last_accessed_at, inst.last_accessed_at);
+    }
+
+    #[test]
+    fn decide_passive_transition_never_fabricates_last_accessed_at() {
+        // A session that transitions status before any user touch has
+        // last_accessed_at == None on disk; the patch must preserve that,
+        // not fabricate a stamp, or a brand-new session gains a spurious
+        // "touched" signal that idle-reap and the freshness sort rely on
+        // being absent.
+        let mut inst = Instance::new("tmux-session", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.last_accessed_at = None;
+
+        let decision = decide_passive_transition(&inst, Status::Running, false);
+
+        let patch = decision.patch.expect("plain tmux session must get a patch");
+        assert_eq!(patch.last_accessed_at, None);
     }
 
     #[test]
@@ -4459,17 +4471,17 @@ mod tests {
         let mut inst = Instance::new("tmux-session", "/tmp/test");
         inst.status = Status::Idle;
 
-        let decision = decide_passive_transition(&inst, Status::Running, true, chrono::Utc::now());
+        let decision = decide_passive_transition(&inst, Status::Running, true);
         assert!(decision.mark_unread);
 
-        let decision = decide_passive_transition(&inst, Status::Waiting, true, chrono::Utc::now());
+        let decision = decide_passive_transition(&inst, Status::Waiting, true);
         assert!(
             !decision.mark_unread,
             "only a Running -> Idle transition marks unread"
         );
 
         inst.unread = true;
-        let decision = decide_passive_transition(&inst, Status::Running, true, chrono::Utc::now());
+        let decision = decide_passive_transition(&inst, Status::Running, true);
         assert!(
             !decision.mark_unread,
             "already-unread sessions must not re-mark"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2982,6 +2982,39 @@ fn decrement_reported_count(counter: &std::sync::atomic::AtomicU32, reported: u3
     });
 }
 
+/// What to do with one instance's status_poll_loop diff, once a genuine
+/// `old != inst.status` transition (against the tick's `prev` snapshot) has
+/// already been established by the caller.
+struct PassiveTransitionDecision {
+    /// `None` for structured (ACP) sessions: their `status` isn't
+    /// poller-authoritative (see the `is_structured()` guard in
+    /// `update_status_with_metadata_inner`, and `apply_acp_overlay_inplace`,
+    /// which is the sole authority for their status/timestamps). Persisting
+    /// a patch here would write a bogus tmux-derived status to disk for a
+    /// session the poller never actually controls. Regression: #2697.
+    patch: Option<crate::session::PassiveStatusPatch>,
+    mark_unread: bool,
+}
+
+fn decide_passive_transition(
+    inst: &Instance,
+    old_status: Status,
+    unread_enabled: bool,
+    now: chrono::DateTime<chrono::Utc>,
+) -> PassiveTransitionDecision {
+    let patch = (!inst.is_structured()).then(|| crate::session::PassiveStatusPatch {
+        id: inst.id.clone(),
+        status: inst.status,
+        idle_entered_at: inst.idle_entered_at,
+        last_accessed_at: inst.last_accessed_at.unwrap_or(now),
+    });
+    let mark_unread = unread_enabled
+        && old_status == Status::Running
+        && inst.status == Status::Idle
+        && !inst.unread;
+    PassiveTransitionDecision { patch, mark_unread }
+}
+
 /// Background task that periodically refreshes session statuses. On each
 /// tick, diffs pre- and post-refresh statuses and emits a `StatusChange`
 /// on `state.status_tx` for every transition. Keeping the diff here,
@@ -3092,20 +3125,14 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     new: inst.status,
                     at: now,
                 });
-                patches_by_profile
-                    .entry(inst.source_profile.clone())
-                    .or_default()
-                    .push(crate::session::PassiveStatusPatch {
-                        id: inst.id.clone(),
-                        status: inst.status,
-                        idle_entered_at: inst.idle_entered_at,
-                        last_accessed_at: inst.last_accessed_at.unwrap_or(now),
-                    });
-                if unread_enabled
-                    && *old == Status::Running
-                    && inst.status == Status::Idle
-                    && !inst.unread
-                {
+                let decision = decide_passive_transition(inst, *old, unread_enabled, now);
+                if let Some(patch) = decision.patch {
+                    patches_by_profile
+                        .entry(inst.source_profile.clone())
+                        .or_default()
+                        .push(patch);
+                }
+                if decision.mark_unread {
                     inst.mark_unread();
                     newly_idle_by_profile
                         .entry(inst.source_profile.clone())
@@ -4392,6 +4419,62 @@ pub mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decide_passive_transition_skips_patch_for_structured_session() {
+        // #2697: a status_poll_loop CI regression. Structured/ACP sessions
+        // have no tmux pane for the poller to probe; their `status` is not
+        // poller-authoritative (the ACP overlay is), so a disk/detected
+        // mismatch must not be persisted as a passive status patch.
+        let mut inst = Instance::new("acp-session", "/tmp/test");
+        inst.view = crate::session::View::Structured;
+        inst.status = Status::Idle;
+
+        let decision =
+            decide_passive_transition(&inst, Status::Starting, false, chrono::Utc::now());
+
+        assert!(
+            decision.patch.is_none(),
+            "structured sessions must never get a passive status patch"
+        );
+    }
+
+    #[test]
+    fn decide_passive_transition_patches_plain_tmux_session() {
+        let mut inst = Instance::new("tmux-session", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.idle_entered_at = Some(chrono::Utc::now());
+        inst.last_accessed_at = Some(chrono::Utc::now());
+
+        let decision = decide_passive_transition(&inst, Status::Running, false, chrono::Utc::now());
+
+        let patch = decision.patch.expect("plain tmux session must get a patch");
+        assert_eq!(patch.id, inst.id);
+        assert_eq!(patch.status, Status::Idle);
+        assert_eq!(patch.idle_entered_at, inst.idle_entered_at);
+    }
+
+    #[test]
+    fn decide_passive_transition_marks_unread_only_on_running_to_idle() {
+        let mut inst = Instance::new("tmux-session", "/tmp/test");
+        inst.status = Status::Idle;
+
+        let decision = decide_passive_transition(&inst, Status::Running, true, chrono::Utc::now());
+        assert!(decision.mark_unread);
+
+        let decision = decide_passive_transition(&inst, Status::Waiting, true, chrono::Utc::now());
+        assert!(
+            !decision.mark_unread,
+            "only a Running -> Idle transition marks unread"
+        );
+
+        inst.unread = true;
+        let decision = decide_passive_transition(&inst, Status::Running, true, chrono::Utc::now());
+        assert!(
+            !decision.mark_unread,
+            "already-unread sessions must not re-mark"
+        );
+    }
 
     #[test]
     fn extract_web_build_id_finds_entry_bundle() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3027,6 +3027,15 @@ async fn status_poll_loop(state: Arc<AppState>) {
         let suppressed_ids =
             crate::session::recovery::snapshot_recently_restarted(&state.recently_restarted);
         let file_watch_for_poll = state.file_watch.clone();
+        // Seed each freshly-disk-loaded instance's live status baseline from
+        // `prev` (the true previous-tick live status) rather than letting
+        // `update_status_with_metadata` fall back to comparing against its
+        // own possibly-stale disk-loaded `status`. Without this, every tick
+        // that finds disk out of sync with live reality (the common case,
+        // since nothing persists a passive transition until the patch below
+        // lands) misreads that mismatch as a brand new transition and
+        // restamps idle_entered_at/last_accessed_at. See #2690.
+        let prev_for_poll = prev.clone();
         let updated = tokio::task::spawn_blocking(move || {
             let mut instances = load_all_instances(&file_watch_for_poll).unwrap_or_default();
             crate::tmux::refresh_session_cache();
@@ -3036,6 +3045,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                     inst.status = Status::Starting;
                     continue;
                 }
+                inst.live_status_baseline = prev_for_poll.get(&inst.id).copied();
                 let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
                 let metadata = pane_metadata.get(&session_name);
                 inst.update_status_with_metadata(metadata);
@@ -3049,57 +3059,84 @@ async fn status_poll_loop(state: Arc<AppState>) {
             // post-suppression, post-tmux-scrape values, never the acp
             // overlay applied by the helper.
             let now = chrono::Utc::now();
-            for inst in &instances {
-                if let Some(old) = prev.get(&inst.id) {
-                    if *old != inst.status {
-                        let _ = state.status_tx.send(StatusChange {
-                            instance_id: inst.id.clone(),
-                            instance_title: inst.title.clone(),
-                            old: *old,
-                            new: inst.status,
-                            at: now,
-                        });
-                    }
-                }
-            }
-
+            let unread_enabled = crate::session::unread_enabled();
+            // Passive status transitions observed this tick, persisted
+            // promptly so the next reload (including the next tick, since
+            // this loop reloads from disk every cycle) finds disk already
+            // in sync with live reality instead of restamping again. See
+            // #2690. Batched per profile: one `Storage::update` per profile
+            // per tick, not one per transitioned session.
+            let mut patches_by_profile: std::collections::HashMap<
+                String,
+                Vec<crate::session::PassiveStatusPatch>,
+            > = std::collections::HashMap::new();
             // Auto-mark unread on a finished turn (Running -> Idle), the same
             // transition the TUI marks on. This is what lets a web-only user
             // (no TUI process polling) accrue the indicator. There's no
             // server-side "is being viewed" exemption: the client suppresses
             // the chip on the session it is actively viewing and clears the
-            // auto marker on open. Mutate the in-memory rows we're about to
-            // install AND persist per profile so the next disk reload keeps it.
-            if crate::session::unread_enabled() {
-                let mut newly_idle: std::collections::HashMap<String, Vec<String>> =
-                    std::collections::HashMap::new();
-                for inst in &mut instances {
-                    let finished_turn = prev.get(&inst.id) == Some(&Status::Running)
-                        && inst.status == Status::Idle
-                        && !inst.unread;
-                    if finished_turn {
-                        inst.mark_unread();
-                        newly_idle
-                            .entry(inst.source_profile.clone())
-                            .or_default()
-                            .push(inst.id.clone());
-                    }
+            // auto marker on open.
+            let mut newly_idle_by_profile: std::collections::HashMap<String, Vec<String>> =
+                std::collections::HashMap::new();
+            for inst in &mut instances {
+                let Some(old) = prev.get(&inst.id) else {
+                    continue;
+                };
+                if *old == inst.status {
+                    continue;
                 }
-                for (profile, ids) in newly_idle {
-                    let _ = api::persist_session_update(
-                        profile,
-                        "auto-unread",
-                        state.file_watch.clone(),
-                        move |insts| {
-                            for inst in insts.iter_mut() {
-                                if ids.contains(&inst.id) {
-                                    inst.mark_unread();
-                                }
+                let _ = state.status_tx.send(StatusChange {
+                    instance_id: inst.id.clone(),
+                    instance_title: inst.title.clone(),
+                    old: *old,
+                    new: inst.status,
+                    at: now,
+                });
+                patches_by_profile
+                    .entry(inst.source_profile.clone())
+                    .or_default()
+                    .push(crate::session::PassiveStatusPatch {
+                        id: inst.id.clone(),
+                        status: inst.status,
+                        idle_entered_at: inst.idle_entered_at,
+                        last_accessed_at: inst.last_accessed_at.unwrap_or(now),
+                    });
+                if unread_enabled
+                    && *old == Status::Running
+                    && inst.status == Status::Idle
+                    && !inst.unread
+                {
+                    inst.mark_unread();
+                    newly_idle_by_profile
+                        .entry(inst.source_profile.clone())
+                        .or_default()
+                        .push(inst.id.clone());
+                }
+            }
+            let profiles: std::collections::HashSet<String> = patches_by_profile
+                .keys()
+                .chain(newly_idle_by_profile.keys())
+                .cloned()
+                .collect();
+            for profile in profiles {
+                let patches = patches_by_profile.remove(&profile).unwrap_or_default();
+                let unread_ids = newly_idle_by_profile.remove(&profile).unwrap_or_default();
+                let _ = api::persist_session_update(
+                    profile,
+                    "passive-status",
+                    state.file_watch.clone(),
+                    move |insts| {
+                        for inst in insts.iter_mut() {
+                            if let Some(patch) = patches.iter().find(|p| p.id == inst.id) {
+                                inst.merge_passive_status_patch(patch);
                             }
-                        },
-                    )
-                    .await;
-                }
+                            if unread_ids.contains(&inst.id) {
+                                inst.mark_unread();
+                            }
+                        }
+                    },
+                )
+                .await;
             }
 
             reload_state_instances_from_disk(&state, instances, StatusSource::TmuxApplied).await;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1020,13 +1020,36 @@ fn publish_session_to_tmux_env(tmux_session_name: &str, instance_id: &str, sessi
 /// Produced by the TUI's and daemon's background pollers when a genuine
 /// live status change is observed (see [`Instance::update_status_with_metadata`]
 /// and its `live_status_baseline` field), consumed by
-/// [`Instance::merge_passive_status_patch`].
+/// [`Instance::merge_passive_status_patch`]. `pub(crate)`: this is an
+/// internal wire format between the pollers and `merge_passive_status_patch`,
+/// not a stable type for out-of-tree consumers.
 #[derive(Debug, Clone)]
-pub struct PassiveStatusPatch {
+pub(crate) struct PassiveStatusPatch {
     pub id: String,
     pub status: Status,
     pub idle_entered_at: Option<DateTime<Utc>>,
-    pub last_accessed_at: DateTime<Utc>,
+    /// `None` when the source `Instance` was never touched by a user
+    /// (`last_accessed_at` itself `None`); must stay `None` in that case
+    /// rather than fabricating a stamp, or a session that transitions
+    /// status before anyone ever attaches would gain a spurious
+    /// `last_accessed_at` and break the "`None` = never touched" contract
+    /// idle-reap and the freshness sort rely on.
+    pub last_accessed_at: Option<DateTime<Utc>>,
+}
+
+impl PassiveStatusPatch {
+    /// Build a patch from the current state of `inst`, as observed by a
+    /// background poller. Single construction site for both the TUI and
+    /// daemon pollers, so the `last_accessed_at` None-preservation policy
+    /// lives in one place.
+    pub(crate) fn from_instance(inst: &Instance) -> Self {
+        Self {
+            id: inst.id.clone(),
+            status: inst.status,
+            idle_entered_at: inst.idle_entered_at,
+            last_accessed_at: inst.last_accessed_at,
+        }
+    }
 }
 
 impl Instance {
@@ -1337,28 +1360,38 @@ impl Instance {
         self.idle_entered_at = src.idle_entered_at;
     }
 
-    /// Apply a passively-detected status transition to a disk row. Narrower
-    /// than [`Self::merge_from_tui`]: touches only `status`,
-    /// `idle_entered_at`, `last_accessed_at`, never group/archive/favorite/
-    /// title/etc, so it is safe to call from the background poller (TUI or
-    /// daemon) without racing an explicit user action on the same instance.
+    /// Apply a passively-detected status transition to a disk row. Touches
+    /// the same three fields as [`Self::merge_from_tui`] (`status`,
+    /// `idle_entered_at`, `last_accessed_at`); the real distinction is the
+    /// API shape (a minimal [`PassiveStatusPatch`] rather than a full
+    /// `Self`) and the merge policy on `last_accessed_at`: `merge_from_tui`
+    /// takes the monotone max, this drops the incoming `last_accessed_at`
+    /// outright when disk already has a strictly newer one, so a
+    /// poller-produced patch loses to a newer explicit user touch instead of
+    /// racing it.
     ///
-    /// `last_accessed_at` guards against a delayed passive write regressing
-    /// a newer explicit action: if disk already has a strictly newer
-    /// `last_accessed_at` than the patch, the patch is dropped. `status`/
-    /// `idle_entered_at` always apply otherwise, since the poller is the
-    /// sole authority on detected agent status. See #2690.
-    pub fn merge_passive_status_patch(&mut self, patch: &PassiveStatusPatch) {
-        if self
-            .last_accessed_at
-            .zip(Some(patch.last_accessed_at))
-            .is_some_and(|(disk, incoming)| disk > incoming)
-        {
-            return;
-        }
+    /// `status`/`idle_entered_at` always apply regardless: the poller is the
+    /// sole authority on detected agent status, and gating them on the
+    /// `last_accessed_at` comparison would let an unrelated peer touch
+    /// strand a real status transition on disk until the next one. See
+    /// #2690, #2697.
+    pub(crate) fn merge_passive_status_patch(&mut self, patch: &PassiveStatusPatch) {
         self.status = patch.status;
         self.idle_entered_at = patch.idle_entered_at;
-        self.last_accessed_at = Some(patch.last_accessed_at);
+        let Some(incoming) = patch.last_accessed_at else {
+            return;
+        };
+        if self.last_accessed_at.is_some_and(|disk| disk > incoming) {
+            tracing::debug!(
+                target: "session.store",
+                session_id = %patch.id,
+                disk_ts = ?self.last_accessed_at,
+                patch_ts = ?patch.last_accessed_at,
+                "dropped stale passive status patch's last_accessed_at (status/idle_entered_at still applied)"
+            );
+            return;
+        }
+        self.last_accessed_at = Some(incoming);
     }
 
     /// Per-field-conditional splice: copy `post.X` onto `self.X` only when
@@ -5550,26 +5583,67 @@ mod tests {
         disk.status = Status::Running;
         disk.idle_entered_at = None;
         disk.last_accessed_at = Some(Utc::now() - chrono::Duration::hours(1));
+        disk.title = "peer-title".to_string();
+        disk.group_path = "peer/group".to_string();
+        disk.unread = true;
+        disk.archived_at = Some(Utc::now());
+        disk.favorited_at = None;
+        disk.pinned_at = Some(Utc::now());
+        let before = disk.clone();
 
         let now = Utc::now();
         let patch = PassiveStatusPatch {
             id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: Some(now),
-            last_accessed_at: now,
+            last_accessed_at: Some(now),
         };
         disk.merge_passive_status_patch(&patch);
 
         assert_eq!(disk.status, Status::Idle);
         assert_eq!(disk.idle_entered_at, Some(now));
         assert_eq!(disk.last_accessed_at, Some(now));
+        // Narrow splice: nothing else moves.
+        assert_eq!(disk.title, before.title);
+        assert_eq!(disk.group_path, before.group_path);
+        assert_eq!(disk.unread, before.unread);
+        assert_eq!(disk.archived_at, before.archived_at);
+        assert_eq!(disk.favorited_at, before.favorited_at);
+        assert_eq!(disk.pinned_at, before.pinned_at);
     }
 
     #[test]
-    fn test_merge_passive_status_patch_drops_stale_patch() {
-        // A peer (CLI, TUI apply_user_action) touched this row more
-        // recently than the passive patch's snapshot: the patch is stale
-        // and must not regress the newer write.
+    fn test_merge_passive_status_patch_never_fabricates_last_accessed_at() {
+        // The source Instance was never touched by a user (last_accessed_at
+        // itself None); the patch must preserve that rather than fabricate
+        // a stamp, or a session that transitions status before anyone
+        // attaches gains a spurious "touched" signal.
+        let mut disk = Instance::new("session", "/tmp/test");
+        disk.status = Status::Starting;
+        disk.last_accessed_at = None;
+
+        let patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: Some(Utc::now()),
+            last_accessed_at: None,
+        };
+        disk.merge_passive_status_patch(&patch);
+
+        assert_eq!(disk.status, Status::Idle, "status must still apply");
+        assert_eq!(
+            disk.last_accessed_at, None,
+            "must not fabricate a last_accessed_at the source never had"
+        );
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_status_and_idle_entered_at_apply_even_when_last_accessed_at_is_stale(
+    ) {
+        // A peer (CLI, TUI apply_user_action) touched last_accessed_at more
+        // recently than the passive patch's snapshot: only last_accessed_at
+        // is guarded. status/idle_entered_at still apply, or a real status
+        // transition would silently strand on disk until the next one.
         let mut disk = Instance::new("session", "/tmp/test");
         let peer_touch = Utc::now();
         disk.status = Status::Running;
@@ -5580,13 +5654,125 @@ mod tests {
             id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: Some(peer_touch - chrono::Duration::minutes(5)),
-            last_accessed_at: peer_touch - chrono::Duration::minutes(5),
+            last_accessed_at: Some(peer_touch - chrono::Duration::minutes(5)),
         };
         disk.merge_passive_status_patch(&stale_patch);
 
-        assert_eq!(disk.status, Status::Running, "stale patch must not apply");
-        assert_eq!(disk.last_accessed_at, Some(peer_touch));
-        assert_eq!(disk.idle_entered_at, None);
+        assert_eq!(
+            disk.status,
+            Status::Idle,
+            "status must apply even when last_accessed_at is stale"
+        );
+        assert_eq!(
+            disk.idle_entered_at,
+            Some(peer_touch - chrono::Duration::minutes(5)),
+            "idle_entered_at must apply even when last_accessed_at is stale"
+        );
+        assert_eq!(
+            disk.last_accessed_at,
+            Some(peer_touch),
+            "only last_accessed_at itself is guarded against the stale patch"
+        );
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_last_accessed_at_boundary_equal_applies() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        let ts = Utc::now();
+        disk.last_accessed_at = Some(ts);
+
+        let patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: None,
+            last_accessed_at: Some(ts),
+        };
+        disk.merge_passive_status_patch(&patch);
+
+        assert_eq!(
+            disk.last_accessed_at,
+            Some(ts),
+            "equal timestamps must apply (guard is strict >, not >=)"
+        );
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_last_accessed_at_boundary_newer_applies() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        let older = Utc::now() - chrono::Duration::minutes(1);
+        disk.last_accessed_at = Some(older);
+
+        let newer = Utc::now();
+        let patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: None,
+            last_accessed_at: Some(newer),
+        };
+        disk.merge_passive_status_patch(&patch);
+
+        assert_eq!(disk.last_accessed_at, Some(newer));
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_last_accessed_at_boundary_disk_none_applies() {
+        // disk.last_accessed_at == None means never touched, not "newer":
+        // `is_some_and` short-circuits to false, so the patch always wins.
+        let mut disk = Instance::new("session", "/tmp/test");
+        disk.last_accessed_at = None;
+
+        let ts = Utc::now();
+        let patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: None,
+            last_accessed_at: Some(ts),
+        };
+        disk.merge_passive_status_patch(&patch);
+
+        assert_eq!(disk.last_accessed_at, Some(ts));
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_twice_identical_is_idempotent() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        let ts = Utc::now();
+        let patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: Some(ts),
+            last_accessed_at: Some(ts),
+        };
+        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&patch);
+
+        assert_eq!(disk.status, Status::Idle);
+        assert_eq!(disk.idle_entered_at, Some(ts));
+        assert_eq!(disk.last_accessed_at, Some(ts));
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_twice_increasing_newer_wins() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        let t0 = Utc::now() - chrono::Duration::minutes(1);
+        let t1 = Utc::now();
+
+        disk.merge_passive_status_patch(&PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Running,
+            idle_entered_at: None,
+            last_accessed_at: Some(t0),
+        });
+        disk.merge_passive_status_patch(&PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: Some(t1),
+            last_accessed_at: Some(t1),
+        });
+
+        assert_eq!(disk.status, Status::Idle);
+        assert_eq!(disk.idle_entered_at, Some(t1));
+        assert_eq!(disk.last_accessed_at, Some(t1));
     }
 
     #[test]
@@ -5666,6 +5852,89 @@ mod tests {
         let last_accessed = inst.last_accessed_at.expect("must be restamped");
         assert!(last_accessed >= before && last_accessed <= after);
         assert_eq!(inst.live_status_baseline, Some(Status::Error));
+    }
+
+    #[test]
+    fn test_update_status_with_metadata_twice_same_status_never_restamps() {
+        // Two consecutive calls that both detect the same status (no real
+        // tmux session, so detection is deterministically Error) must
+        // neither restamp: not the first (baseline already matches), and
+        // not the second either.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.live_status_baseline = Some(Status::Error);
+        inst.status = Status::Error;
+        let sentinel_idle = Some(Utc::now() - chrono::Duration::hours(3));
+        let sentinel_accessed = Some(Utc::now() - chrono::Duration::hours(3));
+        inst.idle_entered_at = sentinel_idle;
+        inst.last_accessed_at = sentinel_accessed;
+
+        inst.update_status_with_metadata(None);
+        assert_eq!(inst.status, Status::Error);
+        assert_eq!(
+            inst.idle_entered_at, sentinel_idle,
+            "first call must not restamp"
+        );
+        assert_eq!(
+            inst.last_accessed_at, sentinel_accessed,
+            "first call must not restamp"
+        );
+
+        inst.update_status_with_metadata(None);
+        assert_eq!(inst.status, Status::Error);
+        assert_eq!(
+            inst.idle_entered_at, sentinel_idle,
+            "second call must not restamp"
+        );
+        assert_eq!(
+            inst.last_accessed_at, sentinel_accessed,
+            "second call must not restamp"
+        );
+    }
+
+    #[test]
+    fn test_update_status_with_metadata_twice_different_statuses_both_restamp() {
+        // Two back-to-back genuine transitions must both restamp, and the
+        // baseline must update between calls so the second comparison is
+        // against the first call's result, not the original value.
+        //
+        // Archiving short-circuits update_status_with_metadata_inner before
+        // it touches `status` (see the `is_archived()` guard), which lets
+        // this test fully control the "detected" status for two
+        // independent calls without a real tmux session.
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
+        inst.live_status_baseline = Some(Status::Idle);
+        inst.status = Status::Running;
+
+        let before1 = Utc::now();
+        inst.update_status_with_metadata(None);
+        let after1 = Utc::now();
+        assert_eq!(
+            inst.status,
+            Status::Running,
+            "archived guard preserves status"
+        );
+        assert_eq!(inst.idle_entered_at, None, "non-idle transition clears it");
+        let first_stamp = inst
+            .last_accessed_at
+            .expect("first transition must restamp");
+        assert!(first_stamp >= before1 && first_stamp <= after1);
+        assert_eq!(inst.live_status_baseline, Some(Status::Running));
+
+        inst.status = Status::Idle;
+        let before2 = Utc::now();
+        inst.update_status_with_metadata(None);
+        let after2 = Utc::now();
+        assert_eq!(inst.status, Status::Idle);
+        let second_idle = inst
+            .idle_entered_at
+            .expect("second transition must restamp");
+        assert!(second_idle >= before2 && second_idle <= after2);
+        assert!(
+            second_idle >= first_stamp,
+            "second restamp must not be older than the first"
+        );
+        assert_eq!(inst.live_status_baseline, Some(Status::Idle));
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5545,6 +5545,51 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_passive_status_patch_applies_status_and_timestamps() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        disk.status = Status::Running;
+        disk.idle_entered_at = None;
+        disk.last_accessed_at = Some(Utc::now() - chrono::Duration::hours(1));
+
+        let now = Utc::now();
+        let patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: Some(now),
+            last_accessed_at: now,
+        };
+        disk.merge_passive_status_patch(&patch);
+
+        assert_eq!(disk.status, Status::Idle);
+        assert_eq!(disk.idle_entered_at, Some(now));
+        assert_eq!(disk.last_accessed_at, Some(now));
+    }
+
+    #[test]
+    fn test_merge_passive_status_patch_drops_stale_patch() {
+        // A peer (CLI, TUI apply_user_action) touched this row more
+        // recently than the passive patch's snapshot: the patch is stale
+        // and must not regress the newer write.
+        let mut disk = Instance::new("session", "/tmp/test");
+        let peer_touch = Utc::now();
+        disk.status = Status::Running;
+        disk.last_accessed_at = Some(peer_touch);
+        disk.idle_entered_at = None;
+
+        let stale_patch = PassiveStatusPatch {
+            id: disk.id.clone(),
+            status: Status::Idle,
+            idle_entered_at: Some(peer_touch - chrono::Duration::minutes(5)),
+            last_accessed_at: peer_touch - chrono::Duration::minutes(5),
+        };
+        disk.merge_passive_status_patch(&stale_patch);
+
+        assert_eq!(disk.status, Status::Running, "stale patch must not apply");
+        assert_eq!(disk.last_accessed_at, Some(peer_touch));
+        assert_eq!(disk.idle_entered_at, None);
+    }
+
+    #[test]
     fn test_merge_from_tui_copies_status_pipeline() {
         let mut stored = Instance::new("session", "/tmp/test");
         stored.status = Status::Idle;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -691,6 +691,17 @@ pub struct Instance {
     pub last_error_check: Option<std::time::Instant>,
     #[serde(skip)]
     pub last_start_time: Option<std::time::Instant>,
+    /// Last status a caller has actually observed live (as opposed to
+    /// whatever `status` happens to hold after a fresh disk load). `None`
+    /// means no live observation has happened yet for this in-memory
+    /// object, so `update_status_with_metadata` must not treat a mismatch
+    /// against a possibly-stale disk-loaded `status` as a real transition.
+    /// See #2690: comparing against disk `status` directly caused every
+    /// restart (TUI relaunch, daemon reload) to misdetect "disk hasn't
+    /// caught up yet" as "just transitioned now", clobbering
+    /// `idle_entered_at`/`last_accessed_at`.
+    #[serde(skip)]
+    pub live_status_baseline: Option<Status>,
     #[serde(skip)]
     pub last_error: Option<String>,
     #[serde(skip)]
@@ -1005,6 +1016,19 @@ fn publish_session_to_tmux_env(tmux_session_name: &str, instance_id: &str, sessi
     }
 }
 
+/// A passively-detected status transition, queued for a batched disk write.
+/// Produced by the TUI's and daemon's background pollers when a genuine
+/// live status change is observed (see [`Instance::update_status_with_metadata`]
+/// and its `live_status_baseline` field), consumed by
+/// [`Instance::merge_passive_status_patch`].
+#[derive(Debug, Clone)]
+pub struct PassiveStatusPatch {
+    pub id: String,
+    pub status: Status,
+    pub idle_entered_at: Option<DateTime<Utc>>,
+    pub last_accessed_at: DateTime<Utc>,
+}
+
 impl Instance {
     pub fn new(title: &str, project_path: &str) -> Self {
         Self {
@@ -1060,6 +1084,12 @@ impl Instance {
             fork_pending: None,
             last_error_check: None,
             last_start_time: None,
+            // A freshly constructed (not deserialized) Instance has a
+            // known-good live status right now: itself. Seeding the
+            // baseline here means the first real transition after
+            // creation restamps normally instead of being swallowed as
+            // a "no live history yet" seed.
+            live_status_baseline: Some(Status::Idle),
             last_error: None,
             session_id_poller: None,
             retroactive_capture_excludes: HashSet::new(),
@@ -1305,6 +1335,30 @@ impl Instance {
         self.status = src.status;
         self.last_accessed_at = self.last_accessed_at.max(src.last_accessed_at);
         self.idle_entered_at = src.idle_entered_at;
+    }
+
+    /// Apply a passively-detected status transition to a disk row. Narrower
+    /// than [`Self::merge_from_tui`]: touches only `status`,
+    /// `idle_entered_at`, `last_accessed_at`, never group/archive/favorite/
+    /// title/etc, so it is safe to call from the background poller (TUI or
+    /// daemon) without racing an explicit user action on the same instance.
+    ///
+    /// `last_accessed_at` guards against a delayed passive write regressing
+    /// a newer explicit action: if disk already has a strictly newer
+    /// `last_accessed_at` than the patch, the patch is dropped. `status`/
+    /// `idle_entered_at` always apply otherwise, since the poller is the
+    /// sole authority on detected agent status. See #2690.
+    pub fn merge_passive_status_patch(&mut self, patch: &PassiveStatusPatch) {
+        if self
+            .last_accessed_at
+            .zip(Some(patch.last_accessed_at))
+            .is_some_and(|(disk, incoming)| disk > incoming)
+        {
+            return;
+        }
+        self.status = patch.status;
+        self.idle_entered_at = patch.idle_entered_at;
+        self.last_accessed_at = Some(patch.last_accessed_at);
     }
 
     /// Per-field-conditional splice: copy `post.X` onto `self.X` only when
@@ -4033,18 +4087,32 @@ impl Instance {
 
     /// Update status using pre-fetched pane metadata to avoid per-instance
     /// subprocess spawns. Falls back to subprocess calls if metadata is missing.
+    ///
+    /// Restamps `idle_entered_at`/`last_accessed_at` only when the detected
+    /// status differs from `live_status_baseline`, the last status this
+    /// in-memory object actually observed live, NOT `self.status` as loaded.
+    /// `self.status` can be a stale disk snapshot right after a fresh load
+    /// (TUI relaunch, or every tick of the daemon's `status_poll_loop`,
+    /// which reloads instances from disk every cycle); comparing against it
+    /// misreads "disk hasn't caught up yet" as "just transitioned now" and
+    /// clobbers the timestamps every time disk and live detection disagree.
+    /// `live_status_baseline == None` means no live observation exists yet,
+    /// so the first check seeds the baseline without restamping. See #2690.
     pub fn update_status_with_metadata(&mut self, metadata: Option<&tmux::PaneMetadata>) {
-        let prev_status = self.status;
+        let baseline = self.live_status_baseline;
         self.update_status_with_metadata_inner(metadata);
-        if self.status != prev_status {
-            let now = Utc::now();
-            self.last_accessed_at = Some(now);
-            self.idle_entered_at = if self.status == Status::Idle {
-                Some(now)
-            } else {
-                None
-            };
+        if let Some(prev_status) = baseline {
+            if self.status != prev_status {
+                let now = Utc::now();
+                self.last_accessed_at = Some(now);
+                self.idle_entered_at = if self.status == Status::Idle {
+                    Some(now)
+                } else {
+                    None
+                };
+            }
         }
+        self.live_status_baseline = Some(self.status);
     }
 
     fn update_status_with_metadata_inner(&mut self, metadata: Option<&tmux::PaneMetadata>) {
@@ -5490,6 +5558,69 @@ mod tests {
 
         assert_eq!(stored.status, Status::Running);
         assert_eq!(stored.idle_entered_at, src.idle_entered_at);
+    }
+
+    #[test]
+    fn test_update_status_with_metadata_seeds_baseline_without_restamp() {
+        // #2690: a session loaded fresh from disk (e.g. TUI relaunch, or
+        // every tick of the daemon's status_poll_loop) has no live
+        // observation history yet: `live_status_baseline` is `None`. The
+        // very first status check must not treat a mismatch between the
+        // disk-loaded `status` and the freshly detected status as a real
+        // transition, or every reload would reset idle_entered_at/
+        // last_accessed_at to `now`. Red on the pre-fix tree (which compares
+        // against `self.status` directly and always restamps here, since no
+        // real tmux session exists for this instance).
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.live_status_baseline = None;
+        inst.status = Status::Starting;
+        let stale_idle_entered_at = Some(Utc::now() - chrono::Duration::hours(2));
+        let stale_last_accessed_at = Some(Utc::now() - chrono::Duration::hours(2));
+        inst.idle_entered_at = stale_idle_entered_at;
+        inst.last_accessed_at = stale_last_accessed_at;
+
+        inst.update_status_with_metadata(None);
+
+        // No real tmux session exists for this instance, so detection
+        // resolves to Error, differing from the stale disk `Starting`. That
+        // mismatch must NOT be treated as a genuine transition.
+        assert_eq!(inst.status, Status::Error);
+        assert_eq!(
+            inst.idle_entered_at, stale_idle_entered_at,
+            "first check after a fresh load must not clobber a stale-but-real idle_entered_at"
+        );
+        assert_eq!(
+            inst.last_accessed_at, stale_last_accessed_at,
+            "first check after a fresh load must not clobber a stale-but-real last_accessed_at"
+        );
+        assert_eq!(
+            inst.live_status_baseline,
+            Some(Status::Error),
+            "the first check must seed the baseline for subsequent comparisons"
+        );
+    }
+
+    #[test]
+    fn test_update_status_with_metadata_restamps_on_genuine_transition() {
+        // Once a live baseline is established, a real status change still
+        // restamps normally (no regression from the #2690 fix).
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.live_status_baseline = Some(Status::Idle);
+        inst.status = Status::Idle;
+        inst.idle_entered_at = Some(Utc::now() - chrono::Duration::hours(2));
+        inst.last_accessed_at = Some(Utc::now() - chrono::Duration::hours(2));
+
+        let before = Utc::now();
+        inst.update_status_with_metadata(None);
+        let after = Utc::now();
+
+        // No real tmux session exists, so detection resolves to Error: a
+        // genuine transition away from the established Idle baseline.
+        assert_eq!(inst.status, Status::Error);
+        assert_eq!(inst.idle_entered_at, None);
+        let last_accessed = inst.last_accessed_at.expect("must be restamped");
+        assert!(last_accessed >= before && last_accessed <= after);
+        assert_eq!(inst.live_status_baseline, Some(Status::Error));
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -58,11 +58,11 @@ pub use groups::{
 };
 #[cfg(feature = "serve")]
 pub(crate) use instance::ResumeAttemptPolicy;
-pub(crate) use instance::{persist_session_to_storage, ResumeIntent, SidWrite};
+pub(crate) use instance::{persist_session_to_storage, PassiveStatusPatch, ResumeIntent, SidWrite};
 pub use instance::{
-    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, PassiveStatusPatch,
-    SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View, WorkspaceInfo,
-    WorkspaceRepo, WorktreeInfo, TMUX_SESSION_GONE_ERROR,
+    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo, SessionBucket,
+    StartOutcome, Status, TerminalInfo, View, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
+    TMUX_SESSION_GONE_ERROR,
 };
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -60,9 +60,9 @@ pub use groups::{
 pub(crate) use instance::ResumeAttemptPolicy;
 pub(crate) use instance::{persist_session_to_storage, ResumeIntent, SidWrite};
 pub use instance::{
-    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo, SessionBucket,
-    StartOutcome, Status, TerminalInfo, View, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
-    TMUX_SESSION_GONE_ERROR,
+    EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, PassiveStatusPatch,
+    SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View, WorkspaceInfo,
+    WorkspaceRepo, WorktreeInfo, TMUX_SESSION_GONE_ERROR,
 };
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/tui/attached_status_hooks.rs
+++ b/src/tui/attached_status_hooks.rs
@@ -146,6 +146,7 @@ fn snapshot(sessions: &[AttachedStatusHookSession]) -> Vec<StatusUpdate> {
             idle_entered_at: session.instance.idle_entered_at,
             last_accessed_at: session.instance.last_accessed_at,
             pane_dead: session.instance.pane_dead_observed,
+            live_status_baseline: session.instance.live_status_baseline,
         })
         .collect()
 }
@@ -181,6 +182,7 @@ mod tests {
                 idle_entered_at: None,
                 last_accessed_at: None,
                 pane_dead: false,
+                live_status_baseline: None,
             }],
             true,
         );

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2722,12 +2722,6 @@ impl HomeView {
 
             if let Some(old) = old_status {
                 if old != new_status {
-                    self.persist_passive_status_transition(&update.id);
-                    if let Some(inst) = self.get_instance(&update.id).cloned() {
-                        self.handle_status_transition(
-                            &inst, old, new_status, play_sound, run_hooks,
-                        );
-                    }
                     // Auto-mark unread when a turn finishes (Running ->
                     // Idle), unless the user is currently viewing this
                     // session in live-send. This runs in both the with-
@@ -2736,22 +2730,34 @@ impl HomeView {
                     // elsewhere still gets marked. The attached session
                     // itself is cleared on attach-return, so a turn that
                     // finishes during an attach nets to read.
-                    if crate::session::unread_enabled()
+                    let is_live_target = self
+                        .live_send
+                        .as_ref()
+                        .is_some_and(|s| s.session_id == update.id);
+                    // Skip when already unread (the mark is a no-op) so a
+                    // re-finishing session doesn't churn the flock once
+                    // per turn.
+                    let already_unread =
+                        self.get_instance(&update.id).is_some_and(|i| i.is_unread());
+                    let should_mark_unread = crate::session::unread_enabled()
                         && old == Status::Running
                         && new_status == Status::Idle
-                    {
-                        let is_live_target = self
-                            .live_send
-                            .as_ref()
-                            .is_some_and(|s| s.session_id == update.id);
-                        // Skip the disk write when already unread (the mark
-                        // is a no-op) so a re-finishing session doesn't churn
-                        // the flock once per turn.
-                        let already_unread =
-                            self.get_instance(&update.id).is_some_and(|i| i.is_unread());
-                        if !is_live_target && !already_unread {
-                            let _ = self.apply_user_action(&update.id, |inst| inst.mark_unread());
-                        }
+                        && !is_live_target
+                        && !already_unread;
+
+                    // One flock for both the status/timestamp patch and the
+                    // unread mark, matching the daemon's per-tick batching
+                    // shape (server/mod.rs's status_poll_loop) instead of
+                    // two separate Storage::update calls on the same row.
+                    self.persist_passive_status_transition(&update.id, should_mark_unread);
+                    if should_mark_unread {
+                        self.mutate_instance(&update.id, |inst| inst.mark_unread());
+                    }
+
+                    if let Some(inst) = self.get_instance(&update.id).cloned() {
+                        self.handle_status_transition(
+                            &inst, old, new_status, play_sound, run_hooks,
+                        );
                     }
                 }
             }
@@ -5231,22 +5237,25 @@ impl HomeView {
     /// roll back the in-memory status update, since the poller is the sole
     /// authority on live status regardless of whether disk persistence
     /// succeeds.
-    pub(super) fn persist_passive_status_transition(&self, id: &str) {
+    ///
+    /// `mark_unread` folds the Running -> Idle unread mark into the same
+    /// `Storage::update` call instead of a second flock round-trip on the
+    /// same row in the same tick, matching the daemon's per-tick batching
+    /// shape in `status_poll_loop`.
+    pub(super) fn persist_passive_status_transition(&self, id: &str, mark_unread: bool) {
         let Some(inst) = self.instance_map.get(id) else {
             return;
         };
         let Some(storage) = self.storages.get(&inst.source_profile) else {
             return;
         };
-        let patch = crate::session::PassiveStatusPatch {
-            id: inst.id.clone(),
-            status: inst.status,
-            idle_entered_at: inst.idle_entered_at,
-            last_accessed_at: inst.last_accessed_at.unwrap_or_else(chrono::Utc::now),
-        };
+        let patch = crate::session::PassiveStatusPatch::from_instance(inst);
         let _ = storage.update(|insts, _groups| {
             if let Some(disk) = insts.iter_mut().find(|i| i.id == patch.id) {
                 disk.merge_passive_status_patch(&patch);
+                if mark_unread {
+                    disk.mark_unread();
+                }
             }
             Ok(())
         });

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2698,6 +2698,7 @@ impl HomeView {
             let new_status = update.status;
             let new_error = update.last_error;
             let new_idle_entered_at = update.idle_entered_at;
+            let new_live_status_baseline = update.live_status_baseline;
             self.mutate_instance(&update.id, |inst| {
                 inst.status = new_status;
                 inst.last_error = new_error;
@@ -2707,6 +2708,14 @@ impl HomeView {
                 inst.idle_entered_at = new_idle_entered_at;
                 if new_last_accessed.is_some() {
                     inst.last_accessed_at = new_last_accessed;
+                }
+                // Conditional, not unconditional like idle_entered_at: a
+                // producer that never establishes a baseline (attached_
+                // status_hooks's snapshot, when its own instance clone
+                // hasn't polled yet) must not clear one this instance
+                // already has. See #2690 CodeRabbit follow-up.
+                if let Some(baseline) = new_live_status_baseline {
+                    inst.live_status_baseline = Some(baseline);
                 }
                 inst.pane_dead_observed = new_pane_dead;
             });

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2713,6 +2713,7 @@ impl HomeView {
 
             if let Some(old) = old_status {
                 if old != new_status {
+                    self.persist_passive_status_transition(&update.id);
                     if let Some(inst) = self.get_instance(&update.id).cloned() {
                         self.handle_status_transition(
                             &inst, old, new_status, play_sound, run_hooks,
@@ -5211,6 +5212,35 @@ impl HomeView {
             self.instance_map.insert(id.to_string(), inst.clone());
         }
         Ok(())
+    }
+
+    /// Persist a passively-detected status transition for one instance so
+    /// the next disk reload (a TUI relaunch, or a peer like `aoe serve`)
+    /// finds disk already caught up instead of comparing against a stale
+    /// snapshot and misreading it as a fresh transition. See #2690. Best
+    /// effort: unlike `apply_user_action`, a write failure here does not
+    /// roll back the in-memory status update, since the poller is the sole
+    /// authority on live status regardless of whether disk persistence
+    /// succeeds.
+    pub(super) fn persist_passive_status_transition(&self, id: &str) {
+        let Some(inst) = self.instance_map.get(id) else {
+            return;
+        };
+        let Some(storage) = self.storages.get(&inst.source_profile) else {
+            return;
+        };
+        let patch = crate::session::PassiveStatusPatch {
+            id: inst.id.clone(),
+            status: inst.status,
+            idle_entered_at: inst.idle_entered_at,
+            last_accessed_at: inst.last_accessed_at.unwrap_or_else(chrono::Utc::now),
+        };
+        let _ = storage.update(|insts, _groups| {
+            if let Some(disk) = insts.iter_mut().find(|i| i.id == patch.id) {
+                disk.merge_passive_status_patch(&patch);
+            }
+            Ok(())
+        });
     }
 
     /// Atomic per-action mutate: in-memory once, disk via

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6113,6 +6113,7 @@ fn apply_status_update_propagates_idle_entered_at_into_live_instance() {
         idle_entered_at: Some(now),
         last_accessed_at: None,
         pane_dead: false,
+        live_status_baseline: None,
     });
 
     let inst = env.view.get_instance(&id).unwrap();
@@ -6123,7 +6124,51 @@ fn apply_status_update_propagates_idle_entered_at_into_live_instance() {
 // #2690: a passively-detected status transition must land on disk
 // immediately, not just in memory, so the next reload (TUI relaunch, or
 // a peer like `aoe serve`) finds disk already caught up instead of
-// misreading a stale snapshot as a fresh transition.
+// CodeRabbit follow-up to #2690: `update_status_with_metadata` compares
+// against `live_status_baseline`, but the background poller only ever
+// mutates a *clone* of the real `Instance` (see `status_poller.rs`). If
+// `StatusUpdate` doesn't carry the clone's freshly-seeded baseline back,
+// the real `Instance` in `self.instances` keeps `live_status_baseline ==
+// None` forever, so every poll looks like "no baseline yet" and no real
+// transition after the first ever restamps again.
+#[test]
+#[serial]
+fn apply_status_update_propagates_live_status_baseline_from_poller() {
+    use crate::tui::status_poller::{poll_statuses_once, StatusPollState};
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    assert_eq!(
+        env.view.get_instance(&id).unwrap().live_status_baseline,
+        None,
+        "freshly loaded instance has no live baseline yet"
+    );
+
+    // Drive a real poll cycle through the same path the background thread
+    // uses: clone -> poll_statuses_once -> project into StatusUpdate ->
+    // apply back onto the real Instance.
+    let mut poll_state = StatusPollState::new();
+    let instances = env.view.pollable_instances();
+    let updates = poll_statuses_once(instances, &mut poll_state);
+    for update in updates {
+        env.view.apply_one_status_update(update);
+    }
+
+    assert!(
+        env.view
+            .get_instance(&id)
+            .unwrap()
+            .live_status_baseline
+            .is_some(),
+        "the polling clone's seeded baseline must survive back into the \
+         real Instance via StatusUpdate, or every future poll re-seeds \
+         instead of restamping real transitions"
+    );
+}
+
 #[test]
 #[serial]
 fn apply_status_update_persists_genuine_transition_to_disk() {
@@ -6145,6 +6190,7 @@ fn apply_status_update_persists_genuine_transition_to_disk() {
         idle_entered_at: None,
         last_accessed_at: Some(now),
         pane_dead: false,
+        live_status_baseline: None,
     });
 
     let reloaded = Storage::new_unwatched("test").unwrap().load().unwrap();
@@ -6178,6 +6224,7 @@ fn apply_status_update_clears_idle_entered_at_on_idle_to_running() {
         idle_entered_at: Some(stop_time),
         last_accessed_at: None,
         pane_dead: false,
+        live_status_baseline: None,
     });
     assert_eq!(
         env.view.get_instance(&id).unwrap().idle_entered_at,
@@ -6195,6 +6242,7 @@ fn apply_status_update_clears_idle_entered_at_on_idle_to_running() {
         idle_entered_at: None,
         last_accessed_at: None,
         pane_dead: false,
+        live_status_baseline: None,
     });
 
     let inst = env.view.get_instance(&id).unwrap();
@@ -6292,6 +6340,7 @@ fn apply_status_update_skips_terminal_states() {
         idle_entered_at: Some(stale_ts),
         last_accessed_at: None,
         pane_dead: false,
+        live_status_baseline: None,
     });
 
     // Status and timestamp should both stay untouched.
@@ -6367,6 +6416,7 @@ fn apply_status_update_runs_status_hook_on_transition() {
         idle_entered_at: None,
         last_accessed_at: None,
         pane_dead: false,
+        live_status_baseline: None,
     });
 
     let launches = take_recorded_launches();
@@ -6432,6 +6482,7 @@ fn apply_status_update_does_not_run_status_hook_for_same_status() {
         idle_entered_at: None,
         last_accessed_at: None,
         pane_dead: false,
+        live_status_baseline: None,
     });
 
     assert!(take_recorded_launches().is_empty());
@@ -6465,6 +6516,7 @@ fn apply_status_updates_without_hooks_does_not_run_status_hook() {
             idle_entered_at: None,
             last_accessed_at: None,
             pane_dead: false,
+            live_status_baseline: None,
         }]);
 
     assert_eq!(env.view.get_instance(&id).unwrap().status, Status::Waiting);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6120,6 +6120,43 @@ fn apply_status_update_propagates_idle_entered_at_into_live_instance() {
     assert_eq!(inst.idle_entered_at, Some(now));
 }
 
+// #2690: a passively-detected status transition must land on disk
+// immediately, not just in memory, so the next reload (TUI relaunch, or
+// a peer like `aoe serve`) finds disk already caught up instead of
+// misreading a stale snapshot as a fresh transition.
+#[test]
+#[serial]
+fn apply_status_update_persists_genuine_transition_to_disk() {
+    use crate::session::{Status, Storage};
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    assert_eq!(env.view.get_instance(&id).unwrap().status, Status::Idle);
+
+    let now = chrono::Utc::now();
+    env.view.apply_one_status_update(StatusUpdate {
+        id: id.clone(),
+        status: Status::Running,
+        last_error: None,
+        idle_entered_at: None,
+        last_accessed_at: Some(now),
+        pane_dead: false,
+    });
+
+    let reloaded = Storage::new_unwatched("test").unwrap().load().unwrap();
+    let row = reloaded.iter().find(|i| i.id == id).expect("row present");
+    assert_eq!(
+        row.status,
+        Status::Running,
+        "the genuine Idle -> Running transition must be persisted, not just in-memory"
+    );
+    assert_eq!(row.last_accessed_at, Some(now));
+}
+
 #[test]
 #[serial]
 fn apply_status_update_clears_idle_entered_at_on_idle_to_running() {

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -58,6 +58,17 @@ pub struct StatusUpdate {
     /// Attention sort can treat dead panes as tier 99 without re-querying
     /// tmux per sort.
     pub pane_dead: bool,
+    /// Snapshot of the polled clone's `live_status_baseline` after
+    /// `update_status_with_metadata` ran. Same reasoning as
+    /// `idle_entered_at`: the wrapper's baseline write lives only on the
+    /// polling clone and would be lost when projected into a `StatusUpdate`,
+    /// which would make the real `Instance` in `self.instances` compare
+    /// against `None` on every poll forever, silently disabling restamping
+    /// for the standalone TUI (#2690 follow-up). `None` from a producer
+    /// that never establishes a baseline (e.g. `attached_status_hooks`'s
+    /// snapshot) must NOT clear an already-established baseline, so the
+    /// consumer applies this conditionally, mirroring `last_accessed_at`.
+    pub live_status_baseline: Option<Status>,
 }
 
 pub(super) struct StatusPollState {
@@ -154,6 +165,7 @@ pub(super) fn poll_statuses_once(
                                 // Sandboxed sessions don't have a tmux pane in the
                                 // usual sense; the Error tier itself sinks the row.
                                 pane_dead: false,
+                                live_status_baseline: Some(Status::Error),
                             });
                         }
                     }
@@ -174,6 +186,7 @@ pub(super) fn poll_statuses_once(
                 idle_entered_at: inst.idle_entered_at,
                 last_accessed_at: inst.last_accessed_at,
                 pane_dead,
+                live_status_baseline: inst.live_status_baseline,
             })
         })
         .collect()
@@ -255,6 +268,7 @@ mod tests {
             idle_entered_at: Some(ts),
             last_accessed_at: None,
             pane_dead: false,
+            live_status_baseline: None,
         };
         assert_eq!(update.idle_entered_at, Some(ts));
     }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The TUI session list's activity-time column reset to `<1m` for every session whenever `aoe` reloaded or the daemon restarted, even for sessions idle for hours. Root cause: `Instance::update_status_with_metadata` restamped `idle_entered_at`/`last_accessed_at` whenever the detected status differed from whatever `status` happened to be loaded from disk. On a TUI relaunch, or on every 2s tick of the daemon's `status_poll_loop` (which reloads every instance fresh from disk by design), that disk value can be stale, since nothing previously persisted a passively-detected transition back to `sessions.json`. A live re-detection reporting the true, unchanged status still looked like a brand-new transition and clobbered both timestamps.

Confirmed with a live repro against a real daemon, tmux pane, and hook status file: with `sessions.json` `status` artificially stuck, `idle_entered_at`/`last_accessed_at` advanced to `now()` on every single 2-second poll tick, indefinitely, until disk caught up.

Fix, in three commits:
1. `Instance` now tracks a `live_status_baseline` separate from the disk-loaded `status`, and only restamps when that baseline (not the freshly loaded value) differs from the newly detected status. The first check after a fresh load seeds the baseline instead of restamping.
2. The daemon's `status_poll_loop` seeds each instance's baseline from its own already-computed previous-tick snapshot, and now persists every genuine transition it observes, batched into one `Storage::update` per profile per tick (combined with the existing auto-unread write).
3. The TUI's `apply_status_update` persists a genuine transition for the affected instance immediately, instead of relying on an unrelated future `save()` to incidentally flush it.

Approach was reviewed via `/debate` (gemini-3.1-pro-preview and gpt-5.5) before implementation; both converged on comparing against a live baseline plus prompt, batched persistence.

Closes #2690

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the bug is a background-poller timing issue (disk/live status desync across a process restart), not reachable through the TUI's black-box e2e harness (tmux keypress + screen assertions). Covered instead with unit tests exercising the exact mechanism directly: `update_status_with_metadata`'s baseline-seed/restamp guard, `merge_passive_status_patch`'s disk splice, and an integration-style TUI test (`apply_status_update_persists_genuine_transition_to_disk`) that drives a real `Storage` round-trip and asserts the transition lands on disk immediately. Full e2e suite (136 tests) still run and green to confirm no regression.

## How to test

- [ ] Create a plain tmux session, let it go idle, confirm the activity column shows a real, growing age (e.g. `5m`, `1h`).
- [ ] Quit and relaunch the TUI: the activity column still shows the real elapsed idle time, not `<1m`.
- [ ] Run `aoe serve`, let a session go idle, restart the daemon (`aoe serve --stop` then `aoe serve`): `GET /api/sessions` and `sessions.json` still show the real `idle_entered_at`, not a value reset to the restart time.
- [ ] With `aoe serve` running, let a session finish a real turn (`Running -> Idle`): confirm `idle_entered_at` stamps to "now" as expected, and `sessions.json` reflects it within the same 2s tick (no need to wait for an unrelated save).
- [ ] Trigger 3+ `Running -> Idle` transitions in the same 2s window (same profile): confirm `sessions.json` shows all of them transitioned within that tick's write, and no `status_poll_loop` warning appears in `debug.log`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill), with `/debate` consulting gemini-3.1-pro-preview and gpt-5.5 on the fix approach.

**Any Additional AI Details you'd like to share:**
Investigation (including a live repro against a real daemon to pin the exact mechanism), plan, `/debate` consultation, and implementation were drafted by Claude under my direction. I reviewed each commit, approved the plan and the debated fix shape, and will run the manual test steps above before marking ready.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change fixes the TUI activity-time reset bug by preserving a session’s real last-activity baseline across reloads and daemon restarts.

What changed:
- Added a live status baseline so restored sessions don’t get mistaken for fresh state changes
- Updated the daemon poll flow to carry that baseline forward on each tick
- Changed passive status updates to be saved back to disk more consistently
- Folded unread-marking into the same persistence step to reduce extra writes
- Expanded tests around reload behavior, passive update merging, and transition handling

Benefits:
- Activity time now stays accurate after reopening the TUI or restarting the daemon
- Idle sessions keep their true timestamps instead of resetting to “<1m”
- Persistence is more reliable and less likely to overwrite real history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->