### PR TITLE
feat(ui): make session row suffix configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,6 +278,13 @@ name = "e2e"
 path = "tests/e2e/main.rs"
 required-features = ["e2e-tests"]
 
+[[test]]
+# The orphan-runner test invokes the hidden `aoe __acp-runner` command, which is
+# compiled only with the structured-view/web-dashboard feature set.
+name = "acp_runner_orphan"
+path = "tests/acp_runner_orphan.rs"
+required-features = ["serve"]
+
 [[bin]]
 name = "aoe"
 path = "src/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,13 +278,6 @@ name = "e2e"
 path = "tests/e2e/main.rs"
 required-features = ["e2e-tests"]
 
-[[test]]
-# The orphan-runner test invokes the hidden `aoe __acp-runner` command, which is
-# compiled only with the structured-view/web-dashboard feature set.
-name = "acp_runner_orphan"
-path = "tests/acp_runner_orphan.rs"
-required-features = ["serve"]
-
 [[bin]]
 name = "aoe"
 path = "src/main.rs"

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -76,6 +76,7 @@ agent_status_hooks = true
 smart_rename = true
 smart_rename_agent = ""    # "" = use the session's own agent; e.g. "codex"
 auto_stop_idle_secs = 0   # 0 disables; e.g. 7200 = stop after 2h idle
+row_tag = "branch"       # none | auto | profile | sandbox | branch
 
 # Per-agent structured-view defaults live under [acp], not [session].
 [acp.acp_defaults.opencode]
@@ -91,6 +92,7 @@ mode = "plan"             # default mode, applied when the agent advertises one
 |--------|---------|-------------|
 | `default_tool` | (auto-detect) | Default agent for new sessions. Falls back to the first available tool if unset or unavailable. Can be set to a custom agent name. |
 | `auto_stop_idle_secs` | `0` | Seconds a plain tmux session may sit `Idle` before it is auto-stopped: its tmux session and any sandbox container are killed, leaving a restartable `Stopped` row. `0` disables it; no session is ever auto-stopped for inactivity. Idle age is measured from the later of the last transition into `Idle` and the last user interaction, and a session with an attached tmux client is always spared, so a session you are reading is never reaped. Evaluated about once a minute (by the TUI and by `aoe serve`), so the stop can lag the threshold by up to a minute. Structured view workers use the separate `acp.auto_stop_idle_secs`. See #1689 and #1690. |
