### PR TITLE
fix(session): start empty Claude threads fresh-pinned, not --resume

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -118,6 +118,39 @@ pub(crate) fn capture_claude_session_id(
     anyhow::bail!("No active Claude session found for {}", project_path)
 }
 
+/// Whether we can affirmatively prove Claude has *no* persisted transcript for
+/// `session_id` under `project_path` on the host filesystem.
+///
+/// Claude only writes `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` once a
+/// conversation has real content. A session AoE minted a UUID for but that was
+/// killed before the first prompt (an "empty thread") therefore has a stored
+/// `agent_session_id` that never hit disk, and `claude --resume <uuid>` on it
+/// fails with "No conversation found" every time. Callers use this to launch
+/// such an id as a fresh pinned session (`--session-id <uuid>`) instead of a
+/// guaranteed-to-fail `--resume`.
+///
+/// Returns `true` ONLY when the Claude home resolves and the transcript file is
+/// confirmed missing. Any uncertainty (home dir unresolved) returns `false` so
+/// the caller preserves the existing `--resume` attempt rather than risk
+/// downgrading a real conversation to a fresh start. The check is
+/// existence-only (no mtime freshness gate), so an idle-but-real conversation
+/// whose jsonl is older than the live-capture window is still reported present.
+pub(crate) fn claude_host_transcript_confirmed_absent(
+    project_path: &str,
+    session_id: &str,
+) -> bool {
+    let Ok(claude_home) = resolve_agent_home(Some("CLAUDE_CONFIG_DIR"), ".claude") else {
+        return false;
+    };
+    let canonical = canonicalize_or_raw(project_path);
+    let dir_name = encode_claude_project_path(&canonical.to_string_lossy());
+    let transcript = claude_home
+        .join("projects")
+        .join(dir_name)
+        .join(format!("{session_id}.jsonl"));
+    !transcript.is_file()
+}
+
 /// Scan `~/.claude/projects/{encoded-path}/` and pick this poller's session.
 ///
 /// Tie-break:
@@ -2331,6 +2364,50 @@ mod tests {
 
         let result = capture_claude_session_id("/tmp/myproject", None, &HashSet::new());
         assert_eq!(result.unwrap(), uuid_new);
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_claude_host_transcript_confirmed_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let present = "11111111-2222-3333-4444-555555555555";
+        let missing = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let file = project_dir.join(format!("{present}.jsonl"));
+        std::fs::write(&file, "data\n").unwrap();
+        // Existence-only: an old mtime (past the live-capture window) must not
+        // read as absent, or an idle real conversation would lose its resume.
+        let hour_ago = std::time::SystemTime::now() - Duration::from_secs(3600);
+        std::fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(hour_ago))
+            .unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        assert!(
+            !claude_host_transcript_confirmed_absent("/tmp/myproject", present),
+            "a transcript on disk (even stale) must not be reported absent"
+        );
+        assert!(
+            claude_host_transcript_confirmed_absent("/tmp/myproject", missing),
+            "an unwritten sid must be reported confirmed-absent"
+        );
+        // A project dir that was never created is also confirmed-absent.
+        assert!(claude_host_transcript_confirmed_absent(
+            "/tmp/never-opened-project",
+            present
+        ));
 
         match old_val {
             Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1853,6 +1853,34 @@ impl Instance {
                 self.agent_session_id = Some(fresh.clone());
                 return (Some(fresh), true);
             }
+            // A stored Claude sid with no transcript on disk is not resumable:
+            // Claude minted the UUID at first launch but nothing was ever
+            // written (an empty thread killed before the first prompt), so
+            // `--resume <sid>` is a guaranteed launch failure that lands the
+            // session in the "resume failed for sid ...; preserved for explicit
+            // retry" state. Launch it as a fresh pinned session instead
+            // (`is_existing = false` -> `--session-id <sid>`), which succeeds
+            // and keeps the id stable so a later first prompt stays continuous.
+            // Claude is the only tool AoE pre-mints a UUID for (see the fresh
+            // arm below), so no other agent reaches this branch with a
+            // self-created empty-thread sid. Host-only: a sandboxed transcript
+            // lives inside the container, which may not be up at acquire time.
+            if self.tool == "claude"
+                && !self.is_sandboxed()
+                && super::capture::claude_host_transcript_confirmed_absent(
+                    &self.project_path,
+                    &stored,
+                )
+            {
+                tracing::info!(
+                    target: "session.store",
+                    sid = %stored,
+                    "stored Claude sid has no transcript on disk; launching fresh \
+                     with --session-id instead of --resume to avoid a certain \
+                     resume failure"
+                );
+                return (Some(stored), false);
+            }
             return (Some(stored), true);
         }
 
