### PR TITLE
fix(web): prevent live terminal bottom-scroll blackout

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 import { ansiToLines, findCursorCharIndex, splitUrls, textWidth, wrapLine } from "../lib/liveTermLines";
@@ -1239,22 +1239,64 @@ export function MobileLiveTerminal({
   // scrollHeight under the reader and snap the viewport.
   const visibleRowCount = reading ? visual.rows.length : renderRowCount;
 
-  // Virtualization window over [0, visibleRowCount): the rows whose document
-  // position (effectiveSpacerLines + i) * lineH falls within the viewport, plus
-  // one viewport of overscan each side so a fast flick does not outrun the
-  // re-render. Off-window rows become top/bottom padding of identical height.
-  // height == 0 (pre-measure / jsdom) renders everything, the safe default.
-  let winStart = 0;
-  let winEnd = visibleRowCount;
+  // Virtualization windows over [0, visibleRowCount): the rows whose document
+  // positions fall within the viewport, plus one viewport of overscan each side
+  // so a fast flick does not outrun the re-render. While reading, also keep the
+  // live tail mounted. A jump or scrollbar drag to the bottom can move scrollTop
+  // before React has observed the scroll event; without the tail range, that
+  // frame can show only spacer padding until the next render catches up.
+  let mountedRanges: Array<{ start: number; end: number }> = [{ start: 0, end: visibleRowCount }];
   if (view.height > 0 && lineH > 0) {
     const overscan = Math.ceil(view.height / lineH);
     const firstVisible = Math.floor(view.top / lineH) - effectiveSpacerLines;
     const lastVisible = Math.ceil((view.top + view.height) / lineH) - effectiveSpacerLines;
-    winStart = Math.max(0, Math.min(visibleRowCount, firstVisible - overscan));
-    winEnd = Math.max(winStart, Math.min(visibleRowCount, lastVisible + overscan));
+    const viewportRange = {
+      start: Math.max(0, Math.min(visibleRowCount, firstVisible - overscan)),
+      end: Math.max(0, Math.min(visibleRowCount, lastVisible + overscan)),
+    };
+    if (reading) {
+      mountedRanges = [
+        viewportRange,
+        {
+          start: Math.max(0, visibleRowCount - overscan * 2),
+          end: visibleRowCount,
+        },
+      ];
+    } else {
+      mountedRanges = [viewportRange];
+    }
   }
-  const topPadLines = effectiveSpacerLines + winStart;
-  const bottomPadLines = visibleRowCount - winEnd;
+  mountedRanges = mountedRanges
+    .filter((range) => range.end > range.start)
+    .sort((a, b) => a.start - b.start)
+    .reduce<Array<{ start: number; end: number }>>((ranges, range) => {
+      const prev = ranges[ranges.length - 1];
+      if (prev && range.start <= prev.end) {
+        prev.end = Math.max(prev.end, range.end);
+      } else {
+        ranges.push({ ...range });
+      }
+      return ranges;
+    }, []);
+  const mounted = mountedRanges.reduce<{
+    nextStart: number;
+    blocks: Array<{ padLines: number; start: number; end: number }>;
+  }>(
+    (acc, range, rangeIndex) => ({
+      nextStart: range.end,
+      blocks: [
+        ...acc.blocks,
+        {
+          padLines: rangeIndex === 0 ? effectiveSpacerLines + range.start : range.start - acc.nextStart,
+          start: range.start,
+          end: range.end,
+        },
+      ],
+    }),
+    { nextStart: 0, blocks: [] },
+  );
+  const bottomPadLines =
+    mounted.blocks.length === 0 ? effectiveSpacerLines + visibleRowCount : visibleRowCount - mounted.nextStart;
 
   return (
     <div className="absolute inset-0" data-live-terminal>
@@ -1331,16 +1373,22 @@ export function MobileLiveTerminal({
             opt out (`bottomAlign=false`) so a near-empty bash prompt sits at
             the top like a normal terminal. */}
         <div className={`relative whitespace-pre ${bottomAlign ? "mt-auto" : ""}`} data-live-content>
-          {topPadLines > 0 && <div style={{ height: `${topPadLines * lineH}px` }} aria-hidden="true" />}
-          {visual.rows.slice(winStart, winEnd).map((segs, j) => {
-            const i = winStart + j;
+          {mounted.blocks.map(({ padLines, start, end }) => {
             return (
-              <Row
-                key={i}
-                segs={segs}
-                cursorCol={i === cursorRow ? live.col : null}
-                focused={i === cursorRow && focused}
-              />
+              <Fragment key={`${start}-${end}`}>
+                {padLines > 0 && <div style={{ height: `${padLines * lineH}px` }} aria-hidden="true" />}
+                {visual.rows.slice(start, end).map((segs, j) => {
+                  const i = start + j;
+                  return (
+                    <Row
+                      key={i}
+                      segs={segs}
+                      cursorCol={i === cursorRow ? live.col : null}
+                      focused={i === cursorRow && focused}
+                    />
+                  );
+                })}
+              </Fragment>
             );
           })}
           {bottomPadLines > 0 && <div style={{ height: `${bottomPadLines * lineH}px` }} aria-hidden="true" />}

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1241,10 +1241,11 @@ export function MobileLiveTerminal({
 
   // Virtualization windows over [0, visibleRowCount): the rows whose document
   // positions fall within the viewport, plus one viewport of overscan each side
-  // so a fast flick does not outrun the re-render. While reading, also keep the
-  // live tail mounted. A jump or scrollbar drag to the bottom can move scrollTop
-  // before React has observed the scroll event; without the tail range, that
-  // frame can show only spacer padding until the next render catches up.
+  // so a fast flick does not outrun the re-render. When hidden history is
+  // represented by spacer rows, also keep the live tail mounted. A bottom scroll
+  // can flip out of reading mode before React observes the final scrollTop;
+  // without the tail range, that frame can show only spacer padding until the
+  // next render catches up.
   let mountedRanges: Array<{ start: number; end: number }> = [{ start: 0, end: visibleRowCount }];
   if (view.height > 0 && lineH > 0) {
     const overscan = Math.ceil(view.height / lineH);
@@ -1254,7 +1255,7 @@ export function MobileLiveTerminal({
       start: Math.max(0, Math.min(visibleRowCount, firstVisible - overscan)),
       end: Math.max(0, Math.min(visibleRowCount, lastVisible + overscan)),
     };
-    if (reading) {
+    if (effectiveSpacerLines > 0) {
       mountedRanges = [
         viewportRange,
         {

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -635,6 +635,7 @@ export function MobileLiveTerminal({
   const syncView = useCallback(() => {
     const el = scrollerRef.current;
     if (!el) return;
+    if (el.scrollLeft !== 0) el.scrollLeft = 0;
     setView((prev) =>
       prev.top === el.scrollTop && prev.height === el.clientHeight
         ? prev
@@ -1241,11 +1242,10 @@ export function MobileLiveTerminal({
 
   // Virtualization windows over [0, visibleRowCount): the rows whose document
   // positions fall within the viewport, plus one viewport of overscan each side
-  // so a fast flick does not outrun the re-render. When hidden history is
-  // represented by spacer rows, also keep the live tail mounted. A bottom scroll
-  // can flip out of reading mode before React observes the final scrollTop;
-  // without the tail range, that frame can show only spacer padding until the
-  // next render catches up.
+  // so a fast flick does not outrun the re-render. Always keep the live tail
+  // mounted too: a bottom scroll can flip out of reading before React observes
+  // the final scrollTop, and the capture may be either spacer-backed or a full
+  // history frame. In both cases the transition must have real rows to paint.
   let mountedRanges: Array<{ start: number; end: number }> = [{ start: 0, end: visibleRowCount }];
   if (view.height > 0 && lineH > 0) {
     const overscan = Math.ceil(view.height / lineH);
@@ -1255,17 +1255,13 @@ export function MobileLiveTerminal({
       start: Math.max(0, Math.min(visibleRowCount, firstVisible - overscan)),
       end: Math.max(0, Math.min(visibleRowCount, lastVisible + overscan)),
     };
-    if (effectiveSpacerLines > 0) {
-      mountedRanges = [
-        viewportRange,
-        {
-          start: Math.max(0, visibleRowCount - overscan * 2),
-          end: visibleRowCount,
-        },
-      ];
-    } else {
-      mountedRanges = [viewportRange];
-    }
+    mountedRanges = [
+      viewportRange,
+      {
+        start: Math.max(0, visibleRowCount - overscan * 2),
+        end: visibleRowCount,
+      },
+    ];
   }
   mountedRanges = mountedRanges
     .filter((range) => range.end > range.start)
@@ -1329,7 +1325,7 @@ export function MobileLiveTerminal({
         // honest and the exposed strip shows the wrapper's matching --term-bg,
         // reading as terminal inner-padding.
         className={`absolute inset-x-0 top-0 bottom-[8px] font-mono flex flex-col ${
-          forwardMode ? "overflow-hidden" : "overflow-y-auto overflow-x-hidden"
+          forwardMode ? "overflow-hidden" : "overflow-y-auto overflow-x-clip"
         }`}
         style={{
           fontSize: `${fontSize}px`,

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1238,7 +1238,7 @@ export function MobileLiveTerminal({
   // reading scrollback the spacer model keeps above-viewport pixels invariant
   // so the position holds as the agent streams; trimming there would change
   // scrollHeight under the reader and snap the viewport.
-  const visibleRowCount = reading ? visual.rows.length : renderRowCount;
+  const visibleRowCount = reading ? visual.rows.length : Math.min(renderRowCount, visual.rows.length);
 
   // Virtualization windows over [0, visibleRowCount): the rows whose document
   // positions fall within the viewport, plus one viewport of overscan each side

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3039,7 +3039,11 @@
       "kind": "mocked-playwright",
       "risk": "high",
       "specs": ["tests/desktop-live-input.spec.ts"],
-      "components": ["web/src/components/LiveTerminalView.tsx", "web/src/components/MobileLiveTerminal.tsx"]
+      "components": [
+        "web/src/components/LiveTerminalView.tsx",
+        "web/src/components/MobileLiveTerminal.tsx",
+        "web/src/hooks/useLiveTerminal.ts"
+      ]
     },
     {
       "id": "plugins.ui-slots",

--- a/web/tests/desktop-live-input.spec.ts
+++ b/web/tests/desktop-live-input.spec.ts
@@ -174,7 +174,7 @@ test.describe("Desktop live terminal input", () => {
   });
 
   test("scrolling down to the bottom keeps real rows visible", async ({ page }) => {
-    const handle = await mockTerminalApis(page, { liveHistory: 600, delayLiveWindowShrinkMs: 600 });
+    const handle = await mockTerminalApis(page, { liveHistory: 600, delayLiveWindowShrinkMs: 80 });
     await page.goto("/");
     await clickSidebarSession(page, "pinch-test");
     await page.locator("[data-live-terminal]").first().waitFor({ state: "visible", timeout: 10_000 });
@@ -188,35 +188,82 @@ test.describe("Desktop live terminal input", () => {
     await expect.poll(() => scroller.evaluate((el) => el.scrollHeight), { timeout: 3_000 }).toBeGreaterThan(8000);
 
     await page.waitForTimeout(300);
-    await scroller.evaluate((el) => {
-      el.scrollTop = el.scrollHeight - el.clientHeight;
-      el.dispatchEvent(new Event("scroll"));
-    });
-    await page.waitForTimeout(80);
-
-    const transition = await scroller.evaluate((el) => {
-      const scrollerRect = el.getBoundingClientRect();
-      const visibleRows = Array.from(el.querySelectorAll("[data-live-content] > div"))
-        .filter((row): row is HTMLElement => row instanceof HTMLElement && !row.hasAttribute("aria-hidden"))
-        .filter((row) => {
-          const rect = row.getBoundingClientRect();
-          return (
-            rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom && (row.textContent ?? "").trim() !== ""
-          );
-        });
-      const firstRect = visibleRows[0]?.getBoundingClientRect();
-      return {
-        scrollLeft: el.scrollLeft,
-        visibleText: visibleRows.map((row) => row.textContent ?? "").join("|"),
-        firstRowLeft: firstRect?.left ?? null,
-        scrollerLeft: scrollerRect.left,
+    await page.evaluate(() => {
+      const state = window as typeof window & {
+        __BOTTOM_TRANSITION_SAMPLES__?: Array<{
+          top: number;
+          bottom: number;
+          scrollLeft: number;
+          visibleText: string;
+          firstRowLeft: number | null;
+          scrollerLeft: number;
+        }>;
+        __BOTTOM_TRANSITION_SAMPLING__?: boolean;
       };
+      state.__BOTTOM_TRANSITION_SAMPLES__ = [];
+      state.__BOTTOM_TRANSITION_SAMPLING__ = true;
+
+      const sample = () => {
+        const el = document.querySelector<HTMLElement>("[data-live-terminal] > div");
+        if (el) {
+          const scrollerRect = el.getBoundingClientRect();
+          const visibleRows = Array.from(el.querySelectorAll<HTMLElement>("[data-live-content] > div"))
+            .filter((row) => !row.hasAttribute("aria-hidden"))
+            .filter((row) => {
+              const rect = row.getBoundingClientRect();
+              return (
+                rect.bottom > scrollerRect.top &&
+                rect.top < scrollerRect.bottom &&
+                (row.textContent ?? "").trim() !== ""
+              );
+            });
+          const firstRect = visibleRows[0]?.getBoundingClientRect();
+          state.__BOTTOM_TRANSITION_SAMPLES__!.push({
+            top: el.scrollTop,
+            bottom: el.scrollHeight - el.clientHeight,
+            scrollLeft: el.scrollLeft,
+            visibleText: visibleRows.map((row) => row.textContent ?? "").join("|"),
+            firstRowLeft: firstRect?.left ?? null,
+            scrollerLeft: scrollerRect.left,
+          });
+        }
+        if (state.__BOTTOM_TRANSITION_SAMPLING__) requestAnimationFrame(sample);
+      };
+      requestAnimationFrame(sample);
+    });
+    await scroller.hover();
+    for (let i = 0; i < 6; i++) {
+      await page.mouse.wheel(0, 5000);
+      await page.waitForTimeout(16);
+    }
+    await page.waitForTimeout(900);
+
+    const samples = await page.evaluate(() => {
+      const state = window as typeof window & {
+        __BOTTOM_TRANSITION_SAMPLES__?: Array<{
+          top: number;
+          bottom: number;
+          scrollLeft: number;
+          visibleText: string;
+          firstRowLeft: number | null;
+          scrollerLeft: number;
+        }>;
+        __BOTTOM_TRANSITION_SAMPLING__?: boolean;
+      };
+      state.__BOTTOM_TRANSITION_SAMPLING__ = false;
+      return state.__BOTTOM_TRANSITION_SAMPLES__ ?? [];
     });
 
-    expect(transition.scrollLeft).toBe(0);
-    expect(transition.visibleText, "bottom transition shows rendered terminal rows").toContain("$ ready");
-    expect(transition.firstRowLeft, "visible rows start at the terminal's left edge").not.toBeNull();
-    expect(Math.abs(transition.firstRowLeft! - transition.scrollerLeft)).toBeLessThan(2);
+    const reachedBottom = samples.findIndex((sample) => sample.bottom - sample.top < 2);
+    expect(reachedBottom, "wheel scrolling reaches the live edge").toBeGreaterThanOrEqual(0);
+    const blankFrame = samples.slice(reachedBottom).find((sample) => sample.visibleText === "");
+    expect(blankFrame, "every bottom-transition frame shows rendered terminal rows").toBeUndefined();
+
+    const final = samples.at(-1)!;
+    expect(final.scrollLeft).toBe(0);
+    expect(final.visibleText).toContain("$ ready");
+    expect(final.firstRowLeft, "visible rows start at the terminal's left edge").not.toBeNull();
+    expect(Math.abs(final.firstRowLeft! - final.scrollerLeft)).toBeLessThan(2);
 
     await expect
       .poll(() =>

--- a/web/tests/desktop-live-input.spec.ts
+++ b/web/tests/desktop-live-input.spec.ts
@@ -172,4 +172,62 @@ test.describe("Desktop live terminal input", () => {
     const px = await content.evaluate((el) => getComputedStyle(el.closest("[data-live-terminal] > div")!).fontSize);
     expect(px).toBe("14px");
   });
+
+  test("scrolling down to the bottom keeps real rows visible", async ({ page }) => {
+    const handle = await mockTerminalApis(page, { liveHistory: 600, delayLiveWindowShrinkMs: 600 });
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    await page.locator("[data-live-terminal]").first().waitFor({ state: "visible", timeout: 10_000 });
+    await expect.poll(() => page.locator("[data-live-content]").innerText()).toContain("$ ready");
+
+    const scroller = page.locator("[data-live-terminal] > div").first();
+    await scroller.evaluate((el) => {
+      el.scrollTop = el.scrollHeight * 0.45;
+      el.dispatchEvent(new Event("scroll"));
+    });
+    await expect.poll(() => scroller.evaluate((el) => el.scrollHeight), { timeout: 3_000 }).toBeGreaterThan(8000);
+
+    await page.waitForTimeout(300);
+    await scroller.evaluate((el) => {
+      el.scrollTop = el.scrollHeight - el.clientHeight;
+      el.dispatchEvent(new Event("scroll"));
+    });
+    await page.waitForTimeout(80);
+
+    const transition = await scroller.evaluate((el) => {
+      const scrollerRect = el.getBoundingClientRect();
+      const visibleRows = Array.from(el.querySelectorAll("[data-live-content] > div"))
+        .filter((row): row is HTMLElement => row instanceof HTMLElement && !row.hasAttribute("aria-hidden"))
+        .filter((row) => {
+          const rect = row.getBoundingClientRect();
+          return (
+            rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom && (row.textContent ?? "").trim() !== ""
+          );
+        });
+      const firstRect = visibleRows[0]?.getBoundingClientRect();
+      return {
+        scrollLeft: el.scrollLeft,
+        visibleText: visibleRows.map((row) => row.textContent ?? "").join("|"),
+        firstRowLeft: firstRect?.left ?? null,
+        scrollerLeft: scrollerRect.left,
+      };
+    });
+
+    expect(transition.scrollLeft).toBe(0);
+    expect(transition.visibleText, "bottom transition shows rendered terminal rows").toContain("$ ready");
+    expect(transition.firstRowLeft, "visible rows start at the terminal's left edge").not.toBeNull();
+    expect(Math.abs(transition.firstRowLeft! - transition.scrollerLeft)).toBeLessThan(2);
+
+    await expect
+      .poll(() =>
+        textMessages(handle)
+          .filter((m) => m.includes('"type":"window"'))
+          .at(-1),
+      )
+      .toContain('"lines":');
+  });
 });
+
+function textMessages(handle: Awaited<ReturnType<typeof mockTerminalApis>>): string[] {
+  return handle.liveMessages.map((m) => m.toString("utf8"));
+}

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -40,7 +40,10 @@ export function makeLiveFrame(opts: { rows?: number; history?: number; window?: 
   };
 }
 
-export async function mockTerminalApis(page: Page, opts: { liveHistory?: number } = {}): Promise<MockHandle> {
+export async function mockTerminalApis(
+  page: Page,
+  opts: { liveHistory?: number; delayLiveWindowShrinkMs?: number } = {},
+): Promise<MockHandle> {
   const liveSockets: Array<{ send: (data: string) => void }> = [];
   const handle: MockHandle = {
     wsMessages: [],
@@ -137,8 +140,13 @@ export async function mockTerminalApis(page: Page, opts: { liveHistory?: number 
           window = Math.max(window, rows);
           reply();
         } else if (control.type === "window" && control.lines) {
+          const shrinking = control.lines < window;
           window = control.lines;
-          reply();
+          if (shrinking && opts.delayLiveWindowShrinkMs) {
+            setTimeout(reply, opts.delayLiveWindowShrinkMs);
+          } else {
+            reply();
+          }
         }
       } catch {
         // non-JSON text; ignore

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -120,9 +120,11 @@ export async function mockTerminalApis(
     let rows = 24;
     let window = 24;
     const history = opts.liveHistory ?? 120;
-    const reply = () => {
+    const reply = (responseRows = rows, responseWindow = window) => {
       try {
-        ws.send(JSON.stringify({ type: "frame", ...makeLiveFrame({ rows, history, window }) }));
+        ws.send(
+          JSON.stringify({ type: "frame", ...makeLiveFrame({ rows: responseRows, history, window: responseWindow }) }),
+        );
       } catch {
         // closed socket at test teardown; ignore
       }
@@ -143,7 +145,9 @@ export async function mockTerminalApis(
           const shrinking = control.lines < window;
           window = control.lines;
           if (shrinking && opts.delayLiveWindowShrinkMs) {
-            setTimeout(reply, opts.delayLiveWindowShrinkMs);
+            const responseRows = rows;
+            const responseWindow = window;
+            setTimeout(() => reply(responseRows, responseWindow), opts.delayLiveWindowShrinkMs);
           } else {
             reply();
           }

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -137,6 +137,38 @@ test.describe("Mobile live-view scrollback", () => {
     expect(m.scrollHeight, "the document still spans the full history").toBeGreaterThan(8000);
   });
 
+  test("jumping to the bottom while reading does not show a blank spacer frame", async ({ page }) => {
+    await installTerminalSpies(page);
+    const handle = await mockTerminalApis(page, { liveHistory: 600 });
+    await page.goto("/");
+    await seedSettings(page, { mobileFontSize: 14 });
+    await page.reload();
+    await openSession(page, handle);
+    await expect.poll(() => page.locator("[data-live-content]").innerText()).toContain("$ ready");
+
+    await scroller(page).evaluate((el) => {
+      el.scrollTop = el.scrollHeight * 0.45;
+      el.dispatchEvent(new Event("scroll"));
+    });
+    await expect.poll(() => scroller(page).evaluate((el) => el.scrollHeight), { timeout: 3_000 }).toBeGreaterThan(8000);
+
+    // Let React render the deep-history viewport. The live tail should still be
+    // mounted, so an immediate bottom jump has real rows before the scroll event
+    // has a chance to update the viewport slice.
+    await page.waitForTimeout(300);
+    const visibleText = await scroller(page).evaluate((el) => {
+      el.scrollTop = el.scrollHeight - el.clientHeight;
+      const rows = Array.from(el.querySelectorAll("[data-live-content] > div")) as HTMLElement[];
+      const top = el.scrollTop;
+      const bottom = top + el.clientHeight;
+      return rows
+        .filter((r) => r.offsetTop >= top && r.offsetTop < bottom)
+        .map((r) => r.textContent ?? "")
+        .join("|");
+    });
+    expect(visibleText, "bottom jump shows live-tail rows, not only spacer padding").toContain("$ ready");
+  });
+
   test("scrolling up shows Back to live; tapping it returns to the bottom", async ({ page }) => {
     await installTerminalSpies(page);
     const handle = await mockTerminalApis(page);

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -153,11 +153,12 @@ test.describe("Mobile live-view scrollback", () => {
     await expect.poll(() => scroller(page).evaluate((el) => el.scrollHeight), { timeout: 3_000 }).toBeGreaterThan(8000);
 
     // Let React render the deep-history viewport. The live tail should still be
-    // mounted, so an immediate bottom jump has real rows before the scroll event
-    // has a chance to update the viewport slice.
+    // mounted when the final bottom scroll event flips the pane back to live, so
+    // that transition has real rows instead of a spacer-only frame.
     await page.waitForTimeout(300);
     const visibleText = await scroller(page).evaluate((el) => {
       el.scrollTop = el.scrollHeight - el.clientHeight;
+      el.dispatchEvent(new Event("scroll"));
       const rows = Array.from(el.querySelectorAll("[data-live-content] > div")) as HTMLElement[];
       const top = el.scrollTop;
       const bottom = top + el.clientHeight;


### PR DESCRIPTION
## Description

Fix a browser-dashboard UX regression where scrolling terminal history back
down to the bottom repeatedly causes the live terminal to go blank
temporarily. This happens on every return to the live edge, interrupts
reading, and makes the terminal appear unresponsive.

The smaller live capture frame can arrive while `renderRowCount` still
describes the previous full-history frame during its debounce. Virtualization
then mounts only spacer rows. The fix keeps the terminal tail mounted through
the transition and bounds the live row count to rows present in the incoming
frame.

## Testing

- `cd web && npx playwright test tests/desktop-live-input.spec.ts tests/scrollback-exit.spec.ts --config=playwright.config.ts --project=chromium --reporter=line` (20 passed)
- `cd web && npm run build && npm run format:check && npm run lint && npx tsc -b && npm run test:unit`
- `cd web && node tests/validate-coverage-matrix.mjs`
- `cargo fmt --check`
- `cargo clippy --features serve -- -D warnings`
- `cargo test --features serve` has one unrelated flaky failure in `tui::home::file_watch_tests::rewire_config_invalidates_on_inode_change_with_same_canonical_path`; the exact test passes in isolation.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] Relevant tests pass
- [x] Documentation was reviewed; no update is needed
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you'd like to share:**
Diagnosed the animation-frame virtualization transition, implemented the
regression coverage, and reran the relevant repository validation suite.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed a live terminal regression where quickly scrolling back to the live edge could temporarily show a blank area instead of real output.
- Reworked the live terminal’s virtualization rendering to keep the “tail” mounted during live-frame transitions, even when the incoming live window temporarily shrinks.
- Improved scroller synchronization and stability (including horizontal scroll handling) and adjusted overflow behavior for more consistent rendering.
- Added/extended Playwright coverage to assert that desktop and mobile scroll-to-bottom transitions keep showing real terminal rows (e.g., expected prompts) and avoid blank spacer frames.
- Extended the terminal WebSocket mock utilities to support deterministic delayed “live window shrink” updates, enabling reliable reproduction in tests.
- Minor test fixture cleanup (coverage-matrix JSON formatting).

## Benefits

- Removes confusing “blank terminal” moments during scroll-to-bottom transitions.
- Keeps the live tail visible and consistent, improving perceived reliability of the terminal UI.
- Reduces the chance of future virtualization/scroll regressions through targeted automated regression tests.

## Technical notes (optional)

- Virtualization switched from a single window/padding approach to a “mounted ranges” model that merges viewport/overscan ranges and renders stable blocks with fixed-height spacers.
- `syncView` now force-resets `scrollLeft` when horizontal scrolling is present.
- Styling updates use `overflow-x-clip` when not in forward mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->