### PR TITLE
fix: retain bounded live terminal scrollback

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -359,7 +359,14 @@ async fn handle_live_ws(
             #[cfg(unix)]
             {
                 outcome = match &capture_vt {
-                    Some(ch) if ch.is_alive() => {
+                    // The VT grid intentionally retains tmux's default
+                    // 2,000-line scrollback for fast live-edge snapshots.
+                    // The web protocol permits a bounded 4,000-line reading
+                    // window, though, so never let that smaller cache make
+                    // retained tmux history disappear. Deep reads take the
+                    // authoritative capture-pane path below; the normal
+                    // screen-sized live tail stays on the event-driven grid.
+                    Some(ch) if ch.is_alive() && lines <= crate::tmux::vt::SCROLLBACK_LINES => {
                         let ch = ch.clone();
                         match tokio::task::spawn_blocking(move || ch.sample(lines)).await {
                             Ok((content, cursor)) => CaptureOutcome::Frame(content, cursor),

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -84,7 +84,7 @@ static SOCK_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// the pane. Matches tmux's default `history-limit` so a freshly armed channel
 /// (e.g. after switching away from a session and back) has the pane's history
 /// immediately, not just the visible screen.
-const SCROLLBACK_LINES: usize = 2000;
+pub(crate) const SCROLLBACK_LINES: usize = 2000;
 
 fn lookup(session: &str) -> Option<Arc<VtChannel>> {
     REGISTRY

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -133,7 +133,8 @@
       "kind": "live-playwright",
       "risk": "high",
       "specs": ["tests/live/mobile-live-scrollback-buffer.spec.ts"],
-      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/hooks/useLiveTerminal.ts"]
+      "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/hooks/useLiveTerminal.ts"],
+      "reason": "Covers the server-backed capture fallback when the requested browser history exceeds the VT cache."
     },
     {
       "id": "terminal.live-size-owner",

--- a/web/tests/live/mobile-live-scrollback-buffer.spec.ts
+++ b/web/tests/live/mobile-live-scrollback-buffer.spec.ts
@@ -13,7 +13,7 @@ import { test, expect } from "../helpers/liveTest";
 import { spawnAoeServe, resolveAoeBinary } from "../helpers/aoeServe";
 import { clickSidebarSession, openMobileSidebar } from "../helpers/sidebar";
 
-test("recent scrollback is kept loaded above the live screen", async ({ browser }, testInfo) => {
+test("scrollback remains available through the web capture limit", async ({ browser }, testInfo) => {
   test.setTimeout(90_000);
   const serve = await spawnAoeServe({
     authMode: "none",
@@ -21,12 +21,14 @@ test("recent scrollback is kept loaded above the live screen", async ({ browser 
     parallelIndex: testInfo.parallelIndex,
     seedFn: (e) => {
       const tool = join(e.shimBin, "dumper");
-      // Print 400 numbered lines into tmux scrollback, then idle at a prompt so
-      // the pane stays alive with a deep history above the live screen.
+      // Let the test raise this pane's tmux history limit before emitting more
+      // than the VT channel's 2,000-line seed cache. The web transport itself
+      // promises up to 4,000 captured lines, so line 1 must remain reachable.
       writeFileSync(
         tool,
         `#!/bin/bash
-for i in $(seq 1 400); do echo "scrollline $i"; done
+sleep 5
+for i in $(seq 1 2500); do echo "scrollline $i"; done
 echo "PROMPT_READY"
 while true; do sleep 1; done
 `,
@@ -35,6 +37,18 @@ while true; do sleep 1; done
       const pd = join(e.home, "project");
       mkdirSync(pd, { recursive: true });
       spawnSync("git", ["init", "-q"], { cwd: pd });
+      const bootstrap = spawnSync(
+        "tmux",
+        ["-S", e.env.AOE_TMUX_SOCKET!, "new-session", "-d", "-s", "history-bootstrap", "sleep 30"],
+        { env: e.env },
+      );
+      if (bootstrap.status !== 0) throw new Error(String(bootstrap.stderr));
+      const historyLimit = spawnSync(
+        "tmux",
+        ["-S", e.env.AOE_TMUX_SOCKET!, "set-option", "-g", "history-limit", "4000"],
+        { env: e.env },
+      );
+      if (historyLimit.status !== 0) throw new Error(String(historyLimit.stderr));
       const r = spawnSync(
         resolveAoeBinary(),
         ["add", pd, "-t", "scrollback-test", "-c", "claude", "--cmd-override", tool],
@@ -77,21 +91,29 @@ while true; do sleep 1; done
     // captured the span would be ~one screen.
     expect(m.max! - m.min!, "buffered scrollback spans more than one screen").toBeGreaterThan(m.screenRows);
 
-    // Scroll up one viewport and confirm the revealed rows are real text,
-    // already loaded (not the blank spacer).
+    // Jump to the oldest retained row. The fast VT path caches 2,000 lines,
+    // but the browser's advertised capture limit is 4,000; its fallback must
+    // therefore retrieve the older 500 lines from tmux instead of treating
+    // them as permanently lost history.
     await scroller.evaluate((el) => {
-      el.scrollTop = Math.max(0, el.scrollHeight - 2 * el.clientHeight);
+      el.scrollTop = 0;
+      el.dispatchEvent(new Event("scroll"));
     });
-    const visible = await scroller.evaluate((el) => {
-      const rows = Array.from(el.querySelectorAll("[data-live-content] > div")) as HTMLElement[];
-      const top = el.scrollTop;
-      const bottom = top + el.clientHeight;
-      return rows
-        .filter((r) => r.offsetTop >= top && r.offsetTop < bottom)
-        .map((r) => r.textContent ?? "")
-        .join("|");
-    });
-    expect(visible, "a scroll-up lands on loaded scrollback, not blank").toContain("scrollline");
+    await expect
+      .poll(
+        () =>
+          scroller.evaluate((el) => {
+            const top = el.scrollTop;
+            const bottom = top + el.clientHeight;
+            return Array.from(el.querySelectorAll("[data-live-content] > div"))
+              .filter((row): row is HTMLElement => row instanceof HTMLElement)
+              .filter((row) => row.offsetTop >= top && row.offsetTop < bottom)
+              .map((row) => row.textContent ?? "")
+              .join("|");
+          }),
+        { timeout: 10_000 },
+      )
+      .toContain("scrollline 1");
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/mobile-live-scrollback-buffer.spec.ts
+++ b/web/tests/live/mobile-live-scrollback-buffer.spec.ts
@@ -66,8 +66,12 @@ while true; do sleep 1; done
     await page.locator("[data-live-terminal]").waitFor({ state: "visible", timeout: 15_000 });
     await page
       .locator("[data-live-content]")
+      // The seed idles 5s before flooding 2,500 lines, so PROMPT_READY lands
+      // late; on a loaded CI runner (two live-serve workers per shard) the
+      // stream + render can outlast a 15s budget. 30s (well within the 90s
+      // test cap) keeps this deterministic without masking a real hang.
       .filter({ hasText: "PROMPT_READY" })
-      .waitFor({ state: "attached", timeout: 15_000 });
+      .waitFor({ state: "attached", timeout: 30_000 });
     // Let the sizing effect settle the grid + the buffered window land.
     await page.waitForTimeout(1200);
 


### PR DESCRIPTION
## Description

Fix retained browser terminal scrollback above the VT grid's 2,000-line cache. The web capture protocol supports a bounded 4,000-line reading window, so deep requests now use tmux's authoritative capture path rather than treating older retained history as unavailable.

The live regression configures tmux history before pane creation, emits 2,500 lines, and verifies that the oldest retained line is visible in the browser.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**

- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `npm run format:check`
- `npm run lint`
- `npx tsc -b`
- `node tests/validate-coverage-matrix.mjs`
- `cargo fmt --check`
- `cargo clippy --features serve -- -D warnings`
- `cargo test --features serve -- --test-threads=1 </dev/null`
- `npx playwright test --config=playwright.live.config.ts tests/live/mobile-live-scrollback-buffer.spec.ts --reporter=list`

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:** AI assisted with isolating the patch, validation, and PR preparation.

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Fixed deep “live scrollback” requests so the browser receives the correct portion of terminal history once the requested window goes beyond the VT grid’s 2,000-line cache.
- Updated the VT scrollback limit to be available inside the crate so the server can make the right fallback decision.
- Expanded the mobile live scrollback regression test to seed 2,500 numbered lines, set tmux history to 4,000, and verify that the oldest retained line is actually visible in the browser view.
- Updated the coverage-matrix entry to document this specific fallback scenario.

### Benefits
Users can reliably access much older terminal output in the retained scrollback buffer (instead of missing content or seeing blank spacer rows), with stronger end-to-end coverage via formatting/linting/type/Rust checks, automated tests, coverage validation, and Playwright.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->