### PR TITLE
test(tui): cover archived project attention rows

### DIFF
--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7979,6 +7979,71 @@ fn project_groups_sort_by_top_attention_member() {
     );
 }
 
+/// Archiving a project header while in Attention sort must remove the project
+/// from the main flow once all of its live sessions are archived. The archived
+/// rows still appear under the synthetic Archived section's project sub-header.
+#[test]
+#[serial]
+fn project_attention_archive_selected_group_removes_empty_main_header() {
+    use crate::session::{
+        archived_project_sub_path,
+        config::{GroupByMode, SortOrder},
+        is_within_archived_section,
+    };
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.sort_order = SortOrder::Attention;
+    env.view.archived_section_collapsed = true;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let beta_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|i| {
+            matches!(
+                i,
+                Item::Group { name, path, .. }
+                    if name == "beta" && !is_within_archived_section(path)
+            )
+        })
+        .expect("beta project header present");
+    env.view.cursor = beta_idx;
+    env.view.update_selected();
+    assert_eq!(env.view.selected_group.as_deref(), Some("beta"));
+
+    env.view.archive_selected_group().unwrap();
+
+    assert!(
+        env.view
+            .instances
+            .iter()
+            .filter(|i| super::project_group_name(i) == "beta")
+            .all(|i| i.is_archived()),
+        "all beta sessions must be archived"
+    );
+    assert!(
+        !env.view.flat_items.iter().any(|item| matches!(
+            item,
+            Item::Group { name, path, .. }
+                if name == "beta" && !is_within_archived_section(path)
+        )),
+        "archived-only beta must not leave a main-flow project header; got flat_items: {:?}",
+        env.view.flat_items
+    );
+    let archived_beta = archived_project_sub_path("beta");
+    assert!(
+        env.view.flat_items.iter().any(|item| matches!(
+            item,
+            Item::Group { path, name, session_count, .. }
+                if path == &archived_beta && name == "beta" && *session_count == 2
+        )),
+        "archived beta sessions must stay reachable under the Archived section; got flat_items: {:?}",
+        env.view.flat_items
+    );
+}
+
 /// A registered (pinned) project with no sessions surfaces as an empty
 /// header in project view, mirroring the WebUI where an empty project is just
 /// a registry entry decoupled from sessions. This is the core of #2047.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a focused TUI regression test for the archived-only project row bug in Project grouping with Attention sort enabled. The test archives a selected project header and verifies the project disappears from the main session flow instead of lingering as an empty `beta (0)` row.

The existing production guard already seeds project headers from live sessions only. This PR locks that behavior against future regressions while still verifying archived sessions remain reachable under the Archived section's per-project sub-header.

Closes #1807

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the TUI with Project grouping and Attention sort enabled, with at least two sessions under one project.
- [ ] Archive the selected project header.
- [ ] Confirm that project no longer appears as an empty row in the main session list.
- [ ] Expand Archived and confirm the archived sessions remain visible under that project's Archived sub-header.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: covered by a focused TUI unit regression and no production UI code changed

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
OpenCode with GPT-5.5, using the agent-of-empires `/aoe-implement` skill.

**Any Additional AI Details you'd like to share:**
Investigation, plan, test implementation, and validation were drafted by AI under my direction. I made the scope decision to keep this as regression coverage because current production code already contains the scoped guard.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a regression test to cover a TUI grouping bug when Attention sort is used with project grouping. The test archives a project’s selected header and confirms the project no longer lingers as an empty row in the main session list. It also verifies archived sessions still appear in the Archived section under the correct project grouping.

Benefit: this helps keep the grouped session view clean and consistent after archiving, while preserving access to archived sessions where expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->