### PR TITLE
fix(web): align live terminal enter chords

### DIFF
--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -300,13 +300,11 @@ pub fn parse_chord(s: &str) -> Option<Chord> {
             c.to_ascii_lowercase()
         };
         KeyCode::Char(c)
-    } else if let Some(n) = key
-        .strip_prefix(['F', 'f'])
-        .and_then(|n| n.parse::<u8>().ok())
-    {
-        KeyCode::F(n)
     } else {
-        return None;
+        let n = key
+            .strip_prefix(['F', 'f'])
+            .and_then(|n| n.parse::<u8>().ok())?;
+        KeyCode::F(n)
     };
     Some(Chord { code, ctrl })
 }

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1139,8 +1139,7 @@ export function MobileLiveTerminal({
           e.altKey &&
           !e.ctrlKey &&
           !e.metaKey &&
-          (e.key === "Enter" ||
-            e.key === "Backspace" ||
+          (e.key === "Backspace" ||
             e.key === "ArrowUp" ||
             e.key === "ArrowDown" ||
             e.key === "ArrowRight" ||

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -190,6 +190,13 @@ function altPrintableMetaKey(
   return e.shiftKey ? letter : letter.toLowerCase();
 }
 
+function liveEnterSequence(e: { key: string; ctrlKey: boolean; shiftKey: boolean; altKey: boolean; metaKey: boolean }) {
+  if (e.key !== "Enter") return null;
+  if (e.altKey && !e.ctrlKey && !e.metaKey) return "\x1b\r";
+  if ((e.ctrlKey || e.shiftKey) && !e.altKey && !e.metaKey) return "\x1b\r";
+  return "\r";
+}
+
 // Wrap http(s) URLs in a segment's text as clickable anchors, so agent output
 // (PR links, localhost dev servers, docs) opens in one tap instead of a
 // manual select-copy-paste (#2685). Plain text returns as-is.
@@ -1101,10 +1108,14 @@ export function MobileLiveTerminal({
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (composingRef.current || e.nativeEvent.isComposing) return;
+      const enterSeq = liveEnterSequence(e);
+      if (enterSeq) {
+        e.preventDefault();
+        sendData(enterSeq);
+        return;
+      }
       const seq = (() => {
         switch (e.key) {
-          case "Enter":
-            return "\r";
           case "Backspace":
             return "\x7f";
           case "Tab":

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -192,8 +192,7 @@ function altPrintableMetaKey(
 
 function liveEnterSequence(e: { key: string; ctrlKey: boolean; shiftKey: boolean; altKey: boolean; metaKey: boolean }) {
   if (e.key !== "Enter") return null;
-  if (e.altKey && !e.ctrlKey && !e.metaKey) return "\x1b\r";
-  if ((e.ctrlKey || e.shiftKey) && !e.altKey && !e.metaKey) return "\x1b\r";
+  if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) return "\x1b\r";
   return "\r";
 }
 

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -190,18 +190,25 @@ describe("MobileLiveTerminal paste", () => {
     expect(sendData).toHaveBeenCalledWith("\x1b\r");
   });
 
-  it("sends Shift+Enter as terminal Meta Enter for agent line breaks", () => {
+  it("sends Shift+Enter as carriage return", () => {
     const { input, sendData } = renderTerm();
 
     expect(fireEvent.keyDown(input, { key: "Enter", shiftKey: true })).toBe(false);
-    expect(sendData).toHaveBeenCalledWith("\x1b\r");
+    expect(sendData).toHaveBeenCalledWith("\r");
   });
 
-  it("sends Ctrl+Shift+Enter as terminal Meta Enter for agent line breaks", () => {
+  it("sends Ctrl+Shift+Enter as carriage return", () => {
     const { input, sendData } = renderTerm();
 
     expect(fireEvent.keyDown(input, { key: "Enter", ctrlKey: true, shiftKey: true })).toBe(false);
-    expect(sendData).toHaveBeenCalledWith("\x1b\r");
+    expect(sendData).toHaveBeenCalledWith("\r");
+  });
+
+  it("sends Alt+Enter as carriage return", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "Enter", altKey: true })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\r");
   });
 
   it("forwards Alt+letter chords as terminal Meta sequences", () => {
@@ -249,11 +256,8 @@ describe("MobileLiveTerminal paste", () => {
     expect(sendData).not.toHaveBeenCalled();
   });
 
-  it("prefixes supported Alt special keys with terminal Meta", () => {
+  it("prefixes supported Alt navigation keys with terminal Meta", () => {
     const { input, sendData } = renderTerm();
-
-    expect(fireEvent.keyDown(input, { key: "Enter", altKey: true })).toBe(false);
-    expect(sendData).toHaveBeenCalledWith("\x1b\r");
 
     expect(fireEvent.keyDown(input, { key: "Backspace", altKey: true })).toBe(false);
     expect(sendData).toHaveBeenCalledWith("\x1b\x7f");

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -176,6 +176,34 @@ describe("MobileLiveTerminal paste", () => {
     expect(sendData).toHaveBeenCalledWith("\x03");
   });
 
+  it("sends plain Enter as carriage return", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "Enter" })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\r");
+  });
+
+  it("sends Ctrl+Enter as terminal Meta Enter for agent line breaks", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "Enter", ctrlKey: true })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\x1b\r");
+  });
+
+  it("sends Shift+Enter as terminal Meta Enter for agent line breaks", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "Enter", shiftKey: true })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\x1b\r");
+  });
+
+  it("sends Ctrl+Shift+Enter as terminal Meta Enter for agent line breaks", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "Enter", ctrlKey: true, shiftKey: true })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\x1b\r");
+  });
+
   it("forwards Alt+letter chords as terminal Meta sequences", () => {
     const { input, sendData } = renderTerm();
 


### PR DESCRIPTION
## Description
Fixes the web dashboard live terminal Enter handling so it matches the confirmed terminal behavior for agent input line breaks.

`Ctrl+Enter` now sends the terminal Meta Enter sequence used for agent line breaks, while plain `Enter`, `Shift+Enter`, `Ctrl+Shift+Enter`, and `Alt+Enter` send a normal carriage return. This avoids surprising web-only newline shortcuts while preserving existing Alt printable/navigation key handling.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement, test, and prepare this PR.

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `cd web && npx vitest run src/components/__tests__/MobileLiveTerminal.paste.test.tsx`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### High-level
- Fixed the web “live terminal” Enter key handling to match the confirmed terminal behavior.
- Added a clear mapping for Enter variants:
  - Plain Enter, Shift+Enter, Ctrl+Shift+Enter, and Alt+Enter send a normal carriage return.
  - Ctrl+Enter sends the special “Meta Enter” sequence used for agent line breaks.
- Adjusted the existing keyboard flow so Enter is handled in a dedicated early path, preventing it from being treated like other special keys.
- Updated the test suite to assert the new Enter-key sequences and refined the Alt-key coverage to focus on navigation keys.

### Benefits
- Makes typing and sending agent input consistent between the web dashboard and the confirmed terminal.
- Prevents incorrect web-only newline behavior for Enter key combinations.
- Improves confidence with targeted automated coverage for the updated keyboard chords.

### Technical notes
- Implemented a `liveEnterSequence` helper that returns `"\x1b\r"` for Ctrl+Enter and `"\r"` for other Enter cases.
- Updated `onKeyDown` to intercept Enter early: prevent default, send the computed sequence, and exit before the prior generic/special-key handling.
- Removed Enter from the later meta-special-key set since it’s already handled by the new early path.
- Included additional Vitest assertions for Enter combinations and adjusted Alt-navigation test expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->