@@ -6911,10 +6939,13 @@ mod tests {
         inst.tool = "claude".to_string();
         inst.agent_session_id = Some("session-42".to_string());
 
-        let (session_id, is_existing) = inst.acquire_session_id();
-
+        // A persisted sid is returned as the session this instance owns. The
+        // `--resume` vs `--session-id` decision (is_existing) is
+        // transcript-dependent for Claude and is covered hermetically in
+        // `verify_on_resume`; asserting it here would read the developer's real
+        // `~/.claude`.
+        let (session_id, _is_existing) = inst.acquire_session_id();
         assert_eq!(session_id, Some("session-42".to_string()));
-        assert!(is_existing);
     }
 
     #[test]
@@ -6941,10 +6972,15 @@ mod tests {
         let flags = build_resume_flags(&inst.tool, inst.agent_session_id.as_ref().unwrap(), true);
         assert_eq!(flags, "--resume invalid-session-id");
 
-        // The method should return the existing session ID and mark it as existing
-        let (session_id, is_existing) = inst.acquire_session_id();
+        // A fresh (no prior transcript) launch pins the id instead.
+        let flags = build_resume_flags(&inst.tool, inst.agent_session_id.as_ref().unwrap(), false);
+        assert_eq!(flags, "--session-id invalid-session-id");
+
+        // The method returns the persisted id as the owned session. The
+        // is_existing flag is transcript-dependent for Claude (see
+        // `verify_on_resume`) and would read the real `~/.claude` here.
+        let (session_id, _is_existing) = inst.acquire_session_id();
         assert_eq!(session_id, Some("invalid-session-id".to_string()));
-        assert!(is_existing);
     }
 
     #[test]
@@ -7114,9 +7150,13 @@ mod tests {
         let (first, first_existing) = inst.acquire_session_id();
         let (second, second_existing) = inst.acquire_session_id();
 
+        // Repeated acquire yields a STABLE id. The first mint reports fresh; a
+        // second acquire with no transcript on disk stays fresh-pinned (an empty
+        // thread's sid is not resumable) but returns the same id, so a later
+        // relaunch keeps `--session-id <same>` rather than a doomed `--resume`.
         assert!(first.is_some());
         assert!(!first_existing);
-        assert!(second_existing);
+        assert!(!second_existing);
         assert_eq!(first, second);
     }
 
