### PR TITLE
fix(tui): reveal hidden idle sessions on w

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3242,11 +3242,40 @@ impl HomeView {
         }
     }
 
+    fn jump_to_session_id(&mut self, id: &str) {
+        if let Some(idx) = self
+            .flat_items
+            .iter()
+            .position(|item| matches!(item, Item::Session { id: sid, .. } if sid == id))
+        {
+            self.cursor = idx;
+            self.update_selected();
+            return;
+        }
+
+        let previous = self.selected_session.clone();
+        self.select_and_reveal_session(id);
+        if self.selected_session != previous {
+            self.preview_scroll_offset = 0;
+            self.manual_unread_hold = None;
+        }
+    }
+
     fn jump_to_next_waiting(&mut self) {
         let len = self.flat_items.len();
         if len == 0 {
             return;
         }
+
+        let visible_sessions: std::collections::HashSet<String> = self
+            .flat_items
+            .iter()
+            .filter_map(|item| match item {
+                Item::Session { id, .. } => Some(id.clone()),
+                Item::Group { .. } => None,
+            })
+            .collect();
+        let current_session = self.selected_session.clone();
 
         // Pass 1: forward-walk from cursor+1, wrapping, for the next Waiting
         // session OR a freshly-stopped Idle session (within
@@ -3270,11 +3299,31 @@ impl HomeView {
                         || matches!(inst.idle_age(), Some(age) if age < window)
                         || (crate::session::unread_enabled() && inst.is_unread()));
                 if is_actionable {
-                    self.cursor = idx;
-                    self.update_selected();
+                    self.jump_to_session_id(&id);
                     return;
                 }
             }
+        }
+
+        let hidden_actionable = self
+            .instances
+            .iter()
+            .find(|inst| {
+                if visible_sessions.contains(&inst.id)
+                    || current_session.as_deref() == Some(inst.id.as_str())
+                    || inst.is_archived()
+                    || inst.is_trashed()
+                {
+                    return false;
+                }
+                inst.status == Status::Waiting
+                    || matches!(inst.idle_age(), Some(age) if age < window)
+                    || (crate::session::unread_enabled() && inst.is_unread())
+            })
+            .map(|inst| inst.id.clone());
+        if let Some(id) = hidden_actionable {
+            self.jump_to_session_id(&id);
+            return;
         }
 
         // Pass 2: fall back to the most-recently-accessed Idle session, skipping
@@ -3313,8 +3362,40 @@ impl HomeView {
         }
 
         if let Some((idx, _)) = best {
-            self.cursor = idx;
-            self.update_selected();
+            let id = match self.flat_items.get(idx) {
+                Some(Item::Session { id, .. }) => id.clone(),
+                _ => return,
+            };
+            self.jump_to_session_id(&id);
+            return;
+        }
+
+        let mut best_hidden: Option<(String, Option<chrono::DateTime<chrono::Utc>>)> = None;
+        for inst in &self.instances {
+            if visible_sessions.contains(&inst.id)
+                || current_session.as_deref() == Some(inst.id.as_str())
+                || inst.is_archived()
+                || inst.is_trashed()
+                || inst.status != Status::Idle
+            {
+                continue;
+            }
+            let ts = inst.last_accessed_at;
+            let beats = match best_hidden {
+                None => true,
+                Some((_, b)) => match (ts, b) {
+                    (Some(a), Some(b)) => a > b,
+                    (Some(_), None) => true,
+                    (None, _) => false,
+                },
+            };
+            if beats {
+                best_hidden = Some((inst.id.clone(), ts));
+            }
+        }
+
+        if let Some((id, _)) = best_hidden {
+            self.jump_to_session_id(&id);
             return;
         }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3714,6 +3714,54 @@ fn attention_env_running_then_waiting() -> (TestEnv, usize, usize) {
     (env, running, waiting)
 }
 
