### PR TITLE
fix(cli): sanitize explicit worktree branches

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -403,7 +403,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         use crate::session::WorktreeInfo;
         use chrono::Utc;
 
-        let branch = branch_raw.trim();
+        let branch_owned = builder::git_sanitize_branch_name(branch_raw);
+        let branch = branch_owned.as_str();
         let init_submodules = config.worktree.init_submodules && !args.no_submodules;
 
         if !all_extra_repos.is_empty() {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -188,7 +188,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         bail!("Path is not a directory: {}", path.display());
     }
 
-    if (!args.extra_repos.is_empty() || !args.projects.is_empty()) && args.worktree_branch.is_none()
+    if (!args.extra_repos.is_empty() || !args.projects.is_empty())
+        && explicit_worktree_branch(&args).is_none()
     {
         bail!("--repo/--project requires --worktree to specify a branch\nTip: aoe add /path --project repoB -w branch-name");
     }
@@ -277,7 +278,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // Fork intent appends. Reject these up front (before any resource creation)
     // rather than launch a fork that can't find its parent. See PR review.
     if args.fork_from.is_some() {
-        if args.worktree_branch.is_some() || args.create_branch {
+        if explicit_worktree_branch(&args).is_some() || args.create_branch {
             bail!(
                 "`--fork-from` cannot be combined with --worktree or --new-branch: a fork must run \
                  in the parent's working directory to resume its conversation."
@@ -398,7 +399,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         None
     };
 
-    if let Some(branch_raw) = &args.worktree_branch {
+    if let Some(branch_raw) = explicit_worktree_branch(&args) {
         use crate::git::GitWorktree;
         use crate::session::WorktreeInfo;
         use chrono::Utc;
@@ -1205,8 +1206,8 @@ fn resolve_session_title(args: &AddArgs, instances: &[Instance]) -> Result<Strin
     if let Some(title) = &args.title {
         return Ok(title.trim().to_string());
     }
-    let default_title = if let Some(ref branch) = args.worktree_branch {
-        branch.trim().to_string()
+    let default_title = if let Some(branch) = explicit_worktree_branch(args) {
+        branch.to_string()
     } else {
         let existing_titles: Vec<&str> = instances.iter().map(|i| i.title.as_str()).collect();
         civilizations::generate_random_title(&existing_titles)
@@ -1216,6 +1217,13 @@ fn resolve_session_title(args: &AddArgs, instances: &[Instance]) -> Result<Strin
     } else {
         Ok(default_title)
     }
+}
+
+fn explicit_worktree_branch(args: &AddArgs) -> Option<&str> {
+    args.worktree_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())
 }
 
 fn prompt_session_title(default_title: &str) -> Result<String> {

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1380,6 +1380,52 @@ fn test_cli_add_attaches_to_existing_worktree() {
 
 #[test]
 #[serial]
+fn test_cli_add_sanitizes_explicit_worktree_branch() {
+    let h = TuiTestHarness::new("cli_branch_sanitize");
+    let project = h.home_path().join("branch-sanitize-project");
+    init_git_repo(&project);
+
+    let add_output = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-w",
+        "Exploration and issues v2",
+        "-b",
+        "-t",
+        "SanitizedBranch",
+    ]);
+    assert!(
+        add_output.status.success(),
+        "aoe add with unsanitized explicit branch should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add_output.stdout),
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let session = sessions
+        .iter()
+        .find(|s| s["title"].as_str() == Some("SanitizedBranch"))
+        .expect("SanitizedBranch session should exist");
+    assert_eq!(
+        session["worktree_info"]["branch"].as_str(),
+        Some("Exploration-and-issues-v2"),
+        "CLI should persist the same sanitized explicit branch name as the TUI/API path"
+    );
+
+    let branch = Command::new("git")
+        .args(["branch", "--list", "Exploration-and-issues-v2"])
+        .current_dir(&project)
+        .output()
+        .expect("git branch --list");
+    assert!(
+        String::from_utf8_lossy(&branch.stdout).contains("Exploration-and-issues-v2"),
+        "sanitized branch should exist in the source repo"
+    );
+}
+
+#[test]
+#[serial]
 fn test_cli_add_scratch_provisions_dir() {
     let h = TuiTestHarness::new("cli_add_scratch");
 

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1426,6 +1426,45 @@ fn test_cli_add_sanitizes_explicit_worktree_branch() {
 
 #[test]
 #[serial]
+fn test_cli_add_blank_worktree_branch_falls_back_to_normal_title() {
+    let h = TuiTestHarness::new("cli_blank_branch_title_fallback");
+    let project = h.home_path().join("blank-branch-title-project");
+    init_git_repo(&project);
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-w", "   ", "-b"]);
+    assert!(
+        add_output.status.success(),
+        "blank explicit worktree branch should fall back instead of creating branch 'session':\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add_output.stdout),
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    assert_eq!(sessions.len(), 1, "expected exactly one session");
+    let session = &sessions[0];
+    assert!(
+        !session["title"].as_str().unwrap_or_default().is_empty(),
+        "blank worktree branch should not become an empty session title"
+    );
+    assert!(
+        session["worktree_info"].is_null(),
+        "blank worktree branch should not create a managed worktree"
+    );
+
+    let branch = Command::new("git")
+        .args(["branch", "--list", "session"])
+        .current_dir(&project)
+        .output()
+        .expect("git branch --list");
+    assert!(
+        String::from_utf8_lossy(&branch.stdout).trim().is_empty(),
+        "blank explicit branch should not create the sanitizer fallback branch"
+    );
+}
+
+#[test]
+#[serial]
 fn test_cli_add_scratch_provisions_dir() {
     let h = TuiTestHarness::new("cli_add_scratch");
 

--- a/tests/e2e/intro.rs
+++ b/tests/e2e/intro.rs
@@ -126,6 +126,10 @@ fn intro_theme_pick_persists_to_config() {
     // BUILTIN_THEMES (src/tui/styles/mod.rs) is ordered `default, empire, ...`
     // so a single Down from the default-seeded cursor lands on `empire`.
     h.send_keys("Down");
+    // Wait for the selection marker to land on `empire` before advancing, so a
+    // dropped/late Down keystroke can't leave the cursor on the default theme
+    // (render_theme_picker marks the selected row with a leading `▶`).
+    h.wait_for("▶ empire");
     h.send_keys("Enter"); // -> page 6 (done)
     h.wait_for("(6/6)");
     h.send_keys("Enter"); // submit
@@ -167,6 +171,9 @@ fn intro_lets_user_choose_tmux_attach() {
     h.wait_for("(4/6)");
     // Pre-selected LiveSend; flip to Tmux.
     h.send_keys("Down");
+    // Confirm the marker moved to Tmux before advancing, so a dropped Down
+    // can't leave LiveSend selected (render_attach_mode marks the row `▶`).
+    h.wait_for("▶ Tmux mode");
     h.send_keys("Enter"); // -> theme
     h.wait_for("(5/6)");
     h.send_keys("Enter"); // -> done


### PR DESCRIPTION
## Description
Fixes the CLI worktree branch path for `aoe add <repo> -w <name> -b` so explicit branch names are sanitized before they are passed to git.

The TUI/session-builder path already used `git_sanitize_branch_name`, and its nearby defense-in-depth comment calls out the CLI/API case where a user types a title-shaped string into the branch field. The CLI path only trimmed the raw worktree name and forwarded it directly to `GitWorktree::create_worktree`, so names such as `Exploration and issues v2` failed with an invalid git ref instead of creating the same sanitized branch that the rest of the session flow expects.

This PR reuses the existing sanitizer in the CLI path, treats blank explicit worktree branch values as absent so they fall back to normal title generation instead of branch `session`, and adds e2e regression coverage for both behaviors.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (not needed for this CLI bug fix)
- [x] For UI changes: included screenshot or recording (N/A: no UI changes)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## Validation

- `PATH="$HOME/.cargo/bin:$PATH" cargo test --features e2e-tests --test e2e test_cli_add_sanitizes_explicit_worktree_branch -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --features e2e-tests --test e2e test_cli_add_blank_worktree_branch_falls_back_to_normal_title -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `git diff --check`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:**

Used Codex to inspect the CLI/session-builder branch creation paths, reproduce the invalid-ref failure locally, implement the focused sanitizer reuse and blank-branch fallback, and run the validation commands listed above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fixed `aoe add -w/--worktree` branch handling by sanitizing explicit user-provided worktree branch names before using them for git worktree/branch creation (so names with spaces/special characters won’t be treated as invalid git refs).
- Added shared parsing for the “explicit worktree branch” value that treats blank/whitespace-only input as “not provided,” tightening related CLI checks and ensuring worktree-specific logic only runs when there’s a real value.
- Updated CLI fallback behavior: when `-w/--worktree` is blank, the session title falls back to the normal generated title (instead of ending up with/creating a `session` branch), and `worktree_info` branch data isn’t set.
- Added/extended end-to-end CLI regression tests that verify:
  - explicit branch names like `Exploration and issues v2` are converted to a safe git branch form (e.g., `Exploration-and-issues-v2`) and the branch is created
  - whitespace-only `-w` doesn’t break the command, doesn’t set `worktree_info`, and doesn’t create an unexpected `session` branch
- Tweaked E2E first-run intro UI tests to wait for the selection marker before proceeding between steps.

Benefits:
- Prevents CLI failures caused by human-friendly worktree branch names that don’t map cleanly to git ref rules.
- Makes CLI behavior consistent with the existing session/TUI flow’s branch-name sanitization and blank-input handling.
- Adds coverage to prevent regressions in both “sanitized explicit branch” and “blank fallback” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->