### PR TITLE
test(hooks): cover acl shell mode suffixes

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -4022,6 +4022,70 @@ hooks_auto_accept: false
             .unwrap_or(false)
     }
 
+    #[cfg(target_os = "linux")]
+    fn acl_probe_uid() -> u32 {
+        let euid = nix::unistd::geteuid().as_raw();
+        [65534u32, 65533, 1, 2]
+            .into_iter()
+            .find(|uid| *uid != euid)
+            .expect("probe uid list must include a uid different from euid")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn try_setfacl(path: &Path, spec: &str) -> bool {
+        match std::process::Command::new("setfacl")
+            .args(["-m", spec])
+            .arg(path)
+            .output()
+        {
+            Ok(output) if output.status.success() => true,
+            Ok(output) => {
+                eprintln!(
+                    "skipping: setfacl failed for {}: {}",
+                    path.display(),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                false
+            }
+            Err(e) => {
+                eprintln!("skipping: setfacl unavailable: {e}");
+                false
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn ls_ldn_mode(path: &Path) -> Option<String> {
+        let output = std::process::Command::new("ls")
+            .args(["-ldn"])
+            .arg(path)
+            .env("LC_ALL", "C")
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8(output.stdout)
+            .ok()?
+            .split_whitespace()
+            .next()
+            .map(str::to_string)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn chmod_0700(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn hook_accepts_mode(mode: &str) -> bool {
+        matches!(
+            mode,
+            "drwx------" | "drwx------." | "drwx------+" | "drwx------@"
+        )
+    }
+
     #[test]
     fn host_shell_in_dash_refuses_wrong_mode() {
         if !dash_available() {
@@ -4047,6 +4111,95 @@ hooks_auto_accept: false
         assert!(
             !base.join("dash_wrong_mode").exists(),
             "dash must reject 0o755 parent and refuse to mkdir under it"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn host_shell_accepts_acl_suffix_when_mode_tight() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("aoe-hooks-acl-tight");
+        let inst = base.join("acl_tight");
+        std::fs::create_dir_all(&inst).unwrap();
+        chmod_0700(&base);
+        chmod_0700(&inst);
+
+        let probe_uid = acl_probe_uid();
+        let tight_acl = format!("u::rwx,g::---,o::---,u:{probe_uid}:---,m::---");
+        if !try_setfacl(&base, &tight_acl) || !try_setfacl(&inst, &tight_acl) {
+            return;
+        }
+
+        for path in [&base, &inst] {
+            let mode = ls_ldn_mode(path).expect("ls -ldn must report mode");
+            assert!(
+                mode.starts_with("drwx------") && mode.ends_with('+'),
+                "precondition failed: {} must report a tight ACL suffix, got {mode}",
+                path.display()
+            );
+            assert!(
+                hook_accepts_mode(&mode),
+                "precondition failed: hook pattern must accept {mode}"
+            );
+        }
+
+        let cmd =
+            hook_command_with_base("running", base.to_str().unwrap(), HookInstallTarget::Host);
+        let output = std::process::Command::new("sh")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", "acl_tight")
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "hook must exit 0");
+        assert_eq!(
+            std::fs::read_to_string(inst.join("status")).unwrap(),
+            "running",
+            "snippet must write status when ACL suffix is tight"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn host_shell_rejects_acl_widening() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("aoe-hooks-acl-wide");
+        let inst = base.join("acl_wide");
+        std::fs::create_dir_all(&inst).unwrap();
+        chmod_0700(&base);
+        chmod_0700(&inst);
+
+        let probe_uid = acl_probe_uid();
+        let wide_acl = format!("u::rwx,g::---,o::---,u:{probe_uid}:r-x,m::r-x");
+        if !try_setfacl(&inst, &wide_acl) {
+            return;
+        }
+
+        let base_mode = ls_ldn_mode(&base).expect("ls -ldn must report base mode");
+        assert!(
+            hook_accepts_mode(&base_mode),
+            "precondition failed: base must pass before instance guard is tested"
+        );
+
+        let inst_mode = ls_ldn_mode(&inst).expect("ls -ldn must report instance mode");
+        assert!(
+            inst_mode.ends_with('+') && !hook_accepts_mode(&inst_mode),
+            "precondition failed: widened ACL must produce a rejected + mode, got {inst_mode}"
+        );
+
+        let cmd =
+            hook_command_with_base("running", base.to_str().unwrap(), HookInstallTarget::Host);
+        let output = std::process::Command::new("sh")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", "acl_wide")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "hook must exit 0 even when ACL widens access"
+        );
+        assert!(
+            !inst.join("status").exists(),
+            "snippet must not write status when ACL widens access"
         );
     }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

Adds Linux-only behavioral coverage for the host hook shell snippet's ACL-tolerant mode guard. The existing tests pinned the literal `drwx------|drwx------.|drwx------+|drwx------@` bytes, but did not run the shell snippet against real ACL-tagged directories.

The new tests create temporary hook base and instance directories, apply POSIX ACLs with `setfacl`, verify what `LC_ALL=C ls -ldn` reports, and then execute the actual host shell snippet. One test proves a tight `drwx------+` directory still writes status; the other proves a widened ACL exits 0 without writing status.

Closes #2230

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] On Linux with `setfacl` support, run AoE hooks against a tight ACL-tagged status directory and confirm the status file is written.
- [ ] On Linux with `setfacl` support, widen the ACL on the instance status directory and confirm the hook exits quietly without writing status.
- [ ] Confirm platforms without Linux POSIX ACL support skip the new behavioral checks instead of failing setup.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=/tmp/opencode/aoe-fix-hooks-target CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`
- [x] `cargo test host_shell_`
- [x] `cargo test --features serve --test acp_runner_orphan`
- [ ] `cargo test`: local default suite is blocked by `tests/acp_runner_orphan.rs`, because `__acp-runner` is compiled only with `--features serve`.
- [ ] `cargo test --features serve`: local suite hit unrelated timing flakes. `rewire_disk_subscriptions_drops_removed_profile_entry` passed in isolation. `storage_concurrency::test_cross_process_independent_profiles_do_not_serialise` also fails at the start commit (`59337734`), so it predates this PR.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Claude investigated the issue, drafted the plan, implemented the tests, and ran validation under my direction.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Linux-only integration tests for host hook behavior with POSIX ACLs.
- Added helpers to create ACL-tagged directories, inspect permissions, and run the shell snippet.
- Verified tight ACLs allow status writes, while widened ACLs exit cleanly without writing.
- ACL tests are skipped on systems without Linux POSIX ACL support.

## Benefits

Improves end-to-end coverage of ACL-sensitive mode checks using real filesystem permissions instead of testing shell patterns alone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->