### PR TITLE
feat(web): explain composer usage/cost indicator with a hover tooltip

### DIFF
--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -13,7 +13,18 @@ import { clampMenuPosition } from "../lib/menuPosition";
 // rows live inside an `overflow-x-hidden overflow-y-auto` scroller, so a span
 // nested under the trigger (the old approach) got cut off at the sidebar edge
 // regardless of z-index. See #2214.
-export function Tooltip({ text, children }: { text: string; children: ReactNode }) {
+export function Tooltip({
+  text,
+  children,
+  multiline = false,
+}: {
+  text: string;
+  children: ReactNode;
+  // Single-line callers (sidebar, sort picker) keep the default `whitespace-nowrap`
+  // pill. Set `multiline` for a sentence-length explanation that should wrap inside
+  // a width cap instead of stretching off-screen.
+  multiline?: boolean;
+}) {
   const triggerRef = useRef<HTMLSpanElement>(null);
   const tipRef = useRef<HTMLSpanElement>(null);
   const [open, setOpen] = useState(false);
@@ -70,7 +81,9 @@ export function Tooltip({ text, children }: { text: string; children: ReactNode 
             ref={tipRef}
             role="tooltip"
             style={{ left: pos?.x ?? 0, top: pos?.y ?? 0, visibility: pos ? "visible" : "hidden" }}
-            className="pointer-events-none fixed z-50 px-2 py-1 rounded bg-surface-950 border border-surface-700 text-[11px] text-text-secondary whitespace-nowrap"
+            className={`pointer-events-none fixed z-50 px-2 py-1 rounded bg-surface-950 border border-surface-700 text-[11px] text-text-secondary ${
+              multiline ? "max-w-xs whitespace-normal" : "whitespace-nowrap"
+            }`}
           >
             {text}
           </span>,

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -20,6 +20,7 @@ import { AtSign, ChevronUp, Paperclip, Pencil, Slash, Square, X } from "lucide-r
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import { SessionConfigControls } from "./SessionConfigControls";
+import { Tooltip } from "../Tooltip";
 import { SwitchAgentModal } from "./SwitchAgentModal";
 import {
   clearPendingSwitchAgent,
@@ -1451,21 +1452,23 @@ function UsageHint({ usage }: { usage: AcpState["sessionUsage"] }) {
   const usedLabel = formatTokens(usage.used);
   const sizeLabel = formatTokens(usage.size);
   const cost = usage.cost ? formatCost(usage.cost.amount, usage.cost.currency) : null;
-  const title =
-    `Context: ${usage.used.toLocaleString()} / ${usage.size.toLocaleString()} tokens (${pct}%)` +
-    (cost ? ` · session cost ${cost}` : "");
+  const explanation =
+    `Context window: ${usage.used.toLocaleString()} of ${usage.size.toLocaleString()} tokens used (${pct}%). ` +
+    `Color warns as the window fills.` +
+    (cost ? ` ${cost} is cumulative session spend since the last /clear or /compact.` : "");
   return (
-    <span
-      className={`hidden sm:inline-flex items-center gap-1 text-[11px] tabular-nums ${tone}`}
-      title={title}
-      aria-label={title}
-    >
-      <span>
-        {usedLabel}/{sizeLabel}
+    <Tooltip text={explanation} multiline>
+      <span
+        className={`hidden sm:inline-flex items-center gap-1 text-[11px] tabular-nums ${tone}`}
+        aria-label={explanation}
+      >
+        <span>
+          {usedLabel}/{sizeLabel}
+        </span>
+        <span className="opacity-70">({pct}%)</span>
+        {cost ? <span className="opacity-70">· {cost}</span> : null}
       </span>
-      <span className="opacity-70">({pct}%)</span>
-      {cost ? <span className="opacity-70">· {cost}</span> : null}
-    </span>
+    </Tooltip>
   );
 }
 

--- a/web/src/components/acp/Composer.usageHint.test.tsx
+++ b/web/src/components/acp/Composer.usageHint.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+//
+// User stories (#2800): hovering the composer usage indicator must explain
+// what the numbers mean, not just restate them. The token figure is current
+// context-window usage; the dollar amount is cumulative session spend since
+// the last /clear or /compact. When the agent reports no cost, the tooltip
+// explains context usage and omits the cost sentence.
+//
+// The indicator lives in UsageHint (Composer.tsx) wrapped in the shared
+// <Tooltip>, so hovering the trigger reveals the explanatory text.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { AssistantRuntimeProvider, useExternalStoreRuntime, type ThreadMessageLike } from "@assistant-ui/react";
+
+import { Composer } from "./Composer";
+import type { SessionUsage } from "../../lib/acpTypes";
+
+function Harness({ usage }: { usage: SessionUsage | null }) {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages: [],
+    isRunning: false,
+    convertMessage: (m) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Composer
+        sessionId="sess-usage"
+        currentAgent="claude"
+        availableModes={[]}
+        currentModeId={null}
+        legacyMode="Default"
+        configOptions={[]}
+        pendingConfigOption={null}
+        setConfigOption={() => {}}
+        sessionUsage={usage}
+        availableCommands={[]}
+        connected
+        turnActive={false}
+        queuedCount={0}
+        enqueuePrompt={() => {}}
+        promptCapabilities={null}
+        pendingAttachments={[]}
+        setPendingAttachments={() => {}}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ files: [] }),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+});
+
+describe("composer usage indicator tooltip", () => {
+  it("explains context-window usage and cumulative cost on hover", () => {
+    render(<Harness usage={{ used: 120_000, size: 200_000, cost: { amount: 0.42, currency: "USD" } }} />);
+    // aria-label carries the same explanation for screen readers; use it to
+    // locate the trigger, then hover its Tooltip wrapper (the parent span).
+    const indicator = screen.getByLabelText(/Context window:/);
+    fireEvent.mouseEnter(indicator.parentElement!);
+
+    const tip = screen.getByRole("tooltip").textContent ?? "";
+    expect(tip).toContain("120,000 of 200,000 tokens used (60%)");
+    expect(tip).toContain("cumulative session spend since the last /clear or /compact");
+  });
+
+  it("omits the cost sentence when the agent reports no cost", () => {
+    render(<Harness usage={{ used: 50_000, size: 200_000, cost: null }} />);
+    const indicator = screen.getByLabelText(/Context window:/);
+    fireEvent.mouseEnter(indicator.parentElement!);
+
+    const tip = screen.getByRole("tooltip").textContent ?? "";
+    expect(tip).toContain("50,000 of 200,000 tokens used (25%)");
+    expect(tip).not.toContain("cumulative session spend");
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1705,6 +1705,13 @@
       "components": ["web/src/components/acp/Composer.tsx", "web/src/components/acp/recallNav.ts"]
     },
     {
+      "id": "acp.composer-usage-tooltip",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/acp/Composer.usageHint.test.tsx"],
+      "components": ["web/src/components/acp/Composer.tsx", "web/src/components/Tooltip.tsx"]
+    },
+    {
       "id": "acp.config-pickers",
       "kind": "live-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured view's composer footer shows a compact usage indicator (`used/size (pct%) · $cost`), but it only ever explained itself through a native browser `title` that restated the same numbers. A user reading `120k/200k (60%) · $0.42` had no way to know the token figure is context-window pressure (not lifetime tokens), what the color shift means, or that the dollar amount is cumulative session spend rebased on every `/clear` and `/compact` rather than a lifetime total.

This wraps the indicator in the shared `<Tooltip>` and gives it explanatory copy: the token figure is current context-window usage, the color warns as the window fills, and the cost is cumulative session spend since the last `/clear` or `/compact`. The explanation also rides on `aria-label` so screen-reader users get the same meaning. The shared `Tooltip` gained an opt-in `multiline` variant so a sentence wraps inside a width cap instead of running off-screen; existing single-line callers (sidebar, sort picker) are unchanged.

Mobile visibility of the usage surface is out of scope here and tracked separately in #1719; the cost/rebase semantics this tooltip explains were established in #1354.

Closes #2800

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, attach an ACP session, and send a prompt so the agent reports usage.
- [ ] On desktop, hover the usage indicator in the composer footer and confirm the tooltip explains that the token figure is current context-window usage and shows used/size and the percentage.
- [ ] With a session that reports cost, confirm the tooltip states the dollar amount is cumulative session spend since the last `/clear` or `/compact`.
- [ ] With an agent that reports no cost, confirm the tooltip explains context usage and shows no cost sentence.
- [ ] Confirm the sidebar and sort-picker tooltips still render as single-line pills (unchanged).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Covered with Vitest (`web/src/components/acp/Composer.usageHint.test.tsx`) rather than Playwright, since the behavior is a hover tooltip on a component; `web/tests/coverage-matrix.json` gains the `acp.composer-usage-tooltip` entry.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a shared multiline tooltip for the composer usage indicator.
- Explained context-window usage, token percentage, and cumulative session cost since `/clear` or `/compact`.
- Added accessible `aria-label` text and preserved existing usage formatting and color behavior.
- Added coverage for sessions with and without reported costs.
- Updated the web coverage matrix.

## Benefits

Users can better understand token usage and session spending, while the tooltip remains compatible with existing single-line uses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->