### PR TITLE
feat(acp): raise default structured-view worker cap to 100

### DIFF
--- a/docs/development/internals/structured-view.md
+++ b/docs/development/internals/structured-view.md
@@ -102,7 +102,7 @@ Profiles are conservative: an unverified tool surface is omitted rather than gue
 default_agent = "aoe-agent"
 approval_timeout_secs = 300
 destructive_require_double_confirm = true
-max_concurrent_workers = 5
+max_concurrent_workers = 100
 max_concurrent_resumes = 4        # parallel cold-start spawns/attaches on daemon boot (#1088)
 replay_events = 0                 # 0 = unlimited; caps per-session rows and the web client buffer (#1111)
 replay_bytes = 5_242_880
@@ -112,7 +112,7 @@ queue_drain_mode = "combined"     # "combined" | "serial" (#1031)
 force_end_turn_threshold_secs = 30
 silent_orphan_grace_secs = 120    # 0 disables (#1240)
 silent_orphan_fast_grace_secs = 20
-auto_stop_idle_secs = 0           # 0 disables; next prompt respawns the worker (#1689)
+auto_stop_idle_secs = 3600        # 0 disables; next prompt respawns the worker
 rate_limit_auto_resume = false
 rate_limit_auto_resume_grace_secs = 15
 ```

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -483,10 +483,10 @@ pub struct AcpConfig {
     /// events and no in-flight turn) after which the daemon shuts a
     /// worker down and marks its session dormant so the reconciler does
     /// not respawn it. The next user prompt wakes the session and the
-    /// reconciler spawns a fresh worker. `0` (default) disables the
-    /// feature entirely; no worker is ever stopped for inactivity. See
-    /// #1689.
-    #[serde(default = "default_auto_stop_idle_secs")]
+    /// reconciler spawns a fresh worker. Default 3600 (1 hour); `0`
+    /// disables the feature entirely, so no worker is ever stopped for
+    /// inactivity.
+    #[serde(default = "default_acp_auto_stop_idle_secs")]
     #[setting(
         label = "Auto-stop idle worker (s)",
         widget = "number",
@@ -559,6 +559,10 @@ fn default_auto_stop_idle_secs() -> u32 {
     0
 }
 
+fn default_acp_auto_stop_idle_secs() -> u32 {
+    3600
+}
+
 fn default_max_concurrent_resumes() -> u32 {
     4
 }
@@ -622,7 +626,7 @@ impl Default for AcpConfig {
             force_end_turn_threshold_secs: default_force_end_turn_threshold_secs(),
             silent_orphan_grace_secs: default_silent_orphan_grace_secs(),
             silent_orphan_fast_grace_secs: default_silent_orphan_fast_grace_secs(),
-            auto_stop_idle_secs: default_auto_stop_idle_secs(),
+            auto_stop_idle_secs: default_acp_auto_stop_idle_secs(),
             rate_limit_auto_resume: false,
             rate_limit_auto_resume_grace_secs: default_rate_limit_auto_resume_grace_secs(),
             allow_agent_install: false,
@@ -635,7 +639,7 @@ fn default_agent() -> String {
     "aoe-agent".to_string()
 }
 fn default_max_workers() -> u32 {
-    5
+    100
 }
 fn default_replay_events() -> u32 {
     // 0 = unlimited. The event store's prune already gates on `> 0`


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Raises the default `[acp] max_concurrent_workers` cap from 5 to 100 (`src/session/config.rs`). 5 concurrent structured-view sessions was too restrictive for normal usage; users kept hitting the queue.

To offset the higher ceiling, `acp.auto_stop_idle_secs` now defaults to 3600 (1 hour) instead of 0/disabled, so idle Node worker processes get reclaimed automatically rather than accumulating unbounded under the new cap. The plain TUI/tmux `session.auto_stop_idle_secs` knob is unaffected; it kept its own default of 0 (split into a separate default function since both fields previously shared one).

Docs (`docs/development/internals/structured-view.md`) updated to match both new defaults.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (default-value change on existing, already-tested settings fields; no new UI surface)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle (pure default-value change, existing `session::config` unit tests cover serde/merge behavior)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code)

**Any Additional AI Details you'd like to share:** I asked for the default bump; Claude investigated the shared default fn (which would've also silently changed the unrelated plain-session auto-stop default), split it into two, and updated docs to match. I reviewed the diff and ran the full validation sweep.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Raised the default ACP worker limit from 5 to 100, so structured-view sessions can handle more concurrent work by default.

Also changed ACP idle workers to stop automatically after 1 hour instead of staying disabled, helping prevent worker buildup with the higher cap. The plain TUI/tmux session idle setting was left unchanged.

Updated the structured-view documentation to match the new defaults.

Benefits: better out-of-the-box concurrency, fewer stale workers, and clearer docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->