+fn attention_env_running_then_idle() -> (TestEnv, usize, usize) {
+    use crate::session::config::{GroupByMode, SortOrder};
+    use crate::session::Status;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+
+    let mut running = Instance::new("running", "/tmp/running");
+    running.status = Status::Running;
+    let mut idle = Instance::new("idle", "/tmp/idle");
+    idle.status = Status::Idle;
+    let instances = vec![running, idle];
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        tools,
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.strict_hotkeys = false;
+    view.group_by = GroupByMode::Manual;
+    view.sort_order = SortOrder::Attention;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+    let env = TestEnv { _temp: temp, view };
+
+    let status_at = |env: &TestEnv, idx: usize| match env.view.flat_items.get(idx) {
+        Some(Item::Session { id, .. }) => env.view.get_instance(id).map(|i| i.status),
+        _ => None,
+    };
+    let running = (0..env.view.flat_items.len())
+        .find(|&i| status_at(&env, i) == Some(Status::Running))
+        .expect("a Running session row");
+    let idle = (0..env.view.flat_items.len())
+        .find(|&i| status_at(&env, i) == Some(Status::Idle))
+        .expect("an Idle session row");
+    (env, running, idle)
+}
+
 #[test]
 #[serial]
 fn test_non_strict_w_jumps_to_next_waiting_in_attention_sort() {
@@ -3742,6 +3790,99 @@ fn test_non_strict_w_jumps_to_next_waiting_in_attention_sort() {
         landed,
         Some(Status::Waiting),
         "`w` should land the cursor on the Waiting session"
+    );
+}
+
+#[test]
+#[serial]
+fn test_non_strict_w_on_running_jumps_to_idle_in_attention_sort() {
+    use crate::session::Status;
+
+    let (mut env, running, _idle) = attention_env_running_then_idle();
+    env.view.cursor = running;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    assert!(
+        env.view.snooze_duration_dialog.is_none(),
+        "`w` on a Running session must jump, not open the snooze dialog"
+    );
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => env.view.get_instance(id).map(|i| i.status),
+        _ => None,
+    };
+    assert_eq!(
+        landed,
+        Some(Status::Idle),
+        "`w` should fall back to the available Idle session"
+    );
+}
+
+#[test]
+#[serial]
+fn test_non_strict_w_on_collapsed_project_group_reveals_idle_in_attention_sort() {
+    use crate::session::config::{GroupByMode, SortOrder};
+    use crate::session::Status;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new_unwatched("test").unwrap();
+
+    let mut alpha_idle = Instance::new("alpha-idle", "/repos/alpha");
+    alpha_idle.status = Status::Idle;
+    let alpha_id = alpha_idle.id.clone();
+    let mut beta_running = Instance::new("beta-running", "/repos/beta");
+    beta_running.status = Status::Running;
+    let instances = vec![alpha_idle, beta_running];
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let mut view = HomeView::new(
+        Some("test".to_string()),
+        AvailableTools::with_tools(&["claude"]),
+        crate::file_watch::FileWatchService::noop(),
+    )
+    .unwrap();
+    view.strict_hotkeys = false;
+    view.group_by = GroupByMode::Project;
+    view.sort_order = SortOrder::Attention;
+    view.project_group_collapsed
+        .insert("alpha".to_string(), true);
+    view.flat_items = view.build_flat_items();
+
+    let alpha_group = view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { name, collapsed, .. } if name == "alpha" && *collapsed))
+        .expect("collapsed alpha project group");
+    assert!(
+        !view
+            .flat_items
+            .iter()
+            .any(|item| matches!(item, Item::Session { id, .. } if id == &alpha_id)),
+        "precondition: alpha idle session should be hidden by the collapsed group"
+    );
+    view.cursor = alpha_group;
+    view.update_selected();
+
+    view.handle_key(key(KeyCode::Char('w')), None);
+
+    assert!(
+        view.snooze_duration_dialog.is_none(),
+        "`w` on a collapsed group must jump, not open the snooze dialog"
+    );
+    assert_eq!(view.selected_session.as_deref(), Some(alpha_id.as_str()));
+    assert!(
+        view.flat_items
+            .iter()
+            .any(|item| matches!(item, Item::Session { id, .. } if id == &alpha_id)),
+        "jumping to a hidden idle session should reveal its project group"
     );
 }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes the TUI Attention-mode `w` navigation path so it can reveal and jump to an idle session hidden inside a collapsed project group. The existing jump routine only considered visible `flat_items`, so pressing `w` on a collapsed group could leave the cursor on the group instead of moving to the available idle agent.

The same path now uses a shared session-id jump helper, so visible candidates keep the existing behavior while hidden candidates are revealed through the existing `select_and_reveal_session` expansion logic. This also keeps `w` on an active/running row as navigation, not snooze.

Closes #1805

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is covered by deterministic HomeView unit regressions for `w` on running rows and collapsed project groups.

## How to test

- [ ] In the TUI, switch to Project grouping plus Attention sort, collapse a project containing an idle session, place the cursor on that project header, press `w`, and confirm the project expands with the idle session selected.
- [ ] In Attention sort, place the cursor on a running session with an idle peer, press `w`, and confirm focus moves to the idle session without opening snooze.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenCode using the agent-of-empires `/aoe-implement` workflow.

**Any Additional AI Details you'd like to share:**

Investigation, implementation, and PR prose were drafted by an AI agent under my direction. I reviewed the changes and validation results.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR improves `w` navigation in Attention mode so it now reliably jumps to the next idle session, even when that session is inside a collapsed project group. It also keeps `w` behaving as navigation when the cursor is on an active/running session, instead of opening snooze.

The main change is that session jumping now goes through a shared session-selection path, which lets hidden targets be revealed automatically while preserving the existing behavior for visible ones. The final fallback for finding the “next best” idle session was also adjusted to better handle hidden items.

Tests were updated to cover:
- jumping from a running session to an idle one,
- jumping from a collapsed project header to a hidden idle session,
- and confirming snooze is not triggered in those cases.

Benefits:
- More predictable keyboard navigation
- Better support for collapsed groups
- Fewer accidental snooze actions
- Stronger test coverage for Attention mode

Technical note:
- `jump_to_next_waiting` now routes through a shared `jump_to_session_id` helper, which uses existing reveal/select logic for hidden sessions and keeps selection state in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->