### PR TITLE
fix(tui): exclude trashed sessions from sidebar group count

### DIFF
--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -1362,7 +1362,6 @@ mod tests {
         instances[0].trash();
         assert_eq!(group_count(&instances), 1);
 
-        // Restoring brings the count back.
         instances[0].untrash();
         assert_eq!(group_count(&instances), 2);
     }

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -935,12 +935,11 @@ fn flatten_group(
     }
 }
 
+/// Count of the sessions that render under a group header. Delegates to
+/// `group_members` so the header badge and the visible rows share one
+/// predicate (excluding archived and trashed sessions).
 fn count_sessions_in_group(path: &str, instances: &[Instance]) -> usize {
-    let prefix = format!("{}/", path);
-    instances
-        .iter()
-        .filter(|i| (i.group_path == path || i.group_path.starts_with(&prefix)) && !i.is_archived())
-        .count()
+    group_members(path, instances).count()
 }
 
 /// Append the synthetic "Archived" section to `items`, pinned to the
@@ -1330,6 +1329,42 @@ mod tests {
         {
             assert_eq!(*session_count, 2);
         }
+    }
+
+    #[test]
+    fn test_session_count_excludes_trashed_and_restores_on_untrash() {
+        let mut a = Instance::new("a", "/tmp/a");
+        a.group_path = "work".to_string();
+        let mut b = Instance::new("b", "/tmp/b");
+        b.group_path = "work".to_string();
+        let mut instances = vec![a, b];
+
+        let group_count = |instances: &[Instance]| {
+            let tree = GroupTree::new_with_groups(instances, &[]);
+            let items = flatten_tree(&tree, instances, SortOrder::Oldest);
+            items
+                .iter()
+                .find_map(|i| match i {
+                    Item::Group {
+                        path,
+                        session_count,
+                        ..
+                    } if path == "work" => Some(*session_count),
+                    _ => None,
+                })
+                .expect("work group present")
+        };
+
+        assert_eq!(group_count(&instances), 2);
+
+        // Trashing a session drops it from both the visible rows and the
+        // header badge, matching the row filter in `flatten_group`.
+        instances[0].trash();
+        assert_eq!(group_count(&instances), 1);
+
+        // Restoring brings the count back.
+        instances[0].untrash();
+        assert_eq!(group_count(&instances), 2);
     }
 
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2541,13 +2541,14 @@ fn create_test_env_with_group_sessions() -> TestEnv {
     TestEnv { _temp: temp, view }
 }
 
