### PR TITLE
feat(agents): configure hook status maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,12 @@ codegen-units = 16
 debug-assertions = false
 
 [[test]]
+# ACP runner is part of the serve / structured-view surface.
+name = "acp_runner_orphan"
+path = "tests/acp_runner_orphan.rs"
+required-features = ["serve"]
+
+[[test]]
 # Explicit target so the `e2e-tests` feature gate applies. Without this entry
 # Cargo auto-discovers tests/e2e/main.rs unconditionally; the gate lets CI split
 # the serve suite into "everything except e2e" and "e2e only" shards. The other

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -59,6 +59,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe profile delete`↴](#aoe-profile-delete)
 * [`aoe profile rename`↴](#aoe-profile-rename)
 * [`aoe profile default`↴](#aoe-profile-default)
+* [`aoe profile show`↴](#aoe-profile-show)
 * [`aoe project`↴](#aoe-project)
 * [`aoe project list`↴](#aoe-project-list)
 * [`aoe project add`↴](#aoe-project-add)
@@ -879,6 +880,7 @@ Manage profiles (separate workspaces)
 * `delete` — Delete a profile
 * `rename` — Rename a profile
 * `default` — Show or set default profile
+* `show` — Show profile-derived values for scripts
 
 
 
@@ -936,6 +938,19 @@ Show or set default profile
 ###### **Arguments:**
 
 * `<NAME>` — Profile name (optional, shows current if not provided)
+
+
+
+## `aoe profile show`
+
+Show profile-derived values for scripts
+
+**Usage:** `aoe profile show [OPTIONS]`
+
+###### **Options:**
+
+* `--status-map <AGENT>` — Print the resolved status map for an agent
+* `--json` — Emit JSON output
 
 
 

--- a/docs/development/adding-agents.md
+++ b/docs/development/adding-agents.md
@@ -32,11 +32,11 @@ Each level is additive; do only what the agent supports.
 
 **1. Research:** binary name, detection (`which`), YOLO/auto-approve flag, resume flag, hook support + format (JSON/YAML/TOML), config dir, install command.
 
-**2. `AgentDef` (`src/agents.rs`):** add to the `AGENTS` array. Key fields: `detection: DetectionMethod::Which(...)`, `yolo: Some(YoloMode::CliFlag(...))`, either `hook_config` (with `format: HookFormat::JsonSettings` or `HookFormat::CodexToml`) or `sidecar_hooks` (with `format: SidecarFormat::SettlToml`, `HermesYaml`, or `KiroJson`), `resume_strategy`, `host_only`, `install_hint`. The format enums drive installer and marker-walker dispatch; adding a hook-based agent without picking a variant is a compile error. `set_default_command: true` only when the binary name alone isn't enough to relaunch (e.g. opencode).
+**2. `AgentDef` (`src/agents.rs`):** add to the `AGENTS` array. Key fields: `detection: DetectionMethod::Which(...)`, `yolo: Some(YoloMode::CliFlag(...))`, either `hook_config` (with `format: HookFormat::JsonSettings` or `HookFormat::CodexJson`) or `sidecar_hooks` (with `format: SidecarFormat::SettlToml`, `HermesYaml`, or `KiroJson`, plus `events: ..._SIDECAR_EVENTS`), `resume_strategy`, `host_only`, `install_hint`. The format enums drive installer and marker-walker dispatch; adding a hook-based agent without picking a variant is a compile error. `set_default_command: true` only when the binary name alone isn't enough to relaunch (e.g. opencode).
 
 **3. Status detection (`src/tmux/status_detection.rs`):** hook-based agents get a stub returning `Status::Idle`. Pane-parse agents get a function matching on lowercased pane content. Prefer `--format json` over substring matching when the CLI offers it; human-readable output changes between versions.
 
-**4. Hooks (if applicable):** for non-Claude formats add a custom installer in `src/hooks/mod.rs` (see `install_hermes_hooks`, `install_kiro_hooks`). Wire it into `install_agent_status_hooks()` in `src/session/instance.rs`, and add the tool name to `status_hook_env_prefix()` so `AOE_INSTANCE_ID` reaches the hook (without it hooks write nothing). Keep installers as pure file IO; any subprocess work (e.g. setting a default agent) goes in a separate function so `cargo test` doesn't mutate the dev's real environment.
+**4. Hooks (if applicable):** for non-Claude formats add a custom installer in `src/hooks/mod.rs` (see `install_hermes_hooks_with_events`, `install_kiro_hooks_with_events`). Wire it into `SidecarHooks::install`, and make sure `status_hook_env_prefix()` includes the agent so `AOE_INSTANCE_ID` and `AOE_PROFILE` reach the hook (without the instance id hooks write nothing). Hook statuses use `HookStatus` (`Running`, `Waiting`, `Idle`, `Error`), not raw strings, and sidecar event defaults live on the agent so profile `agents.<name>.status_map` entries feed host and sandbox installs through the same resolver. Keep installers as pure file IO; any subprocess work (e.g. setting a default agent) goes in a separate function so `cargo test` doesn't mutate the dev's real environment.
 
 **5. Container mount (`src/session/container_config.rs`):** add an `AgentConfigMount` (`tool_name`, `host_rel`, `container_suffix`, `skip_entries`). Host hook installation does not cover sandbox sessions; if the agent uses hooks, wire them into `build_container_config` so the sidecar volume mounts and config materializes in the container.
 
@@ -79,7 +79,7 @@ Each entry in `events: &[HookEvent]` carries:
 |-------|---------|
 | `name` | Agent's event name (e.g. `"PreToolUse"`). |
 | `matcher` | Optional pattern for events that need it (e.g. Claude's `Notification` matcher). |
-| `status` | `Some("running"\|"waiting"\|"idle")` to install a status-writer on this event, or `None` for a purely lifecycle event. |
+| `status` | `Some(HookStatus::Running\|Waiting\|Idle\|Error)` to install a status-writer on this event, or `None` for a purely lifecycle event. |
 | `session_id_capture` | `true` installs a command that extracts `session_id` from the agent's stdin JSON and writes it to `/tmp/aoe-hooks-<euid>/<AOE_INSTANCE_ID>/session_id` (host) or `/tmp/aoe-hooks/<AOE_INSTANCE_ID>/session_id` (sandbox; see issue #1844 for the host/container path split), read by [session-resume](../guides/session-resume.md). Currently only Claude (`SessionStart`, `UserPromptSubmit`). With `status` also set, both commands share the matcher block and the session-id command runs first so it consumes stdin before the status writer. |
 
 ### Codex (custom TOML)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -85,6 +85,11 @@ mode = "plan"             # default mode, applied when the agent advertises one
 
 [acp.acp_defaults.opencode.effort_by_model]
 "openai/gpt-5.5" = "high"  # overrides `effort` when this model is resolved
+
+# Trusted global/profile hook event to AoE status overrides.
+[agents.claude.status_map]
+Stop = "idle"
+Notification = "waiting"
 ```
 
 | Option | Default | Description |
@@ -101,6 +106,7 @@ mode = "plan"             # default mode, applied when the agent advertises one
 | `agent_detect_as` | `{}` | Status detection mapping: maps an agent name to a built-in agent whose status heuristics should be used. |
 | `agent_acp_cmd` | `{}` | ACP launch command for a custom agent, enabling it to run in structured view (e.g., `{ "oc-superpowers" = "ocp run sp acp" }`). A custom agent with an entry here is structured view-capable; without one it stays tmux-only. Unlike `custom_agents`, the value is split into argv and run directly, with no shell. |
 | `acp.acp_defaults` | `{}` | Per-agent defaults for structured view startup (under the `[acp]` section, not `[session]`). `model` is forwarded when the worker starts; `effort` (thinking) and `mode` are applied through the agent's ACP config options (`thought_level`, `mode`) when advertised, and skipped with a warning otherwise. `effort_by_model` (a `{model = effort}` map) overrides `effort` for the resolved model. Editable per agent from the web dashboard (Structured view tab, Structured View Defaults). Example: `[acp.acp_defaults.opencode] model = "openai/gpt-5.5" effort = "high" mode = "plan"`. |
+| `agents.<name>.status_map` | `{}` | Trusted global/profile-only hook event to AoE status mappings. Valid statuses are `running`, `waiting`, `idle`, and `error`. Entries apply by event name to built-in hook defaults, so duplicate event names with different matchers all receive the same status; new event names are added to the installed hooks when the agent format supports event keys. Existing hook files update on the next hook install, usually a new or restarted session. Agent processes with installed status hooks receive `AOE_PROFILE`, so hook scripts can query the resolved map with `aoe -p "$AOE_PROFILE" profile show --status-map <agent> --json`. |
 
 For Codex, AoE preserves existing `[hooks.state]` trust data and writes `~/.codex/config.toml` through `config.toml.lock` plus an atomic replace. This keeps repeated or concurrent AoE launches from duplicating hook blocks or leaving partial TOML.
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1017,6 +1017,10 @@ fn configured_status_map<'a>(
         .filter(|status_map| !status_map.is_empty())
 }
 
+// The CLI status-map query is event-name keyed, matching the config shape.
+// Duplicate built-in events with different matchers collapse to the first
+// default here; resolved_hook_events still applies an override to every
+// matcher variant with that event name.
 fn default_status_map_for_agent(agent: &AgentDef) -> BTreeMap<String, HookStatus> {
     let mut map = BTreeMap::new();
     if let Some(hook_cfg) = &agent.hook_config {

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -5,6 +5,35 @@
 
 use crate::session::Status;
 use crate::tmux::status_detection;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Status values a hook may write to AoE's hook sidecar file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookStatus {
+    Running,
+    Waiting,
+    Idle,
+    Error,
+}
+
+impl HookStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookStatus::Running => "running",
+            HookStatus::Waiting => "waiting",
+            HookStatus::Idle => "idle",
+            HookStatus::Error => "error",
+        }
+    }
+}
+
+impl std::fmt::Display for HookStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// How to check whether an agent binary is installed on the host.
 pub enum DetectionMethod {
@@ -69,12 +98,29 @@ pub struct HookEvent {
     pub name: &'static str,
     /// Optional matcher pattern (e.g. `"permission_prompt|elicitation_dialog"`).
     pub matcher: Option<&'static str>,
-    /// AoE status to write when this event fires (`"running"`, `"idle"`, `"waiting"`).
-    pub status: Option<&'static str>,
+    /// AoE status to write when this event fires.
+    pub status: Option<HookStatus>,
     /// When `true`, install an additional hook command that extracts
     /// `session_id` from the agent's stdin JSON payload and writes it to
     /// `/tmp/aoe-hooks-<euid>/<AOE_INSTANCE_ID>/session_id`.
     pub session_id_capture: bool,
+}
+
+/// A hook event after applying profile/global status-map overrides.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedHookEvent {
+    pub name: String,
+    pub matcher: Option<String>,
+    pub status: Option<HookStatus>,
+    pub session_id_capture: bool,
+}
+
+/// Sidecar hook defaults for agents whose config format is not the generic
+/// JSON hook schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SidecarHookEvent {
+    pub name: &'static str,
+    pub status: HookStatus,
 }
 
 /// On-disk format an agent uses for its status-detection hooks. Each variant
