### PR TITLE
fix: validate plugin uninstall targets

### DIFF
--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{anyhow, bail, Context, Result};
-use aoe_plugin_api::{BuildStep, PluginManifest, RuntimeSpec, UiContribution};
+use aoe_plugin_api::{BuildStep, PluginId, PluginManifest, RuntimeSpec, UiContribution};
 use serde::Serialize;
 
 use crate::session::{save_config, CapabilityGrant, Config, PluginConfig};
@@ -936,17 +936,18 @@ fn skip_reason(prepared: &Prepared) -> String {
 /// Remove an installed external plugin: its tree, its config entry, and its
 /// lockfile entry.
 pub fn uninstall(id: &str) -> Result<()> {
-    let dir = super::plugins_dir()?.join(id);
+    PluginId::new(id.to_string()).map_err(|e| anyhow!("{e}"))?;
     let mut config = Config::load()?;
     let is_external = config
         .plugins
         .get(id)
         .and_then(|p| p.source.as_ref())
         .is_some();
-    if !dir.exists() && !is_external {
+    if !is_external {
         bail!("{id} is not an installed external plugin");
     }
 
+    let dir = super::plugins_dir()?.join(id);
     if dir.exists() {
         std::fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
     }
@@ -1470,6 +1471,41 @@ fn write_lock(
 mod tests {
     use super::*;
     use aoe_plugin_api::UiSlot;
+    use serial_test::serial;
+    use std::ffi::OsString;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        old: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let old = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    fn isolated_app_env() -> (tempfile::TempDir, EnvVarGuard, EnvVarGuard) {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let xdg = tmp.path().join("xdg");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&xdg).unwrap();
+        let home_guard = EnvVarGuard::set("HOME", &home);
+        let xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &xdg);
+        (tmp, home_guard, xdg_guard)
+    }
 
     fn ui(slot: UiSlot, id: &str) -> UiContribution {
         UiContribution {
@@ -1536,5 +1572,61 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("gh:"), "{err}");
+    }
+
+    #[test]
+    #[serial]
+    fn uninstall_rejects_malformed_id_before_touching_plugin_dir() {
+        let (_tmp, _home, _xdg) = isolated_app_env();
+        let plugins = super::super::plugins_dir().unwrap();
+        let jobs = plugins.join("jobs");
+        let keep = plugins.join("keepdir");
+        std::fs::create_dir_all(&jobs).unwrap();
+        std::fs::create_dir_all(&keep).unwrap();
+        std::fs::write(keep.join("keep.log"), b"keep").unwrap();
+
+        let err = uninstall("jobs/../keepdir").unwrap_err().to_string();
+        assert!(err.contains("invalid plugin id"), "{err}");
+        assert!(
+            keep.join("keep.log").exists(),
+            "malformed ids must not remove plugin subdirectories"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn uninstall_requires_external_plugin_config_before_removing_dir() {
+        let (_tmp, _home, _xdg) = isolated_app_env();
+        let plugins = super::super::plugins_dir().unwrap();
+        let jobs = plugins.join("jobs");
+        std::fs::create_dir_all(&jobs).unwrap();
+        std::fs::write(jobs.join("keep.log"), b"keep").unwrap();
+
+        let err = uninstall("jobs").unwrap_err().to_string();
+        assert!(err.contains("not an installed external plugin"), "{err}");
+        assert!(
+            jobs.join("keep.log").exists(),
+            "uninstall should not remove non-plugin subdirectories"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn uninstall_external_plugin_cleans_config_even_when_dir_is_missing() {
+        let (_tmp, _home, _xdg) = isolated_app_env();
+        let mut config = Config::default();
+        config.plugins.insert(
+            "acme.thing".to_string(),
+            PluginConfig {
+                source: Some("gh:acme/thing".to_string()),
+                ..PluginConfig::default()
+            },
+        );
+        save_config(&config).unwrap();
+
+        uninstall("acme.thing").unwrap();
+
+        let config = Config::load().unwrap();
+        assert!(!config.plugins.contains_key("acme.thing"));
     }
 }


### PR DESCRIPTION
## Description
Plugin uninstall currently builds the plugin directory from the raw requested id before validating it and allows removal when that directory exists even if the config does not identify the id as an installed external plugin.

This fixes the uninstall path by validating the id with `PluginId` first and requiring an external plugin config entry before removing any tree. It prevents malformed ids such as `jobs/../keepdir` from targeting sibling plugin directories and prevents valid-but-internal names such as `jobs` from deleting non-plugin subdirectories.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is a host-side plugin lifecycle guard with focused unit regressions plus the existing plugin install integration shard covering normal uninstall behavior.

Validation run locally:

- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test plugin::install::tests -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test plugin_install -- --nocapture`
- `git diff --check`

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
OpenAI Codex


**Any Additional AI Details you'd like to share:**
Used Codex to inspect the uninstall path, implement the guard, and run the validation commands listed above.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change tightens plugin uninstall behavior so only valid, installed external plugins can be removed. It adds stronger ID validation before uninstalling, prevents accidental deletion of unrelated folders, and keeps uninstall cleanup working even if the plugin directory is already gone.

It also expands the test coverage around uninstall edge cases, including invalid IDs, missing config entries, and missing plugin directories.

Benefits:
- Prevents unsafe or accidental directory removal
- Makes uninstall behavior more predictable
- Improves confidence with additional isolated tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->