### PR TITLE
fix(test): stop home-isolation helpers leaking XDG config

### DIFF
--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -151,6 +151,40 @@ pub(crate) fn isolate_app_dir() -> AppDirGuard {
     }
 }
 
+/// RAII guard: like [`isolate_app_dir`], but for callers that already own
+/// their tempdir and just need `HOME`/`XDG_CONFIG_HOME` pointed at an
+/// existing path rather than one this helper creates and owns. Sets
+/// `XDG_CONFIG_HOME` unconditionally (not gated to Linux/macOS): see
+/// issue #1948, the fix this branch lands.
+#[must_use = "HomeGuard restores env vars on Drop; bind it to `_home` or `_guard`, not `_`, or the isolation ends on the same line and the test body runs against the caller's real env"]
+pub(crate) struct HomeGuard {
+    prev_home: Option<OsString>,
+    prev_xdg: Option<OsString>,
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+/// Points `HOME`/`XDG_CONFIG_HOME` at `temp` for the current test body,
+/// restoring the prior values on `Drop`. Unlike [`isolate_app_dir`], the
+/// caller supplies (and owns) the tempdir.
+pub(crate) fn isolate_home(temp: &Path) -> HomeGuard {
+    let prev_home = std::env::var_os("HOME");
+    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    // SAFETY (staged for Rust 2024 edition migration): same invariant
+    // as [`restore_or_remove`] above.
+    std::env::set_var("HOME", temp);
+    std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    HomeGuard {
+        prev_home,
+        prev_xdg,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/home/file_watch_tests.rs
+++ b/src/tui/home/file_watch_tests.rs
@@ -18,60 +18,8 @@ use tempfile::TempDir;
 
 use super::HomeView;
 use crate::file_watch::FileWatchService;
+use crate::session::test_support::isolate_home;
 use crate::session::{Instance, Storage};
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
-/// body and restores the prior values on `Drop`. `#[serial]` on every
-/// caller linearizes this against other tests in the binary; without
-/// the restore, a later test could inherit this test's (by-then-dropped)
-/// tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(temp: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", temp) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
-
-/// Thin wrapper kept so existing call sites don't need renaming; see
-/// `HomeGuard` for the isolation/restore behavior.
-fn isolate_home(temp: &std::path::Path) -> HomeGuard {
-    HomeGuard::new(temp)
-}
 
 fn watcher_err(profile: Option<&str>, message: &str) -> super::WatcherInitError {
     super::WatcherInitError {

--- a/src/tui/home/file_watch_tests.rs
+++ b/src/tui/home/file_watch_tests.rs
@@ -23,10 +23,7 @@ use crate::session::{Instance, Storage};
 fn isolate_home(temp: &std::path::Path) {
     // SAFETY: env mutation; #[serial] guards cross-test races on HOME.
     unsafe { std::env::set_var("HOME", temp) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
 }
 
 fn watcher_err(profile: Option<&str>, message: &str) -> super::WatcherInitError {

--- a/src/tui/home/file_watch_tests.rs
+++ b/src/tui/home/file_watch_tests.rs
@@ -32,6 +32,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(temp: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -49,6 +51,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {
@@ -63,6 +67,8 @@ impl Drop for HomeGuard {
     }
 }
 
+/// Thin wrapper kept so existing call sites don't need renaming; see
+/// `HomeGuard` for the isolation/restore behavior.
 fn isolate_home(temp: &std::path::Path) -> HomeGuard {
     HomeGuard::new(temp)
 }

--- a/src/tui/home/file_watch_tests.rs
+++ b/src/tui/home/file_watch_tests.rs
@@ -20,10 +20,51 @@ use super::HomeView;
 use crate::file_watch::FileWatchService;
 use crate::session::{Instance, Storage};
 
-fn isolate_home(temp: &std::path::Path) {
-    // SAFETY: env mutation; #[serial] guards cross-test races on HOME.
-    unsafe { std::env::set_var("HOME", temp) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
+/// body and restores the prior values on `Drop`. `#[serial]` on every
+/// caller linearizes this against other tests in the binary; without
+/// the restore, a later test could inherit this test's (by-then-dropped)
+/// tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(temp: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", temp) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+fn isolate_home(temp: &std::path::Path) -> HomeGuard {
+    HomeGuard::new(temp)
 }
 
 fn watcher_err(profile: Option<&str>, message: &str) -> super::WatcherInitError {
@@ -78,7 +119,7 @@ impl Drop for E2eDebugGuard {
 #[serial]
 async fn home_view_new_spawns_adapter_that_flips_disk_dirty() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("hv-adapter").expect("seed dir");
@@ -121,7 +162,7 @@ async fn home_view_new_spawns_adapter_that_flips_disk_dirty() {
 #[serial]
 async fn rewire_disk_subscriptions_drops_removed_profile_entry() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("hv-keep").expect("dir");
@@ -168,7 +209,7 @@ async fn rewire_disk_subscriptions_drops_removed_profile_entry() {
 #[serial]
 async fn config_subscriptions_remove_then_recreate_does_not_leak_or_double_subscribe() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("cfg-leak").expect("seed dir");
@@ -224,7 +265,7 @@ async fn config_subscriptions_remove_then_recreate_does_not_leak_or_double_subsc
 async fn rewire_config_subscriptions_does_not_resurrect_deleted_profile_dir() {
     use super::ConfigWatchKey;
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     let profile_dir = crate::session::get_profile_dir("ghost").expect("seed dir");
@@ -269,7 +310,7 @@ async fn rewire_config_subscriptions_does_not_resurrect_deleted_profile_dir() {
 #[serial]
 async fn reload_storage_only_keeps_disk_watch_scoped_in_single_profile_mode() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("active-only").expect("seed active dir");
@@ -329,7 +370,7 @@ async fn reload_storage_only_keeps_disk_watch_scoped_in_single_profile_mode() {
 #[serial]
 async fn rewire_after_profile_delete_keeps_disk_watch_scoped_in_single_profile_mode() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("active-scoped").expect("seed active");
@@ -386,7 +427,7 @@ async fn rewire_after_profile_delete_keeps_disk_watch_scoped_in_single_profile_m
 #[serial]
 async fn rewire_after_profile_delete_surfaces_dialog_when_list_profiles_fails() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("seam-test").expect("seed dir");
@@ -422,7 +463,7 @@ async fn rewire_after_profile_delete_surfaces_dialog_when_list_profiles_fails() 
 #[serial]
 async fn reload_storage_only_survives_list_profiles_failure() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("reload-fallback").expect("seed dir");
@@ -462,7 +503,7 @@ async fn reload_storage_only_survives_list_profiles_failure() {
 #[serial]
 async fn rewire_after_profile_delete_preserves_existing_info_dialog() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("dialog-guard").expect("seed dir");
@@ -511,7 +552,7 @@ async fn rewire_after_profile_delete_preserves_existing_info_dialog() {
 #[serial]
 async fn rewire_after_profile_delete_watcher_warning_survives_recovery_edge() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("watcher-warning-edge").expect("seed dir");
@@ -565,7 +606,7 @@ async fn rewire_after_profile_delete_watcher_warning_survives_recovery_edge() {
 #[serial]
 async fn rewire_no_op_preserves_latched_disk_watcher_init_failure() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("hv-noop").expect("seed dir");
@@ -612,7 +653,7 @@ async fn rewire_no_op_preserves_latched_disk_watcher_init_failure() {
 #[serial]
 async fn rewire_disk_clears_stale_latch_when_failing_profile_is_removed() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("active-stale").expect("seed active");
@@ -651,7 +692,7 @@ async fn rewire_disk_clears_stale_latch_when_failing_profile_is_removed() {
 #[serial]
 async fn rewire_config_clears_stale_latch_when_failing_profile_is_removed() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("active-stale-cfg").expect("seed active");
@@ -692,7 +733,7 @@ async fn rewire_config_clears_stale_latch_when_failing_profile_is_removed() {
 #[serial]
 async fn config_init_failure_survives_concurrent_disk_rewire_clear() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("hv-iso").expect("seed dir");
@@ -1007,7 +1048,7 @@ fn reload_failure_re_arms_when_failure_fully_clears_then_returns() {
 #[serial]
 async fn try_present_reload_failure_dialog_refreshes_body_for_new_source() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("body-refresh").expect("seed dir");
@@ -1062,7 +1103,7 @@ async fn try_present_reload_failure_dialog_refreshes_body_for_new_source() {
 #[serial]
 async fn try_present_reload_failure_dialog_skips_while_foreign_dialog_occupies_slot() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("foreign-skip").expect("seed dir");
@@ -1121,7 +1162,7 @@ async fn try_present_reload_failure_dialog_skips_while_foreign_dialog_occupies_s
 async fn rewire_config_subscriptions_install_loop_skips_missing_profile_dir() {
     use super::ConfigWatchKey;
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("active").expect("seed active");
@@ -1170,7 +1211,7 @@ async fn rewire_config_subscriptions_install_loop_skips_missing_profile_dir() {
 #[serial]
 async fn rewire_disk_subscriptions_install_loop_skips_missing_profile_dir() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("disk-active").expect("seed active");
@@ -1214,7 +1255,7 @@ async fn rewire_disk_subscriptions_install_loop_skips_missing_profile_dir() {
 #[serial]
 async fn try_present_reload_failure_dialog_refreshes_body_on_partial_recovery() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("partial-recovery").expect("seed dir");
@@ -1291,7 +1332,7 @@ async fn try_present_reload_failure_dialog_refreshes_body_on_partial_recovery() 
 #[serial]
 async fn watcher_config_refresh_count_exports_to_e2e_debug_file() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     crate::session::get_profile_dir("e2e-debug").expect("seed dir");
@@ -1355,7 +1396,7 @@ async fn watcher_config_refresh_count_exports_to_e2e_debug_file() {
 #[serial]
 async fn rewire_config_invalidates_on_inode_change_with_same_canonical_path() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     let _seed = crate::session::get_profile_dir("inode-drift-cfg").expect("seed dir");
@@ -1407,7 +1448,7 @@ async fn rewire_config_invalidates_on_inode_change_with_same_canonical_path() {
 #[serial]
 async fn rewire_disk_invalidates_on_inode_change_with_same_canonical_path() {
     let temp = TempDir::new().expect("tempdir");
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let live = FileWatchService::new().expect("live svc");
     let _seed = crate::session::get_profile_dir("inode-drift-disk").expect("seed dir");

--- a/tests/e2e/filewatch_tui_burst_reload.rs
+++ b/tests/e2e/filewatch_tui_burst_reload.rs
@@ -13,54 +13,7 @@ use agent_of_empires::file_watch::FileWatchService;
 use agent_of_empires::session::{Instance, Storage};
 use serial_test::serial;
 
-use crate::harness::{require_tmux, TuiTestHarness};
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
-/// for the test process and restores the prior values on `Drop`.
-/// `#[serial]` on every caller linearizes this against other tests in
-/// the binary; without the restore, a later test could inherit this
-/// test's (by-then-dropped) tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(home: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", home) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
+use crate::harness::{require_tmux, HomeGuard, TuiTestHarness};
 
 #[test]
 #[serial]

--- a/tests/e2e/filewatch_tui_burst_reload.rs
+++ b/tests/e2e/filewatch_tui_burst_reload.rs
@@ -15,6 +15,49 @@ use serial_test::serial;
 
 use crate::harness::{require_tmux, TuiTestHarness};
 
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
+/// for the test process and restores the prior values on `Drop`.
+/// `#[serial]` on every caller linearizes this against other tests in
+/// the binary; without the restore, a later test could inherit this
+/// test's (by-then-dropped) tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(home: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", home) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
 #[test]
 #[serial]
 fn back_to_back_peer_writes_surface_within_sub_tick_budget() {
@@ -24,10 +67,7 @@ fn back_to_back_peer_writes_surface_within_sub_tick_budget() {
     h.spawn_tui();
     h.wait_for(" aoe ");
 
-    // SAFETY: env mutation; the harness owns its own isolated $HOME.
-    // `#[serial]` guards cross-test races.
-    unsafe { std::env::set_var("HOME", h.home_path()) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
+    let _home = HomeGuard::new(h.home_path());
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new("default", svc).expect("storage in test process");

--- a/tests/e2e/filewatch_tui_burst_reload.rs
+++ b/tests/e2e/filewatch_tui_burst_reload.rs
@@ -27,6 +27,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(home: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -44,6 +46,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {

--- a/tests/e2e/filewatch_tui_burst_reload.rs
+++ b/tests/e2e/filewatch_tui_burst_reload.rs
@@ -27,10 +27,7 @@ fn back_to_back_peer_writes_surface_within_sub_tick_budget() {
     // SAFETY: env mutation; the harness owns its own isolated $HOME.
     // `#[serial]` guards cross-test races.
     unsafe { std::env::set_var("HOME", h.home_path()) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new("default", svc).expect("storage in test process");

--- a/tests/e2e/filewatch_tui_dynamic_profile.rs
+++ b/tests/e2e/filewatch_tui_dynamic_profile.rs
@@ -42,10 +42,7 @@ fn dynamic_profile_add_and_remove_keeps_subscriptions_in_sync() {
     // SAFETY: env mutation; the harness owns its own isolated $HOME.
     // `#[serial]` guards cross-test races.
     unsafe { std::env::set_var("HOME", h.home_path()) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new(new_profile, svc).expect("storage for new profile");
@@ -132,10 +129,7 @@ fn filtered_profile_switch_rewires_disk_watch_to_new_profile() {
     // SAFETY: env mutation; the harness owns its own isolated $HOME.
     // `#[serial]` guards cross-test races.
     unsafe { std::env::set_var("HOME", h.home_path()) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new("beta", svc).expect("storage for beta profile");

--- a/tests/e2e/filewatch_tui_dynamic_profile.rs
+++ b/tests/e2e/filewatch_tui_dynamic_profile.rs
@@ -15,54 +15,7 @@ use agent_of_empires::file_watch::FileWatchService;
 use agent_of_empires::session::{Instance, Storage};
 use serial_test::serial;
 
-use crate::harness::{require_tmux, TuiTestHarness};
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
-/// for the test process and restores the prior values on `Drop`.
-/// `#[serial]` on every caller linearizes this against other tests in
-/// the binary; without the restore, a later test could inherit this
-/// test's (by-then-dropped) tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(home: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", home) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
+use crate::harness::{require_tmux, HomeGuard, TuiTestHarness};
 
 #[test]
 #[serial]

--- a/tests/e2e/filewatch_tui_dynamic_profile.rs
+++ b/tests/e2e/filewatch_tui_dynamic_profile.rs
@@ -17,6 +17,49 @@ use serial_test::serial;
 
 use crate::harness::{require_tmux, TuiTestHarness};
 
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
+/// for the test process and restores the prior values on `Drop`.
+/// `#[serial]` on every caller linearizes this against other tests in
+/// the binary; without the restore, a later test could inherit this
+/// test's (by-then-dropped) tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(home: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", home) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
 #[test]
 #[serial]
 fn dynamic_profile_add_and_remove_keeps_subscriptions_in_sync() {
@@ -39,10 +82,7 @@ fn dynamic_profile_add_and_remove_keeps_subscriptions_in_sync() {
     h.send_keys("Enter");
     h.wait_for_absent("Profiles", Duration::from_secs(5));
 
-    // SAFETY: env mutation; the harness owns its own isolated $HOME.
-    // `#[serial]` guards cross-test races.
-    unsafe { std::env::set_var("HOME", h.home_path()) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
+    let _home = HomeGuard::new(h.home_path());
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new(new_profile, svc).expect("storage for new profile");
@@ -126,10 +166,7 @@ fn filtered_profile_switch_rewires_disk_watch_to_new_profile() {
     h.assert_screen_contains("Beta Session");
     h.assert_screen_not_contains("Alpha Session");
 
-    // SAFETY: env mutation; the harness owns its own isolated $HOME.
-    // `#[serial]` guards cross-test races.
-    unsafe { std::env::set_var("HOME", h.home_path()) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
+    let _home = HomeGuard::new(h.home_path());
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new("beta", svc).expect("storage for beta profile");

--- a/tests/e2e/filewatch_tui_dynamic_profile.rs
+++ b/tests/e2e/filewatch_tui_dynamic_profile.rs
@@ -29,6 +29,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(home: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -46,6 +48,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {

--- a/tests/e2e/filewatch_tui_reload.rs
+++ b/tests/e2e/filewatch_tui_reload.rs
@@ -16,54 +16,7 @@ use agent_of_empires::file_watch::FileWatchService;
 use agent_of_empires::session::{Instance, Storage};
 use serial_test::serial;
 
-use crate::harness::{require_tmux, TuiTestHarness};
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
-/// for the test process and restores the prior values on `Drop`.
-/// `#[serial]` on every caller linearizes this against other tests in
-/// the binary; without the restore, a later test could inherit this
-/// test's (by-then-dropped) tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(home: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", home) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
+use crate::harness::{require_tmux, HomeGuard, TuiTestHarness};
 
 #[test]
 #[serial]

--- a/tests/e2e/filewatch_tui_reload.rs
+++ b/tests/e2e/filewatch_tui_reload.rs
@@ -31,10 +31,7 @@ fn peer_storage_update_reflects_within_sub_tick_budget() {
     // we set it for THIS process so `Storage::new` resolves the same
     // app dir the TUI is watching. `#[serial]` guards cross-test races.
     unsafe { std::env::set_var("HOME", h.home_path()) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new("default", svc).expect("storage in test process");

--- a/tests/e2e/filewatch_tui_reload.rs
+++ b/tests/e2e/filewatch_tui_reload.rs
@@ -30,6 +30,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(home: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -47,6 +49,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {

--- a/tests/e2e/filewatch_tui_reload.rs
+++ b/tests/e2e/filewatch_tui_reload.rs
@@ -18,6 +18,49 @@ use serial_test::serial;
 
 use crate::harness::{require_tmux, TuiTestHarness};
 
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
+/// for the test process and restores the prior values on `Drop`.
+/// `#[serial]` on every caller linearizes this against other tests in
+/// the binary; without the restore, a later test could inherit this
+/// test's (by-then-dropped) tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(home: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", home) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
 #[test]
 #[serial]
 fn peer_storage_update_reflects_within_sub_tick_budget() {
@@ -27,11 +70,9 @@ fn peer_storage_update_reflects_within_sub_tick_budget() {
     h.spawn_tui();
     h.wait_for(" aoe ");
 
-    // SAFETY: env mutation; the harness owns its own isolated $HOME and
-    // we set it for THIS process so `Storage::new` resolves the same
-    // app dir the TUI is watching. `#[serial]` guards cross-test races.
-    unsafe { std::env::set_var("HOME", h.home_path()) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", h.home_path().join(".config")) };
+    // Set HOME/XDG_CONFIG_HOME for THIS process so `Storage::new`
+    // resolves the same app dir the TUI is watching.
+    let _home = HomeGuard::new(h.home_path());
 
     let svc: Arc<FileWatchService> = FileWatchService::noop();
     let storage = Storage::new("default", svc).expect("storage in test process");

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -36,6 +36,57 @@ pub fn app_dir_in(home: &Path) -> PathBuf {
 }
 
 // ---------------------------------------------------------------------------
+// HOME isolation guard
+// ---------------------------------------------------------------------------
+
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at the harness's tempdir
+/// for the test process and restores the prior values on `Drop`.
+/// `#[serial]` on every caller linearizes this against other tests in
+/// the binary; without the restore, a later test could inherit this
+/// test's (by-then-dropped) tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+pub struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
+    pub fn new(home: &Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", home) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+// ---------------------------------------------------------------------------
 // tmux availability guard
 // ---------------------------------------------------------------------------
 

--- a/tests/filewatch_tui_adapter_lifetime.rs
+++ b/tests/filewatch_tui_adapter_lifetime.rs
@@ -23,10 +23,7 @@ use tempfile::TempDir;
 fn isolate_home(temp: &std::path::Path) {
     // SAFETY: env mutation; #[serial] guards cross-test races.
     unsafe { std::env::set_var("HOME", temp) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
 }
 
 struct ForwarderHarness {

--- a/tests/filewatch_tui_adapter_lifetime.rs
+++ b/tests/filewatch_tui_adapter_lifetime.rs
@@ -10,6 +10,8 @@
 //! "forwarder task accidentally dropped on construct," which would close
 //! the channel and leave the dirty flag forever stuck.
 
+mod home_isolation;
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -17,61 +19,9 @@ use std::time::{Duration, Instant};
 
 use agent_of_empires::file_watch::{FileMatcher, FileWatchService, WatchSpec};
 use agent_of_empires::session::{Instance, Storage};
+use home_isolation::isolate_home;
 use serial_test::serial;
 use tempfile::TempDir;
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
-/// body and restores the prior values on `Drop`. `#[serial]` on every
-/// caller linearizes this against other tests in the binary; without
-/// the restore, a later test could inherit this test's (by-then-dropped)
-/// tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(temp: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", temp) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
-
-/// Thin wrapper kept so existing call sites don't need renaming; see
-/// `HomeGuard` for the isolation/restore behavior.
-fn isolate_home(temp: &std::path::Path) -> HomeGuard {
-    HomeGuard::new(temp)
-}
 
 struct ForwarderHarness {
     disk_dirty: Arc<AtomicBool>,

--- a/tests/filewatch_tui_adapter_lifetime.rs
+++ b/tests/filewatch_tui_adapter_lifetime.rs
@@ -32,6 +32,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(temp: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -49,6 +51,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {
@@ -63,6 +67,8 @@ impl Drop for HomeGuard {
     }
 }
 
+/// Thin wrapper kept so existing call sites don't need renaming; see
+/// `HomeGuard` for the isolation/restore behavior.
 fn isolate_home(temp: &std::path::Path) -> HomeGuard {
     HomeGuard::new(temp)
 }

--- a/tests/filewatch_tui_adapter_lifetime.rs
+++ b/tests/filewatch_tui_adapter_lifetime.rs
@@ -20,10 +20,51 @@ use agent_of_empires::session::{Instance, Storage};
 use serial_test::serial;
 use tempfile::TempDir;
 
-fn isolate_home(temp: &std::path::Path) {
-    // SAFETY: env mutation; #[serial] guards cross-test races.
-    unsafe { std::env::set_var("HOME", temp) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
+/// body and restores the prior values on `Drop`. `#[serial]` on every
+/// caller linearizes this against other tests in the binary; without
+/// the restore, a later test could inherit this test's (by-then-dropped)
+/// tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(temp: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", temp) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+fn isolate_home(temp: &std::path::Path) -> HomeGuard {
+    HomeGuard::new(temp)
 }
 
 struct ForwarderHarness {
@@ -66,7 +107,7 @@ async fn spawn_harness(svc: Arc<FileWatchService>, dir: PathBuf) -> ForwarderHar
 #[serial]
 async fn adapter_flips_disk_dirty_after_storage_update() {
     let temp = TempDir::new().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let svc: Arc<FileWatchService> = FileWatchService::new().expect("init");
 

--- a/tests/filewatch_tui_drop_then_abort.rs
+++ b/tests/filewatch_tui_drop_then_abort.rs
@@ -35,6 +35,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(temp: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -52,6 +54,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {
@@ -66,6 +70,8 @@ impl Drop for HomeGuard {
     }
 }
 
+/// Thin wrapper kept so existing call sites don't need renaming; see
+/// `HomeGuard` for the isolation/restore behavior.
 fn isolate_home(temp: &std::path::Path) -> HomeGuard {
     HomeGuard::new(temp)
 }

--- a/tests/filewatch_tui_drop_then_abort.rs
+++ b/tests/filewatch_tui_drop_then_abort.rs
@@ -13,6 +13,8 @@
 //! `None` because the subscription's `DeliverySink` was deregistered).
 //! No `try_send` runs after the drop point.
 
+mod home_isolation;
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -20,61 +22,9 @@ use std::time::{Duration, Instant};
 
 use agent_of_empires::file_watch::{FileMatcher, FileWatchService, WatchSpec};
 use agent_of_empires::session::{Instance, Storage};
+use home_isolation::isolate_home;
 use serial_test::serial;
 use tempfile::TempDir;
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
-/// body and restores the prior values on `Drop`. `#[serial]` on every
-/// caller linearizes this against other tests in the binary; without
-/// the restore, a later test could inherit this test's (by-then-dropped)
-/// tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(temp: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", temp) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
-
-/// Thin wrapper kept so existing call sites don't need renaming; see
-/// `HomeGuard` for the isolation/restore behavior.
-fn isolate_home(temp: &std::path::Path) -> HomeGuard {
-    HomeGuard::new(temp)
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]

--- a/tests/filewatch_tui_drop_then_abort.rs
+++ b/tests/filewatch_tui_drop_then_abort.rs
@@ -26,10 +26,7 @@ use tempfile::TempDir;
 fn isolate_home(temp: &std::path::Path) {
     // SAFETY: env mutation; #[serial] guards cross-test races.
     unsafe { std::env::set_var("HOME", temp) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/filewatch_tui_drop_then_abort.rs
+++ b/tests/filewatch_tui_drop_then_abort.rs
@@ -23,17 +23,58 @@ use agent_of_empires::session::{Instance, Storage};
 use serial_test::serial;
 use tempfile::TempDir;
 
-fn isolate_home(temp: &std::path::Path) {
-    // SAFETY: env mutation; #[serial] guards cross-test races.
-    unsafe { std::env::set_var("HOME", temp) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
+/// body and restores the prior values on `Drop`. `#[serial]` on every
+/// caller linearizes this against other tests in the binary; without
+/// the restore, a later test could inherit this test's (by-then-dropped)
+/// tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(temp: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", temp) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+fn isolate_home(temp: &std::path::Path) -> HomeGuard {
+    HomeGuard::new(temp)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn dropping_handle_closes_source_channel_before_forwarder_aborts() {
     let temp = TempDir::new().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let svc: Arc<FileWatchService> = FileWatchService::new().expect("init");
 

--- a/tests/home_isolation/mod.rs
+++ b/tests/home_isolation/mod.rs
@@ -1,0 +1,74 @@
+//! Shared `HOME`/`XDG_CONFIG_HOME` test-isolation support for the
+//! standalone integration-test binaries under `tests/` that don't also
+//! need `tests/common`'s port helpers.
+//!
+//! This is a separate module (not folded into `tests/common/mod.rs`)
+//! because binaries that include a module get `dead_code` warnings for
+//! any of its public items they don't call — `pick_free_port`/
+//! `wait_for_port` in `tests/common/mod.rs` are unused by the isolation-only
+//! consumers below, so this splits the two concerns into separate shared
+//! modules. It is also a separate copy from `src/session/test_support.rs`
+//! (the in-crate copy, used by unit tests compiled into the library) and
+//! from `tests/e2e/harness.rs` (used by the `tests/e2e` binary) — each
+//! standalone `tests/*.rs` file Cargo auto-discovers is compiled as its
+//! own separate crate, and `tests/e2e` is yet another separate crate, so
+//! none of the three can share code directly across those boundaries.
+//!
+//! Naming this file `mod.rs` (rather than a sibling `tests/home_isolation.rs`)
+//! opts it out of Cargo's test-binary auto-discovery, so it stays a
+//! shared module rather than becoming its own (empty) test binary.
+
+use std::path::Path;
+
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
+/// body and restores the prior values on `Drop`. `#[serial]` on every
+/// caller linearizes this against other tests in the binary; without
+/// the restore, a later test could inherit this test's (by-then-dropped)
+/// tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+pub struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
+    pub fn new(temp: &Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", temp) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+/// Thin wrapper kept so existing call sites don't need renaming; see
+/// `HomeGuard` for the isolation/restore behavior.
+pub fn isolate_home(temp: &Path) -> HomeGuard {
+    HomeGuard::new(temp)
+}

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -269,7 +269,6 @@ fn spawn_favorite(aoe: &str, home: &std::path::Path, id: &str) -> std::process::
     cmd.args(["session", "favorite", id])
         .env("HOME", home)
         .env_remove("AGENT_OF_EMPIRES_DEBUG");
-    #[cfg(target_os = "linux")]
     cmd.env("XDG_CONFIG_HOME", home.join(".config"));
     cmd.stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -539,7 +538,6 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
     cmd_b
         .args(["session", "favorite", "--profile", "profile-b", &id_b])
         .env("HOME", &home);
-    #[cfg(target_os = "linux")]
     cmd_b.env("XDG_CONFIG_HOME", home.join(".config"));
     let started = std::time::Instant::now();
     let status = cmd_b

--- a/tests/serve_dynamic_profile_rewire.rs
+++ b/tests/serve_dynamic_profile_rewire.rs
@@ -35,7 +35,7 @@ use common::{pick_free_port, wait_for_port};
 #[serial]
 async fn dynamic_profile_rewire_inserts_and_removes_entries() {
     let temp = tempfile::tempdir().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
     let _ = agent_of_empires::session::get_profile_dir("rewire-profile").expect("profile dir");
 
     let state = build_test_app_state(Vec::new());
@@ -83,7 +83,7 @@ async fn dynamic_profile_rewire_inserts_and_removes_entries() {
 #[serial]
 async fn dynamic_profile_rewire_overwrite_replaces_existing_subscription() {
     let temp = tempfile::tempdir().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
     let _ = agent_of_empires::session::get_profile_dir("rewire-profile").expect("profile dir");
 
     let state = build_test_app_state(Vec::new());
@@ -120,7 +120,7 @@ async fn rewire_after_rename_drops_old_subscribes_new() {
     // `src/server/api/system.rs`. Without these two calls the old
     // canonical dir's handle leaks and the renamed dir is unwatched.
     let temp = tempfile::tempdir().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
     let _ = agent_of_empires::session::get_profile_dir("rename-old").expect("profile dir");
     let _ = agent_of_empires::session::get_profile_dir("rename-new").expect("profile dir");
 
@@ -223,10 +223,51 @@ async fn dynamic_profile_delete_via_http_api() {
     );
 }
 
-fn isolate_home(temp: &Path) {
-    // SAFETY: env mutation; #[serial] guards cross-test races.
-    unsafe { std::env::set_var("HOME", temp) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
+/// body and restores the prior values on `Drop`. `#[serial]` on every
+/// caller linearizes this against other tests in the binary; without
+/// the restore, a later test could inherit this test's (by-then-dropped)
+/// tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(temp: &Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", temp) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+fn isolate_home(temp: &Path) -> HomeGuard {
+    HomeGuard::new(temp)
 }
 
 async fn list_profiles(client: &reqwest::Client, daemon: &ServeDaemon) -> Vec<String> {

--- a/tests/serve_dynamic_profile_rewire.rs
+++ b/tests/serve_dynamic_profile_rewire.rs
@@ -235,6 +235,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(temp: &Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -252,6 +254,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {
@@ -266,6 +270,8 @@ impl Drop for HomeGuard {
     }
 }
 
+/// Thin wrapper kept so existing call sites don't need renaming; see
+/// `HomeGuard` for the isolation/restore behavior.
 fn isolate_home(temp: &Path) -> HomeGuard {
     HomeGuard::new(temp)
 }

--- a/tests/serve_dynamic_profile_rewire.rs
+++ b/tests/serve_dynamic_profile_rewire.rs
@@ -226,10 +226,7 @@ async fn dynamic_profile_delete_via_http_api() {
 fn isolate_home(temp: &Path) {
     // SAFETY: env mutation; #[serial] guards cross-test races.
     unsafe { std::env::set_var("HOME", temp) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
 }
 
 async fn list_profiles(client: &reqwest::Client, daemon: &ServeDaemon) -> Vec<String> {
@@ -275,7 +272,6 @@ impl ServeDaemon {
             &port.to_string(),
         ]);
         cmd.env("HOME", home.path());
-        #[cfg(target_os = "linux")]
         cmd.env("XDG_CONFIG_HOME", home.path().join(".config"));
         cmd.env_remove("AGENT_OF_EMPIRES_DEBUG");
 
@@ -301,7 +297,11 @@ impl ServeDaemon {
 
     fn app_dir(&self) -> PathBuf {
         let home = self.home.path();
-        if cfg!(target_os = "linux") {
+        // Mirrors `get_app_dir_path`'s per-platform resolution: Linux and
+        // macOS both resolve via `XDG_CONFIG_HOME` (forwarded to the child
+        // unconditionally above), while Windows ignores that env var
+        // entirely and falls back to the legacy home-dotfile path.
+        if cfg!(any(target_os = "linux", target_os = "macos")) {
             home.join(".config")
                 .join(agent_of_empires::session::APP_DIR_NAME_XDG)
         } else {

--- a/tests/serve_dynamic_profile_rewire.rs
+++ b/tests/serve_dynamic_profile_rewire.rs
@@ -16,8 +16,9 @@
 #![cfg(feature = "serve")]
 
 mod common;
+mod home_isolation;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,6 +31,7 @@ use serial_test::serial;
 use tempfile::TempDir;
 
 use common::{pick_free_port, wait_for_port};
+use home_isolation::isolate_home;
 
 #[tokio::test]
 #[serial]
@@ -221,59 +223,6 @@ async fn dynamic_profile_delete_via_http_api() {
         "DELETE /api/profiles/alt must remove the on-disk profile dir at {}",
         profile_dir.display()
     );
-}
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
-/// body and restores the prior values on `Drop`. `#[serial]` on every
-/// caller linearizes this against other tests in the binary; without
-/// the restore, a later test could inherit this test's (by-then-dropped)
-/// tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(temp: &Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", temp) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
-
-/// Thin wrapper kept so existing call sites don't need renaming; see
-/// `HomeGuard` for the isolation/restore behavior.
-fn isolate_home(temp: &Path) -> HomeGuard {
-    HomeGuard::new(temp)
 }
 
 async fn list_profiles(client: &reqwest::Client, daemon: &ServeDaemon) -> Vec<String> {

--- a/tests/serve_filewatch_propagation.rs
+++ b/tests/serve_filewatch_propagation.rs
@@ -29,10 +29,7 @@ const NEG_WAIT: Duration = Duration::from_millis(300);
 fn isolate_home(temp: &std::path::Path) {
     // SAFETY: env mutation; #[serial] guards cross-test races.
     unsafe { std::env::set_var("HOME", temp) };
-    #[cfg(target_os = "linux")]
-    unsafe {
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"))
-    };
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
 }
 
 /// Storage::update fires `notify_local_change` after each successful

--- a/tests/serve_filewatch_propagation.rs
+++ b/tests/serve_filewatch_propagation.rs
@@ -38,6 +38,8 @@ struct HomeGuard {
 }
 
 impl HomeGuard {
+    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
+    /// so `Drop` can restore the caller's real environment.
     fn new(temp: &std::path::Path) -> Self {
         let prev_home = std::env::var_os("HOME");
         let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
@@ -55,6 +57,8 @@ impl HomeGuard {
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
+        /// Restores `key` to its prior value, or removes it if it was
+        /// previously unset.
         fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
             // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
             unsafe {
@@ -69,6 +73,8 @@ impl Drop for HomeGuard {
     }
 }
 
+/// Thin wrapper kept so existing call sites don't need renaming; see
+/// `HomeGuard` for the isolation/restore behavior.
 fn isolate_home(temp: &std::path::Path) -> HomeGuard {
     HomeGuard::new(temp)
 }

--- a/tests/serve_filewatch_propagation.rs
+++ b/tests/serve_filewatch_propagation.rs
@@ -26,10 +26,51 @@ use tokio::time::timeout;
 const KERNEL_WAIT: Duration = Duration::from_millis(2_500);
 const NEG_WAIT: Duration = Duration::from_millis(300);
 
-fn isolate_home(temp: &std::path::Path) {
-    // SAFETY: env mutation; #[serial] guards cross-test races.
-    unsafe { std::env::set_var("HOME", temp) };
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
+/// body and restores the prior values on `Drop`. `#[serial]` on every
+/// caller linearizes this against other tests in the binary; without
+/// the restore, a later test could inherit this test's (by-then-dropped)
+/// tempdir path.
+#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
+struct HomeGuard {
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl HomeGuard {
+    fn new(temp: &std::path::Path) -> Self {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: env mutation; #[serial] linearizes this against every
+        // other #[serial] test in the binary, so no concurrent
+        // reader/writer exists.
+        unsafe { std::env::set_var("HOME", temp) };
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
+            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
+            unsafe {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        restore_or_remove("HOME", self.prev_home.take());
+        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+    }
+}
+
+fn isolate_home(temp: &std::path::Path) -> HomeGuard {
+    HomeGuard::new(temp)
 }
 
 /// Storage::update fires `notify_local_change` after each successful
@@ -41,7 +82,7 @@ fn isolate_home(temp: &std::path::Path) {
 #[serial]
 async fn storage_update_avoids_immediate_duplicate_delivery_after_local_notify() {
     let temp = TempDir::new().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
     let svc: Arc<FileWatchService> =
         agent_of_empires::file_watch::test_support::new_filewatch().expect("init");
     let storage = Storage::new("propagation-test", svc.clone()).expect("storage");
@@ -117,7 +158,7 @@ async fn storage_update_avoids_immediate_duplicate_delivery_after_local_notify()
 #[serial]
 async fn cross_process_kernel_path_delivers_when_local_is_noop() {
     let temp = TempDir::new().unwrap();
-    isolate_home(temp.path());
+    let _home = isolate_home(temp.path());
 
     let writer_storage = Storage::new_unwatched("xproc-test").expect("writer");
     writer_storage

--- a/tests/serve_filewatch_propagation.rs
+++ b/tests/serve_filewatch_propagation.rs
@@ -14,70 +14,20 @@
 
 #![cfg(feature = "serve")]
 
+mod home_isolation;
+
 use std::sync::Arc;
 use std::time::Duration;
 
 use agent_of_empires::file_watch::{EventSource, FileMatcher, FileWatchService, WatchSpec};
 use agent_of_empires::session::{Instance, Storage};
+use home_isolation::isolate_home;
 use serial_test::serial;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
 const KERNEL_WAIT: Duration = Duration::from_millis(2_500);
 const NEG_WAIT: Duration = Duration::from_millis(300);
-
-/// RAII guard: points `HOME`/`XDG_CONFIG_HOME` at `temp` for the test
-/// body and restores the prior values on `Drop`. `#[serial]` on every
-/// caller linearizes this against other tests in the binary; without
-/// the restore, a later test could inherit this test's (by-then-dropped)
-/// tempdir path.
-#[must_use = "HomeGuard restores env vars on Drop; bind it, don't discard it, or isolation ends immediately"]
-struct HomeGuard {
-    prev_home: Option<std::ffi::OsString>,
-    prev_xdg: Option<std::ffi::OsString>,
-}
-
-impl HomeGuard {
-    /// Snapshots the current `HOME`/`XDG_CONFIG_HOME` before overriding them,
-    /// so `Drop` can restore the caller's real environment.
-    fn new(temp: &std::path::Path) -> Self {
-        let prev_home = std::env::var_os("HOME");
-        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        // SAFETY: env mutation; #[serial] linearizes this against every
-        // other #[serial] test in the binary, so no concurrent
-        // reader/writer exists.
-        unsafe { std::env::set_var("HOME", temp) };
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.join(".config")) };
-        Self {
-            prev_home,
-            prev_xdg,
-        }
-    }
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        /// Restores `key` to its prior value, or removes it if it was
-        /// previously unset.
-        fn restore_or_remove(key: &str, prev: Option<std::ffi::OsString>) {
-            // SAFETY: same invariant as HomeGuard::new; #[serial] guards this.
-            unsafe {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
-
-/// Thin wrapper kept so existing call sites don't need renaming; see
-/// `HomeGuard` for the isolation/restore behavior.
-fn isolate_home(temp: &std::path::Path) -> HomeGuard {
-    HomeGuard::new(temp)
-}
 
 /// Storage::update fires `notify_local_change` after each successful
 /// `atomic_write`. Subscribers wired to the same `FileWatchService`


### PR DESCRIPTION
## Description
Several test helpers redirected `HOME` to a tempdir for isolation but only forwarded `XDG_CONFIG_HOME` under `cfg(target_os = "linux")`. On macOS, with `XDG_CONFIG_HOME` set in the ambient shell, `macos_app_dir`'s XDG-opt-in rule resolved to the real `~/.config/agent-of-empires(-dev)` instead of the isolated tempdir, leaking stray profile directories named after test fixtures.

Drops the cfg gate entirely and forwards `XDG_CONFIG_HOME` unconditionally — `get_app_dir_path()` never reads it on Windows, so setting it there is a no-op. Also refactors the isolation helper into a `HomeGuard` RAII pattern that snapshots and restores both env vars on drop, and consolidates what had become 7-8 hand-duplicated copies into 3 shared helpers split along crate-visibility boundaries.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle — it's a test-isolation infrastructure fix, not new user-facing behavior

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
opencode (anthropic/claude-sonnet-5)

**Any Additional AI Details you'd like to share:**
Root cause and fix were independently re-verified twice before landing (once against the pristine base commit to rule out pre-existing behavior).

- [x] I am an AI Agent filling out this form (check box if true)