+| `row_tag` | `"branch"` | Controls the compact metadata shown next to each TUI session title: `none` shows nothing; `auto` shows the profile code only in all-profiles view; `profile` always shows the profile code; `sandbox` shows `sb` on sandboxed sessions; `branch` shows a compact worktree or workspace branch tag. |
 | `yolo_mode_default` | `false` | Enable YOLO mode by default for new sessions (skip permission prompts). Works with or without sandbox. In tmux mode this passes `--dangerously-skip-permissions` to the agent CLI; in structured view it maps to ACP `bypassPermissions` (see [Structured view: Permission modes and YOLO](../structured-view/controls.md#permission-modes-and-yolo) for the adapter caveat). |
 | `agent_status_hooks` | `true` | Install status-detection hooks into the agent's config file. Codex uses the `[hooks]` table in its resolved `config.toml` (typically `~/.codex/config.toml`); other JSON-based agents use their settings JSON. Config-dir overrides are honored: `CODEX_HOME` (Codex), `CLAUDE_CONFIG_DIR` (Claude), or `CURSOR_CONFIG_DIR` (Cursor) set in the session's profile environment or in AoE's own environment redirects hooks to that directory instead of the `~/.codex` / `~/.claude` / `~/.cursor` default. When disabled, status detection falls back to tmux pane content parsing. Codex is hook-first, but known hook gaps are reconciled from pane content. |
 | `smart_rename` | `true` | Auto-rename a new structured view (ACP) session from its first message, using the session's own agent in one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`). Runs only while the session still carries its auto-generated civilization name; a manually named session is never touched. Title only: the worktree directory is not moved, since the running agent holds it. Skipped for sandboxed sessions (a host one-shot lacks the container's auth), agents with no one-shot mode, and command-overridden agents. Best-effort: a failed or timed-out call leaves the generated name and never affects the prompt. |
@@ -209,7 +211,7 @@ path_template = "../{repo-name}-worktrees/{branch}"   # template vars: {repo-nam
 auto_cleanup = true                                   # prompt to remove the worktree on session delete
 ```
 
-See [Git Worktrees](worktrees.md) for the full key reference (`bare_repo_path_template`, `show_branch_in_tui`, `delete_branch_on_cleanup`, `init_submodules`) and template details.
+See [Git Worktrees](worktrees.md) for the full key reference (`bare_repo_path_template`, `delete_branch_on_cleanup`, `init_submodules`) and template details.
 
 ## Sandbox (Docker)
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -115,7 +115,6 @@ enabled = true
 path_template = "../{repo-name}-worktrees/{branch}"
 bare_repo_path_template = "./{branch}"
 auto_cleanup = true
-show_branch_in_tui = true
 delete_branch_on_cleanup = false
 ```
 

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -113,10 +113,12 @@ enabled = false
 path_template = "../{repo-name}-worktrees/{branch}"
 bare_repo_path_template = "./{branch}"
 auto_cleanup = true
-show_branch_in_tui = true
 delete_branch_on_cleanup = false
 init_submodules = true
 ```
+
+Use `[session] row_tag = "branch"` to show worktree and workspace branch tags in
+the TUI session list, or `"none"` to hide suffix metadata next to session names.
 
 ### Skipping submodule init
 

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -27,13 +27,14 @@ mod v016_clear_archived_tmux_gone_error;
 mod v017_rewrite_hook_strings_for_per_user_base;
 mod v018_strip_codex_config_toml_hooks;
 mod v019_move_acp_defaults_to_acp;
+mod v020_move_tui_branch_suffix_to_row_tag;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 19;
+const CURRENT_VERSION: u32 = 20;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -137,6 +138,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 19,
         name: "move_acp_defaults_to_acp",
         run: v019_move_acp_defaults_to_acp::run,
+    },
+    Migration {
+        version: 20,
+        name: "move_tui_branch_suffix_to_row_tag",
+        run: v020_move_tui_branch_suffix_to_row_tag::run,
     },
 ];
 

--- a/src/migrations/v020_move_tui_branch_suffix_to_row_tag.rs
+++ b/src/migrations/v020_move_tui_branch_suffix_to_row_tag.rs
@@ -1,0 +1,173 @@
+//! Migration v020: replace `worktree.show_branch_in_tui` with `session.row_tag`.
+//!
+//! The old worktree toggle only covered branch text and is now superseded by the
+//! broader TUI row suffix selector. If a user explicitly hid branches with the
+//! old key, preserve that intent by seeding `session.row_tag = "none"` unless a
+//! row tag value already exists. Then drop the stale worktree key so settings
+//! expose a single source of truth.
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir)
+}
+
+pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
+    migrate_config_file(&app_dir.join("config.toml"))?;
+
+    let profiles_dir = app_dir.join("profiles");
+    if profiles_dir.exists() {
+        for entry in fs::read_dir(&profiles_dir)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                migrate_config_file(&entry.path().join("config.toml"))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn migrate_config_file(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(path)?;
+    let mut doc: toml::Table = match content.parse() {
+        Ok(table) => table,
+        Err(e) => {
+            debug!("failed to parse {}: {e}, skipping", path.display());
+            return Ok(());
+        }
+    };
+
+    let removed = {
+        let Some(worktree) = doc.get_mut("worktree").and_then(toml::Value::as_table_mut) else {
+            return Ok(());
+        };
+        worktree.remove("show_branch_in_tui")
+    };
+    let Some(removed) = removed else {
+        return Ok(());
+    };
+
+    let seeded_none = if removed.as_bool() == Some(false) {
+        let session = doc
+            .entry("session".to_string())
+            .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+        if let Some(table) = session.as_table_mut() {
+            if table.contains_key("row_tag") {
+                false
+            } else {
+                table.insert(
+                    "row_tag".to_string(),
+                    toml::Value::String("none".to_string()),
+                );
+                true
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    crate::session::atomic_write(path, toml::to_string_pretty(&doc)?.as_bytes())?;
+    info!(
+        "v020: removed worktree.show_branch_in_tui from {}{}",
+        path.display(),
+        if seeded_none {
+            " and seeded session.row_tag = none"
+        } else {
+            ""
+        }
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn false_legacy_toggle_seeds_row_tag_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "[worktree]\nshow_branch_in_tui = false\nauto_cleanup = true\n",
+        )
+        .unwrap();
+
+        migrate_config_file(&path).unwrap();
+
+        let doc: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(doc["session"]["row_tag"].as_str(), Some("none"));
+        assert!(!doc["worktree"]
+            .as_table()
+            .unwrap()
+            .contains_key("show_branch_in_tui"));
+        assert_eq!(doc["worktree"]["auto_cleanup"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn true_legacy_toggle_only_removes_stale_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[worktree]\nshow_branch_in_tui = true\n").unwrap();
+
+        migrate_config_file(&path).unwrap();
+
+        let doc: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert!(!doc["worktree"]
+            .as_table()
+            .unwrap()
+            .contains_key("show_branch_in_tui"));
+        assert!(doc.get("session").is_none());
+    }
+
+    #[test]
+    fn existing_row_tag_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "[session]\nrow_tag = \"profile\"\n\n[worktree]\nshow_branch_in_tui = false\n",
+        )
+        .unwrap();
+
+        migrate_config_file(&path).unwrap();
+
+        let doc: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(doc["session"]["row_tag"].as_str(), Some("profile"));
+        assert!(!doc["worktree"]
+            .as_table()
+            .unwrap()
+            .contains_key("show_branch_in_tui"));
+    }
+
+    #[test]
+    fn migrates_profile_configs() {
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join("profiles/default");
+        fs::create_dir_all(&profile).unwrap();
+        fs::write(
+            profile.join("config.toml"),
+            "[worktree]\nshow_branch_in_tui = false\n",
+        )
+        .unwrap();
+
+        run_in(dir.path()).unwrap();
+
+        let doc: toml::Table = fs::read_to_string(profile.join("config.toml"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(doc["session"]["row_tag"].as_str(), Some("none"));
+    }
+}

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1112,9 +1112,9 @@ pub struct SessionConfig {
     #[setting(label = "Restart Wake Message", widget = "text")]
     pub restart_wake_message: String,
 
-    /// What to show next to each session title: Auto (profile in all-profiles
-    /// view), None, Profile (always), Sandbox (sb on sandboxed rows), or
-    /// Branch.
+    /// What to show next to each session title: Branch (default), Auto
+    /// (profile in all-profiles view), None, Profile (always), or Sandbox
+    /// (sb on sandboxed rows).
     #[serde(default)]
     #[setting(
         label = "Row Tag",
@@ -1362,16 +1362,13 @@ pub enum NewSessionAttachMode {
 
 /// What to render in the per-row tag slot next to the session title.
 ///
-/// Defaults to `None` so existing users see no behavior change. Power
-/// users opt in via Settings: pick `Auto` (profile tag in all-profiles
-/// view only), `Profile`, `Sandbox`, or `Branch`.
+/// Defaults to `Branch` to preserve worktree branch visibility. Users can pick
+/// `None` to hide the suffix, `Auto` for profile tags in all-profiles view,
+/// `Profile`, or `Sandbox`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RowTagMode {
-    /// Never render a per-row tag. The historical behavior on `main`
-    /// before the row-tag feature landed; default so the feature is
-    /// fully opt-in.
-    #[default]
+    /// Never render suffix metadata next to the session title.
     None,
     /// Show the profile short code in all-profiles view, nothing in
     /// filtered views.
@@ -1380,8 +1377,8 @@ pub enum RowTagMode {
     Profile,
     /// Render `sb` on sandboxed sessions, nothing on host sessions.
     Sandbox,
-    /// Render the worktree branch name (last segment if `/`-namespaced,
-    /// truncated to 8 chars).
+    /// Render the worktree or workspace branch name, compacted into the row tag.
+    #[default]
     Branch,
 }
 
@@ -1909,11 +1906,6 @@ pub struct WorktreeConfig {
     )]
     pub auto_cleanup: bool,
 
-    /// Show the worktree branch name in the TUI session list.
-    #[serde(default = "default_true")]
-    #[setting(label = "Show Branch in TUI", widget = "toggle", advanced)]
-    pub show_branch_in_tui: bool,
-
     /// Also delete the git branch when deleting a worktree. Default: false
     /// (unchecked in the delete dialog).
     #[serde(default)]
@@ -1980,7 +1972,6 @@ impl Default for WorktreeConfig {
             path_template: default_worktree_template(),
             bare_repo_path_template: default_bare_repo_template(),
             auto_cleanup: true,
-            show_branch_in_tui: true,
             delete_branch_on_cleanup: false,
             workspace_path_template: default_workspace_template(),
             init_submodules: true,
@@ -2803,7 +2794,6 @@ mod tests {
         assert!(!wt.enabled);
         assert_eq!(wt.path_template, "../{repo-name}-worktrees/{branch}");
         assert!(wt.auto_cleanup);
-        assert!(wt.show_branch_in_tui);
         assert!(
             wt.init_submodules,
             "init_submodules must default to true to preserve #942 behavior"
@@ -2816,14 +2806,12 @@ mod tests {
             enabled = true
             path_template = "/custom/{branch}"
             auto_cleanup = false
-            show_branch_in_tui = false
             init_submodules = false
         "#;
         let wt: WorktreeConfig = toml::from_str(toml).unwrap();
         assert!(wt.enabled);
         assert_eq!(wt.path_template, "/custom/{branch}");
         assert!(!wt.auto_cleanup);
-        assert!(!wt.show_branch_in_tui);
         assert!(!wt.init_submodules);
     }
 
@@ -2991,6 +2979,22 @@ mod tests {
         let toml = "default_tool = \"claude\"\n";
         let session: SessionConfig = toml::from_str(toml).unwrap();
         assert!(session.show_tips);
+    }
+
+    #[test]
+    fn test_session_config_row_tag_defaults_to_branch() {
+        let session: SessionConfig = toml::from_str("").unwrap();
+        assert_eq!(session.row_tag, RowTagMode::Branch);
+    }
+
+    #[test]
+    fn test_session_config_row_tag_roundtrip() {
+        let session: SessionConfig = toml::from_str("row_tag = \"none\"\n").unwrap();
+        assert_eq!(session.row_tag, RowTagMode::None);
+
+        let serialized = toml::to_string(&session).unwrap();
+        let reparsed: SessionConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.row_tag, RowTagMode::None);
     }
 
     // Full config serialization roundtrip

--- a/src/session/settings_schema/registry.rs
+++ b/src/session/settings_schema/registry.rs
@@ -117,6 +117,18 @@ mod tests {
     }
 
     #[test]
+    fn session_row_tag_is_select_with_options() {
+        let d = descriptor("session", "row_tag").expect("row_tag");
+        match d.widget {
+            WidgetKind::Select { options } => {
+                let values: Vec<_> = options.iter().map(|o| o.value.as_str()).collect();
+                assert_eq!(values, ["none", "auto", "profile", "sandbox", "branch"]);
+            }
+            other => panic!("expected select, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn schema_serializes_with_tagged_widget_policy_validation() {
         // Locks the JSON contract the web `SettingsFieldDescriptor` TS type
         // depends on (GET /api/settings/schema). Widgets are tagged `kind`,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -13,7 +13,7 @@ use super::{
     ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED, ICON_STOPPED, ICON_UNKNOWN, ICON_UNREAD,
 };
 use crate::containers::image_update::ImageUpdate;
-use crate::session::config::{GroupByMode, SortOrder};
+use crate::session::config::{GroupByMode, RowTagMode, SortOrder};
 use crate::session::{Item, Status};
 use crate::tui::components::preview::{self, CachedPreview};
 use crate::tui::components::{
@@ -281,6 +281,8 @@ pub(crate) struct RowTag {
     pub max_width: usize,
 }
 
+const BRANCH_TAG_WIDTH: usize = 12;
+
 impl RowTag {
     pub fn rendered(&self) -> String {
         format!("[{:<width$}]", self.content, width = self.max_width)
@@ -292,13 +294,12 @@ impl RowTag {
 ///
 /// `Auto` only renders in all-profiles view (no `active_profile`). Other
 /// modes always render when their content is available (e.g. `Branch`
-/// returns `None` for sessions without a worktree).
+/// returns `None` for sessions without branch metadata).
 pub(crate) fn compute_row_tag(
     inst: &crate::session::Instance,
-    mode: crate::session::config::RowTagMode,
+    mode: RowTagMode,
     in_all_profiles_view: bool,
 ) -> Option<RowTag> {
-    use crate::session::config::RowTagMode;
     match mode {
         RowTagMode::None => None,
         RowTagMode::Auto => {
@@ -336,35 +337,51 @@ pub(crate) fn compute_row_tag(
                 None
             }
         }
-        RowTagMode::Branch => inst.worktree_info.as_ref().and_then(|w| {
-            // Complement the existing branch-on-divergence display
-            // (rendered in `theme.branch` color earlier in the row) rather
-            // than duplicate it. When `branch != title` the divergence
-            // display already shows the branch, so the tag would just be
-            // redundant. When `branch == title` the divergence display
-            // stays quiet and the tag fills in.
-            //
-            // Workspace sessions (multi-repo, rendered as
-            // `<branch> [N repos]`) are handled by a separate display
-            // path and have no `worktree_info`, so they fall through to
-            // `None` here naturally.
-            if w.branch != inst.title {
-                return None;
-            }
-            // Show the last `/`-segment of the branch (most informative
-            // for `feature/foo` style names), truncated to 8 chars so the
-            // tag stays narrow.
-            let last = w.branch.rsplit('/').next().unwrap_or("");
-            let trimmed: String = last.chars().take(8).collect();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(RowTag {
-                    content: trimmed,
-                    max_width: 8,
-                })
-            }
-        }),
+        RowTagMode::Branch => branch_row_tag(inst),
+    }
+}
+
+fn branch_row_tag(inst: &crate::session::Instance) -> Option<RowTag> {
+    if let Some(ws) = &inst.workspace_info {
+        workspace_branch_row_tag(&ws.branch, ws.repos.len())
+    } else {
+        inst.worktree_info
+            .as_ref()
+            .and_then(|w| branch_tag_content(&w.branch, BRANCH_TAG_WIDTH))
+            .map(|content| RowTag {
+                content,
+                max_width: BRANCH_TAG_WIDTH,
+            })
+    }
+}
+
+fn workspace_branch_row_tag(branch: &str, repo_count: usize) -> Option<RowTag> {
+    let suffix = format!("+{repo_count}");
+    let suffix_width = suffix.chars().count();
+    if suffix_width >= BRANCH_TAG_WIDTH {
+        return Some(RowTag {
+            content: suffix.chars().take(BRANCH_TAG_WIDTH).collect(),
+            max_width: BRANCH_TAG_WIDTH,
+        });
+    }
+
+    let branch_width = BRANCH_TAG_WIDTH - suffix_width;
+    branch_tag_content(branch, branch_width).map(|mut content| {
+        content.push_str(&suffix);
+        RowTag {
+            content,
+            max_width: BRANCH_TAG_WIDTH,
+        }
+    })
+}
+
+fn branch_tag_content(branch: &str, max_width: usize) -> Option<String> {
+    let last = branch.rsplit('/').next().unwrap_or("");
+    let trimmed: String = last.chars().take(max_width).collect();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
     }
 }
 
@@ -1364,41 +1381,19 @@ impl HomeView {
 
         if let Item::Session { id, .. } = item {
             if let Some(inst) = self.get_instance(id) {
-                if let Some(ws_info) = &inst.workspace_info {
-                    let branch_style = Style::default().fg(theme.branch);
-                    line_spans.push(Span::styled(
-                        format!("  {} [{} repos]", ws_info.branch, ws_info.repos.len()),
-                        if is_selected {
-                            selected_row_style(branch_style, theme)
-                        } else {
-                            branch_style
-                        },
-                    ));
-                } else if let Some(wt_info) = &inst.worktree_info {
-                    if wt_info.branch != inst.title {
-                        let branch_style = Style::default().fg(theme.branch);
-                        line_spans.push(Span::styled(
-                            format!("  {}", wt_info.branch),
-                            if is_selected {
-                                selected_row_style(branch_style, theme)
-                            } else {
-                                branch_style
-                            },
-                        ));
-                    }
-                }
-
-                // Per-row tag. The mode is config-driven (see
-                // `SessionConfig.row_tag` and the Settings UI "Row Tag"
-                // field). Default is `None` so existing users see no
-                // tag; power users opt in for `Auto` (profile in all-
-                // profiles view), `Profile`, `Sandbox`, or `Branch`.
-                // Counted into `used_width` below so the activity
-                // column still right-aligns past the tag.
+                // Config-driven suffix next to the session title. This owns
+                // the branch/profile/sandbox slot, so `None` means no suffix.
+                // Counted into `used_width` below so the activity column still
+                // right-aligns past the tag.
                 if let Some(tag) =
                     compute_row_tag(inst, self.row_tag_mode, self.active_profile.is_none())
                 {
-                    let tag_style = Style::default().fg(theme.dimmed);
+                    let tag_style =
+                        Style::default().fg(if self.row_tag_mode == RowTagMode::Branch {
+                            theme.branch
+                        } else {
+                            theme.dimmed
+                        });
                     line_spans.push(Span::styled(
                         format!("  {}", tag.rendered()),
                         if is_selected {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4332,21 +4332,20 @@ fn rendered_row_text(view: &HomeView, item: &Item) -> String {
         .collect()
 }
 
-/// Default `RowTagMode::None` renders no tag in any view; existing users
-/// see no change from the row-tag feature being added.
-#[test]
-#[serial]
-fn test_default_row_tag_mode_renders_no_tag() {
+fn rendered_single_session_text(
+    inst: Instance,
+    row_tag_mode: crate::session::config::RowTagMode,
+) -> String {
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
 
-    let storage_a = Storage::new_unwatched("alpha").unwrap();
-    let instances_a = vec![Instance::new("A1", "/tmp/a")];
-    let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
-    storage_a
+    let storage = Storage::new_unwatched("alpha").unwrap();
+    let instances = vec![inst];
+    let group_tree = GroupTree::new_with_groups(&instances, &[]);
+    storage
         .update(|i, g| {
-            *i = instances_a.to_vec();
-            *g = group_tree_a.get_all_groups();
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
             Ok(())
         })
         .unwrap();
@@ -4354,19 +4353,40 @@ fn test_default_row_tag_mode_renders_no_tag() {
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
     view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = row_tag_mode;
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    // Default `row_tag_mode` is `None`; no row should carry a bracketed tag.
-    for item in &view.flat_items {
-        if let Item::Session { .. } = item {
-            let text = rendered_row_text(&view, item);
-            assert!(
-                !text.contains('['),
-                "default RowTagMode::None must render no tag: {text:?}"
-            );
-        }
-    }
+    view.flat_items
+        .iter()
+        .find_map(|item| {
+            if let Item::Session { .. } = item {
+                Some(rendered_row_text(&view, item))
+            } else {
+                None
+            }
+        })
+        .expect("session row should render")
+}
+
+/// Default `RowTagMode::Branch` keeps worktree branch information visible.
+#[test]
+#[serial]
+fn test_default_row_tag_mode_renders_branch_tag() {
+    let mut inst = Instance::new("my-session", "/tmp/a");
+    inst.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: "feature/foo".to_string(),
+        main_repo_path: "/tmp/a-main".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+
+    let text = rendered_single_session_text(inst, crate::session::config::RowTagMode::default());
+    assert!(
+        text.contains("[foo         ]"),
+        "default row tag mode should show the compact branch tag: {text:?}"
+    );
 }
 
 /// `RowTagMode::Auto` shows the profile short code in all-profiles view.
@@ -4525,20 +4545,11 @@ fn test_row_tag_profile_renders_in_filtered_view() {
     assert!(seen > 0);
 }
 
-/// `RowTagMode::Branch` complements the existing branch-on-divergence
-/// display rather than duplicating it: when `worktree.branch != title`
-/// the divergence display already shows the branch (in `theme.branch`
-/// color, earlier in the row), so the Branch tag suppresses itself to
-/// avoid showing the same information twice.
+/// `RowTagMode::Branch` owns the branch suffix. It renders a compact tag even
+/// when the title differs from the branch, with no raw hardcoded branch suffix.
 #[test]
 #[serial]
-fn test_row_tag_branch_dedups_with_divergence_display() {
-    let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
-
-    let storage = Storage::new_unwatched("alpha").unwrap();
-    // Title and branch DIFFER, so the existing divergence display
-    // would render the branch.
+fn test_row_tag_branch_renders_when_branch_differs_from_title() {
     let mut inst = Instance::new("my-session", "/tmp/a");
     inst.worktree_info = Some(crate::session::WorktreeInfo {
         branch: "feature/foo".to_string(),
@@ -4547,44 +4558,19 @@ fn test_row_tag_branch_dedups_with_divergence_display() {
         created_at: chrono::Utc::now(),
         base_branch: None,
     });
-    let instances = vec![inst];
-    let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage
-        .update(|i, g| {
-            *i = instances.to_vec();
-            *g = group_tree.get_all_groups();
-            Ok(())
-        })
-        .unwrap();
 
-    let tools = AvailableTools::with_tools(&["claude"]);
-    let mut view = HomeView::new(None, tools, crate::file_watch::FileWatchService::noop()).unwrap();
-    view.group_by = crate::session::config::GroupByMode::Manual;
-    view.row_tag_mode = crate::session::config::RowTagMode::Branch;
-    view.flat_items = view.build_flat_items();
-    view.update_selected();
-
-    // No bracketed `[...]` tag on this row: divergence display owns the
-    // branch label here. The plain `feature/foo` from the divergence
-    // display is still expected in the rendered text.
-    for item in &view.flat_items {
-        if let Item::Session { .. } = item {
-            let text = rendered_row_text(&view, item);
-            assert!(
-                !text.contains('['),
-                "Branch mode must suppress its tag when divergence display already shows the branch: {text:?}"
-            );
-            assert!(
-                text.contains("feature/foo"),
-                "the existing divergence display should still render: {text:?}"
-            );
-        }
-    }
+    let text = rendered_single_session_text(inst, crate::session::config::RowTagMode::Branch);
+    assert!(
+        text.contains("[foo         ]"),
+        "Branch mode should render the compact branch tag: {text:?}"
+    );
+    assert!(
+        !text.contains("feature/foo"),
+        "Branch mode should not render the old raw branch suffix: {text:?}"
+    );
 }
 
-/// `RowTagMode::Branch` DOES render the tag when title matches branch
-/// (the divergence display stays quiet, so the user would otherwise not
-/// know which branch this session is on).
+/// `RowTagMode::Branch` renders the tag when title matches branch.
 #[test]
 #[serial]
 fn test_row_tag_branch_renders_when_title_matches_branch() {
@@ -4618,11 +4604,11 @@ fn test_row_tag_branch_renders_when_title_matches_branch() {
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    // The tag uses the last `/`-segment of the branch, truncated to 8
-    // chars, so `feature/foo` becomes `foo` padded to width 8.
+    // The tag uses the last `/`-segment of the branch and pads to the branch
+    // tag width so the row layout stays stable.
     let rendered = super::render::RowTag {
         content: "foo".to_string(),
-        max_width: 8,
+        max_width: 12,
     }
     .rendered();
     for item in &view.flat_items {
@@ -4634,6 +4620,97 @@ fn test_row_tag_branch_renders_when_title_matches_branch() {
             );
         }
     }
+}
+
+#[test]
+#[serial]
+fn test_row_tag_none_hides_worktree_branch_suffix() {
+    let mut inst = Instance::new("my-session", "/tmp/a");
+    inst.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: "feature/foo".to_string(),
+        main_repo_path: "/tmp/a-main".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+
+    let text = rendered_single_session_text(inst, crate::session::config::RowTagMode::None);
+    assert!(
+        !text.contains("feature/foo") && !text.contains("[foo") && !text.contains('['),
+        "None mode should hide all worktree suffix metadata: {text:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_row_tag_none_hides_workspace_suffix() {
+    let mut inst = Instance::new("workspace-session", "/tmp/workspace");
+    inst.workspace_info = Some(crate::session::WorkspaceInfo {
+        branch: "feature/foo".to_string(),
+        workspace_dir: "/tmp/workspace".to_string(),
+        repos: vec![
+            crate::session::WorkspaceRepo {
+                name: "api".to_string(),
+                source_path: "/src/api".to_string(),
+                branch: "feature/foo".to_string(),
+                worktree_path: "/tmp/workspace/api".to_string(),
+                main_repo_path: "/src/api".to_string(),
+                managed_by_aoe: true,
+            },
+            crate::session::WorkspaceRepo {
+                name: "web".to_string(),
+                source_path: "/src/web".to_string(),
+                branch: "feature/foo".to_string(),
+                worktree_path: "/tmp/workspace/web".to_string(),
+                main_repo_path: "/src/web".to_string(),
+                managed_by_aoe: true,
+            },
+        ],
+        created_at: chrono::Utc::now(),
+        cleanup_on_delete: true,
+    });
+
+    let text = rendered_single_session_text(inst, crate::session::config::RowTagMode::None);
+    assert!(
+        !text.contains("feature/foo") && !text.contains("repos") && !text.contains('['),
+        "None mode should hide all workspace suffix metadata: {text:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_row_tag_branch_renders_workspace_branch_repo_count() {
+    let mut inst = Instance::new("workspace-session", "/tmp/workspace");
+    inst.workspace_info = Some(crate::session::WorkspaceInfo {
+        branch: "feature/foo".to_string(),
+        workspace_dir: "/tmp/workspace".to_string(),
+        repos: vec![
+            crate::session::WorkspaceRepo {
+                name: "api".to_string(),
+                source_path: "/src/api".to_string(),
+                branch: "feature/foo".to_string(),
+                worktree_path: "/tmp/workspace/api".to_string(),
+                main_repo_path: "/src/api".to_string(),
+                managed_by_aoe: true,
+            },
+            crate::session::WorkspaceRepo {
+                name: "web".to_string(),
+                source_path: "/src/web".to_string(),
+                branch: "feature/foo".to_string(),
+                worktree_path: "/tmp/workspace/web".to_string(),
+                main_repo_path: "/src/web".to_string(),
+                managed_by_aoe: true,
+            },
+        ],
+        created_at: chrono::Utc::now(),
+        cleanup_on_delete: true,
+    });
+
+    let text = rendered_single_session_text(inst, crate::session::config::RowTagMode::Branch);
+    assert!(
+        text.contains("[foo+2       ]"),
+        "Branch mode should render compact workspace branch and repo count: {text:?}"
+    );
 }
 
 /// Legacy `Instance::new` left `source_profile` empty before the per-profile

--- a/tests/integration/config_wiring.rs
+++ b/tests/integration/config_wiring.rs
@@ -152,7 +152,6 @@ fn test_all_worktree_config_fields_accessible() {
     let _ = config.enabled;
     let _ = config.path_template.as_str();
     let _ = config.auto_cleanup;
-    let _ = config.show_branch_in_tui;
 }
 
 #[test]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,6 +75,7 @@ import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { normalizeProjectPathKey } from "./lib/registeredProjects";
 import { IdleDecayWindowContext, parseIdleDecayWindowMs, useIdleDecayWindowMs } from "./lib/idleDecay";
 import { parseUnreadIndicatorEnabled, UnreadIndicatorContext, useUnreadIndicatorEnabled } from "./lib/unreadIndicator";
+import { parseSessionRowTagMode, SessionRowTagContext, type SessionRowTagMode } from "./lib/sessionRowTag";
 import { toastBus, reportError } from "./lib/toastBus";
 import { resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
@@ -149,6 +150,17 @@ export default function App() {
   const [tokenExpired, setTokenExpired] = useState(false);
   const [idleDecayWindowMs, setIdleDecayWindowMs] = useState(IDLE_DECAY_WINDOW_MS);
   const [unreadIndicatorEnabled, setUnreadIndicatorEnabled] = useState(true);
+  const [sessionRowTagMode, setSessionRowTagMode] = useState<SessionRowTagMode>("branch");
+
+  const applyAppSettings = useCallback((settings: Record<string, unknown> | null | undefined) => {
+    setIdleDecayWindowMs(parseIdleDecayWindowMs(settings));
+    setUnreadIndicatorEnabled(parseUnreadIndicatorEnabled(settings));
+    setSessionRowTagMode(parseSessionRowTagMode(settings));
+  }, []);
+
+  const refreshAppSettings = useCallback(async () => {
+    applyAppSettings(await fetchSettings());
+  }, [applyAppSettings]);
 
   useEffect(() => {
     const onTokenExpired = () => setTokenExpired(true);
@@ -177,11 +189,8 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    fetchSettings().then((settings) => {
-      setIdleDecayWindowMs(parseIdleDecayWindowMs(settings));
-      setUnreadIndicatorEnabled(parseUnreadIndicatorEnabled(settings));
-    });
-  }, []);
+    fetchSettings().then(applyAppSettings);
+  }, [applyAppSettings]);
 
   const handleTokenSuccess = () => {
     setTokenExpired(false);
@@ -221,13 +230,15 @@ export default function App() {
   return (
     <IdleDecayWindowContext.Provider value={idleDecayWindowMs}>
       <UnreadIndicatorContext.Provider value={unreadIndicatorEnabled}>
-        {/* PluginUiProvider must sit above AppContent: AppContent itself reads
-            the plugin UI snapshot (usePluginPanes), so the provider can't live
-            inside its own return. */}
-        <PluginUiProvider>
-          <AppContent loginRequired={loginRequired} onLogout={handleLogout} />
-        </PluginUiProvider>
-        <ElevationPrompt />
+        <SessionRowTagContext.Provider value={sessionRowTagMode}>
+          {/* PluginUiProvider must sit above AppContent: AppContent itself reads
+              the plugin UI snapshot (usePluginPanes), so the provider can't live
+              inside its own return. */}
+          <PluginUiProvider>
+            <AppContent loginRequired={loginRequired} onLogout={handleLogout} onSettingsRefresh={refreshAppSettings} />
+          </PluginUiProvider>
+          <ElevationPrompt />
+        </SessionRowTagContext.Provider>
       </UnreadIndicatorContext.Provider>
     </IdleDecayWindowContext.Provider>
   );
@@ -249,7 +260,15 @@ function isInsideEditable(target: EventTarget | null): boolean {
   return false;
 }
 
-function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
+function AppContent({
+  loginRequired,
+  onLogout,
+  onSettingsRefresh,
+}: {
+  loginRequired: boolean;
+  onLogout: () => void;
+  onSettingsRefresh: () => Promise<void> | void;
+}) {
   // Wire the localStorage write chokepoint and pull the server-side UI-state
   // blob into localStorage. AppContent only mounts past auth, so this runs as
   // the authenticated user. Background (does NOT gate render): blocking first
@@ -1429,6 +1448,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             navigate(`/settings/${t}${p ? `?profile=${encodeURIComponent(p)}` : ""}`);
           }}
           onServerAboutRefresh={refreshServerAbout}
+          onSettingsRefresh={onSettingsRefresh}
           profile={searchParams.get("profile")}
           onSelectProfile={(p) => {
             const next = new URLSearchParams(searchParams);

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -115,6 +115,7 @@ interface Props {
   tab: string | null;
   onSelectTab: (tab: TabId) => void;
   onServerAboutRefresh: () => Promise<void> | void;
+  onSettingsRefresh?: () => Promise<void> | void;
   /** Profile to preselect, sourced from the `?profile=` query so the
    *  Profiles page can deep-link into a specific profile's section. */
   profile?: string | null;
@@ -185,6 +186,7 @@ export function SettingsView({
   tab,
   onSelectTab,
   onServerAboutRefresh,
+  onSettingsRefresh = () => {},
   profile,
   onSelectProfile,
   readOnly,
@@ -460,6 +462,9 @@ export function SettingsView({
                 focusRequest={focusRequest}
                 values={session}
                 onSaveField={saveSubField}
+                onAfterSave={(descriptor) => {
+                  if (descriptor.field === "row_tag") return onSettingsRefresh();
+                }}
                 advancedSubtitle="Idle auto-stop, attach modes, live-send, and other session tuning."
               />
             )}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -72,6 +72,7 @@ import { STATUS_DOT_CLASS, getStatusTextClass, isSessionActive } from "../lib/se
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { exceedsTouchSlop } from "../lib/longPress";
 import { useUnreadIndicatorEnabled } from "../lib/unreadIndicator";
+import { computeSessionRowTag, useSessionRowTagMode } from "../lib/sessionRowTag";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   createSession,
@@ -946,9 +947,11 @@ export const SessionRow = memo(function SessionRow({
   const sessionTitle = firstSession?.title.trim() ?? "";
   const branchLabel = workspace.branch ?? null;
   const baseBranch = firstSession?.base_branch ?? null;
+  const rowTagMode = useSessionRowTagMode();
+  const rowTag = computeSessionRowTag(workspace, rowTagMode);
+  const rowTagTitle =
+    rowTag?.kind === "branch" && baseBranch ? `${rowTag.title} (based on ${baseBranch})` : rowTag?.title;
   const label = singleSession ? sessionTitle || branchLabel || "default" : branchLabel || sessionTitle || "default";
-  const subtitle = singleSession && sessionTitle && branchLabel && sessionTitle !== branchLabel ? branchLabel : null;
-  const subtitleTitle = subtitle && baseBranch ? `${subtitle} (based on ${baseBranch})` : subtitle;
   // Workspace renders as favorited when any of its sessions are
   // favorited. Mirrors the TUI's within-tier pin: the star promotes the
   // row visually so the user can find their starred work fast. Toggled
@@ -1379,6 +1382,19 @@ export const SessionRow = memo(function SessionRow({
               <span className="truncate" title={label}>
                 {label}
               </span>
+              {rowTag && (
+                <span
+                  data-testid="sidebar-session-row-tag"
+                  title={rowTagTitle}
+                  className={`inline-flex shrink-0 items-center rounded border px-1 py-0 text-[10px] font-mono font-medium ${
+                    rowTag.kind === "branch"
+                      ? "border-brand-700/40 bg-brand-950/20 text-brand-300"
+                      : "border-surface-700/40 bg-surface-800/40 text-text-dim"
+                  }`}
+                >
+                  [{rowTag.content}]
+                </span>
+              )}
               {hasDraft && (
                 <span title="Unsent draft" aria-label="Unsent draft" className="inline-flex shrink-0">
                   <Pencil className="h-3 w-3 text-amber-400/90" />
@@ -1460,12 +1476,6 @@ export const SessionRow = memo(function SessionRow({
               {firstSession?.monitor_active && <MonitorBadge description={firstSession.monitor_description} />}
             </span>
             {firstSession && <PluginRowLine sessionId={firstSession.id} />}
-            {subtitle && (
-              <span className="block text-[11px] font-mono text-text-dim truncate" title={subtitleTitle ?? subtitle}>
-                {subtitle}
-                {baseBranch && <span className="ml-1 text-text-dim/70">← {baseBranch}</span>}
-              </span>
-            )}
             {firstSession?.plan_summary &&
               firstSession.plan_summary.total > 0 &&
               // Hide the completed-plan bar when the session is also

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1388,7 +1388,7 @@ export const SessionRow = memo(function SessionRow({
                   title={rowTagTitle}
                   className={`inline-flex shrink-0 items-center rounded border px-1 py-0 text-[10px] font-mono font-medium ${
                     rowTag.kind === "branch"
-                      ? "border-brand-700/40 bg-brand-950/20 text-brand-300"
+                      ? "border-brand-700/40 bg-brand-700/5 text-brand-300"
                       : "border-surface-700/40 bg-surface-800/40 text-text-dim"
                   }`}
                 >

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -22,6 +22,7 @@ const SINGLE_BULK_API: RowBulkApi = {
   snooze: () => {},
 };
 import { UnreadIndicatorContext } from "../../lib/unreadIndicator";
+import { SessionRowTagContext, type SessionRowTagMode } from "../../lib/sessionRowTag";
 import { useSidebarTriage } from "../../hooks/useSidebarTriage";
 import type { SessionResponse, Workspace } from "../../lib/types";
 import { OPEN_SESSION_EVENT } from "../../lib/sessionRoute";
@@ -75,9 +76,13 @@ function workspace(id: string, sessions: SessionResponse[]): Workspace {
   };
 }
 
-function Wrap({ children }: { children: ReactNode }) {
+function Wrap({ children, rowTagMode = "branch" }: { children: ReactNode; rowTagMode?: SessionRowTagMode }) {
   const ref = useRef(0);
-  return <DragSuppressContext.Provider value={ref}>{children}</DragSuppressContext.Provider>;
+  return (
+    <DragSuppressContext.Provider value={ref}>
+      <SessionRowTagContext.Provider value={rowTagMode}>{children}</SessionRowTagContext.Provider>
+    </DragSuppressContext.Provider>
+  );
 }
 
 // Mounts a SessionRow wired to the real `useSidebarTriage` controller, the
@@ -221,6 +226,84 @@ describe("SessionRow chips", () => {
     // coexisting at the session level, but defensive rendering
     // hides the snooze chip if the workspace surfaces both.
     expect(screen.queryByLabelText("Snoozed")).toBeNull();
+  });
+});
+
+describe("SessionRow row tags", () => {
+  it("renders a compact branch tag and removes the hardcoded branch subtitle", () => {
+    const ws = {
+      ...workspace("w-branch", [session({ branch: "feature/web-row-tag" })]),
+      branch: "feature/web-row-tag",
+    };
+    render(
+      <Wrap rowTagMode="branch">
+        <Row ws={ws} />
+      </Wrap>,
+    );
+
+    expect(screen.getByTestId("sidebar-session-row-tag").textContent).toBe("[web-row-tag]");
+    expect(screen.queryByText("feature/web-row-tag")).toBeNull();
+  });
+
+  it("hides all session suffix metadata when row_tag is none", () => {
+    const ws = {
+      ...workspace("w-none", [session({ branch: "feature/hidden" })]),
+      branch: "feature/hidden",
+    };
+    render(
+      <Wrap rowTagMode="none">
+        <Row ws={ws} />
+      </Wrap>,
+    );
+
+    expect(screen.queryByTestId("sidebar-session-row-tag")).toBeNull();
+    expect(screen.queryByText("feature/hidden")).toBeNull();
+  });
+
+  it("renders profile, auto, and sandbox tags from the first session", () => {
+    const ws = workspace("w-profile", [session({ profile: "forit-backup", is_sandboxed: true })]);
+
+    const { rerender } = render(
+      <Wrap rowTagMode="profile">
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.getByTestId("sidebar-session-row-tag").textContent).toBe("[fb]");
+
+    rerender(
+      <Wrap rowTagMode="auto">
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.getByTestId("sidebar-session-row-tag").textContent).toBe("[fb]");
+
+    rerender(
+      <Wrap rowTagMode="sandbox">
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.getByTestId("sidebar-session-row-tag").textContent).toBe("[sb]");
+  });
+
+  it("renders multi-repo workspace branch tags without removing repo chips", () => {
+    const ws = workspace("w-workspace", [
+      session({
+        workspace_repos: [
+          { name: "api", source_path: "/repo/api", branch: "feature/web-tags" },
+          { name: "web", source_path: "/repo/web", branch: "feature/web-tags" },
+        ],
+      }),
+    ]);
+
+    render(
+      <Wrap rowTagMode="branch">
+        <Row ws={ws} />
+      </Wrap>,
+    );
+
+    expect(screen.getByTestId("sidebar-session-row-tag").textContent).toBe("[web-tags+2]");
+    expect(screen.getByText("api")).not.toBeNull();
+    expect(screen.getByText("web")).not.toBeNull();
   });
 });
 

--- a/web/src/components/__tests__/SettingsView.session.test.tsx
+++ b/web/src/components/__tests__/SettingsView.session.test.tsx
@@ -52,6 +52,27 @@ const SESSION_SCHEMA = [
     validation: { rule: "none" },
     advanced: false,
   },
+  {
+    section: "session",
+    field: "row_tag",
+    category: "Sessions",
+    label: "Row Tag",
+    description: "What to show next to each session title",
+    widget: {
+      kind: "select",
+      options: [
+        { value: "none", label: "None" },
+        { value: "auto", label: "Auto" },
+        { value: "profile", label: "Profile" },
+        { value: "sandbox", label: "Sandbox" },
+        { value: "branch", label: "Branch" },
+      ],
+    },
+    web_write: { policy: "allow" },
+    profile_overridable: true,
+    validation: { rule: "none" },
+    advanced: false,
+  },
 ];
 
 vi.mock("../../lib/api", () => ({
@@ -134,6 +155,7 @@ describe("Session tab auto-stop idle field", () => {
   });
 
   it("persists session.smart_rename through the profile path", async () => {
+    const onSettingsRefresh = vi.fn();
     vi.mocked(api.fetchSettings).mockResolvedValue({
       session: { smart_rename: true },
       acp: {},
@@ -142,7 +164,13 @@ describe("Session tab auto-stop idle field", () => {
     } as never);
 
     const { container } = render(
-      <SettingsView onClose={() => {}} tab="session" onSelectTab={() => {}} onServerAboutRefresh={() => {}} />,
+      <SettingsView
+        onClose={() => {}}
+        tab="session"
+        onSelectTab={() => {}}
+        onServerAboutRefresh={() => {}}
+        onSettingsRefresh={onSettingsRefresh}
+      />,
     );
     await screen.findByText("Smart Session Rename");
 
@@ -156,6 +184,42 @@ describe("Session tab auto-stop idle field", () => {
         session: { smart_rename: false },
       }),
     );
+    expect(onSettingsRefresh).not.toHaveBeenCalled();
+  });
+
+  it("refreshes app-level settings after saving session.row_tag", async () => {
+    const onSettingsRefresh = vi.fn();
+    vi.mocked(api.fetchSettings).mockResolvedValue({
+      session: { row_tag: "branch" },
+      acp: {},
+      sandbox: {},
+      worktree: {},
+    } as never);
+
+    const { container } = render(
+      <SettingsView
+        onClose={() => {}}
+        tab="session"
+        onSelectTab={() => {}}
+        onServerAboutRefresh={() => {}}
+        onSettingsRefresh={onSettingsRefresh}
+      />,
+    );
+    await screen.findByText("Row Tag");
+
+    const selects = Array.from(container.querySelectorAll("select"));
+    const rowTagSelect = selects.find((select) =>
+      Array.from(select.options).some((option) => option.value === "sandbox"),
+    ) as HTMLSelectElement | undefined;
+    expect(rowTagSelect).toBeTruthy();
+    fireEvent.change(rowTagSelect!, { target: { value: "none" } });
+
+    await waitFor(() =>
+      expect(vi.mocked(api.updateProfileSettings)).toHaveBeenCalledWith("main", {
+        session: { row_tag: "none" },
+      }),
+    );
+    expect(onSettingsRefresh).toHaveBeenCalledTimes(1);
   });
 
   it("persists acp.acp_defaults through the profile path via the raw-JSON fold", async () => {

--- a/web/src/lib/sessionRowTag.test.ts
+++ b/web/src/lib/sessionRowTag.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { computeSessionRowTag, parseSessionRowTagMode } from "./sessionRowTag";
+import type { SessionResponse, Workspace } from "./types";
+
+function session(overrides: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "row title",
+    project_path: "/repo",
+    artifact_dir: "/tmp/artifacts/s1",
+    group_path: "/repo",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    scratch: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+      delete_to_trash: true,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    ...overrides,
+  };
+}
+
+function workspace(overrides: Partial<Workspace> = {}, sessions = [session()]): Workspace {
+  return {
+    id: "w1",
+    branch: null,
+    projectPath: "/repo",
+    displayName: "row title",
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions,
+    ...overrides,
+  };
+}
+
+describe("parseSessionRowTagMode", () => {
+  it("accepts known session.row_tag values and defaults invalid input to branch", () => {
+    expect(parseSessionRowTagMode({ session: { row_tag: "none" } })).toBe("none");
+    expect(parseSessionRowTagMode({ session: { row_tag: "auto" } })).toBe("auto");
+    expect(parseSessionRowTagMode({ session: { row_tag: "profile" } })).toBe("profile");
+    expect(parseSessionRowTagMode({ session: { row_tag: "sandbox" } })).toBe("sandbox");
+    expect(parseSessionRowTagMode({ session: { row_tag: "branch" } })).toBe("branch");
+    expect(parseSessionRowTagMode({ session: { row_tag: "bogus" } })).toBe("branch");
+    expect(parseSessionRowTagMode(null)).toBe("branch");
+  });
+});
+
+describe("computeSessionRowTag", () => {
+  it("uses the last branch path segment and truncates to the TUI branch width", () => {
+    const tag = computeSessionRowTag(workspace({ branch: "feature/configurable-session-name-suffix" }), "branch");
+    expect(tag?.content).toBe("configurable");
+    expect(tag?.title).toBe("feature/configurable-session-name-suffix");
+  });
+
+  it("adds the workspace repo count to common multi-repo branch tags", () => {
+    const ws = workspace({}, [
+      session({
+        workspace_repos: [
+          { name: "api", source_path: "/repo/api", branch: "feature/web-tags" },
+          { name: "web", source_path: "/repo/web", branch: "feature/web-tags" },
+        ],
+      }),
+    ]);
+
+    const tag = computeSessionRowTag(ws, "branch");
+    expect(tag?.content).toBe("web-tags+2");
+    expect(tag?.title).toBe("feature/web-tags across 2 repos");
+  });
+
+  it("uses the row's first session for profile and sandbox tags", () => {
+    const ws = workspace({}, [session({ profile: "forit-backup", is_sandboxed: true })]);
+
+    expect(computeSessionRowTag(ws, "profile")?.content).toBe("fb");
+    expect(computeSessionRowTag(ws, "auto")?.content).toBe("fb");
+    expect(computeSessionRowTag(ws, "sandbox")?.content).toBe("sb");
+  });
+
+  it("returns no tag for none, host sandbox mode, or mixed multi-repo branches", () => {
+    expect(computeSessionRowTag(workspace(), "none")).toBeNull();
+    expect(computeSessionRowTag(workspace(), "sandbox")).toBeNull();
+    expect(
+      computeSessionRowTag(
+        workspace({}, [
+          session({
+            workspace_repos: [
+              { name: "api", source_path: "/repo/api", branch: "feature/api" },
+              { name: "web", source_path: "/repo/web", branch: "feature/web" },
+            ],
+          }),
+        ]),
+        "branch",
+      ),
+    ).toBeNull();
+  });
+});

--- a/web/src/lib/sessionRowTag.ts
+++ b/web/src/lib/sessionRowTag.ts
@@ -1,0 +1,112 @@
+import { createContext, useContext } from "react";
+
+import type { Workspace, WorkspaceRepoSummary } from "./types";
+
+export type SessionRowTagMode = "none" | "auto" | "profile" | "sandbox" | "branch";
+
+export interface SessionRowTag {
+  content: string;
+  title: string;
+  kind: Exclude<SessionRowTagMode, "none">;
+}
+
+const DEFAULT_ROW_TAG_MODE: SessionRowTagMode = "branch";
+const PROFILE_TAG_WIDTH = 4;
+const BRANCH_TAG_WIDTH = 12;
+
+export const SessionRowTagContext = createContext<SessionRowTagMode>(DEFAULT_ROW_TAG_MODE);
+
+export function parseSessionRowTagMode(settings: Record<string, unknown> | null | undefined): SessionRowTagMode {
+  const session = settings?.session;
+  if (!session || typeof session !== "object") return DEFAULT_ROW_TAG_MODE;
+  const raw = (session as Record<string, unknown>).row_tag;
+  switch (raw) {
+    case "none":
+    case "auto":
+    case "profile":
+    case "sandbox":
+    case "branch":
+      return raw;
+    default:
+      return DEFAULT_ROW_TAG_MODE;
+  }
+}
+
+export function useSessionRowTagMode(): SessionRowTagMode {
+  return useContext(SessionRowTagContext);
+}
+
+export function computeSessionRowTag(workspace: Workspace, mode: SessionRowTagMode): SessionRowTag | null {
+  const primary = workspace.sessions[0];
+  if (!primary) return null;
+
+  switch (mode) {
+    case "none":
+      return null;
+    case "auto":
+    case "profile": {
+      const content = profileShortCode(primary.profile);
+      return content ? { content, title: primary.profile, kind: mode } : null;
+    }
+    case "sandbox":
+      return primary.is_sandboxed ? { content: "sb", title: "Sandboxed", kind: mode } : null;
+    case "branch":
+      return branchRowTag(workspace);
+  }
+}
+
+function profileShortCode(profile: string): string {
+  const segments = profile.split(/[-_]/).filter(Boolean);
+  const code =
+    segments.length === 0
+      ? ""
+      : segments.length === 1
+        ? Array.from(segments[0]!).slice(0, 3).join("")
+        : segments
+            .map((segment) => Array.from(segment)[0])
+            .filter((char): char is string => !!char)
+            .slice(0, PROFILE_TAG_WIDTH)
+            .join("");
+  return code.toLowerCase();
+}
+
+function branchRowTag(workspace: Workspace): SessionRowTag | null {
+  const primary = workspace.sessions[0];
+  if (!primary) return null;
+  const repos = primary.workspace_repos ?? [];
+  if (repos.length > 1) {
+    const branch = workspace.branch ?? commonWorkspaceBranch(repos);
+    if (!branch) return null;
+    const content = workspaceBranchTagContent(branch, repos.length);
+    return content ? { content, title: `${branch} across ${repos.length} repos`, kind: "branch" } : null;
+  }
+
+  const branch = workspace.branch ?? primary.branch;
+  if (!branch) return null;
+  const content = branchTagContent(branch, BRANCH_TAG_WIDTH);
+  return content ? { content, title: branch, kind: "branch" } : null;
+}
+
+function commonWorkspaceBranch(repos: WorkspaceRepoSummary[]): string | null {
+  const first = repos[0]?.branch;
+  if (!first) return null;
+  return repos.every((repo) => repo.branch === first) ? first : null;
+}
+
+function workspaceBranchTagContent(branch: string, repoCount: number): string | null {
+  const suffix = `+${repoCount}`;
+  const suffixWidth = Array.from(suffix).length;
+  if (suffixWidth >= BRANCH_TAG_WIDTH) {
+    return Array.from(suffix).slice(0, BRANCH_TAG_WIDTH).join("");
+  }
+
+  const branchWidth = BRANCH_TAG_WIDTH - suffixWidth;
+  const content = branchTagContent(branch, branchWidth);
+  return content ? `${content}${suffix}` : null;
+}
+
+function branchTagContent(branch: string, maxWidth: number): string | null {
+  const last = branch.split("/").pop() ?? "";
+  const content = Array.from(last).slice(0, maxWidth).join("");
+  return content ? content : null;
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1088,6 +1088,17 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.row-tag",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SessionRowTriage.test.tsx",
+        "src/components/__tests__/SettingsView.session.test.tsx",
+        "src/lib/sessionRowTag.test.ts"
+      ],
+      "components": ["web/src/components/WorkspaceSidebar.tsx", "web/src/components/SettingsView.tsx"]
+    },
+    {
       "id": "sidebar.sort-pure",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/sidebar-multi-session.spec.ts
+++ b/web/tests/sidebar-multi-session.spec.ts
@@ -14,8 +14,48 @@ interface MockSession {
   status?: string;
 }
 
-async function mockApis(page: Page, sessions: MockSession[]) {
+const ROW_TAG_SCHEMA = [
+  {
+    section: "session",
+    field: "row_tag",
+    category: "Sessions",
+    label: "Row Tag",
+    description: "What to show next to each session title",
+    widget: {
+      kind: "select",
+      options: [
+        { value: "none", label: "None" },
+        { value: "auto", label: "Auto" },
+        { value: "profile", label: "Profile" },
+        { value: "sandbox", label: "Sandbox" },
+        { value: "branch", label: "Branch" },
+      ],
+    },
+    web_write: { policy: "allow" },
+    profile_overridable: true,
+    validation: { rule: "none" },
+    advanced: false,
+  },
+];
+
+async function mockApis(
+  page: Page,
+  sessions: MockSession[],
+  options: { rowTag?: "none" | "auto" | "profile" | "sandbox" | "branch" } = {},
+) {
+  let rowTag = options.rowTag ?? "branch";
   await page.route("**/api/login/status", (r) => r.fulfill({ json: { required: false, authenticated: true } }));
+  await page.route("**/api/settings**", (r) => {
+    const pathname = new URL(r.request().url()).pathname;
+    if (pathname === "/api/settings/schema") return r.fulfill({ json: ROW_TAG_SCHEMA });
+    if (pathname === "/api/settings") return r.fulfill({ json: { session: { row_tag: rowTag } } });
+    return r.fulfill({ status: 404 });
+  });
+  await page.route("**/api/profiles/*/settings", async (r) => {
+    const body = r.request().postDataJSON() as { session?: { row_tag?: typeof rowTag } };
+    rowTag = body.session?.row_tag ?? rowTag;
+    return r.fulfill({ json: { ok: true } });
+  });
   await page.route("**/api/sessions", (r) => {
     if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
     return r.fulfill({
@@ -42,7 +82,7 @@ async function mockApis(page: Page, sessions: MockSession[]) {
       },
     });
   });
-  for (const path of ["settings", "themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
+  for (const path of ["themes", "agents", "profiles", "groups", "devices", "docker/status", "about"]) {
     await page.route(`**/api/${path}`, (r) => r.fulfill({ json: path === "docker/status" ? {} : [] }));
   }
 }
@@ -217,8 +257,40 @@ test.describe("Sidebar multi-session (#956)", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await expect(page.locator("header")).toBeVisible();
-    await expect(page.getByRole("link", { name: /feature\/a/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /feature\/b/i })).toBeVisible();
+    const rowA = page.getByRole("link", { name: /Italians/i });
+    const rowB = page.getByRole("link", { name: /Magyars/i });
+    await expect(rowA).toBeVisible();
+    await expect(rowA.getByTestId("sidebar-session-row-tag")).toHaveText("[a]");
+    await expect(rowB).toBeVisible();
+    await expect(rowB.getByTestId("sidebar-session-row-tag")).toHaveText("[b]");
+  });
+
+  test("saving row tag settings refreshes the sidebar suffix", async ({ page }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Italians",
+        project_path: "/tmp/agent-of-empires",
+        branch: "feature/a",
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+    const row = page.getByRole("link", { name: /Italians/i });
+    await expect(row.getByTestId("sidebar-session-row-tag")).toHaveText("[a]");
+
+    await page.goto("/settings/session");
+    await expect(page.getByText("Row Tag", { exact: true })).toBeVisible();
+    const refreshedSettings = page.waitForResponse((response) => {
+      const request = response.request();
+      return request.method() === "GET" && new URL(response.url()).pathname === "/api/settings";
+    });
+    await page.getByRole("combobox").last().selectOption("none");
+    await refreshedSettings;
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+    await expect(page.getByRole("link", { name: /Italians/i }).getByTestId("sidebar-session-row-tag")).toHaveCount(0);
   });
 
   test("project group context menu stores alias and background color", async ({ page }) => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Makes the metadata shown next to each session name controlled by the existing `session.row_tag` setting in both the TUI and web dashboard sidebar. The row suffix slot now has one source of truth: `branch`, `none`, `auto`, `profile`, `sandbox`. Setting `row_tag = "none"` now hides worktree and workspace suffix metadata instead of leaving old hardcoded branch text behind.

Branch mode renders a compact bracketed branch tag for single-worktree sessions and multi-repo workspace sessions. The default remains `branch`, preserving existing branch visibility. The web sidebar now reads the same setting, updates after a Row Tag save, and removes the old branch subtitle so the setting controls the full suffix area.

The old `worktree.show_branch_in_tui` toggle is removed from settings and migrated to `session.row_tag = "none"` when users had explicitly set it to `false`.

Closes #1368

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the TUI with a worktree session using default settings: the row shows a compact branch tag next to the session title.
- [ ] Set `[session] row_tag = "none"` or choose Row Tag = None in settings, reload the TUI, and confirm worktree and workspace branch suffixes disappear from session rows.
- [ ] Set Row Tag = Profile and confirm rows show compact profile tags next to the session title.
- [ ] Set Row Tag = Sandbox and confirm sandboxed rows show `sb` while host rows do not show a suffix.
- [ ] Open the web dashboard with default settings and confirm the sidebar shows the compact branch tag inline next to the session title, with no separate branch subtitle.
- [ ] In web Settings, change Sessions > Row Tag to None and confirm the sidebar suffix disappears after save without a full page reload.
- [ ] Start once with an old config containing `[worktree] show_branch_in_tui = false` and confirm the config migrates to `[session] row_tag = "none"` with the stale worktree key removed.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Added or updated Vitest component coverage for the row-tag helper, Settings save hook, and sidebar rendering.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is covered by deterministic TUI render unit tests for `branch`, `none`, `profile`, `sandbox`, and workspace rows, plus migration and schema tests. No tmux/session lifecycle path changed.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a `/debate` design pass, implementation, tests, and PR prose were drafted by Claude under my direction. I made the design calls and reviewed the final diff.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
