### PR TITLE
fix(web): gray out current agent in switch-agent modal

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -184,6 +184,16 @@ pub struct SessionResponse {
     #[cfg(feature = "serve")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acp_session_id: Option<String>,
+    /// The session's resolved ACP registry key (`agent_name` when set, else
+    /// `tool`), matching the `name` entries `/api/acp/agents` returns. The
+    /// structured view's switch-agent modal reads this as the current-agent
+    /// fallback before the first `AgentSwitched` event lands (which is the
+    /// only event that populates the reduced `state.agent`), so it can gray
+    /// out the running backend on a never-switched session. Omitted for
+    /// sessions with no resolved agent. See #2803.
+    #[cfg(feature = "serve")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acp_agent: Option<String>,
     /// True when this session's agent can run a structured ACP `session/fork`:
     /// it is ACP-capable AND declares a real fork strategy. Resume-only ACP
     /// agents (e.g. the bundled `aoe-agent`, which advertises `loadSession` but
@@ -403,6 +413,19 @@ impl SessionResponse {
             },
             #[cfg(feature = "serve")]
             acp_session_id: inst.acp_session_id.clone(),
+            // Resolved the same way as `acp_capable` above: `agent_name` when
+            // set and non-empty, else `tool`. This is the ACP registry key,
+            // so it matches `/api/acp/agents` names the switch-agent modal
+            // filters against. See #2803.
+            #[cfg(feature = "serve")]
+            acp_agent: {
+                let resolved = inst
+                    .agent_name
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(inst.tool.as_str());
+                (!resolved.is_empty()).then(|| resolved.to_string())
+            },
             // Shares `agent_is_structured_fork_capable` with the create-time
             // guard so the web "Fork" affordance and server-side acceptance
             // cannot drift: forkable = ACP-capable AND a real fork strategy.
@@ -8728,6 +8751,8 @@ mod workspace_ordering_tests {
             acp_capable: false,
             #[cfg(feature = "serve")]
             acp_session_id: None,
+            #[cfg(feature = "serve")]
+            acp_agent: None,
             #[cfg(feature = "serve")]
             acp_can_fork: false,
             claude_fullscreen: false,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1582,6 +1582,7 @@ function AppContent({
                         sessionId={activeSessionId!}
                         acpWorkerState={activeSession.acp_worker_state ?? "absent"}
                         tool={activeSession.tool}
+                        acpAgent={activeSession.acp_agent ?? null}
                         archivedAt={activeSession.archived_at ?? null}
                         snoozedUntil={activeSession.snoozed_until ?? null}
                         trashedAt={activeSession.trashed_at ?? null}

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -115,6 +115,7 @@ export function MobileMainPane({
                 sessionId={activeSessionId!}
                 acpWorkerState={activeSession.acp_worker_state ?? "absent"}
                 tool={activeSession.tool}
+                acpAgent={activeSession.acp_agent ?? null}
                 archivedAt={activeSession.archived_at ?? null}
                 snoozedUntil={activeSession.snoozed_until ?? null}
                 trashedAt={activeSession.trashed_at ?? null}

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -77,6 +77,12 @@ interface Props {
    *  / etc.). Resolves the active AgentProfile that drives card
    *  dispatch and claude-specific capability gates. */
   tool: string | null | undefined;
+  /** Session's resolved ACP registry key from `SessionResponse.acp_agent`
+   *  (`agent_name` when set, else `tool`). Used as the switch-agent modal's
+   *  current-agent fallback before the first `AgentSwitched` event lands, so
+   *  the modal can gray out the running backend on a never-switched session.
+   *  See #2803. */
+  acpAgent: string | null;
   /** RFC3339 archived-at timestamp, or null. Drives the
    *  archived-specific "worker stopped" banner that replaces the
    *  generic `aoe acp stop`-style message when the user has
@@ -126,6 +132,7 @@ export function StructuredView(props: Props) {
     sessionId,
     acpWorkerState,
     tool,
+    acpAgent,
     archivedAt,
     snoozedUntil,
     trashedAt,
@@ -160,6 +167,7 @@ export function StructuredView(props: Props) {
                 <AcpChrome
                   sessionId={sessionId}
                   acpWorkerState={acpWorkerState}
+                  acpAgent={acpAgent}
                   showClearedTurns={showClearedTurns}
                   onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
                   toolDensity={toolDensity}
@@ -218,6 +226,7 @@ export function StructuredViewRoot({ children }: { children: React.ReactNode }) 
 function AcpChrome({
   sessionId,
   acpWorkerState,
+  acpAgent,
   showClearedTurns,
   onToggleClearedTurns,
   toolDensity,
@@ -256,6 +265,7 @@ function AcpChrome({
 }: AcpContext & {
   sessionId: string;
   acpWorkerState: "absent" | "resuming" | "running";
+  acpAgent: string | null;
   showClearedTurns: boolean;
   onToggleClearedTurns: () => void;
   toolDensity: "detailed" | "compact";
@@ -464,7 +474,11 @@ function AcpChrome({
       <AttentionChime approvals={state.pendingApprovals.length} elicitations={state.pendingElicitations.length} />
       <PlanStrip plan={state.plan} />
 
-      <RateLimitRecoverySection sessionId={sessionId} currentAgent={state.agent} onPrefill={recoveryHandoffPrefill}>
+      <RateLimitRecoverySection
+        sessionId={sessionId}
+        currentAgent={state.agent ?? acpAgent}
+        onPrefill={recoveryHandoffPrefill}
+      >
         {({ onSwitchAgent }) =>
           status !== "open" || state.lagged || state.rateLimit || reconnecting ? (
             <SystemNotices
@@ -666,7 +680,7 @@ function AcpChrome({
 
               <Composer
                 sessionId={sessionId}
-                currentAgent={state.agent}
+                currentAgent={state.agent ?? acpAgent}
                 availableModes={state.availableModes}
                 currentModeId={state.currentModeId}
                 legacyMode={state.mode}

--- a/web/src/components/acp/SwitchAgentModal.test.tsx
+++ b/web/src/components/acp/SwitchAgentModal.test.tsx
@@ -80,13 +80,18 @@ function mount(props?: Partial<React.ComponentProps<typeof SwitchAgentModal>>) {
 }
 
 describe("SwitchAgentModal (rate_limit)", () => {
-  it("filters out the current agent and preselects codex", async () => {
+  it("shows the current agent grayed out and disabled, preselecting a switchable target", async () => {
     const { container, findByText } = mount();
     await findByText(/Continue in codex/);
+    // The current agent stays visible for context, marked and disabled.
+    await findByText("(current)");
     const radios = Array.from(container.querySelectorAll<HTMLInputElement>("input[name=acp-agent-target]"));
-    const values = radios.map((r) => r.value);
-    expect(values).toEqual(expect.arrayContaining(["codex", "opencode"]));
-    expect(values).not.toContain("claude");
+    const byValue = Object.fromEntries(radios.map((r) => [r.value, r] as const));
+    expect(Object.keys(byValue)).toEqual(expect.arrayContaining(["claude", "codex", "opencode"]));
+    expect(byValue.claude?.disabled).toBe(true);
+    expect(byValue.codex?.disabled).toBe(false);
+    expect(byValue.opencode?.disabled).toBe(false);
+    // Default selection is a switchable target, never the current agent.
     const checked = radios.find((r) => r.checked);
     expect(checked?.value).toBe("codex");
   });
@@ -183,10 +188,19 @@ describe("SwitchAgentModal (rate_limit)", () => {
     await findByText(/Continue in opencode/);
   });
 
-  it("renders an install hint when no alternative agents are registered", async () => {
+  it("shows the disabled current agent and an install hint when nothing else is registered", async () => {
     mockFetchAgents.mockResolvedValue([{ name: "claude", description: "claude", command: "claude-agent-acp" }]);
-    const { findByText } = mount();
-    await findByText(/No alternative structured view agents are registered/i);
+    const { container, findByText } = mount();
+    // Current agent still renders (disabled) even with no switch targets.
+    await findByText("(current)");
+    await findByText(/No other structured view agents are registered/i);
+    const claude = container.querySelector<HTMLInputElement>("input[name=acp-agent-target][value=claude]");
+    expect(claude?.disabled).toBe(true);
+    // Nothing to switch to, so confirm stays disabled.
+    const confirm = Array.from(container.querySelectorAll("button")).find((b) =>
+      /Continue in/.test(b.textContent ?? ""),
+    );
+    expect(confirm?.disabled).toBe(true);
   });
 });
 

--- a/web/src/components/acp/SwitchAgentModal.tsx
+++ b/web/src/components/acp/SwitchAgentModal.tsx
@@ -71,13 +71,16 @@ export function SwitchAgentModal({ open, sessionId, currentAgent, onClose, onPre
     fetchAcpAgents()
       .then((list) => {
         if (cancelled) return;
-        const filtered = list.filter((a) => a.name !== currentAgent);
-        setAgents(filtered);
+        // Keep the full registry so the current agent can render grayed out
+        // and disabled (see #2803); it is never a selectable target. The
+        // default and every switchable pick come from the alternatives.
+        setAgents(list);
+        const targets = list.filter((a) => a.name !== currentAgent);
         // On the rate-limit path, prefer codex when installed. On a
         // manual switch we have no preferred direction, so just pick the
         // first remaining entry. The user can change the pick either way.
-        const preferred = rateLimited ? filtered.find((a) => a.name === PREFERRED_FALLBACK) : undefined;
-        setSelected(preferred?.name ?? filtered[0]?.name ?? null);
+        const preferred = rateLimited ? targets.find((a) => a.name === PREFERRED_FALLBACK) : undefined;
+        setSelected(preferred?.name ?? targets[0]?.name ?? null);
       })
       .catch((e) => {
         if (cancelled) return;
@@ -154,6 +157,9 @@ export function SwitchAgentModal({ open, sessionId, currentAgent, onClose, onPre
   };
 
   const title = rateLimited ? "Continue in another agent?" : "Switch agent?";
+  // The current agent renders in the list but is never switchable, so
+  // "can I switch anywhere" is about the other entries only. See #2803.
+  const hasAlternatives = agents.some((a) => a.name !== currentAgent);
 
   return (
     <div
@@ -189,35 +195,58 @@ export function SwitchAgentModal({ open, sessionId, currentAgent, onClose, onPre
           <div className="mt-4 text-xs text-text-muted">Loading agents...</div>
         ) : agents.length === 0 ? (
           <div className="mt-4 text-xs text-status-error">
-            No alternative structured view agents are registered. Install one (e.g. `npm i -g
+            No structured view agents are registered. Install one (e.g. `npm i -g
             @agentclientprotocol/codex-acp@latest`) and try again.
           </div>
         ) : (
-          <ul className="mt-4 max-h-64 space-y-1 overflow-y-auto">
-            {agents.map((a) => (
-              <li key={a.name}>
-                <label
-                  className={`flex cursor-pointer items-start gap-3 rounded border px-3 py-2 transition-colors ${
-                    selected === a.name ? "border-brand-500 bg-brand-900/30" : "border-surface-700 hover:bg-surface-800"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="acp-agent-target"
-                    value={a.name}
-                    checked={selected === a.name}
-                    onChange={() => setSelected(a.name)}
-                    className="mt-0.5"
-                    disabled={submitting}
-                  />
-                  <span className="flex-1">
-                    <span className="block text-sm font-mono">{a.name}</span>
-                    <span className="block text-xs text-text-muted">{a.description}</span>
-                  </span>
-                </label>
-              </li>
-            ))}
-          </ul>
+          <>
+            <ul className="mt-4 max-h-64 space-y-1 overflow-y-auto">
+              {agents.map((a) => {
+                // The running backend stays visible for context but is
+                // grayed out and non-selectable; you can only switch away
+                // from it. See #2803.
+                const isCurrent = a.name === currentAgent;
+                return (
+                  <li key={a.name}>
+                    <label
+                      className={`flex items-start gap-3 rounded border px-3 py-2 transition-colors ${
+                        isCurrent
+                          ? "cursor-not-allowed border-surface-700 bg-surface-800/40 opacity-60"
+                          : selected === a.name
+                            ? "cursor-pointer border-brand-500 bg-brand-900/30"
+                            : "cursor-pointer border-surface-700 hover:bg-surface-800"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="acp-agent-target"
+                        value={a.name}
+                        checked={selected === a.name}
+                        onChange={() => {
+                          if (!isCurrent) setSelected(a.name);
+                        }}
+                        className="mt-0.5 disabled:cursor-not-allowed"
+                        disabled={submitting || isCurrent}
+                      />
+                      <span className="flex-1">
+                        <span className="block text-sm font-mono">
+                          {a.name}
+                          {isCurrent && <span className="ml-2 font-sans text-xs text-text-muted">(current)</span>}
+                        </span>
+                        <span className="block text-xs text-text-muted">{a.description}</span>
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+            {!hasAlternatives && (
+              <div className="mt-3 text-xs text-status-error">
+                No other structured view agents are registered. Install one (e.g. `npm i -g
+                @agentclientprotocol/codex-acp@latest`) and try again.
+              </div>
+            )}
+          </>
         )}
 
         {error && (
@@ -241,7 +270,7 @@ export function SwitchAgentModal({ open, sessionId, currentAgent, onClose, onPre
             ref={confirmRef}
             type="button"
             onClick={handleConfirm}
-            disabled={!selected || submitting || agents.length === 0}
+            disabled={!selected || submitting || !hasAlternatives}
             className="rounded border border-brand-700 bg-brand-900/40 px-3 py-1 text-xs font-medium text-brand-100 hover:bg-brand-900/60 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {submitting ? "Switching..." : `${rateLimited ? "Continue in" : "Switch to"} ${selected ?? ""}`}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -134,6 +134,13 @@ export interface SessionResponse {
    *  structured row with a captured id to diverge from). Absent for terminal
    *  sessions and structured ones whose worker has not minted an id yet. */
   acp_session_id?: string;
+  /** The session's resolved ACP registry key (`agent_name` when set, else
+   *  `tool`), matching the `name` entries `/api/acp/agents` returns. The
+   *  structured view's switch-agent modal uses this as the current-agent
+   *  fallback before the first `AgentSwitched` event lands (which is the only
+   *  event that populates the reduced `state.agent`), so it can gray out the
+   *  running backend on a never-switched session. See #2803. */
+  acp_agent?: string;
   /** True when this session's agent can run a structured ACP `session/fork`:
    *  it is ACP-capable AND declares a real fork strategy. Resume-only ACP
    *  agents (e.g. the bundled `aoe-agent`, which advertises `loadSession` but


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The web structured-view "switch agent" modal is meant to offer only *other* installed ACP backends as handoff targets. On a session that had never been switched it did not: the current agent appeared as a fully selectable radio option and could even be the default selection, so a user could issue a pointless no-op self-handoff.

Root cause: the modal filtered the current agent with `state.agent`, but the frontend reducer only sets `state.agent` on the `AgentSwitched` event; it initializes to `null`. A never-switched session therefore had `currentAgent = null`, the filter matched nothing, and the running backend leaked into the list. The backend knew the agent all along but never serialized it to the frontend.

This change serializes the session's resolved ACP registry key (`agent_name` when set, else `tool`, the same value `acp_capable` already derives and matching the `/api/acp/agents` names the modal filters against) as a new `acp_agent` field on `SessionResponse`, threads it into the structured view as the `currentAgent` fallback, and renders the current backend as a dimmed, disabled row with a `(current)` marker instead of hiding it. The default selection and the confirm gate now come from the switchable alternatives only. As a side effect it also fixes the modal's "The current agent (unknown)" copy on the rate-limit recovery path.

Approach chosen after a two-model debate over three options: reject an event-log-based approach (pollutes the append-only log with per-reconnect UI state) and a two-line hack reusing `tool` (knowingly wrong for custom agents where `agent_name != tool`), in favor of the serialized-field approach that is fully correct with a contained diff.

Closes #2803

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view session on any ACP backend (e.g. `claude`) with at least one other backend installed (e.g. `codex`).
- [ ] Open the composer "Switch agent" control without switching first. Confirm the current agent appears grayed out with a `(current)` marker and its radio is disabled.
- [ ] Confirm the preselected target is one of the *other* agents, never the current one.
- [ ] With only the current agent installed, confirm the row shows disabled, the "No other structured view agents are registered" hint appears, and the confirm button stays disabled.
- [ ] Trigger the rate-limit recovery banner's "Continue in another agent" flow and confirm the copy reads "The current agent (claude)..." with the real name, not "unknown".
- [ ] Switch from A to B, reopen the modal, and confirm B is now the grayed-out current agent while A is selectable again.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Skipped a test, because:

Note: the regression coverage lives in the Vitest + RTL spec `web/src/components/acp/SwitchAgentModal.test.tsx`, which `web/tests/coverage-matrix.json` already maps for the `acp.switch-agent-manual` entry. This is UI-logic (list filtering, disabled-row rendering, default-selection, confirm-gate) best exercised at the RTL layer; a live Playwright would need a second real ACP backend installed on the runner. The matrix validator passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a two-model design debate to pick the data-source approach. I made the design calls, reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed the switch-agent modal to show the active agent as disabled and marked “(current)” instead of allowing it to be selected.
- Added session-level tracking of the resolved ACP agent so the UI can identify the current agent reliably.
- Improved default selection, confirmation behavior, and empty-state messaging when no alternatives are available.
- Corrected rate-limit recovery messaging to display the current agent’s name.
- Added tests covering current-agent display, selection behavior, and sessions without alternate agents.

## Benefits

- Prevents accidental switching to the already active agent.
- Provides clearer feedback and more reliable behavior before agent events are received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->