### PR TITLE
feat(serve): configurable pane-text rules with command actions

### DIFF
--- a/docs/guides/pane-rules.md
+++ b/docs/guides/pane-rules.md
@@ -1,0 +1,110 @@
+# Pane Rules
+
+Pane rules let the `aoe serve` daemon watch every session's terminal output for text you care about and run a command when it appears. Think of them as "when a pane says X, do Y": detect a usage-limit banner and rotate work to another account, catch a sign-in prompt and send yourself a push notification, or flag any agent that prints a phrase your team uses for "I need a human".
+
+The daemon periodically captures the tail of each registered session's tmux pane, runs your rules against it, and executes the matching rule's command with the session context in its environment. Rules are pure configuration; no code changes are needed to add one.
+
+Pane rules require a running daemon (`aoe serve`). A read-only daemon never runs pane rules, since they execute user commands.
+
+## Quick start
+
+Add a `[watchdog]` section to `~/.agent-of-empires/config.toml` (or your platform's config path):
+
+```toml
+[[watchdog.rules]]
+name = "usage-cap"
+kind = "cap"
+pattern = '(?i)^usage limit reached'
+command = "~/bin/notify-capped.sh"
+```
+
+Restart the daemon. Every scan (default: every 3 minutes), any session whose recent pane output contains a line starting with "usage limit reached" runs `~/bin/notify-capped.sh` with these variables in its environment:
+
+| Variable | Value |
+|----------|-------|
+| `AOE_RULE_NAME` | The rule's `name` ("usage-cap") |
+| `AOE_RULE_KIND` | The rule's `kind` ("cap") |
+| `AOE_SESSION_ID` | The matched session's id |
+| `AOE_SESSION_TITLE` | The matched session's title |
+| `AOE_SESSION_PROFILE` | The profile the session belongs to |
+
+The command runs via `sh -c`, is killed after 60 seconds, and its failures are logged, never fatal.
+
+## Rule reference
+
+```toml
+[watchdog]
+# disabled = true          # turn the watchdog off without deleting rules
+# interval_secs = 180      # scan cadence (minimum 10)
+
+[[watchdog.rules]]
+name = "device-code"           # required: label for logs and AOE_RULE_NAME
+kind = "auth"                  # optional: free-form category, AOE_RULE_KIND
+pattern = '(?is)devicelogin.*code'   # required: regex (Rust regex syntax)
+negative = ['(?i)example']     # optional: text matching any of these never fires the rule
+tail_lines = 8                 # optional: how many recent non-empty lines are in scope (default 15)
+scope = "window"               # optional: "line" (default) or "window"
+strip_decoration = true        # optional: strip leading TUI chrome before matching (default true)
+priority = 1                   # optional: lower fires first when several rules match (default 0)
+enabled = true                 # optional: set false to keep a rule but skip it
+command = "notify.sh"          # optional: run on match; omit to only log
+cooldown_secs = 1800           # optional: per-session refire floor (default 30 minutes)
+```
+
+Field notes:
+
+- **`pattern`** is matched case-sensitively; start it with `(?i)` for case-insensitive. Anchors (`^`) apply per line in `line` scope and to the joined window text in `window` scope.
+- **`scope = "line"`** tries the pattern against each recent non-empty line individually. **`scope = "window"`** joins the tail into one string first, for prompts that span lines (add `(?s)` so `.` crosses newlines).
+- **`tail_lines`** counts non-empty lines from the live edge of the pane. Keep it small: a tight window keeps stale scrollback (a banner from an hour ago, an error the agent already recovered from) from firing.
+- **`strip_decoration`** removes leading selector glyphs, bullets, and a `1.` or `2)` option enumerator so an anchored pattern still matches a highlighted TUI menu row. It applies only in `line` scope, and only for the pattern; `negative` guards always see the raw line.
+- **`negative`** guards suppress a match, useful when the trigger phrase also appears in benign text.
+- **`cooldown_secs`** stops a pane that stays in the matched state from re-running the command every scan. The first match fires immediately; repeats within the window are skipped per session and rule.
+- ANSI escape sequences are stripped from the pane before matching.
+
+An invalid regex does not break the daemon: the rule is dropped with a warning in the daemon log and the remaining rules keep running.
+
+## Examples
+
+Notify your phone when any agent is waiting on a device-code sign-in (see [Push Notifications](../push-notifications.md) for a richer channel):
+
+```toml
+[[watchdog.rules]]
+name = "device-code"
+kind = "auth"
+pattern = '(?is)devicelogin.*[A-Z0-9]{8,9}'
+scope = "window"
+tail_lines = 8
+cooldown_secs = 600
+command = "notify-send 'AoE' \"$AOE_SESSION_TITLE needs a device-code sign-in\""
+```
+
+Log every session that hits a provider usage cap, with a guard against prose mentions:
+
+```toml
+[[watchdog.rules]]
+name = "usage-cap"
+kind = "cap"
+pattern = '(?i)^(usage limit reached|you.ve hit your usage limit)'
+negative = ['(?i)if you hit your usage limit']
+tail_lines = 30
+command = "echo \"$(date -u +%FT%TZ) $AOE_SESSION_ID $AOE_SESSION_TITLE\" >> ~/aoe-capped.log"
+```
+
+Escalate when an agent prints your team's hand-off phrase, using a case-sensitive anchored match so prose does not trigger it:
+
+```toml
+[[watchdog.rules]]
+name = "needs-human"
+kind = "escalation"
+pattern = '^ACTION REQUIRED'
+strip_decoration = false
+priority = 5
+command = "~/bin/page-oncall.sh"
+```
+
+## How scanning works
+
+- The daemon scans on a fixed interval (`interval_secs`, default 180 seconds, minimum 10). Each scan captures the pane tail of every registered session that is not running in the structured agent view (structured sessions do not have meaningful pane text).
+- Rules are evaluated in `priority` order and the first match per session wins, so give your most specific rules the lowest numbers.
+- Matches are logged under the `server.pane_watchdog` tracing target whether or not a `command` is set, so you can dry-run a new rule by watching the daemon log.
+- Command stdout is discarded; stderr appears in the daemon log when the command exits non-zero.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod github;
 pub mod hooks;
 pub mod logging;
 pub mod migrations;
+pub mod pane_rules;
 pub mod plugin;
 pub mod process;
 #[cfg(feature = "serve")]

--- a/src/pane_rules.rs
+++ b/src/pane_rules.rs
@@ -123,13 +123,24 @@ pub struct CompiledRule {
 }
 
 /// Compile a rule list, dropping disabled entries and (with a warning) any
-/// rule whose pattern or guards fail to parse. The result is sorted by
-/// `priority` (stable, so config order breaks ties).
+/// rule whose pattern or guards fail to parse, plus later duplicates of a
+/// `name` already seen — the watchdog's cooldown map is keyed by rule name,
+/// so duplicates would share (and corrupt) each other's cooldown state.
+/// The result is sorted by `priority` (stable, so config order breaks ties).
 pub fn compile(rules: &[PaneRuleConfig]) -> Vec<CompiledRule> {
+    let mut seen_names = std::collections::HashSet::new();
     let mut compiled: Vec<CompiledRule> = rules
         .iter()
         .filter(|r| r.enabled)
         .filter_map(|r| {
+            if !seen_names.insert(r.name.clone()) {
+                tracing::warn!(
+                    target: "pane_rules",
+                    rule = %r.name,
+                    "duplicate rule name; rule dropped"
+                );
+                return None;
+            }
             let pattern = match Regex::new(&r.pattern) {
                 Ok(p) => p,
                 Err(e) => {
@@ -302,6 +313,19 @@ mod tests {
         assert_eq!(compiled.len(), 2);
         assert_eq!(compiled[0].name, "first");
         assert_eq!(compiled[1].name, "second");
+    }
+
+    #[test]
+    fn compile_drops_duplicate_names_keeps_first() {
+        let mut a = rule("dup", "^first$");
+        a.cooldown_secs = 60;
+        let mut b = rule("dup", "^second$");
+        b.cooldown_secs = 999;
+        let compiled = compile(&[a, b, rule("other", "^ok$")]);
+        assert_eq!(compiled.len(), 2);
+        assert_eq!(compiled[0].name, "dup");
+        assert_eq!(compiled[0].cooldown, std::time::Duration::from_secs(60));
+        assert_eq!(compiled[1].name, "other");
     }
 
     #[test]

--- a/src/pane_rules.rs
+++ b/src/pane_rules.rs
@@ -1,0 +1,392 @@
+//! Configurable pane-text rules: regex patterns that classify a captured
+//! tmux pane tail into named events.
+//!
+//! This is the detection engine behind the daemon's pane watchdog
+//! (`server::pane_watchdog`). Rules are pure data, declared in config as
+//! `[[watchdog.rules]]` entries:
+//!
+//! ```toml
+//! [watchdog]
+//! interval_secs = 180
+//!
+//! [[watchdog.rules]]
+//! name = "usage-cap"
+//! kind = "cap"
+//! pattern = '(?i)^usage limit reached'
+//! negative = ['(?i)not your usage limit']
+//! tail_lines = 30
+//! command = "notify-operator.sh"
+//! ```
+//!
+//! Everything is fail-open: an invalid pattern logs and drops that rule at
+//! compile time; the rest keep working. See `docs/guides/pane-rules.md`.
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+/// Where a rule's pattern is applied within the pane tail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleScope {
+    /// Match each non-empty line of the tail window individually.
+    #[default]
+    Line,
+    /// Match once against the tail window joined with newlines (for
+    /// multi-line prompts like device-code sign-in blocks).
+    Window,
+}
+
+fn default_tail_lines() -> usize {
+    15
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_cooldown_secs() -> u64 {
+    30 * 60
+}
+
+/// One declarative pane-text rule, as written in config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneRuleConfig {
+    /// Unique-ish label used in logs and exported to the rule command as
+    /// `AOE_RULE_NAME`.
+    pub name: String,
+    /// Free-form category label ("cap", "auth", ...), exported to the rule
+    /// command as `AOE_RULE_KIND`.
+    #[serde(default)]
+    pub kind: String,
+    /// Regex tried against each line ([`RuleScope::Line`]) or the joined
+    /// tail window ([`RuleScope::Window`]). Case-sensitive unless the
+    /// pattern opts into `(?i)`.
+    pub pattern: String,
+    /// Negative-guard regexes: text they match can never fire this rule
+    /// (applied to the raw line or window before the pattern).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub negative: Vec<String>,
+    /// How many non-empty lines from the live edge of the pane are in
+    /// scope. Small windows keep stale scrollback (a finished sign-in
+    /// flow, a recovered error) from firing.
+    #[serde(default = "default_tail_lines")]
+    pub tail_lines: usize,
+    #[serde(default)]
+    pub scope: RuleScope,
+    /// Strip leading decoration (selector glyphs, bullets) and a `1.` or
+    /// `2)` option enumerator from each line before matching, so anchored
+    /// patterns survive TUI chrome. Line scope only.
+    #[serde(default = "default_true")]
+    pub strip_decoration: bool,
+    /// Evaluation order: lower fires first when several rules match.
+    #[serde(default)]
+    pub priority: u32,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Shell command run when the rule matches, with `AOE_RULE_NAME`,
+    /// `AOE_RULE_KIND`, `AOE_SESSION_ID`, and `AOE_SESSION_TITLE` in its
+    /// environment. Omit to only log matches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Floor in seconds between firings of this rule for the same session,
+    /// so a pane that stays blocked does not run the command every tick.
+    #[serde(default = "default_cooldown_secs")]
+    pub cooldown_secs: u64,
+}
+
+/// Watchdog section of the user config (`[watchdog]`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WatchdogConfig {
+    /// Disable the pane watchdog without deleting the rules.
+    #[serde(default)]
+    pub disabled: bool,
+    /// Scan interval in seconds (minimum 10; default 180).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<PaneRuleConfig>,
+}
+
+/// A rule with its regexes compiled, ready to run against pane text.
+#[derive(Debug)]
+pub struct CompiledRule {
+    pub name: String,
+    pub kind: String,
+    pattern: Regex,
+    negative: Vec<Regex>,
+    tail_lines: usize,
+    scope: RuleScope,
+    strip_decoration: bool,
+    pub priority: u32,
+    pub command: Option<String>,
+    pub cooldown: std::time::Duration,
+}
+
+/// Compile a rule list, dropping disabled entries and (with a warning) any
+/// rule whose pattern or guards fail to parse. The result is sorted by
+/// `priority` (stable, so config order breaks ties).
+pub fn compile(rules: &[PaneRuleConfig]) -> Vec<CompiledRule> {
+    let mut compiled: Vec<CompiledRule> = rules
+        .iter()
+        .filter(|r| r.enabled)
+        .filter_map(|r| {
+            let pattern = match Regex::new(&r.pattern) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "pane_rules",
+                        rule = %r.name,
+                        error = %e,
+                        "invalid rule pattern; rule dropped"
+                    );
+                    return None;
+                }
+            };
+            let mut negative = Vec::with_capacity(r.negative.len());
+            for n in &r.negative {
+                match Regex::new(n) {
+                    Ok(g) => negative.push(g),
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "pane_rules",
+                            rule = %r.name,
+                            error = %e,
+                            "invalid negative guard; rule dropped"
+                        );
+                        return None;
+                    }
+                }
+            }
+            Some(CompiledRule {
+                name: r.name.clone(),
+                kind: r.kind.clone(),
+                pattern,
+                negative,
+                tail_lines: r.tail_lines.max(1),
+                scope: r.scope,
+                strip_decoration: r.strip_decoration,
+                priority: r.priority,
+                command: r.command.clone(),
+                cooldown: std::time::Duration::from_secs(r.cooldown_secs),
+            })
+        })
+        .collect();
+    compiled.sort_by_key(|r| r.priority);
+    compiled
+}
+
+/// Largest tail window across a rule set, used to size the pane capture.
+pub fn max_tail_lines(rules: &[CompiledRule]) -> usize {
+    rules.iter().map(|r| r.tail_lines).max().unwrap_or(0)
+}
+
+/// Strip leading non-alphanumeric decoration, then a numeric option
+/// enumerator (`1.` or `2)` only, so a line like "5-hour limit reached"
+/// survives). Case is preserved; patterns opt into `(?i)` themselves.
+fn normalize_line(line: &str) -> &str {
+    let trimmed = line.trim_start_matches(|c: char| !c.is_alphanumeric());
+    let digits = trimmed.chars().take_while(|c| c.is_ascii_digit()).count();
+    let rest = &trimmed[digits..];
+    if digits > 0 && (rest.starts_with('.') || rest.starts_with(')')) {
+        rest[1..].trim_start()
+    } else {
+        trimmed
+    }
+}
+
+/// Run the compiled rules against a raw `capture-pane` tail. Returns the
+/// first matching rule in priority order, or None for a healthy pane.
+pub fn classify<'a>(raw: &str, rules: &'a [CompiledRule]) -> Option<&'a CompiledRule> {
+    let stripped = crate::tmux::utils::strip_ansi(raw);
+    let lines: Vec<&str> = stripped
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    rules.iter().find(|rule| {
+        let window = &lines[lines.len().saturating_sub(rule.tail_lines)..];
+        match rule.scope {
+            RuleScope::Window => {
+                let text = window.join("\n");
+                if rule.negative.iter().any(|g| g.is_match(&text)) {
+                    return false;
+                }
+                rule.pattern.is_match(&text)
+            }
+            RuleScope::Line => window.iter().any(|line| {
+                if rule.negative.iter().any(|g| g.is_match(line)) {
+                    return false;
+                }
+                let candidate = if rule.strip_decoration {
+                    normalize_line(line)
+                } else {
+                    line
+                };
+                rule.pattern.is_match(candidate)
+            }),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(name: &str, pattern: &str) -> PaneRuleConfig {
+        PaneRuleConfig {
+            name: name.into(),
+            kind: String::new(),
+            pattern: pattern.into(),
+            negative: Vec::new(),
+            tail_lines: default_tail_lines(),
+            scope: RuleScope::Line,
+            strip_decoration: true,
+            priority: 0,
+            enabled: true,
+            command: None,
+            cooldown_secs: default_cooldown_secs(),
+        }
+    }
+
+    #[test]
+    fn toml_rule_parses_with_defaults() {
+        let cfg: WatchdogConfig = toml::from_str(
+            r#"
+            [[rules]]
+            name = "my-banner"
+            kind = "cap"
+            pattern = '(?i)^some banner'
+            command = "notify.sh"
+            "#,
+        )
+        .unwrap();
+        let r = &cfg.rules[0];
+        assert_eq!(r.name, "my-banner");
+        assert_eq!(r.kind, "cap");
+        assert_eq!(r.tail_lines, 15);
+        assert_eq!(r.scope, RuleScope::Line);
+        assert!(r.strip_decoration);
+        assert!(r.enabled);
+        assert!(r.negative.is_empty());
+        assert_eq!(r.command.as_deref(), Some("notify.sh"));
+        assert_eq!(r.cooldown_secs, 30 * 60);
+        assert!(!cfg.disabled);
+        assert_eq!(cfg.interval_secs, None);
+    }
+
+    #[test]
+    fn compile_drops_invalid_regex_keeps_valid() {
+        let rules = vec![rule("bad", "(unclosed"), rule("good", "^fine$")];
+        let compiled = compile(&rules);
+        assert_eq!(compiled.len(), 1);
+        assert_eq!(compiled[0].name, "good");
+    }
+
+    #[test]
+    fn compile_drops_invalid_negative_guard() {
+        let mut r = rule("guarded", "^fine$");
+        r.negative = vec!["(unclosed".into()];
+        assert!(compile(&[r]).is_empty());
+    }
+
+    #[test]
+    fn compile_drops_disabled_and_sorts_by_priority() {
+        let mut a = rule("second", "a");
+        a.priority = 5;
+        let mut b = rule("first", "b");
+        b.priority = 1;
+        let mut c = rule("off", "c");
+        c.enabled = false;
+        let compiled = compile(&[a, b, c]);
+        assert_eq!(compiled.len(), 2);
+        assert_eq!(compiled[0].name, "first");
+        assert_eq!(compiled[1].name, "second");
+    }
+
+    #[test]
+    fn line_rule_matches_anchored_banner() {
+        let compiled = compile(&[rule("cap", r"(?i)^usage limit reached")]);
+        let pane = "some earlier output\nUsage limit reached, resets 3pm\n";
+        assert_eq!(
+            classify(pane, &compiled).map(|m| m.name.as_str()),
+            Some("cap")
+        );
+        // Mid-sentence prose must not fire an anchored pattern.
+        assert!(classify("we saw usage limit reached earlier\n", &compiled).is_none());
+    }
+
+    #[test]
+    fn window_rule_fires_across_lines() {
+        let mut r = rule("multi", r"(?is)first half[\s\S]*second half");
+        r.scope = RuleScope::Window;
+        r.tail_lines = 5;
+        let compiled = compile(&[r]);
+        let pane = "first half of the prompt\nsome middle text\nsecond half here\n";
+        assert_eq!(
+            classify(pane, &compiled).map(|m| m.name.as_str()),
+            Some("multi")
+        );
+    }
+
+    #[test]
+    fn negative_guard_suppresses_match() {
+        let mut r = rule("guarded", r"(?i)^usage limit reached");
+        r.negative = vec![r"(?i)not your usage limit".into()];
+        let compiled = compile(&[r]);
+        assert!(classify("Usage limit reached, resets 3pm\n", &compiled).is_some());
+        assert!(classify("usage limit reached (not your usage limit)\n", &compiled).is_none());
+    }
+
+    #[test]
+    fn strip_decoration_handles_selector_and_enumerator() {
+        let compiled = compile(&[rule("opt", r"(?i)^stop and wait")]);
+        assert!(classify(" > 1. Stop and wait for limit reset\n", &compiled).is_some());
+        // Leading digits without a dot or paren are not an enumerator and
+        // must survive normalization.
+        let compiled = compile(&[rule("hour", r"(?i)^5-hour limit")]);
+        assert!(classify("5-hour limit reached\n", &compiled).is_some());
+    }
+
+    #[test]
+    fn strip_decoration_off_keeps_raw_line() {
+        let mut r = rule("gate", r"^ACTION REQUIRED");
+        r.strip_decoration = false;
+        let compiled = compile(&[r]);
+        assert!(classify("ACTION REQUIRED: approve the send\n", &compiled).is_some());
+        assert!(classify("  * ACTION REQUIRED: approve the send\n", &compiled).is_none());
+    }
+
+    #[test]
+    fn tail_lines_bounds_the_window() {
+        let mut r = rule("edge", r"(?i)^stale banner");
+        r.tail_lines = 3;
+        let compiled = compile(&[r]);
+        let mut pane = String::from("stale banner\n");
+        for i in 0..10 {
+            pane.push_str(&format!("later line {i}\n"));
+        }
+        assert!(classify(&pane, &compiled).is_none());
+    }
+
+    #[test]
+    fn ansi_escapes_are_stripped_before_matching() {
+        let compiled = compile(&[rule("cap", r"(?i)^usage limit reached")]);
+        let pane = "\x1b[31mUsage limit reached\x1b[0m\n";
+        assert!(classify(pane, &compiled).is_some());
+    }
+
+    #[test]
+    fn priority_picks_first_match() {
+        let mut cap = rule("cap", r"(?i)^usage limit reached");
+        cap.priority = 0;
+        let mut gate = rule("gate", r"^ACTION REQUIRED");
+        gate.priority = 1;
+        let compiled = compile(&[gate, cap]);
+        let pane = "ACTION REQUIRED: something\nUsage limit reached\n";
+        assert_eq!(
+            classify(pane, &compiled).map(|m| m.name.as_str()),
+            Some("cap")
+        );
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,6 +12,7 @@ pub mod auth;
 pub mod live_ws;
 pub mod login;
 mod pane;
+mod pane_watchdog;
 pub mod push;
 pub mod push_send;
 pub mod rate_limit;
@@ -1068,6 +1069,11 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // status seeding plus the synchronous recovery marking (so that first tick's
     // session counts reflect the restored state rather than a half-loaded one).
     spawn_serve_snapshot_loop(state.clone());
+
+    // Pane watchdog: user-configured pane-text rules (config `[watchdog]`).
+    // No-op unless rules are configured; skipped in read-only mode since it
+    // runs user commands.
+    pane_watchdog::spawn(state.clone());
 
     // GC the recently_restarted suppression map periodically; the TTL
     // check on read filters but does not remove entries. Without this,

--- a/src/server/pane_watchdog.rs
+++ b/src/server/pane_watchdog.rs
@@ -1,0 +1,236 @@
+//! Pane watchdog: a daemon background loop that periodically captures each
+//! registered session's tmux pane tail, classifies it against the
+//! user-configured rules in `[watchdog]` (see [`crate::pane_rules`]), and
+//! runs the matching rule's command.
+//!
+//! The watchdog only observes panes and runs user commands; it never mutates
+//! session state itself. Everything is fail-open: a session whose pane
+//! cannot be captured is skipped, a command that fails or times out is
+//! logged, and the loop keeps ticking.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::file_watch::FileWatchService;
+use crate::pane_rules::CompiledRule;
+
+use super::AppState;
+
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(180);
+const MIN_INTERVAL: Duration = Duration::from_secs(10);
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Spawn the watchdog loop if the config enables it. No-op when the daemon
+/// is read-only, `[watchdog]` is disabled, or no rule compiles.
+pub fn spawn(state: Arc<AppState>) {
+    if state.read_only {
+        return;
+    }
+    let cfg = crate::session::Config::load_or_warn().watchdog;
+    if cfg.disabled {
+        return;
+    }
+    let rules = Arc::new(crate::pane_rules::compile(&cfg.rules));
+    if rules.is_empty() {
+        return;
+    }
+    let interval = cfg
+        .interval_secs
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_INTERVAL)
+        .max(MIN_INTERVAL);
+    tracing::info!(
+        target: "server.pane_watchdog",
+        rules = rules.len(),
+        interval_secs = interval.as_secs(),
+        "pane watchdog enabled"
+    );
+
+    let shutdown = state.shutdown.clone();
+    crate::task_util::spawn_supervised(
+        "server.pane_watchdog",
+        crate::task_util::PanicPolicy::Log,
+        async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // Per-(session, rule) last-fired times, enforcing each rule's
+            // cooldown so a pane that stays in a matching state does not run
+            // its command every tick.
+            let mut last_fired: HashMap<(String, String), Instant> = HashMap::new();
+            // Swallow the immediate first tick; sessions restored during
+            // daemon startup should settle before the first scan.
+            ticker.tick().await;
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => tick(&state, &rules, &mut last_fired).await,
+                    _ = shutdown.cancelled() => break,
+                }
+            }
+        },
+    );
+}
+
+struct PaneMatch {
+    session_id: String,
+    title: String,
+    profile: String,
+    rule_name: String,
+    kind: String,
+    command: Option<String>,
+    cooldown: Duration,
+}
+
+async fn tick(
+    state: &Arc<AppState>,
+    rules: &Arc<Vec<CompiledRule>>,
+    last_fired: &mut HashMap<(String, String), Instant>,
+) {
+    let file_watch = state.file_watch.clone();
+    let scan_rules = rules.clone();
+    let matches =
+        match tokio::task::spawn_blocking(move || scan_panes(&file_watch, &scan_rules)).await {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(target: "server.pane_watchdog", error = %e, "pane scan task failed");
+                return;
+            }
+        };
+
+    // Entries past their rule's cooldown can never suppress again; drop them
+    // so the map stays bounded across session churn.
+    last_fired.retain(|(_, rule_name), fired| {
+        rules
+            .iter()
+            .any(|r| r.name == *rule_name && fired.elapsed() < r.cooldown)
+    });
+
+    for m in matches {
+        let key = (m.session_id.clone(), m.rule_name.clone());
+        if let Some(fired) = last_fired.get(&key) {
+            if fired.elapsed() < m.cooldown {
+                continue;
+            }
+        }
+        last_fired.insert(key, Instant::now());
+        tracing::info!(
+            target: "server.pane_watchdog",
+            session = %m.session_id,
+            title = %m.title,
+            rule = %m.rule_name,
+            kind = %m.kind,
+            "pane rule matched"
+        );
+        if m.command.is_some() {
+            run_command(m);
+        }
+    }
+}
+
+/// Capture and classify every registered non-structured session's pane tail.
+/// Blocking (tmux subprocesses + storage reads); run under `spawn_blocking`.
+fn scan_panes(file_watch: &Arc<FileWatchService>, rules: &[CompiledRule]) -> Vec<PaneMatch> {
+    let instances = match super::load_all_instances(file_watch) {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::warn!(
+                target: "server.pane_watchdog",
+                error = %e,
+                "load_all_instances failed; skipping tick"
+            );
+            return Vec::new();
+        }
+    };
+    // Rule windows count non-empty lines, so capture more raw lines than the
+    // widest window to leave room for blanks and TUI padding.
+    let capture_lines = crate::pane_rules::max_tail_lines(rules)
+        .saturating_mul(2)
+        .max(50);
+    instances
+        .iter()
+        .filter(|inst| !inst.is_structured())
+        .filter_map(|inst| {
+            let sess = inst.tmux_session().ok()?;
+            if !sess.exists() {
+                return None;
+            }
+            let content = sess.capture_pane(capture_lines).ok()?;
+            let rule = crate::pane_rules::classify(&content, rules)?;
+            Some(PaneMatch {
+                session_id: inst.id.clone(),
+                title: inst.title.clone(),
+                profile: inst.source_profile.clone(),
+                rule_name: rule.name.clone(),
+                kind: rule.kind.clone(),
+                command: rule.command.clone(),
+                cooldown: rule.cooldown,
+            })
+        })
+        .collect()
+}
+
+/// Run a matched rule's command via `sh -c` with the match context in the
+/// environment. Detached from the tick loop so a slow command cannot stall
+/// scanning; killed after [`COMMAND_TIMEOUT`].
+fn run_command(m: PaneMatch) {
+    let command = m.command.clone().expect("checked by caller");
+    crate::task_util::spawn_supervised(
+        "server.pane_watchdog.command",
+        crate::task_util::PanicPolicy::Log,
+        async move {
+            let output = tokio::time::timeout(
+                COMMAND_TIMEOUT,
+                tokio::process::Command::new("sh")
+                    .arg("-c")
+                    .arg(&command)
+                    .env("AOE_RULE_NAME", &m.rule_name)
+                    .env("AOE_RULE_KIND", &m.kind)
+                    .env("AOE_SESSION_ID", &m.session_id)
+                    .env("AOE_SESSION_TITLE", &m.title)
+                    .env("AOE_SESSION_PROFILE", &m.profile)
+                    .stdin(std::process::Stdio::null())
+                    .kill_on_drop(true)
+                    .output(),
+            )
+            .await;
+            match output {
+                Err(_) => {
+                    tracing::warn!(
+                        target: "server.pane_watchdog",
+                        rule = %m.rule_name,
+                        session = %m.session_id,
+                        timeout_secs = COMMAND_TIMEOUT.as_secs(),
+                        "rule command timed out; killed"
+                    );
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        target: "server.pane_watchdog",
+                        rule = %m.rule_name,
+                        session = %m.session_id,
+                        error = %e,
+                        "rule command failed to run"
+                    );
+                }
+                Ok(Ok(out)) if !out.status.success() => {
+                    tracing::warn!(
+                        target: "server.pane_watchdog",
+                        rule = %m.rule_name,
+                        session = %m.session_id,
+                        status = %out.status,
+                        stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                        "rule command exited non-zero"
+                    );
+                }
+                Ok(Ok(_)) => {
+                    tracing::debug!(
+                        target: "server.pane_watchdog",
+                        rule = %m.rule_name,
+                        session = %m.session_id,
+                        "rule command completed"
+                    );
+                }
+            }
+        },
+    );
+}

