### PR TITLE
refactor: consolidate duplicated reliability-critical patterns and fix latent bugs

### DIFF
--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -45,6 +45,10 @@ const RESTART_WINDOW: Duration = Duration::from_secs(60);
 /// Brief backoff before respawning an exited worker so we don't
 /// hot-loop when the agent process crashes immediately on startup.
 const RESPAWN_BACKOFF: Duration = Duration::from_millis(500);
+/// How long request-path forwarders (`ready_client`) wait for a
+/// mid-resume worker to land before failing with `UnknownSession`.
+/// Sized to cover the ACP handshake plus a slow sandboxed spawn.
+const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Look up the stored ACP session id for `session_id` and, if present,
 /// fire the experimental `session/delete` RPC against the live worker.
@@ -860,15 +864,23 @@ impl<S: BroadcastSink> Supervisor<S> {
         self.registry.lock().await.get(name).is_some()
     }
 
+    /// Allocate the session's next seq and publish `event` on the sink in
+    /// one step. Returns the assigned seq for callers that log it or hand
+    /// it back to the API layer. Publishes that must go through
+    /// `publish_persisted` (attachment-carrying prompts) stay hand-rolled.
+    fn publish_next(&self, session_id: &str, event: &Event) -> u64 {
+        let seq = next_seq(&self.next_seqs, session_id);
+        self.sink.publish(session_id, seq, event);
+        seq
+    }
+
     /// Publish a synthetic AgentStartupError event for a session whose
     /// worker never came online. Used by the auto-spawn-after-create
     /// path so the UI shows a remediation hint instead of an empty,
     /// silent conversation when `claude-agent-acp` isn't installed (or
     /// `npx -y` is still downloading on first run).
     pub fn publish_startup_error(&self, session_id: &str, message: String) {
-        let seq = next_seq(&self.next_seqs, session_id);
-        self.sink
-            .publish(session_id, seq, &Event::AgentStartupError { message });
+        self.publish_next(session_id, &Event::AgentStartupError { message });
     }
 
     /// Mirror an `AcpError::IncompatibleAgent` onto the broadcast sink
@@ -881,18 +893,14 @@ impl<S: BroadcastSink> Supervisor<S> {
         let AcpError::IncompatibleAgent(payload) = err else {
             return;
         };
-        let detail_seq = next_seq(&self.next_seqs, session_id);
-        self.sink.publish(
+        self.publish_next(
             session_id,
-            detail_seq,
             &Event::IncompatibleAgent {
                 detail: payload.detail.clone(),
             },
         );
-        let msg_seq = next_seq(&self.next_seqs, session_id);
-        self.sink.publish(
+        self.publish_next(
             session_id,
-            msg_seq,
             &Event::AgentStartupError {
                 message: payload.message.clone(),
             },
@@ -917,10 +925,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         to: String,
         reason: String,
     ) -> u64 {
-        let seq = next_seq(&self.next_seqs, session_id);
-        self.sink
-            .publish(session_id, seq, &Event::AgentSwitched { from, to, reason });
-        seq
+        self.publish_next(session_id, &Event::AgentSwitched { from, to, reason })
     }
 
     /// Publish a `RateLimitAutoResumed` breadcrumb for a session the
@@ -937,10 +942,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         session_id: &str,
         resets_at: chrono::DateTime<chrono::Utc>,
     ) -> u64 {
-        let seq = next_seq(&self.next_seqs, session_id);
-        self.sink
-            .publish(session_id, seq, &Event::RateLimitAutoResumed { resets_at });
-        seq
+        self.publish_next(session_id, &Event::RateLimitAutoResumed { resets_at })
     }
 
     /// Like `shutdown` but waits for the runner process to actually exit
@@ -1022,20 +1024,18 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// watchdog instead). Without this the UI's "thinking" indicator
     /// for the dead turn stays on indefinitely after restart.
     pub fn synthesize_stopped_for_orphan(&self, session_id: &str, reason: &str) {
-        let seq = next_seq(&self.next_seqs, session_id);
+        let seq = self.publish_next(
+            session_id,
+            &Event::Stopped {
+                reason: reason.to_string(),
+            },
+        );
         info!(
             target: "acp.supervisor",
             session = %session_id,
             seq,
             %reason,
             "publishing synthetic Stopped for orphaned in-flight turn"
-        );
-        self.sink.publish(
-            session_id,
-            seq,
-            &Event::Stopped {
-                reason: reason.to_string(),
-            },
         );
     }
 
@@ -1102,8 +1102,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             return;
         }
         if is_clear {
-            let seq = next_seq(&self.next_seqs, session_id);
-            self.sink.publish(session_id, seq, &Event::SessionCleared);
+            self.publish_next(session_id, &Event::SessionCleared);
         }
     }
 
