### PR TITLE
feat(web): add text size toggle to TopBar

### DIFF
--- a/web/src/components/TextSizeToggle.tsx
+++ b/web/src/components/TextSizeToggle.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { Type } from "lucide-react";
+
+type SizeKey = "sm" | "base" | "lg" | "xl";
+
+const SIZE_STEPS: SizeKey[] = ["sm", "base", "lg", "xl"];
+const SIZE_LABELS: Record<SizeKey, string> = {
+  sm: "Small",
+  base: "Default",
+  lg: "Large",
+  xl: "Extra Large",
+};
+
+const STORAGE_KEY = "aoe-text-size";
+
+export function TextSizeToggle() {
+  const [size, setSize] = useState<SizeKey>("base");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const stored = localStorage.getItem(STORAGE_KEY) as SizeKey | null;
+    if (stored && SIZE_STEPS.includes(stored)) {
+      setSize(stored);
+      applySize(stored);
+    } else {
+      applySize("base");
+    }
+  }, []);
+
+  const applySize = (newSize: SizeKey) => {
+    const root = document.documentElement;
+    SIZE_STEPS.forEach((s) => root.classList.remove(`text-${s}`));
+    root.classList.add(`text-${newSize}`);
+  };
+
+  const cycleSize = () => {
+    const currentIndex = SIZE_STEPS.indexOf(size);
+    const nextIndex = (currentIndex + 1) % SIZE_STEPS.length;
+    const nextSize = SIZE_STEPS[nextIndex];
+    setSize(nextSize);
+    localStorage.setItem(STORAGE_KEY, nextSize);
+    applySize(nextSize);
+  };
+
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        className="w-8 h-8 flex items-center justify-center rounded-md transition-colors text-text-dim hover:text-text-secondary hover:bg-surface-700/50"
+        aria-label="Text size"
+        disabled
+      >
+        <Type className="h-4 w-4" strokeWidth={2.5} />
+      </button>
+    );
+  }
+
+  return (
+    <div className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={cycleSize}
+        className="w-8 h-8 flex items-center justify-center rounded-md transition-colors text-text-secondary hover:text-text-primary hover:bg-surface-700/50"
+        aria-label={`Text size: ${SIZE_LABELS[size]}. Click to cycle.`}
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
+        <Type className="h-5 w-5" strokeWidth={2.5} />
+      </button>
+      <span className="sr-only">Text size: {SIZE_LABELS[size]}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add a text size toggle to the web dashboard TopBar so users can adjust font size for better mobile readability.

## Changes

1. **New `TextSizeToggle` component** (`web/src/components/TextSizeToggle.tsx`):
   - 4 size steps: Small (14px), Default (16px), Large (18px), Extra Large (20px)
   - Cycles through sizes on click
   - Persists preference in `localStorage` (`aoe-text-size`)
   - Shows current size in tooltip/aria-label

2. **CSS variable for global scaling** (`web/src/index.css`):
   - Added `--text-base-size` CSS variable (default 1rem)
   - Applied to `body` element so all text scales proportionally
   - `html.text-{sm,base,lg,xl}` classes override the variable

3. **TopBar integration** (`web/src/components/TopBar.tsx`):
   - Added toggle to right zone (next to offline/debug indicators)
   - Visible on both desktop and mobile

## Testing

- Dev server starts and renders correctly
- Toggle cycles through 4 sizes
- Preference persists across reloads
- Works on mobile viewport

## Notes

- No auto-detection of mobile - user controls size explicitly
- Follows existing code patterns (localStorage, CSS variables, component structure)
- Minimal, focused change - no refactoring of unrelated code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a text-size toggle to the dashboard TopBar with four readability options.
- Added persistence through `localStorage`, accessible labels, and responsive desktop/mobile placement.
- Added global text scaling support through a CSS variable and root HTML classes.
- Included coverage for initialization, cycling, persistence, and mobile behavior.

## Benefits

Improves readability on smaller screens and lets users retain their preferred text size across sessions.

## Technical details

Introduced the reusable `TextSizeToggle` component with SSR-safe initialization, size validation, class application, and localStorage synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->