### PR TITLE
fix: quiet tmux "no server running" log spam

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -146,6 +146,16 @@ struct SessionCache {
 // `\037`), so anything non-printable is unreliable. Pipe is safe.
 const FIELD_SEP: char = '|';
 
+/// tmux exits non-zero with `no server running on <socket>` on stderr when no
+/// tmux server is up. That is the normal idle state whenever aoe has no
+/// terminal-view sessions, not a failure, so callers log it at trace like an
+/// empty success rather than warn. Without this the ~2s status poll floods the
+/// log with identical warnings (tens of thousands per day) that bury real
+/// signal, even though nothing is actually wrong.
+fn tmux_server_absent(stderr: &[u8]) -> bool {
+    String::from_utf8_lossy(stderr).contains("no server running")
+}
+
 pub fn refresh_session_cache() {
     let start = Instant::now();
     let output = tmux_command()
@@ -163,6 +173,10 @@ pub fn refresh_session_cache() {
                 }
             }
             Some(map)
+        }
+        Ok(out) if tmux_server_absent(&out.stderr) => {
+            tracing::trace!(target: "tmux.cache", "no tmux server running; cache cleared");
+            None
         }
         Ok(out) => {
             tracing::warn!(
@@ -270,12 +284,16 @@ pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
             Ok(parse_pane_metadata(&stdout))
         }
         Ok(out) => {
-            tracing::warn!(
-                target: "tmux.pane",
-                status = ?out.status,
-                stderr_bytes = out.stderr.len(),
-                "list-panes returned non-zero",
-            );
+            if tmux_server_absent(&out.stderr) {
+                tracing::trace!(target: "tmux.pane", "no tmux server running");
+            } else {
+                tracing::warn!(
+                    target: "tmux.pane",
+                    status = ?out.status,
+                    stderr_bytes = out.stderr.len(),
+                    "list-panes returned non-zero",
+                );
+            }
             Err(anyhow::anyhow!(
                 "tmux list-panes returned non-zero status: {:?}",
                 out.status
@@ -328,11 +346,15 @@ pub fn attached_session_names() -> anyhow::Result<HashSet<String>> {
             Ok(attached)
         }
         Ok(out) => {
-            tracing::warn!(
-                target: "tmux.cache",
-                status = ?out.status,
-                "list-sessions (attached) returned non-zero",
-            );
+            if tmux_server_absent(&out.stderr) {
+                tracing::trace!(target: "tmux.cache", "no tmux server running (attached query)");
+            } else {
+                tracing::warn!(
+                    target: "tmux.cache",
+                    status = ?out.status,
+                    "list-sessions (attached) returned non-zero",
+                );
+            }
             Err(anyhow::anyhow!(
                 "tmux list-sessions returned non-zero status: {:?}",
                 out.status
@@ -564,6 +586,18 @@ mod tests {
             tmux_socket_path().is_some(),
             "unit tests must not fall back to the default socket"
         );
+    }
+
+    #[test]
+    fn tmux_server_absent_detects_no_server_and_ignores_real_errors() {
+        // The exact stderr tmux emits when nothing is listening on its socket.
+        assert!(tmux_server_absent(
+            b"no server running on /tmp/tmux-1001/default\n"
+        ));
+        // A genuine tmux failure must NOT be mistaken for the benign case, so
+        // it still logs at warn.
+        assert!(!tmux_server_absent(b"can't find session: aoe_foo\n"));
+        assert!(!tmux_server_absent(b""));
     }
 
     #[test]


### PR DESCRIPTION
## Description

The three tmux status pollers (`refresh_session_cache`, `batch_pane_metadata`, `attached_session_names`) logged every non-zero `tmux list-sessions` / `list-panes` exit at `warn`. But `no server running on <socket>` is tmux's normal exit-1 when no tmux server is up, which is the routine idle state whenever aoe has no terminal-view sessions, not a failure.

The status poll runs roughly every 2s, so that benign state produced tens of thousands of identical `list-sessions returned non-zero; cache cleared` warnings per day, dominating `debug.log` and burying real signal. (Observed on a live machine: ~82k such lines in a single log segment after the tmux server went away while all ACP/structured-view work continued fine.)

**Fix:** a small `tmux_server_absent(stderr)` helper detects the `no server running` case; the three pollers log it at `trace!` (matching the success path, which is already `trace!` for exactly this "don't flood the ~2s poll" reason) while keeping genuine tmux failures at `warn!`.

**Deliberately minimal — control flow is unchanged.** `batch_pane_metadata` and `attached_session_names` still return `Err` in the no-server case, because their callers rely on `Err` meaning "don't know, skip this pass" (the idle reapers must not mistake it for "nothing attached" and kill a live pane). Only the log level changed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed)
- [ ] For UI changes: included screenshot or recording (N/A, no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. It changes log verbosity of an internal poller; covered by a new in-module unit test (`tmux_server_absent_detects_no_server_and_ignores_real_errors`) asserting the benign string is detected and real errors / empty stderr are not.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Diagnosed from a live daemon log flooding with this warning; AI drafted the log-level fix and unit test. Human-reviewed.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added logic to recognize tmux’s expected “no server running” stderr as a normal idle state.
- Reduced log noise by downgrading that specific case from warnings to trace-level logs in session cache refresh and two other tmux polling paths.
- Kept behavior consistent for real tmux failures: genuine errors still produce warnings and the pollers still return errors.
- Added a unit test to verify the benign stderr detection while rejecting real error output and empty stderr.

## Benefits

- Significantly cleaner logs during periods when tmux isn’t running (no tmux server yet / fully idle).
- Preserves clearer signal by continuing to warn on actual tmux problems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->