@@ -7124,9 +7164,15 @@ mod tests {
     fn apply_session_flags_returns_acquire_is_existing() {
         let mut inst = Instance::new("Test", "/tmp/test");
         inst.tool = "claude".to_string();
+        // Fresh mint (no prior transcript): acquire reports a new session
+        // (`--session-id`), so apply_session_flags returns false.
         let mut cmd = String::from("claude");
         assert!(!inst.apply_session_flags(&mut cmd, "test"));
-        assert!(inst.apply_session_flags(&mut cmd, "test"));
+        // A user-pinned resume intent reports an existing session
+        // unconditionally, so apply_session_flags returns true.
+        inst.resume_intent = ResumeIntent::Use("019342ab-1234-7def-8901-abcdef012345".to_string());
+        let mut cmd2 = String::from("claude");
+        assert!(inst.apply_session_flags(&mut cmd2, "test"));
     }
 
     #[test]
@@ -8131,9 +8177,12 @@ mod tests {
             inst.agent_session_id = Some("observed".to_string());
             inst.resume_intent = ResumeIntent::Default;
 
-            let (sid, is_existing) = inst.acquire_session_id();
+            // Default intent returns the observed sid as the owned session. The
+            // is_existing flag is transcript-dependent for Claude (covered in
+            // `verify_on_resume`); asserting it here would read the real
+            // `~/.claude`.
+            let (sid, _is_existing) = inst.acquire_session_id();
             assert_eq!(sid.as_deref(), Some("observed"));
-            assert!(is_existing);
         }
 
         #[test]
@@ -8231,6 +8280,28 @@ mod tests {
                 inst.resume_intent,
                 ResumeIntent::Use("peer-pinned".to_string())
             );
+        }
+
+        /// Seed a Claude transcript on disk for `sid` under `project_path`, in
+        /// the exact location `acquire_session_id`'s existence check reads
+        /// (`CLAUDE_CONFIG_DIR` or `$HOME/.claude`). The probe tests below drive
+        /// the `--resume` cascade, which acquire now only takes when a stored
+        /// sid has a real prior conversation on disk; an empty thread's sid
+        /// launches fresh-pinned (`--session-id`) instead. Callers must have set
+        /// `HOME` to a temp dir first.
+        fn seed_claude_transcript(project_path: &str, sid: &str) {
+            let home = std::env::var("CLAUDE_CONFIG_DIR")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| dirs::home_dir().expect("home dir").join(".claude"));
+            let canonical = std::fs::canonicalize(project_path)
+                .unwrap_or_else(|_| std::path::PathBuf::from(project_path));
+            let dir =
+                home.join("projects")
+                    .join(crate::session::capture::encode_claude_project_path(
+                        &canonical.to_string_lossy(),
+                    ));
+            std::fs::create_dir_all(&dir).expect("create claude project dir");
+            std::fs::write(dir.join(format!("{sid}.jsonl")), "seed\n").expect("write transcript");
         }
 
         fn write_sidecar(instance_id: &str, sid: &str) -> std::path::PathBuf {
@@ -8638,9 +8709,15 @@ mod tests {
                 assert_eq!(inst.agent_session_id.as_deref(), Some(live));
             }
 
+            // An empty Claude thread killed before its first prompt has a
+            // stored sid but no transcript on disk. `claude --resume <sid>`
+            // would fail for it every time (the "resume failed for sid ...;
+            // preserved for explicit retry" loop), so acquire must launch it as
+            // a fresh pinned session (`--session-id <sid>`, is_existing=false)
+            // while keeping the id stable for a later first prompt.
             #[test]
             #[serial]
-            fn stored_sid_returned_when_no_jsonl_on_disk() {
+            fn stored_sid_without_transcript_launches_fresh_pinned() {
                 let temp = tempdir().unwrap();
                 let _guard = ClaudeHomeGuard::set(&temp);
 
@@ -8654,7 +8731,49 @@ mod tests {
 
                 let (sid, is_existing) = inst.acquire_session_id();
                 assert_eq!(sid.as_deref(), Some(stored));
-                assert!(is_existing);
+                assert!(
+                    !is_existing,
+                    "a stored sid with no transcript must launch fresh-pinned, not --resume"
+                );
+                assert_eq!(inst.agent_session_id.as_deref(), Some(stored));
+            }
+
+            // Regression guard for the existence-only transcript check: an idle
+            // but real conversation whose jsonl is older than the 5-minute
+            // live-capture window must still resume. The mtime scan returns
+            // nothing (stale), so acquire falls through to the transcript check,
+            // which is age-agnostic and confirms the sid is resumable.
+            #[test]
+            #[serial]
+            fn stored_sid_with_stale_transcript_still_resumes() {
+                let temp = tempdir().unwrap();
+                let _guard = ClaudeHomeGuard::set(&temp);
+
+                let project_path = "/tmp/aoe-test-stale-transcript";
+                let claude_dir = temp
+                    .path()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_claude_project_path(project_path));
+                fs::create_dir_all(&claude_dir).unwrap();
+
+                let stored = "12121212-3434-5656-7878-9a9a9a9a9a9a";
+                write_jsonl_with_mtime(
+                    &claude_dir.join(format!("{stored}.jsonl")),
+                    SystemTime::now() - Duration::from_secs(3600),
+                );
+
+                let mut inst = Instance::new("verify-claude-stale", project_path);
+                inst.tool = "claude".to_string();
+                inst.agent_session_id = Some(stored.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(stored));
+                assert!(
+                    is_existing,
+                    "a real (if idle) transcript on disk must resume with --resume"
+                );
                 assert_eq!(inst.agent_session_id.as_deref(), Some(stored));
             }
 
@@ -9345,6 +9464,8 @@ mod tests {
             inst.command = "/bin/false".to_string();
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
+            // Real prior conversation on disk so acquire takes the --resume path.
+            seed_claude_transcript(&inst.project_path, &stale_sid);
             let id = inst.id.clone();
 
             let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
@@ -9420,6 +9541,8 @@ mod tests {
             );
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
+            // Real prior conversation on disk so acquire takes the --resume path.
+            seed_claude_transcript(&inst.project_path, &stale_sid);
 
             let xs = vec![inst.clone()];
             storage
@@ -9559,6 +9682,8 @@ mod tests {
             inst.command = "/bin/false".to_string();
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
+            // Real prior conversation on disk so acquire takes the --resume path.
+            seed_claude_transcript(&inst.project_path, &stale_sid);
 
             let xs = vec![inst.clone()];
             storage
@@ -9615,6 +9740,10 @@ mod tests {
             inst.command = "/bin/false".to_string();
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
+            // Real prior conversation on disk so the FIRST attempt takes the
+            // --resume path (and fails); the loop-breaker on the second attempt
+            // then fires from the persisted marker, independent of the transcript.
+            seed_claude_transcript(&inst.project_path, &stale_sid);
 
             let xs = vec![inst.clone()];
             storage
@@ -9701,6 +9830,8 @@ mod tests {
             );
             inst.agent_session_id = Some(stale_sid.clone());
             inst.status = Status::Idle;
+            // Real prior conversation on disk so acquire takes the --resume path.
+            seed_claude_transcript(&inst.project_path, &stale_sid);
 
             let xs = vec![inst.clone()];
             storage

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8041,6 +8041,15 @@ fn restart_selected_session_surfaces_resume_failed_after_async_restart() {
         })
         .unwrap();
 
+    // A real prior conversation on disk so the restart drives the --resume
+    // cascade (and its ResumeFailed path). A stored sid with no transcript now
+    // launches fresh-pinned (`--session-id`), which would not surface here.
+    let claude_dir = temp.path().join(".claude").join("projects").join(
+        crate::session::capture::encode_claude_project_path("/tmp/x"),
+    );
+    std::fs::create_dir_all(&claude_dir).unwrap();
+    std::fs::write(claude_dir.join(format!("{stale_sid}.jsonl")), "seed\n").unwrap();
+
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(
         Some(profile.to_string()),


### PR DESCRIPTION
## Description

An empty Claude thread that is killed before its first prompt lands in a permanent `resume failed for sid <uuid>; preserved for explicit retry` error, and pressing `e` (restart) does not durably recover it.

**Root cause.** A Claude session is minted a session UUID at first launch, before the user sends any message. Claude only writes its transcript (`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`) once the conversation has real content, so an "empty thread" has a stored `agent_session_id` that never hit disk. On restart, `acquire_session_id` trusted that stored id unconditionally (`is_existing = true`) and launched `claude --resume <uuid>`, which fails with "No conversation found" every time. The pane dies inside the resume probe, so `start_with_resume_fallback` reports `ResumeFailed` and preserves the sid.

The per-sid loop-breaker (`resume_probe_failed_sid`, #2612) only routes the *next explicit* restart to a fresh launch, and that fresh launch re-mints another empty UUID that fails again on its next kill, so the failure recurs rather than resolving.

**Fix.** Gate `is_existing` in `acquire_session_id` on whether Claude actually has a transcript on disk for the stored sid (new `capture::claude_host_transcript_confirmed_absent`). When the transcript is confirmed absent, launch a fresh pinned session (`--session-id <sid>`, which succeeds and keeps the id stable so a later first prompt stays continuous) instead of `--resume <sid>`. The check is existence-only (no mtime gate), so a real but idle conversation whose jsonl is older than the live-capture window still resumes. It is scoped to Claude (the only tool AoE pre-mints a UUID for) and host-only (a sandboxed transcript lives in a container that may not be up at acquire time; noted in the code as a possible follow-up).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Added unit coverage for the new behavior:
- `capture::tests::test_claude_host_transcript_confirmed_absent` — present (even stale) vs missing vs never-created dir.
- `instance::...::verify_on_resume::stored_sid_without_transcript_launches_fresh_pinned` — the empty-thread case now launches fresh-pinned.
- `instance::...::verify_on_resume::stored_sid_with_stale_transcript_still_resumes` — regression guard: an idle real conversation must still `--resume`.

Updated the existing resume-probe/cascade tests to seed a real transcript (they represent resuming an existing conversation) and adjusted the acquire/idempotence tests to the new contract.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: covered by the existing `restart_selected_session_surfaces_resume_failed_after_async_restart` TUI test (updated to seed a transcript) and the `verify_on_resume` unit suite; this is a session-id acquisition change with no new TUI-render or CLI-subcommand surface.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and implementation done via Claude Code; author reviewed and verified `cargo fmt`, `cargo clippy --all-targets`, and the full test suite locally.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed Claude session restarts for empty threads without saved transcripts.
- Added transcript presence checks to distinguish resumable sessions from sessions that need a fresh launch.
- Preserved stored session IDs when starting fresh, maintaining future conversation continuity.
- Added regression coverage for missing, stale, and existing transcripts, including restart behavior.

## Benefits

- Prevents permanent resume failures for sessions interrupted before their first prompt.
- Keeps valid conversations resumable, including those with older transcripts.
- Makes restart behavior more reliable and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->