### PR TITLE
fix(acp): warn about stale adapters on serve startup

### DIFF
--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -66,9 +66,19 @@ fn opencode_min_version() -> semver::Version {
     semver::Version::parse(OPENCODE_MIN_VERSION).expect("OPENCODE_MIN_VERSION must be valid semver")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VersionGate {
+    pub expected: ExpectedAgent,
+    pub binary: &'static str,
+    pub package_name: &'static str,
+    pub min_version: &'static str,
+    pub install_command: &'static str,
+    pub auto_install: bool,
+}
+
 /// The adapter aoe is trying to launch. Drives which `CompatibilityPolicy`
 /// is applied at initialize-time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ExpectedAgent {
     ClaudeAgentAcp,
     CodexAcp,
@@ -444,6 +454,33 @@ fn auto_install_for(expected: ExpectedAgent) -> bool {
         .is_some()
 }
 
+pub fn version_gate_for(expected: ExpectedAgent) -> Option<VersionGate> {
+    let (binary, package_name, min_version) = match expected {
+        ExpectedAgent::ClaudeAgentAcp => (
+            "claude-agent-acp",
+            "@agentclientprotocol/claude-agent-acp",
+            CLAUDE_AGENT_ACP_MIN_VERSION,
+        ),
+        ExpectedAgent::OpenCode => ("opencode", "OpenCode", OPENCODE_MIN_VERSION),
+        _ => return None,
+    };
+    Some(VersionGate {
+        expected,
+        binary,
+        package_name,
+        min_version,
+        install_command: crate::acp::install_hints::install_hint_for(binary)
+            .unwrap_or("(see project docs)"),
+        auto_install: crate::acp::install_hints::npm_package_for(binary).is_some(),
+    })
+}
+
+pub fn version_gates() -> impl Iterator<Item = VersionGate> {
+    [ExpectedAgent::ClaudeAgentAcp, ExpectedAgent::OpenCode]
+        .into_iter()
+        .filter_map(version_gate_for)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,6 +525,24 @@ mod tests {
         assert!(!auto_install_for(ExpectedAgent::PiAcp));
         assert!(!auto_install_for(ExpectedAgent::AoeAgent));
         assert!(!auto_install_for(ExpectedAgent::Other));
+    }
+
+    #[test]
+    fn version_gates_expose_floor_metadata() {
+        let claude = version_gate_for(ExpectedAgent::ClaudeAgentAcp).unwrap();
+        assert_eq!(claude.binary, "claude-agent-acp");
+        assert_eq!(claude.package_name, "@agentclientprotocol/claude-agent-acp");
+        assert_eq!(claude.min_version, CLAUDE_AGENT_ACP_MIN_VERSION);
+        assert!(claude.auto_install);
+
+        let opencode = version_gate_for(ExpectedAgent::OpenCode).unwrap();
+        assert_eq!(opencode.binary, "opencode");
+        assert_eq!(opencode.package_name, "OpenCode");
+        assert_eq!(opencode.min_version, OPENCODE_MIN_VERSION);
+        assert!(!opencode.auto_install);
+
+        assert!(version_gate_for(ExpectedAgent::CodexAcp).is_none());
+        assert!(version_gate_for(ExpectedAgent::Other).is_none());
     }
 
     #[test]

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -40,6 +40,8 @@ pub mod session_tee;
 pub mod state;
 pub mod supervisor;
 pub mod terminal_handler;
+#[cfg(feature = "serve")]
+pub mod version_probe;
 pub mod worker_registry;
 
 pub use agent_registry::{AgentRegistry, AgentSpec};

--- a/src/acp/version_probe.rs
+++ b/src/acp/version_probe.rs
@@ -1,0 +1,338 @@
+use std::collections::HashSet;
+use std::process::Stdio;
+use std::time::Duration;
+
+use semver::Version;
+
+use crate::acp::agent_compat::{version_gate_for, ExpectedAgent, VersionGate};
+use crate::acp::agent_registry::AgentRegistry;
+use crate::session::Instance;
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeStatus {
+    Missing,
+    Version { raw: String, parsed: Version },
+    Unparseable { raw: String },
+    Failed { message: String },
+    TimedOut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionWarningKind {
+    Missing,
+    BelowMinimum { installed: String },
+    Unparseable { raw: String },
+    Failed { message: String },
+    TimedOut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionWarning {
+    pub gate: VersionGate,
+    pub kind: VersionWarningKind,
+}
+
+impl VersionWarning {
+    pub fn reason(&self) -> String {
+        match &self.kind {
+            VersionWarningKind::Missing => "not found on PATH".to_string(),
+            VersionWarningKind::BelowMinimum { installed } => format!(
+                "installed {installed}; requires >={}",
+                self.gate.min_version
+            ),
+            VersionWarningKind::Unparseable { raw } => {
+                format!("reported an unparseable version `{raw}`")
+            }
+            VersionWarningKind::Failed { message } => format!("version probe failed: {message}"),
+            VersionWarningKind::TimedOut => "version probe timed out".to_string(),
+        }
+    }
+
+    pub fn render(&self) -> String {
+        format!(
+            "warning: structured ACP adapter {} {}; aoe requires {} >= {}. Run: {}. Existing structured sessions using this adapter will fail until upgraded.",
+            self.gate.binary,
+            self.reason(),
+            self.gate.package_name,
+            self.gate.min_version,
+            self.gate.install_command,
+        )
+    }
+}
+
+pub fn extract_semver(raw: &str) -> Option<Version> {
+    raw.split(|c: char| !(c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+'))
+        .filter_map(|token| {
+            let token = token.trim_start_matches('v');
+            token
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_digit())
+                .then(|| Version::parse(token).ok())
+                .flatten()
+        })
+        .next()
+}
+
+pub async fn probe_binary_version(binary: &str) -> ProbeStatus {
+    let Ok(path) = which::which(binary) else {
+        return ProbeStatus::Missing;
+    };
+    let child = tokio::process::Command::new(&path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn();
+    let child = match child {
+        Ok(child) => child,
+        Err(e) => {
+            return ProbeStatus::Failed {
+                message: e.to_string(),
+            }
+        }
+    };
+    match tokio::time::timeout(PROBE_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            let raw = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            )
+            .trim()
+            .to_string();
+            if !output.status.success() {
+                return ProbeStatus::Failed {
+                    message: if raw.is_empty() {
+                        format!("exited with {}", output.status)
+                    } else {
+                        raw
+                    },
+                };
+            }
+            match extract_semver(&raw) {
+                Some(parsed) => ProbeStatus::Version { raw, parsed },
+                None => ProbeStatus::Unparseable { raw },
+            }
+        }
+        Ok(Err(e)) => ProbeStatus::Failed {
+            message: e.to_string(),
+        },
+        Err(_) => ProbeStatus::TimedOut,
+    }
+}
+
+pub fn warning_for_probe(gate: VersionGate, probe: &ProbeStatus) -> Option<VersionWarning> {
+    match probe {
+        ProbeStatus::Missing => Some(VersionWarning {
+            gate,
+            kind: VersionWarningKind::Missing,
+        }),
+        ProbeStatus::Version { parsed, .. } => {
+            let min = Version::parse(gate.min_version).ok()?;
+            (parsed < &min).then(|| VersionWarning {
+                gate,
+                kind: VersionWarningKind::BelowMinimum {
+                    installed: parsed.to_string(),
+                },
+            })
+        }
+        ProbeStatus::Unparseable { raw } => Some(VersionWarning {
+            gate,
+            kind: VersionWarningKind::Unparseable { raw: raw.clone() },
+        }),
+        ProbeStatus::Failed { message } => Some(VersionWarning {
+            gate,
+            kind: VersionWarningKind::Failed {
+                message: message.clone(),
+            },
+        }),
+        ProbeStatus::TimedOut => Some(VersionWarning {
+            gate,
+            kind: VersionWarningKind::TimedOut,
+        }),
+    }
+}
+
+pub fn gates_needed_by_instances(instances: &[Instance]) -> Vec<VersionGate> {
+    let registry = AgentRegistry::with_defaults();
+    let mut seen = HashSet::new();
+    let mut gates = Vec::new();
+    for inst in instances.iter().filter(|inst| inst.is_structured()) {
+        let explicit_agent = inst.agent_name.as_deref().filter(|name| !name.is_empty());
+        let Some(spec) = explicit_agent
+            .and_then(|agent| registry.get(agent))
+            .or_else(|| {
+                explicit_agent
+                    .is_none()
+                    .then(|| registry.get(&inst.tool))
+                    .flatten()
+            })
+        else {
+            continue;
+        };
+        let expected = ExpectedAgent::from_command(&spec.command);
+        let Some(gate) = version_gate_for(expected) else {
+            continue;
+        };
+        if seen.insert(gate.expected) {
+            gates.push(gate);
+        }
+    }
+    gates
+}
+
+pub async fn warn_for_structured_sessions(instances: &[Instance], print_to_stderr: bool) {
+    let gates = gates_needed_by_instances(instances);
+    let mut printed = false;
+    for gate in gates {
+        let probe = probe_binary_version(gate.binary).await;
+        if let Some(warning) = warning_for_probe(gate, &probe) {
+            let message = warning.render();
+            if print_to_stderr {
+                eprintln!("{message}");
+                printed = true;
+            }
+            tracing::warn!(
+                target: "acp.preflight",
+                binary = warning.gate.binary,
+                package = warning.gate.package_name,
+                required = warning.gate.min_version,
+                reason = %warning.reason(),
+                "structured ACP adapter preflight failed"
+            );
+        }
+    }
+    if printed {
+        eprintln!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::agent_compat::{CLAUDE_AGENT_ACP_MIN_VERSION, OPENCODE_MIN_VERSION};
+    use crate::session::View;
+
+    fn claude_gate() -> VersionGate {
+        version_gate_for(ExpectedAgent::ClaudeAgentAcp).unwrap()
+    }
+
+    #[test]
+    fn extract_semver_handles_realistic_outputs() {
+        assert_eq!(extract_semver("0.55.0").unwrap().to_string(), "0.55.0");
+        assert_eq!(
+            extract_semver("claude-agent-acp 0.55.0")
+                .unwrap()
+                .to_string(),
+            "0.55.0"
+        );
+        assert_eq!(extract_semver("v1.16.0").unwrap().to_string(), "1.16.0");
+        assert_eq!(
+            extract_semver("version=0.55.0-alpha.1")
+                .unwrap()
+                .to_string(),
+            "0.55.0-alpha.1"
+        );
+        assert!(extract_semver("not-semver").is_none());
+    }
+
+    #[test]
+    fn warning_for_probe_flags_only_unusable_versions() {
+        let gate = claude_gate();
+        assert!(matches!(
+            warning_for_probe(
+                gate,
+                &ProbeStatus::Version {
+                    raw: "0.0.1".to_string(),
+                    parsed: Version::parse("0.0.1").unwrap(),
+                },
+            )
+            .unwrap()
+            .kind,
+            VersionWarningKind::BelowMinimum { .. }
+        ));
+        assert!(warning_for_probe(
+            gate,
+            &ProbeStatus::Version {
+                raw: CLAUDE_AGENT_ACP_MIN_VERSION.to_string(),
+                parsed: Version::parse(CLAUDE_AGENT_ACP_MIN_VERSION).unwrap(),
+            },
+        )
+        .is_none());
+        assert!(warning_for_probe(
+            gate,
+            &ProbeStatus::Version {
+                raw: "999.0.0".to_string(),
+                parsed: Version::parse("999.0.0").unwrap(),
+            },
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn warning_for_probe_covers_failed_probes() {
+        let gate = claude_gate();
+        assert!(matches!(
+            warning_for_probe(gate, &ProbeStatus::Missing).unwrap().kind,
+            VersionWarningKind::Missing
+        ));
+        assert!(matches!(
+            warning_for_probe(
+                gate,
+                &ProbeStatus::Unparseable {
+                    raw: "weird".to_string(),
+                },
+            )
+            .unwrap()
+            .kind,
+            VersionWarningKind::Unparseable { .. }
+        ));
+        assert!(matches!(
+            warning_for_probe(gate, &ProbeStatus::TimedOut)
+                .unwrap()
+                .kind,
+            VersionWarningKind::TimedOut
+        ));
+    }
+
+    #[test]
+    fn gates_needed_by_instances_scopes_to_structured_sessions_and_dedupes() {
+        let mut terminal = Instance::new("terminal", "/tmp/terminal");
+        terminal.tool = "claude".to_string();
+
+        let mut structured_claude = Instance::new("structured", "/tmp/structured");
+        structured_claude.view = View::Structured;
+        structured_claude.tool = "claude".to_string();
+
+        let mut duplicate_claude = Instance::new("structured 2", "/tmp/structured-2");
+        duplicate_claude.view = View::Structured;
+        duplicate_claude.tool = "claude".to_string();
+
+        let mut structured_opencode = Instance::new("opencode", "/tmp/opencode");
+        structured_opencode.view = View::Structured;
+        structured_opencode.tool = "opencode".to_string();
+
+        let mut custom_agent = Instance::new("custom", "/tmp/custom");
+        custom_agent.view = View::Structured;
+        custom_agent.tool = "claude".to_string();
+        custom_agent.agent_name = Some("custom-acp".to_string());
+
+        let gates = gates_needed_by_instances(&[
+            terminal,
+            structured_claude,
+            duplicate_claude,
+            structured_opencode,
+            custom_agent,
+        ]);
+
+        assert_eq!(gates.len(), 2);
+        assert!(gates
+            .iter()
+            .any(|g| g.min_version == CLAUDE_AGENT_ACP_MIN_VERSION));
+        assert!(gates.iter().any(|g| g.min_version == OPENCODE_MIN_VERSION));
+    }
+}

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -207,7 +207,7 @@ struct AgentDoctorEntry {
 
 /// ACP adapters that ship as npm packages (binary name → package id).
 /// The doctor's `--fix` path runs `npm install -g <package>` for each
-/// entry whose binary isn't already on PATH.
+/// missing entry, and for version-gated entries with a stale parsed version.
 const NPM_INSTALLABLE_ACP: &[(&str, &str)] = &[
     (
         "claude-agent-acp",
@@ -216,6 +216,107 @@ const NPM_INSTALLABLE_ACP: &[(&str, &str)] = &[
     ("codex-acp", "@agentclientprotocol/codex-acp@latest"),
     ("pi-acp", "pi-acp"),
 ];
+
+#[cfg(feature = "serve")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DoctorFixAction {
+    InstallNpm { reason: String },
+    PrintHint { reason: String },
+    Skip,
+}
+
+#[cfg(feature = "serve")]
+fn doctor_fix_action(
+    gate: Option<crate::acp::agent_compat::VersionGate>,
+    npm_pkg: Option<&str>,
+    probe: &crate::acp::version_probe::ProbeStatus,
+) -> DoctorFixAction {
+    use crate::acp::version_probe::ProbeStatus;
+    let is_gated = gate.is_some();
+
+    match probe {
+        ProbeStatus::Missing => npm_pkg.map_or(
+            DoctorFixAction::PrintHint {
+                reason: "not found on PATH".to_string(),
+            },
+            |_| DoctorFixAction::InstallNpm {
+                reason: "not found on PATH".to_string(),
+            },
+        ),
+        ProbeStatus::Version { parsed, .. } => {
+            let Some(gate) = gate else {
+                return DoctorFixAction::Skip;
+            };
+            let Ok(min) = semver::Version::parse(gate.min_version) else {
+                return DoctorFixAction::Skip;
+            };
+            if parsed >= &min {
+                return DoctorFixAction::Skip;
+            }
+            let reason = format!("installed {parsed}; requires >={}", gate.min_version);
+            if npm_pkg.is_some() {
+                DoctorFixAction::InstallNpm { reason }
+            } else {
+                DoctorFixAction::PrintHint { reason }
+            }
+        }
+        ProbeStatus::Unparseable { raw } if is_gated => DoctorFixAction::PrintHint {
+            reason: format!("reported an unparseable version `{raw}`"),
+        },
+        ProbeStatus::Failed { message } if is_gated => DoctorFixAction::PrintHint {
+            reason: format!("version probe failed: {message}"),
+        },
+        ProbeStatus::TimedOut if is_gated => DoctorFixAction::PrintHint {
+            reason: "version probe timed out".to_string(),
+        },
+        ProbeStatus::Unparseable { .. } | ProbeStatus::Failed { .. } | ProbeStatus::TimedOut => {
+            DoctorFixAction::Skip
+        }
+    }
+}
+
+#[cfg(feature = "serve")]
+async fn run_doctor_fix_action(binary: &str, npm_pkg: Option<&str>) -> bool {
+    let gate = crate::acp::agent_compat::version_gate_for(
+        crate::acp::agent_compat::ExpectedAgent::from_command(binary),
+    );
+    let probe = crate::acp::version_probe::probe_binary_version(binary).await;
+    match doctor_fix_action(gate, npm_pkg, &probe) {
+        DoctorFixAction::InstallNpm { reason } => {
+            let Some(npm_pkg) = npm_pkg else {
+                return true;
+            };
+            println!("Installing {npm_pkg} globally via npm ({reason})...");
+            install_npm_package(npm_pkg)
+        }
+        DoctorFixAction::PrintHint { reason } => {
+            let hint = install_hint_for(binary).unwrap_or("(see project docs)");
+            println!("{binary}: {reason}. Install manually: {hint}");
+            true
+        }
+        DoctorFixAction::Skip => true,
+    }
+}
+
+fn install_npm_package(npm_pkg: &str) -> bool {
+    let status = std::process::Command::new("npm")
+        .args(["install", "-g", npm_pkg])
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            println!("Installed {npm_pkg}.");
+            true
+        }
+        Ok(s) => {
+            println!("npm install {npm_pkg} exited with status {s}");
+            true
+        }
+        Err(e) => {
+            println!("Could not run npm: {e}. Install Node.js + npm first.");
+            false
+        }
+    }
+}
 
 async fn doctor(json: bool, fix: bool) -> Result<()> {
     if fix {
@@ -242,26 +343,32 @@ async fn doctor(json: bool, fix: bool) -> Result<()> {
                 Err(e) => println!("Cannot probe Node: {e}"),
             }
         }
-        // Auto-install npm-distributed ACP adapters that aren't on
-        // PATH. Native CLIs (opencode / gemini / vibe) have to be
-        // installed via their own channels; we only print a hint for
-        // those.
+        // Auto-install npm-distributed ACP adapters that aren't on PATH.
+        // With the serve feature, also upgrade known-stale gated adapters.
+        // Native CLIs (opencode / gemini / vibe) stay manual.
         for (binary, npm_pkg) in NPM_INSTALLABLE_ACP {
-            if find_in_path(binary).is_some() {
+            #[cfg(feature = "serve")]
+            {
+                if !run_doctor_fix_action(binary, Some(npm_pkg)).await {
+                    break;
+                }
                 continue;
             }
-            println!("Installing {npm_pkg} globally via npm...");
-            let status = std::process::Command::new("npm")
-                .args(["install", "-g", npm_pkg])
-                .status();
-            match status {
-                Ok(s) if s.success() => println!("Installed {npm_pkg}."),
-                Ok(s) => println!("npm install {npm_pkg} exited with status {s}"),
-                Err(e) => {
-                    println!("Could not run npm: {e}. Install Node.js + npm first.");
+
+            #[cfg(not(feature = "serve"))]
+            {
+                if find_in_path(binary).is_some() {
+                    continue;
+                }
+                println!("Installing {npm_pkg} globally via npm...");
+                if !install_npm_package(npm_pkg) {
                     break;
                 }
             }
+        }
+        #[cfg(feature = "serve")]
+        for gate in crate::acp::agent_compat::version_gates().filter(|gate| !gate.auto_install) {
+            let _ = run_doctor_fix_action(gate.binary, None).await;
         }
     }
     let registry = AgentRegistry::with_defaults();
@@ -937,6 +1044,97 @@ mod tests {
         assert_eq!(parse_node_major("v20.0.0"), Some(20));
         assert_eq!(parse_node_major("18.17.1"), Some(18));
         assert_eq!(parse_node_major("not a version"), None);
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn doctor_fix_plans_missing_and_stale_npm_installs() {
+        let claude = crate::acp::agent_compat::version_gate_for(
+            crate::acp::agent_compat::ExpectedAgent::ClaudeAgentAcp,
+        );
+        let pkg = Some("@agentclientprotocol/claude-agent-acp@latest");
+
+        assert!(matches!(
+            doctor_fix_action(
+                claude,
+                pkg,
+                &crate::acp::version_probe::ProbeStatus::Missing
+            ),
+            DoctorFixAction::InstallNpm { .. }
+        ));
+        assert!(matches!(
+            doctor_fix_action(
+                claude,
+                pkg,
+                &crate::acp::version_probe::ProbeStatus::Version {
+                    raw: "0.0.1".to_string(),
+                    parsed: semver::Version::parse("0.0.1").unwrap(),
+                },
+            ),
+            DoctorFixAction::InstallNpm { .. }
+        ));
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn doctor_fix_skips_current_and_uncertain_npm_versions() {
+        let claude = crate::acp::agent_compat::version_gate_for(
+            crate::acp::agent_compat::ExpectedAgent::ClaudeAgentAcp,
+        );
+        let pkg = Some("@agentclientprotocol/claude-agent-acp@latest");
+        assert_eq!(
+            doctor_fix_action(
+                claude,
+                pkg,
+                &crate::acp::version_probe::ProbeStatus::Version {
+                    raw: crate::acp::agent_compat::CLAUDE_AGENT_ACP_MIN_VERSION.to_string(),
+                    parsed: semver::Version::parse(
+                        crate::acp::agent_compat::CLAUDE_AGENT_ACP_MIN_VERSION,
+                    )
+                    .unwrap(),
+                },
+            ),
+            DoctorFixAction::Skip,
+        );
+        assert!(matches!(
+            doctor_fix_action(
+                claude,
+                pkg,
+                &crate::acp::version_probe::ProbeStatus::Unparseable {
+                    raw: "weird".to_string(),
+                },
+            ),
+            DoctorFixAction::PrintHint { .. }
+        ));
+        assert_eq!(
+            doctor_fix_action(
+                None,
+                Some("@agentclientprotocol/codex-acp@latest"),
+                &crate::acp::version_probe::ProbeStatus::Unparseable {
+                    raw: "weird".to_string(),
+                },
+            ),
+            DoctorFixAction::Skip,
+        );
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn doctor_fix_never_auto_installs_non_npm_stale_agents() {
+        let opencode = crate::acp::agent_compat::version_gate_for(
+            crate::acp::agent_compat::ExpectedAgent::OpenCode,
+        );
+        assert!(matches!(
+            doctor_fix_action(
+                opencode,
+                None,
+                &crate::acp::version_probe::ProbeStatus::Version {
+                    raw: "1.15.0".to_string(),
+                    parsed: semver::Version::parse("1.15.0").unwrap(),
+                },
+            ),
+            DoctorFixAction::PrintHint { .. }
+        ));
     }
 
     /// Story 3: `aoe acp ps` surfaces the worker build version, tags

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -802,6 +802,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     let local_port = listener.local_addr()?.port();
 
+    crate::acp::version_probe::warn_for_structured_sessions(&instances, !is_daemon).await;
+
     // Start tunnel if remote mode. Preference order:
     //  1. User-specified named Cloudflare tunnel (stable, explicit choice).
     //  2. Tailscale Funnel if tailscale is installed and logged in


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

This fixes stale ACP adapter handling for structured-view sessions. `aoe serve` now performs a read-only startup check for adapters used by existing structured sessions, warns when a known compatibility floor is not met, and points users at `aoe acp doctor --fix` instead of trying to install packages during server startup.

The compatibility policy stays single-source in the ACP agent compatibility layer. The same minimum versions drive startup warnings, startup-error copy, and doctor remediation for npm-backed adapters.

`aoe acp doctor --fix` now handles both missing and stale npm-backed adapters by running the appropriate global npm install. Non-npm or uncertain stale adapters still get a manual remediation hint instead of an unsafe automatic upgrade.

Local validation completed: targeted ACP compatibility tests, targeted doctor tests, full serve-feature test suite, formatting, clippy, and serve build. Plain `cargo test` still exposes the existing non-serve `tests/acp_runner_orphan.rs` feature mismatch, which invokes the serve-only `__acp-runner` subcommand without `serve`.

Closes #1967

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With an existing structured Claude ACP session and `@agentclientprotocol/claude-agent-acp` below `0.55.0`, run `aoe serve` and confirm startup prints an outdated-adapter warning with an `aoe acp doctor --fix` hint.
- [ ] Run `aoe acp doctor --fix` with a missing known npm ACP adapter and confirm it installs the expected global npm package.
- [ ] Run `aoe acp doctor --fix` with a stale known npm ACP adapter and confirm it upgrades the expected global npm package.
- [ ] Run `aoe serve` with no structured sessions or only terminal-backed sessions and confirm no ACP adapter warning is printed.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic Rust unit tests cover the ACP doctor install and stale-upgrade planning paths plus startup warning selection without requiring npm or a live daemon.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I reviewed the design choices and validation results before opening the PR.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
