### PR TITLE
fix(acp): honor structured-view acp_defaults (model + effort) on aoe add and reconciler respawns

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1374,6 +1374,18 @@ impl<S: BroadcastSink> Supervisor<S> {
             }
         }
 
+        // Resolve the per-agent structured-view defaults once, at this single
+        // spawn choke point, so CLI create, reconciler respawn, and web create
+        // all honor the same model/effort/mode defaults. An explicit
+        // per-request model or effort wins; otherwise the configured default
+        // fills in. Mode has no per-request override today.
+        // ponytail: resolve here instead of threading model/effort/mode through
+        // every SpawnRequest site; revisit if explicit per-request values land.
+        let acp_defaults = resolved_cfg.acp.acp_defaults_for(&agent);
+        let (model, effort) =
+            crate::session::config::resolve_spawn_model_effort(acp_defaults, model, effort);
+        let default_mode = acp_defaults.and_then(|defaults| defaults.mode());
+
         let mut env = provider_env;
         if let Some(model) = model {
             env.push(("AOE_AGENT_MODEL".into(), model));
@@ -1413,16 +1425,6 @@ impl<S: BroadcastSink> Supervisor<S> {
             );
             Vec::new()
         });
-
-        // Mode has no per-request override today, so resolve it from the same
-        // repo/profile config already loaded above. The apply step only runs on
-        // session/new, so a resumed session/load is unaffected.
-        // ponytail: resolve here instead of threading mode through every
-        // SpawnRequest site; revisit if an explicit per-request mode lands.
-        let default_mode = resolved_cfg
-            .acp
-            .acp_defaults_for(&agent)
-            .and_then(|defaults| defaults.mode());
 
         let config = SpawnConfig {
             agent_key: agent.clone(),

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -750,27 +750,6 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         // back to the terminal view with a warning so `aoe add` still
         // succeeds on a machine without the adapter installed.
         if instance.is_structured() {
-            // Pin the structured-view model like the web create path: an
-            // explicit --model wins, otherwise the per-agent configured
-            // default. Persisting it (rather than resolving lazily at spawn)
-            // keeps a CLI-created session pinned to the model it started with,
-            // matching web-created sessions, instead of floating to whatever the
-            // default is at the next respawn. Terminal-view sessions never get a
-            // default written; agent_model is ACP-only. `agent_name` here is the
-            // same key the spawn resolves defaults against (see
-            // pick_agent_for_tool). Effort has no Instance field, so the spawn
-            // path resolves the default effort.
-            if instance
-                .agent_model
-                .as_deref()
-                .is_none_or(|m| m.trim().is_empty())
-            {
-                instance.agent_model = config
-                    .acp
-                    .acp_defaults_for(&agent_name)
-                    .and_then(|d| d.model());
-            }
-
             let (mut spec, spec_from_registry) = match registry.get(&agent_name) {
                 Some(spec) => (spec.clone(), true),
                 None => match config.session.agent_acp_cmd.get(&agent_name) {
@@ -826,6 +805,25 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 );
                 instance.view = crate::session::View::Terminal;
             }
+        }
+
+        // Pin the structured-view model AFTER the adapter check above, which may
+        // have downgraded the session to terminal. Only a session that stays
+        // structured persists the per-agent default: agent_model is ACP-only, so
+        // a terminal fallback must not retain an ACP-derived default. Routed
+        // through the shared resolver so an explicit --model wins and is trimmed
+        // identically to the web create path; an explicit --model on a
+        // downgraded session is left untouched. `agent_name` is the same key the
+        // spawn resolves defaults against (see pick_agent_for_tool). Effort has
+        // no Instance field, so the spawn path resolves the default effort.
+        if instance.is_structured() {
+            let defaults = config.acp.acp_defaults_for(&agent_name);
+            instance.agent_model = crate::session::config::resolve_spawn_model_effort(
+                defaults,
+                instance.agent_model.take(),
+                None,
+            )
+            .0;
         }
     }
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -750,6 +750,27 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         // back to the terminal view with a warning so `aoe add` still
         // succeeds on a machine without the adapter installed.
         if instance.is_structured() {
+            // Pin the structured-view model like the web create path: an
+            // explicit --model wins, otherwise the per-agent configured
+            // default. Persisting it (rather than resolving lazily at spawn)
+            // keeps a CLI-created session pinned to the model it started with,
+            // matching web-created sessions, instead of floating to whatever the
+            // default is at the next respawn. Terminal-view sessions never get a
+            // default written; agent_model is ACP-only. `agent_name` here is the
+            // same key the spawn resolves defaults against (see
+            // pick_agent_for_tool). Effort has no Instance field, so the spawn
+            // path resolves the default effort.
+            if instance
+                .agent_model
+                .as_deref()
+                .is_none_or(|m| m.trim().is_empty())
+            {
+                instance.agent_model = config
+                    .acp
+                    .acp_defaults_for(&agent_name)
+                    .and_then(|d| d.model());
+            }
+
             let (mut spec, spec_from_registry) = match registry.get(&agent_name) {
                 Some(spec) => (spec.clone(), true),
                 None => match config.session.agent_acp_cmd.get(&agent_name) {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4454,18 +4454,17 @@ pub async fn create_session(
                 std::path::Path::new(&instance.project_path),
             );
             let defaults = resolved_config.acp.acp_defaults_for(&agent_key);
-            instance.agent_model = body
-                .agent_model
-                .filter(|s| !s.trim().is_empty())
-                .or_else(|| defaults.and_then(|d| d.model.clone()));
-            // Per-model effort override wins when a model is resolved, else the
-            // flat default effort. The explicit request effort always wins.
-            let mut agent_effort =
-                body.agent_effort
-                    .filter(|s| !s.trim().is_empty())
-                    .or_else(|| {
-                        defaults.and_then(|d| d.effort_for_model(instance.agent_model.as_deref()))
-                    });
+            // Explicit request wins, else the per-agent default; effort is keyed
+            // on the resolved model. Same single-source resolver the spawn path
+            // uses; persist the model here so the composer shows it and the
+            // session stays pinned to it. See resolve_spawn_model_effort.
+            let (resolved_model, mut agent_effort) =
+                crate::session::config::resolve_spawn_model_effort(
+                    defaults,
+                    body.agent_model,
+                    body.agent_effort,
+                );
+            instance.agent_model = resolved_model;
             // Don't trust the client's capability decision. Re-resolve
             // whether this agent can actually run in structured view; a custom
             // agent without an `agent_acp_cmd` (or any non-ACP tool)

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4454,6 +4454,16 @@ pub async fn create_session(
                 std::path::Path::new(&instance.project_path),
             );
             let defaults = resolved_config.acp.acp_defaults_for(&agent_key);
+            // Preserve the explicit request model separately (trimmed to match
+            // the resolver's normalization) so a terminal fallback below can
+            // keep it while dropping any ACP-derived default; agent_model is
+            // ACP-only.
+            let explicit_model = body
+                .agent_model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
             // Explicit request wins, else the per-agent default; effort is keyed
             // on the resolved model. Same single-source resolver the spawn path
             // uses; persist the model here so the composer shows it and the
@@ -4461,7 +4471,7 @@ pub async fn create_session(
             let (resolved_model, mut agent_effort) =
                 crate::session::config::resolve_spawn_model_effort(
                     defaults,
-                    body.agent_model,
+                    explicit_model.clone(),
                     body.agent_effort,
                 );
             instance.agent_model = resolved_model;
@@ -4503,6 +4513,9 @@ pub async fn create_session(
 
             if !instance.is_structured() {
                 agent_effort = None;
+                // Terminal sessions keep only an explicitly requested model,
+                // never an ACP-derived default (agent_model is ACP-only).
+                instance.agent_model = explicit_model;
             }
 
             agent_effort

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1308,6 +1308,12 @@ impl AcpAgentDefaults {
             && self.effort_by_model.is_empty()
     }
 
+    /// Default model, with empty strings treated as unset (mirrors `mode`) so a
+    /// blank value never overrides the agent's own default at spawn.
+    pub fn model(&self) -> Option<String> {
+        self.model.clone().filter(|value| !value.is_empty())
+    }
+
     /// Default mode, with empty strings treated as unset (mirrors
     /// `effort_for_model`) so a blank value never triggers a pointless ACP
     /// config update on spawn.
@@ -1338,6 +1344,27 @@ impl AcpConfig {
             .get(agent)
             .filter(|defaults| !defaults.is_empty())
     }
+}
+
+/// Resolve the model + effort a structured-view spawn should use: an explicit
+/// per-request value (trimmed, non-empty) always wins, otherwise the per-agent
+/// structured-view default. Effort is keyed on the resolved model so a
+/// per-model override in `effort_by_model` applies to a defaulted model too.
+///
+/// Single source for every spawn path (CLI create, reconciler respawn, web
+/// create); see `AcpConfig::acp_defaults_for`.
+pub fn resolve_spawn_model_effort(
+    defaults: Option<&AcpAgentDefaults>,
+    req_model: Option<String>,
+    req_effort: Option<String>,
+) -> (Option<String>, Option<String>) {
+    let model = req_model
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| defaults.and_then(|d| d.model()));
+    let effort = req_effort
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| defaults.and_then(|d| d.effort_for_model(model.as_deref())));
+    (model, effort)
 }
 
 /// What a single mouse click on a session row does in the Agent view.
@@ -3396,6 +3423,88 @@ mod tests {
         assert_eq!(defaults.mode(), None);
         defaults.mode = Some("plan".to_string());
         assert_eq!(defaults.mode().as_deref(), Some("plan"));
+    }
+
+    #[test]
+    fn acp_defaults_model_treats_empty_as_unset() {
+        let mut defaults = AcpAgentDefaults::default();
+        assert_eq!(defaults.model(), None);
+        defaults.model = Some(String::new());
+        assert_eq!(defaults.model(), None);
+        defaults.model = Some("openai/gpt-5.5".to_string());
+        assert_eq!(defaults.model().as_deref(), Some("openai/gpt-5.5"));
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_explicit_request_wins() {
+        let defaults = AcpAgentDefaults {
+            model: Some("openai/gpt-5.5".to_string()),
+            effort: Some("low".to_string()),
+            ..Default::default()
+        };
+        let (model, effort) = resolve_spawn_model_effort(
+            Some(&defaults),
+            Some("anthropic/claude".to_string()),
+            Some("high".to_string()),
+        );
+        assert_eq!(model.as_deref(), Some("anthropic/claude"));
+        assert_eq!(effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_falls_back_to_default() {
+        let defaults = AcpAgentDefaults {
+            model: Some("openai/gpt-5.5".to_string()),
+            effort: Some("low".to_string()),
+            ..Default::default()
+        };
+        let (model, effort) = resolve_spawn_model_effort(Some(&defaults), None, None);
+        assert_eq!(model.as_deref(), Some("openai/gpt-5.5"));
+        assert_eq!(effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_blank_request_treated_as_unset() {
+        let defaults = AcpAgentDefaults {
+            model: Some("openai/gpt-5.5".to_string()),
+            effort: Some("low".to_string()),
+            ..Default::default()
+        };
+        let (model, effort) = resolve_spawn_model_effort(
+            Some(&defaults),
+            Some("   ".to_string()),
+            Some(String::new()),
+        );
+        assert_eq!(model.as_deref(), Some("openai/gpt-5.5"));
+        assert_eq!(effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_per_model_effort_keyed_on_resolved_model() {
+        let mut defaults = AcpAgentDefaults {
+            model: Some("gpt-5".to_string()),
+            effort: Some("low".to_string()),
+            ..Default::default()
+        };
+        defaults
+            .effort_by_model
+            .insert("gpt-5".to_string(), "high".to_string());
+        // Model resolves to the default gpt-5, so the per-model effort applies.
+        let (model, effort) = resolve_spawn_model_effort(Some(&defaults), None, None);
+        assert_eq!(model.as_deref(), Some("gpt-5"));
+        assert_eq!(effort.as_deref(), Some("high"));
+        // An explicit model that has no per-model override falls back to flat.
+        let (model, effort) =
+            resolve_spawn_model_effort(Some(&defaults), Some("other".to_string()), None);
+        assert_eq!(model.as_deref(), Some("other"));
+        assert_eq!(effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_no_defaults_no_request_is_none() {
+        let (model, effort) = resolve_spawn_model_effort(None, None, None);
+        assert_eq!(model, None);
+        assert_eq!(effort, None);
     }
 
     #[test]

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1359,10 +1359,12 @@ pub fn resolve_spawn_model_effort(
     req_effort: Option<String>,
 ) -> (Option<String>, Option<String>) {
     let model = req_model
-        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
         .or_else(|| defaults.and_then(|d| d.model()));
     let effort = req_effort
-        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
         .or_else(|| defaults.and_then(|d| d.effort_for_model(model.as_deref())));
     (model, effort)
 }
@@ -3498,6 +3500,32 @@ mod tests {
             resolve_spawn_model_effort(Some(&defaults), Some("other".to_string()), None);
         assert_eq!(model.as_deref(), Some("other"));
         assert_eq!(effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn resolve_spawn_model_effort_trims_padded_request_values() {
+        let mut defaults = AcpAgentDefaults {
+            effort: Some("low".to_string()),
+            ..Default::default()
+        };
+        defaults
+            .effort_by_model
+            .insert("gpt-5".to_string(), "high".to_string());
+        // A padded request model is trimmed before it is retained, so it both
+        // persists clean and matches its per-model effort override.
+        let (model, effort) = resolve_spawn_model_effort(
+            Some(&defaults),
+            Some("  gpt-5  ".to_string()),
+            Some("  high  ".to_string()),
+        );
+        assert_eq!(model.as_deref(), Some("gpt-5"));
+        assert_eq!(effort.as_deref(), Some("high"));
+        // With no explicit effort, the trimmed model still keys the per-model
+        // override.
+        let (model, effort) =
+            resolve_spawn_model_effort(Some(&defaults), Some("  gpt-5  ".to_string()), None);
+        assert_eq!(model.as_deref(), Some("gpt-5"));
+        assert_eq!(effort.as_deref(), Some("high"));
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`aoe add` and reconciler respawns ignored the per-agent structured-view defaults. Setting `acp_defaults.opencode.model = "openai/gpt-5.5"` and running `aoe add --agent opencode` (no `--model`) launched the session on opencode's own built-in model, not the configured default. The same setting was honored from the web dashboard, so behavior diverged by the surface that created the session.

Root cause: the default resolution (`acp_defaults_for`, explicit-wins-else-default) lived only in the web REST create handler. The CLI path (`src/cli/add.rs`) set the model from `--model` only, and the reconciler (`src/server/acp_reconciler.rs`) forwarded the model verbatim and hard-coded `effort: None`. Since `Instance` persists `agent_model` but has no effort field, effort was resolved at web-create-time and passed straight to the first spawn, so even a web-created session lost its configured default effort on any reconciler respawn (for example after a daemon restart). Mode already resolved at the shared spawn choke point, which is why mode survived.

Fix: resolve model + effort once, at the single spawn choke point (`supervisor::spawn_inner`), next to the existing mode resolution, via a shared `resolve_spawn_model_effort` helper. Every spawn path now honors the defaults: CLI create, reconciler respawn, and web-session respawn. `aoe add` additionally pins the resolved model onto the instance for structured sessions, matching the web create path, so a CLI-created session stays pinned to its model across respawns instead of floating to whatever the default is at spawn time. The web handler was refactored onto the same helper so there is one source of the resolution logic.

Effort still has no durable `Instance` field, so a runtime composer effort change cannot survive a daemon restart under any path; that is a pre-existing schema gap left as a follow-up.

Closes #2804

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Set a structured-view default model for an agent, e.g. in config `[acp.acp_defaults.opencode]` `model = "openai/gpt-5.5"`.
- [ ] Run `aoe add --agent opencode` (no `--model`) with the daemon running, open the session in the structured view, confirm it runs `openai/gpt-5.5`, not opencode's built-in default.
- [ ] Run `aoe add --agent opencode --model <something-else>` and confirm the explicit `--model` wins over the configured default.
- [ ] With a default effort configured, create a session via `aoe add`, restart the daemon so the reconciler respawns it, and confirm the configured default effort is still applied (previously dropped to none on respawn).
- [ ] Create a session from the web dashboard with an explicit model/effort and confirm it is unchanged (the web path is a behavior-preserving refactor).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

<!-- The only web-adjacent change is the backend session-create handler switching to the shared resolver with identical behavior; no web/src files changed. -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the observable surface (an env var handed to the worker) needs a live daemon plus a fake ACP agent to assert e2e, which is heavy for this logic. The resolution is unit-tested at the config layer (`resolve_spawn_model_effort`: explicit-wins, blank-as-unset, default-fill, per-model effort keyed on the resolved model, no-defaults), matching how `effort_for_model` is already tested and per the issue's own guidance.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a `/debate` between two models on the fix shape, plan, and implementation drafted by Claude under my direction. I made the design calls (single-source spawn resolution plus CLI model pinning), reviewed each commit, and ran the validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Centralized structured-view model + effort resolution into a shared helper (`resolve_spawn_model_effort`) and wired it into all structured spawn paths (CLI, web session creation, and the supervisor spawn/reconcile flow).
- Clarified “unset” behavior: empty or whitespace-only model values (including padded ones) are treated as missing, so configured per-agent defaults are applied reliably.
- Ensured precedence is consistent: when a user explicitly provides `model` (and/or `effort`), those values win over configured defaults; otherwise defaults are used.
- Resolved both model and effort at the same spawn “choke point” (and derived `mode` from the same resolved defaults), reducing mismatches between partially-resolved code paths.
- Updated CLI-created structured sessions to keep the resolved model on the instance so it remains stable across reconciler respawns.
- Adjusted terminal fallback handling so terminal sessions don’t retain an ACP-derived default model; they revert to the explicitly requested model, while clearing effort as before.
- Added unit tests for explicit vs blank values, whitespace/padding normalization, per-model effort selection, and cases where defaults are missing.

## Benefits

- `aoe add`, web-created sessions, and reconciler respawns now honor the same structured-view defaulting rules.
- Explicit CLI inputs behave consistently and reliably override configured defaults.
- Reduced duplicated/respecified logic lowers the chance of future spawn-path drift and inconsistent behavior.

## Potential follow-up

- If the instance ever gains an effort field, consider persisting the resolved effort so effort can remain durable across daemon restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->