### PR TITLE
test: eliminate 3 flakiness classes in Tests workflow

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -8673,13 +8673,12 @@ pub async fn read_output(
 #[cfg(test)]
 mod workspace_ordering_tests {
     use super::*;
+    use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
     use serial_test::serial;
     use tempfile::tempdir;
 
-    fn setup_test_home(temp: &std::path::Path) {
-        std::env::set_var("HOME", temp);
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    fn setup_test_home(temp: &std::path::Path) -> AppDirGuard {
+        isolate_app_dir_at(temp)
     }
 
     fn mock_response(id: &str, project_path: &str, branch: Option<&str>) -> SessionResponse {
@@ -8781,7 +8780,7 @@ mod workspace_ordering_tests {
     #[serial]
     fn merge_prepends_unseen_newest_first() -> anyhow::Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         // Persisted ordering already contains `b`. Sessions come in
         // creation order (oldest first) `[b, a, c]`; `a` and `c` are
@@ -8818,7 +8817,7 @@ mod workspace_ordering_tests {
     #[serial]
     fn merge_dedupes_within_a_single_request() -> anyhow::Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         // Two sessions on the same workspace (rare but legal: multiple
         // agents in one worktree). The workspace id appears once.
@@ -8836,7 +8835,7 @@ mod workspace_ordering_tests {
     #[serial]
     fn merge_no_op_when_all_known() -> anyhow::Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         crate::session::update_workspace_ordering(|ord| {
             ord.order = vec!["/tmp/repo::a".to_string(), "/tmp/repo::b".to_string()];
@@ -8860,7 +8859,7 @@ mod workspace_ordering_tests {
     #[serial]
     fn merge_read_only_returns_merged_but_does_not_write() -> anyhow::Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         // Empty starting state. Read-only request observes a new
         // workspace; the response includes it but disk is untouched.

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -730,14 +730,13 @@ fn save_recent_projects(store: &RecentProjects) -> Result<()> {
 mod tests {
     use super::*;
     use crate::file_watch::{FileMatcher, FileWatchService, WatchSpec};
+    use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
     use crate::session::GroupTree;
     use serial_test::serial;
     use tempfile::tempdir;
 
-    fn setup_test_home(temp: &std::path::Path) {
-        std::env::set_var("HOME", temp);
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    fn setup_test_home(temp: &std::path::Path) -> AppDirGuard {
+        isolate_app_dir_at(temp)
     }
 
     #[cfg(unix)]
@@ -832,7 +831,7 @@ mod tests {
     #[serial]
     fn test_storage_roundtrip() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-profile")?;
 
@@ -859,7 +858,7 @@ mod tests {
     #[serial]
     fn test_load_skips_corrupt_row_and_quarantines() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
         let storage = Storage::new_unwatched("test-profile")?;
 
         // [ valid, malformed, valid ]: the malformed row is an object that
@@ -913,7 +912,7 @@ mod tests {
     #[serial]
     fn test_load_top_level_corruption_still_errors() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
         let storage = Storage::new_unwatched("test-profile")?;
 
         fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
@@ -946,7 +945,7 @@ mod tests {
         // resolves through `resolve_default_profile`, which bootstraps the
         // first profile. The name is "main", never the magic "default".
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("")?;
         assert_eq!(storage.profile(), "main");
@@ -959,7 +958,7 @@ mod tests {
         // When profiles already exist, an empty profile argument resolves to
         // the first one (sorted), not a hard-coded name.
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         get_profile_dir("work")?;
         get_profile_dir("personal")?;
@@ -975,7 +974,7 @@ mod tests {
         // An explicitly configured default_profile wins over the first-found
         // directory.
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         get_profile_dir("work")?;
         get_profile_dir("personal")?;
@@ -994,7 +993,7 @@ mod tests {
     #[serial]
     fn test_storage_new_with_custom_profile() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("custom-profile")?;
         assert_eq!(storage.profile(), "custom-profile");
@@ -1005,7 +1004,7 @@ mod tests {
     #[serial]
     fn test_storage_load_nonexistent_file() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-empty")?;
         let loaded = storage.load()?;
@@ -1018,7 +1017,7 @@ mod tests {
     #[serial]
     fn test_storage_load_empty_file() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-empty-file")?;
 
@@ -1035,7 +1034,7 @@ mod tests {
     #[serial]
     fn test_storage_load_whitespace_only_file() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-whitespace")?;
 
@@ -1051,7 +1050,7 @@ mod tests {
     #[serial]
     fn test_storage_save_leaves_no_temp_files() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-no-debris")?;
 
@@ -1085,7 +1084,7 @@ mod tests {
     #[serial]
     fn test_storage_save_empty_array() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-empty-save")?;
         {
@@ -1106,7 +1105,7 @@ mod tests {
     #[serial]
     fn test_storage_load_with_groups_no_groups_file() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-no-groups")?;
 
@@ -1127,7 +1126,7 @@ mod tests {
     #[serial]
     fn test_storage_save_and_load_with_groups() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-with-groups")?;
 
@@ -1154,7 +1153,7 @@ mod tests {
     #[serial]
     fn test_load_with_groups_skips_corrupt_row_and_quarantines() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-groups-corrupt-row")?;
         fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
@@ -1206,7 +1205,7 @@ mod tests {
     #[serial]
     fn test_load_with_groups_repeated_read_overwrites_quarantine() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-groups-corrupt-row-repeat")?;
         fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
@@ -1240,7 +1239,7 @@ mod tests {
     #[serial]
     fn test_load_with_groups_top_level_corruption_still_errors() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-groups-top-level-corrupt")?;
         fs::create_dir_all(storage.sessions_path.parent().unwrap())?;
@@ -1267,7 +1266,7 @@ mod tests {
     #[serial]
     fn test_storage_load_invalid_json() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-invalid")?;
 
@@ -1283,7 +1282,7 @@ mod tests {
     #[serial]
     fn test_storage_preserves_instance_fields() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-fields")?;
 
@@ -1316,7 +1315,7 @@ mod tests {
     #[serial]
     fn test_storage_profile_accessor() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         // Verify profiles are correctly named
         let storage1 = Storage::new_unwatched("profile-alpha")?;
@@ -1334,7 +1333,7 @@ mod tests {
     #[serial]
     fn test_storage_groups_file_empty() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-empty-groups")?;
 
@@ -1362,7 +1361,7 @@ mod tests {
     #[serial]
     fn test_workspace_ordering_roundtrip() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         // Empty by default.
         let empty = load_workspace_ordering()?;
@@ -1386,7 +1385,7 @@ mod tests {
     #[serial]
     fn test_workspace_ordering_overwrites_on_save() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         save_workspace_ordering(&WorkspaceOrdering {
             order: vec!["a".to_string(), "b".to_string()],
@@ -1404,7 +1403,7 @@ mod tests {
     #[serial]
     fn test_workspace_ordering_handles_empty_file() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let path = workspace_ordering_path()?;
         if let Some(parent) = path.parent() {
@@ -1421,7 +1420,7 @@ mod tests {
     #[serial]
     fn test_update_atomic_load_modify_save() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-update-roundtrip")?;
         storage.update(|i, g| {
@@ -1446,7 +1445,7 @@ mod tests {
     #[serial]
     fn test_update_propagates_closure_error() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-update-err")?;
         let initial = vec![Instance::new("keep", "/tmp/keep")];
@@ -1472,7 +1471,7 @@ mod tests {
     #[serial]
     fn test_update_serializes_concurrent_writers_same_profile() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-update-concurrent")?;
         storage.update(|i, g| {
@@ -1521,7 +1520,7 @@ mod tests {
     #[serial]
     fn test_update_does_not_serialize_across_profiles() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage_a = Storage::new_unwatched("test-update-profile-a")?;
         let storage_b = Storage::new_unwatched("test-update-profile-b")?;
@@ -1557,7 +1556,7 @@ mod tests {
         use std::time::{Duration, Instant};
 
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-commit-lock")?;
         storage.update(|i, g| {
@@ -1620,7 +1619,7 @@ mod tests {
     #[serial]
     fn test_workspace_ordering_update_serializes() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         update_workspace_ordering(|ord| {
             ord.order.clear();
@@ -1655,7 +1654,7 @@ mod tests {
     #[serial]
     fn test_profile_lock_registry_returns_same_arc_for_same_profile() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let s1 = Storage::new_unwatched("test-registry-shared")?;
         let s2 = Storage::new_unwatched("test-registry-shared")?;
@@ -1670,7 +1669,7 @@ mod tests {
     #[serial]
     fn test_update_writes_both_sessions_and_groups_files() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-update-both-files")?;
         storage.update(|i, g| {
@@ -1699,7 +1698,7 @@ mod tests {
     #[serial]
     fn test_update_closure_err_leaves_both_files_untouched() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-update-err-untouched")?;
         let seed = vec![Instance::new("seed", "/tmp/seed")];
@@ -1735,7 +1734,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let svc = FileWatchService::new().expect("live svc");
         let storage = Storage::new("test-update-no-notify", svc.clone())?;
@@ -1813,7 +1812,7 @@ mod tests {
     #[serial]
     fn test_update_skips_groups_write_when_groups_unchanged() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-skip-groups-write")?;
         let seed_instances = [Instance::new("seed", "/tmp/seed")];
@@ -1845,7 +1844,7 @@ mod tests {
     #[serial]
     fn test_update_rewrites_groups_when_changed() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage = Storage::new_unwatched("test-rewrite-groups")?;
         let seed_instances = [Instance::new("seed", "/tmp/seed")];
@@ -1877,7 +1876,7 @@ mod tests {
     #[serial]
     fn test_save_lock_registry_recovers_from_poison() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         let storage_outer = Storage::new_unwatched("test-poison-recovery")?;
         let _ = std::thread::spawn(move || {
@@ -1930,7 +1929,7 @@ mod tests {
     #[serial]
     fn record_recent_project_upserts_sorts_and_caps() -> Result<()> {
         let temp = tempdir()?;
-        setup_test_home(temp.path());
+        let _guard = setup_test_home(temp.path());
 
         // Capacity + 5 distinct projects, oldest first.
         for i in 0..(RECENT_PROJECTS_CAP + 5) {

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -1,22 +1,32 @@
 //! Shared test-support helpers.
 //!
 //! Tests across the crate need to point `HOME` (and, on Linux/macOS,
-//! `XDG_CONFIG_HOME`) at an isolated temporary directory so `get_app_dir_path`
-//! resolves to a scratch location instead of the developer's real config.
-//! Returning a bare `TempDir` from the old duplicated `isolate_app_dir`
-//! helpers meant the tempdir was cleaned up on drop, but the env vars leaked
-//! into the process for the rest of the test run, poisoning any later test
-//! that read them. See issue #2306.
+//! `XDG_CONFIG_HOME` plus `XDG_DATA_HOME`) at an isolated temporary
+//! directory so both the crate's dot-dir resolution and the opencode
+//! data-dir lookup land in a scratch location instead of the caller's
+//! real dirs. Returning a bare `TempDir` from the old duplicated
+//! `isolate_app_dir` helpers meant the tempdir was cleaned up on drop,
+//! but the env vars leaked into the process for the rest of the test
+//! run, poisoning any later test that read them. See issue #2306.
 //!
-//! `AppDirGuard` owns both the tempdir and a snapshot of the previous env
-//! values, so its `Drop` closes the leak: env vars are restored to their
-//! prior state (or removed if they were previously unset) even if the test
-//! panics. The `Drop` restore-or-remove pattern is similar to
-//! `StorageHomeGuard` at [`crate::session::sync`], with two deliberate
-//! divergences: (a) `AppDirGuard` snapshots `OsString` via `env::var_os`
-//! rather than `String` via `env::var`, so a non-UTF-8 prior value round-trips
-//! faithfully instead of coercing to `None`; (b) `AppDirGuard` owns the
-//! tempdir so a single binding covers both concerns.
+//! `AppDirGuard` snapshots the previous env values, so its `Drop`
+//! closes the leak: env vars are restored to their prior state (or
+//! removed if they were previously unset) even if the test panics.
+//! The `Drop` restore-or-remove pattern is similar to
+//! `StorageHomeGuard` at [`crate::session::sync`], with the deliberate
+//! divergence that `AppDirGuard` snapshots `OsString` via `env::var_os`
+//! rather than `String` via `env::var`, so a non-UTF-8 prior value
+//! round-trips faithfully instead of coercing to `None`.
+//!
+//! Two constructors are offered. [`isolate_app_dir`] creates and owns
+//! a fresh tempdir; reach for it when the caller has no directory to
+//! share. [`isolate_app_dir_at`] takes a caller-owned
+//! [`std::path::Path`] and leaves tempdir lifetime management to the
+//! caller; reach for it when a struct or helper already owns a
+//! `TempDir` and needs the guard to co-exist with it. When the guard
+//! does not own the tempdir, the caller must declare the `TempDir`
+//! AFTER the guard in the enclosing struct so field drop order runs
+//! env-restore before tempdir cleanup.
 //!
 //! Scope: the guard isolates tests on Linux and macOS (the crate's
 //! supported native targets; Windows is WSL2-only per the README). On
@@ -28,16 +38,18 @@
 //! rather than more env vars in this snapshot set.
 
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
-/// RAII guard: isolates `HOME` and `XDG_CONFIG_HOME` for one test; restores
-/// them on `Drop`. See the [module documentation](crate::session::test_support)
-/// for the process-global env-leak motivation (issue #2306).
+/// RAII guard: isolates `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME`
+/// for one test; restores them on `Drop`. See the
+/// [module documentation](crate::session::test_support) for the
+/// process-global env-leak motivation (issue #2306).
 ///
 /// `Debug` is intentionally not derived: the snapshot fields carry the
-/// caller's real `$HOME` and `$XDG_CONFIG_HOME`, and a derived `Debug`
-/// impl would print them verbatim in test failure output (unwrap-panic
+/// caller's real `$HOME`, `$XDG_CONFIG_HOME`, and `$XDG_DATA_HOME`, and
+/// a derived `Debug` impl would print them verbatim in test failure
+/// output (unwrap-panic
 /// backtraces, `assert!` messages that format the guard). Path values on
 /// developer machines are often personally identifying; keep the guard
 /// opaque.
@@ -51,18 +63,22 @@ use tempfile::TempDir;
 /// avoid the log entirely.
 #[must_use = "AppDirGuard restores env vars on Drop; bind it to `_tmp` or `_guard`, not `_`, or the isolation ends on the same line and the test body runs against the caller's real env"]
 pub(crate) struct AppDirGuard {
-    temp: TempDir,
+    // `None` when the caller retains ownership via `isolate_app_dir_at`.
+    temp: Option<TempDir>,
+    // Snapshotted at construction so `path()` works whether we own the tempdir or not.
+    path: PathBuf,
     prev_home: Option<OsString>,
     prev_xdg: Option<OsString>,
+    prev_xdg_data: Option<OsString>,
 }
 
 impl AppDirGuard {
-    /// Returns the tempdir root. See also `impl AsRef<Path>` below: both
+    /// Returns the app-dir root. See also `impl AsRef<Path>` below: both
     /// accessors are intentionally offered so callers can pick the one
     /// that fits: `guard.path()` for direct use, `&guard` for
     /// `impl AsRef<Path>`-style generic call sites.
     pub(crate) fn path(&self) -> &Path {
-        self.temp.path()
+        &self.path
     }
 }
 
@@ -77,16 +93,20 @@ impl AsRef<Path> for AppDirGuard {
 
 impl Drop for AppDirGuard {
     fn drop(&mut self) {
-        // `prev_xdg` is snapshotted unconditionally at construction (line
-        // below), while the constructor only mutates `XDG_CONFIG_HOME`
-        // under `cfg(any(target_os = "linux", target_os = "macos"))`. On
-        // other targets the restore writes back the same value the
-        // constructor observed (a no-op on the ambient env); the
-        // asymmetry is deliberate so a future target that starts
-        // consulting `XDG_CONFIG_HOME` inherits the restore path
-        // automatically without a matching cfg edit here.
+        // `prev_xdg` and `prev_xdg_data` are snapshotted unconditionally at
+        // construction, while the constructor only mutates `XDG_CONFIG_HOME`
+        // and `XDG_DATA_HOME` under `cfg(any(target_os = "linux", target_os
+        // = "macos"))`. On other targets the restore writes back the same
+        // value the constructor observed (a no-op on the ambient env); the
+        // asymmetry is deliberate so a future target that starts consulting
+        // these vars inherits the restore path automatically without a
+        // matching cfg edit here.
         restore_or_remove("HOME", self.prev_home.take());
         restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+        restore_or_remove("XDG_DATA_HOME", self.prev_xdg_data.take());
+        // Env vars are restored; only now release the owned tempdir (if
+        // any) so `HOME` no longer points at a directory being deleted.
+        let _ = self.temp.take();
     }
 }
 
@@ -100,8 +120,9 @@ fn restore_or_remove(key: &str, prev: Option<OsString>) {
     //      tests, so the whole call sequence (snapshot -> set_var ->
     //      test body -> Drop -> restore_or_remove) is linearized against
     //      every other `#[serial]` test in the crate.
-    //   2. Non-`#[serial]` tests in the crate do not read `HOME` or
-    //      `XDG_CONFIG_HOME` (grep-verified; see the module doc).
+    //   2. Non-`#[serial]` tests in the crate do not read `HOME`,
+    //      `XDG_CONFIG_HOME`, or `XDG_DATA_HOME` (grep-verified; see
+    //      the module doc).
     //   3. The `#[tokio::test]` sites that use this helper all run on
     //      the default single-threaded runtime; no worker task reads env
     //      concurrently with the mutation.
@@ -111,13 +132,15 @@ fn restore_or_remove(key: &str, prev: Option<OsString>) {
     }
 }
 
-/// Isolate the app dir for one test.
+/// Isolate the app dir for one test using a freshly-created tempdir.
 ///
 /// Points `HOME` at a fresh tempdir root, and on Linux/macOS points
-/// `XDG_CONFIG_HOME` at `<tempdir>/.config` (the shape `get_app_dir_path`
-/// resolves against). The two vars land at different paths on purpose: the
-/// crate's config resolution uses `HOME` for user-scoped paths and
-/// `XDG_CONFIG_HOME` for the crate's own dot-dir subtree.
+/// `XDG_CONFIG_HOME` at `<tempdir>/.config` and `XDG_DATA_HOME` at
+/// `<tempdir>/.local/share` (the shape `get_app_dir_path` and the
+/// opencode data-dir lookup both resolve against). The three vars land
+/// at different paths on purpose: `HOME` for user-scoped paths,
+/// `XDG_CONFIG_HOME` for the crate's own dot-dir subtree, and
+/// `XDG_DATA_HOME` for the opencode capture/db subtree.
 ///
 /// The prior values are snapshotted via [`std::env::var_os`] (`OsString`,
 /// not `String`) so a non-UTF-8 prior value survives round-tripping through
@@ -135,19 +158,55 @@ fn restore_or_remove(key: &str, prev: Option<OsString>) {
 ///   practice.
 pub(crate) fn isolate_app_dir() -> AppDirGuard {
     let temp_home = TempDir::new().expect("create tempdir for AppDirGuard");
+    let path = temp_home.path().to_path_buf();
+    install_env_vars(path, Some(temp_home))
+}
+
+/// Isolate the app dir for one test against a caller-owned path.
+///
+/// Same env-var installation as [`isolate_app_dir`], but the caller owns
+/// the tempdir (or any other path they wish to expose as `HOME`). The
+/// guard captures neither ownership nor lifetime of `path`; on `Drop`
+/// only the env vars are restored.
+///
+/// The typical shape is:
+///
+/// ```ignore
+/// struct TestEnv {
+///     view: HomeView,
+///     _guard: crate::session::test_support::AppDirGuard,
+///     _temp: tempfile::TempDir,
+/// }
+/// ```
+///
+/// Fields drop top-to-bottom, so `view` drops first (any reader of
+/// `HOME` runs while the guard is still live), then the guard restores
+/// env vars, then `_temp` deletes the tempdir. Declaring `_temp` before
+/// `_guard` would delete the dir while `HOME` still points at it.
+pub(crate) fn isolate_app_dir_at(path: &Path) -> AppDirGuard {
+    install_env_vars(path.to_path_buf(), None)
+}
+
+fn install_env_vars(path: PathBuf, temp: Option<TempDir>) -> AppDirGuard {
     let prev_home = std::env::var_os("HOME");
     let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    let prev_xdg_data = std::env::var_os("XDG_DATA_HOME");
     // SAFETY (staged for Rust 2024 edition migration): same invariant
     // as [`restore_or_remove`] above. Callers are `#[serial]`-annotated
     // tests; no other thread reads or writes `HOME` / `XDG_CONFIG_HOME`
-    // while this function runs.
-    std::env::set_var("HOME", temp_home.path());
+    // / `XDG_DATA_HOME` while this function runs.
+    std::env::set_var("HOME", &path);
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+    {
+        std::env::set_var("XDG_CONFIG_HOME", path.join(".config"));
+        std::env::set_var("XDG_DATA_HOME", path.join(".local/share"));
+    }
     AppDirGuard {
-        temp: temp_home,
+        temp,
+        path,
         prev_home,
         prev_xdg,
+        prev_xdg_data,
     }
 }
 
@@ -158,14 +217,15 @@ mod tests {
     use std::panic::AssertUnwindSafe;
 
     /// Locks the fix for #2306: `Drop` MUST restore `HOME` and (on
-    /// Linux/macOS) `XDG_CONFIG_HOME` to their pre-guard values. A future
-    /// refactor that quietly drops the `Drop` impl would reintroduce the
-    /// leak this PR closes.
+    /// Linux/macOS) `XDG_CONFIG_HOME` plus `XDG_DATA_HOME` to their
+    /// pre-guard values. A future refactor that quietly drops the `Drop`
+    /// impl would reintroduce the leak this PR closes.
     #[test]
     #[serial]
     fn app_dir_guard_drop_restores_env_vars() {
         let before_home = std::env::var_os("HOME");
         let before_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let before_xdg_data = std::env::var_os("XDG_DATA_HOME");
 
         {
             let guard = isolate_app_dir();
@@ -180,11 +240,18 @@ mod tests {
                 "HOME must point at the guard's tempdir during the test body"
             );
             #[cfg(any(target_os = "linux", target_os = "macos"))]
-            assert_eq!(
-                std::env::var_os("XDG_CONFIG_HOME"),
-                Some(guard.path().join(".config").into_os_string()),
-                "XDG_CONFIG_HOME must point at <tempdir>/.config"
-            );
+            {
+                assert_eq!(
+                    std::env::var_os("XDG_CONFIG_HOME"),
+                    Some(guard.path().join(".config").into_os_string()),
+                    "XDG_CONFIG_HOME must point at <tempdir>/.config"
+                );
+                assert_eq!(
+                    std::env::var_os("XDG_DATA_HOME"),
+                    Some(guard.path().join(".local/share").into_os_string()),
+                    "XDG_DATA_HOME must point at <tempdir>/.local/share"
+                );
+            }
         }
 
         assert_eq!(
@@ -196,6 +263,11 @@ mod tests {
             std::env::var_os("XDG_CONFIG_HOME"),
             before_xdg,
             "XDG_CONFIG_HOME must be restored on guard Drop"
+        );
+        assert_eq!(
+            std::env::var_os("XDG_DATA_HOME"),
+            before_xdg_data,
+            "XDG_DATA_HOME must be restored on guard Drop"
         );
     }
 
@@ -215,20 +287,24 @@ mod tests {
         struct AmbientEnvRestore {
             home: Option<OsString>,
             xdg: Option<OsString>,
+            xdg_data: Option<OsString>,
         }
         impl Drop for AmbientEnvRestore {
             fn drop(&mut self) {
                 restore_or_remove("HOME", self.home.take());
                 restore_or_remove("XDG_CONFIG_HOME", self.xdg.take());
+                restore_or_remove("XDG_DATA_HOME", self.xdg_data.take());
             }
         }
 
         let _restore = AmbientEnvRestore {
             home: std::env::var_os("HOME"),
             xdg: std::env::var_os("XDG_CONFIG_HOME"),
+            xdg_data: std::env::var_os("XDG_DATA_HOME"),
         };
         std::env::remove_var("HOME");
         std::env::remove_var("XDG_CONFIG_HOME");
+        std::env::remove_var("XDG_DATA_HOME");
 
         {
             let guard = isolate_app_dir();
@@ -252,10 +328,15 @@ mod tests {
             None,
             "XDG_CONFIG_HOME must stay unset on Drop when it was unset before construction"
         );
+        assert_eq!(
+            std::env::var_os("XDG_DATA_HOME"),
+            None,
+            "XDG_DATA_HOME must stay unset on Drop when it was unset before construction"
+        );
 
         // `_restore` fires on scope exit (or on panic before this line):
-        // its `Drop` re-applies `before_home` / `before_xdg` for any
-        // downstream serial test that reads them.
+        // its `Drop` re-applies the ambient env for any downstream
+        // serial test.
     }
 
     /// `AsRef<Path>` lets call sites pass `&guard` wherever a
@@ -335,6 +416,88 @@ mod tests {
             std::env::var_os("HOME"),
             before_home,
             "Drop must restore the pre-construction snapshot, not the mid-scope write"
+        );
+    }
+
+    /// A peer thread writing `HOME` mid-scope must not survive the
+    /// guard's `Drop`: `Drop` unconditionally restores the
+    /// pre-construction snapshot regardless of intervening writes from
+    /// any thread. The barrier rendezvous makes the peer swap land at a
+    /// deterministic point in the guard's live scope so this test does
+    /// not rely on sampling.
+    #[test]
+    #[serial]
+    fn app_dir_guard_survives_concurrent_peer_env_swap() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let before_home = std::env::var_os("HOME");
+
+        let peer_at_swap = Arc::new(Barrier::new(2));
+        let peer_done = Arc::new(Barrier::new(2));
+
+        let peer_at_swap_clone = Arc::clone(&peer_at_swap);
+        let peer_done_clone = Arc::clone(&peer_done);
+        let peer = thread::spawn(move || {
+            peer_at_swap_clone.wait();
+            std::env::set_var("HOME", "/tmp/aoe-peer-swap-sentinel");
+            peer_done_clone.wait();
+        });
+
+        {
+            let guard = isolate_app_dir();
+            let guard_path = guard.path().to_path_buf();
+
+            peer_at_swap.wait();
+            peer_done.wait();
+
+            assert_eq!(
+                std::env::var_os("HOME"),
+                Some(OsString::from("/tmp/aoe-peer-swap-sentinel")),
+                "peer thread must have swapped HOME by now (Barrier rendezvous)"
+            );
+
+            assert_eq!(
+                guard.path(),
+                guard_path,
+                "guard.path() must remain the snapshotted path even after a peer env swap"
+            );
+        }
+
+        peer.join().expect("peer thread must not panic");
+
+        assert_eq!(
+            std::env::var_os("HOME"),
+            before_home,
+            "guard Drop must restore the pre-construction HOME even when a peer thread swapped it mid-scope"
+        );
+    }
+
+    /// `isolate_app_dir_at` reads a caller-owned path and MUST NOT own
+    /// or delete it: after the guard drops, the caller's directory is
+    /// still on disk (only env vars are restored). A refactor that
+    /// silently starts moving the caller's `TempDir` into the guard
+    /// would delete the dir on Drop and pass every other test in this
+    /// module.
+    #[test]
+    #[serial]
+    fn app_dir_guard_at_preserves_caller_tempdir() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().to_path_buf();
+        assert!(path.exists(), "precondition: caller tempdir exists");
+
+        {
+            let guard = isolate_app_dir_at(&path);
+            assert_eq!(
+                guard.path(),
+                path.as_path(),
+                "guard.path() must reflect the caller-provided path, not a fresh tempdir"
+            );
+        }
+
+        assert!(
+            path.exists(),
+            "isolate_app_dir_at must not own or delete the caller-provided tempdir on Drop"
         );
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for HomeView
 
+use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serial_test::serial;
 use tempfile::TempDir;
@@ -15,10 +16,8 @@ fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
 }
 
-fn setup_test_home(temp: &TempDir) {
-    std::env::set_var("HOME", temp.path());
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+fn setup_test_home(temp: &TempDir) -> AppDirGuard {
+    isolate_app_dir_at(temp.path())
 }
 
 fn seed_instances(view: &mut HomeView, insts: &[Instance]) {
@@ -26,14 +25,15 @@ fn seed_instances(view: &mut HomeView, insts: &[Instance]) {
 }
 
 struct TestEnv {
-    _temp: TempDir,
     view: HomeView,
+    _guard: AppDirGuard,
+    _temp: TempDir,
 }
 
 fn create_test_env_empty() -> TestEnv {
     use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap(); // ensure profile dir exists
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(
@@ -45,7 +45,11 @@ fn create_test_env_empty() -> TestEnv {
     view.group_by = GroupByMode::Manual;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    TestEnv { _temp: temp, view }
+    TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    }
 }
 
 // #1897 / CodeRabbit follow-up: `add_instance` is the funnel for both the
@@ -55,6 +59,7 @@ fn create_test_env_empty() -> TestEnv {
 // counts a session that never existed. Asserts deltas (not absolutes) since the
 // counter is a process-global shared with the `telemetry_creates` serial group.
 #[test]
+#[serial]
 #[serial_test::serial(telemetry_creates)]
 fn add_instance_counts_only_finalized_creates() {
     use crate::session::Status;
@@ -85,7 +90,7 @@ fn add_instance_counts_only_finalized_creates() {
 #[serial]
 fn rewire_disk_subscriptions_is_noop_without_tokio_runtime() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(
@@ -118,7 +123,7 @@ fn rewire_disk_subscriptions_is_noop_without_tokio_runtime() {
 #[serial]
 async fn config_watch_keys_distinguish_global_from_profile_named_global() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let profile_name = "<global>";
     let _storage = Storage::new_unwatched(profile_name).unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -144,7 +149,7 @@ async fn config_watch_keys_distinguish_global_from_profile_named_global() {
 #[serial]
 fn watcher_refresh_does_not_reopen_hotkey_warning_dialog() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
     let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
     std::fs::write(
@@ -177,7 +182,7 @@ fn watcher_refresh_does_not_reopen_hotkey_warning_dialog() {
 #[serial]
 fn interactive_refresh_reopens_hotkey_warning_dialog() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
     let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
     std::fs::write(
@@ -206,7 +211,7 @@ fn interactive_refresh_reopens_hotkey_warning_dialog() {
 #[serial]
 fn watcher_refresh_stashes_pending_watcher_theme() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
     let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
     std::fs::write(&global_config, "[theme]\nname = \"dracula\"\n").unwrap();
@@ -234,7 +239,7 @@ fn watcher_refresh_stashes_pending_watcher_theme() {
 #[serial]
 fn interactive_refresh_does_not_stash_pending_watcher_theme() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
     let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
     std::fs::write(&global_config, "[theme]\nname = \"dracula\"\n").unwrap();
@@ -261,7 +266,7 @@ fn interactive_refresh_does_not_stash_pending_watcher_theme() {
 #[serial]
 fn take_pending_watcher_theme_clears_the_field() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
 
     let mut view = HomeView::new(
@@ -286,7 +291,7 @@ fn take_pending_watcher_theme_clears_the_field() {
 fn watcher_refresh_stashes_global_theme_not_profile_override() {
     use crate::session::profile_config::{save_profile_config, ProfileConfig};
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
 
     let global_config = crate::session::get_app_dir().unwrap().join("config.toml");
@@ -320,7 +325,7 @@ fn watcher_refresh_stashes_global_theme_not_profile_override() {
 #[serial]
 fn second_watcher_refresh_overwrites_stale_stash() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
 
     let mut view = HomeView::new(
@@ -347,7 +352,7 @@ fn second_watcher_refresh_overwrites_stale_stash() {
 fn create_test_env_with_sessions(count: usize) -> TestEnv {
     use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
     let mut instances = Vec::new();
     for i in 0..count {
@@ -374,7 +379,11 @@ fn create_test_env_with_sessions(count: usize) -> TestEnv {
     view.group_by = GroupByMode::Manual;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    TestEnv { _temp: temp, view }
+    TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    }
 }
 
 /// Disable trash-first delete for tests that assert the permanent-delete
@@ -405,7 +414,7 @@ fn enable_confirm_delete() {
 fn create_test_env_with_groups() -> TestEnv {
     use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
     let mut instances = Vec::new();
 
@@ -438,14 +447,18 @@ fn create_test_env_with_groups() -> TestEnv {
     view.group_by = GroupByMode::Manual;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    TestEnv { _temp: temp, view }
+    TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    }
 }
 
 fn create_test_env_with_mixed_sessions() -> TestEnv {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
     let mut instances = Vec::new();
 
@@ -483,7 +496,11 @@ fn create_test_env_with_mixed_sessions() -> TestEnv {
     view.group_by = crate::session::config::GroupByMode::Manual;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    TestEnv { _temp: temp, view }
+    TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    }
 }
 
 #[test]
@@ -1349,7 +1366,7 @@ fn test_enter_on_session_returns_attach_action() {
 fn test_enter_on_acp_session_opens_structured_view() {
     use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
     let mut instances = vec![
         Instance::new("plain", "/tmp/0"),
@@ -2321,7 +2338,7 @@ fn test_uppercase_p_picker_esc_closes() {
 #[serial]
 fn test_uppercase_p_picker_switch_profile() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     crate::session::create_profile("first").unwrap();
     crate::session::create_profile("second").unwrap();
@@ -2523,7 +2540,7 @@ fn create_test_env_with_group_sessions() -> TestEnv {
     use crate::session::{GroupTree, SandboxInfo};
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
     let mut instances = Vec::new();
 
@@ -2575,7 +2592,11 @@ fn create_test_env_with_group_sessions() -> TestEnv {
     view.group_by = crate::session::config::GroupByMode::Manual;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    TestEnv { _temp: temp, view }
+    TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    }
 }
 
 /// Trashing and restoring a session through the view's own actions keeps the
@@ -2632,7 +2653,7 @@ fn test_group_has_managed_worktrees() {
     use chrono::Utc;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst1 = Instance::new("work-session", "/tmp/work");
@@ -2680,7 +2701,7 @@ fn test_group_has_containers() {
     use crate::session::SandboxInfo;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst1 = Instance::new("work-session", "/tmp/work");
@@ -2855,7 +2876,7 @@ fn test_archive_selected_group_widened_teardown_persists_synchronously() {
 #[serial]
 fn test_archive_selected_group_project_mode() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     // Two sessions sharing one repo, one session in a different repo.
@@ -3014,7 +3035,7 @@ fn test_delete_group_with_sessions_respects_worktree_option() {
     use chrono::Utc;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst1 = Instance::new("work-session", "/tmp/work");
@@ -3076,7 +3097,7 @@ fn test_delete_group_with_sessions_respects_container_option() {
     use crate::tui::dialogs::GroupDeleteOptions;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst1 = Instance::new("work-session", "/tmp/work");
@@ -3707,7 +3728,7 @@ fn attention_env_running_then_waiting() -> (TestEnv, usize, usize) {
     use crate::session::Status;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut running = Instance::new("running", "/tmp/running");
@@ -3735,7 +3756,11 @@ fn attention_env_running_then_waiting() -> (TestEnv, usize, usize) {
     view.sort_order = SortOrder::Attention;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    let env = TestEnv { _temp: temp, view };
+    let env = TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    };
 
     let status_at = |env: &TestEnv, idx: usize| match env.view.flat_items.get(idx) {
         Some(Item::Session { id, .. }) => env.view.get_instance(id).map(|i| i.status),
@@ -3755,7 +3780,7 @@ fn attention_env_running_then_idle() -> (TestEnv, usize, usize) {
     use crate::session::Status;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut running = Instance::new("running", "/tmp/running");
@@ -3783,7 +3808,11 @@ fn attention_env_running_then_idle() -> (TestEnv, usize, usize) {
     view.sort_order = SortOrder::Attention;
     view.flat_items = view.build_flat_items();
     view.update_selected();
-    let env = TestEnv { _temp: temp, view };
+    let env = TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    };
 
     let status_at = |env: &TestEnv, idx: usize| match env.view.flat_items.get(idx) {
         Some(Item::Session { id, .. }) => env.view.get_instance(id).map(|i| i.status),
@@ -3862,7 +3891,7 @@ fn test_non_strict_w_on_collapsed_project_group_reveals_idle_in_attention_sort()
     use crate::session::Status;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut alpha_idle = Instance::new("alpha-idle", "/repos/alpha");
@@ -4367,7 +4396,7 @@ fn test_o_key_clamps_cursor_when_list_shrinks() {
 #[serial]
 fn test_all_profiles_view_loads_from_multiple_profiles() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     {
@@ -4412,7 +4441,7 @@ fn test_all_profiles_view_loads_from_multiple_profiles() {
 #[serial]
 fn test_filtered_view_loads_single_profile() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     {
@@ -4458,7 +4487,7 @@ fn test_filtered_view_loads_single_profile() {
 #[serial]
 fn test_all_profiles_view_has_no_profile_headers() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     {
@@ -4504,7 +4533,7 @@ fn test_all_profiles_view_has_no_profile_headers() {
 #[serial]
 fn test_all_profiles_view_shows_all_sessions_flat() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     {
@@ -4560,7 +4589,7 @@ fn rendered_single_session_text(
     row_tag_mode: crate::session::config::RowTagMode,
 ) -> String {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage = Storage::new_unwatched("alpha").unwrap();
     let instances = vec![inst];
@@ -4617,7 +4646,7 @@ fn test_default_row_tag_mode_renders_branch_tag() {
 #[serial]
 fn test_row_tag_auto_renders_profile_in_all_profiles_view() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
@@ -4675,7 +4704,7 @@ fn test_row_tag_auto_renders_profile_in_all_profiles_view() {
 #[serial]
 fn test_row_tag_auto_omits_tag_in_filtered_view() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
@@ -4723,7 +4752,7 @@ fn test_row_tag_auto_omits_tag_in_filtered_view() {
 #[serial]
 fn test_row_tag_profile_renders_in_filtered_view() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage_a = Storage::new_unwatched("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
@@ -4798,7 +4827,7 @@ fn test_row_tag_branch_renders_when_branch_differs_from_title() {
 #[serial]
 fn test_row_tag_branch_renders_when_title_matches_branch() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage = Storage::new_unwatched("alpha").unwrap();
     // Title and branch MATCH, so the divergence display stays quiet.
@@ -4943,7 +4972,7 @@ fn test_row_tag_branch_renders_workspace_branch_repo_count() {
 #[serial]
 fn test_row_tag_auto_skips_for_empty_source_profile() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let storage = Storage::new_unwatched("legacy").unwrap();
     let mut inst = Instance::new("Legacy1", "/tmp/legacy");
@@ -4982,7 +5011,7 @@ fn test_create_session_in_all_mode_is_findable() {
     use crate::tui::dialogs::NewSessionData;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // Create a profile so "all" mode has something
     let storage = Storage::new_unwatched("alpha").unwrap();
@@ -5046,7 +5075,7 @@ fn test_save_preserves_per_profile_collapsed_state() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // Create alpha with group "work" (collapsed)
     let storage_a = Storage::new_unwatched("alpha").unwrap();
@@ -5134,7 +5163,7 @@ fn test_save_preserves_per_profile_collapsed_state() {
 #[serial]
 fn test_create_profile_rejects_reserved_name_all() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("default").unwrap();
 
     let result = crate::session::create_profile("all");
@@ -5155,7 +5184,7 @@ fn test_delete_group_scoped_to_owning_profile() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // Create alpha with group "work"
     let storage_a = Storage::new_unwatched("alpha").unwrap();
@@ -5260,7 +5289,7 @@ fn test_group_delete_dialog_scoped_to_owning_profile() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // alpha owns an EMPTY "work" group (group exists, no sessions).
     let storage_a = Storage::new_unwatched("alpha").unwrap();
@@ -5335,7 +5364,7 @@ fn test_rename_profile_change_prunes_source_group() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // alpha has one session in "work"; beta exists but is empty.
     let storage_a = Storage::new_unwatched("alpha").unwrap();
@@ -5828,7 +5857,7 @@ fn test_shift_n_prefills_main_repo_path_for_worktree_session() {
     use crate::session::WorktreeInfo;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst = Instance::new("worktree-session", "/tmp/repo-worktrees/feature-branch");
@@ -5957,7 +5986,7 @@ fn test_rename_selected_group_with_children() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst1 = Instance::new("parent-session", "/tmp/p");
@@ -6064,7 +6093,7 @@ fn test_rename_group_removes_old_path() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst = Instance::new("work-session", "/tmp/w");
@@ -6108,7 +6137,7 @@ fn test_rename_group_empty_group() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let instances: Vec<Instance> = vec![];
@@ -6158,7 +6187,7 @@ fn test_rename_group_duplicate_returns_error() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut inst1 = Instance::new("work-session", "/tmp/w");
@@ -6202,7 +6231,7 @@ fn test_rename_group_resort_az() {
     use crate::session::GroupTree;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let mut config = Config::default();
     config.app_state.sort_order = Some(SortOrder::AZ);
@@ -6297,7 +6326,7 @@ fn test_apply_creation_results_returns_session_id() {
     use crate::tui::dialogs::NewSessionData;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     let project_dir = temp.path().join("project");
     std::fs::create_dir_all(&project_dir).unwrap();
@@ -6435,7 +6464,7 @@ fn test_cursor_follows_session_after_deletion() {
 #[serial]
 fn home_defaults_to_agent_when_config_unset() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _storage = Storage::new_unwatched("test").unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -8017,7 +8046,7 @@ fn restart_selected_session_surfaces_resume_failed_after_async_restart() {
     }
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let profile = "restart-resume-failed";
     let storage = Storage::new_unwatched(profile).unwrap();
     let stale_sid = "11111111-2222-3333-4444-555555555555";
@@ -8239,7 +8268,7 @@ fn delete_selected_refused_during_restart() {
 fn create_test_env_two_projects_mixed_attention() -> TestEnv {
     use crate::session::Status;
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     let mut alpha_waiting = Instance::new("alpha-waiting", "/repos/alpha");
@@ -8268,7 +8297,11 @@ fn create_test_env_two_projects_mixed_attention() -> TestEnv {
         crate::file_watch::FileWatchService::noop(),
     )
     .unwrap();
-    TestEnv { _temp: temp, view }
+    TestEnv {
+        view,
+        _guard,
+        _temp: temp,
+    }
 }
 
 /// Project grouping must survive Attention sort. Previously `build_flat_items`
@@ -8641,7 +8674,7 @@ fn stale_registry_entry_with_mismatched_archived_path_stays_pinned_and_unpinnabl
     use crate::session::Status;
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let storage = Storage::new_unwatched("test").unwrap();
 
     // A live session in another project, plus an ARCHIVED session whose repo
@@ -8871,7 +8904,7 @@ fn all_profiles_view_includes_profile_scoped_pins() {
     use crate::session::projects::{self, Project, ProjectScope};
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // Two discoverable profiles, each with a session.
     for (profile, title, path) in [
@@ -8929,7 +8962,7 @@ fn unpin_profile_scoped_pin_from_all_profiles_clears_header() {
     use crate::session::projects::{self, Project, ProjectScope};
 
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
 
     // Two discoverable profiles, each with a session, so all-profiles mode
     // loads both registries.
@@ -9223,7 +9256,7 @@ fn manual_grouping_attention_sort_stays_flat() {
 #[serial]
 fn prune_empty_group_drops_source_when_no_session_remains() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _ = Storage::new_unwatched("alpha").unwrap();
     let _ = Storage::new_unwatched("beta").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -9260,7 +9293,7 @@ fn prune_empty_group_drops_source_when_no_session_remains() {
 #[serial]
 fn prune_empty_group_keeps_source_when_sibling_session_remains() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _ = Storage::new_unwatched("alpha").unwrap();
     let _ = Storage::new_unwatched("beta").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -9296,7 +9329,7 @@ fn prune_empty_group_keeps_source_when_sibling_session_remains() {
 #[serial]
 fn prune_empty_group_keeps_source_when_descendant_session_remains() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _ = Storage::new_unwatched("alpha").unwrap();
     let _ = Storage::new_unwatched("beta").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -9334,7 +9367,7 @@ fn prune_empty_group_keeps_source_when_descendant_session_remains() {
 #[serial]
 fn prune_empty_group_keeps_source_when_descendant_group_remains() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _ = Storage::new_unwatched("alpha").unwrap();
     let _ = Storage::new_unwatched("beta").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -9376,7 +9409,7 @@ fn prune_empty_group_keeps_source_when_descendant_group_remains() {
 #[serial]
 fn prune_empty_group_survives_save_and_reload() {
     let temp = TempDir::new().unwrap();
-    setup_test_home(&temp);
+    let _guard = setup_test_home(&temp);
     let _ = Storage::new_unwatched("alpha").unwrap();
     let _ = Storage::new_unwatched("beta").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -13989,9 +14022,12 @@ mod save_field_merge {
     use super::*;
     use chrono::Utc;
 
-    fn boot_view_with_one_session(title: &str, path: &str) -> (TempDir, HomeView, String) {
+    fn boot_view_with_one_session(
+        title: &str,
+        path: &str,
+    ) -> (TempDir, AppDirGuard, HomeView, String) {
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let guard = setup_test_home(&temp);
         let storage = Storage::new_unwatched("test").unwrap();
         let inst = Instance::new(title, path);
         let id = inst.id.clone();
@@ -14010,13 +14046,13 @@ mod save_field_merge {
             crate::file_watch::FileWatchService::noop(),
         )
         .unwrap();
-        (temp, view, id)
+        (temp, guard, view, id)
     }
 
     #[test]
     #[serial]
     fn test_save_preserves_peer_field_update() {
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         let peer_storage = Storage::new_unwatched("test").unwrap();
         let peer_archived_at = Utc::now();
@@ -14043,7 +14079,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_preserves_peer_added_row() {
-        let (_temp, mut view, _id) = boot_view_with_one_session("a", "/tmp/a");
+        let (_temp, _guard, mut view, _id) = boot_view_with_one_session("a", "/tmp/a");
 
         let peer_storage = Storage::new_unwatched("test").unwrap();
         peer_storage
@@ -14070,7 +14106,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_drops_explicitly_deleted_row() {
-        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/victim");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("victim", "/tmp/victim");
 
         view.remove_instance(&id);
         view.save().expect("save must propagate the delete");
@@ -14085,7 +14121,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_drains_pending_deletions_on_ok() {
-        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/victim");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("victim", "/tmp/victim");
 
         view.remove_instance(&id);
         assert!(
@@ -14106,7 +14142,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_preserves_peer_added_group() {
-        let (_temp, mut view, _id) = boot_view_with_one_session("a", "/tmp/a");
+        let (_temp, _guard, mut view, _id) = boot_view_with_one_session("a", "/tmp/a");
 
         let peer_storage = Storage::new_unwatched("test").unwrap();
         peer_storage
@@ -14133,7 +14169,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_apply_user_action_persists_atomically() {
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         view.apply_user_action(&id, |inst| inst.archive())
             .expect("apply_user_action must persist");
@@ -14149,7 +14185,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_apply_user_action_does_not_clobber_peer_field() {
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         let peer_storage = Storage::new_unwatched("test").unwrap();
         peer_storage
@@ -14177,7 +14213,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_apply_user_action_disk_and_memory_share_one_timestamp() {
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         view.apply_user_action(&id, |inst| inst.archive())
             .expect("apply_user_action must persist");
@@ -14209,7 +14245,7 @@ mod save_field_merge {
         // the TUI then archives, archive wins because it is the
         // indefinite sink; leaving both flags persisted would surface
         // contradictory triage state on the next render.
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         let peer_storage = Storage::new_unwatched("test").unwrap();
         peer_storage
@@ -14241,7 +14277,7 @@ mod save_field_merge {
         // instead of archive so the snoozed_until field IS touched on
         // both sides and the test isolates the peer-field-survival
         // invariant from the archive XOR rules tested above.
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         let peer_storage = Storage::new_unwatched("test").unwrap();
         peer_storage
@@ -14268,7 +14304,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_drops_peer_deleted_row_from_mirror() {
-        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/peer-rm");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("victim", "/tmp/peer-rm");
 
         // Simulate `aoe session remove victim` from another process: peer
         // deletes the row from disk while TUI still has it in memory.
@@ -14301,7 +14337,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_pushes_tui_added_row_to_disk() {
-        let (_temp, mut view, _) = boot_view_with_one_session("seed", "/tmp/seed");
+        let (_temp, _guard, mut view, _) = boot_view_with_one_session("seed", "/tmp/seed");
 
         let mut new_inst = Instance::new("tui-added", "/tmp/added");
         new_inst.source_profile = "test".to_string();
@@ -14324,7 +14360,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_save_add_then_remove_in_same_cycle_does_not_persist() {
-        let (_temp, mut view, _) = boot_view_with_one_session("seed", "/tmp/seed");
+        let (_temp, _guard, mut view, _) = boot_view_with_one_session("seed", "/tmp/seed");
 
         let mut new_inst = Instance::new("ephemeral", "/tmp/ephemeral");
         new_inst.source_profile = "test".to_string();
@@ -14344,7 +14380,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_move_to_profile_marks_tombstone_and_pending_added() {
-        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
         view.storages.insert(
             "target".to_string(),
             Storage::new_unwatched("target").unwrap(),
@@ -14373,7 +14409,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_move_to_profile_save_roundtrip_persists_under_target() {
-        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
         view.storages.insert(
             "target".to_string(),
             Storage::new_unwatched("target").unwrap(),
@@ -14397,7 +14433,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_move_to_profile_same_profile_only_updates_group_path() {
-        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
 
         view.move_to_profile(&id, "test", "newgrp".to_string())
             .unwrap();
@@ -14413,7 +14449,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn test_reload_honors_peer_cleared_session_id() {
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/sid");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/sid");
 
         // Seed a stale sid via the in-memory mirror + persist.
         view.mutate_instance(&id, |inst| {
@@ -14454,7 +14490,7 @@ mod save_field_merge {
     fn stamp_last_accessed_on_archived_row_unsinks_persistently() {
         use crate::session::{is_archived_section_path, Item};
 
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/grp");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/grp");
 
         view.apply_user_action(&id, |inst| inst.archive())
             .expect("seed archive must persist");
@@ -14504,7 +14540,7 @@ mod save_field_merge {
     #[test]
     #[serial]
     fn stamp_last_accessed_on_snoozed_row_persistently_clears_snooze() {
-        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/grp");
+        let (_temp, _guard, mut view, id) = boot_view_with_one_session("session", "/tmp/grp");
 
         view.apply_user_action(&id, |inst| inst.snooze(30))
             .expect("seed snooze must persist");
@@ -15233,7 +15269,7 @@ mod apply_session_id_updates {
             return;
         }
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let _guard = setup_test_home(&temp);
 
         let profile = "apply-publish";
         let inst = fresh_instance(profile, "apa");
@@ -15255,7 +15291,7 @@ mod apply_session_id_updates {
             return;
         }
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let _guard = setup_test_home(&temp);
 
         let profile = "apply-terminal-publish";
         let mut inst = fresh_instance(profile, "terminal-post-cas");
@@ -15280,7 +15316,7 @@ mod apply_session_id_updates {
             return;
         }
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let _guard = setup_test_home(&temp);
 
         let profile = "apply-excludes";
         let inst = fresh_instance(profile, "aer");
@@ -15325,7 +15361,7 @@ mod apply_session_id_updates {
             return;
         }
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let _guard = setup_test_home(&temp);
 
         let profile = "apply-skipped";
         let peer_sid = "019342aa-3333-7eee-8fff-aaaabbbbcccc";
@@ -15379,7 +15415,7 @@ mod apply_session_id_updates {
             return;
         }
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let _guard = setup_test_home(&temp);
 
         let profile = "apply-invalid";
         let inst = fresh_instance(profile, "aiv");
@@ -15413,7 +15449,7 @@ mod apply_session_id_updates {
             return;
         }
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let _guard = setup_test_home(&temp);
 
         let profile = "apply-pane-dead";
         let inst = fresh_instance(profile, "apds");

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1021,23 +1021,22 @@ mod tests {
 
     mod search_overlay {
         use super::*;
+        use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
         use crate::session::Storage;
         use crate::tui::settings::SettingsView;
         use serial_test::serial;
         use tempfile::TempDir;
 
-        fn setup_test_home(temp: &TempDir) {
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        fn setup_test_home(temp: &TempDir) -> AppDirGuard {
+            isolate_app_dir_at(temp.path())
         }
 
-        fn fresh_view() -> (TempDir, SettingsView) {
+        fn fresh_view() -> (TempDir, AppDirGuard, SettingsView) {
             let temp = TempDir::new().unwrap();
-            setup_test_home(&temp);
+            let guard = setup_test_home(&temp);
             let _ = Storage::new_unwatched("test").unwrap();
             let view = SettingsView::new("test", None).unwrap();
-            (temp, view)
+            (temp, guard, view)
         }
 
         fn press(view: &mut SettingsView, code: KeyCode) {
@@ -1055,7 +1054,7 @@ mod tests {
         #[test]
         #[serial]
         fn slash_opens_search_overlay() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             assert!(view.search_input.is_none());
             press(&mut view, KeyCode::Char('/'));
             assert!(view.search_input.is_some(), "/ must enter search mode");
@@ -1074,7 +1073,7 @@ mod tests {
         #[test]
         #[serial]
         fn typing_filters_hits_and_finds_moved_field() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             press(&mut view, KeyCode::Char('/'));
             type_text(&mut view, "live");
             let labels: Vec<String> = view
@@ -1098,7 +1097,7 @@ mod tests {
         #[test]
         #[serial]
         fn enter_jumps_to_hit_category_and_field() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             press(&mut view, KeyCode::Char('/'));
             type_text(&mut view, "default tool");
             assert!(!view.search_hits.is_empty(), "no hits for 'default tool'");
@@ -1137,7 +1136,7 @@ mod tests {
         #[serial]
         fn category_nav_skips_section_dividers() {
             use crate::tui::settings::CategoryRow;
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             // Constructor lands on the first Tab (Theme, the only tab
             // in Appearance). One Down should jump over the next
             // section header ("Sessions") and onto Session.
@@ -1171,7 +1170,7 @@ mod tests {
         #[test]
         #[serial]
         fn esc_closes_search_without_changing_selection() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             let cat_before = view.selected_category;
             let field_before = view.selected_field;
             press(&mut view, KeyCode::Char('/'));
@@ -1185,30 +1184,29 @@ mod tests {
 
     mod mouse_routing {
         use super::*;
+        use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
         use crate::session::Storage;
         use crate::tui::settings::{SettingsScope, SettingsView};
         use ratatui::layout::Rect;
         use serial_test::serial;
         use tempfile::TempDir;
 
-        fn setup_test_home(temp: &TempDir) {
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        fn setup_test_home(temp: &TempDir) -> AppDirGuard {
+            isolate_app_dir_at(temp.path())
         }
 
-        fn fresh_view() -> (TempDir, SettingsView) {
+        fn fresh_view() -> (TempDir, AppDirGuard, SettingsView) {
             let temp = TempDir::new().unwrap();
-            setup_test_home(&temp);
+            let guard = setup_test_home(&temp);
             let _ = Storage::new_unwatched("test").unwrap();
             let view = SettingsView::new("test", None).unwrap();
-            (temp, view)
+            (temp, guard, view)
         }
 
         #[test]
         #[serial]
         fn click_on_scope_tab_switches_scope() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             // Stage a Profile scope rect at known coords.
             view.scope_tab_rects
                 .push((SettingsScope::Profile, Rect::new(40, 0, 18, 1)));
@@ -1220,7 +1218,7 @@ mod tests {
         #[test]
         #[serial]
         fn click_on_scope_tab_with_unsaved_changes_warns() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.has_changes = true;
             view.scope_tab_rects
                 .push((SettingsScope::Profile, Rect::new(40, 0, 18, 1)));
@@ -1239,7 +1237,7 @@ mod tests {
         #[test]
         #[serial]
         fn click_on_category_row_focuses_and_selects() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.focus = crate::tui::settings::SettingsFocus::Fields;
             let original = view.selected_category;
             // Pick a different Tab row to stage a click against.
@@ -1262,7 +1260,7 @@ mod tests {
         #[test]
         #[serial]
         fn click_on_field_focuses_and_selects() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
             view.field_rects.push((1, Rect::new(20, 8, 50, 2)));
             view.selected_field = 0;
@@ -1274,7 +1272,7 @@ mod tests {
         #[test]
         #[serial]
         fn handle_click_returns_none_when_editing() {
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.editing_input = Some(tui_input::Input::new("typing".to_string()));
             view.scope_tab_rects
                 .push((SettingsScope::Profile, Rect::new(40, 0, 18, 1)));
@@ -1291,7 +1289,7 @@ mod tests {
             // otherwise the mouse drifting across the fields panel
             // silently changes which field a subsequent Enter / Space
             // targets. Click still navigates.
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
             view.field_rects.push((1, Rect::new(20, 8, 50, 2)));
             view.focus = crate::tui::settings::SettingsFocus::Categories;
@@ -1309,7 +1307,7 @@ mod tests {
             // it must not touch keyboard selection state. Verify both:
             // mouse_pos is set and resolves to the right field, but
             // selected_field stays put.
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
             view.field_rects.push((1, Rect::new(20, 8, 50, 2)));
             view.selected_field = 0;
@@ -1326,7 +1324,7 @@ mod tests {
             // switched to keyboard would otherwise stay lit on a row
             // the user is no longer interacting with. Any keystroke
             // invalidates it.
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
             view.handle_hover(25, 5);
             assert_eq!(view.hovered_field(), Some(0));
@@ -1344,7 +1342,7 @@ mod tests {
             // surface is keyboard-only; a lingering hover highlight
             // there would mislead the user about what a click does
             // (in fact, click is also gated during edit).
-            let (_t, mut view) = fresh_view();
+            let (_t, _guard, mut view) = fresh_view();
             view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
             view.editing_input = Some(tui_input::Input::new(String::new()));
             view.handle_hover(25, 5);

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -1508,22 +1508,21 @@ mod tests {
 mod field_height_tests {
     use super::super::fields::FieldKind;
     use super::super::{FieldValue, SettingField, SettingsCategory, SettingsView};
+    use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
     use crate::session::Storage;
     use serial_test::serial;
     use tempfile::TempDir;
 
-    fn setup_test_home(temp: &TempDir) {
-        std::env::set_var("HOME", temp.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+    fn setup_test_home(temp: &TempDir) -> AppDirGuard {
+        isolate_app_dir_at(temp.path())
     }
 
-    fn fresh_view() -> (TempDir, SettingsView) {
+    fn fresh_view() -> (TempDir, AppDirGuard, SettingsView) {
         let temp = TempDir::new().unwrap();
-        setup_test_home(&temp);
+        let guard = setup_test_home(&temp);
         let _ = Storage::new_unwatched("test").unwrap();
         let view = SettingsView::new("test", None).unwrap();
-        (temp, view)
+        (temp, guard, view)
     }
 
     /// At a normal panel width, a short description fits on one row, so
@@ -1534,7 +1533,7 @@ mod field_height_tests {
     #[test]
     #[serial]
     fn field_height_grows_with_wrapped_description() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
 
         let field = SettingField {
             kind: FieldKind::HostEnvironment,
@@ -1569,7 +1568,7 @@ mod field_height_tests {
     #[test]
     #[serial]
     fn field_height_section_header_tracks_wrapped_subtitle() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
 
         let header = SettingField {
             kind: FieldKind::SectionMarker,
@@ -1594,6 +1593,7 @@ mod status_message_tests {
     use super::super::fields::FieldKind;
     use super::super::{FieldValue, SettingField, SettingsCategory, SettingsScope, SettingsView};
     use crate::session::settings_schema::{ValidationKind, WidgetKind};
+    use crate::session::test_support::{isolate_app_dir_at, AppDirGuard};
     use crate::session::Storage;
     use crate::tui::styles::load_theme;
     use ratatui::backend::TestBackend;
@@ -1604,14 +1604,12 @@ mod status_message_tests {
     use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
-    fn fresh_view() -> (TempDir, SettingsView) {
+    fn fresh_view() -> (TempDir, AppDirGuard, SettingsView) {
         let temp = TempDir::new().unwrap();
-        std::env::set_var("HOME", temp.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        let guard = isolate_app_dir_at(temp.path());
         let _ = Storage::new_unwatched("test").unwrap();
         let view = SettingsView::new("test", None).unwrap();
-        (temp, view)
+        (temp, guard, view)
     }
 
     fn row_text(buf: &Buffer, y: u16) -> String {
@@ -1648,7 +1646,7 @@ mod status_message_tests {
     #[test]
     #[serial]
     fn clipped_bottom_field_does_not_spill_below_panel() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
         let theme = load_theme("empire");
 
         // FieldA fits fully; FieldB lands at the bottom clipped to ~2 rows even
@@ -1700,7 +1698,7 @@ mod status_message_tests {
     #[test]
     #[serial]
     fn footer_shows_status_below_hints() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
         let theme = load_theme("empire");
         let area = Rect::new(0, 0, 100, 3);
 
@@ -1751,7 +1749,7 @@ mod status_message_tests {
     #[test]
     #[serial]
     fn tick_status_expires_success_but_keeps_error() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
 
         // Expired success toast: cleared, and the tick reports a redraw.
         view.success_message = Some("Settings saved".to_string());
@@ -1785,7 +1783,7 @@ mod status_message_tests {
     #[test]
     #[serial]
     fn save_arms_the_success_toast_timer() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
         // Profile scope avoids the Global telemetry side effect; no fields means
         // validation passes straight through to a real write.
         view.scope = SettingsScope::Profile;
@@ -1806,7 +1804,7 @@ mod status_message_tests {
     #[test]
     #[serial]
     fn save_error_names_the_field() {
-        let (_temp, mut view) = fresh_view();
+        let (_temp, _guard, mut view) = fresh_view();
 
         // A set-but-invalid value (not a cleared one, which now validates as
         // unset) so validation genuinely fails and we can check the prefix.

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
+import { expect } from "@playwright/test";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -182,6 +183,51 @@ export async function listSessions(
   if (Array.isArray(body)) return body;
   if (body && Array.isArray(body.sessions)) return body.sessions;
   throw new Error(`GET /api/sessions returned an unexpected shape: ${JSON.stringify(body).slice(0, 200)}`);
+}
+
+/**
+ * Poll `GET /api/sessions` until the given session's `view` reaches
+ * `expected`. The sessions list is a cache the daemon reconciles on a
+ * 2s tick, so a disk snapshot taken just before an endpoint's write
+ * can briefly clobber the in-memory view before self-correcting; a
+ * bare `expect(sessions.find(...).view === expected)` on the very
+ * next `listSessions()` after a view-mutating endpoint is the flake
+ * shape. The endpoint's own response body remains the authoritative
+ * synchronous check; use this helper for reads that go back through
+ * the sessions list.
+ *
+ * The server omits the `view` field for `Terminal` sessions (serde
+ * `skip_serializing_if`); this helper treats a missing field on a
+ * present session as `"terminal"` so callers pass one of two
+ * symmetric string values. A missing session (unknown or deleted id)
+ * is not coerced: the callback throws, and since `expect.poll`
+ * propagates a thrown callback immediately (only a failed matcher is
+ * retried), this fails fast on a bad or never-created id rather than
+ * false-passing `.toBe("terminal")`.
+ */
+export async function waitForView(
+  baseUrl: string,
+  sessionId: string,
+  expected: "structured" | "terminal",
+  timeout = 10_000,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const sessions = await listSessions(baseUrl);
+        const session = sessions.find((s) => s.id === sessionId);
+        if (session === undefined) {
+          throw new Error(`session ${sessionId} not found in listSessions`);
+        }
+        return session.view ?? "terminal";
+      },
+      {
+        timeout,
+        intervals: [100, 200, 400],
+        message: `session ${sessionId} view should converge to ${expected}`,
+      },
+    )
+    .toBe(expected);
 }
 
 /**

--- a/web/tests/live/acp-disable.spec.ts
+++ b/web/tests/live/acp-disable.spec.ts
@@ -10,7 +10,7 @@
 // `POST /acp/spawn` can re-attach without re-enabling.
 
 import { test, expect } from "@playwright/test";
-import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd, waitForView } from "../helpers/aoeServe";
 
 test("DELETE /acp shuts the worker down with 204 / 404", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
@@ -52,8 +52,7 @@ test("DELETE /acp shuts the worker down with 204 / 404", async ({}, testInfo) =>
     // View state survives the worker teardown: structured_view is
     // still true on the session record. That's the contract that
     // distinguishes shutdown from disable.
-    const after = await listSessions(serve.baseUrl);
-    expect(after.find((s) => s.id === sessionId)!.view === "structured").toBe(true);
+    await waitForView(serve.baseUrl, sessionId, "structured");
 
     // The reconciler may re-spawn the worker for a session whose
     // structured_view is still true, so a second DELETE can land on either

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -63,10 +63,11 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     const resp = await postSeen;
     expect(resp.status()).toBe(200);
     await expect(page.getByText(FIRST_STEP)).toBeHidden();
-    // The POST returns 200 before the server has flushed the flag to
-    // config.toml, so GET /api/settings can briefly still report false.
-    // Poll with the same 10s budget the rest of this spec uses; the default
-    // 5s poll window is too tight under CI load and flakes here.
+    // `mark_web_tour_seen` awaits its `save_config` in `spawn_blocking`
+    // and `GET /api/settings` re-reads config on every call, so the flag
+    // is committed by the time this poll starts. 20s (twice the 10s
+    // budget the rest of this spec uses) covers the `page.evaluate ->
+    // fetch -> daemon -> disk-read` tail under parallel test load.
     await expect
       .poll(
         () =>
@@ -76,7 +77,7 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
             const cfg = await res.json();
             return cfg?.app_state?.has_seen_web_tour === true;
           }),
-        { timeout: 10_000 },
+        { timeout: 20_000 },
       )
       .toBe(true);
 

--- a/web/tests/live/wizard-acp-create-session.spec.ts
+++ b/web/tests/live/wizard-acp-create-session.spec.ts
@@ -4,7 +4,7 @@
 // Setup docs now promise. Closes #1841.
 
 import { test, expect } from "@playwright/test";
-import { listSessions, spawnAoeServe } from "../helpers/aoeServe";
+import { listSessions, spawnAoeServe, waitForView } from "../helpers/aoeServe";
 
 test("wizard with Use structured view on creates a structured_view session", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -47,7 +47,7 @@ test("wizard with Use structured view on creates a structured_view session", asy
 
     const sessions = await listSessions(serve.baseUrl);
     expect(sessions).toHaveLength(1);
-    expect(sessions[0]!.view === "structured").toBe(true);
+    await waitForView(serve.baseUrl, sessions[0]!.id, "structured");
   } finally {
     await serve.stop();
   }


### PR DESCRIPTION
## Description

Root-cause fixes for the flake pattern that made the `Tests` workflow fail
at ~30% on `main` across the last 30 pushes (9/30 failed). Three separable
commits, each independently revertable.

**Commit 1** `test(session): migrate setup_test_home call sites to AppDirGuard RAII`
Every duplicated `setup_test_home` helper used to `std::env::set_var("HOME", ...)`
without a snapshot or restore, so a parallel non-`#[serial]` peer test could
swap HOME between an atomic write's temp-file creation and its rename,
resolving the two paths against different HOMEs and failing the persist
with `ENOENT`. Migrates all six duplicated helpers (~120 call sites across
`src/tui/home/tests.rs`, `src/tui/settings/{render,input}.rs`,
`src/server/api/sessions.rs`, `src/session/storage.rs`) to the `AppDirGuard`
RAII from #2717. Extends `AppDirGuard` to also snapshot `XDG_DATA_HOME`,
adds `isolate_app_dir_at(&Path)` for callers that already own a `TempDir`.
Adds `#[serial]` on top of `#[serial(telemetry_creates)]` for
`add_instance_counts_only_finalized_creates` (keyed serial groups do not
cross-protect). Adds two deterministic regression tests:
`app_dir_guard_survives_concurrent_peer_env_swap` (Barrier-driven peer
HOME swap) and `app_dir_guard_at_preserves_caller_tempdir` (non-ownership
contract of `isolate_app_dir_at`).

**Commit 2** `test(playwright): add waitForView helper for listSessions convergence race`
The sessions list at `GET /api/sessions` is a cache the daemon reconciles
on a 2s tick, so a disk snapshot taken just before an endpoint's write
can briefly clobber the in-memory view before self-correcting. Adds
`waitForView(baseUrl, sessionId, expected, timeout)` in
`web/tests/helpers/aoeServe.ts` using `expect.poll` with intervals
`[100, 200, 400]` and a 10s default, matching the inline polls added
by #2770 for the two view-switch sites so the whole RCA'd set uses
the same shape. Migrates the two sites in
the RCA'd set that #2770 did not touch:
- `web/tests/live/acp-disable.spec.ts` (post-DELETE)
- `web/tests/live/wizard-acp-create-session.spec.ts` (post-create)

The two view-switch sites in `acp-view-switch.spec.ts` (post-enable,
post-disable) landed inline in #2770 with the same shape; left as-is
rather than rewriting a just-merged fix. Other `view === "structured"`
sites in these specs read the mutating endpoint's own response body or
a precondition on the initial state; those are not the flake shape and
are left as-is.

**Commit 3** `test(playwright): give the web-tour poll a 20s budget in tutorial.spec.ts`
The pre-existing 10s budget was bumped from 5s with an in-tree comment
claiming the POST returns before the flag is flushed to disk. That claim
does not match the endpoint: `mark_web_tour_seen` awaits its `save_config`
inside a `spawn_blocking` task, and `GET /api/settings` calls
`Config::load()` on every request, so the write is committed by the time
this poll starts. The remaining flake is the
`page.evaluate -> fetch -> daemon -> disk-read` tail under parallel test
load. Bumps to 20s (twice the 10s budget the rest of the spec uses)
and rewrites the misleading in-tree comment. No product change.

**Commit 4 (dropped).** The original plan had a conditional Commit 4 for
orphan-process cleanup, gated on baseline > 0. The baseline shows ~10
orphans/run in 23/30 runs (mostly `tmux: server` at the `Cargo Test` job
cleanup phase). Those counts are decoupled from the 9/30 test-failure
rate: 77% orphan rate vs 30% failure rate cannot coincide on the same
subset, so orphans are runner-cleanup housekeeping and not the flake
source. Both harnesses (`tests/e2e/harness.rs::TuiTestHarness`'s `Drop`
impl and `web/tests/helpers/aoeServe.ts`'s SIGTERM->SIGKILL escalation)
already have thorough cleanup. Scoped-out per the plan's own fallback
rather than adding a `killpg` catchall that would mask a real leak.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI
- [x] Test-only (root-cause fixes for CI flakiness)

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (in-tree comment at
      `tutorial.spec.ts` rewritten to state the actual persistence
      contract; no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording (N/A: test-only)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/`
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Skipped a test, because:

Note: the migrated Playwright sites are existing user-story assertions
that were racy in shape (bare `listSessions()` read after a mutating
endpoint). The `waitForView` helper is drop-in; no new user story or
`coverage-matrix.json` entry is warranted. Happy to add one on request.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/` (see note below)
- [ ] Skipped a test, because:

Note: no `tests/e2e/` file is modified; the two deterministic regression
tests for Commit 1 live in `src/session/test_support.rs::tests` alongside
the guard they lock (Barrier-driven concurrent-env-swap + caller-tempdir
non-ownership). The Class 1 race is a Rust unit-test-parallelism concern,
not a TUI/CLI user story, so the regressions' natural home is unit-test
scope.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus 4.7) via OpenCode, driven from a
plan generated by prior parallel oracle / explore / librarian review
rounds.

**Any Additional AI Details you'd like to share:** Every claim, file
path, and line number was verified against the repository at HEAD
before editing; RCA-vs-spec cross-validation is why Commit 4 is dropped
and why the Playwright migration scope is narrower than the original
grep count (2 real listSessions-post-mutation sites, coordinating with
the identical inline fix in #2770 for the other 2).

- [x] I am an AI Agent filling out this form (check box if true)

## Verification (local, apple-silicon)

Empirical runs on the branch tip. All green.

| Check | Result |
|---|---|
| `cargo test --lib --no-default-features` (bare-core) | 3761 passed, 0 failed, 2 ignored |
| Bare-core suite stress, 5 sequential full-suite runs | 5/5 green (18 805 test executions, 0 failed) |
| `cargo test --features serve --lib` | 4922 passed, 0 failed |
| `cargo test --features e2e-tests --test e2e` | 116 passed, 0 failed |
| `cd web && npm run test:unit` (Vitest) | 3350 passed, 0 type errors |
| Playwright `acp-disable.spec.ts` stress, 10 iters | 10/10 passed |
| Playwright `wizard-acp-create-session.spec.ts` stress, 10 iters | 10/10 passed |
| Playwright `tutorial.spec.ts` stress, 10 iters | 10/10 passed |
| `cargo fmt --check` + `cargo clippy --features serve -- -D warnings` | clean |
| `cd web && npm run format:check && npm run lint && npx tsc -b` | clean |

The `tmux::session::tests::capture_pane_with_cursor_returns_content_and_cursor`
test that I originally observed failing on this machine early-returns as
passed on subsequent runs when tmux painting timing varies; the failure
is a pre-existing environmental flake on unmodified `main`, not caused
by this PR.

Please merge with **"Rebase and merge"** (not squash) so the three
commits land distinct on `main` for `git bisect` precision.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reworked test home/app-directory setup to use an RAII “app-dir guard” that automatically keeps environment isolation active for the whole test and reliably restores it afterward.
- Expanded isolation to include `XDG_DATA_HOME` (not just `HOME` / `XDG_CONFIG_HOME`) and added support for using caller-provided temporary directories.
- Updated many workspace/session/TUI tests to hold onto the guard for the test lifetime, eliminating timing issues from environment state leaking between tests.
- Added a Playwright helper (`waitForView`) to poll until a session’s view state settles, and applied it to the affected session-view tests.
- Increased the web-tour “seen/persisted” poll timeout from 10 to 20 seconds and updated the related comment.

## Benefits

These changes make the test environment more deterministic and self-cleaning, reducing flaky failures caused by concurrent/asynchronous session updates and accidental cross-test contamination from shared filesystem/environment state.

## Technical details (optional)

- `AppDirGuard` now snapshots/restores `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME`, supports `isolate_app_dir_at(temp_path)` with caller-owned tempdirs, and uses drop-ordering to avoid pointing `HOME` at a deleted directory.
- `waitForView` uses `expect.poll` to wait for `/api/sessions` to reflect the expected `view` state (`structured` vs `terminal`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->