### PR TITLE
fix(acp): persist model pick so respawn keeps it

### DIFF
--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1974,6 +1974,38 @@ pub struct SetConfigOptionRequest {
     pub value: String,
 }
 
+/// Write a picked model back onto the instance, both in the in-memory
+/// registry (what the reconciler reads to respawn a worker this daemon
+/// lifetime) and on disk (what survives a daemon restart). Called from
+/// `acp_set_config_option` after the live pick succeeds; see the comment there
+/// for why the live call alone is not enough.
+async fn persist_agent_model(state: &Arc<AppState>, id: &str, model: &str) {
+    let profile = {
+        let mut instances = state.instances.write().await;
+        let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+            return;
+        };
+        inst.agent_model = Some(model.to_string());
+        inst.source_profile.clone()
+    };
+    if let Ok(storage) = crate::session::Storage::new(&profile, state.file_watch.clone()) {
+        let id_owned = id.to_string();
+        let model_owned = model.to_string();
+        if let Err(e) = storage.update(|instances, _groups| {
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
+                inst.agent_model = Some(model_owned.clone());
+            }
+            Ok(())
+        }) {
+            tracing::error!(
+                target: "http.api.acp",
+                session = %id,
+                "failed to persist agent_model after config-option pick: {e}"
+            );
+        }
+    }
+}
+
 /// Set a per-session selector (model, reasoning effort, etc.) via ACP
 /// `session/set_config_option`. The structured view treats every category
 /// through this one endpoint; rejection surfaces as a non-blocking
@@ -2009,6 +2041,19 @@ pub async fn acp_set_config_option(
                     .telemetry_structured
                     .plan_mode_seen
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            // Persist a model pick so it survives a worker respawn. The live
+            // set_config_option above only reconfigures the running process; the
+            // reconciler re-reads `agent_model` on every spawn and injects it as
+            // AOE_AGENT_MODEL, so without this write-back a respawn reverts to
+            // the stale stored model and silently overrides the agent's own
+            // default. Mirrors the persist step of the agent-switch path above.
+            // ponytail: keys on the well-known "model" config id, which every
+            // current adapter and the frontend use; resolve category == Model
+            // from the session's config_options if a future adapter uses another
+            // id.
+            if req.config_id == "model" {
+                persist_agent_model(&state, &id, &req.value).await;
             }
             StatusCode::ACCEPTED.into_response()
         }
@@ -2338,6 +2383,53 @@ mod tests {
         assert!(!is_plan_mode_value("yolo"));
         assert!(!is_plan_mode_value("Plan"));
         assert!(!is_plan_mode_value(""));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn persist_agent_model_updates_memory_and_storage() {
+        use crate::session::test_support::isolate_app_dir;
+        let _tmp = isolate_app_dir();
+        let profile = "default";
+
+        let mut inst = crate::session::Instance::new("t", "/tmp");
+        inst.source_profile = profile.to_string();
+        inst.agent_model = Some("claude-sonnet-4-6".to_string());
+        let id = inst.id.clone();
+
+        // Seed on disk so the storage write-back can find the row to update.
+        let storage = crate::session::Storage::new_unwatched(profile).unwrap();
+        let seed = inst.clone();
+        storage
+            .update(|instances, _groups| {
+                instances.push(seed);
+                Ok(())
+            })
+            .unwrap();
+
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+        persist_agent_model(&state, &id, "claude-sonnet-5").await;
+
+        // In-memory registry updated (what the reconciler reads to respawn).
+        assert_eq!(
+            state.instances.read().await[0].agent_model.as_deref(),
+            Some("claude-sonnet-5")
+        );
+
+        // On disk too (what survives a daemon restart).
+        let reloaded = crate::session::Storage::new_unwatched(profile)
+            .unwrap()
+            .load()
+            .unwrap();
+        assert_eq!(
+            reloaded
+                .iter()
+                .find(|i| i.id == id)
+                .unwrap()
+                .agent_model
+                .as_deref(),
+            Some("claude-sonnet-5")
+        );
     }
 
     #[tokio::test]

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -922,19 +922,28 @@ pub async fn switch_acp_agent(
             }
         }
     }
