### PR TITLE
fix(tui): stop Copilot session spinner spinning after the turn ends

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1029,21 +1029,11 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
         .join("\n");
     let last_lines_lower = last_lines.to_lowercase();
 
-    if has_any_spinner(&lines) {
-        return Status::Running;
-    }
-
-    if last_lines_lower.contains("thinking")
-        || last_lines_lower.contains("working")
-        || last_lines_lower.contains("esc to interrupt")
-        || last_lines_lower.contains("ctrl+c to interrupt")
-        // Copilot's live footer reads `◎ Working ... esc cancel`; key on the
-        // interrupt hint too so a verb change doesn't drop the Running signal.
-        || last_lines_lower.contains("esc cancel")
-    {
-        return Status::Running;
-    }
-
+    // Terminal states are checked before Running. capture-pane grabs 50 lines of
+    // scrollback (`-S -50`), and Copilot leaves a finished turn's `◎ Working esc
+    // cancel` footer and spinner glyphs in that history. A completed turn whose
+    // live footer is the approval or ready prompt must win over those stale
+    // lines, otherwise the session spins forever (#2815).
     if contains_approval_prompt(
         &last_lines_lower,
         &[
@@ -1069,6 +1059,34 @@ pub fn detect_copilot_status(raw_content: &str) -> Status {
         || matches_input_prompt(&non_empty_lines, 10, &["copilot>"])
     {
         return Status::Waiting;
+    }
+
+    // Running signals only count on the live footer, the bottom few non-empty
+    // lines where Copilot renders its status footer and input box. Scanning the
+    // whole capture would latch onto a completed turn's `◎ Working`/spinner line
+    // still sitting in scrollback and never let go (#2815).
+    let footer: Vec<&str> = non_empty_lines
+        .iter()
+        .rev()
+        .take(3)
+        .rev()
+        .copied()
+        .collect();
+    let footer_lower = footer.join("\n");
+
+    if has_any_spinner(&footer) {
+        return Status::Running;
+    }
+
+    if footer_lower.contains("thinking")
+        || footer_lower.contains("working")
+        || footer_lower.contains("esc to interrupt")
+        || footer_lower.contains("ctrl+c to interrupt")
+        // Copilot's live footer reads `◎ Working ... esc cancel`; key on the
+        // interrupt hint too so a verb change doesn't drop the Running signal.
+        || footer_lower.contains("esc cancel")
+    {
+        return Status::Running;
     }
 
     Status::Idle
@@ -2840,6 +2858,32 @@ run this command? (y/n)
             detect_copilot_status("need more? help is available; use tab next tab to switch"),
             Status::Idle
         );
+    }
+
+    #[test]
+    fn test_detect_copilot_status_stale_working_in_scrollback() {
+        // #2815: capture-pane returns 50 lines of scrollback, so a finished
+        // turn's `◎ Working esc cancel` footer and a frozen spinner glyph
+        // linger above the live idle footer. The turn is done; status must read
+        // Waiting, not spin forever on the stale lines.
+        let pane = "> summarize the readme\n\
+                    ◎ Working esc cancel    MAI-Code-1-Flash\n\
+                    Here is the summary. ⠋\n\
+                    It covers setup and usage.\n\
+                    More detail follows here.\n\
+                    ┃\n\
+                    / commands · ? help · tab next tab";
+        assert_eq!(detect_copilot_status(pane), Status::Waiting);
+
+        // Same stale scrollback, but the live footer is a bare ready prompt
+        // (footer text drifted / no full three-token footer). Still done.
+        let pane_prompt = "> summarize the readme\n\
+                           ◎ Working esc cancel\n\
+                           Here is the summary.\n\
+                           It covers setup and usage.\n\
+                           More detail follows here.\n\
+                           >";
+        assert_eq!(detect_copilot_status(pane_prompt), Status::Waiting);
     }
 
     #[test]

--- a/tests/e2e/resume_fallback.rs
+++ b/tests/e2e/resume_fallback.rs
@@ -105,6 +105,32 @@ fn read_log_lines(path: &Path) -> Vec<String> {
         .collect()
 }
 
+/// Seed a Claude transcript on disk for `sid` so the Default resume path
+/// attempts `--resume <sid>` (and fires the settle probe) instead of the
+/// empty-thread fresh-pin shortcut from #2700, which launches fresh with
+/// `--session-id` and skips the probe entirely. Mirrors the host location
+/// `claude_host_transcript_confirmed_absent` checks: `$HOME/.claude/projects/
+/// <encoded-canonical-project-path>/<sid>.jsonl`, where the encoding maps every
+/// char that is not ASCII-alphanumeric or `-` to `-`. Models a real prior
+/// Claude session whose sid later fails to resume.
+fn seed_claude_transcript(h: &TuiTestHarness, project_path: &Path, sid: &str) {
+    let canonical = fs::canonicalize(project_path).unwrap_or_else(|_| project_path.to_path_buf());
+    let encoded: String = canonical
+        .to_string_lossy()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let dir = h.home_path().join(".claude").join("projects").join(encoded);
+    fs::create_dir_all(&dir).expect("create claude projects dir");
+    fs::write(dir.join(format!("{sid}.jsonl")), "{}\n").expect("write claude transcript");
+}
+
 struct StopSessionOnDrop<'a> {
     h: &'a TuiTestHarness,
 }
