### PR TITLE
feat(tui): auto-enter live-send on view switch, support Tool view

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -36,7 +36,9 @@ when the default attach mode is Tmux.
 Live-send only forwards keyboard input, not mouse events, so
 mouse-driven tool UIs like lazygit and yazi lose mouse interaction
 while you're live-sent to them; use their keyboard bindings instead, or
-exit live mode to click within a full tmux attach.
+exit live mode (`Ctrl+Q`) and then attach normally (`Enter`, depending
+on your Default Attach Mode) to get a full tmux attach with mouse
+support.
 
 ## The leader menu
 

--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -27,11 +27,10 @@ Live-send also works for the Terminal view and Tool views (lazygit,
 yazi, and other embedded tools), not just the agent pane: whichever
 pane is on screen is what your keystrokes reach.
 
-With **Default Attach Mode** set to Live mode, turning on **Auto
-Live-Send On View Switch** (Interaction settings, off by default) skips
-the extra `Enter`/`Tab`/click when you switch into Terminal or Tool
-view: live-send starts as soon as the view switches. It has no effect
-when the default attach mode is Tmux.
+Turning on **Auto Live-Send On View Switch** (Interaction settings, off
+by default) skips the extra `Enter`/`Tab`/click when you switch into
+Terminal or Tool view: live-send starts as soon as the view switches,
+regardless of **Default Attach Mode**.
 
 Live-send only forwards keyboard input, not mouse events, so
 mouse-driven tool UIs like lazygit and yazi lose mouse interaction

--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -23,6 +23,21 @@ you work.
 The status bar shows a `● LIVE → <session>` banner while you are
 relayed, including a reminder of the exit chord and the leader menu.
 
+Live-send also works for the Terminal view and Tool views (lazygit,
+yazi, and other embedded tools), not just the agent pane: whichever
+pane is on screen is what your keystrokes reach.
+
+With **Default Attach Mode** set to Live mode, turning on **Auto
+Live-Send On View Switch** (Interaction settings, off by default) skips
+the extra `Enter`/`Tab`/click when you switch into Terminal or Tool
+view: live-send starts as soon as the view switches. It has no effect
+when the default attach mode is Tmux.
+
+Live-send only forwards keyboard input, not mouse events, so
+mouse-driven tool UIs like lazygit and yazi lose mouse interaction
+while you're live-sent to them; use their keyboard bindings instead, or
+exit live mode to click within a full tmux attach.
+
 ## The leader menu
 
 Almost every key you press in live mode goes to the agent, so AoE

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1209,6 +1209,16 @@ pub struct SessionConfig {
     )]
     pub default_attach_mode: NewSessionAttachMode,
 
+    /// When Default Attach Mode is Live mode, automatically start live-send when switching into
+    /// Terminal or Tool view, instead of requiring a separate Enter/Tab/click.
+    #[serde(default)]
+    #[setting(
+        label = "Auto Live-Send On View Switch",
+        widget = "toggle",
+        category = "Interaction"
+    )]
+    pub live_send_on_view_switch: bool,
+
     /// What a single mouse click on a session row does in the Agent view. Live
     /// mode (default) enters live-send for the clicked row, the historical
     /// behavior. Select only just moves the cursor so you can read the preview
@@ -1424,6 +1434,7 @@ impl Default for SessionConfig {
             live_send_leader: default_live_send_leader(),
             new_session_attach_mode: NewSessionAttachMode::default(),
             default_attach_mode: NewSessionAttachMode::default(),
+            live_send_on_view_switch: false,
             click_action: ClickAction::default(),
             confirm_before_quit: true,
             unread_indicator: true,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1209,8 +1209,8 @@ pub struct SessionConfig {
     )]
     pub default_attach_mode: NewSessionAttachMode,
 
-    /// When Default Attach Mode is Live mode, automatically start live-send when switching into
-    /// Terminal or Tool view, instead of requiring a separate Enter/Tab/click.
+    /// Automatically start live-send when switching into Terminal or Tool
+    /// view, instead of requiring a separate Enter/Tab/click.
     #[serde(default)]
     #[setting(
         label = "Auto Live-Send On View Switch",

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1279,6 +1279,7 @@ impl HomeView {
                     self.view_mode = ViewMode::Tool(tool_name);
                     self.preview_scroll_offset = 0;
                     self.tool_preview_cache = super::PreviewCache::default();
+                    self.pending_dialog_click_action = self.maybe_auto_start_live_send();
                 }
             }
             return true;
@@ -1757,7 +1758,7 @@ impl HomeView {
                     self.view_mode = ViewMode::Tool(tool_name);
                     self.preview_scroll_offset = 0;
                     self.tool_preview_cache = super::PreviewCache::default();
-                    return None;
+                    return self.maybe_auto_start_live_send();
                 }
             }
         }