-/// The sidebar group header count is rebuilt through the same pipeline the
-/// rows use, so trashing a session drops the count and restoring it brings
-/// the count back. Guards against the count and the visible rows drifting.
+/// Trashing and restoring a session through the view's own actions keeps the
+/// group header count in step with the rows, since both are rebuilt from the
+/// same predicate. Guards against the count and the visible rows drifting.
 #[test]
 #[serial]
 fn group_header_count_tracks_trash_and_restore() {
     let mut env = create_test_env_with_group_sessions();
+    env.view.trashed_section_collapsed = false;
 
     let work_count = |env: &TestEnv| -> usize {
         env.view
@@ -2575,24 +2576,15 @@ fn group_header_count_tracks_trash_and_restore() {
         .map(|i| i.id.clone())
         .expect("a direct work session");
 
-    for inst in env.view.instances.iter_mut() {
-        if inst.id == target {
-            inst.trash();
-        }
-    }
-    env.view.flat_items = env.view.build_flat_items();
+    env.view.trash_session_by_id(&target);
     assert_eq!(
         work_count(&env),
         2,
         "trashed session drops out of the count"
     );
 
-    for inst in env.view.instances.iter_mut() {
-        if inst.id == target {
-            inst.untrash();
-        }
-    }
-    env.view.flat_items = env.view.build_flat_items();
+    env.view.select_session_by_id(&target);
+    env.view.toggle_archive_at_cursor().unwrap();
     assert_eq!(work_count(&env), 3, "restored session returns to the count");
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2541,6 +2541,61 @@ fn create_test_env_with_group_sessions() -> TestEnv {
     TestEnv { _temp: temp, view }
 }
 
+/// The sidebar group header count is rebuilt through the same pipeline the
+/// rows use, so trashing a session drops the count and restoring it brings
+/// the count back. Guards against the count and the visible rows drifting.
+#[test]
+#[serial]
+fn group_header_count_tracks_trash_and_restore() {
+    let mut env = create_test_env_with_group_sessions();
+
+    let work_count = |env: &TestEnv| -> usize {
+        env.view
+            .flat_items
+            .iter()
+            .find_map(|i| match i {
+                Item::Group {
+                    path,
+                    session_count,
+                    ..
+                } if path == "work" => Some(*session_count),
+                _ => None,
+            })
+            .expect("work group header present")
+    };
+
+    // "work" holds two direct sessions plus one in the nested "work/projects".
+    assert_eq!(work_count(&env), 3);
+
+    let target = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.group_path == "work")
+        .map(|i| i.id.clone())
+        .expect("a direct work session");
+
+    for inst in env.view.instances.iter_mut() {
+        if inst.id == target {
+            inst.trash();
+        }
+    }
+    env.view.flat_items = env.view.build_flat_items();
+    assert_eq!(
+        work_count(&env),
+        2,
+        "trashed session drops out of the count"
+    );
+
+    for inst in env.view.instances.iter_mut() {
+        if inst.id == target {
+            inst.untrash();
+        }
+    }
+    env.view.flat_items = env.view.build_flat_items();
+    assert_eq!(work_count(&env), 3, "restored session returns to the count");
+}
+
 #[test]
 #[serial]
 fn test_group_has_managed_worktrees() {


### PR DESCRIPTION
## Description

In the TUI left pane, each user group renders a session-count number next to its name. That number did not update when a session in the group was moved to the Trash: the row correctly disappeared from the group's list (it moves to the synthetic Trash section), but the header count stayed the same, so it over-reported. Because the count never dropped on trash, restoring a session never corrected it either.

Root cause: `count_sessions_in_group` (`src/session/groups.rs`) filtered only on `!is_archived()`, while the session rows it labels, rendered in the same `flatten_group`, exclude both archived and trashed (`!is_archived() && !is_trashed()`). The count and the rows had drifted onto different predicates.

The fix routes the count through the existing `group_members` helper, which already carries the correct predicate (same nested-prefix match, plus the archived and trashed exclusions) and is what the group sort keys use. Now the badge and the visible rows share one source of truth, so they cannot disagree.

This is the TUI counterpart of #2372, which fixed the same class of bug on the web sidebar; the web count was already correct via `workspaceIsSunk`.

Closes #2731.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the defect is a pure count-computation drift, fully and deterministically covered by two in-crate regression tests that exercise the real rendering pipeline: `group_header_count_tracks_trash_and_restore` (drives `HomeView::build_flat_items` and asserts the group header count drops on trash and returns on restore) and `test_session_count_excludes_trashed_and_restores_on_untrash` (unit test on `flatten_tree`). Both were confirmed to fail before the fix and pass after. A tmux-driven `tests/e2e/` test would add flakiness for no additional coverage of this data path.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:** I used Claude Code to trace the count/render predicate drift and draft the tests and prose. I directed the investigation, reviewed and verified every change myself (including reproducing the failing assertions before the fix and confirming fmt/clippy clean), and understand all of it.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a TUI sidebar issue where each session group’s header count could disagree with the number of sessions actually shown underneath it.

- Group header counts now use the same filtering logic as the rendered group rows, so trashed sessions no longer inflate the count.
- Added regression coverage to ensure the count decreases when a session is trashed and returns when it’s restored, using the real trash/restore flow rather than direct state mutation.

Benefit: the sidebar badge and the session list stay in sync, preventing confusing “wrong count” moments when trashing or restoring sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->