### PR TITLE
fix(acp): anchor tool-group card id to first child so it stops re-folding

### DIFF
--- a/web/src/components/acp/AcpRuntime.test.ts
+++ b/web/src/components/acp/AcpRuntime.test.ts
@@ -209,6 +209,57 @@ describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
     expect(payload.children.map((c: { toolCallId: string }) => c.toolCallId)).toEqual(["td1", "td2", "td3"]);
   });
 
+  it("anchors the generic group id to the first child, stable as the run grows (#2802)", () => {
+    const groupId = (rows: ActivityRow[]) => {
+      const parts = activityToThreadMessages([userRow("go"), ...rows], false).find((m) => m.role === "assistant")!
+        .content as Array<{ type: string; toolName?: string; toolCallId?: string }>;
+      return parts.find((p) => p.type === "tool-call" && p.toolName === TOOL_GROUP_NAME)!.toolCallId;
+    };
+    const three = groupId([toolStart("t1"), toolStart("t2"), toolStart("t3")]);
+    const four = groupId([toolStart("t1"), toolStart("t2"), toolStart("t3"), toolStart("t4")]);
+    // Keyed by the first child, not the join of every child id, so
+    // appending a tool call does not change the id (which would remount
+    // the card and re-collapse it mid-stream).
+    expect(three).toBe("group-t1");
+    expect(four).toBe(three);
+  });
+
+  it("anchors the todo group id to the first child, stable as the run grows (#2802)", () => {
+    const groupId = (rows: ActivityRow[]) => {
+      const parts = activityToThreadMessages([userRow("go"), ...rows], false).find((m) => m.role === "assistant")!
+        .content as Array<{ type: string; toolName?: string; toolCallId?: string }>;
+      return parts.find((p) => p.type === "tool-call" && p.toolName === TODO_GROUP_NAME)!.toolCallId;
+    };
+    const snap = (id: string, status: string) => todoStart(id, [{ content: "a", status }]);
+    const three = groupId([snap("td1", "pending"), snap("td2", "in_progress"), snap("td3", "completed")]);
+    const four = groupId([
+      snap("td1", "pending"),
+      snap("td2", "in_progress"),
+      snap("td3", "completed"),
+      snap("td4", "completed"),
+    ]);
+    expect(three).toBe("todogroup-td1");
+    expect(four).toBe(three);
+  });
+
+  it("gives two text-split runs distinct group ids so neither collides (#2802)", () => {
+    const parts = activityToThreadMessages(
+      [
+        userRow("go"),
+        toolStart("a1"),
+        toolStart("a2"),
+        toolStart("a3"),
+        messageRow("Found it."),
+        toolStart("b1"),
+        toolStart("b2"),
+        toolStart("b3"),
+      ],
+      false,
+    ).find((m) => m.role === "assistant")!.content as Array<{ type: string; toolName?: string; toolCallId?: string }>;
+    const ids = parts.filter((p) => p.type === "tool-call" && p.toolName === TOOL_GROUP_NAME).map((p) => p.toolCallId);
+    expect(ids).toEqual(["group-a1", "group-b1"]);
+  });
+
   it("uses the generic group for todo-shaped runs when todos are disabled", () => {
     const messages = activityToThreadMessages(
       [

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -836,7 +836,14 @@ function collapseToolRuns(parts: DraftPart[], todosEnabled: boolean): DraftPart[
         const { childIds, children } = buildGroupChildren(run);
         out.push({
           type: "tool-call",
-          toolCallId: `todogroup-${childIds.join("-")}`,
+          // Anchor the group's React identity to the first child, not the
+          // join of every child id. While the tail run is still growing,
+          // appending a child would otherwise mutate the key, remount the
+          // card, and reset its local expand state to collapsed. The first
+          // child id is unique per run (runs are bounded by non-tool-call
+          // parts) and stable across replay, so the card survives appends
+          // and a user's expand sticks. See #2802.
+          toolCallId: `todogroup-${childIds[0]}`,
           toolName: TODO_GROUP_NAME,
           argsText: JSON.stringify({ children }),
         });
@@ -864,7 +871,10 @@ function collapseToolRuns(parts: DraftPart[], todosEnabled: boolean): DraftPart[
       const { childIds, children } = buildGroupChildren(run);
       out.push({
         type: "tool-call",
-        toolCallId: `group-${childIds.join("-")}`,
+        // Anchor the group's React identity to the first child (see the
+        // TodoGroup note above and #2802): the full-join key changed on
+        // every append, remounting the card and re-collapsing it.
+        toolCallId: `group-${childIds[0]}`,
         toolName: TOOL_GROUP_NAME,
         argsText: JSON.stringify({ children }),
       });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

In the web structured view, a run of consecutive tool calls folds into one "N actions" group card. While the agent is still working, that group keeps accreting tool calls. If you expanded the running group to watch it live, it re-folded itself the instant the next action landed, so the group you most want to watch was unwatchable.

The re-fold was a remount side effect, not an explicit collapse. The synthetic group part's React identity was `group-${childIds.join("-")}`, the join of every child tool-call id. Appending a child changed that id, so assistant-ui remounted the card, and its component-local `useState` expand override reset to the collapsed baseline. Individual tool cards never had this problem because their key is their own stable id.

This keys the group part to its first child (`group-${childIds[0]}`, and `todogroup-${childIds[0]}` for the TodoWrite group) instead of the full join. The first child id is unique per run (runs are bounded by non-tool-call parts) and stable across replay, so the id no longer changes as the run grows. The card survives appends and a manual expand sticks. The `argsText` payload still changes on each append, so the card re-renders with the new items; only the reconciliation key is now stable. Nothing parses the id back into children (they ride in `argsText`), so this touches only the React key.

Regression tests live in `web/src/components/acp/AcpRuntime.test.ts` (a spec already mapped to this surface in `web/tests/coverage-matrix.json`): the group id is anchored to the first child and stays identical when the run grows from 3 to 4 children, the same for the TodoWrite group, and two text-split runs get distinct ids so neither collides. All three fail on the pre-fix `.join()` id and pass after.

Closes #2802

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web structured view (`aoe serve`) and start an agent that runs several tools in a row without talking (an investigation phase), so a "N actions" group card appears.
- [ ] While the agent is still running, expand that active group.
- [ ] Confirm the group stays expanded as new actions stream into it (before the fix it snapped shut on every new action).
- [ ] Trigger a run of 3+ consecutive TodoWrite updates; expand the TodoGroup card and confirm it also stays expanded as more snapshots arrive.
- [ ] After the agent emits text and a new run starts, confirm the earlier settled group keeps its own expanded/collapsed state independently.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the bug lives in the group part's id generation in `collapseToolRuns`, so the regression is proven at that layer with Vitest in `web/src/components/acp/AcpRuntime.test.ts` (already mapped to this surface in `coverage-matrix.json`). The re-fold is a pure consequence of the id being stable under React keying; a Playwright spec would exercise React's reconciliation rather than our code.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (anchor to the first child rather than lift expand state into a Set), reviewed the diff, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Stabilized grouped tool-call and TodoWrite card identities by anchoring them to the first child action.
- Preserved users’ expanded or collapsed state as new actions are added.
- Added regression tests for growing groups, TodoWrite groups, and separate runs with distinct identities.

## Benefits

- Prevents cards from unexpectedly re-folding.
- Keeps grouped activity updates consistent while avoiding collisions between separate runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->