### PR TITLE
fix: remove support for x86_64-darwin in flake.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           echo "=== Flake structure ==="
           nix flake show --all-systems
 
-          SYSTEMS="x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin"
+          SYSTEMS="x86_64-linux aarch64-linux aarch64-darwin"
 
           echo ""
           echo "=== Evaluating packages for all systems ==="

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
   outputs = inputs @ { flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
 
       perSystem = { config, self', inputs', pkgs, system, ... }:
         let


### PR DESCRIPTION
## Description

The NixOS project is deprecating support for the x86_64-darwin platform (see
https://nixos.org/manual/nixpkgs/unstable/release-notes#sec-nixpkgs-release-26.05-highlights ). This flake will stop working on the latest nixpkgs unless x86_64-darwin is removed from the supported platforms list.


## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [x] No AI was used
- [ ] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Removed `x86_64-darwin` from the flake’s supported platforms in `flake.nix`.
- Updated the CI workflow to stop evaluating the flake for `x86_64-darwin`, while keeping Linux and ARM-based macOS targets.

## Benefits
- Prevents flake evaluation issues caused by deprecated `x86_64-darwin` support in newer `nixpkgs`.
- Keeps CI focused on architectures that are still supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->