### PR TITLE
fix(tui): keep Trash collapsed on delete and skip trash in w-navigation

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3262,9 +3262,13 @@ impl HomeView {
                 _ => continue,
             };
             if let Some(inst) = self.get_instance(&id) {
-                let is_actionable = inst.status == Status::Waiting
-                    || matches!(inst.idle_age(), Some(age) if age < window)
-                    || (crate::session::unread_enabled() && inst.is_unread());
+                // Trashed rows are stopped and only surface under the collapsed
+                // Trash section; they never "need attention", so skip them even
+                // when a stale unread flag survived the trash (#2489).
+                let is_actionable = !inst.is_trashed()
+                    && (inst.status == Status::Waiting
+                        || matches!(inst.idle_age(), Some(age) if age < window)
+                        || (crate::session::unread_enabled() && inst.is_unread()));
                 if is_actionable {
                     self.cursor = idx;
                     self.update_selected();
@@ -3288,6 +3292,9 @@ impl HomeView {
             let Some(inst) = self.get_instance(&id) else {
                 continue;
             };
+            if inst.is_trashed() {
+                continue;
+            }
             if inst.status != Status::Idle {
                 continue;
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4081,12 +4081,6 @@ impl HomeView {
         });
     }
 
-    /// Expand the synthetic Trash section if collapsed. Used when trashing a
-    /// session so the user sees where the row went. No-op when already open.
-    pub(super) fn reveal_trashed_section(&mut self) {
-        self.trashed_section_collapsed = false;
-    }
-
     pub fn toggle_trashed_section(&mut self) {
         self.trashed_section_collapsed = !self.trashed_section_collapsed;
         self.rebuild_flat_items();

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1458,8 +1458,9 @@ impl HomeView {
     /// Move a session to the trash: stop its tmux sessions (a structured-view
     /// worker is reaped by the daemon reconciler once the row reads trashed)
     /// and set `trashed_at`. Durable artifacts are kept so it can be
-    /// restored. The Trash section is revealed so the user sees where the row
-    /// went. See #2489.
+    /// restored. The Trash section's collapse state is left untouched: like
+    /// single-row archive, the section header's count is the feedback, so a
+    /// user who collapsed it stays collapsed (#2489).
     pub(super) fn trash_session_by_id(&mut self, id: &str) {
         if let Err(e) = self.apply_user_action(id, |inst| inst.trash()) {
             tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
@@ -1483,7 +1484,6 @@ impl HomeView {
         if let Some(reason) = relocate_warning {
             tracing::warn!(target: "tui.session", session = %id, "trash worktree relocation skipped: {reason}");
         }
-        self.reveal_trashed_section();
         self.rebuild_flat_items();
         self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
         self.update_selected();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7175,6 +7175,78 @@ fn trash_then_restore_round_trip() {
     );
 }
 
+/// Regression for #2489: trashing a session must not re-expand a Trash
+/// section the user has collapsed. Like single-row archive, the section
+/// header's count is the feedback; the collapse state is left untouched.
+#[test]
+#[serial]
+fn trashing_leaves_collapsed_trash_section_collapsed() {
+    let mut env = create_test_env_with_sessions(2);
+    assert!(
+        env.view.trashed_section_collapsed,
+        "Trash section defaults to collapsed"
+    );
+    let id = env.view.instances[0].id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    env.view.trash_session_by_id(&id);
+
+    assert!(
+        env.view.get_instance(&id).unwrap().is_trashed(),
+        "session must be trashed"
+    );
+    assert!(
+        env.view.trashed_section_collapsed,
+        "trashing must not re-expand a collapsed Trash section"
+    );
+}
+
+/// Regression for #2489: `w` (jump to next needing-attention) must skip
+/// trashed rows even when a stale unread flag survived the trash. A trashed
+/// session is stopped and only lives under the Trash section, so it never
+/// "needs attention".
+#[test]
+#[serial]
+fn w_skips_unread_trashed_session() {
+    use crate::session::Status;
+    crate::session::set_unread_enabled(true);
+    let mut env = create_test_env_with_sessions(2);
+    // Non-strict so bare `w` routes to the jump handler, not the typing guard.
+    env.view.strict_hotkeys = false;
+    // Keep the Trash section expanded so the trashed row lands in `flat_items`;
+    // that is the only way `w`'s walk could reach it.
+    env.view.trashed_section_collapsed = false;
+
+    let trashed = env.view.instances[0].id.clone();
+    let active = env.view.instances[1].id.clone();
+    // The surviving active row is a plain idle session (the pass-2 fallback);
+    // the trashed row carries an unread flag, as it would after being trashed
+    // while unread.
+    env.view
+        .mutate_instance(&active, |inst| inst.status = Status::Idle);
+    env.view
+        .mutate_instance(&trashed, |inst| inst.mark_unread());
+    env.view.trash_session_by_id(&trashed);
+    assert!(env.view.get_instance(&trashed).unwrap().is_trashed());
+    assert!(
+        env.view.get_instance(&trashed).unwrap().is_unread(),
+        "the trashed row must still carry the unread flag for this regression"
+    );
+
+    env.view.select_session_by_id(&active);
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => Some(id.clone()),
+        _ => None,
+    };
+    assert_ne!(
+        landed.as_deref(),
+        Some(trashed.as_str()),
+        "`w` must not land on a trashed session even when it is unread"
+    );
+}
+
 #[test]
 #[serial]
 fn d_on_session_with_default_trash_persists_trash_marker() {


### PR DESCRIPTION
## Description

Two bugs in the trash feature:

1. **Collapsed Trash group re-expands on every delete.** `trash_session_by_id` called `reveal_trashed_section()` on every delete, unconditionally forcing the Trash section open again. There is no bulk-trash (unlike archive, where whole-group archive justifies revealing), so single-row delete now leaves the collapse state untouched, matching the single-row-archive behavior where the header count is the feedback. Removed the now-dead `reveal_trashed_section`.

2. **`w` (jump to next needing-attention) cycles through unread trash items.** `jump_to_next_waiting` never filtered trashed rows, so an unread trashed session counted as actionable. `trash()` preserves the `unread` flag by design (for faithful restore), so trash rows showed up in the `w`-cycle whenever the Trash section was expanded (compounded by bug 1 keeping it open). Both passes of `jump_to_next_waiting` now skip trashed instances.

No render change was needed: the trash lifecycle override in `render.rs` already runs after the unread logic, so trash rows paint dimmed with a stopped glyph and never show an unread dot.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (doc comment on `trash_session_by_id`)
- [ ] For UI changes: included screenshot or recording (behavior-only, no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: two in-module regression tests in `src/tui/home/tests.rs` — `trashing_leaves_collapsed_trash_section_collapsed` (a collapsed Trash section stays collapsed after a delete) and `w_skips_unread_trashed_session` (`w` never lands on a trashed session even when it is unread).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Used to investigate the trash/attention code paths and draft the fix + regression tests.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR makes Trash behavior in the TUI more consistent and less disruptive:

- Keeping Trash collapsed now stays collapsed after deleting a session.
- `w` navigation now ignores trashed sessions so they no longer get selected by mistake.
- Added regression tests for both cases.
- Updated the trashing doc comment to match the new behavior.

Benefit: the sidebar no longer jumps open unexpectedly, and keyboard navigation is less confusing when deleted items are still present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->