-    if let Ok(storage) = crate::session::Storage::new(&profile_for_save, state.file_watch.clone()) {
-        if let Err(e) = storage.update(|instances, _groups| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_for_save) {
-                inst.agent_name = Some(target_for_save.clone());
-                inst.acp_session_id = None;
-                inst.import_pending = None;
+    match crate::session::Storage::new(&profile_for_save, state.file_watch.clone()) {
+        Ok(storage) => {
+            if let Err(e) = storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_for_save) {
+                    inst.agent_name = Some(target_for_save.clone());
+                    inst.acp_session_id = None;
+                    inst.import_pending = None;
+                }
+                Ok(())
+            }) {
+                tracing::error!(
+                    target: "http.api.acp",
+                    session = %id_for_save,
+                    "failed to persist agent_name after switch: {e}"
+                );
             }
-            Ok(())
-        }) {
+        }
+        Err(e) => {
             tracing::error!(
                 target: "http.api.acp",
                 session = %id_for_save,
-                "failed to persist agent_name after switch: {e}"
+                "failed to open storage to persist agent_name after switch: {e}"
             );
         }
     }
@@ -1988,19 +1997,28 @@ async fn persist_agent_model(state: &Arc<AppState>, id: &str, model: &str) {
         inst.agent_model = Some(model.to_string());
         inst.source_profile.clone()
     };
-    if let Ok(storage) = crate::session::Storage::new(&profile, state.file_watch.clone()) {
-        let id_owned = id.to_string();
-        let model_owned = model.to_string();
-        if let Err(e) = storage.update(|instances, _groups| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
-                inst.agent_model = Some(model_owned.clone());
+    match crate::session::Storage::new(&profile, state.file_watch.clone()) {
+        Ok(storage) => {
+            let id_owned = id.to_string();
+            let model_owned = model.to_string();
+            if let Err(e) = storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
+                    inst.agent_model = Some(model_owned.clone());
+                }
+                Ok(())
+            }) {
+                tracing::error!(
+                    target: "http.api.acp",
+                    session = %id,
+                    "failed to persist agent_model after config-option pick: {e}"
+                );
             }
-            Ok(())
-        }) {
+        }
+        Err(e) => {
             tracing::error!(
                 target: "http.api.acp",
                 session = %id,
-                "failed to persist agent_model after config-option pick: {e}"
+                "failed to open storage to persist agent_model after config-option pick: {e}"
             );
         }
     }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured-view model picker changed the model on the running agent but did not persist the choice. `acp_set_config_option` (`src/server/api/acp.rs`) only forwarded the pick to the live worker via `supervisor.set_config_option(...)`; it never wrote the new value back to `Instance.agent_model`.

That field is persisted and re-injected as the `AOE_AGENT_MODEL` env var on every spawn (the reconciler reads `inst.agent_model` on each respawn). So a stale stored model kept getting force-injected on reconnect/respawn, overriding both the model the user had picked and the agent's own default. Flipping the picker fixed the running process, but since the handler never persisted, the value reverted on the next respawn. That is the "switched to 4.6 then back to 5 and it stuck for a while, then reverted" behavior.

Fix: after the live pick succeeds, persist the model back onto the instance, both in the in-memory registry (what the reconciler reads to respawn a worker within a daemon lifetime) and to on-disk storage (what survives a daemon restart). This mirrors the persist step already used by the agent-switch path in the same file.

The model category is keyed on the well-known `"model"` config id, which every current adapter and the frontend already use. If a third-party adapter ever advertises the model picker under a different id, the upgrade path (noted in a code comment) is to resolve `category == Model` from the session's advertised `config_options`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the persist step runs only after a live ACP worker accepts the pick, so it is not reachable from a mocked frontend flow. Covered instead by a Rust unit test (`persist_agent_model_updates_memory_and_storage`) that asserts the model write-back lands in both the in-memory registry and on-disk storage.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Open a structured-view session on an agent whose default model differs from a previously-picked one.
- [ ] In the model picker, switch to a different model.
- [ ] Trigger a worker respawn (reconnect, or stop/start the structured view) and confirm the picked model is still active, not the old stored one.
- [ ] Restart the daemon (`aoe serve --stop` then relaunch), reattach the session, and confirm the picked model persists.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed the diff, made the design calls, and ran the validation steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Ensured ACP “model” selections persist reliably by writing the chosen `agent_model` to both the in-memory instance registry and on-disk session storage.
- Updated `acp_set_config_option` so that when the supervisor accepts a config change for `config_id: "model"`, the server also persists the new model (not just the live worker).
- Tightened storage handling during agent switching to log failures distinctly (e.g., errors opening storage vs. errors writing updates).
- Added a Rust unit test that seeds on-disk storage, persists `agent_model`, and verifies the update is reflected in both memory and reloaded storage.

## Benefits

Model changes made while a worker is running now survive worker respawns and daemon restarts, preventing the UI/model picker from reverting to an older stale value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->