@@ -2344,12 +2345,12 @@ impl HomeView {
         if let Some(tool_name) = self.match_tool_hotkey(&key) {
             if matches!(&self.view_mode, ViewMode::Tool(current) if current == &tool_name) {
                 self.view_mode = ViewMode::Structured;
-            } else {
-                self.view_mode = ViewMode::Tool(tool_name);
-                self.preview_scroll_offset = 0;
-                self.tool_preview_cache = super::PreviewCache::default();
+                return None;
             }
-            return None;
+            self.view_mode = ViewMode::Tool(tool_name);
+            self.preview_scroll_offset = 0;
+            self.tool_preview_cache = super::PreviewCache::default();
+            return self.maybe_auto_start_live_send();
         }
 
         // Context-dependent Esc handling (not a relocatable action).
@@ -2540,6 +2541,11 @@ impl HomeView {
                     ViewMode::Structured => ViewMode::Terminal,
                     ViewMode::Terminal | ViewMode::Tool(_) => ViewMode::Structured,
                 };
+                if matches!(self.view_mode, ViewMode::Terminal) {
+                    if let Some(action) = self.maybe_auto_start_live_send() {
+                        return Some(action);
+                    }
+                }
             }
             ActionId::SendMessage => self.open_send_message_dialog(),
             ActionId::Stop => self.stop_selected(),
@@ -3236,7 +3242,7 @@ impl HomeView {
                 self.view_mode = ViewMode::Tool(tool_name);
                 self.preview_scroll_offset = 0;
                 self.tool_preview_cache = super::PreviewCache::default();
-                None
+                self.maybe_auto_start_live_send()
             }
             PaletteAction::Cheat(message) => Some(Action::SetTransientStatus(message)),
         }
