### PR TITLE
fix(config): follow symlinks when saving the global config

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2444,7 +2444,10 @@ pub fn save_config(config: &Config) -> Result<()> {
     let path = config_path()?;
     let table = toml::Table::try_from(config)?;
     let content = toml::to_string_pretty(&table)?;
-    super::atomic_write(&path, content.as_bytes())?;
+    // Follow a symlink through to its target so a config file linked from a
+    // dotfiles repo (chezmoi, stow, dotbot) is updated in place rather than
+    // replaced by a fresh regular file, which would break the link (#2784).
+    super::atomic_write_following_symlinks(&path, content.as_bytes())?;
     Ok(())
 }
 
@@ -2591,6 +2594,58 @@ mod tests {
         assert_eq!(
             config.sandbox.enabled_by_default,
             defaults.sandbox.enabled_by_default,
+        );
+    }
+
+    /// A symlinked global `config.toml` must survive a save: the link stays a
+    /// link and its target receives the new content, instead of the save
+    /// replacing the symlink with a regular file (#2784).
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn test_save_config_preserves_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let app_dir = temp_home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_XDG);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
+        std::fs::create_dir_all(&app_dir).unwrap();
+
+        // Simulate a dotfiles repo the user symlinks config.toml into.
+        let dotfiles = temp_home.path().join("dotfiles");
+        std::fs::create_dir_all(&dotfiles).unwrap();
+        let target = dotfiles.join("aoe-config.toml");
+        std::fs::write(&target, "default_profile = \"old\"\n").unwrap();
+
+        let link = app_dir.join("config.toml");
+        symlink(&target, &link).unwrap();
+
+        let mut config = Config::default();
+        config.default_profile = "new".to_string();
+        save_config(&config).unwrap();
+
+        // The link is still a link, not a fresh regular file.
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "save_config must not replace the symlink with a regular file",
+        );
+        // The write landed on the target, not beside the link.
+        let written = std::fs::read_to_string(&target).unwrap();
+        assert!(
+            written.contains("default_profile = \"new\""),
+            "symlink target should hold the saved config, got: {written}",
         );
     }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2444,9 +2444,6 @@ pub fn save_config(config: &Config) -> Result<()> {
     let path = config_path()?;
     let table = toml::Table::try_from(config)?;
     let content = toml::to_string_pretty(&table)?;
-    // Follow a symlink through to its target so a config file linked from a
-    // dotfiles repo (chezmoi, stow, dotbot) is updated in place rather than
-    // replaced by a fresh regular file, which would break the link (#2784).
     super::atomic_write_following_symlinks(&path, content.as_bytes())?;
     Ok(())
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Saving the global config used to clobber a symlinked `~/.agent-of-empires/config.toml`. `save_config` went through the plain `atomic_write` helper, whose temp-file + `rename(2)` dance replaces the symlink itself with a fresh regular file. For anyone who keeps their config in a dotfiles repo (chezmoi, stow, dotbot) and symlinks it into place, every `aoe` quit/restart broke the link and left the dotfile tree out of sync.

The codebase already had the fix, built for exactly this case: `atomic_write_following_symlinks` resolves the symlink chain and writes through to the underlying target, and the hooks code already uses it for agent config files (codex, settl, claude). The global AoE config was simply never switched over. This PR points `save_config` at that helper.

Non-symlinked configs are unaffected: `resolve_symlink_chain` returns the path unchanged when it is not a symlink, so the save is the same atomic replace as before.

Added a Unix-gated regression test that symlinks `config.toml` into a stand-in dotfiles dir, saves, and asserts the link survives and its target holds the new content. Verified it fails on the pre-fix tree (link replaced by a regular file) and passes after.

Closes #2784

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Move `~/.agent-of-empires/config.toml` into a separate dir and symlink it back (`ln -s ~/dotfiles/aoe-config.toml ~/.agent-of-empires/config.toml`).
- [ ] Launch `aoe`, change a setting (or just quit and restart so a save fires).
- [ ] Confirm `~/.agent-of-empires/config.toml` is still a symlink (`ls -l`), not a regular file.
- [ ] Confirm the change landed in the symlink target (`~/dotfiles/aoe-config.toml`).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (scope to the global config, reuse the existing symlink-following helper rather than add a `--config` flag) and reviewed the commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated global configuration saving to preserve symlinked `config.toml` files by writing changes to the symlink target instead of replacing the symlink.
- Added a Unix-only regression test that creates a symlinked `config.toml`, runs `save_config`, verifies the path is still a symlink, and confirms the TOML content was updated at the target.
- Left the behavior unchanged for non-symlinked configuration files.

## Benefits

- Users can safely manage global config via symlinks (e.g., from dotfiles repositories) without the symlink being broken or replaced during saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->