### PR TITLE
fix(acp): treat CapacityFull as a first-class transient (refund budget, retry, no orphan) (#1027)

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2675,6 +2675,32 @@ impl<S: BroadcastSink> Supervisor<S> {
         self.workers.lock().await.len()
     }
 
+    /// Insert a fake in-memory worker so a test can occupy a capacity slot
+    /// without launching a real runner. Mirrors the `WorkerHandle` fixture in
+    /// `capacity_full_returns_after_limit`. The slot is counted by
+    /// `begin_resume` and `is_running`, but no registry entry is written, so
+    /// the reconciler's orphan sweep never touches it.
+    #[cfg(test)]
+    pub(crate) async fn test_insert_worker(&self, session_id: &str) {
+        let (client, _tx) = AcpClient::fake_for_test(AcpSessionId(format!("acp-{session_id}")));
+        self.workers.lock().await.insert(
+            session_id.to_string(),
+            WorkerHandle {
+                client: Arc::new(client),
+                drain_task: tokio::spawn(async {}),
+                restart_history: vec![],
+                kind: WorkerKind::Stdio,
+            },
+        );
+    }
+
+    /// Drop a fake in-memory worker inserted by `test_insert_worker`, freeing
+    /// the capacity slot for the next reconciler tick.
+    #[cfg(test)]
+    pub(crate) async fn test_remove_worker(&self, session_id: &str) {
+        self.workers.lock().await.remove(session_id);
+    }
+
     /// Reap workers whose on-disk registry entry has disappeared while
     /// the in-memory `WorkerHandle` is still installed. This is the
     /// out-of-band stop signal: `aoe acp stop|kill|restart` (a

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -108,6 +108,15 @@ enum ResumeOutcome {
     /// populated; a permanently-failing spawn (e.g. missing
     /// claude-agent-acp) does not loop forever.
     SpawnFinished,
+    /// Spawn refused by `SupervisorError::CapacityFull`: a transient,
+    /// non-crash, user-actionable condition (a slot frees when a peer
+    /// worker stops), not a spawn failure. The join handler refunds this
+    /// tick's respawn-budget entry, re-arms the retry (`attempted.remove`,
+    /// never insert), and publishes the capacity banner once per transition
+    /// via the `capacity_deferred` gate. The per-tick reconciler retry is
+    /// the self-heal. `message` is the `CapacityFull` Display, reused as the
+    /// `AgentStartupError` body so it matches the front-end regex. See #1027.
+    CapacityDeferred { message: String },
 }
 
 /// A single structured view session that needs a worker. Snapshotted from the
@@ -152,6 +161,7 @@ pub async fn reconcile_acp_workers(
     last_rate_limit_reap: &mut Option<std::time::Instant>,
     respawn_history: &mut HashMap<String, Vec<Instant>>,
     parked: &mut HashSet<String>,
+    capacity_deferred: &mut HashSet<String>,
 ) {
     // Respawn build-stale workers that were adopted to drain an in-flight
     // turn (see #1754) and have since gone idle. Runs BEFORE
@@ -261,6 +271,7 @@ pub async fn reconcile_acp_workers(
     // don't grow unbounded and a recreated id starts with a clean budget.
     parked.retain(|id| live.contains(id));
     respawn_history.retain(|id, _| live.contains(id));
+    capacity_deferred.retain(|id| live.contains(id));
 
     // ORDERING INVARIANT: this orphan sweep MUST run before the
     // resume scheduling pass below. The capacity check counts both
@@ -305,6 +316,7 @@ pub async fn reconcile_acp_workers(
             // budget and un-park.
             parked.remove(&id);
             respawn_history.remove(&id);
+            capacity_deferred.remove(&id);
             attempted.insert(id);
             continue;
         }
@@ -449,7 +461,43 @@ pub async fn reconcile_acp_workers(
                     attempted.remove(&id);
                 }
             }
-            Ok((_, ResumeOutcome::Attached)) | Ok((_, ResumeOutcome::SpawnFinished)) => {}
+            Ok((id, ResumeOutcome::CapacityDeferred { message })) => {
+                // Refund the single budget entry this tick recorded at the
+                // decision gate (`record_and_check_respawn_budget`, above):
+                // CapacityFull is not a crash, so it must not burn the #1945
+                // budget. POP the last entry (this tick's), not `remove(&id)`,
+                // which would wipe genuine prior-crash history and let a
+                // crashing session escape the park budget.
+                if let Some(entries) = respawn_history.get_mut(&id) {
+                    entries.pop();
+                    if entries.is_empty() {
+                        respawn_history.remove(&id);
+                    }
+                }
+                // Re-arm the retry so the next tick can try again once a slot
+                // frees. NEVER `attempted.insert`: `attempted` is persistent
+                // (only the live-set retain drops it), so keeping the id there
+                // would skip the session forever and the self-heal would never
+                // fire.
+                attempted.remove(&id);
+                // Publish the capacity banner once per transition; the gate
+                // returns true only on the first insert (mirrors
+                // `parked.insert`), because `publish_startup_error` does not
+                // dedup and per-tick publishing would spam the event store.
+                if capacity_deferred.insert(id.clone()) {
+                    state.acp_supervisor.publish_startup_error(&id, message);
+                }
+            }
+            Ok((id, ResumeOutcome::Attached)) | Ok((id, ResumeOutcome::SpawnFinished)) => {
+                // Clear the capacity marker on the successful-respawn path.
+                // This is the ONLY clear the reconciler-dispatched capacity
+                // case reaches: a successful respawn returns SpawnFinished and
+                // leaves the id in `attempted`, so the `is_running` branch is
+                // unreachable next tick. Without this clear the marker sticks
+                // for the worker's life and a second capacity episode would not
+                // re-publish the banner.
+                capacity_deferred.remove(&id);
+            }
             Err(e) => {
                 // Task panicked or was cancelled. Don't keep retrying
                 // the same id every tick if the task panics on every
@@ -1111,6 +1159,19 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
     let agent = req.agent.clone();
     let spawn_result = state.acp_supervisor.spawn(req).await;
     if let Err(e) = spawn_result {
+        // CapacityFull is transient, not a spawn failure: hand it to the
+        // join handler as CapacityDeferred (refund budget, re-arm, publish
+        // once) instead of burning the crash budget and orphaning the
+        // session. Match before the `format!` below, where the typed error
+        // is otherwise erased into a String. See #1027.
+        if matches!(
+            e,
+            crate::acp::supervisor::SupervisorError::CapacityFull { .. }
+        ) {
+            return ResumeOutcome::CapacityDeferred {
+                message: e.to_string(),
+            };
+        }
         // Re-check whether the session still exists in instances.
         // The user can delete a session during the spawn handshake
         // (2-3s for ACP), and the resulting error is noise for a
@@ -1719,5 +1780,292 @@ mod tests {
     fn exactly_at_threshold_stops() {
         // Boundary: elapsed == threshold reaps (>= comparison).
         assert!(should_auto_stop(3600 * 1000, Some(0), 3600, false));
+    }
+
+    // --- CapacityFull as a first-class transient (#1027) ---
+
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    fn structured_instance(id: &str, project_path: &str) -> crate::session::Instance {
+        use crate::session::{Instance, View};
+        let mut inst = Instance::new(id, project_path);
+        inst.id = id.to_string();
+        inst.view = View::Structured;
+        // Bogus agent: once a slot frees, the fresh spawn fails fast with
+        // UnknownAgent (resolved before any process or socket work) so
+        // resume_one returns SpawnFinished without launching a real runner.
+        // At capacity the agent is irrelevant, since begin_resume returns
+        // CapacityFull before spawn_inner runs.
+        inst.agent_name = Some("aoe-no-such-agent-1027".to_string());
+        inst
+    }
+
+    /// Isolate HOME so the worker registry (and thus the reconciler's orphan
+    /// sweep / capacity count) can't see the developer's real dev-mode
+    /// entries. Returns the temp dirs so the caller keeps them alive.
+    async fn capacity_test_state(
+        id: &str,
+    ) -> (
+        Arc<crate::server::AppState>,
+        tempfile::TempDir,
+        tempfile::TempDir,
+    ) {
+        use crate::server::test_support::build_test_app_state;
+        let home = tempfile::TempDir::new().unwrap();
+        // SAFETY: reconciler capacity tests are `#[serial]`, so no other test
+        // races this process-global env mutation.
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
+        }
+        let project = tempfile::TempDir::new().unwrap();
+        let inst = structured_instance(id, &project.path().to_string_lossy());
+        let state = build_test_app_state(vec![inst]);
+        (state, home, project)
+    }
+
+    async fn run_tick(
+        state: &Arc<crate::server::AppState>,
+        attempted: &mut HashSet<String>,
+        respawn_history: &mut HashMap<String, Vec<Instant>>,
+        parked: &mut HashSet<String>,
+        capacity_deferred: &mut HashSet<String>,
+    ) {
+        let mut last_idle_reap = Some(Instant::now());
+        let mut last_rate_limit_reap = Some(Instant::now());
+        super::reconcile_acp_workers(
+            state,
+            attempted,
+            &mut last_idle_reap,
+            &mut last_rate_limit_reap,
+            respawn_history,
+            parked,
+            capacity_deferred,
+        )
+        .await;
+    }
+
+    fn capacity_startup_errors(state: &Arc<crate::server::AppState>, id: &str) -> usize {
+        state
+            .acp_event_store
+            .replay_from(id, 0)
+            .into_iter()
+            .filter(|(_, e)| {
+                matches!(e, crate::acp::Event::AgentStartupError { message }
+                    if message.contains("capacity full"))
+            })
+            .count()
+    }
+
+    /// The core of the fix: a CapacityFull spawn must re-arm `attempted`
+    /// (remove, never insert) so the SAME process retries on the next tick.
+    /// Testing via a daemon restart would mask this: restart wipes the
+    /// in-memory `attempted`, hiding the "stuck forever" bug.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn capacity_deferred_rearms_attempted_and_retries_next_tick() {
+        let (state, _home, _project) = capacity_test_state("s-cap").await;
+        state.acp_supervisor.test_insert_worker("occupant").await;
+
+        let mut attempted = HashSet::new();
+        let mut respawn_history: HashMap<String, Vec<Instant>> = HashMap::new();
+        let mut parked = HashSet::new();
+        let mut capacity_deferred = HashSet::new();
+
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+        assert!(
+            !attempted.contains("s-cap"),
+            "CapacityDeferred must re-arm the retry, not pin the id in attempted"
+        );
+        assert!(
+            capacity_deferred.contains("s-cap"),
+            "the capacity marker must be set after the deferral"
+        );
+        assert!(
+            !parked.contains("s-cap"),
+            "CapacityFull must not park the session (that is the crash-loop guard)"
+        );
+
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+        assert!(
+            !attempted.contains("s-cap"),
+            "the next tick must retry (attempted stays clear), not skip forever"
+        );
+    }
+
+    /// The capacity banner is published once per transition, not once per
+    /// tick: `publish_startup_error` does not dedup, so without the
+    /// `capacity_deferred` gate a session stuck at capacity would spam the
+    /// event store every 2s.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn capacity_deferred_publishes_once_across_ticks() {
+        let (state, _home, _project) = capacity_test_state("s-once").await;
+        state.acp_supervisor.test_insert_worker("occupant").await;
+
+        let mut attempted = HashSet::new();
+        let mut respawn_history: HashMap<String, Vec<Instant>> = HashMap::new();
+        let mut parked = HashSet::new();
+        let mut capacity_deferred = HashSet::new();
+
+        for _ in 0..3 {
+            run_tick(
+                &state,
+                &mut attempted,
+                &mut respawn_history,
+                &mut parked,
+                &mut capacity_deferred,
+            )
+            .await;
+        }
+
+        assert_eq!(
+            capacity_startup_errors(&state, "s-once"),
+            1,
+            "capacity banner must publish exactly once across ticks, not per tick"
+        );
+    }
+
+    /// The budget refund pops only this tick's decision entry; genuine
+    /// prior-crash history survives so a truly crashing session can't use a
+    /// CapacityFull to escape the #1945 park budget.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn capacity_deferred_pop_preserves_prior_crash_history() {
+        let (state, _home, _project) = capacity_test_state("s-hist").await;
+        state.acp_supervisor.test_insert_worker("occupant").await;
+
+        let mut attempted = HashSet::new();
+        // Two prior crash entries, below the park cap so the session still
+        // reaches the spawn (and thus CapacityFull) this tick.
+        let now = Instant::now();
+        let mut respawn_history: HashMap<String, Vec<Instant>> = HashMap::new();
+        respawn_history.insert("s-hist".to_string(), vec![now, now]);
+        let mut parked = HashSet::new();
+        let mut capacity_deferred = HashSet::new();
+
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+
+        assert_eq!(
+            respawn_history.get("s-hist").map(Vec::len).unwrap_or(0),
+            2,
+            "only this tick's decision entry may be popped; prior crashes survive"
+        );
+    }
+
+    /// When a peer worker stops and the slot frees, the next tick respawns
+    /// the deferred session and clears the capacity marker on the
+    /// SpawnFinished path (the critical clear, since a successful respawn
+    /// leaves the id in `attempted` and never revisits the is_running branch).
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn capacity_deferred_retries_and_succeeds_when_slot_frees() {
+        let (state, _home, _project) = capacity_test_state("s-free").await;
+        state.acp_supervisor.test_insert_worker("occupant").await;
+
+        let mut attempted = HashSet::new();
+        let mut respawn_history: HashMap<String, Vec<Instant>> = HashMap::new();
+        let mut parked = HashSet::new();
+        let mut capacity_deferred = HashSet::new();
+
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+        assert!(
+            capacity_deferred.contains("s-free"),
+            "precondition: the session is capacity-deferred after the first tick"
+        );
+
+        // A peer worker stops: the slot frees.
+        state.acp_supervisor.test_remove_worker("occupant").await;
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+        assert!(
+            !capacity_deferred.contains("s-free"),
+            "a freed slot must respawn the deferred session and clear the marker"
+        );
+    }
+
+    /// §2 create/enable message selection: a CapacityFull spawn publishes the
+    /// capacity Display (matching the front-end capacity regex), not the
+    /// generic crash-style startup error, so the create/enable paths show the
+    /// capacity banner instead of a misleading failure.
+    #[test]
+    fn create_at_capacity_publishes_capacity_status_not_generic_error() {
+        use crate::acp::supervisor::SupervisorError;
+        use crate::server::api::structured_spawn_error_message;
+
+        let capacity = SupervisorError::CapacityFull {
+            current: 1,
+            limit: 1,
+        };
+        let msg = structured_spawn_error_message(&capacity, "claude-code");
+        assert!(
+            msg.contains("capacity full") && msg.contains("max_concurrent_workers"),
+            "capacity errors must surface the capacity Display, got: {msg}"
+        );
+        assert!(
+            !msg.contains("Failed to start structured view agent"),
+            "capacity errors must not use the generic crash-style message"
+        );
+
+        let generic = SupervisorError::UnknownAgent("bogus".to_string());
+        let generic_msg = structured_spawn_error_message(&generic, "bogus");
+        assert!(
+            generic_msg.contains("Failed to start structured view agent"),
+            "non-capacity errors keep the generic message, got: {generic_msg}"
+        );
+    }
+
+    /// The enable path shares the same message selection as create, so a
+    /// tmux to structured switch at capacity also shows the capacity banner.
+    #[test]
+    fn acp_enable_at_capacity_publishes_capacity_status() {
+        use crate::acp::supervisor::SupervisorError;
+        use crate::server::api::structured_spawn_error_message;
+
+        let capacity = SupervisorError::CapacityFull {
+            current: 2,
+            limit: 2,
+        };
+        let msg = structured_spawn_error_message(&capacity, "opencode");
+        assert!(
+            msg.contains("capacity full") && msg.contains("max_concurrent_workers"),
+            "enable at capacity must surface the capacity Display, got: {msg}"
+        );
     }
 }

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -188,6 +188,10 @@ pub async fn reconcile_acp_workers(
         // budget so a session that was crash-loop-parked gets a clean slate.
         parked.remove(id);
         respawn_history.remove(id);
+        // Same clean-slate intent for the capacity marker: an explicit retry
+        // that still hits capacity should re-publish a fresh banner rather
+        // than staying gated behind the previous episode's marker.
+        capacity_deferred.remove(id);
     }
 
     // Out-of-band respawn requests (web "Update & restart" after a global
