### PR TITLE
fix(session): sanitize invalid branch ref edges

### DIFF
--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -951,7 +951,12 @@ pub(crate) fn git_sanitize_branch_name(s: &str) -> String {
     // `foo.lock`).
     out = out
         .split('/')
-        .map(|seg| seg.strip_suffix(".lock").unwrap_or(seg))
+        .map(|mut seg| {
+            while let Some(stripped) = seg.strip_suffix(".lock") {
+                seg = stripped;
+            }
+            seg
+        })
         .collect::<Vec<_>>()
         .join("/");
     while matches!(out.chars().last(), Some('-' | '.' | '/')) {
@@ -960,8 +965,9 @@ pub(crate) fn git_sanitize_branch_name(s: &str) -> String {
     while matches!(out.chars().next(), Some('-' | '.' | '/')) {
         out.remove(0);
     }
-    // A lone '@' is also rejected by git as a complete ref name.
-    if out.is_empty() || out == "@" {
+    // A lone '@' and the symbolic ref HEAD are also rejected by git as
+    // complete ref names.
+    if out.is_empty() || out == "@" || out == "HEAD" {
         "session".to_string()
     } else {
         out
@@ -1266,14 +1272,19 @@ mod tests {
             git_sanitize_branch_name("feat/release.lock/v2"),
             "feat/release/v2"
         );
+        assert_eq!(git_sanitize_branch_name("foo.lock.lock"), "foo");
+        assert_eq!(
+            git_sanitize_branch_name("feat/release.lock.lock/v2.lock.lock"),
+            "feat/release/v2"
+        );
     }
 
     #[test]
-    fn test_git_sanitize_branch_name_rejects_bare_at_sign() {
-        // git-check-ref-format also rejects the single character "@" as a
-        // complete ref name; fall back to "session" rather than producing
-        // a name libgit2 will refuse.
+    fn test_git_sanitize_branch_name_rejects_special_complete_refs() {
+        // git-check-ref-format also rejects special complete ref names; fall
+        // back to "session" rather than producing a name libgit2 will refuse.
         assert_eq!(git_sanitize_branch_name("@"), "session");
+        assert_eq!(git_sanitize_branch_name("HEAD"), "session");
     }
 
     #[test]


### PR DESCRIPTION
## Description
Tightens the shared worktree branch sanitizer so its output keeps matching the `git-check-ref-format` contract described by the helper comments.

During review of #2698, two pre-existing edge cases were called out in `git_sanitize_branch_name`:

- `foo.lock.lock` only stripped one `.lock` suffix, producing `foo.lock`, which git rejects as an invalid branch name.
- Bare `HEAD` passed through unchanged even though `git check-ref-format --branch HEAD` rejects it as a symbolic ref name, not a branch.

This PR strips repeated `.lock` suffixes from each slash-separated component and maps the special complete ref name `HEAD` to the existing `session` fallback, the same fallback already used for an empty result and bare `@`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (not needed for this sanitizer bug fix)
- [x] For UI changes: included screenshot or recording (N/A: no UI changes)

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is a shared sanitizer helper edge case covered by focused `session::builder` unit tests; existing worktree path tests continue to cover the caller behavior.

Validation:

- `git check-ref-format --branch foo.lock.lock` -> rejected by git before the fix
- `git check-ref-format --branch HEAD` -> rejected by git before the fix
- `PATH="$HOME/.cargo/bin:$PATH" cargo test session::builder::tests::test_git_sanitize_branch_name -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test session::builder::tests -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `git diff --check`

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
OpenAI Codex


**Any Additional AI Details you'd like to share:**
Used Codex to inspect the existing branch sanitizer, verify the invalid ref cases with git, implement the focused fix, and run the validation commands listed above.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated branch-name sanitizing so it better matches Git’s ref rules. The change now removes repeated trailing `.lock` parts from branch components and treats `HEAD` the same as other invalid names, falling back to `session` when needed.

This improves safety by avoiding invalid ref names and makes the fallback behavior more consistent. Focused tests were added and updated to cover the new edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->