### PR TITLE
test(session): cover resume fallback loop breaker e2e

### DIFF
--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -43,6 +43,7 @@ mod opencode_sandbox_resume;
 mod plugins;
 mod profile_picker;
 mod project_registry;
+mod resume_fallback;
 mod sandbox;
 mod serve;
 mod settings;

--- a/tests/e2e/resume_fallback.rs
+++ b/tests/e2e/resume_fallback.rs
@@ -1,0 +1,205 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+use serial_test::serial;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+const TITLE: &str = "ResumeFallbackE2E";
+const FAKE_AGENT: &str = "aoe-resume-fallback-agent";
+const STALE_SID: &str = "11111111-1111-4111-8111-111111111111";
+
+fn new_harness(test_name: &str) -> TuiTestHarness {
+    #[cfg(unix)]
+    {
+        TuiTestHarness::new_in_tmp(test_name)
+    }
+    #[cfg(not(unix))]
+    {
+        TuiTestHarness::new(test_name)
+    }
+}
+
+fn sessions_path(h: &TuiTestHarness) -> PathBuf {
+    crate::harness::app_dir_in(h.home_path()).join("profiles/default/sessions.json")
+}
+
+fn read_sessions(h: &TuiTestHarness) -> Value {
+    let path = sessions_path(h);
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+    serde_json::from_str(&content).expect("invalid sessions JSON")
+}
+
+fn session_by_title<'a>(sessions: &'a Value, title: &str) -> &'a Value {
+    sessions
+        .as_array()
+        .and_then(|arr| arr.iter().find(|s| s["title"].as_str() == Some(title)))
+        .unwrap_or_else(|| panic!("no session titled '{title}' in sessions.json"))
+}
+
+fn patch_session<F>(h: &TuiTestHarness, title: &str, patch: F)
+where
+    F: FnOnce(&mut Map<String, Value>),
+{
+    let path = sessions_path(h);
+    let mut sessions = read_sessions(h);
+    let row = sessions
+        .as_array_mut()
+        .and_then(|arr| arr.iter_mut().find(|s| s["title"].as_str() == Some(title)))
+        .unwrap_or_else(|| panic!("no session titled '{title}' in sessions.json"));
+    let row = row.as_object_mut().expect("session row must be an object");
+    patch(row);
+    fs::write(&path, serde_json::to_string_pretty(&sessions).unwrap())
+        .unwrap_or_else(|e| panic!("failed to write {}: {}", path.display(), e));
+}
+
+fn assert_default_resume_intent(row: &Value) {
+    let intent = &row["resume_intent"];
+    assert!(
+        intent.is_null() || intent["kind"].as_str() == Some("Default"),
+        "resume_intent should be absent/null/default, got {intent:?}"
+    );
+}
+
+fn install_fake_agent(h: &mut TuiTestHarness) -> PathBuf {
+    let bin = h.install_path_command(FAKE_AGENT);
+    let log = h.home_path().join("resume-fallback-agent.log");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\ncase \"$*\" in\n  *{}*) exit 42 ;;\nesac\nexec sleep 30\n",
+        sh_quote(&log),
+        STALE_SID,
+    );
+    let script_path = bin.join(FAKE_AGENT);
+    fs::write(&script_path, script).expect("write fake agent");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
+            .expect("chmod fake agent");
+    }
+    log
+}
+
+fn sh_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+}
+
+fn disable_restart_wake_message(h: &TuiTestHarness) {
+    let config_path = crate::harness::app_dir_in(h.home_path()).join("config.toml");
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(&config_path)
+        .unwrap_or_else(|e| panic!("failed to open {}: {}", config_path.display(), e));
+    file.write_all(b"\n[session]\nrestart_wake_message = \"\"\n")
+        .expect("disable restart wake message");
+}
+
+fn read_log_lines(path: &Path) -> Vec<String> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+struct StopSessionOnDrop<'a> {
+    h: &'a TuiTestHarness,
+}
+
+impl Drop for StopSessionOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.h.run_cli(&["session", "stop", TITLE]);
+    }
+}
+
+#[test]
+#[serial]
+fn stale_resume_failure_persists_loop_breaker_and_next_restart_starts_fresh() {
+    require_tmux!();
+
+    let mut h = new_harness("resume_fallback_loop_breaker");
+    disable_restart_wake_message(&h);
+    let log_path = install_fake_agent(&mut h);
+    let project = h.project_path();
+
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "--cmd",
+        "claude",
+        "-t",
+        TITLE,
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let _cleanup = StopSessionOnDrop { h: &h };
+
+    patch_session(&h, TITLE, |row| {
+        row.insert("command".to_string(), Value::String(FAKE_AGENT.to_string()));
+        row.insert("tool".to_string(), Value::String("claude".to_string()));
+        row.insert("status".to_string(), Value::String("idle".to_string()));
+        row.insert(
+            "agent_session_id".to_string(),
+            Value::String(STALE_SID.to_string()),
+        );
+        row.remove("resume_probe_failed_sid");
+        row.remove("resume_intent");
+    });
+
+    let first = h.run_cli(&["session", "restart", TITLE]);
+    assert!(
+        !first.status.success(),
+        "first restart should fail after passing stale sid"
+    );
+
+    let sessions = read_sessions(&h);
+    let row = session_by_title(&sessions, TITLE);
+    assert_eq!(row["agent_session_id"].as_str(), Some(STALE_SID));
+    assert_eq!(row["resume_probe_failed_sid"].as_str(), Some(STALE_SID));
+    assert_default_resume_intent(row);
+
+    let first_lines = read_log_lines(&log_path);
+    assert!(
+        first_lines.iter().any(|line| line.contains(STALE_SID)),
+        "first restart must pass stale sid to fake agent; log={first_lines:?}"
+    );
+
+    let before_second = first_lines.len();
+    let second = h.run_cli(&["session", "restart", TITLE]);
+    assert!(
+        second.status.success(),
+        "second restart should start fresh after loop-breaker: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    let sessions = read_sessions(&h);
+    let row = session_by_title(&sessions, TITLE);
+    let fresh_sid = row["agent_session_id"]
+        .as_str()
+        .expect("fresh restart should persist a new agent_session_id");
+    assert_ne!(fresh_sid, STALE_SID);
+    assert!(!fresh_sid.trim().is_empty());
+    assert!(
+        row["resume_probe_failed_sid"].is_null(),
+        "fresh restart should clear resume_probe_failed_sid, got {:?}",
+        row["resume_probe_failed_sid"]
+    );
+    assert_default_resume_intent(row);
+
+    let all_lines = read_log_lines(&log_path);
+    let second_lines = &all_lines[before_second..];
+    assert!(
+        !second_lines.is_empty(),
+        "second restart should invoke fake agent; log={all_lines:?}"
+    );
+    assert!(
+        second_lines.iter().all(|line| !line.contains(STALE_SID)),
+        "second restart must not retry stale sid; new log lines={second_lines:?}"
+    );
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds an end-to-end regression test for the resume-fallback loop-breaker path behind #1849. The test creates a real CLI session under the e2e harness, seeds an ambient stale `agent_session_id`, and swaps in a fake agent command that exits only when AoE passes that stale sid back through resume flags.

The first restart proves the stale sid is attempted and persisted as `resume_probe_failed_sid`. The second restart proves the loop-breaker starts fresh instead of retrying the same stale sid, and verifies the marker clears on disk.

This follows the current `main` behavior. The older #1778 cleared-shape expectation is no longer the session contract, because ambiguous resume probe failures now preserve the sid and use `resume_probe_failed_sid` as the durable loop-breaker.

Closes #1849

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass for the touched surface; full `cargo test` hit unrelated file-watch flakes noted below
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, test-only change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## How to test

- [ ] In an isolated AoE profile, create a Claude terminal session whose command exits when invoked with a known stale sid, then seed that sid into `sessions.json` as the ambient `agent_session_id`.
- [ ] Restart the session once and confirm AoE reports resume failure while preserving `agent_session_id` and writing `resume_probe_failed_sid` for the stale sid.
- [ ] Restart the same session again and confirm AoE starts fresh without passing the stale sid to the agent command, then clears `resume_probe_failed_sid`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --features e2e-tests -- -D warnings`
- [x] `CARGO_BUILD_JOBS=1 cargo test --features e2e-tests --test e2e resume_fallback -- --nocapture`
- [x] `CARGO_BUILD_JOBS=1 cargo test --lib session::instance::tests::resume_fallback -- --nocapture`
- [x] `CARGO_BUILD_JOBS=1 cargo test --lib tui::home::file_watch_tests::reload_storage_only_survives_list_profiles_failure -- --nocapture`
- [x] `CARGO_BUILD_JOBS=1 cargo test --lib tui::home::file_watch_tests::rewire_disk_invalidates_on_inode_change_with_same_canonical_path -- --nocapture`

Full `CARGO_BUILD_JOBS=1 cargo test` was attempted twice. The first run failed on `tui::home::file_watch_tests::reload_storage_only_survives_list_profiles_failure`; the second failed on `tui::home::file_watch_tests::rewire_disk_invalidates_on_inode_change_with_same_canonical_path`. Both passed when rerun in isolation, and neither touches this PR's files.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenCode gpt-5.5 with the agent-of-empires `/aoe-implement` workflow; `consult-llm` debate used Gemini and gpt-5.5.

**Any Additional AI Details you'd like to share:**

AI assisted with investigation, design review, implementation, test writing, and validation. The design decision to test the current `resume_probe_failed_sid` loop-breaker contract instead of the older #1778 clear-to-default shape was made after checking current source and running a two-model debate.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