@@ -201,6 +205,7 @@ pub async fn reconcile_acp_workers(
         attempted.remove(&id);
         parked.remove(&id);
         respawn_history.remove(&id);
+        capacity_deferred.remove(&id);
     }
 
     // Idle auto-stop (#1689). Cadence-gated to IDLE_REAP_INTERVAL so the
@@ -478,7 +483,10 @@ pub async fn reconcile_acp_workers(
                 // frees. NEVER `attempted.insert`: `attempted` is persistent
                 // (only the live-set retain drops it), so keeping the id there
                 // would skip the session forever and the self-heal would never
-                // fire.
+                // fire. Unlike `RetryAfterAttachTimeout` this needs no
+                // `!parked` guard: an id only reaches a spawn (and thus
+                // CapacityFull) after passing the parked check, so it is never
+                // parked here.
                 attempted.remove(&id);
                 // Publish the capacity banner once per transition; the gate
                 // returns true only on the first insert (mirrors
@@ -1976,13 +1984,15 @@ mod tests {
         );
     }
 
-    /// When a peer worker stops and the slot frees, the next tick respawns
+    /// When a peer worker stops and the slot frees, the next tick re-attempts
     /// the deferred session and clears the capacity marker on the
-    /// SpawnFinished path (the critical clear, since a successful respawn
-    /// leaves the id in `attempted` and never revisits the is_running branch).
+    /// SpawnFinished path (the critical clear, since a re-attempt leaves the id
+    /// in `attempted` and never revisits the is_running branch). The re-attempt
+    /// here fails fast (bogus agent) but still routes through SpawnFinished, so
+    /// it exercises the exact clear path a real respawn would.
     #[tokio::test]
     #[serial_test::serial]
