### PR TITLE
fix(tui): render structured tool paths repo-relative

### DIFF
--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -17,6 +17,7 @@ use crate::acp::protocol::{
     ApprovalDecisionWire, FilesResponse, PromptRequest, ReplayResponse, ResolveApprovalRequest,
     SwitchAgentRequest, SwitchAgentResponse,
 };
+use crate::acp::session_paths::SessionPathRoots;
 use crate::plugin::ui_state::UiSnapshot;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -28,6 +29,11 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 struct AboutResponse {
     #[serde(default)]
     acp_queue_drain_mode: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SessionsEnvelope<T> {
+    sessions: Vec<T>,
 }
 
 /// Page size requested by [`HttpClient::replay_paged`]. Stays at or
@@ -310,7 +316,20 @@ impl HttpClient {
         let url = format!("{}/api/sessions", self.endpoint.base_url);
         let res = self.auth(self.http.get(&url)).send().await?;
         let res = check_status(res, "<sessions>").await?;
-        Ok(res.json::<Vec<T>>().await?)
+        Ok(res.json::<SessionsEnvelope<T>>().await?.sessions)
+    }
+
+    /// Session root paths used to render tool-call file labels relative to the
+    /// active worktree or workspace repository.
+    pub async fn session_path_roots(
+        &self,
+        session_id: &str,
+    ) -> Result<SessionPathRoots, HttpError> {
+        let sessions = self.list_sessions::<SessionPathRoots>().await?;
+        sessions
+            .into_iter()
+            .find(|session| session.id == session_id)
+            .ok_or_else(|| HttpError::SessionNotFound(session_id.to_string()))
     }
 
     /// Lightweight reachability probe used by `require_daemon` (when

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -36,6 +36,7 @@ pub mod protocol;
 pub mod runner;
 #[cfg(feature = "serve")]
 pub mod sandbox;
+pub mod session_paths;
 pub mod session_tee;
 pub mod state;
 pub mod supervisor;

--- a/src/acp/session_paths.rs
+++ b/src/acp/session_paths.rs
@@ -1,0 +1,209 @@
+//! Display helpers for session-scoped file paths.
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SessionPathRoots {
+    pub id: String,
+    pub project_path: String,
+    pub main_repo_path: Option<String>,
+    #[serde(default)]
+    pub workspace_repos: Vec<WorkspaceRepoRoot>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct WorkspaceRepoRoot {
+    pub name: String,
+    pub source_path: String,
+}
+
+struct ResolvedPath {
+    relative_path: String,
+    repo_name: Option<String>,
+}
+
+/// Display form of a tool-call path, matching the web structured view's
+/// `relativeDisplayPath` helper. Paths under a workspace repo are prefixed
+/// with the repo name, paths under the session worktree or main repo are shown
+/// bare relative, and paths outside every known root stay unchanged.
+pub fn relative_display_path(raw: &str, roots: Option<&SessionPathRoots>) -> String {
+    let Some(roots) = roots else {
+        return raw.to_string();
+    };
+    if raw.is_empty() {
+        return raw.to_string();
+    }
+
+    match resolve_to_repo_relative(raw, roots) {
+        Some(ResolvedPath {
+            relative_path,
+            repo_name: Some(repo_name),
+        }) => format!("{repo_name}/{relative_path}"),
+        Some(ResolvedPath {
+            relative_path,
+            repo_name: None,
+        }) => relative_path,
+        None => raw.to_string(),
+    }
+}
+
+fn resolve_to_repo_relative(path: &str, roots: &SessionPathRoots) -> Option<ResolvedPath> {
+    let target = normalize_path_for_match(path);
+    let is_absolute = target.starts_with('/') || is_windows_absolute(&target);
+
+    if !is_absolute {
+        let rel = target.strip_prefix("./").unwrap_or(&target);
+        return (!rel.is_empty()).then(|| ResolvedPath {
+            relative_path: rel.to_string(),
+            repo_name: None,
+        });
+    }
+
+    for repo in &roots.workspace_repos {
+        let root = normalize_root(&repo.source_path);
+        if let Some(rel) = target.strip_prefix(&root) {
+            return Some(ResolvedPath {
+                relative_path: rel.to_string(),
+                repo_name: Some(repo.name.clone()),
+            });
+        }
+    }
+
+    let root = normalize_root(&roots.project_path);
+    if let Some(rel) = target.strip_prefix(&root) {
+        return Some(ResolvedPath {
+            relative_path: rel.to_string(),
+            repo_name: None,
+        });
+    }
+
+    if let Some(main_repo_path) = &roots.main_repo_path {
+        let root = normalize_root(main_repo_path);
+        if let Some(rel) = target.strip_prefix(&root) {
+            return Some(ResolvedPath {
+                relative_path: rel.to_string(),
+                repo_name: None,
+            });
+        }
+    }
+
+    None
+}
+
+fn normalize_path_for_match(path: &str) -> String {
+    let mut normalized = path.replace('\\', "/");
+    let bytes = normalized.as_bytes();
+    if bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/' {
+        let drive = normalized[0..1].to_ascii_lowercase();
+        normalized.replace_range(0..1, &drive);
+    }
+    normalized
+}
+
+fn normalize_root(root: &str) -> String {
+    let mut normalized = normalize_path_for_match(root);
+    if !normalized.ends_with('/') {
+        normalized.push('/');
+    }
+    normalized
+}
+
+fn is_windows_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roots() -> SessionPathRoots {
+        SessionPathRoots {
+            id: "s-1".into(),
+            project_path: "/Users/me/.aoe/worktrees/feat".into(),
+            main_repo_path: Some("/Users/me/repo".into()),
+            workspace_repos: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn strips_worktree_root_to_relative_path() {
+        assert_eq!(
+            relative_display_path(
+                "/Users/me/.aoe/worktrees/feat/src/hooks/mod.rs",
+                Some(&roots())
+            ),
+            "src/hooks/mod.rs"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_main_repo_root() {
+        assert_eq!(
+            relative_display_path("/Users/me/repo/src/app.ts", Some(&roots())),
+            "src/app.ts"
+        );
+    }
+
+    #[test]
+    fn does_not_match_sibling_with_shared_prefix() {
+        assert_eq!(
+            relative_display_path("/Users/me/repo_old/src/app.ts", Some(&roots())),
+            "/Users/me/repo_old/src/app.ts"
+        );
+    }
+
+    #[test]
+    fn treats_relative_path_as_already_relative() {
+        assert_eq!(
+            relative_display_path("src/app.ts", Some(&roots())),
+            "src/app.ts"
+        );
+        assert_eq!(
+            relative_display_path("./src/app.ts", Some(&roots())),
+            "src/app.ts"
+        );
+    }
+
+    #[test]
+    fn matches_windows_drive_root_case_insensitively() {
+        let roots = SessionPathRoots {
+            id: "s-1".into(),
+            project_path: "C:\\Users\\me\\repo".into(),
+            main_repo_path: None,
+            workspace_repos: Vec::new(),
+        };
+        assert_eq!(
+            relative_display_path("c:\\Users\\me\\repo\\src\\app.ts", Some(&roots)),
+            "src/app.ts"
+        );
+    }
+
+    #[test]
+    fn prefixes_workspace_repo_name() {
+        let roots = SessionPathRoots {
+            id: "s-1".into(),
+            project_path: "/Users/me/.aoe/worktrees/ws".into(),
+            main_repo_path: None,
+            workspace_repos: vec![WorkspaceRepoRoot {
+                name: "api".into(),
+                source_path: "/Users/me/api".into(),
+            }],
+        };
+        assert_eq!(
+            relative_display_path("/Users/me/api/src/h.ts", Some(&roots)),
+            "api/src/h.ts"
+        );
+    }
+
+    #[test]
+    fn returns_raw_path_outside_known_roots() {
+        assert_eq!(
+            relative_display_path("/etc/hosts", Some(&roots())),
+            "/etc/hosts"
+        );
+    }
+
+    #[test]
+    fn returns_raw_path_without_roots() {
+        assert_eq!(relative_display_path("/tmp/a.rs", None), "/tmp/a.rs");
+    }
+}

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -190,6 +190,18 @@ pub async fn run_for_endpoint(
     state.focus = Focus::Transcript;
 
     let mut toast_deadline: Option<Instant> = None;
+    let (path_roots_tx, mut path_roots_rx) = tokio::sync::mpsc::channel(1);
+    {
+        let http = state.http.clone();
+        let session_id = state.session_id.clone();
+        tokio::spawn(async move {
+            let result = http
+                .session_path_roots(&session_id)
+                .await
+                .map_err(|e| e.to_string());
+            let _ = path_roots_tx.send(result).await;
+        });
+    }
 
     // Resolve the queue drain mode from the daemon (not local config:
     // this view can attach to a remote daemon). A failure here is
@@ -386,6 +398,15 @@ pub async fn run_for_endpoint(
             Some(snapshot) = plugin_rx.recv() => {
                 state.ingest_plugin_ui(snapshot);
                 drain_plugin_toast(&mut state, &mut toast_deadline);
+                redraw(terminal, theme, &state)?;
+            }
+            Some(result) = path_roots_rx.recv() => {
+                match result {
+                    Ok(roots) => state.path_roots = Some(roots),
+                    Err(e) => {
+                        tracing::warn!(target: "acp.tui", "session path roots fetch failed; rendering raw paths: {e}");
+                    }
+                }
                 redraw(terminal, theme, &state)?;
             }
             _ = redraw_ticker.tick() => {

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -22,6 +22,7 @@ use super::input::Focus;
 use super::reducer::{AcpTranscript, ActivityRow, NoteKind, ToolCallRow};
 use super::state::{FileIndex, StructuredViewState};
 use crate::acp::approvals::ApprovalDecision;
+use crate::acp::session_paths::{relative_display_path, SessionPathRoots};
 use crate::tui::plugin_ui;
 use crate::tui::styles::Theme;
 
@@ -336,6 +337,7 @@ fn render_transcript(frame: &mut Frame, area: Rect, theme: &Theme, state: &Struc
         state.selected_approval,
         state.focus,
         theme,
+        state.path_roots.as_ref(),
     );
     // Clamp scroll against the *wrapped* visual row count, not
     // `lines.len()`. Streaming `AgentMessage` rows grew text inside
@@ -669,6 +671,7 @@ fn transcript_lines<'a>(
     selected_approval: Option<usize>,
     focus: Focus,
     theme: &Theme,
+    path_roots: Option<&SessionPathRoots>,
 ) -> Vec<Line<'a>> {
     let mut out: Vec<Line<'a>> = Vec::new();
     let mut approval_render_idx: usize = 0;
@@ -686,7 +689,7 @@ fn transcript_lines<'a>(
                 out.push(Line::default());
             }
             ActivityRow::ToolCall(tool) => {
-                out.extend(render_tool_lines(tool, theme));
+                out.extend(render_tool_lines(tool, theme, path_roots));
                 out.push(Line::default());
             }
             ActivityRow::Approval(row) => {
@@ -802,7 +805,11 @@ const TOOL_PREVIEW_MAX_LINES: usize = 12;
 /// `ToolKind`) to a per-kind body; any kind we don't special-case, or
 /// one whose args don't parse into the expected shape, falls back to the
 /// generic one-liner so unknown tools still render.
-fn render_tool_lines(tool: &ToolCallRow, theme: &Theme) -> Vec<Line<'static>> {
+fn render_tool_lines(
+    tool: &ToolCallRow,
+    theme: &Theme,
+    path_roots: Option<&SessionPathRoots>,
+) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let header = format!(
         "tool {} · {}",
@@ -820,10 +827,10 @@ fn render_tool_lines(tool: &ToolCallRow, theme: &Theme) -> Vec<Line<'static>> {
 
     let args = parse_args_object(&tool.args);
     let body = match tool.kind.as_str() {
-        "edit" | "write" => render_edit_body(args.as_ref(), theme),
+        "edit" | "write" => render_edit_body(args.as_ref(), theme, path_roots),
         "execute" => render_execute_body(args.as_ref(), tool),
-        "read" => render_read_body(args.as_ref(), tool),
-        "delete" => render_delete_body(args.as_ref()),
+        "read" => render_read_body(args.as_ref(), tool, path_roots),
+        "delete" => render_delete_body(args.as_ref(), path_roots),
         _ => None,
     };
     lines.extend(body.unwrap_or_else(|| render_generic_body(tool)));
@@ -859,13 +866,17 @@ fn pick_str<'a>(
 fn render_edit_body(
     args: Option<&serde_json::Map<String, serde_json::Value>>,
     theme: &Theme,
+    path_roots: Option<&SessionPathRoots>,
 ) -> Option<Vec<Line<'static>>> {
     let new = pick_str(args, NEW_KEYS)?;
     let old = pick_str(args, OLD_KEYS).unwrap_or("");
     if old.is_empty() && new.is_empty() {
         return None;
     }
-    let path = pick_str(args, PATH_KEYS).unwrap_or("(unknown file)");
+    let path = relative_display_path(
+        pick_str(args, PATH_KEYS).unwrap_or("(unknown file)"),
+        path_roots,
+    );
     let mut lines = vec![Line::from(format!("  {path}"))];
     lines.extend(diff_lines(old, new, theme));
     Some(lines)
@@ -932,8 +943,9 @@ fn render_execute_body(
 fn render_read_body(
     args: Option<&serde_json::Map<String, serde_json::Value>>,
     tool: &ToolCallRow,
+    path_roots: Option<&SessionPathRoots>,
 ) -> Option<Vec<Line<'static>>> {
-    let path = pick_str(args, PATH_KEYS)?;
+    let path = relative_display_path(pick_str(args, PATH_KEYS)?, path_roots);
     let mut lines = vec![Line::from(format!("  {path}"))];
     lines.extend(output_preview_lines(tool));
     Some(lines)
@@ -942,8 +954,9 @@ fn render_read_body(
 /// Delete: just the target path.
 fn render_delete_body(
     args: Option<&serde_json::Map<String, serde_json::Value>>,
+    path_roots: Option<&SessionPathRoots>,
 ) -> Option<Vec<Line<'static>>> {
-    let path = pick_str(args, PATH_KEYS)?;
+    let path = relative_display_path(pick_str(args, PATH_KEYS)?, path_roots);
     Some(vec![Line::from(format!("  {path}"))])
 }
 
@@ -1377,6 +1390,7 @@ mod tests {
             None,
             Focus::Transcript,
             &Theme::default(),
+            None,
         ));
         assert!(out.contains("you  ▸ Proceed?: Yes"), "{out:?}");
         assert!(out.contains("you  ▸ Mode: Fast"), "{out:?}");
@@ -1389,7 +1403,7 @@ mod tests {
             r#"{"file_path":"src/a.rs","old_string":"let x = 1;","new_string":"let x = 2;"}"#,
             None,
         );
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("src/a.rs"), "path missing: {out:?}");
         assert!(
             out.contains("- let x = 1;"),
@@ -1405,7 +1419,7 @@ mod tests {
             r#"{"file_path":"new.txt","content":"line one\nline two"}"#,
             None,
         );
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("new.txt"));
         assert!(out.contains("+ line one"), "{out:?}");
         assert!(out.contains("+ line two"), "{out:?}");
@@ -1418,7 +1432,7 @@ mod tests {
         let args =
             serde_json::json!({ "file_path": "big.txt", "old_string": "", "new_string": new_body });
         let row = tool_row("edit", &args.to_string(), None);
-        let lines = render_tool_lines(&row, &Theme::default());
+        let lines = render_tool_lines(&row, &Theme::default(), None);
         let plus = lines
             .iter()
             .filter(|l| line_text(l).trim_start().starts_with("+ "))
@@ -1438,7 +1452,7 @@ mod tests {
             r#"{"command":"ls -la"}"#,
             Some((true, "file_a\nfile_b")),
         );
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("$ ls -la"), "command missing: {out:?}");
         assert!(out.contains("file_a"), "output preview missing: {out:?}");
         assert!(out.contains("file_b"), "{out:?}");
@@ -1451,7 +1465,7 @@ mod tests {
             r#"{"path":"src/lib.rs"}"#,
             Some((true, "pub fn main() {}")),
         );
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("src/lib.rs"), "path missing: {out:?}");
         assert!(
             out.contains("pub fn main()"),
@@ -1462,17 +1476,87 @@ mod tests {
     #[test]
     fn delete_kind_renders_only_path() {
         let row = tool_row("delete", r#"{"path":"old.txt"}"#, Some((true, "")));
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("old.txt"), "path missing: {out:?}");
         // No diff gutters for a delete.
         assert!(!out.contains("+ "), "{out:?}");
         assert!(!out.contains("- "), "{out:?}");
     }
 
+    fn path_roots() -> SessionPathRoots {
+        SessionPathRoots {
+            id: "s-1".into(),
+            project_path: "/Users/me/.aoe/worktrees/feat".into(),
+            main_repo_path: Some("/Users/me/repo".into()),
+            workspace_repos: vec![crate::acp::session_paths::WorkspaceRepoRoot {
+                name: "api".into(),
+                source_path: "/Users/me/api".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn edit_path_under_worktree_renders_repo_relative() {
+        let row = tool_row(
+            "edit",
+            r#"{"file_path":"/Users/me/.aoe/worktrees/feat/src/a.rs","old_string":"a","new_string":"b"}"#,
+            None,
+        );
+        let roots = path_roots();
+        let out = joined(&render_tool_lines(&row, &Theme::default(), Some(&roots)));
+        assert!(out.contains("src/a.rs"), "relative path missing: {out:?}");
+        assert!(
+            !out.contains("/Users/me/.aoe/worktrees/feat/src/a.rs"),
+            "absolute path leaked: {out:?}"
+        );
+    }
+
+    #[test]
+    fn read_path_under_workspace_repo_renders_repo_prefixed() {
+        let row = tool_row(
+            "read",
+            r#"{"path":"/Users/me/api/src/h.ts"}"#,
+            Some((true, "export const h = 1;")),
+        );
+        let roots = path_roots();
+        let out = joined(&render_tool_lines(&row, &Theme::default(), Some(&roots)));
+        assert!(out.contains("api/src/h.ts"), "repo path missing: {out:?}");
+        assert!(
+            !out.contains("/Users/me/api/src/h.ts"),
+            "absolute path leaked: {out:?}"
+        );
+    }
+
+    #[test]
+    fn delete_path_outside_roots_stays_absolute() {
+        let row = tool_row("delete", r#"{"path":"/etc/hosts"}"#, Some((true, "")));
+        let roots = path_roots();
+        let out = joined(&render_tool_lines(&row, &Theme::default(), Some(&roots)));
+        assert!(
+            out.contains("/etc/hosts"),
+            "absolute fallback missing: {out:?}"
+        );
+    }
+
+    #[test]
+    fn sibling_prefix_path_stays_absolute() {
+        let row = tool_row(
+            "read",
+            r#"{"path":"/Users/me/repo_old/src/lib.rs"}"#,
+            Some((true, "pub fn main() {}")),
+        );
+        let roots = path_roots();
+        let out = joined(&render_tool_lines(&row, &Theme::default(), Some(&roots)));
+        assert!(
+            out.contains("/Users/me/repo_old/src/lib.rs"),
+            "sibling path should stay absolute: {out:?}"
+        );
+    }
+
     #[test]
     fn unknown_kind_falls_back_to_generic_one_liner() {
         let row = tool_row("fetch", "https://example.com", Some((true, "200 OK")));
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         // Generic body shows the raw args prefixed with `$ ` and the output.
         assert!(out.contains("$ https://example.com"), "{out:?}");
         assert!(out.contains("200 OK"), "{out:?}");
@@ -1483,7 +1567,7 @@ mod tests {
         // Truncated JSON (16KB ingest cap can clip mid-object) must not
         // panic or vanish; it falls through to the generic renderer.
         let row = tool_row("edit", r#"{"file_path":"a.rs","old_str"#, None);
-        let out = joined(&render_tool_lines(&row, &Theme::default()));
+        let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("$ {\"file_path\""), "{out:?}");
     }
 

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -13,6 +13,7 @@ use super::queue::PromptQueue;
 use super::reducer::AcpTranscript;
 use super::slash;
 use crate::acp::client::{DaemonEndpoint, HttpClient, WsHandle};
+use crate::acp::session_paths::SessionPathRoots;
 use crate::acp::state::AvailableCommand;
 use crate::plugin::ui_state::{Notification, UiSnapshot};
 use crate::session::config::QueueDrainMode;
@@ -66,6 +67,9 @@ pub struct StructuredViewState {
     /// Workspace file list for the `@`-mention picker, fetched once per
     /// session on the first `@` and cached for its lifetime.
     pub file_index: FileIndex,
+    /// Session roots used to shorten tool-call paths in the transcript.
+    /// Fetched best-effort from the daemon; `None` keeps raw paths.
+    pub path_roots: Option<SessionPathRoots>,
     /// `Some` while the `@`-mention picker is open. Holds only the
     /// highlighted-row index; the query and token range are always
     /// recomputed from the composer via [`super::mention::active_mention`]
@@ -178,6 +182,7 @@ impl StructuredViewState {
             slash_selected: 0,
             dismissed_slash_query: None,
             file_index: FileIndex::Unloaded,
+            path_roots: None,
             mention: None,
             dismissed_mention: None,
             recall: None,


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Native TUI structured-view tool rows now render file paths relative to the active session roots, matching the web dashboard fix from #2143 / PR #2162. Paths under the session worktree show as bare repo-relative paths, paths under secondary workspace repos show as `repo/path`, and paths outside every known root keep their original absolute form.

The TUI fetches the session root metadata best-effort from the existing `/api/sessions` response and caches it on `StructuredViewState`. If the metadata fetch fails, rendering falls back to the previous absolute-path behavior and logs a warning instead of interrupting the session with a toast.

The shared Rust resolver mirrors the web `relativeDisplayPath` behavior, including trailing-slash prefix guards, relative path handling, backslash normalization, and Windows drive-letter normalization. The existing TUI tool render path now threads the cached roots into edit, write, read, and delete cards without mutating transcript data.

Closes #2163

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a native TUI structured-view session where an agent edits a file inside the session worktree; confirm the tool row shows `src/...`, not the full absolute worktree path.
- [ ] In a multi-repo workspace, have the agent read or edit a file in a secondary repo; confirm the tool row shows `repo/src/...` with the repo prefix.
- [ ] Have the agent touch a file outside every known session root; confirm the TUI keeps the absolute path unchanged.

## Checklist

- [x] New and existing tests pass, except `storage_concurrency::test_cross_process_independent_profiles_do_not_serialise`, which also fails on `origin/main` in this local environment
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is pure structured-view rendering and root path resolution; deterministic unit tests cover worktree-relative paths, workspace repo prefixes, sibling-prefix guards, and outside-root absolute fallback without the cost and flake risk of a full tmux e2e.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a `/debate` design pass, implementation, and validation were drafted by Claude under my direction. I made the design calls and reviewed the resulting diff.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Structured-view tool rows now display paths relative to the active session and workspace repositories.
- Added session root lookup with cached state and graceful fallback to absolute paths when unavailable.
- Added shared path resolution for cross-platform paths, prefix safety, and workspace repository labels.
- Updated edit, write, read, and delete tool rendering without changing transcript data.
- Added deterministic unit tests for path resolution and rendering behavior.

## Benefits

- Makes file paths easier to read and navigate in the TUI.
- Preserves safe, accurate rendering for paths outside known roots or when metadata cannot be fetched.

## Follow-up

- TUI end-to-end coverage could be added in a future change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->