@@ -5058,7 +5064,7 @@ impl HomeView {
         // throw voice text on the floor; losing dictation is worse than
         // silently catching it.
         if let Some((id, title, target)) = self.resolve_send_target() {
-            let label = live_send::format_target_label(&title, target);
+            let label = live_send::format_target_label(&title, target.clone());
             self.pending_send_session = Some(id);
             self.pending_send_target = target;
             let mut dialog = SendMessageDialog::new(&label);
@@ -5154,9 +5160,8 @@ impl HomeView {
         // currently previewing. Structured view → agent pane (historical
         // default). Terminal view → the paired host or container
         // terminal pane, so 'm'/Tab compose against the same shell
-        // the user sees. Tool view stays out of live-send (no clean
-        // target for lazygit/yazi etc.; let the caller fall back to
-        // AttachToolSession).
+        // the user sees. Tool view → the named tool's paired pane, so
+        // live-send can drive lazygit/yazi/etc. the same way.
         self.pending_live_send_target = match &self.view_mode {
             ViewMode::Structured => live_send::LiveSendTarget::Agent,
             ViewMode::Terminal => {
@@ -5166,9 +5171,31 @@ impl HomeView {
                     live_send::LiveSendTarget::Terminal
                 }
             }
-            ViewMode::Tool(_) => return None,
+            ViewMode::Tool(name) => live_send::LiveSendTarget::Tool(name.clone()),
         };
         Some(Action::EnterLiveSend(id))
+    }
+
+    /// Auto-start live-send after an explicit view switch (`ToggleView`,
+    /// opening a tool session) when the `Auto Live-Send On View Switch`
+    /// setting is on for the selected session's resolved config and its
+    /// `default_attach_mode` is `LiveSend`. `None` when there's no
+    /// selected session, the setting is off, or the resolved attach mode
+    /// isn't live-send; the caller then leaves the plain view switch alone.
+    /// Deliberately not wired into list navigation/selection: this only
+    /// fires from the explicit view-switch call sites that invoke it.
+    pub(super) fn maybe_auto_start_live_send(&mut self) -> Option<Action> {
+        let id = self.selected_session.clone()?;
+        if !self.live_send_on_view_switch(&id) {
+            return None;
+        }
+        if !matches!(
+            self.default_attach_mode(&id),
+            Some(crate::session::NewSessionAttachMode::LiveSend)
+        ) {
+            return None;
+        }
+        self.start_live_send()
     }
 
     /// Translate one key event in live-send mode and hand the result to
@@ -5371,7 +5398,7 @@ impl HomeView {
         let Some(inst) = self.get_instance(&state.session_id) else {
             return Some("Session was deleted while live mode was active.");
         };
-        let current_name = match state.target {
+        let current_name = match &state.target {
             live_send::LiveSendTarget::Agent => {
                 crate::tmux::Session::generate_name(&inst.id, &inst.title)
             }
@@ -5380,6 +5407,9 @@ impl HomeView {
             }
             live_send::LiveSendTarget::ContainerTerminal => {
                 crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::Tool(_) => {
+                crate::tmux::Session::generate_name(&inst.id, &inst.title)
             }
         };
         if current_name != state.tmux_name {
@@ -5403,7 +5433,7 @@ impl HomeView {
         let Some((id, title, target)) = self.resolve_send_target() else {
             return;
         };
-        let label = live_send::format_target_label(&title, target);
+        let label = live_send::format_target_label(&title, target.clone());
         self.pending_send_session = Some(id);
         self.pending_send_target = target;
         let mut dialog = SendMessageDialog::new(&label);
@@ -5451,13 +5481,14 @@ impl HomeView {
             return None;
         }
         let target = self.current_send_target();
-        let ready = match target {
+        let ready = match &target {
             live_send::LiveSendTarget::Agent => crate::tmux::Session::new(&inst.id, &inst.title)
                 .map(|s| s.exists())
                 .unwrap_or(false),
             live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => {
                 true
             }
+            live_send::LiveSendTarget::Tool(_) => true,
         };
         if !ready {
             return None;
@@ -5489,7 +5520,7 @@ impl HomeView {
         }
 
         if let Some((id, title, target)) = self.resolve_send_target() {
-            let label = live_send::format_target_label(&title, target);
+            let label = live_send::format_target_label(&title, target.clone());
             self.pending_send_session = Some(id);
             self.pending_send_target = target;
             let mut dialog = SendMessageDialog::new(&label);

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5178,21 +5178,14 @@ impl HomeView {
 
     /// Auto-start live-send after an explicit view switch (`ToggleView`,
     /// opening a tool session) when the `Auto Live-Send On View Switch`
-    /// setting is on for the selected session's resolved config and its
-    /// `default_attach_mode` is `LiveSend`. `None` when there's no
-    /// selected session, the setting is off, or the resolved attach mode
-    /// isn't live-send; the caller then leaves the plain view switch alone.
-    /// Deliberately not wired into list navigation/selection: this only
-    /// fires from the explicit view-switch call sites that invoke it.
+    /// setting is on for the selected session's resolved config. `None`
+    /// when there's no selected session or the setting is off; the
+    /// caller then leaves the plain view switch alone. Deliberately not
+    /// wired into list navigation/selection: this only fires from the
+    /// explicit view-switch call sites that invoke it.
     pub(super) fn maybe_auto_start_live_send(&mut self) -> Option<Action> {
         let id = self.selected_session.clone()?;
         if !self.live_send_on_view_switch(&id) {
-            return None;
-        }
-        if !matches!(
-            self.default_attach_mode(&id),
-            Some(crate::session::NewSessionAttachMode::LiveSend)
-        ) {
             return None;
         }
         self.start_live_send()

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5064,7 +5064,7 @@ impl HomeView {
         // throw voice text on the floor; losing dictation is worse than
         // silently catching it.
         if let Some((id, title, target)) = self.resolve_send_target() {
-            let label = live_send::format_target_label(&title, target.clone());
+            let label = live_send::format_target_label(&title, &target);
             self.pending_send_session = Some(id);
             self.pending_send_target = target;
             let mut dialog = SendMessageDialog::new(&label);
@@ -5408,8 +5408,10 @@ impl HomeView {
             live_send::LiveSendTarget::ContainerTerminal => {
                 crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
             }
-            live_send::LiveSendTarget::Tool(_) => {
-                crate::tmux::Session::generate_name(&inst.id, &inst.title)
+            live_send::LiveSendTarget::Tool(name) => {
+                crate::tmux::ToolSession::new(&inst.id, &inst.title, name)
+                    .session_name()
+                    .to_string()
             }
         };
         if current_name != state.tmux_name {
@@ -5433,7 +5435,7 @@ impl HomeView {
         let Some((id, title, target)) = self.resolve_send_target() else {
             return;
         };
-        let label = live_send::format_target_label(&title, target.clone());
+        let label = live_send::format_target_label(&title, &target);
         self.pending_send_session = Some(id);
         self.pending_send_target = target;
         let mut dialog = SendMessageDialog::new(&label);
@@ -5520,7 +5522,7 @@ impl HomeView {
         }
 
         if let Some((id, title, target)) = self.resolve_send_target() {
-            let label = live_send::format_target_label(&title, target.clone());
+            let label = live_send::format_target_label(&title, &target);
             self.pending_send_session = Some(id);
             self.pending_send_target = target;
             let mut dialog = SendMessageDialog::new(&label);
@@ -6029,15 +6031,15 @@ mod tests {
         // banner route through the same helper so the label can't drift.
         use live_send::{format_target_label, LiveSendTarget};
         assert_eq!(
-            format_target_label("my-session", LiveSendTarget::Agent),
+            format_target_label("my-session", &LiveSendTarget::Agent),
             "my-session",
         );
         assert_eq!(
-            format_target_label("my-session", LiveSendTarget::Terminal),
+            format_target_label("my-session", &LiveSendTarget::Terminal),
             "my-session (terminal)",
         );
         assert_eq!(
-            format_target_label("my-session", LiveSendTarget::ContainerTerminal),
+            format_target_label("my-session", &LiveSendTarget::ContainerTerminal),
             "my-session (container)",
         );
     }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -323,7 +323,7 @@ pub(in crate::tui) enum LiveSendTarget {
 /// Agent keeps the bare title (historical look); terminal variants
 /// get a short parenthetical so the user sees which pane the
 /// keystrokes will land on without having to read the preview chrome.
-pub(in crate::tui) fn format_target_label(title: &str, target: LiveSendTarget) -> String {
+pub(in crate::tui) fn format_target_label(title: &str, target: &LiveSendTarget) -> String {
     match target {
         LiveSendTarget::Agent => title.to_string(),
         LiveSendTarget::Terminal => format!("{title} (terminal)"),

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -304,7 +304,7 @@ pub(in crate::tui) struct LiveSendState {
 /// pane is the historical default; terminal panes (host and
 /// container) reuse the same live-send dispatch machinery but route
 /// to the paired terminal's tmux session.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(in crate::tui) enum LiveSendTarget {
     /// The agent's tmux pane (default, pre-existing behavior).
     #[default]
@@ -314,6 +314,8 @@ pub(in crate::tui) enum LiveSendTarget {
     /// The paired container-shell terminal pane (sandboxed sessions
     /// in container terminal mode).
     ContainerTerminal,
+    /// A named tool's paired tmux pane.
+    Tool(String),
 }
 
 /// Format a display label for a `(title, target)` pair so the compose
@@ -326,6 +328,7 @@ pub(in crate::tui) fn format_target_label(title: &str, target: LiveSendTarget) -
         LiveSendTarget::Agent => title.to_string(),
         LiveSendTarget::Terminal => format!("{title} (terminal)"),
         LiveSendTarget::ContainerTerminal => format!("{title} (container)"),
+        LiveSendTarget::Tool(name) => format!("{title} ({name})"),
     }
 }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -4552,7 +4552,7 @@ impl HomeView {
         // live-send does (see `ensure_pane_ready_with_size`): otherwise it
         // boots at tmux's 80x24 default and runs narrow until something
         // resizes it.
-        match target {
+        match &target {
             live_send::LiveSendTarget::Agent => {
                 let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
                     inst.ensure_pane_ready_with_size(size).map_err(Into::into)
@@ -4593,6 +4593,16 @@ impl HomeView {
                     return;
                 }
             }
+            live_send::LiveSendTarget::Tool(name) => {
+                let name = name.clone();
+                if let Err(e) = self.ensure_tool_pane_ready(session_id, &name, size) {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Send Failed",
+                        &format!("Cannot prepare tool '{}': {}", name, e),
+                    ));
+                    return;
+                }
+            }
         };
         let Some(inst) = self.get_instance(session_id) else {
             self.info_dialog = Some(InfoDialog::new(
@@ -4601,7 +4611,7 @@ impl HomeView {
             ));
             return;
         };
-        let tmux_session = match target {
+        let tmux_session = match &target {
             live_send::LiveSendTarget::Agent => {
                 match crate::tmux::Session::new(&inst.id, &inst.title) {
                     Ok(s) => s,
@@ -4620,13 +4630,18 @@ impl HomeView {
             live_send::LiveSendTarget::ContainerTerminal => crate::tmux::Session::from_name(
                 &crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title),
             ),
+            live_send::LiveSendTarget::Tool(name) => crate::tmux::Session::from_name(
+                crate::tmux::ToolSession::new(&inst.id, &inst.title, name).session_name(),
+            ),
         };
         // Agent gets a tool-specific Enter delay so paste-burst-aware
         // agents (e.g. Codex) don't swallow the final Enter. Shells in
         // the paired terminal panes don't need the delay.
-        let delay = match target {
+        let delay = match &target {
             live_send::LiveSendTarget::Agent => crate::agents::send_keys_enter_delay(&inst.tool),
-            live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => 0,
+            live_send::LiveSendTarget::Terminal
+            | live_send::LiveSendTarget::ContainerTerminal
+            | live_send::LiveSendTarget::Tool(_) => 0,
         };
         if let Err(e) = tmux_session.send_keys_with_delay(message, delay) {
             self.info_dialog = Some(InfoDialog::new(
@@ -4684,8 +4699,10 @@ impl HomeView {
     /// Returns `Err(())` if the pane could not be readied (`info_dialog` is
     /// set with the underlying error so the caller only has to clear its toast).
     pub fn prepare_live_send(&mut self, session_id: &str) -> Result<(), ()> {
-        let target = self.pending_live_send_target;
-        self.pending_live_send_target = live_send::LiveSendTarget::Agent;
+        let target = std::mem::replace(
+            &mut self.pending_live_send_target,
+            live_send::LiveSendTarget::Agent,
+        );
         let size = crate::terminal::get_size();
         // Agent targets revive the agent pane via the full
         // ensure_pane_ready cascade (Docker, splash, resume). Terminal
@@ -4700,7 +4717,7 @@ impl HomeView {
         // lost, leaves the pane pinned at ~50% width until live mode is
         // re-entered. See `Instance::ensure_pane_ready_with_size`.
         let agent_boot_size = self.live_send_boot_size();
-        match target {
+        match &target {
             live_send::LiveSendTarget::Agent => {
                 let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
                     inst.ensure_pane_ready_with_size(agent_boot_size)
@@ -4742,6 +4759,16 @@ impl HomeView {
                     return Err(());
                 }
             }
+            live_send::LiveSendTarget::Tool(name) => {
+                let name = name.clone();
+                if let Err(e) = self.ensure_tool_pane_ready(session_id, &name, size) {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Live send failed",
+                        &format!("Cannot prepare tool '{}': {}", name, e),
+                    ));
+                    return Err(());
+                }
+            }
         };
         let inst = match self.get_instance(session_id) {
             Some(inst) => inst.clone(),
@@ -4759,7 +4786,7 @@ impl HomeView {
         };
         // Resolve the tmux session name up front so the worker thread
         // can reconstruct a Session without re-touching HomeView.
-        let tmux_name = match target {
+        let tmux_name = match &target {
             live_send::LiveSendTarget::Agent => {
                 match crate::tmux::Session::new(&inst.id, &inst.title) {
                     Ok(s) => s.name().to_string(),
@@ -4777,6 +4804,11 @@ impl HomeView {
             }
             live_send::LiveSendTarget::ContainerTerminal => {
                 crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::Tool(name) => {
+                crate::tmux::ToolSession::new(&inst.id, &inst.title, name)
+                    .session_name()
+                    .to_string()
             }
         };
         // Switching live mode from session A to session B (click on a
@@ -5622,6 +5654,38 @@ impl HomeView {
         Ok(())
     }
 
+    /// Tool-pane counterpart of `ensure_terminal_pane_ready`: mirrors
+    /// `App::attach_tool_session`'s on-demand creation so live-send can
+    /// target a tool (lazygit, yazi, etc.) that hasn't been launched yet.
+    /// Used by `prepare_live_send` when the live target is `Tool(name)`.
+    fn ensure_tool_pane_ready(
+        &mut self,
+        session_id: &str,
+        tool_name: &str,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<()> {
+        let inst = self
+            .get_instance(session_id)
+            .ok_or_else(|| anyhow::anyhow!("session not found: {}", session_id))?
+            .clone();
+        let tool_config = self
+            .tool_configs
+            .get(tool_name)
+            .ok_or_else(|| anyhow::anyhow!("tool '{}' is not configured", tool_name))?
+            .clone();
+        if tool_config.command.is_empty() {
+            anyhow::bail!("Tool '{}' has no command configured", tool_name);
+        }
+        let tool = crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
+        if !tool.exists() || tool.is_pane_dead() {
+            if tool.exists() {
+                let _ = tool.kill();
+            }
+            tool.create_with_size(&inst.project_path, &tool_config.command, size)?;
+        }
+        Ok(())
+    }
+
     pub fn restart_instance_with_size_opts(
         &mut self,
         id: &str,
@@ -5862,6 +5926,15 @@ impl HomeView {
     ) -> Option<crate::session::NewSessionAttachMode> {
         self.resolve_session_config_for(session_id)
             .map(|s| s.default_attach_mode)
+    }
+
+    /// Resolve `live_send_on_view_switch` for an existing session row:
+    /// whether switching into Terminal or Tool view should auto-start
+    /// live-send instead of waiting for a separate Enter/Tab/click. See
+    /// `resolve_session_config_for` for resolution rules.
+    pub(super) fn live_send_on_view_switch(&self, session_id: &str) -> bool {
+        self.resolve_session_config_for(session_id)
+            .is_some_and(|s| s.live_send_on_view_switch)
     }
 
     /// True when Enter on the *currently selected session row* would

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1885,7 +1885,22 @@ impl HomeView {
         );
     }
 
-    fn refresh_tool_preview_cache_if_needed(&mut self, width: u16, height: u16, tool_name: &str) {
+    pub(super) fn refresh_tool_preview_cache_if_needed(
+        &mut self,
+        width: u16,
+        height: u16,
+        tool_name: &str,
+    ) {
+        // Symmetric with `refresh_terminal_preview_cache_if_needed` /
+        // `refresh_container_terminal_preview_cache_if_needed`: when live-send
+        // is pointed at this tool pane (lazygit, yazi, etc.), keep its tmux
+        // pane sized to the visible output area so a window resize or
+        // info-header toggle reflows immediately.
+        self.resize_live_pane_if_target(
+            live_send::LiveSendTarget::Tool(tool_name.to_string()),
+            width,
+            height,
+        );
         if self.apply_worker_capture(width, height, |s| &mut s.tool_preview_cache) {
             return;
         }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2792,7 +2792,7 @@ impl HomeView {
             // Surface which pane keystrokes are landing on; the shared
             // formatter keeps this label in lockstep with the compose
             // dialog's title.
-            let raw_title = live_send::format_target_label(base_title, state.target.clone());
+            let raw_title = live_send::format_target_label(base_title, &state.target);
             let chip = " \u{25CF} LIVE \u{2192} ";
             let chip_style = Style::default()
                 .fg(theme.background)

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2792,7 +2792,7 @@ impl HomeView {
             // Surface which pane keystrokes are landing on; the shared
             // formatter keeps this label in lockstep with the compose
             // dialog's title.
-            let raw_title = live_send::format_target_label(base_title, state.target);
+            let raw_title = live_send::format_target_label(base_title, state.target.clone());
             let chip = " \u{25CF} LIVE \u{2192} ";
             let chip_style = Style::default()
                 .fg(theme.background)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -13894,6 +13894,123 @@ mod default_attach_mode {
 
     #[test]
     #[serial]
+    fn start_live_send_in_tool_view_targets_tool_pane() {
+        // Tool-view counterpart of `start_live_send_in_terminal_view_targets_terminal_pane`:
+        // when previewing a named tool (lazygit, yazi, etc.), `start_live_send`
+        // must resolve to that tool's own paired pane, not fall back to the
+        // agent or bail out entirely.
+        let mut env = create_test_env_empty();
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.view_mode = crate::tui::home::ViewMode::Tool("lazygit".to_string());
+        let action = env.view.start_live_send();
+        assert_eq!(action, Some(Action::EnterLiveSend(id)));
+        assert_eq!(
+            env.view.pending_live_send_target,
+            crate::tui::home::live_send::LiveSendTarget::Tool("lazygit".to_string())
+        );
+    }
+
+    fn write_live_send_on_view_switch(mode: NewSessionAttachMode, on_view_switch: bool) {
+        let mut config = Config::default();
+        config.session.default_attach_mode = mode;
+        config.session.live_send_on_view_switch = on_view_switch;
+        save_config(&config).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn toggle_view_auto_starts_live_send_when_setting_enabled_and_default_is_live_send() {
+        // With `live_send_on_view_switch` on and `default_attach_mode =
+        // LiveSend`, pressing 't' (ToggleView) from Structured view must
+        // not just flip the preview to Terminal; it must also enter
+        // live-send immediately, without a separate Enter/Tab/click.
+        let mut env = create_test_env_empty();
+        write_live_send_on_view_switch(NewSessionAttachMode::LiveSend, true);
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.handle_key(key(KeyCode::Char('t')), None);
+        assert_eq!(
+            env.view.view_mode,
+            crate::tui::home::ViewMode::Terminal,
+            "ToggleView must still flip the preview to Terminal"
+        );
+        assert_eq!(action, Some(Action::EnterLiveSend(id)));
+    }
+
+    #[test]
+    #[serial]
+    fn toggle_view_does_not_auto_start_live_send_when_setting_disabled() {
+        // The setting defaults to off: even with `default_attach_mode =
+        // LiveSend`, ToggleView must leave live-send alone and only
+        // change the preview.
+        let mut env = create_test_env_empty();
+        write_live_send_on_view_switch(NewSessionAttachMode::LiveSend, false);
+        let _id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.handle_key(key(KeyCode::Char('t')), None);
+        assert_eq!(env.view.view_mode, crate::tui::home::ViewMode::Terminal);
+        assert_eq!(
+            action, None,
+            "auto live-send must stay off when the setting is disabled"
+        );
+        assert!(env.view.live_send.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn toggle_view_does_not_auto_start_live_send_when_default_is_tmux() {
+        // The setting alone isn't enough: it only fires when the
+        // resolved `default_attach_mode` is also LiveSend. With the
+        // historical Tmux default, ToggleView stays a plain preview
+        // switch even with the setting enabled.
+        let mut env = create_test_env_empty();
+        write_live_send_on_view_switch(NewSessionAttachMode::Tmux, true);
+        let _id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.handle_key(key(KeyCode::Char('t')), None);
+        assert_eq!(env.view.view_mode, crate::tui::home::ViewMode::Terminal);
+        assert_eq!(
+            action, None,
+            "auto live-send must stay off when default_attach_mode is Tmux"
+        );
+        assert!(env.view.live_send.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn tool_hotkey_auto_starts_live_send_when_setting_enabled_and_default_is_live_send() {
+        // Parallel case for the other explicit view-switch entry point:
+        // opening a tool via its configured hotkey must apply the same
+        // auto-entry check as ToggleView.
+        let mut env = create_test_env_empty();
+        write_live_send_on_view_switch(NewSessionAttachMode::LiveSend, true);
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.tool_hotkey_cache =
+            vec![("lazygit".to_string(), KeyCode::Char('g'), KeyModifiers::ALT)];
+        let action = env
+            .view
+            .handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::ALT), None);
+        assert_eq!(
+            env.view.view_mode,
+            crate::tui::home::ViewMode::Tool("lazygit".to_string())
+        );
+        assert_eq!(action, Some(Action::EnterLiveSend(id)));
+    }
+
+    #[test]
+    #[serial]
     fn help_live_on_enter_returns_none_when_no_session_selected() {
         // Cursor parked off any session row: the help overlay shouldn't
         // claim a session-attach behavior, so `help_live_on_enter`

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -13941,6 +13941,44 @@ mod default_attach_mode {
 
     #[test]
     #[serial]
+    fn refresh_tool_preview_cache_resizes_live_pane_when_targeted() {
+        // Reviewer-requested fix (CodeRabbit + Seluj78 on #2777):
+        // `refresh_tool_preview_cache_if_needed` must call
+        // `resize_live_pane_if_target` up front, the same as the
+        // Terminal/ContainerTerminal siblings, so a window resize while
+        // live-sent to a Tool pane (lazygit, yazi) reflows it instead of
+        // waiting for a live-mode re-enter. `resize_live_pane_if_target`
+        // records the dedup in `live_send_last_resize` even without a
+        // spawned worker, so that's the observable signal here.
+        let mut env = create_test_env_empty();
+        let id = add_session(&mut env.view, "session-one");
+        let inst = env.view.get_instance(&id).unwrap().clone();
+        let tmux_name = crate::tmux::ToolSession::new(&inst.id, &inst.title, "lazygit")
+            .session_name()
+            .to_string();
+        env.view.live_send = Some(crate::tui::home::live_send::LiveSendState {
+            session_id: id.clone(),
+            title: inst.title.clone(),
+            tmux_name,
+            target: crate::tui::home::live_send::LiveSendTarget::Tool("lazygit".to_string()),
+            exit_chords: Vec::new(),
+            leader: None,
+        });
+        env.view.selected_session = Some(id);
+        assert_eq!(env.view.live_send_last_resize, None);
+
+        env.view
+            .refresh_tool_preview_cache_if_needed(80, 24, "lazygit");
+
+        assert_eq!(
+            env.view.live_send_last_resize,
+            Some((80, 24)),
+            "resize_live_pane_if_target must fire for a targeted Tool pane"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn start_live_send_in_tool_view_targets_tool_pane() {
         // Tool-view counterpart of `start_live_send_in_terminal_view_targets_terminal_pane`:
         // when previewing a named tool (lazygit, yazi, etc.), `start_live_send`

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -13169,6 +13169,53 @@ mod live_send_mode {
 
     #[test]
     #[serial]
+    fn drift_check_does_not_exit_for_tool_target_named_via_tool_session() {
+        // Regression guard: the Tool arm of the drift check must resolve
+        // the current name the same way `prepare_live_send` computed
+        // `tmux_name` at entry (via `ToolSession::new(..).session_name()`).
+        // A prior bug instead re-derived the Tool arm's "current name"
+        // through `Session::generate_name`, the agent-pane naming scheme,
+        // which never matches a tool's own tmux name. That mismatch made
+        // every Tool-view live-send look "renamed" on its very first
+        // keystroke and auto-exit immediately.
+        let mut env = create_test_env_with_sessions(1);
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has one session");
+        let inst = env.view.get_instance(&id).unwrap().clone();
+        let tmux_name = crate::tmux::ToolSession::new(&inst.id, &inst.title, "lazygit")
+            .session_name()
+            .to_string();
+        crate::tmux::test_inject_session_into_cache(&tmux_name);
+        env.view.live_send = Some(LiveSendState {
+            session_id: inst.id.clone(),
+            title: inst.title,
+            tmux_name,
+            target: crate::tui::home::live_send::LiveSendTarget::Tool("lazygit".to_string()),
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
+            leader: None,
+        });
+
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), None);
+
+        assert!(
+            env.view.live_send.is_some(),
+            "first keystroke in a Tool-view live-send must not trip spurious drift"
+        );
+        assert!(env.view.info_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
     fn live_mode_makes_has_dialog_true() {
         // Every dialog-gating predicate that already inspects has_dialog()
         // (mouse swallow, list nav suspend, palette skip) inherits live

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14050,24 +14050,23 @@ mod default_attach_mode {
 
     #[test]
     #[serial]
-    fn toggle_view_does_not_auto_start_live_send_when_default_is_tmux() {
-        // The setting alone isn't enough: it only fires when the
-        // resolved `default_attach_mode` is also LiveSend. With the
-        // historical Tmux default, ToggleView stays a plain preview
-        // switch even with the setting enabled.
+    fn toggle_view_auto_starts_live_send_regardless_of_default_attach_mode() {
+        // The setting is the only gate: with the historical Tmux
+        // default, ToggleView still auto-enters live-send when
+        // `live_send_on_view_switch` is enabled.
         let mut env = create_test_env_empty();
         write_live_send_on_view_switch(NewSessionAttachMode::Tmux, true);
-        let _id = add_session(&mut env.view, "session-one");
+        let id = add_session(&mut env.view, "session-one");
         env.view.flat_items = env.view.build_flat_items();
         env.view.cursor = 0;
         env.view.update_selected();
         let action = env.view.handle_key(key(KeyCode::Char('t')), None);
         assert_eq!(env.view.view_mode, crate::tui::home::ViewMode::Terminal);
         assert_eq!(
-            action, None,
-            "auto live-send must stay off when default_attach_mode is Tmux"
+            action,
+            Some(Action::EnterLiveSend(id)),
+            "auto live-send must fire even when default_attach_mode is Tmux"
         );
-        assert!(env.view.live_send.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description
Adds a `live_send_on_view_switch` setting: when enabled and Default Attach Mode is
Live mode, switching a selected session into Terminal view (`t`) or a Tool view (a
tool hotkey, e.g. lazygit/yazi) now automatically starts live-send, so the user can
type directly into the pane through the live preview without pressing Tab/Enter
first and without a full tmux attach.

Also extends live-send itself to support `ViewMode::Tool` panes (previously
excluded), adding `ensure_tool_pane_ready` to spin up the tool's tmux pane on
demand, mirroring the existing terminal-pane path.

Tradeoff: live-send only forwards keyboard input, so mouse-driven tool UIs
(lazygit, yazi) lose mouse interaction while live-sent. Documented, not fixed here.

## PR Type
- [x] New Feature

## Checklist
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Skipped a test, because: added 5 focused unit tests in `src/tui/home/tests.rs`
covering the setting on/off × attach-mode gating and Tool-view live-send targeting,
plus manually smoke-tested end-to-end against a real tmux session (positive and
negative cases both confirmed). The behavior is internal state-transition logic
better suited to unit-level coverage than the e2e harness.

## AI Usage
- [x] AI was used

**AI Model/Tool used:** Claude (Sonnet 5) via OpenCode multi-agent pipeline (plan/build/QA sub-agents), orchestrated interactively with human review at each phase.

**Any Additional AI Details you'd like to share:** N/A

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an opt-in `live_send_on_view_switch` setting to automatically start **live-send** when switching into **Terminal** or **Tool** view, **independent of Default Attach Mode**.
- Expanded live-send support to **Tool panes** by lazily preparing tool panes on demand (`ensure_tool_pane_ready`) and correctly targeting tool-backed tmux sessions for drift checks, sending, and status labeling.
- Improved live-send behavior across view-change entry points (tool picker submit, tool hotkeys, toggle-to-terminal, command palette tool entry), with dedicated logic to decide when to auto-enter live-send on view switch.
- Made the Tool live-send pane responsive to layout changes by reflowing/resizing when the window layout updates (including a focused regression test for targeted Tool pane resizing).
- Updated documentation and guidance to note that during tool live-send, **keyboard input is forwarded but mouse interaction inside embedded tools (e.g., lazygit/yazi) is not supported**.

## Benefits

- Removes extra navigation steps by starting live sending immediately after switching into Terminal/Tool view.
- Better coverage for embedded, keyboard-driven tool workflows while staying consistent with the live-send UX model.
- More reliable, “set it and forget it” behavior when terminal layouts resize or toggle.

## Potential areas for further enhancement

- Add or better emulate **mouse support** within tool panes during live-send to match full tmux attach behavior more closely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->