@@ -1123,10 +1122,8 @@ impl<S: BroadcastSink> Supervisor<S> {
         comments: Vec<super::state::DiffComment>,
         assembled_markdown: String,
     ) {
-        let seq = next_seq(&self.next_seqs, session_id);
-        self.sink.publish(
+        self.publish_next(
             session_id,
-            seq,
             &Event::UserDiffCommentsPrompt {
                 intro,
                 outro,
@@ -2108,6 +2105,17 @@ impl<S: BroadcastSink> Supervisor<S> {
             .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
     }
 
+    /// Request-path forwarders (prompt, cancel, mode, config option) all
+    /// tolerate a mid-resume worker: wait up to `WORKER_READY_TIMEOUT` for
+    /// it to land, then resolve the client. Approval/elicitation resolution
+    /// deliberately does NOT route through here; a pending nonce only
+    /// exists on a live worker, so waiting for a respawn would convert an
+    /// honest `UnknownSession` into a misleading `UnknownNonce`.
+    async fn ready_client(&self, session_id: &str) -> Result<Arc<AcpClient>, SupervisorError> {
+        self.wait_for_worker(session_id, WORKER_READY_TIMEOUT).await;
+        self.client_for_session(session_id).await
+    }
+
     /// Send a user prompt (with optional attachments) to a running
     /// structured view worker.
     pub async fn send_prompt(
@@ -2116,9 +2124,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         text: &str,
         attachments: &[crate::acp::event_store::AttachmentBlob],
     ) -> Result<(), SupervisorError> {
-        self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
-            .await;
-        let client = self.client_for_session(session_id).await?;
+        let client = self.ready_client(session_id).await?;
         client.send_prompt(text, attachments).await?;
         Ok(())
     }
@@ -2126,9 +2132,7 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// Cancel the current turn for a running structured view worker. Best-effort:
     /// returns Ok if the worker exists even when no turn is in flight.
     pub async fn cancel_prompt(&self, session_id: &str) -> Result<(), SupervisorError> {
-        self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
-            .await;
-        let client = self.client_for_session(session_id).await?;
+        let client = self.ready_client(session_id).await?;
         client.cancel_prompt().await?;
         Ok(())
     }
@@ -2151,10 +2155,8 @@ impl<S: BroadcastSink> Supervisor<S> {
         if let Ok(client) = self.client_for_session(session_id).await {
             let _ = client.force_cancel().await;
         }
-        let seq = next_seq(&self.next_seqs, session_id);
-        self.sink.publish(
+        self.publish_next(
             session_id,
-            seq,
             &Event::Stopped {
                 reason: "user_forced".into(),
             },
@@ -2163,9 +2165,7 @@ impl<S: BroadcastSink> Supervisor<S> {
 
     /// Set the active session mode via ACP session/set_mode.
     pub async fn set_mode(&self, session_id: &str, mode_id: &str) -> Result<(), SupervisorError> {
-        self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
-            .await;
-        let client = self.client_for_session(session_id).await?;
+        let client = self.ready_client(session_id).await?;
         client.set_mode(mode_id).await?;
         Ok(())
     }
@@ -2178,9 +2178,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         config_id: &str,
         value: &str,
     ) -> Result<(), SupervisorError> {
-        self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
-            .await;
-        let client = self.client_for_session(session_id).await?;
+        let client = self.ready_client(session_id).await?;
         client.set_config_option(config_id, value).await?;
         Ok(())
     }
@@ -2298,10 +2296,8 @@ impl<S: BroadcastSink> Supervisor<S> {
                 WorkerKind::Stdio => false,
             };
             if should_publish {
-                let seq = next_seq(&self.next_seqs, session_id);
-                self.sink.publish(
+                self.publish_next(
                     session_id,
-                    seq,
                     &Event::Stopped {
                         reason: stop_reason.into(),
                     },
@@ -2609,20 +2605,16 @@ impl<S: BroadcastSink> Supervisor<S> {
             "cancelling approvals orphaned by daemon restart"
         );
         for nonce in stale_nonces {
-            let seq = next_seq(&self.next_seqs, session_id);
-            self.sink.publish(
+            self.publish_next(
                 session_id,
-                seq,
                 &Event::ApprovalResolved {
                     nonce,
                     decision: ApprovalDecision::Cancelled,
                 },
             );
         }
-        let seq = next_seq(&self.next_seqs, session_id);
-        self.sink.publish(
+        self.publish_next(
             session_id,
-            seq,
             &Event::Stopped {
                 reason: "approval_cancelled_on_restart".to_string(),
             },
@@ -2654,10 +2646,8 @@ impl<S: BroadcastSink> Supervisor<S> {
             "cancelling elicitations orphaned by daemon restart"
         );
         for nonce in stale_nonces {
-            let seq = next_seq(&self.next_seqs, session_id);
-            self.sink.publish(
+            self.publish_next(
                 session_id,
-                seq,
                 &Event::ElicitationResolved {
                     nonce,
                     outcome: ElicitationOutcome::Cancelled,
@@ -2751,10 +2741,8 @@ impl<S: BroadcastSink> Supervisor<S> {
                 reason,
                 "registry entry gone while worker handle live; tearing down"
             );
-            let seq = next_seq(&self.next_seqs, &id);
-            self.sink.publish(
+            self.publish_next(
                 &id,
-                seq,
                 &Event::Stopped {
                     reason: reason.to_string(),
                 },

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -81,19 +81,17 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
     let (instances, groups) = storage.load_with_groups()?;
 
     let group_tree = GroupTree::new_with_groups(&instances, &groups);
+    let session_count = |path: &str| instances.iter().filter(|i| i.group_path == path).count();
 
     if args.json {
         let group_list: Vec<GroupInfo> = group_tree
             .get_all_groups()
             .iter()
-            .map(|g| {
-                let session_count = instances.iter().filter(|i| i.group_path == g.path).count();
-                GroupInfo {
-                    name: g.name.clone(),
-                    path: g.path.clone(),
-                    session_count,
-                    children: g.children.iter().map(|c| c.name.clone()).collect(),
-                }
+            .map(|g| GroupInfo {
+                name: g.name.clone(),
+                path: g.path.clone(),
+                session_count: session_count(&g.path),
+                children: g.children.iter().map(|c| c.name.clone()).collect(),
             })
             .collect();
         super::output::print_json(&group_list)?;
@@ -107,10 +105,7 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
 
         println!("Groups:\n");
         for group in &all_groups {
-            let session_count = instances
-                .iter()
-                .filter(|i| i.group_path == group.path)
-                .count();
+            let session_count = session_count(&group.path);
             let indent = group.path.matches('/').count();
             println!(
                 "{}• {} ({} sessions)",
@@ -200,13 +195,11 @@ async fn move_session(profile: &str, args: GroupMoveArgs) -> Result<()> {
     let group = args.group.trim().to_string();
 
     let old_group = storage.update(|instances, groups| {
-        let id = super::resolve_session(&identifier, instances)?.id.clone();
-        let inst = instances
-            .iter_mut()
-            .find(|i| i.id == id)
-            .expect("resolve_session returned an id that is no longer in instances");
-        let old = inst.group_path.clone();
-        inst.group_path = group.clone();
+        let old = super::patch_instance(instances, &identifier, |inst| {
+            let old = inst.group_path.clone();
+            inst.group_path = group.clone();
+            Ok(old)
+        })?;
 
         if !group.is_empty() {
             let mut group_tree = GroupTree::new_with_groups(instances, groups);

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -65,6 +65,21 @@ fn worktree_for(inst: &Instance) -> Option<WorktreeJson> {
     })
 }
 
+fn session_json(inst: &Instance, profile: &str) -> SessionJson {
+    SessionJson {
+        id: inst.id.clone(),
+        title: inst.title.clone(),
+        path: inst.project_path.clone(),
+        group: inst.group_path.clone(),
+        tool: inst.tool.clone(),
+        command: inst.command.clone(),
+        profile: profile.to_string(),
+        created_at: inst.created_at,
+        workspace_repos: workspace_repos_for(inst),
+        worktree: worktree_for(inst),
+    }
+}
+
 fn workspace_repos_for(inst: &Instance) -> Vec<WorkspaceRepoJson> {
     inst.workspace_info
         .as_ref()
@@ -131,18 +146,7 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
     if args.json {
         let sessions: Vec<SessionJson> = instances
             .iter()
-            .map(|inst| SessionJson {
-                id: inst.id.clone(),
-                title: inst.title.clone(),
-                path: inst.project_path.clone(),
-                group: inst.group_path.clone(),
-                tool: inst.tool.clone(),
-                command: inst.command.clone(),
-                profile: storage.profile().to_string(),
-                created_at: inst.created_at,
-                workspace_repos: workspace_repos_for(inst),
-                worktree: worktree_for(inst),
-            })
+            .map(|inst| session_json(inst, storage.profile()))
             .collect();
         super::output::print_json(&sessions)?;
         return Ok(());
@@ -173,21 +177,8 @@ async fn run_all_profiles(json: bool) -> Result<()> {
         for profile_name in &profiles {
             if let Ok(storage) = Storage::new_unwatched(profile_name) {
                 if let Ok((instances, _)) = storage.load_with_groups() {
-                    for inst in instances {
-                        let workspace_repos = workspace_repos_for(&inst);
-                        let worktree = worktree_for(&inst);
-                        all_sessions.push(SessionJson {
-                            id: inst.id,
-                            title: inst.title,
-                            path: inst.project_path,
-                            group: inst.group_path,
-                            tool: inst.tool,
-                            command: inst.command,
-                            profile: profile_name.clone(),
-                            created_at: inst.created_at,
-                            workspace_repos,
-                            worktree,
-                        });
+                    for inst in &instances {
+                        all_sessions.push(session_json(inst, profile_name));
                     }
                 }
             }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -386,15 +386,10 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new_unwatched(profile)?;
     let title = storage.update(|instances, _groups| {
-        let id = super::resolve_session(&args.identifier, instances)?
-            .id
-            .clone();
-        let inst = instances
-            .iter_mut()
-            .find(|i| i.id == id)
-            .expect("resolve_session returned an id that is no longer in instances");
-        inst.unarchive();
-        Ok(inst.title.clone())
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.unarchive();
+            Ok(inst.title.clone())
+        })
     })?;
     println!("Unarchived: {}", title);
     Ok(())

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -1,8 +1,6 @@
 use super::container_interface::{docker_env_args, ContainerConfig};
 use super::error::{sanitize_stderr, DockerError, Result};
-use std::io::Read;
-use std::process::{Child, Command, Output, Stdio};
-use std::sync::mpsc;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 /// Upper bound on a single `docker pull`. `docker pull` has no overall timeout
@@ -11,57 +9,6 @@ use std::time::{Duration, Instant};
 /// generously so a genuinely large
 /// image on a slow link still completes; it only fires on a wedged pull.
 const PULL_TIMEOUT: Duration = Duration::from_secs(600);
-
-/// Wait for `child` to exit, killing it if it outlives `timeout`.
-///
-/// stdout/stderr are drained on dedicated threads so a full pipe buffer cannot
-/// wedge the child (and thus this wait) before the deadline. Returns `Ok(None)`
-/// when the timeout fired and the child was killed.
-fn wait_with_timeout(mut child: Child, timeout: Duration) -> std::io::Result<Option<Output>> {
-    let mut stdout_pipe = child.stdout.take();
-    let mut stderr_pipe = child.stderr.take();
-    let (otx, orx) = mpsc::channel();
-    let (etx, erx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(ref mut p) = stdout_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        let _ = otx.send(buf);
-    });
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(ref mut p) = stderr_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        let _ = etx.send(buf);
-    });
-
-    let deadline = Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait()? {
-            // The child exited, but if it spawned a grandchild that inherited
-            // the pipe, `read_to_end` (and thus an unbounded `recv`) would block
-            // forever. Cap the drain at the remaining deadline so the timeout
-            // guarantee holds even then; the exit status is already in hand.
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            let stdout = orx.recv_timeout(remaining).unwrap_or_default();
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            let stderr = erx.recv_timeout(remaining).unwrap_or_default();
-            return Ok(Some(Output {
-                status,
-                stdout,
-                stderr,
-            }));
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Ok(None);
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
 
 /// Shared implementation for container runtimes.
 ///
@@ -321,12 +268,9 @@ impl RuntimeBase {
         cmd.args(self.pull_prefix);
         cmd.arg(image);
         cmd.stdin(Stdio::null());
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
         let start = Instant::now();
         tracing::info!(target: "containers.image", runtime = %self.name, %image, "pulling image");
-        let child = cmd.spawn()?;
-        let output = match wait_with_timeout(child, PULL_TIMEOUT)? {
+        let output = match crate::process::run_with_timeout(&mut cmd, PULL_TIMEOUT)? {
             Some(output) => output,
             None => {
                 let dur_ms = start.elapsed().as_millis() as u64;
@@ -1316,69 +1260,5 @@ mod tests {
         const { assert!(RuntimeBase::DOCKER.supports_named_volumes) };
         const { assert!(RuntimeBase::PODMAN.supports_named_volumes) };
         const { assert!(!RuntimeBase::APPLE_CONTAINER.supports_named_volumes) };
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn wait_with_timeout_kills_child_that_outlives_deadline() {
-        // A `docker pull` that wedges on the network has no timeout of its own
-        // and blocked the caller forever. `sleep 30` stands in for
-        // the wedged child; the timeout must fire and kill it.
-        let mut cmd = Command::new("sleep");
-        cmd.arg("30");
-        cmd.stdout(Stdio::null());
-        cmd.stderr(Stdio::null());
-        let child = cmd.spawn().unwrap();
-
-        let start = Instant::now();
-        let result = wait_with_timeout(child, Duration::from_millis(300)).unwrap();
-        assert!(
-            result.is_none(),
-            "expected the timeout to fire and kill the child"
-        );
-        assert!(
-            start.elapsed() < Duration::from_secs(5),
-            "wait should return promptly after the deadline, not block on the child"
-        );
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn wait_with_timeout_bounds_drain_when_grandchild_holds_pipe() {
-        // The immediate child (sh) exits fast but backgrounds a `sleep` that
-        // inherits stdout, so the pipe never closes. The drain must still
-        // return by the deadline rather than blocking on read_to_end. `sleep 30`
-        // (>> the 5s assertion) ensures an unbounded recv would visibly fail.
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg("sleep 30 >&1 & printf done");
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        let child = cmd.spawn().unwrap();
-
-        let start = Instant::now();
-        let output = wait_with_timeout(child, Duration::from_millis(500))
-            .unwrap()
-            .expect("the sh child exits quickly, so an Output is produced");
-        assert!(
-            start.elapsed() < Duration::from_secs(5),
-            "drain must be bounded by the deadline even while the pipe stays open"
-        );
-        assert!(output.status.success());
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn wait_with_timeout_returns_output_for_fast_child() {
-        let mut cmd = Command::new("printf");
-        cmd.arg("hello");
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        let child = cmd.spawn().unwrap();
-
-        let output = wait_with_timeout(child, Duration::from_secs(10))
-            .unwrap()
-            .expect("fast child should complete before the timeout");
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"hello");
     }
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -29,53 +29,33 @@ pub fn clone_bare_repo(url: &str, destination: &Path) -> Result<String> {
         args = ?["clone", "--bare", &redacted_url, bare_str],
         "spawning git clone --bare"
     );
-    let mut child = std::process::Command::new("git")
-        .args(["clone", "--bare", url, bare_str])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| GitError::CloneFailed(format!("Failed to run git clone --bare: {e}")))?;
-
+    // Stdin is piped to null so SSH passphrase prompts fail immediately;
+    // stdout/stderr draining and the kill-on-deadline are handled by
+    // run_with_timeout, so a grandchild holding the pipe (credential
+    // helper, pager) cannot block past the timeout.
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(["clone", "--bare", url, bare_str])
+        .stdin(std::process::Stdio::null());
     let timeout = std::time::Duration::from_secs(300);
-    let poll_interval = std::time::Duration::from_millis(200);
-    let start = std::time::Instant::now();
 
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) if status.success() => break,
-            Ok(Some(_)) => {
-                let stderr = child
-                    .stderr
-                    .take()
-                    .and_then(|mut s| {
-                        let mut buf = String::new();
-                        std::io::Read::read_to_string(&mut s, &mut buf).ok()?;
-                        Some(buf)
-                    })
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-                let _ = std::fs::remove_dir_all(destination);
-                return Err(GitError::CloneFailed(stderr));
-            }
-            Ok(None) => {
-                if start.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    let _ = std::fs::remove_dir_all(destination);
-                    return Err(GitError::CloneFailed(
-                        "Bare clone timed out after 5 minutes".to_string(),
-                    ));
-                }
-                std::thread::sleep(poll_interval);
-            }
-            Err(e) => {
-                let _ = std::fs::remove_dir_all(destination);
-                return Err(GitError::CloneFailed(format!(
-                    "Failed waiting for git clone --bare: {e}"
-                )));
-            }
+    match crate::process::run_with_timeout(&mut cmd, timeout) {
+        Ok(Some(output)) if output.status.success() => {}
+        Ok(Some(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let _ = std::fs::remove_dir_all(destination);
+            return Err(GitError::CloneFailed(stderr));
+        }
+        Ok(None) => {
+            let _ = std::fs::remove_dir_all(destination);
+            return Err(GitError::CloneFailed(
+                "Bare clone timed out after 5 minutes".to_string(),
+            ));
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(destination);
+            return Err(GitError::CloneFailed(format!(
+                "Failed to run git clone --bare: {e}"
+            )));
         }
     }
 
@@ -255,55 +235,31 @@ pub fn clone_repo(url: &str, destination: &Path, shallow: bool) -> Result<()> {
         args = ?redacted_args,
         "spawning git clone"
     );
-    let mut child = std::process::Command::new("git")
-        .args(&args)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| GitError::CloneFailed(format!("Failed to run git clone: {e}")))?;
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(&args).stdin(std::process::Stdio::null());
 
-    // Poll with a 5-minute timeout to avoid blocking the thread pool forever.
+    // 5-minute timeout to avoid blocking the thread pool forever; output
+    // draining is deadline-bounded too, so a grandchild holding the pipe
+    // cannot hang the wait.
     let timeout = std::time::Duration::from_secs(300);
-    let poll_interval = std::time::Duration::from_millis(200);
-    let start = std::time::Instant::now();
 
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) if status.success() => return Ok(()),
-            Ok(Some(_)) => {
-                let stderr = child
-                    .stderr
-                    .take()
-                    .and_then(|mut s| {
-                        let mut buf = String::new();
-                        std::io::Read::read_to_string(&mut s, &mut buf).ok()?;
-                        Some(buf)
-                    })
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-                return Err(GitError::CloneFailed(stderr));
-            }
-            Ok(None) => {
-                if start.elapsed() >= timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    if destination.exists() {
-                        let _ = std::fs::remove_dir_all(destination);
-                    }
-                    return Err(GitError::CloneFailed(
-                        "Clone timed out after 5 minutes".to_string(),
-                    ));
-                }
-                std::thread::sleep(poll_interval);
-            }
-            Err(e) => {
-                return Err(GitError::CloneFailed(format!(
-                    "Failed waiting for git clone: {e}"
-                )));
-            }
+    match crate::process::run_with_timeout(&mut cmd, timeout) {
+        Ok(Some(output)) if output.status.success() => Ok(()),
+        Ok(Some(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(GitError::CloneFailed(stderr))
         }
+        Ok(None) => {
+            if destination.exists() {
+                let _ = std::fs::remove_dir_all(destination);
+            }
+            Err(GitError::CloneFailed(
+                "Clone timed out after 5 minutes".to_string(),
+            ))
+        }
+        Err(e) => Err(GitError::CloneFailed(format!(
+            "Failed to run git clone: {e}"
+        ))),
     }
 }
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -241,15 +241,41 @@ impl GitWorktree {
     /// Stdin is piped to null to prevent SSH passphrase prompts from
     /// hanging. Times out after 10 seconds.
     pub fn fetch_branch(&self, remote: &str, branch: &str) -> FetchOutcome {
-        let mut child = match std::process::Command::new("git")
-            .args(["fetch", remote, branch])
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(["fetch", remote, branch])
             .current_dir(&self.repo_path)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-        {
-            Ok(child) => child,
+            .stdin(std::process::Stdio::null());
+
+        let timeout = std::time::Duration::from_secs(10);
+        let start = std::time::Instant::now();
+
+        // run_with_timeout drains stderr with a deadline-bounded read, so a
+        // grandchild holding the pipe (credential helper) cannot block this
+        // past the timeout.
+        match crate::process::run_with_timeout(&mut cmd, timeout) {
+            Ok(Some(output)) => {
+                let elapsed = start.elapsed();
+                if !output.status.success() {
+                    let msg = String::from_utf8_lossy(&output.stderr);
+                    let sanitized = sanitize_remote_credentials(msg.trim());
+                    tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} failed: {sanitized}");
+                    let detail = if sanitized.is_empty() {
+                        format!("git fetch exited with {}", output.status)
+                    } else {
+                        sanitized
+                    };
+                    return FetchOutcome::Failed(detail);
+                }
+                tracing::info!(target: "git.worktree", "git fetch {remote}/{branch} ok in {:?}", elapsed);
+                FetchOutcome::Ok
+            }
+            Ok(None) => {
+                tracing::warn!(target: "git.worktree",
+                    "git fetch {remote}/{branch} timed out after {}s",
+                    timeout.as_secs()
+                );
+                FetchOutcome::TimedOut
+            }
             Err(e) => {
                 tracing::warn!(
                     target: "git.command",
@@ -258,51 +284,7 @@ impl GitWorktree {
                     error = %e,
                     "git fetch spawn failed"
                 );
-                return FetchOutcome::Skipped(format!("spawn failed: {e}"));
-            }
-        };
-
-        let timeout = std::time::Duration::from_secs(10);
-        let start = std::time::Instant::now();
-        let poll_interval = std::time::Duration::from_millis(100);
-
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    let elapsed = start.elapsed();
-                    if !status.success() {
-                        let mut msg = String::new();
-                        if let Some(mut stderr) = child.stderr.take() {
-                            let _ = std::io::Read::read_to_string(&mut stderr, &mut msg);
-                        }
-                        let sanitized = sanitize_remote_credentials(msg.trim());
-                        tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} failed: {sanitized}");
-                        let detail = if sanitized.is_empty() {
-                            format!("git fetch exited with {status}")
-                        } else {
-                            sanitized
-                        };
-                        return FetchOutcome::Failed(detail);
-                    }
-                    tracing::info!(target: "git.worktree", "git fetch {remote}/{branch} ok in {:?}", elapsed);
-                    return FetchOutcome::Ok;
-                }
-                Ok(None) => {
-                    if start.elapsed() > timeout {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        tracing::warn!(target: "git.worktree",
-                            "git fetch {remote}/{branch} timed out after {}s",
-                            timeout.as_secs()
-                        );
-                        return FetchOutcome::TimedOut;
-                    }
-                    std::thread::sleep(poll_interval);
-                }
-                Err(e) => {
-                    tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} error: {e}");
-                    return FetchOutcome::Failed(format!("wait error: {e}"));
-                }
+                FetchOutcome::Skipped(format!("spawn failed: {e}"))
             }
         }
     }

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 pub(super) fn collect_pid_tree(pid: u32) -> Vec<u32> {
     let children_map = build_children_map();
     let mut pids = vec![pid];
-    collect_descendants_from_map(pid, &children_map, &mut pids);
+    super::collect_descendants_from_map(pid, &children_map, &mut pids);
     pids
 }
 
@@ -43,19 +43,6 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
-fn collect_descendants_from_map(
-    pid: u32,
-    children_map: &HashMap<u32, Vec<u32>>,
-    pids: &mut Vec<u32>,
-) {
-    if let Some(children) = children_map.get(&pid) {
-        for &child_pid in children {
-            pids.push(child_pid);
-            collect_descendants_from_map(child_pid, children_map, pids);
-        }
-    }
-}
-
 /// Get the foreground process group leader for a shell PID
 /// Walks the process tree to find the actual foreground process
 pub fn get_foreground_pid(shell_pid: u32) -> Option<u32> {
@@ -83,25 +70,26 @@ fn find_process_in_group(pgrp: u32) -> Option<u32> {
         return None;
     }
 
-    for entry in fs::read_dir(proc_dir).ok()? {
-        let entry = entry.ok()?;
+    // Skip-and-continue on any unreadable or non-PID entry (a process can
+    // exit between readdir and the stat read); aborting the whole scan on
+    // one transient entry would silently fall back to the shell PID.
+    for entry in fs::read_dir(proc_dir).ok()?.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
 
-        // Skip non-numeric entries
-        if !name_str.chars().all(|c| c.is_ascii_digit()) {
+        let Ok(pid) = name_str.parse::<u32>() else {
             continue;
-        }
+        };
 
-        let pid: u32 = name_str.parse().ok()?;
         let stat_path = entry.path().join("stat");
+        let Ok(content) = fs::read_to_string(&stat_path) else {
+            continue;
+        };
 
-        if let Ok(content) = fs::read_to_string(&stat_path) {
-            // Field 5 (0-indexed 4) is the process group ID
-            if let Some(proc_pgrp) = parse_stat_field(&content, 4) {
-                if proc_pgrp as u32 == pgrp {
-                    return Some(pid);
-                }
+        // Field 5 (0-indexed 4) is the process group ID
+        if let Some(proc_pgrp) = parse_stat_field(&content, 4) {
+            if proc_pgrp as u32 == pgrp {
+                return Some(pid);
             }
         }
     }
@@ -136,57 +124,5 @@ mod tests {
         assert_eq!(parse_stat_field(stat, 3), Some(1233)); // ppid
         assert_eq!(parse_stat_field(stat, 4), Some(1234)); // pgrp
         assert_eq!(parse_stat_field(stat, 7), Some(1234)); // tpgid
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_empty() {
-        let children_map = HashMap::new();
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100]);
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_nested() {
-        // Tree: 100 -> 101 -> 102 -> 103
-        let mut children_map = HashMap::new();
-        children_map.insert(100, vec![101]);
-        children_map.insert(101, vec![102]);
-        children_map.insert(102, vec![103]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100, 101, 102, 103]);
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_branching() {
-        // Tree: 100 -> [101, 102], 101 -> [103, 104], 102 -> [105]
-        let mut children_map = HashMap::new();
-        children_map.insert(100, vec![101, 102]);
-        children_map.insert(101, vec![103, 104]);
-        children_map.insert(102, vec![105]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-
-        assert!(pids.contains(&100));
-        assert!(pids.contains(&101));
-        assert!(pids.contains(&102));
-        assert!(pids.contains(&103));
-        assert!(pids.contains(&104));
-        assert!(pids.contains(&105));
-        assert_eq!(pids.len(), 6);
-    }
-
-    #[test]
-    fn test_collect_descendants_unrelated_processes() {
-        let mut children_map = HashMap::new();
-        children_map.insert(200, vec![201, 202]);
-        children_map.insert(300, vec![301]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100]);
     }
 }

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 pub(super) fn collect_pid_tree(pid: u32) -> Vec<u32> {
     let children_map = build_children_map();
     let mut pids = vec![pid];
-    collect_descendants_from_map(pid, &children_map, &mut pids);
+    super::collect_descendants_from_map(pid, &children_map, &mut pids);
     pids
 }
 
@@ -33,20 +33,6 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     }
 
     children_map
-}
-
-/// Recursively collect all descendant PIDs using the pre-built children map
-fn collect_descendants_from_map(
-    pid: u32,
-    children_map: &HashMap<u32, Vec<u32>>,
-    pids: &mut Vec<u32>,
-) {
-    if let Some(children) = children_map.get(&pid) {
-        for &child_pid in children {
-            pids.push(child_pid);
-            collect_descendants_from_map(child_pid, children_map, pids);
-        }
-    }
 }
 
 /// Get the foreground process group leader for a shell PID
@@ -100,83 +86,4 @@ fn find_process_in_group(pgrp: u32) -> Option<u32> {
     }
 
     None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_collect_descendants_from_map_empty() {
-        let children_map = HashMap::new();
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100]);
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_single_child() {
-        let mut children_map = HashMap::new();
-        children_map.insert(100, vec![101]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100, 101]);
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_multiple_children() {
-        let mut children_map = HashMap::new();
-        children_map.insert(100, vec![101, 102, 103]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100, 101, 102, 103]);
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_nested() {
-        // Tree: 100 -> 101 -> 102 -> 103
-        let mut children_map = HashMap::new();
-        children_map.insert(100, vec![101]);
-        children_map.insert(101, vec![102]);
-        children_map.insert(102, vec![103]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100, 101, 102, 103]);
-    }
-
-    #[test]
-    fn test_collect_descendants_from_map_branching() {
-        // Tree: 100 -> [101, 102], 101 -> [103, 104], 102 -> [105]
-        let mut children_map = HashMap::new();
-        children_map.insert(100, vec![101, 102]);
-        children_map.insert(101, vec![103, 104]);
-        children_map.insert(102, vec![105]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-
-        // Should contain all PIDs
-        assert!(pids.contains(&100));
-        assert!(pids.contains(&101));
-        assert!(pids.contains(&102));
-        assert!(pids.contains(&103));
-        assert!(pids.contains(&104));
-        assert!(pids.contains(&105));
-        assert_eq!(pids.len(), 6);
-    }
-
-    #[test]
-    fn test_collect_descendants_unrelated_processes() {
-        // Map has processes, but none are descendants of 100
-        let mut children_map = HashMap::new();
-        children_map.insert(200, vec![201, 202]);
-        children_map.insert(300, vec![301]);
-
-        let mut pids = vec![100];
-        collect_descendants_from_map(100, &children_map, &mut pids);
-        assert_eq!(pids, vec![100]);
-    }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,6 +1,10 @@
 //! Process utilities for tmux session management
 
-use std::time::Duration;
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use nix::errno::Errno;
@@ -20,6 +24,101 @@ mod macos;
 /// because its only consumer today is the serve-gated `acp` module.
 #[cfg(feature = "serve")]
 pub mod worker;
+
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Wait for `child` to exit, killing and reaping it if it outlives `timeout`.
+/// Returns `Ok(None)` when the timeout fired and the child was killed.
+///
+/// Only use this directly when the child's stdout/stderr are not piped (or
+/// are drained elsewhere): a full pipe buffer can wedge the child before the
+/// deadline. [`run_with_timeout`] handles piped output safely.
+pub fn wait_with_timeout(
+    child: &mut Child,
+    timeout: Duration,
+) -> std::io::Result<Option<ExitStatus>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(None);
+        }
+        std::thread::sleep(WAIT_POLL_INTERVAL);
+    }
+}
+
+/// Spawn `cmd` with piped stdout/stderr and wait for it to exit, killing it
+/// if it outlives `timeout`. Returns `Ok(None)` when the timeout fired and
+/// the child was killed; `Err` covers spawn/wait failures.
+///
+/// stdout/stderr are drained on dedicated threads so a full pipe buffer
+/// cannot wedge the child (and thus this wait) before the deadline. The
+/// caller keeps control of stdin; pipe it to null when the child might
+/// prompt (SSH passphrases, credential helpers).
+pub fn run_with_timeout(cmd: &mut Command, timeout: Duration) -> std::io::Result<Option<Output>> {
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+
+    let mut stdout_pipe = child.stdout.take();
+    let mut stderr_pipe = child.stderr.take();
+    let (otx, orx) = mpsc::channel();
+    let (etx, erx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(ref mut p) = stdout_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        let _ = otx.send(buf);
+    });
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(ref mut p) = stderr_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        let _ = etx.send(buf);
+    });
+
+    let deadline = Instant::now() + timeout;
+    let Some(status) = wait_with_timeout(&mut child, timeout)? else {
+        return Ok(None);
+    };
+    // The child exited, but if it spawned a grandchild that inherited the
+    // pipe (credential helper, pager, backgrounded job), `read_to_end` (and
+    // thus an unbounded `recv`) would block forever. Cap the drain at the
+    // remaining deadline so the timeout guarantee holds even then; the exit
+    // status is already in hand.
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let stdout = orx.recv_timeout(remaining).unwrap_or_default();
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let stderr = erx.recv_timeout(remaining).unwrap_or_default();
+    Ok(Some(Output {
+        status,
+        stdout,
+        stderr,
+    }))
+}
+
+/// Recursively collect all descendant PIDs of `pid` using a pre-built
+/// parent -> children map. Shared by the per-OS `collect_pid_tree`
+/// implementations, which each build the map their own way (a `/proc`
+/// scan on Linux, a `ps` parse on macOS).
+fn collect_descendants_from_map(
+    pid: u32,
+    children_map: &HashMap<u32, Vec<u32>>,
+    pids: &mut Vec<u32>,
+) {
+    if let Some(children) = children_map.get(&pid) {
+        for &child_pid in children {
+            pids.push(child_pid);
+            collect_descendants_from_map(child_pid, children_map, pids);
+        }
+    }
+}
 
 /// Get the PID of the shell process running in a tmux pane
 pub fn get_pane_pid(session_name: &str) -> Option<u32> {
@@ -206,5 +305,168 @@ fn signal_process_tree(pid: u32, signal: Signal) {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collect_descendants_from_map_empty() {
+        let children_map = HashMap::new();
+        let mut pids = vec![100];
+        collect_descendants_from_map(100, &children_map, &mut pids);
+        assert_eq!(pids, vec![100]);
+    }
+
+    #[test]
+    fn test_collect_descendants_from_map_single_child() {
+        let mut children_map = HashMap::new();
+        children_map.insert(100, vec![101]);
+
+        let mut pids = vec![100];
+        collect_descendants_from_map(100, &children_map, &mut pids);
+        assert_eq!(pids, vec![100, 101]);
+    }
+
+    #[test]
+    fn test_collect_descendants_from_map_multiple_children() {
+        let mut children_map = HashMap::new();
+        children_map.insert(100, vec![101, 102, 103]);
+
+        let mut pids = vec![100];
+        collect_descendants_from_map(100, &children_map, &mut pids);
+        assert_eq!(pids, vec![100, 101, 102, 103]);
+    }
+
+    #[test]
+    fn test_collect_descendants_from_map_nested() {
+        // Tree: 100 -> 101 -> 102 -> 103
+        let mut children_map = HashMap::new();
+        children_map.insert(100, vec![101]);
+        children_map.insert(101, vec![102]);
+        children_map.insert(102, vec![103]);
+
+        let mut pids = vec![100];
+        collect_descendants_from_map(100, &children_map, &mut pids);
+        assert_eq!(pids, vec![100, 101, 102, 103]);
+    }
+
+    #[test]
+    fn test_collect_descendants_from_map_branching() {
+        // Tree: 100 -> [101, 102], 101 -> [103, 104], 102 -> [105]
+        let mut children_map = HashMap::new();
+        children_map.insert(100, vec![101, 102]);
+        children_map.insert(101, vec![103, 104]);
+        children_map.insert(102, vec![105]);
+
+        let mut pids = vec![100];
+        collect_descendants_from_map(100, &children_map, &mut pids);
+
+        assert!(pids.contains(&100));
+        assert!(pids.contains(&101));
+        assert!(pids.contains(&102));
+        assert!(pids.contains(&103));
+        assert!(pids.contains(&104));
+        assert!(pids.contains(&105));
+        assert_eq!(pids.len(), 6);
+    }
+
+    #[test]
+    fn test_collect_descendants_unrelated_processes() {
+        let mut children_map = HashMap::new();
+        children_map.insert(200, vec![201, 202]);
+        children_map.insert(300, vec![301]);
+
+        let mut pids = vec![100];
+        collect_descendants_from_map(100, &children_map, &mut pids);
+        assert_eq!(pids, vec![100]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn wait_with_timeout_returns_status_for_fast_child() {
+        let mut child = Command::new("sh")
+            .args(["-c", "exit 0"])
+            .stdin(Stdio::null())
+            .spawn()
+            .unwrap();
+        let status = wait_with_timeout(&mut child, Duration::from_secs(10))
+            .unwrap()
+            .expect("fast child exits before the timeout");
+        assert!(status.success());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn wait_with_timeout_kills_child_that_outlives_deadline() {
+        let mut child = Command::new("sleep").arg("5").spawn().unwrap();
+
+        let start = Instant::now();
+        let status = wait_with_timeout(&mut child, Duration::from_millis(200)).unwrap();
+        assert!(
+            status.is_none(),
+            "expected the timeout to fire and kill the child"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "wait should return promptly after the deadline, not block on the child"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn run_with_timeout_captures_output_for_fast_child() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf out; printf err >&2"]);
+
+        let output = run_with_timeout(&mut cmd, Duration::from_secs(10))
+            .unwrap()
+            .expect("fast child should complete before the timeout");
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"out");
+        assert_eq!(output.stderr, b"err");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn run_with_timeout_kills_child_that_outlives_deadline() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("5");
+
+        let start = Instant::now();
+        let result = run_with_timeout(&mut cmd, Duration::from_millis(300)).unwrap();
+        assert!(
+            result.is_none(),
+            "expected the timeout to fire and kill the child"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "wait should return promptly after the deadline, not block on the child"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn run_with_timeout_bounds_drain_when_grandchild_holds_pipe() {
+        // The immediate child (sh) exits fast but backgrounds a `sleep` that
+        // inherits the pipes, so they never close. The drain must still
+        // return by the deadline rather than blocking on read_to_end; this is
+        // the exact shape of the git-clone hang (a credential helper or pager
+        // grandchild outliving the parent). `sleep 10` (>> the 4s assertion)
+        // ensures an unbounded recv would visibly fail.
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 10 & printf done"]);
+
+        let start = Instant::now();
+        let output = run_with_timeout(&mut cmd, Duration::from_millis(500))
+            .unwrap()
+            .expect("the sh child exits quickly, so an Output is produced");
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "drain must be bounded by the deadline even while the pipe stays open"
+        );
+        assert!(output.status.success());
     }
 }

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -252,19 +252,45 @@ pub struct SpawnAcpResponse {
 /// by `sessions.rs` write endpoints so the read-only contract is uniform
 /// across the API surface.
 pub(crate) fn read_only_block(state: &AppState) -> Option<axum::response::Response> {
-    if state.read_only {
-        return Some(
-            (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "read_only",
-                    "message": "Server is in read-only mode",
-                })),
-            )
-                .into_response(),
-        );
+    state.read_only.then(super::read_only_response)
+}
+
+/// Canonical status + body mapping for a `SupervisorError`. Bodies stay
+/// plain text: every dashboard consumer of these endpoints reads the raw
+/// body for display (`safeText` in `useAcpSession.ts`), and the behavioral
+/// discriminators (the `worker_not_ready` prefix, nonce-echoing 404s) are
+/// text matches. Context-specific overrides (retryable `worker_not_ready`,
+/// nonce echoes) live as explicit pre-match arms at their call sites.
+/// `context` prefixes the fallback 500 body so "prompt failed" vs "cancel
+/// failed" stays distinguishable in banners and logs.
+fn supervisor_error_response(context: &str, err: &SupervisorError) -> axum::response::Response {
+    match err {
+        SupervisorError::UnknownSession(_) => (
+            StatusCode::NOT_FOUND,
+            "session has no running structured view",
+        )
+            .into_response(),
+        SupervisorError::UnknownAgent(name) => (
+            StatusCode::BAD_REQUEST,
+            format!("unknown structured view agent: {name}"),
+        )
+            .into_response(),
+        SupervisorError::AlreadyRunning(_) => (
+            StatusCode::CONFLICT,
+            "structured view worker already running for session",
+        )
+            .into_response(),
+        SupervisorError::CapacityFull { .. } => {
+            (StatusCode::SERVICE_UNAVAILABLE, err.to_string()).into_response()
+        }
+        SupervisorError::Acp(_)
+        | SupervisorError::InvalidAgentCommand(_)
+        | SupervisorError::SpawnCancelled(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("{context}: {err}"),
+        )
+            .into_response(),
     }
-    None
 }
 
 fn not_structured_response() -> axum::response::Response {
@@ -434,24 +460,7 @@ pub async fn spawn_acp(
             })
             .into_response()
         }
-        Err(SupervisorError::AlreadyRunning(_)) => (
-            StatusCode::CONFLICT,
-            "structured view already running for session",
-        )
-            .into_response(),
-        Err(SupervisorError::UnknownAgent(name)) => (
-            StatusCode::BAD_REQUEST,
-            format!("unknown structured view agent: {name}"),
-        )
-            .into_response(),
-        Err(e @ SupervisorError::CapacityFull { .. }) => {
-            (StatusCode::SERVICE_UNAVAILABLE, format!("{e}")).into_response()
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("spawn failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("spawn failed", &e),
     }
 }
 
@@ -683,12 +692,7 @@ pub async fn shutdown_acp(
     }
     match state.acp_supervisor.shutdown(&id).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(SupervisorError::UnknownSession(_)) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("shutdown failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("shutdown failed", &e),
     }
 }
 
@@ -873,26 +877,7 @@ pub async fn switch_acp_agent(
         })
         .await;
     if let Err(e) = spawn_result {
-        return match e {
-            SupervisorError::UnknownAgent(name) => (
-                StatusCode::BAD_REQUEST,
-                format!("unknown structured view agent: {name}"),
-            )
-                .into_response(),
-            SupervisorError::AlreadyRunning(_) => (
-                StatusCode::CONFLICT,
-                "structured view worker already running for session",
-            )
-                .into_response(),
-            e @ SupervisorError::CapacityFull { .. } => {
-                (StatusCode::SERVICE_UNAVAILABLE, format!("{e}")).into_response()
-            }
-            e => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("spawn failed: {e}"),
-            )
-                .into_response(),
-        };
+        return supervisor_error_response("spawn failed", &e);
     }
 
     // Spawn succeeded: a mid-session agent switch actually happened. Tally it
@@ -1149,28 +1134,16 @@ pub async fn acp_prompt(
         .await
     {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
-        Err(SupervisorError::UnknownSession(_)) => {
-            if needs_resume {
-                // The respawn we kicked above did not finish within
-                // `send_prompt`'s wait window (slow sandbox / spawn). The
-                // worker is still coming; signal a retryable typed status
-                // so the frontend keeps the prompt queued and re-fires on
-                // the next `AcpSessionAssigned`, rather than dropping it
-                // on a 404. See #1748.
-                (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
-            } else {
-                (
-                    StatusCode::NOT_FOUND,
-                    "session has no running structured view",
-                )
-                    .into_response()
-            }
+        // Intentional override of the canonical UnknownSession 404: the
+        // respawn we kicked above did not finish within `send_prompt`'s
+        // wait window (slow sandbox / spawn). The worker is still coming;
+        // signal a retryable typed status so the frontend keeps the prompt
+        // queued and re-fires on the next `AcpSessionAssigned`, rather
+        // than dropping it on a 404. See #1748.
+        Err(SupervisorError::UnknownSession(_)) if needs_resume => {
+            (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("prompt failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("prompt failed", &e),
     }
 }
 
@@ -1247,22 +1220,11 @@ pub async fn acp_prompt_diff_comments(
         .await
     {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
-        Err(SupervisorError::UnknownSession(_)) => {
-            if woke_idle_dormant {
-                (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
-            } else {
-                (
-                    StatusCode::NOT_FOUND,
-                    "session has no running structured view",
-                )
-                    .into_response()
-            }
+        // Retryable worker_not_ready override; mirrors acp_prompt. See #1748.
+        Err(SupervisorError::UnknownSession(_)) if woke_idle_dormant => {
+            (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("prompt failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("prompt failed", &e),
     }
 }
 
@@ -1303,16 +1265,7 @@ pub async fn acp_cancel(
     }
     match state.acp_supervisor.cancel_prompt(&id).await {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
-        Err(SupervisorError::UnknownSession(_)) => (
-            StatusCode::NOT_FOUND,
-            "session has no running structured view",
-        )
-            .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("cancel failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("cancel failed", &e),
     }
 }
 
@@ -1966,14 +1919,7 @@ pub async fn acp_set_mode(
             }
             StatusCode::ACCEPTED.into_response()
         }
-        Err(SupervisorError::UnknownSession(_)) => {
-            (StatusCode::NOT_FOUND, "session has no running acp").into_response()
-        }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("set_mode failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("set_mode failed", &e),
     }
 }
 
@@ -2075,16 +2021,7 @@ pub async fn acp_set_config_option(
             }
             StatusCode::ACCEPTED.into_response()
         }
-        Err(SupervisorError::UnknownSession(_)) => (
-            StatusCode::NOT_FOUND,
-            "session has no running structured view",
-        )
-            .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("set_config_option failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("set_config_option failed", &e),
     }
 }
 
@@ -2111,24 +2048,17 @@ pub async fn resolve_approval(
             record_approval_decision(&state, decision);
             StatusCode::NO_CONTENT.into_response()
         }
-        Err(SupervisorError::UnknownSession(_)) => {
-            (StatusCode::NOT_FOUND, "session has no running acp").into_response()
-        }
         Err(SupervisorError::Acp(crate::acp::acp_client::AcpError::UnknownNonce)) => {
-            // Echo the nonce so clients (web + native TUI) can confirm the
-            // 404 refers to the card they resolved, not a generic miss. See
-            // #1821.
+            // Intentional override of the canonical Acp 500: echo the nonce
+            // so clients (web + native TUI) can confirm the 404 refers to
+            // the card they resolved, not a generic miss. See #1821.
             (
                 StatusCode::NOT_FOUND,
                 format!("no pending approval with nonce {nonce_str}"),
             )
                 .into_response()
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("resolve failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("resolve failed", &e),
     }
 }
 
@@ -2157,25 +2087,19 @@ pub async fn resolve_elicitation(
         .await
     {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(SupervisorError::UnknownSession(_)) => {
-            (StatusCode::NOT_FOUND, "session has no running acp").into_response()
-        }
+        // Intentional override: nonce echo, mirrors resolve_approval. See #1821.
         Err(SupervisorError::Acp(crate::acp::acp_client::AcpError::UnknownNonce)) => (
             StatusCode::NOT_FOUND,
             format!("no pending elicitation with nonce {nonce_str}"),
         )
             .into_response(),
-        // A failed server-side validation leaves the elicitation pending,
-        // so 422 (not 404): the client can correct the answer and resubmit
-        // the same nonce.
+        // Intentional override: a failed server-side validation leaves the
+        // elicitation pending, so 422 (not 404): the client can correct the
+        // answer and resubmit the same nonce.
         Err(SupervisorError::Acp(crate::acp::acp_client::AcpError::InvalidAnswer(msg))) => {
             (StatusCode::UNPROCESSABLE_ENTITY, msg).into_response()
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("resolve failed: {e}"),
-        )
-            .into_response(),
+        Err(e) => supervisor_error_response("resolve failed", &e),
     }
 }
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -76,6 +76,48 @@ pub use telemetry::{
     set_telemetry_consent,
 };
 
+/// Canonical 404 for a session id that does not resolve to a live instance.
+/// Body shape (`error` discriminator + human `message`) matches the rest of
+/// the JSON error surface so the dashboard's generic `.message` handling and
+/// `.error` discrimination both keep working.
+pub(super) fn session_not_found() -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    (
+        axum::http::StatusCode::NOT_FOUND,
+        axum::Json(serde_json::json!({ "error": "not_found", "message": "Session not found" })),
+    )
+        .into_response()
+}
+
+/// Canonical 403 body for `aoe serve --read-only`.
+pub(super) fn read_only_response() -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    (
+        axum::http::StatusCode::FORBIDDEN,
+        axum::Json(serde_json::json!({
+            "error": "read_only",
+            "message": "Server is in read-only mode"
+        })),
+    )
+        .into_response()
+}
+
+/// 404 for the persist-then-apply race: the write was persisted to disk, but
+/// the in-memory instance was concurrently removed before the apply step.
+/// This is a caller-visible "session no longer exists", not a persist
+/// failure, so it must not surface as a 500.
+pub(super) fn session_gone_after_persist() -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    (
+        axum::http::StatusCode::NOT_FOUND,
+        axum::Json(serde_json::json!({
+            "error": "not_found",
+            "message": "Session was removed while the update was being applied"
+        })),
+    )
+        .into_response()
+}
+
 const SHELL_METACHARACTERS: &[char] = &[
     ';', '&', '|', '$', '`', '(', ')', '{', '}', '<', '>', '\n', '\r', '\\', '"', '\'', '!', '#',
     '*', '?', '[', ']', '~', '\t', '\0',

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -889,14 +889,7 @@ pub async fn update_workspace_ordering(
     body: Result<Json<UpdateWorkspaceOrderingBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -1048,13 +1041,7 @@ pub async fn rename_session(
     body: Result<Json<RenameSessionBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -1084,11 +1071,7 @@ pub async fn rename_session(
     let (worktree_info, current_path, status, profile, is_sandboxed, is_structured) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         (
             inst.worktree_info.clone(),
@@ -1246,11 +1229,7 @@ pub async fn rename_session(
     let mut response = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         if let Some(path) = new_path.as_deref() {
             apply_worktree_name_edit(inst, path, new_branch.as_deref());
@@ -1339,13 +1318,7 @@ pub async fn set_worktree_name(
     body: Result<Json<SetWorktreeNameBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -1372,11 +1345,7 @@ pub async fn set_worktree_name(
     let (worktree_info, current_path, status, profile, is_sandboxed, is_structured) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         (
             inst.worktree_info.clone(),
@@ -1533,11 +1502,7 @@ pub async fn set_worktree_name(
     let response = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         apply_worktree_name_edit(inst, &new_path, new_branch.as_deref());
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen())
@@ -1587,14 +1552,7 @@ pub async fn update_session_group(
     body: Result<Json<UpdateGroupBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -1620,11 +1578,7 @@ pub async fn update_session_group(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -1650,12 +1604,12 @@ pub async fn update_session_group(
 
     let mut instances = state.instances.write().await;
     let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-        tracing::error!(
+        tracing::warn!(
             target: "http.api.sessions",
             session = %id,
             "group update: instance vanished after persist"
         );
-        return persist_failed_response();
+        return super::session_gone_after_persist();
     };
     apply_session_group(inst, group);
 
@@ -1782,13 +1736,7 @@ pub async fn update_session_notifications(
     body: Result<Json<UpdateNotificationsBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -1811,11 +1759,7 @@ pub async fn update_session_notifications(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -1847,12 +1791,12 @@ pub async fn update_session_notifications(
 
     let mut instances = state.instances.write().await;
     let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-        tracing::error!(
+        tracing::warn!(
             target: "http.api.sessions",
             session = %id,
             "notification update: instance vanished after persist"
         );
-        return persist_failed_response();
+        return super::session_gone_after_persist();
     };
     apply(&mut inst.notify_on_waiting, waiting);
     apply(&mut inst.notify_on_idle, idle);
@@ -1886,14 +1830,7 @@ pub async fn update_session_diff_base(
     body: Result<Json<UpdateDiffBaseBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -1906,11 +1843,7 @@ pub async fn update_session_diff_base(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -1943,12 +1876,12 @@ pub async fn update_session_diff_base(
 
     let mut instances = state.instances.write().await;
     let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-        tracing::error!(
+        tracing::warn!(
             target: "http.api.sessions",
             session = %id,
             "diff-base update: instance vanished after persist"
         );
-        return persist_failed_response();
+        return super::session_gone_after_persist();
     };
     inst.base_branch_override = new_override;
 
@@ -2035,14 +1968,7 @@ pub async fn update_session_pin(
     body: Result<Json<UpdatePinBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -2055,11 +1981,7 @@ pub async fn update_session_pin(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -2090,12 +2012,12 @@ pub async fn update_session_pin(
 
     let mut instances = state.instances.write().await;
     let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-        tracing::error!(
+        tracing::warn!(
             target: "http.api.sessions",
             session = %id,
             "pin update: instance vanished after persist"
         );
-        return persist_failed_response();
+        return super::session_gone_after_persist();
     };
     if pinned {
         inst.pin();
@@ -2114,14 +2036,7 @@ pub async fn update_session_archive(
     body: Result<Json<UpdateArchiveBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -2138,11 +2053,7 @@ pub async fn update_session_archive(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -2175,12 +2086,12 @@ pub async fn update_session_archive(
     let (was_structured_view, inst_clone, kill_pane) = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            tracing::error!(
+            tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,
                 "archive update: instance vanished after persist"
             );
-            return persist_failed_response();
+            return super::session_gone_after_persist();
         };
         if archived {
             inst.archive();
@@ -2258,11 +2169,7 @@ pub async fn update_session_archive(
             SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
         }
         None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         }
     };
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
@@ -2280,14 +2187,7 @@ pub async fn trash_session(
     body: Option<Json<TrashSessionBody>>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let body = body.map(|Json(b)| b).unwrap_or_default();
 
@@ -2297,11 +2197,7 @@ pub async fn trash_session(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -2327,12 +2223,12 @@ pub async fn trash_session(
     let (was_structured_view, inst_clone) = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            tracing::error!(
+            tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,
                 "trash: instance vanished after persist"
             );
-            return persist_failed_response();
+            return super::session_gone_after_persist();
         };
         inst.trash();
         let structured_view;
@@ -2437,11 +2333,7 @@ pub async fn trash_session(
             SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
         }
         None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         }
     };
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
@@ -2457,14 +2349,7 @@ pub async fn restore_session(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
 
     let lock = state.instance_lock(&id).await;
@@ -2473,11 +2358,7 @@ pub async fn restore_session(
     let (profile, snapshot) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         (inst.source_profile.clone(), inst.clone())
     };
@@ -2576,11 +2457,7 @@ pub async fn force_smart_rename(
             )
         })
     }) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "message": "Session not found" })),
-        )
-            .into_response();
+        return super::session_not_found();
     };
 
     // Preflight the SAME gate the spawned try_smart_rename re-applies, so the
@@ -2661,14 +2538,7 @@ pub async fn stop_session(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
 
     let lock = state.instance_lock(&id).await;
@@ -2680,11 +2550,7 @@ pub async fn stop_session(
     let (profile, is_structured, already_stopped) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         let structured;
         #[cfg(feature = "serve")]
@@ -2711,11 +2577,7 @@ pub async fn stop_session(
                 SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
             }
             None => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "message": "Session not found" })),
-                )
-                    .into_response();
+                return super::session_not_found();
             }
         };
         return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
@@ -2749,12 +2611,12 @@ pub async fn stop_session(
     let inst_clone = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            tracing::error!(
+            tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,
                 "stop session: instance vanished after persist"
             );
-            return persist_failed_response();
+            return super::session_gone_after_persist();
         };
         inst.status = Status::Stopped;
         if is_structured {
@@ -2801,11 +2663,7 @@ pub async fn stop_session(
             SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
         }
         None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         }
     };
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
@@ -2821,13 +2679,7 @@ pub async fn start_session(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
 
     let lock = state.instance_lock(&id).await;
@@ -2836,11 +2688,7 @@ pub async fn start_session(
     let (profile, is_structured, is_stopped, instance) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         let structured;
         #[cfg(feature = "serve")]
@@ -2867,11 +2715,7 @@ pub async fn start_session(
                 SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
             }
             None => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "message": "Session not found" })),
-                )
-                    .into_response();
+                return super::session_not_found();
             }
         };
         return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
@@ -2913,11 +2757,7 @@ pub async fn start_session(
                 SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
             }
             None => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({ "message": "Session not found" })),
-                )
-                    .into_response();
+                return super::session_not_found();
             }
         };
         return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
@@ -2971,11 +2811,7 @@ pub async fn start_session(
                     )
                 }
                 None => {
-                    return (
-                        StatusCode::NOT_FOUND,
-                        Json(serde_json::json!({ "message": "Session not found" })),
-                    )
-                        .into_response();
+                    return super::session_not_found();
                 }
             };
             if let Some(sid) = resume_failed_sid {
@@ -3024,14 +2860,7 @@ pub async fn update_session_snooze(
     body: Result<Json<UpdateSnoozeBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -3060,11 +2889,7 @@ pub async fn update_session_snooze(
     let (was_structured_view, profile) = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         let structured_view;
         #[cfg(feature = "serve")]
@@ -3105,12 +2930,12 @@ pub async fn update_session_snooze(
     {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            tracing::error!(
+            tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,
                 "snooze update: instance vanished after persist"
             );
-            return persist_failed_response();
+            return super::session_gone_after_persist();
         };
         match minutes {
             Some(m) => inst.snooze(m),
@@ -3149,11 +2974,7 @@ pub async fn update_session_snooze(
             SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
         }
         None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         }
     };
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
@@ -3171,14 +2992,7 @@ pub async fn update_session_unread(
     body: Result<Json<UpdateUnreadBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "read_only",
-                "message": "Server is in read-only mode"
-            })),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -3192,11 +3006,7 @@ pub async fn update_session_unread(
     let profile = {
         let instances = state.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         };
         inst.source_profile.clone()
     };
@@ -3227,12 +3037,12 @@ pub async fn update_session_unread(
 
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            tracing::error!(
+            tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,
                 "unread update: instance vanished after persist"
             );
-            return persist_failed_response();
+            return super::session_gone_after_persist();
         };
         if mark_unread {
             inst.mark_unread();
@@ -3247,11 +3057,7 @@ pub async fn update_session_unread(
             SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
         }
         None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "message": "Session not found" })),
-            )
-                .into_response();
+            return super::session_not_found();
         }
     };
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
@@ -3568,12 +3374,7 @@ pub async fn delete_session(
     body: Option<Json<DeleteSessionBody>>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        );
+        return super::read_only_response();
     }
 
     let body = body.map(|Json(b)| b).unwrap_or_default();
@@ -3592,10 +3393,7 @@ pub async fn delete_session(
     };
 
     let Some(instance) = instance else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "message": "Session not found" })),
-        );
+        return super::session_not_found();
     };
 
     // Captured before `instance` moves into the deletion task; recorded into
@@ -3647,7 +3445,7 @@ pub async fn delete_session(
     });
 
     match join.await {
-        Ok(resp) => resp,
+        Ok(resp) => resp.into_response(),
         Err(e) => {
             tracing::error!(target: "http.api.sessions",
                 "Deletion task panicked or was cancelled: {e}");
@@ -3658,6 +3456,7 @@ pub async fn delete_session(
                     "message": "Deletion task failed",
                 })),
             )
+                .into_response()
         }
     }
 }
@@ -4054,13 +3853,7 @@ pub async fn create_session(
     body: Result<Json<CreateSessionBody>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(body) = match body {
         Ok(b) => b,
@@ -5110,13 +4903,7 @@ pub async fn ensure_terminal(
     axum::extract::Query(q): axum::extract::Query<crate::server::live_ws::TerminalIndexQuery>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let index = q.index;
     if index > crate::server::pane::MAX_TERMINAL_INDEX {
@@ -5229,13 +5016,7 @@ pub async fn ensure_container_terminal(
     axum::extract::Query(q): axum::extract::Query<crate::server::live_ws::TerminalIndexQuery>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let index = q.index;
     if index > crate::server::pane::MAX_TERMINAL_INDEX {
@@ -5333,13 +5114,7 @@ pub async fn kill_terminal(
     axum::extract::Query(q): axum::extract::Query<crate::server::live_ws::TerminalIndexQuery>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(
-                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
-            ),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let index = q.index;
     if index == 0 || index > crate::server::pane::MAX_TERMINAL_INDEX {
@@ -5559,13 +5334,10 @@ async fn resolve_diff_repos(
     id: &str,
 ) -> Result<DiffContext, axum::response::Response> {
     let instances = state.instances.read().await;
-    let inst = instances.iter().find(|i| i.id == id).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": "not_found", "message": "Session not found"})),
-        )
-            .into_response()
-    })?;
+    let inst = instances
+        .iter()
+        .find(|i| i.id == id)
+        .ok_or_else(super::session_not_found)?;
     let repos = if let Some(ws) = inst.workspace_info.as_ref() {
         ws.repos
             .iter()
@@ -8133,11 +7905,7 @@ pub async fn send_message(
     req: Result<Json<SendMessageRequest>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": "read_only"})),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(req) = match req {
         Ok(j) => j,
@@ -8471,11 +8239,7 @@ pub async fn paste_image(
     use base64::Engine as _;
 
     if state.read_only {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": "read_only"})),
-        )
-            .into_response();
+        return super::read_only_response();
     }
     let Json(req) = match req {
         Ok(j) => j,

--- a/src/session/mcp_overrides.rs
+++ b/src/session/mcp_overrides.rs
@@ -85,43 +85,22 @@ fn read_root(content: &str) -> Result<Map<String, Value>> {
 /// Apply a mutation to the `mcpServers` object of the global `mcp.json` under an
 /// exclusive lock, preserving every other server and any unknown top-level keys.
 fn mutate_servers(mutate: impl FnOnce(&mut Map<String, Value>)) -> Result<()> {
-    use fs2::FileExt;
-    use std::io::{Read, Seek, SeekFrom, Write};
-
     let path = global_mcp_path()?;
-    if !path.exists() {
-        std::fs::write(&path, "").with_context(|| format!("creating {}", path.display()))?;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
-    }
-
-    let mut file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(&path)
-        .with_context(|| format!("opening {}", path.display()))?;
-    file.lock_exclusive().context("locking global mcp.json")?;
-
-    let mut content = String::new();
-    file.read_to_string(&mut content)?;
-    let mut root = read_root(&content)?;
-
-    let mut servers = match root.remove("mcpServers") {
-        Some(Value::Object(m)) => m,
-        Some(_) => anyhow::bail!("mcpServers in global mcp.json is not an object"),
-        None => Map::new(),
-    };
-    mutate(&mut servers);
-    root.insert("mcpServers".into(), Value::Object(servers));
-
-    let new_content = serde_json::to_string_pretty(&Value::Object(root))?;
-    file.seek(SeekFrom::Start(0))?;
-    file.set_len(0)?;
-    file.write_all(new_content.as_bytes())?;
-    Ok(())
+    super::storage::locked_update(
+        &path,
+        read_root,
+        |root| Ok(serde_json::to_string_pretty(root)?),
+        |root| -> Result<()> {
+            let mut servers = match root.remove("mcpServers") {
+                Some(Value::Object(m)) => m,
+                Some(_) => anyhow::bail!("mcpServers in global mcp.json is not an object"),
+                None => Map::new(),
+            };
+            mutate(&mut servers);
+            root.insert("mcpServers".into(), Value::Object(servers));
+            Ok(())
+        },
+    )?
 }
 
 /// Insert or replace a server in the global `mcp.json` by name. Used by both

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -282,48 +282,20 @@ pub fn resolve_conflict(
     }
 }
 
-/// Open the drift store, lock it exclusively, hand the parsed state to `f`, then
-/// write the (possibly mutated) state back through the same locked handle. The
-/// lock serializes concurrent surface opens (web and TUI) so neither clobbers
-/// the other's snapshot.
+/// Parse the drift store under an exclusive sidecar lock, hand it to `f`, then
+/// persist the (possibly mutated) state atomically while still holding the
+/// lock. The lock serializes concurrent surface opens (web and TUI) so neither
+/// clobbers the other's snapshot; `locked_update` also keeps the store
+/// owner-only, which matters here because it holds the same plaintext secrets
+/// as the user's mcp.json and native configs.
 fn with_locked_state<R>(f: impl FnOnce(&mut McpState) -> R) -> Result<R> {
-    use fs2::FileExt;
-    use std::io::{Read, Seek, SeekFrom, Write};
-
     let path = mcp_state_path()?;
-    if !path.exists() {
-        std::fs::write(&path, "").with_context(|| format!("creating {}", path.display()))?;
-    }
-    // Owner-only: the store holds the same plaintext secrets as the user's
-    // mcp.json and native configs, so it must never widen beyond the owner.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
-    }
-
-    let mut file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(&path)
-        .with_context(|| format!("opening {}", path.display()))?;
-    file.lock_exclusive().context("locking mcp_state.json")?;
-
-    let mut content = String::new();
-    file.read_to_string(&mut content)?;
-    let mut state: McpState = if content.trim().is_empty() {
-        McpState::default()
-    } else {
-        serde_json::from_str(&content).context("parsing mcp_state.json")?
-    };
-
-    let result = f(&mut state);
-
-    let new_content = serde_json::to_string_pretty(&state)?;
-    file.seek(SeekFrom::Start(0))?;
-    file.set_len(0)?;
-    file.write_all(new_content.as_bytes())?;
-    Ok(result)
+    super::storage::locked_update(
+        &path,
+        |content| serde_json::from_str(content).context("parsing mcp_state.json"),
+        |state| Ok(serde_json::to_string_pretty(state)?),
+        |state| Ok::<_, anyhow::Error>(f(state)),
+    )?
 }
 
 #[cfg(test)]

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -147,6 +147,23 @@ fn profile_path(profile: &str) -> Result<PathBuf> {
     Ok(get_profile_dir(profile)?.join("projects.json"))
 }
 
+fn registry_path(profile: &str, scope: ProjectScope) -> Result<PathBuf> {
+    match scope {
+        ProjectScope::Global => global_path(),
+        ProjectScope::Profile => profile_path(profile),
+    }
+}
+
+/// Parse a registry file's content, stamping the (non-persisted) scope on
+/// every entry so callers see where each project came from.
+fn parse_projects(content: &str, scope: ProjectScope) -> Result<Vec<Project>> {
+    let mut projects: Vec<Project> = serde_json::from_str(content)?;
+    for p in &mut projects {
+        p.scope = scope;
+    }
+    Ok(projects)
+}
+
 fn read_file(path: &Path, scope: ProjectScope) -> Result<Vec<Project>> {
     if !path.exists() {
         return Ok(Vec::new());
@@ -155,11 +172,7 @@ fn read_file(path: &Path, scope: ProjectScope) -> Result<Vec<Project>> {
     if content.trim().is_empty() {
         return Ok(Vec::new());
     }
-    let mut projects: Vec<Project> = serde_json::from_str(&content)?;
-    for p in &mut projects {
-        p.scope = scope;
-    }
-    Ok(projects)
+    parse_projects(&content, scope)
 }
 
 fn write_file(path: &Path, projects: &[Project]) -> Result<()> {
@@ -285,11 +298,25 @@ pub fn unpopulated_projects(
 
 /// Replace the contents of one scope's registry file.
 pub fn save_scope(profile: &str, scope: ProjectScope, projects: &[Project]) -> Result<()> {
-    let path = match scope {
-        ProjectScope::Global => global_path()?,
-        ProjectScope::Profile => profile_path(profile)?,
-    };
-    write_file(&path, projects)
+    write_file(&registry_path(profile, scope)?, projects)
+}
+
+/// Read-modify-write one scope's registry under the file's sidecar lock, so
+/// two concurrent mutators (e.g. parallel `aoe project add`) cannot each do
+/// load -> check -> save and silently drop the other's registration.
+fn locked_update_scope<R>(
+    profile: &str,
+    scope: ProjectScope,
+    mutate: impl FnOnce(&mut Vec<Project>) -> std::result::Result<R, RegistryError>,
+) -> std::result::Result<R, RegistryError> {
+    let path = registry_path(profile, scope)?;
+    super::storage::locked_update(
+        &path,
+        |content| parse_projects(content, scope),
+        |projects| Ok(serde_json::to_string_pretty(projects)?),
+        mutate,
+    )
+    .map_err(RegistryError::Other)?
 }
 
 /// Append a project to the given scope.
@@ -311,58 +338,54 @@ pub fn add(
     let canonical = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
     project.path = canonical.to_string_lossy().to_string();
 
-    let mut existing = match scope {
-        ProjectScope::Global => load_global().map_err(RegistryError::Other)?,
-        ProjectScope::Profile => load_profile(profile).map_err(RegistryError::Other)?,
-    };
-
-    for p in &existing {
-        if p.name.eq_ignore_ascii_case(&project.name) {
-            return Err(RegistryError::Conflict(format!(
-                "Project '{}' already registered in {} scope (as '{}')",
-                project.name,
-                scope.as_str(),
-                p.name,
-            )));
-        }
-        if canonical_key(&p.path) == canonical_key(&project.path) {
-            return Err(RegistryError::Conflict(format!(
-                "Path '{}' already registered as '{}' in {} scope",
-                project.path,
-                p.name,
-                scope.as_str()
-            )));
-        }
-    }
-
-    if !allow_override {
-        let other_scope = match scope {
-            ProjectScope::Global => ProjectScope::Profile,
-            ProjectScope::Profile => ProjectScope::Global,
-        };
-        let other = match other_scope {
-            ProjectScope::Global => load_global().unwrap_or_default(),
-            ProjectScope::Profile => load_profile(profile).unwrap_or_default(),
-        };
-        for p in &other {
+    locked_update_scope(profile, scope, |existing| {
+        for p in existing.iter() {
+            if p.name.eq_ignore_ascii_case(&project.name) {
+                return Err(RegistryError::Conflict(format!(
+                    "Project '{}' already registered in {} scope (as '{}')",
+                    project.name,
+                    scope.as_str(),
+                    p.name,
+                )));
+            }
             if canonical_key(&p.path) == canonical_key(&project.path) {
                 return Err(RegistryError::Conflict(format!(
-                    "Path '{}' is already registered as '{}' in {} scope.\n\
-                     Tip: remove it first with `aoe project remove {} --scope {}`,\n\
-                     or pass `--allow-override` to keep both entries (the profile entry shadows the global entry in merged views).",
+                    "Path '{}' already registered as '{}' in {} scope",
                     project.path,
                     p.name,
-                    other_scope.as_str(),
-                    p.name,
-                    other_scope.as_str(),
+                    scope.as_str()
                 )));
             }
         }
-    }
 
-    existing.push(project.clone());
-    save_scope(profile, scope, &existing).map_err(RegistryError::Other)?;
-    Ok(project)
+        if !allow_override {
+            let other_scope = match scope {
+                ProjectScope::Global => ProjectScope::Profile,
+                ProjectScope::Profile => ProjectScope::Global,
+            };
+            let other = match other_scope {
+                ProjectScope::Global => load_global().unwrap_or_default(),
+                ProjectScope::Profile => load_profile(profile).unwrap_or_default(),
+            };
+            for p in &other {
+                if canonical_key(&p.path) == canonical_key(&project.path) {
+                    return Err(RegistryError::Conflict(format!(
+                        "Path '{}' is already registered as '{}' in {} scope.\n\
+                         Tip: remove it first with `aoe project remove {} --scope {}`,\n\
+                         or pass `--allow-override` to keep both entries (the profile entry shadows the global entry in merged views).",
+                        project.path,
+                        p.name,
+                        other_scope.as_str(),
+                        p.name,
+                        other_scope.as_str(),
+                    )));
+                }
+            }
+        }
+
+        existing.push(project.clone());
+        Ok(project)
+    })
 }
 
 /// Remove the entry matching `name_or_path` from the given scope. Returns the
@@ -372,27 +395,23 @@ pub fn remove(
     scope: ProjectScope,
     name_or_path: &str,
 ) -> std::result::Result<Project, RegistryError> {
-    let mut existing = match scope {
-        ProjectScope::Global => load_global().map_err(RegistryError::Other)?,
-        ProjectScope::Profile => load_profile(profile).map_err(RegistryError::Other)?,
-    };
-
     let canonical_target = canonical_key(name_or_path);
-    let idx = existing
-        .iter()
-        .position(|p| {
-            p.name.eq_ignore_ascii_case(name_or_path) || canonical_key(&p.path) == canonical_target
-        })
-        .ok_or_else(|| {
-            RegistryError::NotFound(format!(
-                "No project '{}' in {} scope",
-                name_or_path,
-                scope.as_str()
-            ))
-        })?;
-    let removed = existing.remove(idx);
-    save_scope(profile, scope, &existing).map_err(RegistryError::Other)?;
-    Ok(removed)
+    locked_update_scope(profile, scope, |existing| {
+        let idx = existing
+            .iter()
+            .position(|p| {
+                p.name.eq_ignore_ascii_case(name_or_path)
+                    || canonical_key(&p.path) == canonical_target
+            })
+            .ok_or_else(|| {
+                RegistryError::NotFound(format!(
+                    "No project '{}' in {} scope",
+                    name_or_path,
+                    scope.as_str()
+                ))
+            })?;
+        Ok(existing.remove(idx))
+    })
 }
 
 /// Set or clear the default base branch on the entry matching `name_or_path`

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -464,63 +464,40 @@ fn is_repo_trusted_normalized(
 /// versa. A single approval dialog passes `Some` for every surface it showed.
 ///
 /// Uses file locking to prevent concurrent writes from clobbering each other
-/// (e.g. multiple sessions being created simultaneously). Writes through the
-/// locked file handle to ensure the lock is effective.
+/// (e.g. multiple sessions being created simultaneously).
 pub fn trust_repo(
     project_path: &Path,
     hooks_hash: Option<&str>,
     mcp_hash: Option<&str>,
 ) -> Result<()> {
-    use fs2::FileExt;
-    use std::io::{Read, Seek, SeekFrom, Write};
-
     let normalized = normalize_path(project_path);
     let path = trusted_repos_path()?;
 
-    // Ensure the file exists so we can lock it
-    if !path.exists() {
-        fs::write(&path, "")?;
-    }
+    super::storage::locked_update(
+        &path,
+        |content| toml::from_str(content).context("Failed to parse trusted_repos.toml"),
+        |trusted: &TrustedRepos| Ok(toml::to_string_pretty(trusted)?),
+        |trusted| {
+            // Preserve the surface not being updated by carrying its existing hash.
+            let existing = trusted.repos.iter().find(|r| r.path == normalized);
+            let hooks_final = hooks_hash
+                .map(str::to_string)
+                .or_else(|| existing.and_then(|e| e.hooks_hash.clone()));
+            let mcp_final = mcp_hash
+                .map(str::to_string)
+                .or_else(|| existing.and_then(|e| e.mcp_hash.clone()));
 
-    let mut lock_file = fs::OpenOptions::new().read(true).write(true).open(&path)?;
-    lock_file
-        .lock_exclusive()
-        .context("Failed to acquire lock on trusted_repos.toml")?;
+            trusted.repos.retain(|r| r.path != normalized);
 
-    // Read through the locked handle to avoid a separate file descriptor race
-    let mut content = String::new();
-    lock_file.read_to_string(&mut content)?;
-
-    let mut trusted: TrustedRepos = if content.trim().is_empty() {
-        TrustedRepos::default()
-    } else {
-        toml::from_str(&content).context("Failed to parse trusted_repos.toml")?
-    };
-
-    // Preserve the surface not being updated by carrying its existing hash.
-    let existing = trusted.repos.iter().find(|r| r.path == normalized);
-    let hooks_final = hooks_hash
-        .map(str::to_string)
-        .or_else(|| existing.and_then(|e| e.hooks_hash.clone()));
-    let mcp_final = mcp_hash
-        .map(str::to_string)
-        .or_else(|| existing.and_then(|e| e.mcp_hash.clone()));
-
-    trusted.repos.retain(|r| r.path != normalized);
-
-    trusted.repos.push(TrustedRepo {
-        path: normalized,
-        hooks_hash: hooks_final,
-        mcp_hash: mcp_final,
-        trusted_at: chrono::Utc::now().to_rfc3339(),
-    });
-
-    let new_content = toml::to_string_pretty(&trusted)?;
-    lock_file.seek(SeekFrom::Start(0))?;
-    lock_file.set_len(0)?;
-    lock_file.write_all(new_content.as_bytes())?;
-
-    Ok(())
+            trusted.repos.push(TrustedRepo {
+                path: normalized,
+                hooks_hash: hooks_final,
+                mcp_hash: mcp_final,
+                trusted_at: chrono::Utc::now().to_rfc3339(),
+            });
+            Ok::<_, anyhow::Error>(())
+        },
+    )?
 }
 
 /// Trust state of one reviewable surface (lifecycle hooks or project MCP). Each

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -168,6 +168,65 @@ pub(crate) fn atomic_write_following_symlinks(path: &Path, content: &[u8]) -> Re
     atomic_write(&resolve_symlink_chain(path)?, content)
 }
 
+/// Serialized read-modify-write of a small standalone data file.
+///
+/// Acquires an exclusive cross-process `flock` on a sidecar
+/// (`<dir>/.<file>.lock`), then, under the lock: reads `path` (missing or
+/// blank content parses to `T::default()`), runs `mutate`, and persists the
+/// result via [`atomic_write`]. The sidecar is deliberate: `atomic_write`
+/// replaces the data file by `rename(2)`, which would leave a lock taken on
+/// the data file itself attached to the orphaned inode, letting the next
+/// writer lock the new inode concurrently.
+///
+/// The file lands owner-only (0o600) on Unix: a fresh file gets tempfile's
+/// 0o600 default via `atomic_write`, and pre-existing files are re-tightened
+/// because some callers store secrets (e.g. `mcp_state.json`).
+///
+/// When `mutate` returns `Err`, the file is left untouched and the error
+/// comes back in the inner `Result`; a mutation may modify `T` before
+/// noticing it must fail, and persisting that half-applied state would
+/// destroy data the caller never meant to touch. The outer `Result` carries
+/// lock, parse, and write failures.
+pub(crate) fn locked_update<T, R, E>(
+    path: &Path,
+    parse: impl FnOnce(&str) -> Result<T>,
+    serialize: impl FnOnce(&T) -> Result<String>,
+    mutate: impl FnOnce(&mut T) -> std::result::Result<R, E>,
+) -> Result<std::result::Result<R, E>>
+where
+    T: Default,
+{
+    let dir = path.parent().ok_or_else(|| {
+        anyhow!(
+            "locked_update needs a path with a parent: {}",
+            path.display()
+        )
+    })?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("locked_update needs a file path: {}", path.display()))?;
+    let lock_name = format!(".{}.lock", file_name.to_string_lossy());
+    let _flock = acquire_storage_flock(dir, &lock_name)?;
+
+    let mut value = match fs::read_to_string(path) {
+        Ok(content) if content.trim().is_empty() => T::default(),
+        Ok(content) => parse(&content)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => T::default(),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
+    };
+
+    let result = mutate(&mut value);
+    if result.is_ok() {
+        atomic_write(path, serialize(&value)?.as_bytes())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        }
+    }
+    Ok(result)
+}
+
 /// Process-wide registry of per-profile save mutexes. Every `Storage::new` for
 /// a given profile name resolves to the same `Arc<Mutex<()>>`, so independent
 /// `Storage` handles in different parts of the process serialise correctly.
@@ -738,6 +797,102 @@ mod tests {
         std::env::set_var("HOME", temp);
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    }
+
+    fn parse_u64(s: &str) -> Result<u64> {
+        Ok(s.trim().parse::<u64>()?)
+    }
+
+    fn serialize_u64(v: &u64) -> Result<String> {
+        Ok(v.to_string())
+    }
+
+    #[test]
+    fn locked_update_missing_file_starts_from_default() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("counter.txt");
+        let seen = locked_update(&path, parse_u64, serialize_u64, |v| {
+            let seen = *v;
+            *v += 1;
+            Ok::<_, anyhow::Error>(seen)
+        })
+        .unwrap()
+        .unwrap();
+        assert_eq!(seen, 0, "missing file must parse as T::default()");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "1");
+    }
+
+    #[test]
+    fn locked_update_round_trips_existing_content() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("counter.txt");
+        std::fs::write(&path, "41").unwrap();
+        locked_update(&path, parse_u64, serialize_u64, |v| {
+            *v += 1;
+            Ok::<_, anyhow::Error>(())
+        })
+        .unwrap()
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "42");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "data file must land owner-only");
+        }
+    }
+
+    #[test]
+    fn locked_update_concurrent_writers_lose_no_updates() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("counter.txt");
+        const THREADS: usize = 4;
+        const INCREMENTS: usize = 25;
+
+        let mut handles = Vec::new();
+        for _ in 0..THREADS {
+            let path = path.clone();
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..INCREMENTS {
+                    locked_update(&path, parse_u64, serialize_u64, |v| {
+                        *v += 1;
+                        Ok::<_, anyhow::Error>(())
+                    })
+                    .unwrap()
+                    .unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            (THREADS * INCREMENTS).to_string(),
+            "every increment must land; the sidecar flock serializes read-modify-write"
+        );
+    }
+
+    #[test]
+    fn locked_update_failed_mutation_leaves_file_untouched() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("counter.txt");
+        std::fs::write(&path, "41").unwrap();
+
+        let inner = locked_update(&path, parse_u64, serialize_u64, |v| {
+            *v += 1;
+            Err::<(), _>(anyhow!("validation failed after mutating"))
+        })
+        .unwrap();
+
+        assert!(inner.is_err());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "41",
+            "a failed mutation must not persist half-applied state"
+        );
     }
 
     #[cfg(unix)]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -187,6 +187,12 @@ pub(crate) fn atomic_write_following_symlinks(path: &Path, content: &[u8]) -> Re
 /// noticing it must fail, and persisting that half-applied state would
 /// destroy data the caller never meant to touch. The outer `Result` carries
 /// lock, parse, and write failures.
+///
+/// Symlinks at `path` are resolved up front and everything (sidecar lock,
+/// read, write) operates on the target: users symlink these files into
+/// dotfile repos, and a rename over the symlink would replace it with a
+/// regular file; locking the target also keeps two processes that reach the
+/// same file through different symlink paths mutually exclusive.
 pub(crate) fn locked_update<T, R, E>(
     path: &Path,
     parse: impl FnOnce(&str) -> Result<T>,
@@ -196,6 +202,7 @@ pub(crate) fn locked_update<T, R, E>(
 where
     T: Default,
 {
+    let path = &resolve_symlink_chain(path)?;
     let dir = path.parent().ok_or_else(|| {
         anyhow!(
             "locked_update needs a path with a parent: {}",
@@ -873,6 +880,32 @@ mod tests {
             (THREADS * INCREMENTS).to_string(),
             "every increment must land; the sidecar flock serializes read-modify-write"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn locked_update_preserves_symlinks() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("real-counter.txt");
+        std::fs::write(&target, "41").unwrap();
+        let link = tmp.path().join("counter.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        locked_update(&link, parse_u64, serialize_u64, |v| {
+            *v += 1;
+            Ok::<_, anyhow::Error>(())
+        })
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink must survive; a rename over it would desync dotfile setups"
+        );
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "42");
     }
 
     #[test]

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -96,6 +96,7 @@ impl CreationPoller {
         let data = request.data;
         let hooks = request.hooks;
         let profile = data.profile.clone();
+        let sandbox = data.sandbox;
 
         let existing_titles: Vec<&str> = request
             .existing_instances
@@ -108,25 +109,7 @@ impl CreationPoller {
             .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.as_str()))
             .collect();
 
-        let params = InstanceParams {
-            title: data.title,
-            path: data.path.clone(),
-            group: data.group,
-            tool: data.tool,
-            worktree_enabled: data.worktree_enabled,
-            worktree_branch: data.worktree_branch,
-            create_new_branch: data.create_new_branch,
-            base_branch: data.base_branch,
-            sandbox: data.sandbox,
-            sandbox_image: data.sandbox_image,
-            yolo_mode: data.yolo_mode,
-            extra_env: data.extra_env,
-            extra_args: data.extra_args,
-            command_override: data.command_override,
-            extra_repo_paths: data.extra_repo_paths,
-            scratch: data.scratch,
-            fork_seed: data.fork_seed,
-        };
+        let params = InstanceParams::from(data);
 
         let build_result =
             match builder::build_instance(params, &existing_titles, &existing_branches, &profile) {
@@ -153,7 +136,7 @@ impl CreationPoller {
         // Execute on_create hooks after worktree setup, before starting
         if has_on_create {
             let hooks = hooks.as_ref().unwrap();
-            if data.sandbox {
+            if sandbox {
                 // Ensure the container is running so we can exec hooks inside it.
                 // Don't create the tmux session yet -- that happens at attach time
                 // where the terminal size is available.
@@ -203,7 +186,7 @@ impl CreationPoller {
         // This prevents blocking the UI thread when the session is first attached.
         if has_on_launch {
             let hooks = hooks.as_ref().unwrap();
-            if data.sandbox {
+            if sandbox {
                 if !container_started {
                     if let Err(e) = instance.get_container_for_instance() {
                         let msg = format!("Container startup warning: {:#}", e);
@@ -237,7 +220,7 @@ impl CreationPoller {
             }
         }
 
-        if data.sandbox && !container_started {
+        if sandbox && !container_started {
             // Only ensure the container is running here if hooks didn't already
             // start it. Don't create the tmux session yet -- that happens at attach time
             // where the terminal size is available.

--- a/src/tui/deletion_poller.rs
+++ b/src/tui/deletion_poller.rs
@@ -1,51 +1,31 @@
 //! Background deletion handler for TUI responsiveness
 
-use std::sync::mpsc;
-use std::thread;
+use std::sync::mpsc::TryRecvError;
 
 use crate::session::deletion::perform_deletion;
 pub use crate::session::deletion::{DeletionRequest, DeletionResult};
+use crate::tui::worker::Worker;
 
 pub struct DeletionPoller {
-    request_tx: mpsc::Sender<DeletionRequest>,
-    result_rx: mpsc::Receiver<DeletionResult>,
-    _handle: thread::JoinHandle<()>,
+    worker: Worker<DeletionRequest, DeletionResult>,
 }
 
 impl DeletionPoller {
     pub fn new() -> Self {
-        let (request_tx, request_rx) = mpsc::channel::<DeletionRequest>();
-        let (result_tx, result_rx) = mpsc::channel::<DeletionResult>();
-
-        let handle = thread::spawn(move || {
-            Self::deletion_loop(request_rx, result_tx);
-        });
-
         Self {
-            request_tx,
-            result_rx,
-            _handle: handle,
-        }
-    }
-
-    fn deletion_loop(
-        request_rx: mpsc::Receiver<DeletionRequest>,
-        result_tx: mpsc::Sender<DeletionResult>,
-    ) {
-        while let Ok(request) = request_rx.recv() {
-            let result = perform_deletion(&request);
-            if result_tx.send(result).is_err() {
-                break;
-            }
+            worker: Worker::spawn("aoe-deletion-poller", |request| perform_deletion(&request)),
         }
     }
 
     pub fn request_deletion(&self, request: DeletionRequest) {
-        let _ = self.request_tx.send(request);
+        self.worker.request(request);
     }
 
-    pub fn try_recv_result(&self) -> Option<DeletionResult> {
-        self.result_rx.try_recv().ok()
+    /// Non-blocking poll for a completed deletion. Surfaces `Disconnected`
+    /// (see `Worker::try_recv`) so the caller can recover rows stuck on
+    /// `Status::Deleting` when the worker dies.
+    pub fn try_recv_result(&self) -> Result<DeletionResult, TryRecvError> {
+        self.worker.try_recv()
     }
 }
 
@@ -84,22 +64,21 @@ mod tests {
 
         let mut result = None;
         for _ in 0..50 {
-            result = poller.try_recv_result();
-            if result.is_some() {
+            if let Ok(r) = poller.try_recv_result() {
+                result = Some(r);
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
         }
-        assert!(result.is_some(), "Timed out waiting for deletion result");
+        let result = result.expect("Timed out waiting for deletion result");
 
-        let result = result.unwrap();
         assert_eq!(result.session_id, session_id);
         assert!(result.success);
     }
 
     #[test]
-    fn test_deletion_poller_try_recv_returns_none_when_empty() {
+    fn test_deletion_poller_try_recv_returns_empty_when_idle() {
         let poller = DeletionPoller::new();
-        assert!(poller.try_recv_result().is_none());
+        assert!(matches!(poller.try_recv_result(), Err(TryRecvError::Empty)));
     }
 }

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -72,6 +72,16 @@ pub enum DialogResult<T> {
     Submit(T),
 }
 
+/// Insert pasted text into a single-line `tui_input::Input`, stripping
+/// newlines so a multi-line paste cannot act as a submit or scatter across
+/// fields. Shared by every dialog/settings paste handler that targets an
+/// `Input`; multi-line `TextArea` targets keep their own handling.
+pub fn paste_into_input(input: &mut tui_input::Input, text: &str) {
+    for ch in text.chars().filter(|c| *c != '\n' && *c != '\r') {
+        input.handle(tui_input::InputRequest::InsertChar(ch));
+    }
+}
+
 /// Center a dialog of given size within an area, clamping to fit.
 pub fn centered_rect(
     area: ratatui::layout::Rect,

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -116,6 +116,36 @@ pub struct NewSessionData {
     pub fork_seed: Option<crate::session::ForkSeed>,
 }
 
+/// Single conversion point for turning wizard output into builder input.
+/// Both creation paths (the synchronous `create_session` and the background
+/// `CreationPoller`) go through this, so a newly added field cannot be
+/// forwarded on one path and silently dropped on the other (the bug class
+/// behind the hardcoded `fork_seed: None` regression). `profile` is the one
+/// field deliberately not carried: builders take it as a separate argument.
+impl From<NewSessionData> for crate::session::builder::InstanceParams {
+    fn from(data: NewSessionData) -> Self {
+        Self {
+            title: data.title,
+            path: data.path,
+            group: data.group,
+            tool: data.tool,
+            worktree_enabled: data.worktree_enabled,
+            worktree_branch: data.worktree_branch,
+            create_new_branch: data.create_new_branch,
+            base_branch: data.base_branch,
+            sandbox: data.sandbox,
+            sandbox_image: data.sandbox_image,
+            yolo_mode: data.yolo_mode,
+            extra_env: data.extra_env,
+            extra_args: data.extra_args,
+            command_override: data.command_override,
+            extra_repo_paths: data.extra_repo_paths,
+            scratch: data.scratch,
+            fork_seed: data.fork_seed,
+        }
+    }
+}
+
 pub struct NewSessionDialog {
     pub(super) profile: String,
     pub(super) available_profiles: Vec<String>,
@@ -1957,8 +1987,6 @@ impl NewSessionDialog {
     }
 
     pub fn handle_paste(&mut self, text: &str) {
-        let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-
         // Route to the active sub-mode input if one is open
         let target: &mut Input = if let Some(ref mut input) = self.env_editing_input {
             input
@@ -1977,9 +2005,7 @@ impl NewSessionDialog {
         } else {
             self.current_input_mut()
         };
-        for ch in sanitized.chars() {
-            target.handle(tui_input::InputRequest::InsertChar(ch));
-        }
+        super::paste_into_input(target, text);
     }
 
     fn build_submit_result(&self) -> DialogResult<NewSessionData> {

--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -441,10 +441,7 @@ impl RenameDialog {
 
     pub fn handle_paste(&mut self, text: &str) {
         if let Some(input) = self.focused_input() {
-            let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-            for ch in sanitized.chars() {
-                input.handle(tui_input::InputRequest::InsertChar(ch));
-            }
+            super::paste_into_input(input, text);
         }
     }
 

--- a/src/tui/dialogs/worktree_name.rs
+++ b/src/tui/dialogs/worktree_name.rs
@@ -86,11 +86,7 @@ impl WorktreeNameDialog {
         if self.toggle_focused() {
             return;
         }
-        let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-        for ch in sanitized.chars() {
-            self.new_name
-                .handle(tui_input::InputRequest::InsertChar(ch));
-        }
+        super::paste_into_input(&mut self.new_name, text);
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2637,14 +2637,30 @@ impl HomeView {
     /// Apply any pending status updates from the background poller.
     /// Returns true if updates were applied.
     pub fn apply_status_updates(&mut self) -> bool {
-        if let Some(updates) = self.status_poller.try_recv_updates() {
-            for update in updates {
-                self.apply_one_status_update(update);
+        use std::sync::mpsc::TryRecvError;
+
+        match self.status_poller.try_recv_updates() {
+            Ok(updates) => {
+                for update in updates {
+                    self.apply_one_status_update(update);
+                }
+                self.pending_status_refresh = false;
+                true
             }
-            self.pending_status_refresh = false;
-            return true;
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                // The worker thread is gone (a panic in poll_statuses_once).
+                // Without a respawn, pending_status_refresh stays set and
+                // request_status_refresh never fires again, freezing every
+                // session's live status for the rest of the process.
+                tracing::error!(
+                    target: "tui.home",
+                    "status poller worker gone; respawning a fresh poller",
+                );
+                self.reset_status_refresh();
+                true
+            }
         }
-        false
     }
 
     /// Apply a single status update from the poller. Extracted from the

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2804,69 +2804,136 @@ impl HomeView {
 
     pub fn apply_deletion_results(&mut self) -> bool {
         use crate::session::Status;
+        use std::sync::mpsc::TryRecvError;
 
-        if let Some(result) = self.deletion_poller.try_recv_result() {
-            if result.success {
-                // Captured before the remove (the instance is still in
-                // `self.instances`); recorded only after the deletion is
-                // durably saved, so a failed save leaves no tombstone (#2141).
-                let recent_entry = self
+        match self.deletion_poller.try_recv_result() {
+            Ok(result) => {
+                if result.success {
+                    // Captured before the remove (the instance is still in
+                    // `self.instances`); recorded only after the deletion is
+                    // durably saved, so a failed save leaves no tombstone (#2141).
+                    let recent_entry = self
+                        .instances
+                        .get(&result.session_id)
+                        .and_then(crate::session::recent_project_entry_for);
+                    self.remove_instance(&result.session_id);
+                    self.rebuild_group_trees();
+
+                    if let Err(e) = self.save() {
+                        tracing::error!(target: "tui.home", "Failed to save after deletion: {}", e);
+                    } else if let Some(entry) = recent_entry {
+                        // Best-effort; keeps the project in the wizard Recent tab.
+                        if let Err(e) = crate::session::record_recent_project(entry) {
+                            tracing::warn!(target: "tui.home",
+                                "recording recent project after delete failed: {e}");
+                        }
+                    }
+                    if let Err(e) = self.reload() {
+                        tracing::warn!(target: "tui.home", "Failed to reload session state: {e}");
+                    }
+                } else {
+                    let error = if result.errors.is_empty() {
+                        None
+                    } else {
+                        Some(result.errors.join("; "))
+                    };
+                    self.mutate_instance(&result.session_id, |inst| {
+                        inst.status = Status::Error;
+                        inst.last_error = error;
+                    });
+                }
+                true
+            }
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                // The single worker thread is gone (a panic in
+                // perform_deletion dropped result_tx). Deleting rows are
+                // frozen for the StatusPoller (tier 0), so without this they
+                // would sit on "Deleting" forever. Mirrors the Disconnected
+                // handling in `apply_restart_results`.
+                let stuck: Vec<String> = self
                     .instances
-                    .get(&result.session_id)
-                    .and_then(crate::session::recent_project_entry_for);
-                self.remove_instance(&result.session_id);
-                self.rebuild_group_trees();
-
+                    .values()
+                    .filter(|i| i.status == Status::Deleting)
+                    .map(|i| i.id.clone())
+                    .collect();
+                if stuck.is_empty() {
+                    return false;
+                }
+                tracing::error!(
+                    target: "tui.home",
+                    rows = stuck.len(),
+                    "deletion poller worker gone; marking stuck Deleting rows Error",
+                );
+                for id in &stuck {
+                    self.mutate_instance(id, |inst| {
+                        inst.status = Status::Error;
+                        inst.last_error =
+                            Some("Deletion worker crashed; session was not deleted".to_string());
+                    });
+                }
                 if let Err(e) = self.save() {
                     tracing::error!(target: "tui.home", "Failed to save after deletion: {}", e);
-                } else if let Some(entry) = recent_entry {
-                    // Best-effort; keeps the project in the wizard Recent tab.
-                    if let Err(e) = crate::session::record_recent_project(entry) {
-                        tracing::warn!(target: "tui.home",
-                            "recording recent project after delete failed: {e}");
-                    }
                 }
-                if let Err(e) = self.reload() {
-                    tracing::warn!(target: "tui.home", "Failed to reload session state: {e}");
-                }
-            } else {
-                let error = if result.errors.is_empty() {
-                    None
-                } else {
-                    Some(result.errors.join("; "))
-                };
-                self.mutate_instance(&result.session_id, |inst| {
-                    inst.status = Status::Error;
-                    inst.last_error = error;
-                });
+                true
             }
-            return true;
         }
-        false
     }
 
     /// Apply the result of a background stop. Returns true if an instance was
     /// updated so the caller can trigger a redraw.
     pub fn apply_stop_results(&mut self) -> bool {
         use crate::session::Status;
+        use std::sync::mpsc::TryRecvError;
 
-        if let Some(result) = self.stop_poller.try_recv_result() {
-            if result.success {
-                // Status was already set to Stopped optimistically when the
-                // stop was requested; reassert it in case the disk reload or
-                // a race changed it, and clear any stale error.
-                self.set_instance_error(&result.session_id, None);
-                self.set_instance_status(&result.session_id, Status::Stopped);
-            } else {
-                self.set_instance_error(&result.session_id, result.error);
-                self.set_instance_status(&result.session_id, Status::Error);
+        match self.stop_poller.try_recv_result() {
+            Ok(result) => {
+                if result.success {
+                    // Status was already set to Stopped optimistically when the
+                    // stop was requested; reassert it in case the disk reload or
+                    // a race changed it, and clear any stale error.
+                    self.set_instance_error(&result.session_id, None);
+                    self.set_instance_status(&result.session_id, Status::Stopped);
+                } else {
+                    self.set_instance_error(&result.session_id, result.error);
+                    self.set_instance_status(&result.session_id, Status::Error);
+                }
+                if let Err(e) = self.save() {
+                    tracing::error!(target: "tui.home", "Failed to save after stop: {}", e);
+                }
+                true
             }
-            if let Err(e) = self.save() {
-                tracing::error!(target: "tui.home", "Failed to save after stop: {}", e);
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                // The single worker thread is gone (a panic in perform_stop
+                // dropped result_tx). Rows were optimistically marked Stopped
+                // at request time and Stopped is frozen for the StatusPoller
+                // (tier 0), so a lost failure result would otherwise show
+                // "Stopped" over a still-running container forever; only the
+                // poller's in-flight set knows which rows those are. Mirrors
+                // the Disconnected handling in `apply_restart_results`.
+                let stuck = self.stop_poller.take_pending();
+                if stuck.is_empty() {
+                    return false;
+                }
+                tracing::error!(
+                    target: "tui.home",
+                    rows = stuck.len(),
+                    "stop poller worker gone; marking in-flight stops Error",
+                );
+                for id in &stuck {
+                    self.set_instance_error(
+                        id,
+                        Some("Stop worker crashed; the session may not have stopped".to_string()),
+                    );
+                    self.set_instance_status(id, Status::Error);
+                }
+                if let Err(e) = self.save() {
+                    tracing::error!(target: "tui.home", "Failed to save after stop: {}", e);
+                }
+                true
             }
-            return true;
         }
-        false
     }
 
     /// Apply any pending session ID updates from background pollers.

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1,12 +1,29 @@
 //! Session operations for HomeView (create, delete, rename)
 
 use crate::session::builder::{self, InstanceParams};
-use crate::session::{list_profiles, GroupTree, Item, Status, Storage};
+use crate::session::{list_profiles, GroupTree, Instance, Item, Status, Storage};
 use crate::tui::deletion_poller::DeletionRequest;
 use crate::tui::dialogs::{DeleteOptions, GroupDeleteOptions, InfoDialog, NewSessionData};
 use crate::tui::restart_poller::RestartRequest;
 
 use super::HomeView;
+
+/// Membership predicate for a manual group: matches instances whose
+/// `group_path` equals `group_path` or nests beneath it, optionally scoped to
+/// a single owning profile (`None` matches every profile). `prefix` must be
+/// `"{group_path}/"`; it is taken as an argument rather than computed here
+/// because `group_has_managed_worktrees` / `group_has_containers` already
+/// receive it precomputed from their call sites.
+fn group_membership<'a>(
+    group_path: &'a str,
+    prefix: &'a str,
+    profile: Option<&'a str>,
+) -> impl Fn(&Instance) -> bool + 'a {
+    move |i: &Instance| {
+        (i.group_path == group_path || i.group_path.starts_with(prefix))
+            && profile.is_none_or(|p| i.source_profile == p)
+    }
+}
 
 /// Compact human readable label for the snooze status line (`"30 min"`,
 /// `"1 hr"`, `"24 hr"`, `"2 hr 30 min"`). The picker only ever submits
@@ -239,25 +256,7 @@ impl HomeView {
             .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.as_str()))
             .collect();
 
-        let params = InstanceParams {
-            title: data.title,
-            path: data.path,
-            group: data.group,
-            tool: data.tool,
-            worktree_enabled: data.worktree_enabled,
-            worktree_branch: data.worktree_branch,
-            create_new_branch: data.create_new_branch,
-            base_branch: data.base_branch,
-            sandbox: data.sandbox,
-            sandbox_image: data.sandbox_image,
-            yolo_mode: data.yolo_mode,
-            extra_env: data.extra_env,
-            extra_args: data.extra_args,
-            command_override: data.command_override,
-            extra_repo_paths: data.extra_repo_paths,
-            scratch: data.scratch,
-            fork_seed: data.fork_seed,
-        };
+        let params = InstanceParams::from(data);
 
         let build_result = builder::build_instance(
             params,
@@ -557,15 +556,11 @@ impl HomeView {
         if let Some(group_path) = self.selected_group.take() {
             let owning_profile = self.selected_group_profile.take();
             let prefix = format!("{}/", group_path);
+            let is_member = group_membership(&group_path, &prefix, owning_profile.as_deref());
             let ids_to_clear: Vec<String> = self
                 .instances
                 .values()
-                .filter(|i| {
-                    (i.group_path == group_path || i.group_path.starts_with(&prefix))
-                        && owning_profile
-                            .as_ref()
-                            .is_none_or(|p| p == &i.source_profile)
-                })
+                .filter(|i| is_member(i))
                 .map(|i| i.id.clone())
                 .collect();
             self.bulk_apply_user_action(&ids_to_clear, |inst| {
@@ -596,16 +591,15 @@ impl HomeView {
             let owning_profile = self.selected_group_profile.take();
             let prefix = format!("{}/", group_path);
 
-            let sessions_to_delete: Vec<String> = self
-                .instances()
-                .filter(|i| {
-                    (i.group_path == group_path || i.group_path.starts_with(&prefix))
-                        && owning_profile
-                            .as_ref()
-                            .is_none_or(|p| p == &i.source_profile)
-                })
-                .map(|i| i.id.clone())
-                .collect();
+            // Scoped so the borrow of `group_path` / `owning_profile` ends
+            // before the restart-in-flight bail-out moves them back into self.
+            let sessions_to_delete: Vec<String> = {
+                let is_member = group_membership(&group_path, &prefix, owning_profile.as_deref());
+                self.instances()
+                    .filter(|i| is_member(i))
+                    .map(|i| i.id.clone())
+                    .collect()
+            };
 
             // Refuse the whole group delete if any member is mid-restart (same
             // concurrent-docker race as delete_selected). Restore the selection
@@ -714,11 +708,9 @@ impl HomeView {
         prefix: &str,
         owning_profile: Option<&str>,
     ) -> bool {
-        self.instances().any(|i| {
-            (i.group_path == group_path || i.group_path.starts_with(prefix))
-                && owning_profile.is_none_or(|p| i.source_profile == p)
-                && i.has_managed_worktree_or_workspace()
-        })
+        let is_member = group_membership(group_path, prefix, owning_profile);
+        self.instances()
+            .any(|i| is_member(i) && i.has_managed_worktree_or_workspace())
     }
 
     pub(super) fn group_has_containers(
@@ -727,11 +719,9 @@ impl HomeView {
         prefix: &str,
         owning_profile: Option<&str>,
     ) -> bool {
-        self.instances().any(|i| {
-            (i.group_path == group_path || i.group_path.starts_with(prefix))
-                && owning_profile.is_none_or(|p| i.source_profile == p)
-                && i.sandbox_info.as_ref().is_some_and(|s| s.enabled)
-        })
+        let is_member = group_membership(group_path, prefix, owning_profile);
+        self.instances()
+            .any(|i| is_member(i) && i.sandbox_info.as_ref().is_some_and(|s| s.enabled))
     }
 
     /// Rename a group in-place: the old group path is removed and all sessions and
@@ -779,13 +769,11 @@ impl HomeView {
         let old_prefix = format!("{}/", ctx.old_path);
 
         // Collect sessions belonging to this group and its descendants
+        let is_member = group_membership(&ctx.old_path, &old_prefix, Some(&ctx.old_profile));
         let affected_ids: Vec<String> = self
             .instances
             .values()
-            .filter(|i| {
-                (i.group_path == ctx.old_path || i.group_path.starts_with(&old_prefix))
-                    && i.source_profile == ctx.old_profile
-            })
+            .filter(|i| is_member(i))
             .map(|i| i.id.clone())
             .collect();
 
@@ -1554,15 +1542,12 @@ impl HomeView {
             // owning profile the same way `delete_selected_group` does.
             crate::session::config::GroupByMode::Manual => {
                 let prefix = format!("{}/", group_path);
+                let is_member =
+                    group_membership(group_path, &prefix, self.selected_group_profile.as_deref());
                 self.instances
                     .values()
                     .filter(|i| !i.is_archived() && !i.is_trashed())
-                    .filter(|i| i.group_path == group_path || i.group_path.starts_with(&prefix))
-                    .filter(|i| {
-                        self.selected_group_profile
-                            .as_ref()
-                            .is_none_or(|p| p == &i.source_profile)
-                    })
+                    .filter(|i| is_member(i))
                     .map(|i| i.id.clone())
                     .collect()
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -21,6 +21,7 @@ mod stop_poller;
 #[cfg(feature = "serve")]
 pub(crate) mod structured_view;
 pub(crate) mod styles;
+mod worker;
 
 pub use app::*;
 

--- a/src/tui/restart_poller.rs
+++ b/src/tui/restart_poller.rs
@@ -7,53 +7,25 @@
 //! requests go to a worker thread, results come back over a channel the main
 //! loop polls each frame.
 
-use std::sync::mpsc;
-use std::thread;
+use std::sync::mpsc::TryRecvError;
 
 use crate::session::restart::perform_restart;
 pub use crate::session::restart::{RestartRequest, RestartResult};
+use crate::tui::worker::Worker;
 
 pub struct RestartPoller {
-    request_tx: mpsc::Sender<RestartRequest>,
-    result_rx: mpsc::Receiver<RestartResult>,
-    _handle: thread::JoinHandle<()>,
+    worker: Worker<RestartRequest, RestartResult>,
 }
 
 impl RestartPoller {
     pub fn new() -> Self {
-        let (request_tx, request_rx) = mpsc::channel::<RestartRequest>();
-        let (result_tx, result_rx) = mpsc::channel::<RestartResult>();
-
-        let handle = thread::Builder::new()
-            .name("aoe-restart-poller".to_string())
-            .spawn(move || {
-                Self::restart_loop(request_rx, result_tx);
-            })
-            .expect("failed to spawn restart poller thread");
-
         Self {
-            request_tx,
-            result_rx,
-            _handle: handle,
-        }
-    }
-
-    fn restart_loop(
-        request_rx: mpsc::Receiver<RestartRequest>,
-        result_tx: mpsc::Sender<RestartResult>,
-    ) {
-        while let Ok(request) = request_rx.recv() {
-            let result = perform_restart(request);
-            if result_tx.send(result).is_err() {
-                break;
-            }
+            worker: Worker::spawn("aoe-restart-poller", perform_restart),
         }
     }
 
     pub fn request_restart(&self, request: RestartRequest) {
-        if let Err(e) = self.request_tx.send(request) {
-            tracing::warn!(target: "tui.restart_poller", error = %e, "restart request dropped; worker thread unavailable");
-        }
+        self.worker.request(request);
     }
 
     /// Non-blocking poll for a completed restart. Surfaces `Disconnected`
@@ -61,28 +33,14 @@ impl RestartPoller {
     /// `perform_restart`) rather than collapsing it into `None`, so the caller
     /// can clear stuck in-flight state instead of leaving rows pinned on
     /// `Status::Starting` forever.
-    pub fn try_recv_result(&self) -> Result<RestartResult, mpsc::TryRecvError> {
-        self.result_rx.try_recv()
+    pub fn try_recv_result(&self) -> Result<RestartResult, TryRecvError> {
+        self.worker.try_recv()
     }
 
     #[cfg(test)]
     pub(crate) fn with_result_for_test(result: RestartResult) -> Self {
-        let (request_tx, request_rx) = mpsc::channel::<RestartRequest>();
-        let (result_tx, result_rx) = mpsc::channel::<RestartResult>();
-        result_tx.send(result).expect("seed restart result");
-
-        let handle = thread::Builder::new()
-            .name("aoe-restart-poller-test".to_string())
-            .spawn(move || {
-                while request_rx.recv().is_ok() {}
-                drop(result_tx);
-            })
-            .expect("failed to spawn test restart poller thread");
-
         Self {
-            request_tx,
-            result_rx,
-            _handle: handle,
+            worker: Worker::seeded_for_test("aoe-restart-poller-test", result),
         }
     }
 }
@@ -135,9 +93,6 @@ mod tests {
     #[test]
     fn restart_poller_try_recv_returns_empty_when_no_result() {
         let poller = RestartPoller::new();
-        assert!(matches!(
-            poller.try_recv_result(),
-            Err(mpsc::TryRecvError::Empty)
-        ));
+        assert!(matches!(poller.try_recv_result(), Err(TryRecvError::Empty)));
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -709,19 +709,13 @@ impl SettingsView {
         // emit `Paste` events for clipboard input would silently
         // drop pasted search queries.
         if let Some(ref mut input) = self.search_input {
-            let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-            for ch in sanitized.chars() {
-                input.handle(tui_input::InputRequest::InsertChar(ch));
-            }
+            crate::tui::dialogs::paste_into_input(input, text);
             self.search_selected = 0;
             self.recompute_search_hits();
             return;
         }
         if let Some(ref mut input) = self.editing_input {
-            let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-            for ch in sanitized.chars() {
-                input.handle(tui_input::InputRequest::InsertChar(ch));
-            }
+            crate::tui::dialogs::paste_into_input(input, text);
         }
     }
 

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -265,10 +265,12 @@ impl StatusPoller {
         self.worker.request(instances);
     }
 
-    /// Try to receive status updates without blocking.
-    /// Returns None if no updates are available yet.
-    pub fn try_recv_updates(&self) -> Option<Vec<StatusUpdate>> {
-        self.worker.try_recv().ok()
+    /// Try to receive status updates without blocking. Surfaces
+    /// `Disconnected` (see `Worker::try_recv`) so the caller can respawn the
+    /// worker: swallowing it would leave `pending_status_refresh` set
+    /// forever, silently freezing every session's live status.
+    pub fn try_recv_updates(&self) -> Result<Vec<StatusUpdate>, std::sync::mpsc::TryRecvError> {
+        self.worker.try_recv()
     }
 }
 

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -14,13 +14,12 @@
 //!    (Stopped/Deleting) never.
 
 use std::collections::{BTreeSet, HashMap};
-use std::sync::mpsc;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 
 use crate::session::{Instance, Status};
+use crate::tui::worker::Worker;
 
 /// Adaptive polling intervals (in cycles). 0 = never poll.
 const TIER_HOT: u64 = 1;
@@ -246,51 +245,30 @@ pub(super) fn poll_statuses_once(
 
 /// Background thread that polls session status without blocking the UI
 pub struct StatusPoller {
-    request_tx: mpsc::Sender<Vec<Instance>>,
-    result_rx: mpsc::Receiver<Vec<StatusUpdate>>,
-    _handle: thread::JoinHandle<()>,
+    worker: Worker<Vec<Instance>, Vec<StatusUpdate>>,
 }
 
 impl StatusPoller {
     pub fn new() -> Self {
-        let (request_tx, request_rx) = mpsc::channel::<Vec<Instance>>();
-        let (result_tx, result_rx) = mpsc::channel::<Vec<StatusUpdate>>();
-
-        let handle = thread::spawn(move || {
-            Self::polling_loop(request_rx, result_tx);
-        });
-
-        Self {
-            request_tx,
-            result_rx,
-            _handle: handle,
-        }
-    }
-
-    fn polling_loop(
-        request_rx: mpsc::Receiver<Vec<Instance>>,
-        result_tx: mpsc::Sender<Vec<StatusUpdate>>,
-    ) {
+        // The adaptive-tier state lives in the handler closure so it carries
+        // across refresh cycles for the lifetime of the worker thread.
         let mut state = StatusPollState::new();
-
-        while let Ok(instances) = request_rx.recv() {
-            let updates = poll_statuses_once(instances, &mut state);
-
-            if result_tx.send(updates).is_err() {
-                break;
-            }
+        Self {
+            worker: Worker::spawn("aoe-status-poller", move |instances| {
+                poll_statuses_once(instances, &mut state)
+            }),
         }
     }
 
     /// Request a status refresh for all given instances (non-blocking).
     pub fn request_refresh(&self, instances: Vec<Instance>) {
-        let _ = self.request_tx.send(instances);
+        self.worker.request(instances);
     }
 
     /// Try to receive status updates without blocking.
     /// Returns None if no updates are available yet.
     pub fn try_recv_updates(&self) -> Option<Vec<StatusUpdate>> {
-        self.result_rx.try_recv().ok()
+        self.worker.try_recv().ok()
     }
 }
 

--- a/src/tui/stop_poller.rs
+++ b/src/tui/stop_poller.rs
@@ -6,54 +6,51 @@
 //! worker thread, results come back over a channel the main loop polls each
 //! frame.
 
-use std::sync::mpsc;
-use std::thread;
+use std::collections::HashSet;
+use std::sync::mpsc::TryRecvError;
 
 use crate::session::stop::perform_stop;
 pub use crate::session::stop::{StopRequest, StopResult};
+use crate::tui::worker::Worker;
 
 pub struct StopPoller {
-    request_tx: mpsc::Sender<StopRequest>,
-    result_rx: mpsc::Receiver<StopResult>,
-    _handle: thread::JoinHandle<()>,
+    worker: Worker<StopRequest, StopResult>,
+    /// Session ids with a stop in flight. Rows are optimistically marked
+    /// `Stopped` at request time, so if the worker dies (Disconnected) the
+    /// status alone cannot identify which stops were lost; this set can.
+    pending: HashSet<String>,
 }
 
 impl StopPoller {
     pub fn new() -> Self {
-        let (request_tx, request_rx) = mpsc::channel::<StopRequest>();
-        let (result_tx, result_rx) = mpsc::channel::<StopResult>();
-
-        let handle = thread::spawn(move || {
-            Self::stop_loop(request_rx, result_tx);
-        });
-
         Self {
-            request_tx,
-            result_rx,
-            _handle: handle,
+            worker: Worker::spawn("aoe-stop-poller", |request| perform_stop(&request)),
+            pending: HashSet::new(),
         }
     }
 
-    fn stop_loop(request_rx: mpsc::Receiver<StopRequest>, result_tx: mpsc::Sender<StopResult>) {
-        while let Ok(request) = request_rx.recv() {
-            let result = perform_stop(&request);
-            if result_tx.send(result).is_err() {
-                break;
-            }
-        }
+    pub fn request_stop(&mut self, request: StopRequest) {
+        self.pending.insert(request.session_id.clone());
+        self.worker.request(request);
     }
 
-    pub fn request_stop(&self, request: StopRequest) {
-        if let Err(e) = self.request_tx.send(request) {
-            // `perform_stop` is panic-safe, so a send failure means the worker
-            // thread is gone (channel closed at teardown). Log it rather than
-            // dropping silently so a stuck-looking "Stopping" row is traceable.
-            tracing::warn!(target: "tui.stop_poller", error = %e, "stop request dropped; worker thread unavailable");
+    /// Non-blocking poll for a completed stop. Surfaces `Disconnected` (see
+    /// `Worker::try_recv`) so the caller can recover the sessions still in
+    /// [`Self::take_pending`] instead of leaving them looking stopped while
+    /// their container may still be running.
+    pub fn try_recv_result(&mut self) -> Result<StopResult, TryRecvError> {
+        let result = self.worker.try_recv();
+        if let Ok(ref stop) = result {
+            self.pending.remove(&stop.session_id);
         }
+        result
     }
 
-    pub fn try_recv_result(&self) -> Option<StopResult> {
-        self.result_rx.try_recv().ok()
+    /// Drain the in-flight set. Called once the worker is known dead so the
+    /// consumer can transition the affected rows out of their optimistic
+    /// `Stopped` state.
+    pub fn take_pending(&mut self) -> Vec<String> {
+        self.pending.drain().collect()
     }
 }
 
@@ -75,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_stop_poller_channel_communication() {
-        let poller = StopPoller::new();
+        let mut poller = StopPoller::new();
         let instance = create_test_instance();
         let session_id = instance.id.clone();
 
@@ -86,22 +83,38 @@ mod tests {
 
         let mut result = None;
         for _ in 0..50 {
-            result = poller.try_recv_result();
-            if result.is_some() {
+            if let Ok(r) = poller.try_recv_result() {
+                result = Some(r);
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
         }
-        assert!(result.is_some(), "Timed out waiting for stop result");
+        let result = result.expect("Timed out waiting for stop result");
 
-        let result = result.unwrap();
         assert_eq!(result.session_id, session_id);
         assert!(result.success);
+        // The delivered result must clear the in-flight marker.
+        assert!(poller.take_pending().is_empty());
     }
 
     #[test]
-    fn test_stop_poller_try_recv_returns_none_when_empty() {
-        let poller = StopPoller::new();
-        assert!(poller.try_recv_result().is_none());
+    fn test_stop_poller_try_recv_returns_empty_when_idle() {
+        let mut poller = StopPoller::new();
+        assert!(matches!(poller.try_recv_result(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn test_stop_poller_tracks_pending_requests() {
+        let mut poller = StopPoller::new();
+        let instance = create_test_instance();
+        let session_id = instance.id.clone();
+
+        poller.request_stop(StopRequest {
+            session_id: session_id.clone(),
+            instance,
+        });
+
+        assert_eq!(poller.take_pending(), vec![session_id]);
+        assert!(poller.take_pending().is_empty(), "take_pending drains");
     }
 }

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -1,0 +1,179 @@
+//! Generic request/response worker thread for the TUI.
+//!
+//! Long-running operations (docker stop/start, worktree removal, tmux
+//! batch queries) must not run on the UI event loop. Each poller wraps a
+//! `Worker`: requests go to a dedicated named thread, results come back
+//! over a channel the main loop drains each frame.
+
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+type Handler<Req, Res> = Box<dyn FnMut(Req) -> Res + Send>;
+type LoopState<Req, Res> = (mpsc::Receiver<Req>, mpsc::Sender<Res>, Handler<Req, Res>);
+
+pub struct Worker<Req, Res> {
+    name: String,
+    request_tx: mpsc::Sender<Req>,
+    result_rx: mpsc::Receiver<Res>,
+    _handle: thread::JoinHandle<()>,
+}
+
+impl<Req: Send + 'static, Res: Send + 'static> Worker<Req, Res> {
+    /// Spawn a named worker thread running a recv -> handle -> send loop.
+    /// The loop exits when the `Worker` is dropped (the request channel
+    /// disconnects) or when the result channel is gone.
+    pub fn spawn(thread_name: &str, handler: impl FnMut(Req) -> Res + Send + 'static) -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<Req>();
+        let (result_tx, result_rx) = mpsc::channel::<Res>();
+
+        // The loop state is parked in a shared cell so that a failed named
+        // spawn can hand the same channels to a bare `thread::spawn` instead
+        // of panicking (`thread::Builder::spawn` consumes its closure even
+        // on failure, so a plain retry cannot reuse it).
+        let state: Arc<Mutex<Option<LoopState<Req, Res>>>> =
+            Arc::new(Mutex::new(Some((request_rx, result_tx, Box::new(handler)))));
+
+        let run = {
+            let state = Arc::clone(&state);
+            move || Self::run_loop(&state)
+        };
+        let handle = match thread::Builder::new()
+            .name(thread_name.to_string())
+            .spawn(run)
+        {
+            Ok(handle) => handle,
+            Err(e) => {
+                tracing::warn!(
+                    target: "tui.worker",
+                    worker = thread_name,
+                    error = %e,
+                    "named worker spawn failed; falling back to unnamed thread",
+                );
+                thread::spawn(move || Self::run_loop(&state))
+            }
+        };
+
+        Self {
+            name: thread_name.to_string(),
+            request_tx,
+            result_rx,
+            _handle: handle,
+        }
+    }
+
+    fn run_loop(state: &Mutex<Option<LoopState<Req, Res>>>) {
+        let taken = state.lock().ok().and_then(|mut slot| slot.take());
+        let Some((request_rx, result_tx, mut handler)) = taken else {
+            return;
+        };
+        while let Ok(request) = request_rx.recv() {
+            if result_tx.send(handler(request)).is_err() {
+                break;
+            }
+        }
+    }
+
+    /// Enqueue a request (non-blocking). A send failure means the worker
+    /// thread is gone (channel closed at teardown, or a panic in the
+    /// handler). Log it rather than dropping silently so a stuck-looking
+    /// in-flight row is traceable.
+    pub fn request(&self, req: Req) {
+        if let Err(e) = self.request_tx.send(req) {
+            tracing::warn!(
+                target: "tui.worker",
+                worker = %self.name,
+                error = %e,
+                "request dropped; worker thread unavailable",
+            );
+        }
+    }
+
+    /// Non-blocking poll for a completed result. Surfaces `Disconnected`
+    /// (returned forever once the worker thread is gone, e.g. after a panic
+    /// in the handler) rather than collapsing it into `None`, so the caller
+    /// can clear stuck in-flight state instead of leaving rows pinned on a
+    /// transient status forever.
+    pub fn try_recv(&self) -> Result<Res, mpsc::TryRecvError> {
+        self.result_rx.try_recv()
+    }
+
+    /// Test-only worker with one pre-seeded result and no handler; requests
+    /// are drained and ignored. Lets consumer tests exercise the
+    /// result-application path without running real side effects.
+    #[cfg(test)]
+    pub(crate) fn seeded_for_test(thread_name: &str, result: Res) -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<Req>();
+        let (result_tx, result_rx) = mpsc::channel::<Res>();
+        result_tx.send(result).expect("seed worker result");
+
+        let handle = thread::Builder::new()
+            .name(thread_name.to_string())
+            .spawn(move || {
+                while request_rx.recv().is_ok() {}
+                drop(result_tx);
+            })
+            .expect("failed to spawn test worker thread");
+
+        Self {
+            name: thread_name.to_string(),
+            request_tx,
+            result_rx,
+            _handle: handle,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn recv_with_retries<Req: Send + 'static, Res: Send + 'static>(
+        worker: &Worker<Req, Res>,
+    ) -> Result<Res, mpsc::TryRecvError> {
+        for _ in 0..100 {
+            match worker.try_recv() {
+                Err(mpsc::TryRecvError::Empty) => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                other => return other,
+            }
+        }
+        Err(mpsc::TryRecvError::Empty)
+    }
+
+    #[test]
+    fn worker_round_trips_requests_through_handler() {
+        let worker: Worker<u32, u32> = Worker::spawn("aoe-test-worker", |n| n * 2);
+        worker.request(21);
+        let result = recv_with_retries(&worker).expect("timed out waiting for worker result");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn worker_try_recv_returns_empty_when_idle() {
+        let worker: Worker<u32, u32> = Worker::spawn("aoe-test-worker-idle", |n| n);
+        assert!(matches!(worker.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn worker_try_recv_surfaces_disconnected_after_handler_panic() {
+        // A panicking handler kills the worker thread and drops result_tx;
+        // consumers rely on seeing Disconnected (not Empty/None) to run
+        // their stuck-row recovery.
+        let worker: Worker<u32, u32> = Worker::spawn("aoe-test-worker-panic", |_| panic!("boom"));
+        worker.request(1);
+        let outcome = recv_with_retries(&worker);
+        assert!(matches!(outcome, Err(mpsc::TryRecvError::Disconnected)));
+    }
+
+    #[test]
+    fn worker_processes_requests_in_order() {
+        let worker: Worker<u32, u32> = Worker::spawn("aoe-test-worker-order", |n| n + 1);
+        worker.request(1);
+        worker.request(2);
+        assert_eq!(recv_with_retries(&worker).expect("first result"), 2);
+        assert_eq!(recv_with_retries(&worker).expect("second result"), 3);
+    }
+}

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -114,38 +114,18 @@ fn probe_brew_aoe_path() -> Option<PathBuf> {
 }
 
 fn probe_brew_aoe_path_with_timeout(timeout: std::time::Duration) -> Option<PathBuf> {
-    use std::process::Stdio;
-    use std::time::Instant;
+    let mut cmd = Command::new("brew");
+    cmd.args(["list", "aoe"]);
 
-    let mut child = Command::new("brew")
-        .args(["list", "aoe"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return None;
-                }
-                break;
-            }
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return None;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(25));
-            }
-            Err(_) => return None,
-        }
+    // run_with_timeout kills brew at the deadline and bounds the output
+    // drain by it too, so neither a hung brew nor a grandchild holding the
+    // pipe can block the probe.
+    let output = crate::process::run_with_timeout(&mut cmd, timeout)
+        .ok()
+        .flatten()?;
+    if !output.status.success() {
+        return None;
     }
-
-    let output = child.wait_with_output().ok()?;
     let stdout = String::from_utf8(output.stdout).ok()?;
     for line in stdout.lines() {
         let trimmed = line.trim();
@@ -389,38 +369,16 @@ fn brew_available_version() -> Option<String> {
 }
 
 fn brew_available_version_with_timeout(timeout: std::time::Duration) -> Option<String> {
-    use std::process::Stdio;
-    use std::time::Instant;
+    let mut cmd = Command::new("brew");
+    cmd.args(["info", "aoe", "--json=v2"]);
 
-    let mut child = Command::new("brew")
-        .args(["info", "aoe", "--json=v2"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return None;
-                }
-                break;
-            }
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return None;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(25));
-            }
-            Err(_) => return None,
-        }
+    // Same bounded-wait rationale as probe_brew_aoe_path_with_timeout.
+    let output = crate::process::run_with_timeout(&mut cmd, timeout)
+        .ok()
+        .flatten()?;
+    if !output.status.success() {
+        return None;
     }
-
-    let output = child.wait_with_output().ok()?;
     parse_brew_stable_version(&output.stdout)
 }
 


### PR DESCRIPTION
## Description

Consolidates the ten most duplicated reliability-critical patterns in the codebase. Each shared helper also closes a real defect that the copy-paste drift had produced, so this is a refactor and a set of bug fixes in one.

**New shared helpers**

- `session::storage::locked_update`: serialized read-modify-write for small registry files (sidecar flock, then atomic temp+fsync+rename while holding the lock). Replaces three hand-rolled lock+truncate+rewrite blocks in `mcp_overrides.rs`, `mcp_state.rs`, and `repo_config::trust_repo`, and now also backs `projects::add`/`remove`. A failed mutation skips the persist entirely, so a validation error can never write half-applied state.
- `process::wait_with_timeout` / `process::run_with_timeout`: child-process wait with kill-on-deadline and deadline-bounded output draining (reader threads + `recv_timeout`), lifted from `containers/runtime_base.rs`. Replaces eight near-identical loops across `git/remote.rs`, `git/worktree.rs`, `update/install.rs`, and `runtime_base.rs`.
- `tui::worker::Worker<Req, Res>`: generic named worker thread with logged send failures and a `try_recv` that surfaces `Disconnected`. The stop, deletion, and restart pollers are now thin wrappers over it; `status_poller` reuses it for its channel plumbing.
- `server/api` canonical responses (`session_not_found`, `read_only_response`, `session_gone_after_persist`) and one `supervisor_error_response` mapping in `api/acp.rs`, replacing ~50 inline blocks and 10 hand-rolled `SupervisorError` matches.
- Smaller consolidations: `From<NewSessionData> for InstanceParams` (two field-by-field copies), a shared group-membership predicate (6 copies in `home/operations.rs`), a paste sanitize helper (5 copies across dialogs), `patch_instance` adoption in `unarchive_session`/`move_session`, a single `SessionJson` constructor, `supervisor::publish_next`, and deduped `collect_descendants_from_map` plus its tests in `src/process/`.

**Bugs fixed by the consolidation**

1. The truncate-then-rewrite pattern in the three registry files could permanently destroy trust records or MCP state on a crash or ENOSPC between truncate and write; writes are now atomic under the lock.
2. Two concurrent `aoe project add` calls could silently drop one registration (load, check, save with no lock held across the gap); mutations now run under the file lock.
3. `git clone`/`fetch` and the brew probes could hang forever past their own timeout on an unbounded stderr `read_to_string` when a grandchild (credential helper, pager) held the pipe.
4. A panic in the stop or deletion worker thread was undetectable (`Disconnected` collapsed into `None`), stranding rows on `Deleting` forever or leaving a still-running container labeled `Stopped`. Both consumers now recover the way restart already did; stop tracks in-flight requests since its rows are optimistically marked `Stopped`.
5. Nine `sessions.rs` handlers returned 500 "Failed to persist" after a persist that succeeded, when the session had been concurrently deleted; they now return 404.
6. `SupervisorError::UnknownSession` produced three different response bodies depending on endpoint; there is now one canonical mapping (intentional overrides such as the retryable `worker_not_ready` 503 remain explicit arms).
7. The Linux `/proc` scan in `find_process_in_group` aborted on the first transient unreadable entry, silently falling back to the shell PID; it now skips and continues like its siblings.

The changed error-response bodies are additive for the dashboard: the frontend reads `.message` generically and keys off `.error` values that are preserved, and the ACP endpoints deliberately keep plain-text bodies because the frontend matches them textually (`worker_not_ready` prefix, nonce echoes).

Net effect: 33 files, +1,413 / -1,570.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

No `web/` changes; the error-body changes are additive and verified against the frontend's parsing (`web/src/lib/api.ts` reads `.message` generically, `.error` discriminator values unchanged).

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the only behavior changes are crash-recovery paths that trigger when a worker thread panics, which an e2e cannot force deterministically. They are covered by new deterministic unit tests instead: `worker.rs` (including Disconnected-after-panic), stop-poller pending tracking, `locked_update` (default, round-trip, concurrent writers, no-write-on-failed-mutation), and `process` timeout/drain tests (including a grandchild-holds-pipe case). All other changes preserve behavior and are covered by the existing suites (4,933 lib tests plus all integration targets pass with `--features serve`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**

Duplication audit, implementation, and review performed by Claude Code in a sandboxed session directed by @njbrake. Verification: `cargo fmt` clean, `cargo clippy --all-targets --features serve` zero warnings, `cargo test --features serve --no-fail-fast` green except three pre-existing chmod-based tests that cannot fail when run as root (verified failing identically on the base commit).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Centralized session file updates behind a shared locked, atomic `locked_update` helper to prevent concurrent write loss, partial persistence, and inconsistent state (including symlink-preserving behavior and permission tightening).
- Replaced scattered subprocess “spawn + poll/kill” implementations with shared timeout-bounded execution (`run_with_timeout`), applied across cloning, worktree fetch, image pulls, and Homebrew probes to avoid hangs.
- Introduced a reusable background `Worker` abstraction for TUI polling/workers, refactoring status, stop, deletion, and restart pollers to improve reliability and simplify thread/channel handling.
- Standardized server/API error responses (canonical bodies for unknown sessions, read-only mode, and “session gone after persist”) and reduced endpoint-specific formatting drift.
- Streamlined session and UI behaviors by centralizing common logic: consistent seq publishing in the supervisor, session JSON construction, paste sanitization (strip CR/LF), group membership checks, workspace ordering safety limits, and descendant PID collection shared across OS implementations.
- Improved Linux process-group scanning robustness and rewired process-tree/descendant collection to use shared traversal helpers.

## Benefits

- More reliable behavior under concurrency, failures, and race conditions (especially around session persistence, worker disconnects, and server responses).
- Fewer production hang scenarios from long-running subprocesses by enforcing timeouts consistently.
- Reduced duplicated logic and more consistent user-facing behavior (API responses, paste handling, grouping, and session serialization).

## Potential follow-up

- Expand non-root and cross-platform integration testing for the timeout and process-scanning paths (some test coverage may still rely on environment constraints).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->