### PR TITLE
feat(web): support title-derived worktree sessions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,35 @@ in the TUI's Serve panel). Three transports are accepted:
 Read-only mode (`aoe serve --read-only`) blocks every write endpoint
 with `403 read_only`. Read endpoints work normally.
 
+## POST /api/sessions
+
+Create a session. The web dashboard uses this endpoint for the new-session
+dialog, and external orchestrators may call it directly.
+
+**Worktree fields**
+
+| Field | Notes |
+| --- | --- |
+| `worktree_enabled` | Set `true` to create a managed git worktree even when no explicit branch name is supplied. |
+| `worktree_branch` | Optional explicit branch or worktree name. If omitted while `worktree_enabled` is true, AoE derives a safe branch name from the resolved session title. |
+| `create_new_branch` | `true` creates a new branch; `false` attaches to an existing branch. |
+
+For compatibility, callers that only send `worktree_branch` still opt into
+worktree mode. To get title-derived branch names, send `worktree_enabled` as
+`true` and omit `worktree_branch`.
+
+**Example**
+
+```json
+{
+  "path": "/path/to/repo",
+  "tool": "claude",
+  "title": "Fix Login Flow",
+  "worktree_enabled": true,
+  "create_new_branch": true
+}
+```
+
 ## POST /api/sessions/{id}/send
 
 Type a message into the agent and press Enter, the same way the TUI's

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3642,6 +3642,10 @@ pub struct CreateSessionBody {
     pub group: String,
     #[serde(default)]
     pub yolo_mode: bool,
+    /// Explicit worktree opt-in. When omitted or false, legacy callers that
+    /// send `worktree_branch` still opt into worktree mode.
+    #[serde(default)]
+    pub worktree_enabled: bool,
     pub worktree_branch: Option<String>,
     #[serde(default)]
     pub create_new_branch: bool,
@@ -3718,6 +3722,14 @@ pub struct CreateSessionBody {
     #[cfg(feature = "serve")]
     #[serde(default)]
     pub fork_from: Option<String>,
+}
+
+fn create_body_uses_worktree(body: &CreateSessionBody) -> bool {
+    body.worktree_enabled || body.worktree_branch.is_some()
+}
+
+fn create_body_combines_scratch_and_worktree(body: &CreateSessionBody) -> bool {
+    body.scratch && create_body_uses_worktree(body)
 }
 
 /// Resolve the one-shot fork seed for a `fork_from` create request. A
@@ -4028,12 +4040,12 @@ pub async fn create_session(
     // wrong model for them. Reject the combination before reaching the
     // builder so misbehaving clients get a clear 400 instead of a
     // less-specific builder bail surfaced as 500.
-    if body.scratch && body.worktree_branch.is_some() {
+    if create_body_combines_scratch_and_worktree(&body) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
                 "error": "validation_failed",
-                "message": "Cannot combine scratch with worktree_branch"
+                "message": "Cannot combine scratch with worktree mode"
             })),
         )
             .into_response();
@@ -4168,6 +4180,8 @@ pub async fn create_session(
             .into_response();
     }
 
+    let worktree_enabled = create_body_uses_worktree(&body);
+
     // Importing an existing Claude session (#2276) is tightly scoped: it
     // resumes a specific on-disk session id in its original cwd via the claude
     // structured agent. Reject any request that pairs the id with a different