-    async fn capacity_deferred_retries_and_succeeds_when_slot_frees() {
+    async fn capacity_deferred_clears_marker_when_slot_frees() {
         let (state, _home, _project) = capacity_test_state("s-free").await;
         state.acp_supervisor.test_insert_worker("occupant").await;
 
@@ -2016,16 +2026,66 @@ mod tests {
         .await;
         assert!(
             !capacity_deferred.contains("s-free"),
-            "a freed slot must respawn the deferred session and clear the marker"
+            "a freed slot must re-attempt the deferred session and clear the marker"
+        );
+        assert_eq!(
+            capacity_startup_errors(&state, "s-free"),
+            1,
+            "clearing the marker must not re-publish the capacity banner"
         );
     }
 
-    /// §2 create/enable message selection: a CapacityFull spawn publishes the
-    /// capacity Display (matching the front-end capacity regex), not the
-    /// generic crash-style startup error, so the create/enable paths show the
-    /// capacity banner instead of a misleading failure.
+    /// The second (out-of-band) clear site: a deferred session whose worker
+    /// comes online via a REST spawn is picked up by the `is_running` branch,
+    /// which clears the capacity marker. Covers the path the reconciler's own
+    /// respawn (SpawnFinished) never reaches.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn capacity_deferred_cleared_by_is_running_branch() {
+        let (state, _home, _project) = capacity_test_state("s-oob").await;
+        state.acp_supervisor.test_insert_worker("occupant").await;
+
+        let mut attempted = HashSet::new();
+        let mut respawn_history: HashMap<String, Vec<Instant>> = HashMap::new();
+        let mut parked = HashSet::new();
+        let mut capacity_deferred = HashSet::new();
+
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+        assert!(
+            capacity_deferred.contains("s-oob"),
+            "precondition: the session is capacity-deferred after the first tick"
+        );
+
+        // A REST spawn brings the deferred session's own worker online.
+        state.acp_supervisor.test_insert_worker("s-oob").await;
+        run_tick(
+            &state,
+            &mut attempted,
+            &mut respawn_history,
+            &mut parked,
+            &mut capacity_deferred,
+        )
+        .await;
+        assert!(
+            !capacity_deferred.contains("s-oob"),
+            "the is_running branch must clear the marker for an out-of-band worker"
+        );
+    }
+
+    /// §2 message selection, shared by both the create-path (`create_session`)
+    /// and the enable-path (`acp_enable`) via `structured_spawn_error_message`:
+    /// a CapacityFull spawn surfaces the capacity Display (matching the
+    /// front-end capacity regex) so the session shows the capacity banner, while
+    /// any other error keeps the generic crash-style message.
     #[test]
-    fn create_at_capacity_publishes_capacity_status_not_generic_error() {
+    fn structured_spawn_error_message_prefers_capacity_display_over_generic() {
         use crate::acp::supervisor::SupervisorError;
         use crate::server::api::structured_spawn_error_message;
 
@@ -2048,24 +2108,6 @@ mod tests {
         assert!(
             generic_msg.contains("Failed to start structured view agent"),
             "non-capacity errors keep the generic message, got: {generic_msg}"
-        );
-    }
-
-    /// The enable path shares the same message selection as create, so a
-    /// tmux to structured switch at capacity also shows the capacity banner.
-    #[test]
-    fn acp_enable_at_capacity_publishes_capacity_status() {
-        use crate::acp::supervisor::SupervisorError;
-        use crate::server::api::structured_spawn_error_message;
-
-        let capacity = SupervisorError::CapacityFull {
-            current: 2,
-            limit: 2,
-        };
-        let msg = structured_spawn_error_message(&capacity, "opencode");
-        assert!(
-            msg.contains("capacity full") && msg.contains("max_concurrent_workers"),
-            "enable at capacity must surface the capacity Display, got: {msg}"
         );
     }
 }

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -72,6 +72,26 @@ fn record_and_check_respawn_budget(
     false
 }
 
+/// Drop every per-session reconciler budget/marker entry for `id` so an
+/// explicit user retry (`aoe acp restart` or the #2109 "Update & restart")
+/// starts from a clean slate: re-armed for a fresh spawn, un-parked, respawn
+/// budget reset, and its capacity marker cleared so a repeat capacity block
+/// re-publishes a fresh banner. The `is_running` branch deliberately does NOT
+/// use this (it clears the same three budget maps but *inserts* into
+/// `attempted`), so only the two reaper loops share this reset.
+fn forget_session_budget(
+    id: &str,
+    attempted: &mut HashSet<String>,
+    parked: &mut HashSet<String>,
+    respawn_history: &mut HashMap<String, Vec<Instant>>,
+    capacity_deferred: &mut HashSet<String>,
+) {
+    attempted.remove(id);
+    parked.remove(id);
+    respawn_history.remove(id);
+    capacity_deferred.remove(id);
+}
+
 /// Build the banner published when a structured-view worker exhausts its
 /// respawn budget and the session is parked. When the session's project_path
 /// no longer exists on disk, every respawn is doomed for the same reason: the
@@ -108,14 +128,13 @@ enum ResumeOutcome {
     /// populated; a permanently-failing spawn (e.g. missing
     /// claude-agent-acp) does not loop forever.
     SpawnFinished,
-    /// Spawn refused by `SupervisorError::CapacityFull`: a transient,
-    /// non-crash, user-actionable condition (a slot frees when a peer
-    /// worker stops), not a spawn failure. The join handler refunds this
-    /// tick's respawn-budget entry, re-arms the retry (`attempted.remove`,
-    /// never insert), and publishes the capacity banner once per transition
-    /// via the `capacity_deferred` gate. The per-tick reconciler retry is
-    /// the self-heal. `message` is the `CapacityFull` Display, reused as the
-    /// `AgentStartupError` body so it matches the front-end regex. See #1027.
+    /// Spawn refused by `SupervisorError::CapacityFull`: transient,
+    /// non-crash, and user-actionable (a slot frees when a peer worker
+    /// stops), not a spawn failure. The id is re-armed (dropped from
+    /// `attempted`) so the per-tick retry self-heals; the join handler
+    /// refunds the budget and publishes the banner once. `message` is the
+    /// `CapacityFull` Display, reused verbatim as the `AgentStartupError`
+    /// body so it matches the front-end regex. See #1027.
     CapacityDeferred { message: String },
 }
 
@@ -183,29 +202,20 @@ pub async fn reconcile_acp_workers(
     // reattaches with the cached `acp_session_id`.
     let restart_pending = state.acp_supervisor.reap_user_stopped().await;
     for id in &restart_pending {
-        attempted.remove(id);
-        // `aoe acp restart` is an explicit user retry: wipe the respawn
-        // budget so a session that was crash-loop-parked gets a clean slate.
-        parked.remove(id);
-        respawn_history.remove(id);
-        // Same clean-slate intent for the capacity marker: an explicit retry
-        // that still hits capacity should re-publish a fresh banner rather
-        // than staying gated behind the previous episode's marker.
-        capacity_deferred.remove(id);
+        // `aoe acp restart` is an explicit user retry: give the session a
+        // clean slate (re-armed, un-parked, budget + capacity marker reset).
+        forget_session_budget(id, attempted, parked, respawn_history, capacity_deferred);
     }
 
     // Out-of-band respawn requests (web "Update & restart" after a global
     // adapter install, #2109). These sessions failed their spawn on a
     // compatibility rejection and have no live worker, so the
     // `reap_user_stopped` path above never sees them; they sit pinned in
-    // `attempted`. Clear the guard (and the respawn budget, like an
-    // explicit restart) so the resume pass below fresh-spawns them on the
-    // freshly-installed adapter and the next handshake clears the red X.
+    // `attempted`. Same clean-slate reset (like an explicit restart) so the
+    // resume pass below fresh-spawns them on the freshly-installed adapter and
+    // the next handshake clears the red X.
     for id in state.acp_supervisor.take_respawn_requests() {
-        attempted.remove(&id);
-        parked.remove(&id);
-        respawn_history.remove(&id);
-        capacity_deferred.remove(&id);
+        forget_session_budget(&id, attempted, parked, respawn_history, capacity_deferred);
     }
 
     // Idle auto-stop (#1689). Cadence-gated to IDLE_REAP_INTERVAL so the
@@ -502,8 +512,8 @@ pub async fn reconcile_acp_workers(
                 // case reaches: a successful respawn returns SpawnFinished and
                 // leaves the id in `attempted`, so the `is_running` branch is
                 // unreachable next tick. Without this clear the marker sticks
-                // for the worker's life and a second capacity episode would not
-                // re-publish the banner.
+                // for the worker's life and a second capacity transition would
+                // not re-publish the banner.
                 capacity_deferred.remove(&id);
             }
             Err(e) => {

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -32,6 +32,19 @@ const MAX_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
 /// Maximum decoded size of all attachments on one prompt (20 MiB).
 const MAX_TOTAL_ATTACHMENT_BYTES: usize = 20 * 1024 * 1024;
 
+/// Startup-error banner text for a failed detached structured-view spawn.
+/// `CapacityFull` is transient and user-actionable, so its Display (which
+/// carries "capacity full" + "max_concurrent_workers", matching the
+/// front-end capacity regex) is surfaced verbatim instead of the generic
+/// crash-style message, so the session shows the capacity banner rather
+/// than a misleading failure. See #1027.
+pub(crate) fn structured_spawn_error_message(err: &SupervisorError, agent: &str) -> String {
+    match err {
+        SupervisorError::CapacityFull { .. } => err.to_string(),
+        _ => format!("Failed to start structured view agent {agent:?}: {err}"),
+    }
+}
+
 /// MIME types accepted per attachment kind. Conservative on purpose:
 /// `image/svg+xml` is excluded (scriptable XML), and embedded resources
 /// are limited to inert text/document types. The image kind is also
@@ -1725,7 +1738,11 @@ pub async fn acp_enable(
             })
             .await
         {
-            let message = format!("Failed to start structured view agent {agent_name:?}: {e}");
+            // On CapacityFull the reconciler adopts this orphan next tick and
+            // respawns once a slot frees; its `capacity_deferred` gate
+            // re-publishes the same banner once (a single benign duplicate).
+            // See #1027.
+            let message = structured_spawn_error_message(&e, &agent_name);
             tracing::warn!(target: "acp.switch", session = %session_id, "spawn after enable: {message}");
             supervisor.publish_startup_error(&session_id, message);
         }

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -32,12 +32,16 @@ const MAX_ATTACHMENT_BYTES: usize = 10 * 1024 * 1024;
 /// Maximum decoded size of all attachments on one prompt (20 MiB).
 const MAX_TOTAL_ATTACHMENT_BYTES: usize = 20 * 1024 * 1024;
 
-/// Startup-error banner text for a failed detached structured-view spawn.
-/// `CapacityFull` is transient and user-actionable, so its Display (which
-/// carries "capacity full" + "max_concurrent_workers", matching the
-/// front-end capacity regex) is surfaced verbatim instead of the generic
-/// crash-style message, so the session shows the capacity banner rather
-/// than a misleading failure. See #1027.
+/// Startup-error banner text for a failed detached structured-view spawn,
+/// shared by the create-path (`create_session`) and enable-path
+/// (`acp_enable`). `CapacityFull` is transient and user-actionable, so its
+/// Display (which carries "capacity full" + "max_concurrent_workers", matching
+/// the front-end capacity regex) is surfaced verbatim instead of the generic
+/// crash-style message, so the session shows the capacity banner rather than a
+/// misleading failure. The detached task runs before the reconciler sees the
+/// session, so on `CapacityFull` the first reconciler tick re-publishes the
+/// same banner once via its `capacity_deferred` gate: a single benign
+/// duplicate the front-end reducer collapses idempotently. See #1027.
 pub(crate) fn structured_spawn_error_message(err: &SupervisorError, agent: &str) -> String {
     match err {
         SupervisorError::CapacityFull { .. } => err.to_string(),
@@ -1738,10 +1742,8 @@ pub async fn acp_enable(
             })
             .await
         {
-            // On CapacityFull the reconciler adopts this orphan next tick and
-            // respawns once a slot frees; its `capacity_deferred` gate
-            // re-publishes the same banner once (a single benign duplicate).
-            // See #1027.
+            // Capacity-aware banner selection (and the benign first-tick
+            // duplicate) is documented on `structured_spawn_error_message`.
             let message = structured_spawn_error_message(&e, &agent_name);
             tracing::warn!(target: "acp.switch", session = %session_id, "spawn after enable: {message}");
             supervisor.publish_startup_error(&session_id, message);

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -24,6 +24,8 @@ pub(crate) mod system;
 mod telemetry;
 
 #[cfg(feature = "serve")]
+pub(crate) use acp::structured_spawn_error_message;
+#[cfg(feature = "serve")]
 pub use acp::{
     acp_attachment, acp_cancel, acp_context_primer, acp_disable, acp_enable, acp_files,
     acp_force_end_turn, acp_prompt, acp_prompt_diff_comments, acp_replay, acp_set_config_option,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4515,10 +4515,9 @@ pub async fn create_session(
                             .await
                             .iter()
                             .any(|i| i.id == id);
-                        // On CapacityFull the reconciler adopts this orphan
-                        // next tick and respawns once a slot frees; its
-                        // `capacity_deferred` gate re-publishes the same banner
-                        // once (a single benign duplicate). See #1027.
+                        // Capacity-aware banner selection (and the benign
+                        // first-tick duplicate) is documented on
+                        // `structured_spawn_error_message`.
                         let message =
                             crate::server::api::structured_spawn_error_message(&e, &agent);
                         if still_present {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4515,8 +4515,12 @@ pub async fn create_session(
                             .await
                             .iter()
                             .any(|i| i.id == id);
+                        // On CapacityFull the reconciler adopts this orphan
+                        // next tick and respawns once a slot frees; its
+                        // `capacity_deferred` gate re-publishes the same banner
+                        // once (a single benign duplicate). See #1027.
                         let message =
-                            format!("Failed to start structured view agent {agent:?}: {e}");
+                            crate::server::api::structured_spawn_error_message(&e, &agent);
                         if still_present {
                             tracing::warn!(
                                 target: "acp.supervisor",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3302,6 +3302,13 @@ async fn status_poll_loop(state: Arc<AppState>) {
         std::collections::HashMap::new();
     #[cfg(feature = "serve")]
     let mut acp_parked: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Per-session capacity-deferred marker (#1027). A structured session
+    // refused by `CapacityFull` is re-armed for retry every tick; this set
+    // gates the capacity banner to publish once per transition and is cleared
+    // once the session's worker comes online or leaves the live set.
+    #[cfg(feature = "serve")]
+    let mut acp_capacity_deferred: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     loop {
         interval.tick().await;
 
@@ -3480,6 +3487,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 &mut last_rate_limit_reap,
                 &mut acp_respawn_history,
                 &mut acp_parked,
+                &mut acp_capacity_deferred,
             )
             .await;
 


### PR DESCRIPTION
closes #1027

## Description

At capacity (`[acp] max_concurrent_workers`), structured-view sessions were mishandled at three incoherent spawn sites, none treating `SupervisorError::CapacityFull` as the transient, non-crash, user-actionable condition it is (a slot frees when a peer worker stops):

1. **Reconciler `resume_one`**: `CapacityFull` was swallowed at the join, yet the #1945 respawn budget was already recorded at decision time, so a capacity-blocked session burned its crash budget every tick and parked with a misleading crash-loop banner.
2. **Create-path** (`sessions.rs`): the detached post-201 spawn published a generic `startup_error`, leaving an orphan row with no worker.
3. **`acp_enable`** (`acp.rs`): same detached pattern, same generic error and orphan-at-capacity.

(`prompt_wake_resume` was already correct: gated upstream by `begin_resume`, returned as 503 to `send_prompt`. Untouched.)

**Fix §1** adds `ResumeOutcome::CapacityDeferred`. `resume_one` matches `CapacityFull` before the error type is erased into a string. The join handler then: **pops** the single decision-time budget entry (not `remove`, which would wipe genuine prior-crash history and let a real crash loop escape the park budget); re-arms the retry with **`attempted.remove`** (never `insert`; `attempted` is persistent, so keeping the id there would skip the session forever and kill the self-heal); and publishes the capacity banner **once per transition** via a new `capacity_deferred` gate, reusing `Event::AgentStartupError` (the `CapacityFull` Display already matches the front-end `isCapacity` regex). The marker is cleared on the successful-respawn `SpawnFinished`/`Attached` join arm (the critical site), the `is_running` branch, the live-set retain sweep, and the two explicit-retry reaper loops. This is retry-without-penalty, not a park/hold: the natural per-tick reconciler retry is the self-heal, so no auto-un-park reaper is needed. §1 also repairs the create/enable orphans (the next tick adopts them, does not burn the budget, and respawns once a slot frees).

**Fix §2**: the create-path and `acp_enable` detached spawns publish the `CapacityFull` Display (capacity status) instead of the generic crash-style message, via a shared `structured_spawn_error_message` helper. §2 runs before the reconciler sees the session, so the first reconciler tick emits **one benign duplicate banner** (front-end reducer replaces `startupError`, message idempotent); later ticks are gated. Documented and intentional, no shared flag.

Slot visibility (`GET /api/acp/workers` + `StructuredView` UI) is **split to a fast-follow PR** to keep the web CI (oxfmt/eslint/tsc), Playwright, and the coverage-matrix mandate off this Rust-only diff.

Commits: the core fix, then two review-driven follow-ups (clear the capacity marker on explicit retry + harden tests; de-duplicate the reaper clean-slate reset + tighten docs). No behavior change in the follow-ups beyond the marker clear on explicit retry.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- no UI change; the banner text was already shipped and the slot-visibility UI is a separate PR -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow <!-- Rust-only diff; the front-end capacity banner (`StructuredView.tsx` `isCapacity`) already shipped and is unchanged -->

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the capacity defer/refund/retry/self-heal behavior is covered deterministically by new reconciler-level tests driving `reconcile_acp_workers` across ticks in-process (a full-binary e2e would need real ACP agents held at capacity). Added: `capacity_deferred_rearms_attempted_and_retries_next_tick`, `capacity_deferred_publishes_once_across_ticks`, `capacity_deferred_pop_preserves_prior_crash_history`, `capacity_deferred_clears_marker_when_slot_frees`, `capacity_deferred_cleared_by_is_running_branch`, and `structured_spawn_error_message_prefers_capacity_display_over_generic` (the shared create/enable message selection).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Opus)

**Any Additional AI Details you'd like to share:** Implementation driven from an RCA + cross-validated spec; author reviewed every change against the verbatim code (enum, join arm, budget gate, `begin_resume` capacity gate) before committing. The change was then reviewed over two rounds of three independent parallel reviews each, with the findings cross-validated and applied.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reworks structured-view session handling when worker capacity is full: it treats capacity-full events as a temporary deferral (not a crash loop).
- Adds a dedicated “capacity deferred” path that refunds the appropriate respawn budget entry, re-arms reconciliation for the next tick, retries later (instead of parking incorrectly), and publishes the capacity status only once per transition.
- Introduces tracking/clearing of the deferred marker so sessions resume normally after recovery or explicit relevant state changes.
- Updates structured-view spawn failure messaging for both **create** and **acp_enable** flows to use the exact capacity-full error text (instead of a generic “failed to start” banner), improving orphan-session adoption/retry when capacity becomes available.
- Adds reconciler-level tests for budget handling, retry behavior, notification/banner deduplication, deferred-marker clearing, and correct spawn-error message selection.
- Adds test utilities to simulate occupying and freeing supervisor worker capacity.
- Defers slot-visibility/dashboard changes to a follow-up PR.

### Benefits

Capacity-blocked structured-view sessions are automatically retried without incorrect crash-loop behavior, and users see capacity-appropriate status messaging (with fewer duplicate notifications). Orphaned sessions are more likely to be adopted and resumed when worker slots free up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->