@@ -135,7 +181,11 @@ pub struct SidecarHooks {
     /// `target` parameter selects which `{base}` is baked into the hook
     /// command string (`/tmp/aoe-hooks-<euid>` for host, `/tmp/aoe-hooks` for
     /// sandbox; see `crate::hooks::HookInstallTarget`).
-    pub install: fn(&std::path::Path, crate::hooks::HookInstallTarget) -> anyhow::Result<()>,
+    pub install: fn(
+        &std::path::Path,
+        crate::hooks::HookInstallTarget,
+        &[ResolvedHookEvent],
+    ) -> anyhow::Result<()>,
     /// Remove AoE status hooks from the config file at the given path.
     /// Returns whether anything was changed.
     pub uninstall: fn(&std::path::Path) -> anyhow::Result<bool>,
@@ -154,6 +204,8 @@ pub struct SidecarHooks {
     /// On-disk format of the sidecar's config file. Drives marker-presence
     /// walker dispatch in `crate::hooks::has_aoe_marker`.
     pub format: SidecarFormat,
+    /// Default hook events and statuses for this sidecar format.
+    pub events: &'static [SidecarHookEvent],
 }
 
 /// How to install status hooks into a user-selected named agent, for CLIs
@@ -282,43 +334,43 @@ const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "PreToolUse",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: true,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
     },
     HookEvent {
         name: "StopFailure",
         matcher: None,
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
-        status: Some("waiting"),
+        status: Some(HookStatus::Waiting),
         session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
         matcher: Some("idle_prompt"),
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
     },
     HookEvent {
         name: "ElicitationResult",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
 ];
@@ -331,31 +383,31 @@ const CURSOR_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "PreToolUse",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
-        status: Some("waiting"),
+        status: Some(HookStatus::Waiting),
         session_id_capture: false,
     },
     HookEvent {
         name: "ElicitationResult",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
 ];
@@ -368,31 +420,31 @@ const QWEN_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "PreToolUse",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "PostToolUse",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
-        status: Some("waiting"),
+        status: Some(HookStatus::Waiting),
         session_id_capture: false,
     },
 ];
@@ -402,38 +454,95 @@ const CODEX_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "SessionStart",
         matcher: None,
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "PreToolUse",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "PermissionRequest",
         matcher: None,
-        status: Some("waiting"),
+        status: Some(HookStatus::Waiting),
         session_id_capture: false,
     },
     HookEvent {
         name: "PostToolUse",
         matcher: None,
-        status: Some("running"),
+        status: Some(HookStatus::Running),
         session_id_capture: false,
     },
     HookEvent {
         name: "Stop",
         matcher: None,
-        status: Some("idle"),
+        status: Some(HookStatus::Idle),
         session_id_capture: false,
+    },
+];
+
+pub(crate) const SETTL_SIDECAR_EVENTS: &[SidecarHookEvent] = &[
+    SidecarHookEvent {
+        name: "TurnStarted",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "WaitingForHuman",
+        status: HookStatus::Waiting,
+    },
+    SidecarHookEvent {
+        name: "GameWon",
+        status: HookStatus::Idle,
+    },
+];
+
+pub(crate) const HERMES_SIDECAR_EVENTS: &[SidecarHookEvent] = &[
+    SidecarHookEvent {
+        name: "pre_llm_call",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "pre_tool_call",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "post_llm_call",
+        status: HookStatus::Idle,
+    },
+    SidecarHookEvent {
+        name: "pre_approval_request",
+        status: HookStatus::Waiting,
+    },
+    SidecarHookEvent {
+        name: "post_approval_response",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "on_session_end",
+        status: HookStatus::Idle,
+    },
+];
+
+pub(crate) const KIRO_SIDECAR_EVENTS: &[SidecarHookEvent] = &[
+    SidecarHookEvent {
+        name: "preToolUse",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "userPromptSubmit",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "stop",
+        status: HookStatus::Idle,
     },
 ];
 
@@ -557,25 +666,25 @@ pub const AGENTS: &[AgentDef] = &[
                 HookEvent {
                     name: "BeforeTool",
                     matcher: None,
-                    status: Some("running"),
+                    status: Some(HookStatus::Running),
                     session_id_capture: false,
                 },
                 HookEvent {
                     name: "BeforeAgent",
                     matcher: None,
-                    status: Some("running"),
+                    status: Some(HookStatus::Running),
                     session_id_capture: false,
                 },
                 HookEvent {
                     name: "AfterAgent",
                     matcher: None,
-                    status: Some("idle"),
+                    status: Some(HookStatus::Idle),
                     session_id_capture: false,
                 },
                 HookEvent {
                     name: "Notification",
                     matcher: Some("ToolPermission"),
-                    status: Some("waiting"),
+                    status: Some(HookStatus::Waiting),
                     session_id_capture: false,
                 },
             ],
@@ -699,11 +808,12 @@ pub const AGENTS: &[AgentDef] = &[
         sidecar_hooks: Some(SidecarHooks {
             host_config_subpath: ".settl/config.toml",
             sandbox_config_subpath: "",
-            install: crate::hooks::install_settl_hooks,
+            install: crate::hooks::install_settl_hooks_with_events,
             uninstall: crate::hooks::uninstall_settl_hooks,
             post_install_host: None,
             selected_agent_hooks: None,
             format: SidecarFormat::SettlToml,
+            events: SETTL_SIDECAR_EVENTS,
         }),
         resume_strategy: ResumeStrategy::Unsupported,
         fork_strategy: ForkStrategy::Unsupported,
@@ -736,11 +846,12 @@ pub const AGENTS: &[AgentDef] = &[
         sidecar_hooks: Some(SidecarHooks {
             host_config_subpath: ".hermes/config.yaml",
             sandbox_config_subpath: ".hermes/sandbox/config.yaml",
-            install: crate::hooks::install_hermes_hooks,
+            install: crate::hooks::install_hermes_hooks_with_events,
             uninstall: crate::hooks::uninstall_hermes_hooks,
             post_install_host: None,
             selected_agent_hooks: None,
             format: SidecarFormat::HermesYaml,
+            events: HERMES_SIDECAR_EVENTS,
         }),
         resume_strategy: ResumeStrategy::Flag("--resume"),
         fork_strategy: ForkStrategy::Unsupported,
@@ -774,7 +885,7 @@ pub const AGENTS: &[AgentDef] = &[
         sidecar_hooks: Some(SidecarHooks {
             host_config_subpath: crate::hooks::KIRO_HOOKS_AGENT_FILE,
             sandbox_config_subpath: ".kiro/sandbox/agents/aoe-hooks.json",
-            install: crate::hooks::install_kiro_hooks,
+            install: crate::hooks::install_kiro_hooks_with_events,
             uninstall: crate::hooks::uninstall_kiro_hooks,
             post_install_host: Some(crate::hooks::set_kiro_default_agent_if_builtin),
             // Kiro scopes hooks to the agent selected by `--agent`; when the
@@ -786,6 +897,7 @@ pub const AGENTS: &[AgentDef] = &[
                 resolve_config_file: crate::hooks::resolve_kiro_agent_file,
             }),
             format: SidecarFormat::KiroJson,
+            events: KIRO_SIDECAR_EVENTS,
         }),
         resume_strategy: ResumeStrategy::Flag("--resume-id"),
         fork_strategy: ForkStrategy::Unsupported,
@@ -892,6 +1004,132 @@ impl AgentDef {
 
 pub fn get_agent(name: &str) -> Option<&'static AgentDef> {
     AGENTS.iter().find(|a| a.name == name)
+}
+
+fn configured_status_map<'a>(
+    config: &'a crate::session::config::Config,
+    agent_name: &str,
+) -> Option<&'a BTreeMap<String, HookStatus>> {
+    config
+        .agents
+        .get(agent_name)
+        .map(|agent| &agent.status_map)
+        .filter(|status_map| !status_map.is_empty())
+}
+
+fn default_status_map_for_agent(agent: &AgentDef) -> BTreeMap<String, HookStatus> {
+    let mut map = BTreeMap::new();
+    if let Some(hook_cfg) = &agent.hook_config {
+        for event in hook_cfg.events {
+            if let Some(status) = event.status {
+                map.entry(event.name.to_string()).or_insert(status);
+            }
+        }
+    }
+    if let Some(sidecar) = &agent.sidecar_hooks {
+        for event in sidecar.events {
+            map.entry(event.name.to_string()).or_insert(event.status);
+        }
+    }
+    map
+}
+
+pub fn effective_status_map(
+    config: &crate::session::config::Config,
+    agent_name: &str,
+) -> anyhow::Result<BTreeMap<String, HookStatus>> {
+    let overrides = configured_status_map(config, agent_name);
+    let Some(agent) = get_agent(agent_name) else {
+        if let Some(map) = overrides {
+            return Ok(map.clone());
+        }
+        anyhow::bail!(
+            "unknown agent '{}' has no configured status_map",
+            agent_name
+        );
+    };
+
+    let mut map = default_status_map_for_agent(agent);
+    if let Some(overrides) = overrides {
+        for (event, status) in overrides {
+            map.insert(event.clone(), *status);
+        }
+    }
+
+    if map.is_empty() {
+        anyhow::bail!("agent '{}' does not declare status hooks", agent.name);
+    }
+    Ok(map)
+}
+
+fn append_configured_status_events(
+    events: &mut Vec<ResolvedHookEvent>,
+    overrides: Option<&BTreeMap<String, HookStatus>>,
+) {
+    let Some(overrides) = overrides else {
+        return;
+    };
+    let mut existing: BTreeSet<String> = events.iter().map(|event| event.name.clone()).collect();
+    for (name, status) in overrides {
+        if existing.insert(name.clone()) {
+            events.push(ResolvedHookEvent {
+                name: name.clone(),
+                matcher: None,
+                status: Some(*status),
+                session_id_capture: false,
+            });
+        }
+    }
+}
+
+pub fn resolved_hook_events(
+    agent: &AgentDef,
+    config: &crate::session::config::Config,
+) -> anyhow::Result<Vec<ResolvedHookEvent>> {
+    let Some(hook_cfg) = &agent.hook_config else {
+        return Ok(Vec::new());
+    };
+    let overrides = configured_status_map(config, agent.name);
+    let mut events = hook_cfg
+        .events
+        .iter()
+        .map(|event| ResolvedHookEvent {
+            name: event.name.to_string(),
+            matcher: event.matcher.map(str::to_string),
+            status: overrides
+                .and_then(|map| map.get(event.name).copied())
+                .or(event.status),
+            session_id_capture: event.session_id_capture,
+        })
+        .collect();
+    append_configured_status_events(&mut events, overrides);
+    Ok(events)
+}
+
+pub fn resolved_sidecar_hook_events(
+    agent: &AgentDef,
+    config: &crate::session::config::Config,
+) -> anyhow::Result<Vec<ResolvedHookEvent>> {
+    let Some(sidecar) = &agent.sidecar_hooks else {
+        return Ok(Vec::new());
+    };
+    let overrides = configured_status_map(config, agent.name);
+    let mut events = sidecar
+        .events
+        .iter()
+        .map(|event| ResolvedHookEvent {
+            name: event.name.to_string(),
+            matcher: None,
+            status: Some(
+                overrides
+                    .and_then(|map| map.get(event.name).copied())
+                    .unwrap_or(event.status),
+            ),
+            session_id_capture: false,
+        })
+        .collect();
+    append_configured_status_events(&mut events, overrides);
+    Ok(events)
 }
 
 /// Extract the agent name a user selected via `<flag> NAME` or `<flag>=NAME`