@@ -4197,7 +4211,7 @@ pub async fn create_session(
         {
             return bad("Importing a Claude session requires the built-in claude agent");
         }
-        if body.scratch || body.worktree_branch.is_some() || !body.extra_repo_paths.is_empty() {
+        if body.scratch || worktree_enabled || !body.extra_repo_paths.is_empty() {
             return bad(
                 "Importing a Claude session cannot use scratch, a worktree, or extra repos",
             );
@@ -4328,7 +4342,6 @@ pub async fn create_session(
         )?;
 
         let title = body.title.unwrap_or_default();
-        let worktree_enabled = body.worktree_branch.is_some();
         let worktree_branch = body
             .worktree_branch
             .map(|b| b.trim().to_string())
@@ -6242,6 +6255,57 @@ mod tests {
 
     fn create_body_from_json(value: serde_json::Value) -> CreateSessionBody {
         serde_json::from_value(value).expect("valid CreateSessionBody")
+    }
+
+    #[test]
+    fn worktree_enabled_true_opts_in_without_branch() {
+        let body = create_body_from_json(serde_json::json!({
+            "path": "/tmp/p",
+            "tool": "claude",
+            "worktree_enabled": true,
+        }));
+
+        assert!(create_body_uses_worktree(&body));
+        assert!(body.worktree_branch.is_none());
+    }
+
+    #[test]
+    fn worktree_branch_preserves_legacy_worktree_opt_in() {
+        let explicit = create_body_from_json(serde_json::json!({
+            "path": "/tmp/p",
+            "tool": "claude",
+            "worktree_branch": "feat/api",
+        }));
+        assert!(create_body_uses_worktree(&explicit));
+
+        let empty = create_body_from_json(serde_json::json!({
+            "path": "/tmp/p",
+            "tool": "claude",
+            "worktree_branch": "",
+        }));
+        assert!(create_body_uses_worktree(&empty));
+    }
+
+    #[test]
+    fn worktree_defaults_off_without_flag_or_branch() {
+        let body = create_body_from_json(serde_json::json!({
+            "path": "/tmp/p",
+            "tool": "claude",
+        }));
+
+        assert!(!create_body_uses_worktree(&body));
+    }
+
+    #[test]
+    fn worktree_enabled_conflicts_with_scratch() {
+        let body = create_body_from_json(serde_json::json!({
+            "path": "",
+            "tool": "claude",
+            "scratch": true,
+            "worktree_enabled": true,
+        }));
+
+        assert!(create_body_combines_scratch_and_worktree(&body));
     }
 
     #[test]

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -23,7 +23,6 @@ import { SessionStep } from "./steps/SessionStep";
 import { AgentPickerEssentials } from "./steps/AgentPickerEssentials";
 import { AgentOptions } from "./steps/AgentOptions";
 import { LaunchFooter } from "./LaunchFooter";
-import { getSubmittedBranch } from "./sessionNames";
 import { initialData, reducer, type WizardData } from "./wizardReducer";
 import { commandMapsFromSettings, EMPTY_COMMAND_MAPS, type CommandMaps } from "./commandMaps";
 
@@ -286,7 +285,11 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       title: d.title || undefined,
       group: d.group || undefined,
       yolo_mode: d.yoloMode,
-      worktree_branch: !d.scratch && d.useWorktree ? getSubmittedBranch(d.title, d.worktreeBranch) : undefined,
+      worktree_enabled: !d.scratch && d.useWorktree,
+      worktree_branch:
+        !d.scratch && d.useWorktree && d.worktreeBranchDirty && d.worktreeBranch.trim()
+          ? d.worktreeBranch.trim()
+          : undefined,
       create_new_branch: !d.scratch && d.useWorktree && !d.attachExisting,
       base_branch:
         !d.scratch && d.useWorktree && !d.attachExisting && d.baseBranch.trim() ? d.baseBranch.trim() : undefined,

--- a/web/src/components/session-wizard/sessionNames.test.ts
+++ b/web/src/components/session-wizard/sessionNames.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyBranchOverride, getReviewSummary, getSubmittedBranch, slugifyBranch } from "./sessionNames";
+import { applyBranchOverride, getReviewSummary, slugifyBranch } from "./sessionNames";
 
 describe("applyBranchOverride", () => {
   it("marks a non-empty branch as a manual override", () => {
@@ -21,20 +21,6 @@ describe("applyBranchOverride", () => {
       worktreeBranch: "",
       worktreeBranchDirty: true,
     });
-  });
-});
-
-describe("getSubmittedBranch", () => {
-  it("prefers the explicit branch override", () => {
-    expect(getSubmittedBranch("session-title", "feature/custom")).toBe("feature/custom");
-  });
-
-  it("falls back to the title when the branch field is cleared", () => {
-    expect(getSubmittedBranch("session-title", "")).toBe("session-title");
-  });
-
-  it("leaves the branch empty only when both fields are empty", () => {
-    expect(getSubmittedBranch("", "")).toBe("");
   });
 });
 

--- a/web/src/components/session-wizard/sessionNames.ts
+++ b/web/src/components/session-wizard/sessionNames.ts
@@ -51,17 +51,13 @@ export function applyBranchOverride(
   worktreeBranchDirty: boolean;
 } {
   // Any direct edit on the branch field, including clearing it, marks it
-  // dirty so the title→branch mirror stops overwriting the user's input on
-  // the next keystroke. Empty is a valid UI state; the submit path falls
-  // back to the title via getSubmittedBranch.
+  // dirty so the title-to-branch mirror stops overwriting the user's input on
+  // the next keystroke. Empty is a valid UI state; the submit path omits
+  // worktree_branch so the server derives it from the resolved title.
   return {
     worktreeBranch,
     worktreeBranchDirty: true,
   };
-}
-
-export function getSubmittedBranch(title: string, worktreeBranch: string): string {
-  return worktreeBranch || title || "";
 }
 
 export function getReviewSummary(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -472,6 +472,10 @@ export interface CreateSessionRequest {
   tool: string;
   group?: string;
   yolo_mode?: boolean;
+  /** Enables worktree mode even when no explicit branch is provided. When
+   *  true and `worktree_branch` is omitted, the server derives the branch from
+   *  the resolved session title. */
+  worktree_enabled?: boolean;
   worktree_branch?: string;
   create_new_branch?: boolean;
   /** Branch the new worktree branch is based on (only honored when

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -652,6 +652,21 @@
       ]
     },
     {
+      "id": "wizard.worktree-title-derived-branch",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/wizard-form-ui.spec.ts",
+        "tests/wizard-session-step.spec.ts",
+        "tests/wizard-single-screen.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/sessionNames.ts",
+        "web/src/lib/types.ts"
+      ]
+    },
+    {
       "id": "wizard.recent-projects",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/session-create-duplicate-worktree.spec.ts
+++ b/web/tests/live/session-create-duplicate-worktree.spec.ts
@@ -151,7 +151,7 @@ test("auto-generated worktree branch avoids civilization branch collisions", asy
       body: JSON.stringify({
         path: join(serve.home, "project"),
         tool: "claude",
-        worktree_branch: "",
+        worktree_enabled: true,
         create_new_branch: true,
       }),
     });

--- a/web/tests/wizard-form-ui.spec.ts
+++ b/web/tests/wizard-form-ui.spec.ts
@@ -173,6 +173,7 @@ test.describe("Wizard form UI stories", () => {
 
     await expect.poll(() => captured.body?.tool).toBe("claude");
     expect(captured.body?.path).toBe("/tmp/example");
-    expect(captured.body?.worktree_branch).toBe("kbd-launch");
+    expect(captured.body?.worktree_enabled).toBe(true);
+    expect(captured.body?.worktree_branch).toBeUndefined();
   });
 });

--- a/web/tests/wizard-session-step.spec.ts
+++ b/web/tests/wizard-session-step.spec.ts
@@ -150,9 +150,10 @@ test.describe("Wizard session step (#1219)", () => {
     await expect(branchInput).toHaveValue("my-cool-feature");
   });
 
-  test("submit sends worktree_branch + create_new_branch with More options left closed", async ({ page }) => {
+  test("submit sends worktree_enabled + create_new_branch with More options left closed", async ({ page }) => {
     await mockApis(page);
     let captured: {
+      worktree_enabled?: boolean;
       worktree_branch?: string;
       create_new_branch?: boolean;
     } | null = null;
@@ -196,7 +197,8 @@ test.describe("Wizard session step (#1219)", () => {
     const w = wizard(page);
     await w.getByPlaceholder("Auto-generated if empty").fill("Cool Feature");
     await w.getByRole("button", { name: /Launch session/ }).click();
-    await expect.poll(() => captured?.worktree_branch).toBe("cool-feature");
+    await expect.poll(() => captured?.worktree_enabled).toBe(true);
+    expect(captured?.worktree_branch).toBeUndefined();
     expect(captured?.create_new_branch).toBe(true);
   });
 

--- a/web/tests/wizard-single-screen.spec.ts
+++ b/web/tests/wizard-single-screen.spec.ts
@@ -113,7 +113,8 @@ test.describe("Single-screen wizard (#2210)", () => {
     await page.getByPlaceholder("Uses session title if empty").fill("my-feature-branch");
     await launch(page);
 
-    await expect.poll(() => captured.body?.worktree_branch).toBe("my-feature-branch");
+    await expect.poll(() => captured.body?.worktree_enabled).toBe(true);
+    expect(captured.body?.worktree_branch).toBe("my-feature-branch");
     expect(captured.body?.create_new_branch).toBe(true);
   });
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

This adds an explicit `worktree_enabled` field to the session-create API so web and external API callers can request a managed worktree without inventing or pre-supplying a branch name. When `worktree_enabled` is true and `worktree_branch` is omitted, session creation now reaches the same server-side title-derived branch path used elsewhere, including existing branch dedupe.

The web session wizard now sends `worktree_enabled` when the worktree option is on and omits `worktree_branch` unless the branch field was manually edited. That keeps the wizard preview behavior while letting the server own final title-derived branch generation.

Existing API clients remain compatible: sending `worktree_branch` still opts into worktree mode even when `worktree_enabled` is omitted.

Closes #980

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] Create a web dashboard session with worktrees enabled and only a title, then confirm AoE creates a managed worktree with a title-derived branch.
- [x] Create a web dashboard session with worktrees enabled and a manually edited branch name, then confirm the request uses that branch name.
- [x] Call `POST /api/sessions` with `worktree_enabled: true` and no `worktree_branch`, then confirm session creation creates a managed worktree.
- [x] Call `POST /api/sessions` with only `worktree_branch`, then confirm legacy worktree opt-in still works.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Claude via Claude Code, agent-of-empires `/aoe-implement` skill.

**Any Additional AI Details you'd like to share:**

Investigation, implementation, docs, and test updates were drafted by Claude under human direction. The maintainer made the product decisions and should run the listed manual checks during review.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR makes worktree-based session creation easier and more consistent across the API and web UI.

- Adds an explicit `worktree_enabled` flag to session creation requests, so callers can request a worktree without having to supply a branch name first.
- Keeps older behavior working by still honoring `worktree_branch` when it is provided.
- Updates the web session wizard to send `worktree_enabled` when worktree mode is on, while leaving branch generation to the server unless the user manually edits the branch field.
- Removes the client-side fallback that previously derived the submitted branch name in the wizard.
- Updates docs and tests to reflect the new request shape and the title-driven worktree flow.

Benefit: worktree creation now behaves more predictably, matches the server’s branch-generation rules, and preserves compatibility for existing API users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->