### PR TITLE
fix(tui): open project add form from empty picker

### DIFF
--- a/src/tui/dialogs/projects.rs
+++ b/src/tui/dialogs/projects.rs
@@ -40,6 +40,8 @@ pub struct ProjectsDialog {
     /// directory, explaining that git features are unavailable. Gated by
     /// `app_state.has_seen_non_git_project_warning` so it appears once.
     non_git_notice: Option<InfoDialog>,
+    /// Close the dialog when Esc cancels the add form opened from a direct flow.
+    close_on_add_cancel: bool,
 }
 
 impl ProjectsDialog {
@@ -57,9 +59,27 @@ impl ProjectsDialog {
             error: None,
             info: None,
             non_git_notice: None,
+            close_on_add_cancel: false,
         };
         dialog.reload();
         dialog
+    }
+
+    pub fn new_adding(profile: &str) -> Self {
+        let mut dialog = Self::new(profile);
+        dialog.enter_add_mode(true);
+        dialog
+    }
+
+    fn enter_add_mode(&mut self, close_on_cancel: bool) {
+        self.mode = Mode::Adding;
+        self.add_input = Input::default();
+        self.add_base_branch = Input::default();
+        self.add_scope = ProjectScope::Global;
+        self.add_allow_override = false;
+        self.add_focused = 0;
+        self.error = None;
+        self.close_on_add_cancel = close_on_cancel;
     }
 
     fn reload(&mut self) {
@@ -107,13 +127,7 @@ impl ProjectsDialog {
                 DialogResult::Continue
             }
             KeyCode::Char('a') => {
-                self.mode = Mode::Adding;
-                self.add_input = Input::default();
-                self.add_base_branch = Input::default();
-                self.add_scope = ProjectScope::Global;
-                self.add_allow_override = false;
-                self.add_focused = 0;
-                self.error = None;
+                self.enter_add_mode(false);
                 DialogResult::Continue
             }
             KeyCode::Char('d') | KeyCode::Delete => {
@@ -135,8 +149,12 @@ impl ProjectsDialog {
     fn handle_add_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         match key.code {
             KeyCode::Esc => {
+                if self.close_on_add_cancel {
+                    return DialogResult::Cancel;
+                }
                 self.mode = Mode::Browse;
                 self.error = None;
+                self.close_on_add_cancel = false;
                 DialogResult::Continue
             }
             KeyCode::Tab => {
@@ -207,6 +225,7 @@ impl ProjectsDialog {
                         self.mode = Mode::Browse;
                         self.add_input = Input::default();
                         self.add_base_branch = Input::default();
+                        self.close_on_add_cancel = false;
                         self.reload();
                         if !is_git {
                             self.maybe_warn_non_git(&saved_name);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4412,18 +4412,24 @@ impl HomeView {
     }
 
     /// Open the saved-project picker that starts a new session pre-filled with
-    /// the chosen project's path. Shows an info dialog when no projects exist.
+    /// the chosen project's path. Opens the add-project form when none exist.
     pub(super) fn open_project_session_picker(&mut self) {
         let profile = self.config_profile();
-        let projects = crate::session::projects::load_merged(&profile).unwrap_or_default();
-        if projects.is_empty() {
-            self.info_dialog = Some(InfoDialog::new(
-                "No Projects",
-                "No registered projects available. Add one with `aoe project add <path>`.",
-            ));
-            return;
+        match crate::session::projects::load_merged(&profile) {
+            Ok(projects) if projects.is_empty() => {
+                self.projects_dialog = Some(ProjectsDialog::new_adding(&profile));
+            }
+            Ok(projects) => {
+                self.project_session_picker_dialog =
+                    Some(ProjectSessionPickerDialog::new(projects));
+            }
+            Err(e) => {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Projects Failed",
+                    &format!("Failed to load projects: {e}"),
+                ));
+            }
         }
-        self.project_session_picker_dialog = Some(ProjectSessionPickerDialog::new(projects));
     }
 
     /// Show the sort-order picker dialog seeded with the current order.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1106,12 +1106,45 @@ fn test_b_opens_project_session_picker_when_projects_exist() {
 
 #[test]
 #[serial]
-fn test_b_shows_info_dialog_when_no_projects() {
+fn test_b_opens_project_add_flow_when_no_projects() {
     let mut env = create_test_env_empty();
-    assert!(env.view.info_dialog.is_none());
+    let project_dir = env._temp.path().join("plain-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let profile = env.view.config_profile();
+
     env.view.handle_key(key(KeyCode::Char('b')), None);
-    assert!(env.view.info_dialog.is_some());
     assert!(env.view.project_session_picker_dialog.is_none());
+    assert!(env.view.info_dialog.is_none());
+    assert!(env.view.projects_dialog.is_some());
+
+    for ch in project_dir.to_string_lossy().chars() {
+        env.view.handle_key(key(KeyCode::Char(ch)), None);
+    }
+    env.view.handle_key(key(KeyCode::Enter), None);
+
+    let canonical = project_dir
+        .canonicalize()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let projects = crate::session::projects::load_merged(&profile).unwrap();
+    assert!(
+        projects.iter().any(|p| p.path == canonical),
+        "b empty-state add flow should register the typed path"
+    );
+}
+
+#[test]
+#[serial]
+fn test_b_empty_project_add_flow_escape_closes_dialog() {
+    let mut env = create_test_env_empty();
+
+    env.view.handle_key(key(KeyCode::Char('b')), None);
+    assert!(env.view.projects_dialog.is_some());
+
+    env.view.handle_key(key(KeyCode::Esc), None);
+    assert!(env.view.projects_dialog.is_none());
+    assert!(env.view.info_dialog.is_none());
 }
 
 #[test]

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -525,7 +525,7 @@ fn test_new_session_from_saved_project_prefills_path() {
 
 #[test]
 #[serial]
-fn test_new_session_from_project_empty_state() {
+fn test_new_session_from_project_empty_state_opens_add_form() {
     require_tmux!();
 
     let mut h = TuiTestHarness::new("new_from_project_empty");
@@ -534,7 +534,14 @@ fn test_new_session_from_project_empty_state() {
     h.send_keys("Enter"); // dismiss first-run welcome
     h.wait_for("No sessions yet");
 
-    // With no saved projects, `b` surfaces the info dialog instead.
+    // With no saved projects, `b` opens the project add form directly.
     h.send_keys("b");
-    h.wait_for("No Projects");
+    h.wait_for(" Projects ");
+    h.assert_screen_contains("Path:");
+    h.assert_screen_contains("Base branch:");
+
+    // Esc should cancel the direct add flow without requiring a second Esc.
+    h.send_keys("Escape");
+    h.wait_for_absent(" Projects ", Duration::from_secs(5));
+    h.assert_screen_contains("No sessions yet");
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Pressing `b` in the TUI starts the "New session from saved project" flow. When no projects were registered, that path used to stop at a `No Projects` info dialog that only mentioned `aoe project add <path>`, even though the TUI already has an in-app project add flow.

This PR makes the empty `b` path open the existing Manage Projects dialog directly in add mode, so the next thing the user can do is type the project path. The normal non-empty `b` behavior still opens the project picker, and pressing `Esc` from the direct add form closes the dialog rather than dropping the user into an empty browse list.

During validation, default `cargo test` also exposed that `tests/acp_runner_orphan.rs` spawns the hidden `__acp-runner` command, which only exists with the `serve` feature enabled. The test target is now explicitly gated on `serve`; default TUI-only test runs skip it, while `cargo test --features serve --test acp_runner_orphan` still exercises it.

Closes #2463

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Start `aoe` with no registered projects, press `b`, and confirm the Projects dialog opens in add mode with the cursor in the path field.
- [ ] From that direct add form, enter a valid directory and press `Enter`, then confirm the project is registered.
- [ ] Start again with no registered projects, press `b`, then press `Esc`, and confirm the dialog closes cleanly.
- [ ] Register at least one project, press `b`, and confirm the existing New Session from Project picker still opens.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the flow is covered by focused home-view unit tests and does not require tmux, session lifecycle, or full-binary interaction.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenCode with GPT-5.5, using the agent-of-empires `aoe-implement` workflow

**Any Additional AI Details you'd like to share:**
Investigation, plan, implementation, and validation were drafted by OpenCode under my direction. I approved the plan, reviewed the commits, and made the scope calls.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change makes the empty “new session from saved project” flow much smoother. When no projects are registered, the app now opens the project add form directly instead of showing a dead-end info message. Users can immediately enter a project path, and pressing Esc cleanly exits that add flow. When projects already exist, the normal project picker still appears.

The PR also tightens one test’s feature gating so it only runs when the server feature needed for its hidden command is enabled.

Benefits:
- Removes an unnecessary extra step for adding the first project
- Improves discoverability of the in-app project management flow
- Keeps escape/cancel behavior consistent in the direct add path
- Prevents a serve-only test from running in unsupported default test runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->