@@ -1114,6 +1352,83 @@ mod tests {
     #[test]
     fn test_get_agent_unknown() {
         assert!(get_agent("unknown").is_none());
+    }
+
+    #[test]
+    fn effective_status_map_merges_configured_override() {
+        let mut config = crate::session::config::Config::default();
+        config
+            .agents
+            .entry("claude".to_string())
+            .or_default()
+            .status_map
+            .insert("Stop".to_string(), HookStatus::Error);
+
+        let map = effective_status_map(&config, "claude").unwrap();
+        assert_eq!(map.get("PreToolUse"), Some(&HookStatus::Running));
+        assert_eq!(map.get("Stop"), Some(&HookStatus::Error));
+        assert_eq!(map.get("Notification"), Some(&HookStatus::Waiting));
+    }
+
+    #[test]
+    fn resolved_hook_events_apply_duplicate_event_override() {
+        let mut config = crate::session::config::Config::default();
+        config
+            .agents
+            .entry("claude".to_string())
+            .or_default()
+            .status_map
+            .insert("Notification".to_string(), HookStatus::Running);
+
+        let agent = get_agent("claude").unwrap();
+        let events = resolved_hook_events(agent, &config).unwrap();
+        let notification_statuses: Vec<HookStatus> = events
+            .iter()
+            .filter(|event| event.name == "Notification")
+            .filter_map(|event| event.status)
+            .collect();
+        assert_eq!(
+            notification_statuses,
+            vec![HookStatus::Running, HookStatus::Running]
+        );
+    }
+
+    #[test]
+    fn status_map_adds_configured_event_for_known_agent() {
+        let mut config = crate::session::config::Config::default();
+        config
+            .agents
+            .entry("claude".to_string())
+            .or_default()
+            .status_map
+            .insert("PreCompact".to_string(), HookStatus::Running);
+
+        let map = effective_status_map(&config, "claude").unwrap();
+        assert_eq!(map.get("PreCompact"), Some(&HookStatus::Running));
+
+        let agent = get_agent("claude").unwrap();
+        let events = resolved_hook_events(agent, &config).unwrap();
+        let custom = events
+            .iter()
+            .find(|event| event.name == "PreCompact")
+            .expect("custom event should be appended");
+        assert_eq!(custom.status, Some(HookStatus::Running));
+        assert!(custom.matcher.is_none());
+        assert!(!custom.session_id_capture);
+    }
+
+    #[test]
+    fn configured_unknown_agent_status_map_is_queryable() {
+        let mut config = crate::session::config::Config::default();
+        config
+            .agents
+            .entry("vertex".to_string())
+            .or_default()
+            .status_map
+            .insert("session.idle".to_string(), HookStatus::Idle);
+
+        let map = effective_status_map(&config, "vertex").unwrap();
+        assert_eq!(map.get("session.idle"), Some(&HookStatus::Idle));
     }
 
     #[test]

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -40,10 +40,21 @@ pub enum ProfileCommands {
         /// Profile name (optional, shows current if not provided)
         name: Option<String>,
     },
+
+    /// Show profile-derived values for scripts
+    Show {
+        /// Print the resolved status map for an agent
+        #[arg(long = "status-map", value_name = "AGENT")]
+        status_map: Option<String>,
+
+        /// Emit JSON output
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tracing::instrument(target = "cli.session", skip_all)]
-pub async fn run(command: Option<ProfileCommands>) -> Result<()> {
+pub async fn run(profile: &str, command: Option<ProfileCommands>) -> Result<()> {
     match command {
         Some(ProfileCommands::List) | None => list_profiles().await,
         Some(ProfileCommands::Create { name }) => create_profile(&name).await,
@@ -57,6 +68,9 @@ pub async fn run(command: Option<ProfileCommands>) -> Result<()> {
             } else {
                 show_default_profile().await
             }
+        }
+        Some(ProfileCommands::Show { status_map, json }) => {
+            show_profile_value(profile, status_map.as_deref(), json).await
         }
     }
 }
@@ -135,5 +149,23 @@ async fn set_default_profile(name: &str) -> Result<()> {
 
     session::set_default_profile(name)?;
     println!("✓ Default profile set to: {}", name);
+    Ok(())
+}
+
+async fn show_profile_value(profile: &str, status_map: Option<&str>, json: bool) -> Result<()> {
+    let Some(agent) = status_map else {
+        bail!("nothing to show; pass --status-map <agent>");
+    };
+    let effective_profile = session::config::effective_profile(profile);
+    let config = session::profile_config::resolve_config(&effective_profile)?;
+    let map = crate::agents::effective_status_map(&config, agent)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&map)?);
+    } else {
+        for (event, status) in map {
+            println!("{} = {}", event, status.as_str());
+        }
+    }
     Ok(())
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -456,23 +456,26 @@ pub(super) fn is_aoe_hook_command(cmd: &str) -> bool {
 /// `idle_prompt` → idle). Each becomes its own matcher block appended to that
 /// event name's array, so they coexist instead of the later one clobbering the
 /// earlier.
-fn build_aoe_hooks(events: &[crate::agents::HookEvent], target: HookInstallTarget) -> Value {
+fn build_aoe_hooks(
+    events: impl AsRef<[crate::agents::ResolvedHookEvent]>,
+    target: HookInstallTarget,
+) -> Value {
     let mut hooks_obj = serde_json::Map::new();
-    for event in events {
+    for event in events.as_ref() {
         let mut commands: Vec<String> = Vec::new();
         if event.session_id_capture {
             commands.push(hook_command_session_id(target));
         }
         if let Some(status) = event.status {
-            commands.push(hook_command(status, target));
+            commands.push(hook_command(status.as_str(), target));
         }
         if commands.is_empty() {
             continue;
         }
 
         let mut entry = serde_json::Map::new();
-        if let Some(m) = event.matcher {
-            entry.insert("matcher".to_string(), Value::String(m.to_string()));
+        if let Some(m) = &event.matcher {
+            entry.insert("matcher".to_string(), Value::String(m.clone()));
         }
         let hook_entries: Vec<Value> = commands
             .into_iter()
@@ -485,7 +488,7 @@ fn build_aoe_hooks(events: &[crate::agents::HookEvent], target: HookInstallTarge
             .collect();
         entry.insert("hooks".to_string(), Value::Array(hook_entries));
         match hooks_obj
-            .entry(event.name.to_string())
+            .entry(event.name.clone())
             .or_insert_with(|| Value::Array(Vec::new()))
         {
             Value::Array(groups) => groups.push(Value::Object(entry)),
@@ -530,7 +533,7 @@ fn remove_aoe_entries(matchers: &mut Vec<Value>) {
 /// If the file doesn't exist, it will be created with just the hooks.
 pub fn install_hooks(
     settings_path: &Path,
-    events: &[crate::agents::HookEvent],
+    events: impl AsRef<[crate::agents::ResolvedHookEvent]>,
     target: HookInstallTarget,
 ) -> Result<()> {
     with_config_lock(settings_path, "json.lock", || {
@@ -546,7 +549,7 @@ pub fn install_hooks(
 
         let before = settings.clone();
 
-        let aoe_hooks = build_aoe_hooks(events, target);
+        let aoe_hooks = build_aoe_hooks(events.as_ref(), target);
 
         if !settings.get("hooks").is_some_and(|h| h.is_object()) {
             settings
@@ -563,13 +566,25 @@ pub fn install_hooks(
         let aoe_hooks_obj = aoe_hooks
             .as_object()
             .ok_or_else(|| anyhow::anyhow!("Internal error: built hooks is not a JSON object"))?;
+        let empty_events: Vec<String> = settings_hooks
+            .iter_mut()
+            .filter_map(|(event_name, existing)| {
+                let arr = existing.as_array_mut()?;
+                remove_aoe_entries(arr);
+                arr.is_empty().then(|| event_name.clone())
+            })
+            .collect();
+        for event_name in empty_events {
+            settings_hooks.remove(&event_name);
+        }
+
         for (event_name, aoe_matchers) in aoe_hooks_obj {
-            if let Some(existing) = settings_hooks.get_mut(event_name) {
-                if let Some(arr) = existing.as_array_mut() {
-                    remove_aoe_entries(arr);
-                    if let Some(new_arr) = aoe_matchers.as_array() {
-                        arr.extend(new_arr.iter().cloned());
-                    }
+            if let Some(existing) = settings_hooks
+                .get_mut(event_name)
+                .and_then(|existing| existing.as_array_mut())
+            {
+                if let Some(new_arr) = aoe_matchers.as_array() {
+                    existing.extend(new_arr.iter().cloned());
                 }
             } else {
                 settings_hooks.insert(event_name.clone(), aoe_matchers.clone());
@@ -616,7 +631,7 @@ pub(super) const CODEX_HOOK_EVENT_NAMES: &[&str] = &[
 #[cfg(test)]
 pub(crate) fn install_codex_hooks(
     config_path: &Path,
-    events: &[crate::agents::HookEvent],
+    events: impl AsRef<[crate::agents::ResolvedHookEvent]>,
     target: HookInstallTarget,
 ) -> Result<()> {
     install_codex_hooks_with_preserved_state(config_path, events, None, target)
@@ -660,7 +675,7 @@ pub(crate) fn restore_codex_hooks_state(config_path: &Path, state: toml_edit::It
 
 pub(crate) fn install_codex_hooks_with_preserved_state(
     config_path: &Path,
-    events: &[crate::agents::HookEvent],
+    events: impl AsRef<[crate::agents::ResolvedHookEvent]>,
     preserved_state: Option<toml_edit::Item>,
     target: HookInstallTarget,
 ) -> Result<()> {
@@ -679,7 +694,7 @@ pub(crate) fn install_codex_hooks_with_preserved_state(
             }
         }
         remove_codex_aoe_hooks(&mut config)?;
-        merge_codex_hooks(&mut config, events, target)?;
+        merge_codex_hooks(&mut config, events.as_ref(), target)?;
 
         if config.to_string() == before {
             tracing::debug!(target: "hooks.install",
@@ -821,7 +836,7 @@ fn ensure_codex_event_array<'a>(
 
 fn merge_codex_hooks(
     config: &mut toml_edit::DocumentMut,
-    events: &[crate::agents::HookEvent],
+    events: &[crate::agents::ResolvedHookEvent],
     target: HookInstallTarget,
 ) -> Result<()> {
     let hooks = ensure_codex_hooks_table(config)?;
@@ -831,7 +846,7 @@ fn merge_codex_hooks(
             continue;
         };
 
-        let event_array = ensure_codex_event_array(hooks, event.name)?;
+        let event_array = ensure_codex_event_array(hooks, &event.name)?;
         event_array.push(codex_matcher_group(event, status, target));
     }
 
@@ -839,18 +854,21 @@ fn merge_codex_hooks(
 }
 
 fn codex_matcher_group(
-    event: &crate::agents::HookEvent,
-    status: &str,
+    event: &crate::agents::ResolvedHookEvent,
+    status: crate::agents::HookStatus,
     target: HookInstallTarget,
 ) -> toml_edit::Table {
     let mut group = toml_edit::Table::new();
-    if let Some(matcher) = event.matcher {
-        group.insert("matcher", toml_edit::value(matcher));
+    if let Some(matcher) = &event.matcher {
+        group.insert("matcher", toml_edit::value(matcher.as_str()));
     }
 
     let mut handler = toml_edit::Table::new();
     handler.insert("type", toml_edit::value("command"));
-    handler.insert("command", toml_edit::value(hook_command(status, target)));
+    handler.insert(
+        "command",
+        toml_edit::value(hook_command(status.as_str(), target)),
+    );
 
     let mut handlers = toml_edit::ArrayOfTables::new();
     handlers.push(handler);
@@ -1059,12 +1077,11 @@ pub fn uninstall_hooks(settings_path: &Path) -> Result<bool> {
     })
 }
 
-/// settl hook events and the AoE status they map to.
-const SETTL_HOOKS: &[(&str, &str)] = &[
-    ("TurnStarted", "running"),
-    ("WaitingForHuman", "waiting"),
-    ("GameWon", "idle"),
-];
+fn default_sidecar_events(agent_name: &str) -> Vec<crate::agents::ResolvedHookEvent> {
+    let agent = crate::agents::get_agent(agent_name).expect("sidecar agent is registered");
+    crate::agents::resolved_sidecar_hook_events(agent, &crate::session::config::Config::default())
+        .expect("default sidecar hook events resolve")
+}
 
 /// Install AoE status hooks into a settl TOML config file (typically
 /// `~/.settl/config.toml`).
@@ -1078,6 +1095,15 @@ const SETTL_HOOKS: &[(&str, &str)] = &[
 /// Idempotent on disk: when the on-disk file already encodes the same
 /// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
 pub fn install_settl_hooks(config_path: &Path, target: HookInstallTarget) -> Result<()> {
+    let events = default_sidecar_events("settl");
+    install_settl_hooks_with_events(config_path, target, &events)
+}
+
+pub fn install_settl_hooks_with_events(
+    config_path: &Path,
+    target: HookInstallTarget,
+    events: &[crate::agents::ResolvedHookEvent],
+) -> Result<()> {
     with_config_lock(config_path, "toml.lock", || {
         let mut config: toml::Value = if config_path.exists() {
             let content = std::fs::read_to_string(config_path)?;
@@ -1109,12 +1135,15 @@ pub fn install_settl_hooks(config_path: &Path, target: HookInstallTarget) -> Res
                 .is_some_and(is_aoe_hook_command)
         });
 
-        for (event, status) in SETTL_HOOKS {
+        for event in events {
+            let Some(status) = event.status else {
+                continue;
+            };
             let mut entry = toml::map::Map::new();
-            entry.insert("event".into(), toml::Value::String((*event).into()));
+            entry.insert("event".into(), toml::Value::String(event.name.clone()));
             entry.insert(
                 "command".into(),
-                toml::Value::String(hook_command(status, target)),
+                toml::Value::String(hook_command(status.as_str(), target)),
             );
             hooks_arr.push(toml::Value::Table(entry));
         }
@@ -1174,18 +1203,6 @@ pub fn uninstall_settl_hooks(config_path: &Path) -> Result<bool> {
     })
 }
 
-/// Hermes hook events and the AoE status they map to. Hermes uses an
-/// event-keyed YAML schema (`hooks: { event_name: [ {command, ...} ] }`),
-/// not the flat array settl uses.
-const HERMES_HOOKS: &[(&str, &str)] = &[
-    ("pre_llm_call", "running"),
-    ("pre_tool_call", "running"),
-    ("post_llm_call", "idle"),
-    ("pre_approval_request", "waiting"),
-    ("post_approval_response", "running"),
-    ("on_session_end", "idle"),
-];
-
 /// Install AoE status hooks into Hermes's `config.yaml`.
 ///
 /// Reads the existing YAML, removes any prior AoE-managed hook entries
@@ -1207,6 +1224,15 @@ const HERMES_HOOKS: &[(&str, &str)] = &[
 /// Idempotent on disk: when the YAML config and the allowlist already
 /// encode the same AoE state, neither is rewritten (same inode, same bytes).
 pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Result<()> {
+    let events = default_sidecar_events("hermes");
+    install_hermes_hooks_with_events(config_path, target, &events)
+}
+
+pub fn install_hermes_hooks_with_events(
+    config_path: &Path,
+    target: HookInstallTarget,
+    events: &[crate::agents::ResolvedHookEvent],
+) -> Result<()> {
     with_config_lock(config_path, "yaml.lock", || {
         let mut config: serde_yaml::Value = if config_path.exists() {
             let content = std::fs::read_to_string(config_path)?;
@@ -1235,8 +1261,11 @@ pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Re
         }
         let hooks_map = hooks_value.as_mapping_mut().expect("ensured mapping above");
 
-        for (event, status) in HERMES_HOOKS {
-            let event_key = serde_yaml::Value::String((*event).to_string());
+        for event in events {
+            let Some(status) = event.status else {
+                continue;
+            };
+            let event_key = serde_yaml::Value::String(event.name.clone());
             let entries = hooks_map
                 .entry(event_key)
                 .or_insert_with(|| serde_yaml::Value::Sequence(Vec::new()));
@@ -1256,7 +1285,7 @@ pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Re
             let mut entry = serde_yaml::Mapping::new();
             entry.insert(
                 serde_yaml::Value::String("command".into()),
-                serde_yaml::Value::String(hook_command(status, target)),
+                serde_yaml::Value::String(hook_command(status.as_str(), target)),
             );
             arr.push(serde_yaml::Value::Mapping(entry));
         }
@@ -1266,7 +1295,8 @@ pub fn install_hermes_hooks(config_path: &Path, target: HookInstallTarget) -> Re
         let config_dir = config_path
             .parent()
             .ok_or_else(|| anyhow::anyhow!("config path has no parent"))?;
-        let (allowlist_path, allowlist_formatted) = render_hermes_allowlist(config_dir, target)?;
+        let (allowlist_path, allowlist_formatted) =
+            render_hermes_allowlist(config_dir, target, events)?;
         // Byte-compare (vs the structural YAML compare above) is sound:
         // render_hermes_allowlist preserves approved_at on (event, command)
         // collision and serde_json::to_string_pretty is deterministic, so
@@ -1389,6 +1419,7 @@ pub fn uninstall_hermes_hooks(config_path: &Path) -> Result<bool> {
 fn render_hermes_allowlist(
     config_dir: &Path,
     target: HookInstallTarget,
+    events: &[crate::agents::ResolvedHookEvent],
 ) -> Result<(std::path::PathBuf, String)> {
     let allowlist_path = config_dir.join("shell-hooks-allowlist.json");
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
@@ -1410,14 +1441,17 @@ fn render_hermes_allowlist(
         })
         .ok_or_else(|| anyhow::anyhow!("allowlist root is not a JSON object with approvals[]"))?;
 
-    for (event, status) in HERMES_HOOKS {
-        let cmd = hook_command(status, target);
+    for event in events {
+        let Some(status) = event.status else {
+            continue;
+        };
+        let cmd = hook_command(status.as_str(), target);
         // Preserve the original `approved_at` when an entry with the same
         // (event, command) already exists; only fresh entries get `now`.
         // A `null` value is preserved verbatim: the field records
         // first-approval time, so a null stays a null on re-render.
         let preserved = approvals.iter().find_map(|entry| {
-            let same = entry.get("event").and_then(|v| v.as_str()) == Some(*event)
+            let same = entry.get("event").and_then(|v| v.as_str()) == Some(event.name.as_str())
                 && entry.get("command").and_then(|v| v.as_str()) == Some(&cmd);
             if same {
                 entry.get("approved_at").cloned()
@@ -1426,11 +1460,11 @@ fn render_hermes_allowlist(
             }
         });
         approvals.retain(|entry| {
-            !(entry.get("event").and_then(|v| v.as_str()) == Some(*event)
+            !(entry.get("event").and_then(|v| v.as_str()) == Some(event.name.as_str())
                 && entry.get("command").and_then(|v| v.as_str()) == Some(&cmd))
         });
         approvals.push(serde_json::json!({
-            "event": *event,
+            "event": event.name,
             "command": cmd,
             "approved_at": preserved.unwrap_or_else(|| Value::String(now.clone())),
             "script_mtime_at_approval": Value::Null,
@@ -1440,14 +1474,6 @@ fn render_hermes_allowlist(
     let formatted = serde_json::to_string_pretty(&data)?;
     Ok((allowlist_path, formatted))
 }
-
-/// Kiro CLI hook events. Kiro uses lowercase camelCase event names and a flat
-/// `[{"command": "..."}]` structure in its agent config JSON.
-const KIRO_HOOKS: &[(&str, &str)] = &[
-    ("preToolUse", "running"),
-    ("userPromptSubmit", "running"),
-    ("stop", "idle"),
-];
 
 /// Single source of truth for the `aoe-hooks` Kiro agent identifier. Used
 /// both as the agent name (passed to `kiro-cli agent set-default`) and as the
@@ -1479,6 +1505,15 @@ pub const KIRO_HOOKS_AGENT_FILE: &str = concat!(".kiro/agents/", kiro_hooks_agen
 /// Idempotent on disk: when the on-disk file already encodes the same
 /// AoE-managed hook subtree, it is not rewritten (same inode, same bytes).
 pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -> Result<()> {
+    let events = default_sidecar_events("kiro");
+    install_kiro_hooks_with_events(agent_config_path, target, &events)
+}
+
+pub fn install_kiro_hooks_with_events(
+    agent_config_path: &Path,
+    target: HookInstallTarget,
+    events: &[crate::agents::ResolvedHookEvent],
+) -> Result<()> {
     with_config_lock(agent_config_path, "json.lock", || {
         let mut config: serde_json::Map<String, Value> = if agent_config_path.exists() {
             let content = std::fs::read_to_string(agent_config_path)?;
@@ -1506,9 +1541,12 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
             .cloned()
             .unwrap_or_default();
 
-        for (event, status) in KIRO_HOOKS {
+        for event in events {
+            let Some(status) = event.status else {
+                continue;
+            };
             let entries = hooks_obj
-                .entry((*event).to_string())
+                .entry(event.name.clone())
                 .or_insert_with(|| Value::Array(Vec::new()));
             if let Some(arr) = entries.as_array_mut() {
                 arr.retain(|hook| {
@@ -1517,7 +1555,7 @@ pub fn install_kiro_hooks(agent_config_path: &Path, target: HookInstallTarget) -
                         .and_then(|c| c.as_str())
                         .is_some_and(is_aoe_hook_command)
                 });
-                arr.push(serde_json::json!({ "command": hook_command(status, target) }));
+                arr.push(serde_json::json!({ "command": hook_command(status.as_str(), target) }));
             }
         }
 
@@ -1743,19 +1781,42 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn claude_events() -> &'static [crate::agents::HookEvent] {
-        crate::agents::get_agent("claude")
+    fn claude_events() -> Vec<crate::agents::ResolvedHookEvent> {
+        let agent = crate::agents::get_agent("claude").unwrap();
+        crate::agents::resolved_hook_events(agent, &crate::session::config::Config::default())
             .unwrap()
-            .hook_config
-            .as_ref()
-            .unwrap()
-            .events
     }
 
-    fn codex_events() -> &'static [crate::agents::HookEvent] {
-        crate::agents::get_agent("codex")
+    fn codex_events() -> Vec<crate::agents::ResolvedHookEvent> {
+        let agent = crate::agents::get_agent("codex").unwrap();
+        crate::agents::resolved_hook_events(agent, &crate::session::config::Config::default())
             .unwrap()
-            .hook_config
+    }
+
+    fn resolved_events_with_override(
+        agent_name: &str,
+        event_name: &str,
+        status: crate::agents::HookStatus,
+    ) -> Vec<crate::agents::ResolvedHookEvent> {
+        let mut config = crate::session::config::Config::default();
+        config
+            .agents
+            .entry(agent_name.to_string())
+            .or_default()
+            .status_map
+            .insert(event_name.to_string(), status);
+        let agent = crate::agents::get_agent(agent_name).unwrap();
+        if agent.hook_config.is_some() {
+            crate::agents::resolved_hook_events(agent, &config).unwrap()
+        } else {
+            crate::agents::resolved_sidecar_hook_events(agent, &config).unwrap()
+        }
+    }
+
+    fn sidecar_default_events(agent_name: &str) -> &'static [crate::agents::SidecarHookEvent] {
+        crate::agents::get_agent(agent_name)
+            .unwrap()
+            .sidecar_hooks
             .as_ref()
             .unwrap()
             .events
@@ -1906,6 +1967,41 @@ mod tests {
         assert!(hooks.contains_key("Stop"));
         assert!(hooks.contains_key("Notification"));
         assert!(hooks.contains_key("ElicitationResult"));
+    }
+
+    #[test]
+    fn test_install_hooks_uses_resolved_status_override() {
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join("settings.json");
+        let events = resolved_events_with_override(
+            "claude",
+            "PreToolUse",
+            crate::agents::HookStatus::Waiting,
+        );
+
+        install_hooks(&settings_path, &events, HookInstallTarget::Host).unwrap();
+
+        let content: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let cmd = content["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.contains("printf waiting"), "got command: {cmd}");
+    }
+
+    #[test]
+    fn test_install_hooks_removes_stale_custom_event() {
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join("settings.json");
+        let custom_events =
+            resolved_events_with_override("claude", "PreCompact", crate::agents::HookStatus::Idle);
+
+        install_hooks(&settings_path, &custom_events, HookInstallTarget::Host).unwrap();
+        install_hooks(&settings_path, claude_events(), HookInstallTarget::Host).unwrap();
+
+        let content: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert!(content["hooks"].get("PreCompact").is_none());
     }
 
     #[test]
@@ -2154,20 +2250,20 @@ mod tests {
             .unwrap()
             .as_mapping()
             .unwrap();
-        for (event, _) in HERMES_HOOKS {
+        for event in sidecar_default_events("hermes") {
             assert!(
                 hooks
-                    .get(serde_yaml::Value::String((*event).into()))
+                    .get(serde_yaml::Value::String(event.name.into()))
                     .is_some(),
                 "event {} missing on dotfile target",
-                event
+                event.name
             );
         }
         let allowlist: Value =
             serde_json::from_str(&std::fs::read_to_string(&allowlist_target).unwrap()).unwrap();
         assert_eq!(
             allowlist["approvals"].as_array().unwrap().len(),
-            HERMES_HOOKS.len()
+            sidecar_default_events("hermes").len()
         );
 
         uninstall_hermes_hooks(&config_path).unwrap();
@@ -3035,12 +3131,13 @@ command = "echo user-hook"
 
     #[test]
     fn test_settl_hook_commands_write_correct_status() {
-        for (event, expected_status) in SETTL_HOOKS {
+        for event in sidecar_default_events("settl") {
+            let expected_status = event.status.as_str();
             let cmd = hook_command(expected_status, HookInstallTarget::Host);
             assert!(
                 cmd.contains(&format!("printf {}", expected_status)),
                 "Hook for {} should write '{}': {}",
-                event,
+                event.name,
                 expected_status,
                 cmd
             );
@@ -3065,13 +3162,18 @@ command = "echo user-hook"
             .as_mapping()
             .unwrap();
 
-        for (event, _) in HERMES_HOOKS {
+        for event in sidecar_default_events("hermes") {
             let entries = hooks
-                .get(serde_yaml::Value::String((*event).into()))
-                .unwrap_or_else(|| panic!("event {} missing", event))
+                .get(serde_yaml::Value::String(event.name.into()))
+                .unwrap_or_else(|| panic!("event {} missing", event.name))
                 .as_sequence()
                 .unwrap();
-            assert_eq!(entries.len(), 1, "event {} should have one entry", event);
+            assert_eq!(
+                entries.len(),
+                1,
+                "event {} should have one entry",
+                event.name
+            );
             let cmd = entries[0]
                 .as_mapping()
                 .and_then(|m| m.get(serde_yaml::Value::String("command".into())))
@@ -3089,7 +3191,43 @@ command = "echo user-hook"
         let raw = std::fs::read_to_string(&allowlist).unwrap();
         let parsed: Value = serde_json::from_str(&raw).unwrap();
         let approvals = parsed["approvals"].as_array().unwrap();
-        assert_eq!(approvals.len(), HERMES_HOOKS.len());
+        assert_eq!(approvals.len(), sidecar_default_events("hermes").len());
+    }
+
+    #[test]
+    fn test_install_hermes_hooks_uses_resolved_status_override() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.yaml");
+        let events = resolved_events_with_override(
+            "hermes",
+            "pre_approval_request",
+            crate::agents::HookStatus::Error,
+        );
+
+        install_hermes_hooks_with_events(&config_path, HookInstallTarget::Host, &events).unwrap();
+
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        let config: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let cmd = config["hooks"]["pre_approval_request"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.contains("printf error"), "got command: {cmd}");
+
+        let allowlist: Value = serde_json::from_str(
+            &std::fs::read_to_string(tmp.path().join("shell-hooks-allowlist.json")).unwrap(),
+        )
+        .unwrap();
+        let approval_cmd = allowlist["approvals"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["event"].as_str() == Some("pre_approval_request"))
+            .and_then(|entry| entry["command"].as_str())
+            .unwrap();
+        assert!(
+            approval_cmd.contains("printf error"),
+            "got command: {approval_cmd}"
+        );
     }
 
     #[test]
@@ -3183,7 +3321,7 @@ hooks_auto_accept: false
         let raw = std::fs::read_to_string(&allowlist).unwrap();
         let parsed: Value = serde_json::from_str(&raw).unwrap();
         let approvals = parsed["approvals"].as_array().unwrap();
-        assert_eq!(approvals.len(), HERMES_HOOKS.len());
+        assert_eq!(approvals.len(), sidecar_default_events("hermes").len());
     }
 
     #[test]
@@ -3219,12 +3357,13 @@ hooks_auto_accept: false
 
     #[test]
     fn test_hermes_hook_commands_write_correct_status() {
-        for (event, expected_status) in HERMES_HOOKS {
+        for event in sidecar_default_events("hermes") {
+            let expected_status = event.status.as_str();
             let cmd = hook_command(expected_status, HookInstallTarget::Host);
             assert!(
                 cmd.contains(&format!("printf {}", expected_status)),
                 "Hook for {} should write '{}': {}",
-                event,
+                event.name,
                 expected_status,
                 cmd
             );
@@ -3234,10 +3373,10 @@ hooks_auto_accept: false
 
     #[test]
     fn test_hermes_approval_request_writes_waiting() {
-        let mapped: Vec<&str> = HERMES_HOOKS
+        let mapped: Vec<&str> = sidecar_default_events("hermes")
             .iter()
-            .filter(|(e, _)| *e == "pre_approval_request")
-            .map(|(_, s)| *s)
+            .filter(|event| event.name == "pre_approval_request")
+            .map(|event| event.status.as_str())
             .collect();
         assert_eq!(
             mapped,
@@ -3261,16 +3400,36 @@ hooks_auto_accept: false
         let config: Value = serde_json::from_str(&content).unwrap();
         let hooks = config["hooks"].as_object().unwrap();
 
-        for (event, _) in KIRO_HOOKS {
+        for event in sidecar_default_events("kiro") {
             let entries = hooks
-                .get(*event)
-                .unwrap_or_else(|| panic!("event {} missing", event))
+                .get(event.name)
+                .unwrap_or_else(|| panic!("event {} missing", event.name))
                 .as_array()
                 .unwrap();
-            assert_eq!(entries.len(), 1, "event {} should have one entry", event);
+            assert_eq!(
+                entries.len(),
+                1,
+                "event {} should have one entry",
+                event.name
+            );
             let cmd = entries[0]["command"].as_str().unwrap();
             assert!(is_aoe_hook_command(cmd));
         }
+    }
+
+    #[test]
+    fn test_install_kiro_hooks_uses_resolved_status_override() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("aoe-hooks.json");
+        let events =
+            resolved_events_with_override("kiro", "stop", crate::agents::HookStatus::Error);
+
+        install_kiro_hooks_with_events(&config_path, HookInstallTarget::Host, &events).unwrap();
+
+        let config: Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        let cmd = config["hooks"]["stop"][0]["command"].as_str().unwrap();
+        assert!(cmd.contains("printf error"), "got command: {cmd}");
     }
 
     #[test]
@@ -3306,13 +3465,13 @@ hooks_auto_accept: false
 
         let content = std::fs::read_to_string(&config_path).unwrap();
         let config: Value = serde_json::from_str(&content).unwrap();
-        for (event, _) in KIRO_HOOKS {
-            let entries = config["hooks"][event].as_array().unwrap();
+        for event in sidecar_default_events("kiro") {
+            let entries = config["hooks"][event.name].as_array().unwrap();
             assert_eq!(
                 entries.len(),
                 1,
                 "event {} should still have exactly one AoE entry after double install",
-                event
+                event.name
             );
         }
     }
@@ -3462,13 +3621,13 @@ hooks_auto_accept: false
         // The created file's name must match the selected agent, not the
         // standalone "aoe-hooks" default, so Kiro loads it for --agent custom-agent.
         assert_eq!(config["name"].as_str(), Some("custom-agent"));
-        for (event, _) in KIRO_HOOKS {
-            let entries = config["hooks"][event].as_array().unwrap();
+        for event in sidecar_default_events("kiro") {
+            let entries = config["hooks"][event.name].as_array().unwrap();
             assert_eq!(
                 entries.len(),
                 1,
                 "event {} should have one AoE entry",
-                event
+                event.name
             );
             assert!(is_aoe_hook_command(entries[0]["command"].as_str().unwrap()));
         }
@@ -4164,7 +4323,7 @@ hooks_auto_accept: false
         let settings_path = tmp.path().join("settings.json");
         let events = claude_events();
 
-        install_hooks(&settings_path, events, HookInstallTarget::Host).unwrap();
+        install_hooks(&settings_path, &events, HookInstallTarget::Host).unwrap();
         let canonical = std::fs::read_to_string(&settings_path).unwrap();
         std::fs::remove_file(&settings_path).unwrap();
 
@@ -4173,6 +4332,7 @@ hooks_auto_accept: false
             for _ in 0..8 {
                 let path = settings_path.clone();
                 let b = barrier.clone();
+                let events = &events;
                 s.spawn(move || {
                     b.wait();
                     for _ in 0..100 {

--- a/src/hooks/targets.rs
+++ b/src/hooks/targets.rs
@@ -42,9 +42,9 @@ pub(crate) struct HookTarget {
     pub agent_name: &'static str,
     pub kind: HookTargetKind,
     pub path: PathBuf,
-    /// Hook events to register; empty for `Sidecar` (sidecar installers carry
-    /// their own static event tables internally).
-    pub events: &'static [crate::agents::HookEvent],
+    /// Hook events to register. Migration targets use defaults, not
+    /// profile-specific status maps, because migrations repair canonical files.
+    pub events: Vec<crate::agents::ResolvedHookEvent>,
 }
 
 /// Enumerate every hook target reachable from the running AoE process: the
@@ -89,20 +89,30 @@ pub(crate) fn iter_hook_targets_in(home: &Path, env_lists: &[Vec<String>]) -> Ve
                 crate::agents::HookFormat::CodexJson => HookTargetKind::CodexJson,
             };
             for path in paths {
+                let events = crate::agents::resolved_hook_events(
+                    agent,
+                    &crate::session::config::Config::default(),
+                )
+                .unwrap_or_default();
                 out.push(HookTarget {
                     agent_name: agent.name,
                     kind,
                     path,
-                    events: hook_cfg.events,
+                    events,
                 });
             }
         }
         if let Some(sidecar) = agent.sidecar_hooks.as_ref() {
+            let events = crate::agents::resolved_sidecar_hook_events(
+                agent,
+                &crate::session::config::Config::default(),
+            )
+            .unwrap_or_default();
             out.push(HookTarget {
                 agent_name: agent.name,
                 kind: HookTargetKind::Sidecar(sidecar),
                 path: home.join(sidecar.host_config_subpath),
-                events: &[],
+                events,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,7 +342,7 @@ async fn main() -> Result<()> {
         Some(Commands::Session { command }) => cli::session::run(&profile, command).await,
         Some(Commands::Group { command }) => cli::group::run(&profile, command).await,
         Some(Commands::Plugin { command }) => cli::plugin::run(command).await,
-        Some(Commands::Profile { command }) => cli::profile::run(command).await,
+        Some(Commands::Profile { command }) => cli::profile::run(&profile, command).await,
         Some(Commands::Project { command }) => {
             cli::project::run(&profile, profile_explicit, command).await
         }

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -155,7 +155,7 @@ pub(crate) fn run_in(home: &Path, app_dir: &Path) -> Result<()> {
 fn rewrite_one(target: &HookTarget) -> Result<()> {
     match target.kind {
         HookTargetKind::JsonSettings | HookTargetKind::CodexJson => {
-            install_hooks(&target.path, target.events, HookInstallTarget::Host)
+            install_hooks(&target.path, &target.events, HookInstallTarget::Host)
         }
         // Defensive: `iter_hook_targets_in` does not emit `CodexToml` for
         // any registered agent (codex declares `CodexJson`). The arm stays
@@ -165,7 +165,7 @@ fn rewrite_one(target: &HookTarget) -> Result<()> {
             let preserved = snapshot_codex_hooks_state(&target.path)?;
             install_codex_hooks_with_preserved_state(
                 &target.path,
-                target.events,
+                &target.events,
                 preserved,
                 HookInstallTarget::Host,
             )
@@ -175,7 +175,7 @@ fn rewrite_one(target: &HookTarget) -> Result<()> {
             // Kiro's `set_kiro_default_agent_if_builtin` shells out to
             // `kiro-cli`, which is launcher-state mutation, not file-content
             // reconciliation.
-            (sidecar.install)(&target.path, HookInstallTarget::Host)
+            (sidecar.install)(&target.path, HookInstallTarget::Host, &target.events)
         }
     }
 }
@@ -334,8 +334,10 @@ mod tests {
                                 .push(canonical_session_id_command(HookInstallTarget::Host));
                         }
                         if let Some(status) = event_def.status {
-                            canonical_set
-                                .push(canonical_status_command(status, HookInstallTarget::Host));
+                            canonical_set.push(canonical_status_command(
+                                status.as_str(),
+                                HookInstallTarget::Host,
+                            ));
                         }
                     }
                     assert!(

--- a/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
+++ b/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
@@ -161,19 +161,19 @@ fn rewrite_one(target: &HookTarget) -> Result<()> {
     }
     match target.kind {
         HookTargetKind::JsonSettings | HookTargetKind::CodexJson => {
-            install_hooks(&target.path, target.events, HookInstallTarget::Host)
+            install_hooks(&target.path, &target.events, HookInstallTarget::Host)
         }
         HookTargetKind::CodexToml => {
             let preserved = snapshot_codex_hooks_state(&target.path)?;
             install_codex_hooks_with_preserved_state(
                 &target.path,
-                target.events,
+                &target.events,
                 preserved,
                 HookInstallTarget::Host,
             )
         }
         HookTargetKind::Sidecar(sidecar) => {
-            (sidecar.install)(&target.path, HookInstallTarget::Host)
+            (sidecar.install)(&target.path, HookInstallTarget::Host, &target.events)
         }
     }
 }

--- a/src/migrations/v018_strip_codex_config_toml_hooks.rs
+++ b/src/migrations/v018_strip_codex_config_toml_hooks.rs
@@ -111,14 +111,14 @@ pub(crate) fn run_in(home: &Path, app_dir: &Path) -> Result<()> {
         // Synthetic CodexToml target: the live enumerator does not produce
         // this kind for any registered agent, so v018 builds the marker-gate
         // fixture itself rather than mining `iter_hook_targets_in` for a
-        // variant only this migration constructs. `events: &[]` because
+        // variant only this migration constructs. `events: Vec::new()` because
         // the only consumer here is `has_aoe_marker` (bytes-only marker
         // scan); `uninstall_codex_hooks` reads the file separately.
         let target = HookTarget {
             agent_name: "codex",
             kind: HookTargetKind::CodexToml,
             path: path.clone(),
-            events: &[],
+            events: Vec::new(),
         };
         if !has_aoe_marker(&target) {
             continue;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -5,7 +5,7 @@ use super::repo_config::{HooksConfig, HostHooksConfig};
 use anyhow::Result;
 use aoe_settings_derive::SettingsSection;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
@@ -67,6 +67,11 @@ pub struct Config {
     #[serde(default)]
     pub logging: LoggingConfig,
 
+    /// Trusted global/profile agent runtime overrides. Repo config does not
+    /// merge this section, because hook installation writes durable agent files.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub agents: BTreeMap<String, AgentRuntimeConfig>,
+
     /// Environment variables injected into the host command line for every
     /// session spawned at global scope. Entries are `KEY=value`, `KEY=$VAR`
     /// (read VAR from the host env), `KEY=$$literal` (escape a `$`), or
@@ -94,6 +99,14 @@ pub struct Config {
     /// keys still fail loudly while plugin enable-state survives every save.
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub plugins: std::collections::BTreeMap<String, PluginConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRuntimeConfig {
+    /// Per-agent hook event to AoE status mapping. Overrides built-in hook
+    /// defaults by event name when status hooks are installed.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub status_map: BTreeMap<String, crate::agents::HookStatus>,
 }
 
 /// Configuration for one plugin: whether it is enabled, its install source and
@@ -3292,6 +3305,38 @@ mod tests {
             }),
             "acp_defaults should survive roundtrip"
         );
+    }
+
+    #[test]
+    fn agent_status_map_roundtrips() {
+        let mut config = Config::default();
+        config
+            .agents
+            .entry("claude".to_string())
+            .or_default()
+            .status_map
+            .insert("Stop".to_string(), crate::agents::HookStatus::Error);
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        assert!(serialized.contains("[agents.claude.status_map]"));
+        assert!(serialized.contains("Stop = \"error\""));
+
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.agents["claude"].status_map.get("Stop"),
+            Some(&crate::agents::HookStatus::Error)
+        );
+    }
+
+    #[test]
+    fn agent_status_map_rejects_invalid_status() {
+        let toml = r#"
+            [agents.claude.status_map]
+            Stop = "stopped"
+        "#;
+
+        let err = toml::from_str::<Config>(toml).unwrap_err();
+        assert!(err.to_string().contains("stopped"));
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -974,14 +974,13 @@ fn compute_workspace_volume_paths(
 
 /// Re-sync shared sandbox directories from the host so the container picks up
 /// any credential changes (e.g. re-auth) since it was created.
-pub(crate) fn refresh_agent_configs() {
+pub(crate) fn refresh_agent_configs_for_profile(profile: &str) {
     let Some(home) = dirs::home_dir() else {
         return;
     };
 
-    let hooks_enabled = super::config::Config::load()
-        .map(|c| c.session.agent_status_hooks)
-        .unwrap_or(true);
+    let profile_config = super::profile_config::resolve_config_or_warn(profile);
+    let hooks_enabled = profile_config.session.agent_status_hooks;
 
     for mount in AGENT_CONFIG_MOUNTS {
         let refresh_codex_hooks = hooks_enabled && should_refresh_codex_hooks(mount, &home);
@@ -989,7 +988,7 @@ pub(crate) fn refresh_agent_configs() {
         match prepare_sandbox_dir(mount, &home) {
             Ok(sandbox_dir) => {
                 if refresh_codex_hooks {
-                    refresh_codex_sandbox_hooks(mount, &sandbox_dir);
+                    refresh_codex_sandbox_hooks(mount, &sandbox_dir, &profile_config);
                 }
             }
             Err(e) => {
@@ -1026,20 +1025,33 @@ fn should_refresh_codex_hooks(mount: &AgentConfigMount, home: &Path) -> bool {
     host_hooks.exists() || sandbox_hooks.exists()
 }
 
-fn refresh_codex_sandbox_hooks(mount: &AgentConfigMount, sandbox_dir: &Path) {
-    let Some(hook_cfg) =
-        crate::agents::get_agent(mount.tool_name).and_then(|a| a.hook_config.as_ref())
-    else {
+fn refresh_codex_sandbox_hooks(
+    mount: &AgentConfigMount,
+    sandbox_dir: &Path,
+    profile_config: &super::config::Config,
+) {
+    let Some(agent) = crate::agents::get_agent(mount.tool_name) else {
         return;
     };
 
     let hooks_path = sandbox_dir.join("hooks.json");
+    let events = match crate::agents::resolved_hook_events(agent, profile_config) {
+        Ok(events) => events,
+        Err(e) => {
+            tracing::warn!(target: "session.profile",
+                "Failed to resolve Codex hooks while refreshing sandbox config {}: {}",
+                hooks_path.display(),
+                e
+            );
+            return;
+        }
+    };
     if let Err(e) = crate::hooks::install_hooks(
         &hooks_path,
-        hook_cfg.events,
+        &events,
         crate::hooks::HookInstallTarget::Sandbox,
     ) {
-        tracing::warn!(
+        tracing::warn!(target: "session.profile",
             "Failed to refresh Codex hooks in sandbox config {}: {}",
             hooks_path.display(),
             e
@@ -1296,12 +1308,12 @@ pub(crate) fn build_container_config(
 
     let project_path = Path::new(project_path_str);
     let resolved_profile = super::config::effective_profile(profile);
-    let profile_session_config =
-        super::profile_config::resolve_config_or_warn(&resolved_profile).session;
+    let profile_config = super::profile_config::resolve_config_or_warn(&resolved_profile);
+    let profile_session_config = &profile_config.session;
     let active_agent = resolve_active_agent(
         agent_selection.tool,
         agent_selection.detect_as,
-        &profile_session_config,
+        profile_session_config,
     );
     let config_tool = active_agent.map_or(agent_selection.tool, |agent| agent.name);
 
@@ -1506,62 +1518,85 @@ pub(crate) fn build_container_config(
             }
 
             if let Some(sidecar) = &agent.sidecar_hooks {
-                // Default target: the standalone hooks agent's sandbox config.
-                // When the user selected their own agent via the sidecar's
-                // selected-agent flag (e.g. Kiro `--agent NAME`), the container
-                // loads THAT agent's config (these CLIs have no global hooks), so
-                // install into its staged file instead. The selected agent's dir
-                // is copied into the sandbox via AGENT_CONFIG_MOUNTS, so the
-                // staged path is the sandbox config dir plus the selected name's
-                // file (mirrors the host path in
-                // `Instance::install_sidecar_host_hooks`).
-                let config_file = sidecar
-                    .selected_agent_hooks
-                    .as_ref()
-                    .zip(agent_selection.selected_agent)
-                    .and_then(|(sel, name)| {
-                        // The selected agent's dir is staged into the sandbox
-                        // (parent of sandbox_config_subpath, e.g.
-                        // `.kiro/sandbox/agents`) before this install runs, so
-                        // the resolver can match by `name` there as on the host.
-                        let agents_dir =
-                            home.join(Path::new(sidecar.sandbox_config_subpath).parent()?);
-                        Some((sel.resolve_config_file)(&agents_dir, name))
-                    })
-                    .unwrap_or_else(|| home.join(sidecar.sandbox_config_subpath));
-                if let Err(e) =
-                    (sidecar.install)(&config_file, crate::hooks::HookInstallTarget::Sandbox)
-                {
-                    tracing::warn!(target: "session.profile", "Failed to install {} hooks in sandbox: {}", agent.name, e);
+                let events = match crate::agents::resolved_sidecar_hook_events(
+                    agent,
+                    &profile_config,
+                ) {
+                    Ok(events) => events,
+                    Err(e) => {
+                        tracing::warn!(target: "session.profile", "Failed to resolve {} hooks in sandbox: {}", agent.name, e);
+                        Vec::new()
+                    }
+                };
+                if !events.is_empty() {
+                    // Default target: the standalone hooks agent's sandbox config.
+                    // When the user selected their own agent via the sidecar's
+                    // selected-agent flag (e.g. Kiro `--agent NAME`), the container
+                    // loads THAT agent's config (these CLIs have no global hooks), so
+                    // install into its staged file instead. The selected agent's dir
+                    // is copied into the sandbox via AGENT_CONFIG_MOUNTS, so the
+                    // staged path is the sandbox config dir plus the selected name's
+                    // file (mirrors the host path in
+                    // `Instance::install_sidecar_host_hooks`).
+                    let config_file = sidecar
+                        .selected_agent_hooks
+                        .as_ref()
+                        .zip(agent_selection.selected_agent)
+                        .and_then(|(sel, name)| {
+                            // The selected agent's dir is staged into the sandbox
+                            // (parent of sandbox_config_subpath, e.g.
+                            // `.kiro/sandbox/agents`) before this install runs, so
+                            // the resolver can match by `name` there as on the host.
+                            let agents_dir =
+                                home.join(Path::new(sidecar.sandbox_config_subpath).parent()?);
+                            Some((sel.resolve_config_file)(&agents_dir, name))
+                        })
+                        .unwrap_or_else(|| home.join(sidecar.sandbox_config_subpath));
+                    if let Err(e) = (sidecar.install)(
+                        &config_file,
+                        crate::hooks::HookInstallTarget::Sandbox,
+                        &events,
+                    ) {
+                        tracing::warn!(target: "session.profile", "Failed to install {} hooks in sandbox: {}", agent.name, e);
+                    }
                 }
             } else if let Some(hook_cfg) = &agent.hook_config {
-                // Install hooks into the sandbox config file for the containerized agent.
-                // Shell one-liners work inside containers since they only use sh/mkdir/printf.
-                let rel_path = std::path::Path::new(hook_cfg.settings_rel_path);
-                let config_dir_name = rel_path.parent().unwrap_or(std::path::Path::new("."));
-                let config_file_name = rel_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("settings.json");
-                // Find the matching agent config mount to locate the sandbox dir
-                for mount in AGENT_CONFIG_MOUNTS {
-                    if std::path::Path::new(mount.host_rel) == config_dir_name {
-                        let sandbox_dir = home.join(mount.host_rel).join(SANDBOX_SUBDIR);
-                        let settings_file = sandbox_dir.join(config_file_name);
-                        let result = match hook_cfg.format {
-                            crate::agents::HookFormat::CodexJson
-                            | crate::agents::HookFormat::JsonSettings => {
-                                crate::hooks::install_hooks(
-                                    &settings_file,
-                                    hook_cfg.events,
-                                    crate::hooks::HookInstallTarget::Sandbox,
-                                )
+                let events = match crate::agents::resolved_hook_events(agent, &profile_config) {
+                    Ok(events) => events,
+                    Err(e) => {
+                        tracing::warn!(target: "session.profile", "Failed to resolve hooks in sandbox config: {}", e);
+                        Vec::new()
+                    }
+                };
+                if !events.is_empty() {
+                    // Install hooks into the sandbox config file for the containerized agent.
+                    // Shell one-liners work inside containers since they only use sh/mkdir/printf.
+                    let rel_path = std::path::Path::new(hook_cfg.settings_rel_path);
+                    let config_dir_name = rel_path.parent().unwrap_or(std::path::Path::new("."));
+                    let config_file_name = rel_path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("settings.json");
+                    // Find the matching agent config mount to locate the sandbox dir
+                    for mount in AGENT_CONFIG_MOUNTS {
+                        if std::path::Path::new(mount.host_rel) == config_dir_name {
+                            let sandbox_dir = home.join(mount.host_rel).join(SANDBOX_SUBDIR);
+                            let settings_file = sandbox_dir.join(config_file_name);
+                            let result = match hook_cfg.format {
+                                crate::agents::HookFormat::CodexJson
+                                | crate::agents::HookFormat::JsonSettings => {
+                                    crate::hooks::install_hooks(
+                                        &settings_file,
+                                        &events,
+                                        crate::hooks::HookInstallTarget::Sandbox,
+                                    )
+                                }
+                            };
+                            if let Err(e) = result {
+                                tracing::warn!(target: "session.profile", "Failed to install hooks in sandbox config: {}", e);
                             }
-                        };
-                        if let Err(e) = result {
-                            tracing::warn!(target: "session.profile", "Failed to install hooks in sandbox config: {}", e);
+                            break;
                         }
-                        break;
                     }
                 }
             }
@@ -3868,7 +3903,7 @@ trusted_hash = "keep"
         fs::write(&sandbox_config_path, sandbox_config).unwrap();
         fs::write(codex_dir.join("config.toml"), r#"model = "updated""#).unwrap();
 
-        refresh_agent_configs();
+        refresh_agent_configs_for_profile(&crate::session::config::effective_profile(""));
 
         let config_text = fs::read_to_string(&sandbox_config_path).unwrap();
         let config: toml::Value = toml::from_str(&config_text).unwrap();
@@ -3886,6 +3921,68 @@ trusted_hash = "keep"
             "PreToolUse array must be installed in sandbox hooks.json"
         );
         assert!(hooks_text.contains("aoe-hooks"));
+        crate::hooks::cleanup_hook_status_dir(instance_id);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_refresh_agent_configs_uses_profile_status_map_for_codex_hooks() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let codex_dir = temp_home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(codex_dir.join("config.toml"), r#"model = "initial""#).unwrap();
+
+        let mut profile_config = super::super::profile_config::ProfileConfig::default();
+        profile_config.overrides.insert(
+            "agents".to_string(),
+            serde_json::json!({
+                "codex": {
+                    "status_map": {
+                        "PreToolUse": "waiting"
+                    }
+                }
+            }),
+        );
+        super::super::profile_config::save_profile_config("work", &profile_config).unwrap();
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+        let instance_id = "codex-profile-status-map-refresh-test";
+        build_container_config(
+            project_dir.path().to_str().unwrap(),
+            &sandbox_info,
+            ContainerAgentSelection::new("codex", None),
+            false,
+            instance_id,
+            None,
+            "work",
+        )
+        .unwrap();
+
+        refresh_agent_configs_for_profile("work");
+
+        let hooks_path = codex_dir.join(SANDBOX_SUBDIR).join("hooks.json");
+        let hooks: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        let cmd = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.contains("printf waiting"), "got command: {cmd}");
         crate::hooks::cleanup_hook_status_dir(instance_id);
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -293,11 +293,19 @@ fn default_true() -> bool {
     true
 }
 
-fn status_hook_env_prefix(instance_id: &str, agent: Option<&crate::agents::AgentDef>) -> String {
+fn status_hook_env_prefix(
+    profile: &str,
+    instance_id: &str,
+    agent: Option<&crate::agents::AgentDef>,
+) -> String {
     let has_hooks = agent.is_some_and(|a| a.hook_config.is_some() || a.sidecar_hooks.is_some());
 
     if has_hooks {
-        format!("AOE_INSTANCE_ID={} ", instance_id)
+        format!(
+            "AOE_PROFILE={} AOE_INSTANCE_ID={} ",
+            shell_escape(profile),
+            shell_escape(instance_id)
+        )
     } else {
         String::new()
     }
@@ -2537,7 +2545,13 @@ impl Instance {
                 sandbox,
                 std::path::Path::new(&self.project_path),
             );
-            let docker_args = format!("{} -e AOE_INSTANCE_ID={}", env_info.docker_args, self.id);
+            let profile = self.effective_profile();
+            let docker_args = format!(
+                "{} -e AOE_PROFILE={} -e AOE_INSTANCE_ID={}",
+                env_info.docker_args,
+                shell_escape(&profile),
+                shell_escape(&self.id)
+            );
             let env_part = format!("{} ", docker_args);
             let wrapped =
                 wrap_command_ignore_suspend(&container.exec_command(Some(&env_part), &tool_cmd));
@@ -2594,30 +2608,48 @@ impl Instance {
     /// Respects the `agent_status_hooks` config setting.
     fn install_agent_status_hooks(&self, agent: Option<&'static crate::agents::AgentDef>) {
         let profile = self.effective_profile();
-        let session_cfg = super::profile_config::resolve_config_or_warn(&profile).session;
-        if !session_cfg.agent_status_hooks {
+        let config = super::profile_config::resolve_config_or_warn(&profile);
+        if !config.session.agent_status_hooks {
             return;
         }
-        if let Some(sidecar) = agent.and_then(|a| a.sidecar_hooks.as_ref()) {
-            // Sidecar agents (settl TOML, hermes YAML, kiro per-agent JSON)
-            // install into a host config file; sandbox install is handled by
-            // build_container_config. host_only agents (settl) are never
-            // sandboxed, so the gate is a no-op for them.
-            if !self.is_sandboxed() {
-                if let Some(home) = dirs::home_dir() {
-                    self.install_sidecar_host_hooks(sidecar, &home, &session_cfg);
-                }
-            }
-        } else if let Some(hook_cfg) = agent.and_then(|a| a.hook_config.as_ref()) {
-            if !self.is_sandboxed() {
-                match hook_cfg.format {
-                    crate::agents::HookFormat::CodexJson => self.install_codex_host_hooks(hook_cfg),
-                    crate::agents::HookFormat::JsonSettings => {
-                        self.install_json_host_hooks(hook_cfg)
+        if let Some(agent) = agent {
+            if let Some(sidecar) = agent.sidecar_hooks.as_ref() {
+                let events = match crate::agents::resolved_sidecar_hook_events(agent, &config) {
+                    Ok(events) => events,
+                    Err(e) => {
+                        tracing::warn!(target: "session.store", "Failed to resolve {} status hooks: {}", agent.name, e);
+                        return;
+                    }
+                };
+                // Sidecar agents (settl TOML, hermes YAML, kiro per-agent JSON)
+                // install into a host config file; sandbox install is handled by
+                // build_container_config. host_only agents (settl) are never
+                // sandboxed, so the gate is a no-op for them.
+                if !self.is_sandboxed() {
+                    if let Some(home) = dirs::home_dir() {
+                        self.install_sidecar_host_hooks(sidecar, &home, &config.session, &events);
                     }
                 }
+            } else if let Some(hook_cfg) = agent.hook_config.as_ref() {
+                let events = match crate::agents::resolved_hook_events(agent, &config) {
+                    Ok(events) => events,
+                    Err(e) => {
+                        tracing::warn!(target: "session.store", "Failed to resolve {} status hooks: {}", agent.name, e);
+                        return;
+                    }
+                };
+                if !self.is_sandboxed() {
+                    match hook_cfg.format {
+                        crate::agents::HookFormat::CodexJson => {
+                            self.install_codex_host_hooks(&events)
+                        }
+                        crate::agents::HookFormat::JsonSettings => {
+                            self.install_json_host_hooks(hook_cfg, &events)
+                        }
+                    }
+                }
+                // Sandboxed sessions install via build_container_config.
             }
-            // Sandboxed sessions install via build_container_config.
         }
     }
 
@@ -2631,6 +2663,7 @@ impl Instance {
         sidecar: &'static crate::agents::SidecarHooks,
         home: &Path,
         session_cfg: &super::config::SessionConfig,
+        events: &[crate::agents::ResolvedHookEvent],
     ) {
         if session_cfg.merge_hooks_into_selected_agent {
             if let Some(sel) = sidecar.selected_agent_hooks.as_ref() {
@@ -2649,7 +2682,7 @@ impl Instance {
                             .unwrap_or(Path::new(".")),
                     );
                     let path = (sel.resolve_config_file)(&agents_dir, &name);
-                    match (sidecar.install)(&path, crate::hooks::HookInstallTarget::Host) {
+                    match (sidecar.install)(&path, crate::hooks::HookInstallTarget::Host, events) {
                         Ok(()) => tracing::info!(target: "session.store",
                             "Installed AoE status hooks into {} agent '{}' at {}", self.tool, name, path.display()),
                         Err(e) => tracing::warn!(target: "session.store",
@@ -2661,7 +2694,7 @@ impl Instance {
         }
 
         let config_path = home.join(sidecar.host_config_subpath);
-        match (sidecar.install)(&config_path, crate::hooks::HookInstallTarget::Host) {
+        match (sidecar.install)(&config_path, crate::hooks::HookInstallTarget::Host, events) {
             Ok(()) => {
                 tracing::info!(target: "session.store",
                     "Installed AoE status hooks for {} via standalone hooks agent", self.tool);
@@ -2674,24 +2707,30 @@ impl Instance {
         }
     }
 
-    fn install_codex_host_hooks(&self, hook_cfg: &crate::agents::AgentHookConfig) {
+    fn install_codex_host_hooks(&self, events: &[crate::agents::ResolvedHookEvent]) {
         match crate::hooks::codex_hooks_json_path_for_host_environment(
             &self.profile_host_environment(),
         ) {
             Ok(hooks_path) => {
                 if let Err(e) = crate::hooks::install_hooks(
                     &hooks_path,
-                    hook_cfg.events,
+                    events,
                     crate::hooks::HookInstallTarget::Host,
                 ) {
-                    tracing::warn!("Failed to install codex hooks: {}", e);
+                    tracing::warn!(target: "session.store", "Failed to install codex hooks: {}", e);
                 }
             }
-            Err(e) => tracing::warn!("Failed to resolve codex hooks path: {}", e),
+            Err(e) => {
+                tracing::warn!(target: "session.store", "Failed to resolve codex hooks path: {}", e)
+            }
         }
     }
 
-    fn install_json_host_hooks(&self, hook_cfg: &crate::agents::AgentHookConfig) {
+    fn install_json_host_hooks(
+        &self,
+        hook_cfg: &crate::agents::AgentHookConfig,
+        events: &[crate::agents::ResolvedHookEvent],
+    ) {
         // Install hooks in the agent's host settings file, honoring a
         // config-dir override env var (e.g. CLAUDE_CONFIG_DIR) so hooks
         // land where the agent actually reads them.
@@ -2702,7 +2741,7 @@ impl Instance {
             Ok(settings_path) => {
                 if let Err(e) = crate::hooks::install_hooks(
                     &settings_path,
-                    hook_cfg.events,
+                    events,
                     crate::hooks::HookInstallTarget::Host,
                 ) {
                     tracing::warn!(target: "session.store", "Failed to install agent hooks: {}", e);
@@ -2747,7 +2786,8 @@ impl Instance {
             }
         }
 
-        let mut env_prefix = status_hook_env_prefix(&self.id, agent);
+        let profile = self.effective_profile();
+        let mut env_prefix = status_hook_env_prefix(&profile, &self.id, agent);
 
         // Profile-scoped host environment entries (KEY=value, KEY=$VAR,
         // KEY=$$literal, or bare KEY for passthrough). Sandboxed sessions
@@ -3129,7 +3169,7 @@ impl Instance {
             // Already up: not a come-up, so don't re-mint. Fill lazily only if a
             // fresh process attached to a running container with no values yet.
             self.ensure_before_start_env(false)?;
-            container_config::refresh_agent_configs();
+            container_config::refresh_agent_configs_for_profile(&self.effective_profile());
             self.backfill_container_workdir(&container);
             return Ok(container);
         }
@@ -3138,7 +3178,7 @@ impl Instance {
             // Restart of a stopped container is a come-up: refresh so a
             // short-lived token is re-minted.
             self.ensure_before_start_env(true)?;
-            container_config::refresh_agent_configs();
+            container_config::refresh_agent_configs_for_profile(&self.effective_profile());
             container.start()?;
             self.backfill_container_workdir(&container);
             return Ok(container);
@@ -4706,8 +4746,8 @@ mod tests {
     fn test_codex_gets_status_hook_env_prefix() {
         let agent = crate::agents::get_agent("codex");
         assert_eq!(
-            status_hook_env_prefix("abc123", agent),
-            "AOE_INSTANCE_ID=abc123 "
+            status_hook_env_prefix("work", "abc123", agent),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
     }
 
@@ -7043,24 +7083,24 @@ mod tests {
     #[test]
     fn test_status_hook_env_prefix_includes_hermes() {
         assert_eq!(
-            status_hook_env_prefix("abc123", crate::agents::get_agent("hermes")),
-            "AOE_INSTANCE_ID=abc123 "
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("hermes")),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
         assert_eq!(
-            status_hook_env_prefix("abc123", crate::agents::get_agent("settl")),
-            "AOE_INSTANCE_ID=abc123 "
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("settl")),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
         assert_eq!(
-            status_hook_env_prefix("abc123", crate::agents::get_agent("claude")),
-            "AOE_INSTANCE_ID=abc123 "
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("claude")),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
         assert_eq!(
-            status_hook_env_prefix("abc123", crate::agents::get_agent("opencode")),
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("opencode")),
             ""
         );
         assert_eq!(
-            status_hook_env_prefix("abc123", crate::agents::get_agent("kiro")),
-            "AOE_INSTANCE_ID=abc123 "
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("kiro")),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -41,10 +41,10 @@ pub use crate::status_hooks::StatusHookConfig;
 pub(crate) use capture::is_valid_session_id;
 pub use config::{
     get_telemetry_settings, get_update_settings, load_config, save_config,
-    validate_snooze_duration, CapabilityGrant, ClickAction, Config, ContainerRuntimeName,
-    DefaultTerminalMode, GroupByMode, NewSessionAttachMode, PluginConfig, RowTagMode,
-    SandboxConfig, SessionConfig, TelemetryConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode,
-    TmuxStatusBarMode, UpdatesConfig, VolumeIgnoresStrategy, WorktreeConfig,
+    validate_snooze_duration, AgentRuntimeConfig, CapabilityGrant, ClickAction, Config,
+    ContainerRuntimeName, DefaultTerminalMode, GroupByMode, NewSessionAttachMode, PluginConfig,
+    RowTagMode, SandboxConfig, SessionConfig, TelemetryConfig, ThemeConfig, TmuxClipboardMode,
+    TmuxMouseMode, TmuxStatusBarMode, UpdatesConfig, VolumeIgnoresStrategy, WorktreeConfig,
 };
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -312,6 +312,38 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_configs_with_agent_status_map_overrides() {
+        let mut global = Config::default();
+        global
+            .agents
+            .entry("claude".to_string())
+            .or_default()
+            .status_map
+            .insert("Stop".to_string(), crate::agents::HookStatus::Idle);
+        global
+            .agents
+            .entry("claude".to_string())
+            .or_default()
+            .status_map
+            .insert("PreToolUse".to_string(), crate::agents::HookStatus::Running);
+
+        let profile = profile_from(json!({
+            "agents": {"claude": {"status_map": {"Stop": "error"}}}
+        }));
+
+        let merged = merge_configs(global, &profile);
+        let status_map = &merged.agents["claude"].status_map;
+        assert_eq!(
+            status_map.get("PreToolUse"),
+            Some(&crate::agents::HookStatus::Running)
+        );
+        assert_eq!(
+            status_map.get("Stop"),
+            Some(&crate::agents::HookStatus::Error)
+        );
+    }
+
+    #[test]
     fn test_profile_has_overrides() {
         let empty = ProfileConfig::default();
         assert!(!profile_has_overrides(&empty));

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -13,7 +13,7 @@
 //!    (Idle/Unknown) every 5 cycles, Cold (Error) every 60 cycles, Frozen
 //!    (Stopped/Deleting) never.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -133,7 +133,14 @@ pub(super) fn poll_statuses_once(
     if has_sandboxed && state.last_credential_refresh.elapsed() >= state.credential_refresh_interval
     {
         state.last_credential_refresh = Instant::now();
-        crate::session::container_config::refresh_agent_configs();
+        let profiles: BTreeSet<String> = instances
+            .iter()
+            .filter(|inst| inst.is_sandboxed())
+            .map(|inst| inst.effective_profile())
+            .collect();
+        for profile in profiles {
+            crate::session::container_config::refresh_agent_configs_for_profile(&profile);
+        }
     }
 
     instances


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds trusted global and profile-level `agents.<name>.status_map` configuration so users can override built-in hook event statuses or add custom hook event names without forking AoE's installed hook scripts. The resolved map is typed through `HookStatus`, so only `running`, `waiting`, `idle`, and `error` deserialize successfully.

Hook installation now resolves the profile-merged map before writing host or sandbox agent config files. Generic JSON hooks, Codex hooks, and the Settl, Hermes, and Kiro sidecar installers all consume the same resolved event list. Removed custom JSON events are cleaned up on the next install, and installed hook-capable agent processes receive `AOE_PROFILE` for script queries.

The CLI gains `aoe profile show --status-map <agent> --json` for hook scripts and automation. Documentation covers the TOML shape, valid statuses, additive custom event names, and the query command.

Closes #1025

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: N/A

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new CLI output is deterministic config resolution covered by unit tests and generated CLI docs; the manual checks above exercise the full command.

## How to test

- [ ] Add `[agents.claude.status_map]` with `PreCompact = "running"`, then run `aoe -p <profile> profile show --status-map claude --json` and confirm the output includes both built-in events and `PreCompact`.
- [ ] Override a built-in event such as `Stop = "error"`, restart a hook-capable session in that profile, and confirm the installed hook command for that event writes `error`.
- [ ] Remove the custom event from the profile config, restart the session, and confirm the old AoE-managed custom event hook is gone from the agent settings file.
- [ ] For a sandboxed Codex session in a non-default profile, set `PreToolUse = "waiting"`, restart or reattach the session, and confirm the sandbox `hooks.json` keeps the `waiting` status.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I reviewed the design calls and validation results before opening this PR.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes hook event→status mapping configurable per agent in profile configuration. Users can override built-in lifecycle mappings and add new custom hook event names (without forking or editing the bundled hook scripts). The resolved status map is validated through a typed status model, so only supported statuses deserialize cleanly.

Hook installation was updated to compute and apply the profile-resolved status map consistently across host and sandbox installs (covering JSON hooks, Codex hooks, and sidecar installers). When custom events are removed from config, they’re cleaned up on the next install. Hook-capable agent processes also receive `AOE_PROFILE` so scripts can query the active resolved profile behavior.

A new CLI command was added: `aoe profile show --status-map <agent> --json`, along with documentation updates describing the TOML structure, valid statuses, additive custom event names, and how to query the resolved map for automation.

Overall, this reduces per-agent customization forks and keeps hook behavior aligned with the selected profile across the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->