@@ -151,6 +177,11 @@ fn stale_resume_failure_persists_loop_breaker_and_next_restart_starts_fresh() {
         row.remove("resume_probe_failed_sid");
         row.remove("resume_intent");
     });
+
+    // Without a transcript on disk, #2700 launches a stale Claude sid fresh
+    // (`--session-id`, no probe), so the resume never fails and this test's
+    // premise collapses. Seed one so the restart takes the `--resume` path.
+    seed_claude_transcript(&h, &project, STALE_SID);
 
     let first = h.run_cli(&["session", "restart", TITLE]);
     assert!(


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When running a Copilot CLI session in the TUI, the animated spinner next to the session name kept spinning forever, even after Copilot had finished the turn and was idle.

`detect_copilot_status` (`src/tmux/status_detection.rs`) classified the session `Running` first, and its Running checks were over-broad: `has_any_spinner` scanned all captured lines, and the `working`/`thinking`/`esc cancel` substring checks scanned the last 30 non-empty lines. Pane capture uses `capture-pane -S -50`, so it includes 50 lines of scrollback. Copilot leaves a finished turn's `◎ Working esc cancel` footer and spinner glyphs sitting in that scrollback, so the detector kept reporting `Running` on every poll and the TUI faithfully animated the spinner (`src/tui/home/render.rs:248`).

The fix reorders and scopes the detector, mirroring the active-region principle the cursor detector already uses (`status_detection.rs:936-953`):

1. Terminal states are checked first: approval prompt, then the ready/idle footer. A completed turn whose live footer is the idle prompt now wins over stale `Working`/spinner lines still in scrollback above it.
2. The `Running` signals (spinner glyphs and the `working`/`thinking`/interrupt-hint substrings) are scoped to the live footer (the bottom few non-empty lines) instead of the whole capture, so old scrollback can no longer latch the session into `Running`. This also holds up if the idle footer text drifts between Copilot versions.

Reordering additionally fixes a latent bug: an approval footer carrying `esc cancel` previously read `Running` before the approval check ran.

Closes #2815

### Also: unblock the resume-fallback e2e on main

Rebasing surfaced a pre-existing red on `main`: the resume-fallback loop-breaker e2e (`tests/e2e/resume_fallback.rs`, added by #2796) and the empty-thread fresh-pin change (#2700) each passed their own PR CI but collide once both are on `main`. #2700 launches a stale Claude sid with no transcript on disk fresh via `--session-id` and skips the settle probe, so `session restart` reports `Fresh` instead of `ResumeFailed` and the test's `!success` assertion fails. That leaves `main`'s Tests workflow red for every branch off it.

The test now seeds a Claude transcript for the stale sid under the isolated `$HOME/.claude/projects/<encoded-project>/<sid>.jsonl`, so the restart takes the `--resume` path, the fake agent exits, the probe sees the dead pane, and `ResumeFailed` fires as intended. Test-only; #2700's behavior is correct and unchanged.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a Copilot CLI session in the TUI (`aoe add --cmd copilot`), send a prompt, and confirm the spinner animates while Copilot is working.
- [ ] Wait for Copilot to finish the turn and return to its idle prompt; confirm the session spinner stops (row shows the idle icon, not the animated dots).
- [ ] Trigger a tool/permission approval prompt in Copilot; confirm the session reads as waiting for input, not running.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the fix is a pure status-detection function and is covered by a reproduce-then-fix Rust unit test (`test_detect_copilot_status_stale_working_in_scrollback`), which fails on the pre-fix tree (`Running`) and passes after. A full tmux e2e would need a live Copilot CLI binary on the runner, which the e2e harness does not provide.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed each commit, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed Copilot session status detection so completed or idle sessions no longer show an active spinner.
- Limited activity detection to the current terminal footer, preventing stale scrollback text from keeping sessions marked as running.
- Improved handling of approval prompts and ready states.
- Added unit coverage for stale activity text.
- Updated the resume-fallback end-to-end test to seed the expected Claude transcript and reliably exercise resume failure behavior.

## Benefits

- More accurate session status and spinner behavior.
- Fewer false “working” indicators after Copilot finishes.
- More reliable resume-fallback testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->