### PR TITLE
fix(tui): make w skip snoozed sessions when jumping to next attention

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1658,12 +1658,12 @@ impl Instance {
         self.snoozed_until.map(|t| t > Utc::now()).unwrap_or(false)
     }
 
-    /// Combined "don't bother me" sink-state check: trashed or snoozed.
-    /// Callers that walk sessions looking for something to land on (e.g. the
-    /// `w`/jump-to-next-attention passes) use this instead of the two-call
-    /// form so a row in either sink state is uniformly excluded.
+    /// Combined "don't bother me" sink-state check: trashed, snoozed, or
+    /// archived. Callers that walk sessions looking for something to land on
+    /// (e.g. the `w`/jump-to-next-attention passes) use this instead of the
+    /// three-call form so a row in any sink state is uniformly excluded.
     pub fn is_dismissed(&self) -> bool {
-        self.is_trashed() || self.is_snoozed()
+        self.is_trashed() || self.is_snoozed() || self.is_archived()
     }
 
     /// Remaining snooze duration as a `chrono::Duration`, or `None` if the

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1658,6 +1658,14 @@ impl Instance {
         self.snoozed_until.map(|t| t > Utc::now()).unwrap_or(false)
     }
 
+    /// Combined "don't bother me" sink-state check: trashed or snoozed.
+    /// Callers that walk sessions looking for something to land on (e.g. the
+    /// `w`/jump-to-next-attention passes) use this instead of the two-call
+    /// form so a row in either sink state is uniformly excluded.
+    pub fn is_dismissed(&self) -> bool {
+        self.is_trashed() || self.is_snoozed()
+    }
+
     /// Remaining snooze duration as a `chrono::Duration`, or `None` if the
     /// session isn't snoozed (or the timestamp has already expired).
     pub fn snooze_remaining(&self) -> Option<chrono::Duration> {

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -300,13 +300,11 @@ pub fn parse_chord(s: &str) -> Option<Chord> {
             c.to_ascii_lowercase()
         };
         KeyCode::Char(c)
-    } else if let Some(n) = key
-        .strip_prefix(['F', 'f'])
-        .and_then(|n| n.parse::<u8>().ok())
-    {
-        KeyCode::F(n)
     } else {
-        return None;
+        let n = key
+            .strip_prefix(['F', 'f'])
+            .and_then(|n| n.parse::<u8>().ok())?;
+        KeyCode::F(n)
     };
     Some(Chord { code, ctrl })
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3296,8 +3296,7 @@ impl HomeView {
                 // when a stale unread flag survived the trash (#2489). Snoozed
                 // rows are an explicit "don't bother me" sink state, same as
                 // everywhere else that checks `is_snoozed()`.
-                let is_actionable = !inst.is_trashed()
-                    && !inst.is_snoozed()
+                let is_actionable = !inst.is_dismissed()
                     && (inst.status == Status::Waiting
                         || matches!(inst.idle_age(), Some(age) if age < window)
                         || (crate::session::unread_enabled() && inst.is_unread()));
@@ -3315,8 +3314,7 @@ impl HomeView {
                 if visible_sessions.contains(&inst.id)
                     || current_session.as_deref() == Some(inst.id.as_str())
                     || inst.is_archived()
-                    || inst.is_trashed()
-                    || inst.is_snoozed()
+                    || inst.is_dismissed()
                 {
                     return false;
                 }
@@ -3345,7 +3343,7 @@ impl HomeView {
             let Some(inst) = self.get_instance(&id) else {
                 continue;
             };
-            if inst.is_trashed() || inst.is_snoozed() {
+            if inst.is_dismissed() {
                 continue;
             }
             if inst.status != Status::Idle {
@@ -3379,8 +3377,7 @@ impl HomeView {
             if visible_sessions.contains(&inst.id)
                 || current_session.as_deref() == Some(inst.id.as_str())
                 || inst.is_archived()
-                || inst.is_trashed()
-                || inst.is_snoozed()
+                || inst.is_dismissed()
                 || inst.status != Status::Idle
             {
                 continue;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3294,8 +3294,9 @@ impl HomeView {
                 // Trashed rows are stopped and only surface under the collapsed
                 // Trash section; they never "need attention", so skip them even
                 // when a stale unread flag survived the trash (#2489). Snoozed
-                // rows are an explicit "don't bother me" sink state, same as
-                // everywhere else that checks `is_snoozed()`.
+                // and archived rows are likewise explicit "don't bother me"
+                // sink states, same as everywhere else that checks
+                // `is_snoozed()` / `is_archived()`.
                 let is_actionable = !inst.is_dismissed()
                     && (inst.status == Status::Waiting
                         || matches!(inst.idle_age(), Some(age) if age < window)
@@ -3313,7 +3314,6 @@ impl HomeView {
             .find(|inst| {
                 if visible_sessions.contains(&inst.id)
                     || current_session.as_deref() == Some(inst.id.as_str())
-                    || inst.is_archived()
                     || inst.is_dismissed()
                 {
                     return false;
@@ -3376,7 +3376,6 @@ impl HomeView {
         for inst in &self.instances {
             if visible_sessions.contains(&inst.id)
                 || current_session.as_deref() == Some(inst.id.as_str())
-                || inst.is_archived()
                 || inst.is_dismissed()
                 || inst.status != Status::Idle
             {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3293,8 +3293,11 @@ impl HomeView {
             if let Some(inst) = self.get_instance(&id) {
                 // Trashed rows are stopped and only surface under the collapsed
                 // Trash section; they never "need attention", so skip them even
-                // when a stale unread flag survived the trash (#2489).
+                // when a stale unread flag survived the trash (#2489). Snoozed
+                // rows are an explicit "don't bother me" sink state, same as
+                // everywhere else that checks `is_snoozed()`.
                 let is_actionable = !inst.is_trashed()
+                    && !inst.is_snoozed()
                     && (inst.status == Status::Waiting
                         || matches!(inst.idle_age(), Some(age) if age < window)
                         || (crate::session::unread_enabled() && inst.is_unread()));
@@ -3313,6 +3316,7 @@ impl HomeView {
                     || current_session.as_deref() == Some(inst.id.as_str())
                     || inst.is_archived()
                     || inst.is_trashed()
+                    || inst.is_snoozed()
                 {
                     return false;
                 }
@@ -3341,7 +3345,7 @@ impl HomeView {
             let Some(inst) = self.get_instance(&id) else {
                 continue;
             };
-            if inst.is_trashed() {
+            if inst.is_trashed() || inst.is_snoozed() {
                 continue;
             }
             if inst.status != Status::Idle {
@@ -3376,6 +3380,7 @@ impl HomeView {
                 || current_session.as_deref() == Some(inst.id.as_str())
                 || inst.is_archived()
                 || inst.is_trashed()
+                || inst.is_snoozed()
                 || inst.status != Status::Idle
             {
                 continue;

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7545,6 +7545,84 @@ fn w_skips_unread_trashed_session() {
     );
 }
 
+/// Snooze is the same "don't bother me" sink state as trash/archive for
+/// every other subsystem (see `Instance::is_snoozed`); `w`'s forward walk
+/// (pass 1) must skip a snoozed session even though it is otherwise
+/// `Status::Waiting`, exactly the state `w` is looking for.
+#[test]
+#[serial]
+fn w_skips_snoozed_waiting_session() {
+    use crate::session::Status;
+
+    let mut env = create_test_env_with_sessions(2);
+    env.view.strict_hotkeys = false;
+
+    let snoozed = env.view.instances[0].id.clone();
+    let active = env.view.instances[1].id.clone();
+    // The surviving active row is a plain idle session (the pass-2 fallback);
+    // the snoozed row is otherwise Waiting, as it would be if it started
+    // waiting on input before being snoozed.
+    env.view
+        .mutate_instance(&active, |inst| inst.status = Status::Idle);
+    env.view.mutate_instance(&snoozed, |inst| {
+        inst.status = Status::Waiting;
+        inst.snooze(30);
+    });
+    assert!(env.view.get_instance(&snoozed).unwrap().is_snoozed());
+
+    env.view.select_session_by_id(&active);
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => Some(id.clone()),
+        _ => None,
+    };
+    assert_ne!(
+        landed.as_deref(),
+        Some(snoozed.as_str()),
+        "`w` must not land on a snoozed session even though it is Waiting"
+    );
+}
+
+/// Same contract as `w_skips_snoozed_waiting_session`, but for the pass-2
+/// idle fallback: with the only Idle candidate snoozed, `w` must not treat
+/// it as the "most-recently-accessed Idle session" fallback target.
+#[test]
+#[serial]
+fn w_skips_snoozed_idle_session_in_fallback() {
+    let (mut env, running, idle) = attention_env_running_then_idle();
+    let running_id = match env.view.flat_items.get(running) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the running row to be a session item"),
+    };
+    let idle_id = match env.view.flat_items.get(idle) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the idle row to be a session item"),
+    };
+    env.view.mutate_instance(&idle_id, |inst| inst.snooze(30));
+    assert!(env.view.get_instance(&idle_id).unwrap().is_snoozed());
+
+    env.view.cursor = running;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => Some(id.clone()),
+        _ => None,
+    };
+    assert_ne!(
+        landed.as_deref(),
+        Some(idle_id.as_str()),
+        "`w` must not fall back to a snoozed session even when it is the only Idle candidate"
+    );
+    assert_eq!(
+        landed.as_deref(),
+        Some(running_id.as_str()),
+        "with no eligible target, `w` must leave the cursor on the Running session"
+    );
+}
+
 #[test]
 #[serial]
 fn d_on_session_with_default_trash_persists_trash_marker() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7548,22 +7548,30 @@ fn w_skips_unread_trashed_session() {
 /// Snooze is the same "don't bother me" sink state as trash/archive for
 /// every other subsystem (see `Instance::is_snoozed`); `w`'s forward walk
 /// (pass 1) must skip a snoozed session even though it is otherwise
-/// `Status::Waiting`, exactly the state `w` is looking for.
+/// `Status::Waiting`, exactly the state `w` is looking for. A third,
+/// eligible `Status::Waiting` control session proves the walk actually
+/// found and landed on a real target rather than merely failing to land
+/// on the snoozed one (with only two sessions "landed != snoozed" would
+/// hold trivially even if `w` did nothing at all).
 #[test]
 #[serial]
 fn w_skips_snoozed_waiting_session() {
     use crate::session::Status;
 
-    let mut env = create_test_env_with_sessions(2);
+    let mut env = create_test_env_with_sessions(3);
     env.view.strict_hotkeys = false;
 
     let snoozed = env.view.instances[0].id.clone();
     let active = env.view.instances[1].id.clone();
-    // The surviving active row is a plain idle session (the pass-2 fallback);
-    // the snoozed row is otherwise Waiting, as it would be if it started
-    // waiting on input before being snoozed.
+    let control = env.view.instances[2].id.clone();
+    // The active row is a plain idle session the cursor starts on; the
+    // control row is a legitimate, non-dismissed Waiting session `w` should
+    // land on; the snoozed row is otherwise Waiting too, as it would be if
+    // it started waiting on input before being snoozed.
     env.view
         .mutate_instance(&active, |inst| inst.status = Status::Idle);
+    env.view
+        .mutate_instance(&control, |inst| inst.status = Status::Waiting);
     env.view.mutate_instance(&snoozed, |inst| {
         inst.status = Status::Waiting;
         inst.snooze(30);
@@ -7581,6 +7589,11 @@ fn w_skips_snoozed_waiting_session() {
         landed.as_deref(),
         Some(snoozed.as_str()),
         "`w` must not land on a snoozed session even though it is Waiting"
+    );
+    assert_eq!(
+        landed.as_deref(),
+        Some(control.as_str()),
+        "`w` must land on the eligible Waiting session, proving the forward walk actually ran"
     );
 }
 
@@ -7627,13 +7640,17 @@ fn w_skips_snoozed_idle_session_in_fallback() {
 /// `Instance::archive`'s mutual-exclusion doc comment: archive is "the
 /// strongest dismiss"); `w`'s forward walk (pass 1) must skip an archived
 /// session even though it is otherwise `Status::Waiting`, exactly the state
-/// `w` is looking for.
+/// `w` is looking for. A third, eligible `Status::Waiting` control session
+/// proves the walk actually found and landed on a real target rather than
+/// merely failing to land on the archived one (with only two sessions
+/// "landed != archived" would hold trivially even if `w` did nothing at
+/// all).
 #[test]
 #[serial]
 fn w_skips_archived_waiting_session() {
     use crate::session::Status;
 
-    let mut env = create_test_env_with_sessions(2);
+    let mut env = create_test_env_with_sessions(3);
     env.view.strict_hotkeys = false;
     // Keep the Archived section expanded so the archived row lands in
     // `flat_items`; that is the only way `w`'s walk could reach it.
@@ -7641,11 +7658,15 @@ fn w_skips_archived_waiting_session() {
 
     let archived = env.view.instances[0].id.clone();
     let active = env.view.instances[1].id.clone();
-    // The surviving active row is a plain idle session (the pass-2 fallback);
-    // the archived row is otherwise Waiting, as it would be if it started
-    // waiting on input before being archived.
+    let control = env.view.instances[2].id.clone();
+    // The active row is a plain idle session the cursor starts on; the
+    // control row is a legitimate, non-dismissed Waiting session `w` should
+    // land on; the archived row is otherwise Waiting too, as it would be if
+    // it started waiting on input before being archived.
     env.view
         .mutate_instance(&active, |inst| inst.status = Status::Idle);
+    env.view
+        .mutate_instance(&control, |inst| inst.status = Status::Waiting);
     env.view.mutate_instance(&archived, |inst| {
         inst.status = Status::Waiting;
         inst.archive();
@@ -7663,6 +7684,11 @@ fn w_skips_archived_waiting_session() {
         landed.as_deref(),
         Some(archived.as_str()),
         "`w` must not land on an archived session even though it is Waiting"
+    );
+    assert_eq!(
+        landed.as_deref(),
+        Some(control.as_str()),
+        "`w` must land on the eligible Waiting session, proving the forward walk actually ran"
     );
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7623,6 +7623,92 @@ fn w_skips_snoozed_idle_session_in_fallback() {
     );
 }
 
+/// Archive is the same "don't bother me" sink state as trash/snooze (see
+/// `Instance::archive`'s mutual-exclusion doc comment: archive is "the
+/// strongest dismiss"); `w`'s forward walk (pass 1) must skip an archived
+/// session even though it is otherwise `Status::Waiting`, exactly the state
+/// `w` is looking for.
+#[test]
+#[serial]
+fn w_skips_archived_waiting_session() {
+    use crate::session::Status;
+
+    let mut env = create_test_env_with_sessions(2);
+    env.view.strict_hotkeys = false;
+    // Keep the Archived section expanded so the archived row lands in
+    // `flat_items`; that is the only way `w`'s walk could reach it.
+    env.view.archived_section_collapsed = false;
+
+    let archived = env.view.instances[0].id.clone();
+    let active = env.view.instances[1].id.clone();
+    // The surviving active row is a plain idle session (the pass-2 fallback);
+    // the archived row is otherwise Waiting, as it would be if it started
+    // waiting on input before being archived.
+    env.view
+        .mutate_instance(&active, |inst| inst.status = Status::Idle);
+    env.view.mutate_instance(&archived, |inst| {
+        inst.status = Status::Waiting;
+        inst.archive();
+    });
+    assert!(env.view.get_instance(&archived).unwrap().is_archived());
+
+    env.view.select_session_by_id(&active);
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => Some(id.clone()),
+        _ => None,
+    };
+    assert_ne!(
+        landed.as_deref(),
+        Some(archived.as_str()),
+        "`w` must not land on an archived session even though it is Waiting"
+    );
+}
+
+/// Same contract as `w_skips_archived_waiting_session`, but for the pass-2
+/// idle fallback: with the only Idle candidate archived, `w` must not treat
+/// it as the "most-recently-accessed Idle session" fallback target.
+#[test]
+#[serial]
+fn w_skips_archived_idle_session_in_fallback() {
+    let (mut env, running, idle) = attention_env_running_then_idle();
+    let running_id = match env.view.flat_items.get(running) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the running row to be a session item"),
+    };
+    let idle_id = match env.view.flat_items.get(idle) {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the idle row to be a session item"),
+    };
+    // `mutate_instance` updates the instance in place without rebuilding
+    // `flat_items`, so the now-archived row stays at its original index
+    // (pass 2 re-derives its dismissed state from the live instance, not
+    // from `flat_items`, so this still exercises the real code path).
+    env.view.mutate_instance(&idle_id, |inst| inst.archive());
+    assert!(env.view.get_instance(&idle_id).unwrap().is_archived());
+
+    env.view.cursor = running;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => Some(id.clone()),
+        _ => None,
+    };
+    assert_ne!(
+        landed.as_deref(),
+        Some(idle_id.as_str()),
+        "`w` must not fall back to an archived session even when it is the only Idle candidate"
+    );
+    assert_eq!(
+        landed.as_deref(),
+        Some(running_id.as_str()),
+        "with no eligible target, `w` must leave the cursor on the Running session"
+    );
+}
+
 #[test]
 #[serial]
 fn d_on_session_with_default_trash_persists_trash_marker() {

--- a/tests/e2e/intro.rs
+++ b/tests/e2e/intro.rs
@@ -135,6 +135,7 @@ fn intro_theme_pick_persists_to_config() {
     h.send_keys("Enter"); // submit
 
     h.wait_for("No sessions yet");
+    h.wait_for_absent("(6/6)", Duration::from_secs(3));
 
     let cfg = read_config(&h);
     assert!(
@@ -181,6 +182,7 @@ fn intro_lets_user_choose_tmux_attach() {
     h.send_keys("Enter"); // submit
 
     h.wait_for("No sessions yet");
+    h.wait_for_absent("(6/6)", Duration::from_secs(3));
 
     let cfg = read_config(&h);
     assert!(


### PR DESCRIPTION
## Description
`w` (jump to next attention-needing session) never checked `Instance::is_snoozed()`, even though every other subsystem (recovery, ACP reconciler, plugin API, render) treats a snoozed session as a sunk "don't bother me" state alongside archived/trashed. This let `w` land on a snoozed session if it was `Waiting` or the only `Idle` fallback candidate. Added the `is_snoozed()` exclusion to all four filter passes inside `jump_to_next_waiting`.

## PR Type
- [x] Bug Fix

## Checklist
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: this is a unit-test-level filter fix inside `jump_to_next_waiting`; added two unit regression tests (`w_skips_snoozed_waiting_session`, `w_skips_snoozed_idle_session_in_fallback`) covering the exact behavior instead of an e2e test, since no rendering/CLI/session-lifecycle surface changed.

## AI Usage
- [x] AI was used

**AI Model/Tool used:** Claude (opencode, anthropic/claude-sonnet-5)

**Any Additional AI Details you'd like to share:** Full agent-orchestrated change: searched for a pre-existing issue (none found matching this exact bug — related issues #1524 and #1805 addressed the `w`/snooze key conflict but not this filter gap), then implemented the fix and two new regression tests in `src/tui/home/tests.rs`, modeled on the existing `w_skips_unread_trashed_session` test. `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test` suite (3746 tests) pass.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update fixes the TUI `w` key “jump to next attention-needed session” so it reliably skips sessions the user has dismissed—now including snoozed and archived sessions, not just trashed ones. As a result, the cursor won’t land on sessions that were intentionally marked as “do not bother,” even in idle/fallback navigation paths.

To support this, it adds a shared `Instance::is_dismissed()` helper and updates all selection passes inside `jump_to_next_waiting` to consistently filter out dismissed instances.

Two regression tests were added:
- `w_skips_snoozed_waiting_session`
- `w_skips_snoozed_idle_session_in_fallback`

The PR also expands coverage to ensure the same skip behavior applies to archived sessions during the same `w` navigation flow.

Additional stability/maintenance tweaks:
- Refactors `parse_chord`’s `F`-key handling without changing behavior.
- Improves intro wizard E2E reliability by waiting for the “(6/6)” indicator to disappear before proceeding.

Benefits: fewer surprising cursor jumps, more predictable navigation when snoozed/archived sessions exist, and more stable end-to-end test runs.

```text
Technical (optional):
- Introduced Instance::is_dismissed() (trashed/snoozed/archived) and folded archive handling into dismissed filtering across all passes in jump_to_next_waiting.
- Added regression tests for snoozed and archived skip behavior, including idle fallback behavior.
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->