--- a/src/server/pane_watchdog.rs
+++ b/src/server/pane_watchdog.rs
@@ -121,8 +121,8 @@ async fn tick(
             kind = %m.kind,
             "pane rule matched"
         );
-        if m.command.is_some() {
-            run_command(m);
+        if let Some(command) = m.command.clone() {
+            run_command(m, command);
         }
     }
 }
@@ -172,8 +172,7 @@ fn scan_panes(file_watch: &Arc<FileWatchService>, rules: &[CompiledRule]) -> Vec
 /// Run a matched rule's command via `sh -c` with the match context in the
 /// environment. Detached from the tick loop so a slow command cannot stall
 /// scanning; killed after [`COMMAND_TIMEOUT`].
-fn run_command(m: PaneMatch) {
-    let command = m.command.clone().expect("checked by caller");
+fn run_command(m: PaneMatch, command: String) {
     crate::task_util::spawn_supervised(
         "server.pane_watchdog.command",
         crate::task_util::PanicPolicy::Log,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -67,6 +67,10 @@ pub struct Config {
     #[serde(default)]
     pub logging: LoggingConfig,
 
+    /// Pane watchdog: daemon-side pane-text rules (see docs/guides/pane-rules.md).
+    #[serde(default)]
+    pub watchdog: crate::pane_rules::WatchdogConfig,
+
     /// Environment variables injected into the host command line for every
     /// session spawned at global scope. Entries are `KEY=value`, `KEY=$VAR`
     /// (read VAR from the host env), `KEY=$$literal` (escape a `$`), or

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -55,6 +55,13 @@ const PAGES = [
       "Run AI coding agents in isolated Docker containers with Agent of Empires.",
   },
   {
+    source: "docs/guides/pane-rules.md",
+    dest: "guides/pane-rules.md",
+    title: "Pane Rules",
+    description:
+      "Watch session output for configurable text patterns and run commands on match.",
+  },
+  {
     source: "docs/guides/tmux-status-bar.md",
     dest: "guides/tmux-status-bar.md",
     title: "tmux Status Bar",
@@ -417,6 +424,7 @@ const URL_MAP = {
   "docs/guides/repo-config.md": "/guides/repo-config/",
   "docs/guides/mcp-servers.md": "/guides/mcp-servers/",
   "docs/guides/sandbox.md": "/guides/sandbox/",
+  "docs/guides/pane-rules.md": "/guides/pane-rules/",
   "docs/guides/tmux-status-bar.md": "/guides/tmux-status-bar/",
   "docs/guides/web-dashboard.md": "/guides/web-dashboard/",
   "docs/guides/web/dashboard.md": "/guides/web/dashboard/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -32,6 +32,7 @@ export const docsNav: NavSection[] = [
       { title: "Multi-Repo Workspaces", href: "/guides/multi-repo-workspaces/", description: "Drive one session across several git repositories at once." },
       { title: "Scratch Sessions", href: "/guides/scratch-sessions/", description: "Throwaway sessions for quick experiments without a worktree." },
       { title: "Diff View", href: "/guides/diff-view/", description: "Review git changes and edit files from the TUI." },
+      { title: "Pane Rules", href: "/guides/pane-rules/", description: "Watch session output for text patterns and run commands on match." },
       { title: "tmux Status Bar", href: "/guides/tmux-status-bar/", description: "Show live session status in your tmux status bar." },
       { title: "Agent Command Overrides", href: "/guides/agent-override/", description: "Customize the command used to launch each agent." },
       { title: "Tool Sessions", href: "/guides/tool-sessions/", description: "Run plain shell or tool sessions alongside your agents." },


### PR DESCRIPTION
## Description

Adds configurable pane-text rules: a daemon background loop that watches each registered session's tmux pane tail for user-defined regex patterns and runs a command when one matches. This turns "when a pane says X, do Y" into pure configuration; no code changes needed to add a detector.

Motivating examples: notify your phone when an agent is stuck on a device-code sign-in, log or rotate work when a provider usage-limit banner appears, or page a human when an agent prints your team's escalation phrase.

**How it works:**

- New `src/pane_rules.rs`: a small rule engine. Each `[[watchdog.rules]]` config entry declares a `pattern` regex plus `negative` guard regexes, a bounded `tail_lines` window (counting non-empty lines from the live edge, so stale scrollback can't fire), `line` or `window` scope (window scope joins the tail for multi-line prompts), optional TUI decoration stripping (selector glyphs, bullets, `1.`/`2)` enumerators, so anchored patterns survive menu chrome), and `priority` ordering. ANSI escapes are stripped before matching. Compilation is fail-open: an invalid regex drops that rule with a `tracing` warning and the rest keep working.
- New `src/server/pane_watchdog.rs`: the daemon loop. On a configurable interval (default 180s, min 10s) it captures each non-structured session's pane tail off the runtime via `spawn_blocking`, classifies it, and on a match runs the rule's `command` via `sh -c` with `AOE_RULE_NAME`, `AOE_RULE_KIND`, `AOE_SESSION_ID`, `AOE_SESSION_TITLE`, and `AOE_SESSION_PROFILE` in the environment. Commands run detached from the tick loop, are killed after 60s, and are rate-limited by a per-session-per-rule `cooldown_secs` (default 30 min). Matches are logged whether or not a command is set, so a new rule can be dry-run from the daemon log.
- Config: new `#[serde(default)]` `[watchdog]` section on `Config` (`disabled`, `interval_secs`, `rules`). The loop is a no-op when no rules are configured, and never runs in read-only mode since it executes user commands.
- Docs: new guide `docs/guides/pane-rules.md` with a field reference and worked examples, wired into the website sync script and nav.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the feature is a daemon-internal background task with no TUI rendering or CLI subcommand surface. The rule engine (parsing, compilation fail-open, scoping, guards, decoration stripping, windowing, priority) is covered by 12 unit tests in `src/pane_rules.rs`; the daemon loop is thin glue over existing tested primitives (`capture_pane`, `load_all_instances`, `spawn_supervised`) and observable only through the tracing log.

Verified locally: `cargo fmt`, `cargo clippy --features serve --all-targets` (clean), `cargo test --features serve --lib` (4874 passed; the one failure, `tui::dialogs::hooks_install::tests::test_content_shows_settings_path`, fails identically on a clean `main` checkout in this environment).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:**
Design, implementation, tests, and docs were AI-authored under human direction and review.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a configurable “pane rules” feature to the `serve` daemon, so it can continuously watch tmux pane output and react automatically when user-defined text patterns appear.

What changed / added:
- New pane-rules engine (`src/pane_rules.rs`)
  - Lets you define regex rules with priorities, optional negative “guard” patterns, optional line vs window matching scope, tail-window limits, and optional decoration/ANSI stripping for more reliable matching.
  - Compiles rules with a fail-open approach: invalid regexes won’t break rule processing; they’re warned about and skipped.
  - Detects duplicate rule names at compile time and drops later duplicates to keep cooldown tracking unambiguous.
- New background watchdog (`src/server/pane_watchdog.rs`)
  - Runs a periodic loop that tails each registered session’s tmux pane output, applies the compiled rules, logs matches, enforces per-(session, rule) cooldowns, and (optionally) runs a configured shell command on match.
  - Command execution runs detached from the scan loop, is time-limited (with failures/timeouts logged), and receives match/session context via environment variables.
  - Disabled when the daemon is in read-only mode or when no rules are configured.
- Config wiring
  - Adds a new `watchdog` section to session config (`src/session/config.rs`) to configure the watchdog and rules.
- Public API exposure
  - Exposes the new module (`pub mod pane_rules;` in `src/lib.rs`).
- Server integration
  - Hooks the watchdog into server startup (`src/server/mod.rs`).
- Documentation + website integration
  - Adds `docs/guides/pane-rules.md` and wires it into the site navigation and docs sync (`website/scripts/sync-docs.mjs`, `website/src/data/docsNav.ts`).

Benefits:
- More responsive, automated behavior for sessions (including dry-run style matching via “log-only” matches).
- Safer operations: invalid rules fail open, and cooldowns prevent command spam.
- Better reliability for real-world pane text via decoration/ANSI handling and bounded tail windows.

Potential follow-up:
- Expand examples and guidance for complex rule sets (especially around scope/anchors and negative guards).
- Add more observability around command outcomes and match frequency (beyond startup/match logs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->