### PR TITLE
test(session): cover retroactive session capture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ required-features = ["serve"]
 # Explicit target so the `e2e-tests` feature gate applies. Without this entry
 # Cargo auto-discovers tests/e2e/main.rs unconditionally; the gate lets CI split
 # the serve suite into "everything except e2e" and "e2e only" shards. The other
-# 16 test binaries stay auto-discovered.
+# standalone test binaries stay auto-discovered.
 name = "e2e"
 path = "tests/e2e/main.rs"
 required-features = ["e2e-tests"]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3026,19 +3026,6 @@ impl Instance {
         expected_prior_intent: ResumeIntent,
     ) -> SidPersistOutcome {
         let new_sid = self.agent_session_id.clone();
-        // Cleared, Fork, and Use are all one-shot launch directives: after the
-        // launch they ran with completes, the session resumes its own id
-        // normally, so the intent must auto-promote to Default. A fork left as
-        // Fork on disk would re-fork the parent on the next restart
-        // (double-fork). A Use pin left durable would let the drain never
-        // adopt a post-launch capture (e.g. the resume-probe fallback minting
-        // a fresh sid, or a later `/clear`), so a launched pin hands control
-        // back to normal capture; a pin on a session that never launches keeps
-        // Use and stays authoritative (see #2708).
-        let promote_one_shot = matches!(
-            expected_prior_intent,
-            ResumeIntent::Cleared | ResumeIntent::Fork { .. } | ResumeIntent::Use(_)
-        );
 
         if let Some(ref sid) = new_sid {
             if !is_valid_session_id(sid) {
@@ -3062,6 +3049,30 @@ impl Instance {
                 return SidPersistOutcome::Skip;
             }
         };
+
+        self.persist_session_id_with_storage(&storage, expected_prior_sid, expected_prior_intent)
+    }
+
+    fn persist_session_id_with_storage(
+        &mut self,
+        storage: &super::storage::Storage,
+        expected_prior_sid: Option<&str>,
+        expected_prior_intent: ResumeIntent,
+    ) -> SidPersistOutcome {
+        let new_sid = self.agent_session_id.clone();
+        // Cleared, Fork, and Use are all one-shot launch directives: after the
+        // launch they ran with completes, the session resumes its own id
+        // normally, so the intent must auto-promote to Default. A fork left as
+        // Fork on disk would re-fork the parent on the next restart
+        // (double-fork). A Use pin left durable would let the drain never
+        // adopt a post-launch capture (e.g. the resume-probe fallback minting
+        // a fresh sid, or a later `/clear`), so a launched pin hands control
+        // back to normal capture; a pin on a session that never launches keeps
+        // Use and stays authoritative (see #2708).
+        let promote_one_shot = matches!(
+            expected_prior_intent,
+            ResumeIntent::Cleared | ResumeIntent::Fork { .. } | ResumeIntent::Use(_)
+        );
 
         let instance_id = self.id.clone();
         let new_sid_for_closure = new_sid.clone();
@@ -9297,12 +9308,14 @@ mod tests {
         #[serial]
         fn persist_session_id_writes_none_atomically_when_sid_absent() {
             let temp = tempdir().unwrap();
-            let _home = EnvVarGuard::set("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            let _xdg_config = EnvVarGuard::set("XDG_CONFIG_HOME", temp.path().join(".config"));
-
             let profile = "persist-none-sid";
-            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
+            let storage = crate::session::storage::Storage::new_for_test_path(
+                profile,
+                temp.path()
+                    .join("profiles")
+                    .join(profile)
+                    .join("sessions.json"),
+            );
             let mut inst = Instance::new("title", "/tmp/x");
             inst.source_profile = profile.to_string();
             inst.agent_session_id = None;
@@ -9320,7 +9333,8 @@ mod tests {
                 })
                 .unwrap();
 
-            let outcome = inst.persist_session_id(profile, None, ResumeIntent::Default);
+            let outcome =
+                inst.persist_session_id_with_storage(&storage, None, ResumeIntent::Default);
 
             assert_eq!(outcome, SidPersistOutcome::Published);
             assert_eq!(inst.agent_session_id, None);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -7743,10 +7743,80 @@ mod tests {
     mod resume_fallback {
         use super::super::{
             should_attempt_resume, Instance, LaunchSidOutcome, ResumeAttemptPolicy, ResumeIntent,
-            StartOutcome, Status,
+            SidPersistOutcome, StartOutcome, Status,
         };
         use serial_test::serial;
         use tempfile::tempdir;
+
+        struct EnvVarGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
+        }
+
+        impl EnvVarGuard {
+            fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+                let prev = std::env::var_os(key);
+                std::env::set_var(key, value);
+                Self { key, prev }
+            }
+        }
+
+        impl Drop for EnvVarGuard {
+            fn drop(&mut self) {
+                match self.prev.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+
+        struct TmuxSessionGuard(String);
+
+        impl TmuxSessionGuard {
+            fn create(inst: &Instance) -> Option<Self> {
+                let tmux_available = crate::tmux::tmux_command()
+                    .arg("-V")
+                    .output()
+                    .map(|o| o.status.success())
+                    .unwrap_or(false);
+                if !tmux_available {
+                    eprintln!("Skipping: tmux not available");
+                    return None;
+                }
+
+                let session = inst.tmux_session().unwrap();
+                session
+                    .create(&inst.project_path, Some("sleep 60"))
+                    .expect("create tmux session");
+                Some(Self(session.name().to_string()))
+            }
+        }
+
+        impl Drop for TmuxSessionGuard {
+            fn drop(&mut self) {
+                let _ = crate::tmux::tmux_command()
+                    .args(["kill-session", "-t", &self.0])
+                    .output();
+                crate::tmux::refresh_session_cache();
+            }
+        }
+
+        fn seed_opencode_db(db_path: &std::path::Path, sid: &str, project_path: &str) {
+            let conn = rusqlite::Connection::open(db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE session (
+                    id TEXT PRIMARY KEY,
+                    directory TEXT NOT NULL,
+                    time_updated INTEGER NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+                rusqlite::params![sid, project_path, 1_000_000_i64],
+            )
+            .unwrap();
+        }
 
         #[test]
         fn no_sid_does_not_attempt_resume() {
@@ -8596,6 +8666,33 @@ mod tests {
             assert_eq!(inst.agent_session_id, sid);
         }
 
+        #[test]
+        #[serial]
+        fn acquire_session_id_default_picks_up_retroactive_capture() {
+            let temp = tempdir().unwrap();
+            let project_path = temp.path().join("opencode-project");
+            std::fs::create_dir_all(&project_path).unwrap();
+            let project_path = project_path.to_string_lossy().to_string();
+            let db_path = temp.path().join("opencode.db");
+            let captured_sid = "ses_retroactive_capture";
+            seed_opencode_db(&db_path, captured_sid, &project_path);
+            let _opencode_db = EnvVarGuard::set("OPENCODE_DB", &db_path);
+
+            let mut inst = Instance::new("retroactive-opencode", &project_path);
+            inst.tool = "opencode".to_string();
+            inst.agent_session_id = None;
+            inst.resume_intent = ResumeIntent::Default;
+            let Some(_tmux) = TmuxSessionGuard::create(&inst) else {
+                return;
+            };
+
+            let (sid, is_existing) = inst.acquire_session_id();
+
+            assert_eq!(sid.as_deref(), Some(captured_sid));
+            assert!(is_existing);
+            assert_eq!(inst.agent_session_id.as_deref(), Some(captured_sid));
+        }
+
         mod verify_on_resume {
             use super::*;
             use crate::session::capture::encode_claude_project_path;
@@ -9194,6 +9291,44 @@ mod tests {
                 "Cleared must auto-promote to Default in the same flock"
             );
             assert_eq!(inst.resume_intent, ResumeIntent::Default);
+        }
+
+        #[test]
+        #[serial]
+        fn persist_session_id_writes_none_atomically_when_sid_absent() {
+            let temp = tempdir().unwrap();
+            let _home = EnvVarGuard::set("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            let _xdg_config = EnvVarGuard::set("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "persist-none-sid";
+            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.source_profile = profile.to_string();
+            inst.agent_session_id = None;
+            inst.resume_intent = ResumeIntent::Default;
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(
+                        std::slice::from_ref(&on_disk),
+                        &[],
+                    )
+                    .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            let outcome = inst.persist_session_id(profile, None, ResumeIntent::Default);
+
+            assert_eq!(outcome, SidPersistOutcome::Published);
+            assert_eq!(inst.agent_session_id, None);
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(loaded[0].id, inst.id);
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(loaded[0].resume_intent, ResumeIntent::Default);
         }
 
         #[test]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -409,6 +409,16 @@ impl Storage {
         Self::new(profile, FileWatchService::noop())
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_for_test_path(profile: &str, sessions_path: PathBuf) -> Self {
+        Self {
+            profile: profile.to_string(),
+            sessions_path,
+            save_lock: save_lock_for(profile),
+            file_watch: FileWatchService::noop(),
+        }
+    }
+
     pub fn profile(&self) -> &str {
         &self.profile
     }

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -530,6 +530,7 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
             .unwrap();
     });
 
+    let started = std::time::Instant::now();
     parent_held.wait();
 
     // Cross-profile children must NOT be serialised by profile-a's flock.
@@ -539,7 +540,6 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
         .args(["session", "favorite", "--profile", "profile-b", &id_b])
         .env("HOME", &home);
     cmd_b.env("XDG_CONFIG_HOME", home.join(".config"));
-    let started = std::time::Instant::now();
     let status = cmd_b
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -516,7 +516,7 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
     let id_a = s_a.load()?[0].id.clone();
     let id_b = s_b.load()?[0].id.clone();
 
-    let hold = std::time::Duration::from_millis(500);
+    let hold = std::time::Duration::from_secs(5);
     let storage_clone = Storage::new_unwatched("profile-a")?;
     let parent_held = Arc::new(Barrier::new(2));
     let parent_held_inner = parent_held.clone();


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds focused regression coverage for #1744 around session id capture and persistence.

The new `acquire_session_id_default_picks_up_retroactive_capture` test seeds an OpenCode SQLite session row, starts a short-lived tmux session, and verifies `acquire_session_id()` returns the retroactively captured id as an existing session while storing it on the instance. The new `persist_session_id_writes_none_atomically_when_sid_absent` test covers the `None` session id path and confirms it still publishes the storage update with `ResumeIntent::Default`.

The persistence test now uses a temp-path storage helper rather than changing process-wide `HOME` or `XDG_CONFIG_HOME`, keeping it isolated from parallel tests. This also adds a missing `serve` feature gate for the ACP runner orphan integration target and gives the storage concurrency subprocess test enough lock-hold time to distinguish cross-profile blocking from debug binary startup overhead.

Closes #1744

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Start an OpenCode-backed session after its session row exists on disk, then reopen AoE and confirm the session resumes with that captured session id.
- [ ] Start a resume-capable session before any agent session id is observed and confirm AoE keeps the session id empty until the agent emits one.
- [ ] Run the local Rust validation suite and confirm the default test run does not launch the serve-gated `__acp-runner` target without `serve`.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle behavior
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenAI GPT-5.5 via OpenCode

**Any Additional AI Details you'd like to share:**

OpenCode drafted the investigation, implementation, validation steps, and PR prose under maintainer direction.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Expanded session-ID regression coverage to verify retroactive capture of an existing OpenCode SQLite session ID (via tmux) and correct reporting when the session ID is “existing” vs “new”.
- Added focused persistence tests to ensure `persist_session_id` atomically handles the “no session id present” case (persisting `None` with `ResumeIntent::Default`) without writing or reconciling spurious values.
- Refactored session persistence internals by extracting the storage/CAS + in-memory reconciliation flow into a dedicated helper to improve testability while keeping behavior the same.
- Improved test isolation by enabling `Storage` construction with caller-provided temporary paths.
- Strengthened the ACP runner orphan integration test configuration by ensuring it is properly gated behind the `serve` feature.
- Reduced test flakiness by increasing the simulated lock-hold duration in the storage cross-process concurrency test.
- Updated the Cargo test target comment to avoid hardcoding assumptions about how many test binaries are auto-discovered.

## Benefits

These changes make session resumption and “no session id” persistence behavior much harder to accidentally break, while also improving reliability and ease of running the relevant test suites in isolation (especially around storage paths and concurrency timing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->