### PR TITLE
fix: stop re-asserting an unreachable pane size on a loop (#2766)

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -344,6 +344,7 @@ async fn handle_live_ws(
         let mut last_published: Option<(String, Option<crate::tmux::PaneCursor>)> = None;
         let mut dead_probes: u32 = 0;
         let mut last_reassert = std::time::Instant::now() - REASSERT_MIN_INTERVAL;
+        let mut last_reassert_geom: Option<(u16, u16, u16, u16)> = None;
         let mut last_heartbeat = std::time::Instant::now() - SIZE_OWNER_HEARTBEAT;
         loop {
             let sample_started = std::time::Instant::now();
@@ -453,8 +454,15 @@ async fn handle_live_ws(
                                 && want_rows > 0
                                 && c.pane_width > 0
                                 && (c.pane_width != want_cols || c.pane_height != want_rows);
-                            if drifted && last_reassert.elapsed() >= REASSERT_MIN_INTERVAL {
+                            let geom = (want_cols, want_rows, c.pane_width, c.pane_height);
+                            let stuck = last_reassert_geom == Some(geom);
+                            if !drifted {
+                                last_reassert_geom = None;
+                            }
+                            if drifted && !stuck && last_reassert.elapsed() >= REASSERT_MIN_INTERVAL
+                            {
                                 last_reassert = std::time::Instant::now();
+                                last_reassert_geom = Some(geom);
                                 warn!(
                                     target: "terminal.ws",
                                     tmux = %capture_tmux,


### PR DESCRIPTION
## Description

Addresses #2766.

In a live-send session the owner loop in `src/server/live_ws.rs` re-asserts the tmux window size whenever the pane differs from the client-reported grid. When that grid is **persistently unreachable** — observed invariant `want_rows == pane_height + 1` (client reports `window_height=67`, the pane tmux yields is `66`) — the condition is permanently true, so it re-asserts the **same** target every ~2s forever. Each re-assert repaints the pane, which surfaces as the hosted agent's cursor flickering ~twice a second, plus a `terminal.ws` WARN on the same cadence. Regression in 1.12.x; full evidence in #2766.

This adds a minimal convergence guard: remember the `(want_cols, want_rows, pane_width, pane_height)` of the last re-assert and skip re-asserting when it's identical — the previous resize changed nothing, so repeating it can't help and only repaints.

- A **genuine** drift still re-asserts (geometry differs from last time), so legitimate resizes are unaffected.
- A **stuck** mismatch re-asserts once, then goes quiet until the geometry actually changes — no more 2s repaint loop or WARN spam.

It does **not** fix the underlying off-by-one (why `screen_rows` ends up one greater than the achievable pane height — likely the `Resize` handler / client size reporting). It's a safety net so an unreachable target can't spin forever; happy to follow up on the root cause with a pointer to where the client's `rows` is derived.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass <!-- not verified: no Rust toolchain on this machine, so I couldn't build/test. Opened as draft for that reason — please build before merge. -->
- [ ] Documentation was updated where necessary <!-- N/A -->
- [ ] For UI changes: included screenshot or recording <!-- N/A: server-side resize logic, no UI change -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: no local Rust toolchain to build/run here (opened as draft). Happy to add a `tests/e2e/` regression asserting the owner loop stops re-asserting an unreachable target after one attempt — a pointer to the right harness would help.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Opus 4.8)

**Any Additional AI Details you'd like to share:**
Bug was diagnosed from the aoe daemon logs and binary symbols; the guard was authored with AI assistance. The human author will respond to review directly.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change prevents the live WebSocket loop from repeatedly re-issuing the same tmux pane resize request when the pane can’t converge to the desired geometry.

What changed:
- Added a convergence guard to remember the last resize/re-assert geometry that was attempted.
- The loop now only retries re-assertion when (1) drift is detected, (2) the pane geometry isn’t effectively “stuck” on the same last-attempt values, and (3) a minimum retry interval has elapsed.
- If drift is no longer detected, the stored “last re-assert” geometry is cleared.

Benefits:
- Stops noisy, potentially endless resize retry loops in unreachable size-mismatch situations.
- Reduces repeated pane repaints, cursor flicker, and recurring `terminal.ws` warning log spam.
- Still allows recovery when the pane’s geometry genuinely changes.

One remaining gap:
- It does not fix the underlying off-by-one size mismatch; it only stops repeated retries of the same failing geometry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->