### PR TITLE
fix(web): end the first-run tour on dismiss instead of stranding the scrim

### DIFF
--- a/web/src/components/tour/TourRunner.transition.test.tsx
+++ b/web/src/components/tour/TourRunner.transition.test.tsx
@@ -9,6 +9,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import TourRunner from "./TourRunner";
+import { TOUR_RUNNER_OPTIONS } from "./tourRunnerStyles";
 import { TOUR_ANCHORS, type TourStep } from "../../lib/tourSteps";
 
 vi.mock("react-joyride", async () => {
@@ -25,7 +26,7 @@ vi.mock("react-joyride", async () => {
   return {
     Joyride,
     EVENTS: { STEP_AFTER: "step:after", TOUR_END: "tour:end", TARGET_NOT_FOUND: "error:target_not_found" },
-    ACTIONS: { PREV: "prev", NEXT: "next" },
+    ACTIONS: { PREV: "prev", NEXT: "next", CLOSE: "close", SKIP: "skip" },
     STATUS: { FINISHED: "finished", SKIPPED: "skipped" },
     __getOnEvent: () => latestOnEvent,
   };
@@ -136,5 +137,46 @@ describe("TourRunner controlled transitions", () => {
     fire({ type: "tour:end", index: 0, action: "skip", status: "skipped" });
     expect(onNavigate).toHaveBeenCalledWith(null);
     expect(onFinish).toHaveBeenCalledWith(true);
+  });
+
+  // #2819: dismissing the tour (Escape, or clicking the dim overlay) reaches us
+  // as a STEP_AFTER with action=CLOSE while status is still RUNNING, because
+  // react-joyride's controlled mode does not flip status to FINISHED on a
+  // non-last close. It must end the tour, not fall through to the +1 advance.
+  it("ends and marks seen on a close dismiss instead of advancing", () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    addAnchor(TOUR_ANCHORS.dashboardNewSession);
+    const onFinish = vi.fn();
+    const { getByTestId } = render(
+      <TourRunner run steps={[dashStep, dashStep2]} onFinish={onFinish} onNavigate={vi.fn()} />,
+    );
+    fire({ type: "step:after", index: 0, action: "close", status: "" });
+    expect(onFinish).toHaveBeenCalledWith(true);
+    // Never advanced: still parked on step 0.
+    expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("0");
+  });
+
+  it("does not advance on a non-navigation action", () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    addAnchor(TOUR_ANCHORS.dashboardNewSession);
+    const onFinish = vi.fn();
+    const { getByTestId } = render(
+      <TourRunner run steps={[dashStep, dashStep2]} onFinish={onFinish} onNavigate={vi.fn()} />,
+    );
+    fire({ type: "step:after", index: 0, action: "update", status: "" });
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("0");
+  });
+
+  it("ends without marking seen when the target is missing", () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    const onFinish = vi.fn();
+    render(<TourRunner run steps={[dashStep, dashStep2]} onFinish={onFinish} onNavigate={vi.fn()} />);
+    fire({ type: "error:target_not_found", index: 1, action: "next", status: "" });
+    expect(onFinish).toHaveBeenCalledWith(false);
+  });
+
+  it("disables react-joyride's overlay-click dismiss (the strand-prone path)", () => {
+    expect(TOUR_RUNNER_OPTIONS.overlayClickAction).toBe(false);
   });
 });

--- a/web/src/components/tour/TourRunner.transition.test.tsx
+++ b/web/src/components/tour/TourRunner.transition.test.tsx
@@ -156,6 +156,19 @@ describe("TourRunner controlled transitions", () => {
     expect(getByTestId("joyride").getAttribute("data-step-index")).toBe("0");
   });
 
+  // #2819: advancing past the last step is the user finishing (Done). Each
+  // settings crossing remounts Joyride, so the engine emits no TOUR_END on the
+  // last step in that flow; the handler must end on the past-last advance
+  // itself, or the overlay strands.
+  it("ends and marks seen when advancing past the last step", () => {
+    addAnchor(TOUR_ANCHORS.topbar);
+    addAnchor(TOUR_ANCHORS.dashboardNewSession);
+    const onFinish = vi.fn();
+    render(<TourRunner run steps={[dashStep, dashStep2]} onFinish={onFinish} onNavigate={vi.fn()} />);
+    fire({ type: "step:after", index: 1, action: "next", status: "" });
+    expect(onFinish).toHaveBeenCalledWith(true);
+  });
+
   it("does not advance on a non-navigation action", () => {
     addAnchor(TOUR_ANCHORS.topbar);
     addAnchor(TOUR_ANCHORS.dashboardNewSession);

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -14,7 +14,7 @@
 // poll for the target anchor, and only then remount at the new index. Same path
 // serves Next and Back, so cross-modal navigation can never hand Joyride a
 // missing target.
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ACTIONS, Joyride, EVENTS, STATUS, type EventData, type Step } from "react-joyride";
 import { type TourShortcutHint, type TourStep, tourSelector } from "../../lib/tourSteps";
 import { SHORTCUTS_BY_ID, formatTourShortcut } from "../../lib/shortcuts";
@@ -82,6 +82,24 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
   // away as Settings opens). The poll below lifts it once the next anchor lands.
   const [suspended, setSuspended] = useState(false);
 
+  // Single terminal exit. react-joyride can report the end of a tour more than
+  // once (e.g. Escape on the last step fires STEP_AFTER with action=CLOSE and
+  // TOUR_END with status=FINISHED), so latch the first one and drop the rest to
+  // avoid a double onFinish / double "seen" write. A fresh tour is a fresh
+  // TourRunner mount, so the ref resets naturally.
+  const endedRef = useRef(false);
+  const end = useCallback(
+    (markSeen: boolean, index: number) => {
+      if (endedRef.current) return;
+      endedRef.current = true;
+      // If we end while parked on a settings step, return to the dashboard so
+      // the user does not land stranded in Settings.
+      if (steps[index]?.settingsTab) onNavigate(null);
+      onFinish(markSeen);
+    },
+    [steps, onNavigate, onFinish],
+  );
+
   useEffect(() => {
     if (!suspended) return;
     // stepIndex is always in-bounds here: suspension is only ever set alongside
@@ -101,35 +119,42 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
         // ponytail: end the tour rather than hang; it re-triggers from the menu.
         // Upgrade to skip-the-step-in-direction if a feature-flagged (droppable)
         // settings tab is ever added as a target.
-        if (step.settingsTab) onNavigate(null); // don't strand the user in Settings
-        onFinish(false);
+        end(false, stepIndex);
         return;
       }
       frame = requestAnimationFrame(tick);
     };
     frame = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(frame);
-  }, [suspended, stepIndex, steps, onFinish, onNavigate]);
+  }, [suspended, stepIndex, steps, end]);
 
   const handleEvent = useCallback(
     (data: EventData) => {
-      if (data.type === EVENTS.TOUR_END) {
-        // Gate on the terminal status, not the action: a programmatic stop
-        // (unmount) ends with a non-terminal status and may carry `action:
-        // null`, which an action allowlist would misread as a user finish.
-        const markSeen = data.status === STATUS.FINISHED || data.status === STATUS.SKIPPED;
-        // If the tour ends while parked on a settings step (Skip/Done inside the
-        // modal), return to the dashboard so the user does not land in Settings.
-        if (steps[data.index]?.settingsTab) onNavigate(null);
-        onFinish(markSeen);
+      const { action, index, status, type } = data;
+      const terminalStatus = status === STATUS.FINISHED || status === STATUS.SKIPPED;
+      // A user dismiss (Escape, the close button, Skip) reaches us as an action.
+      // In controlled mode react-joyride leaves status=RUNNING on a non-last
+      // close, so gate the dismiss on the action, not the status; otherwise it
+      // falls through to STEP_AFTER and advances the tour instead of ending it
+      // (#2819). Escape/close arrive as STEP_AFTER(action=CLOSE), not TOUR_END.
+      const userDismiss = action === ACTIONS.CLOSE || action === ACTIONS.SKIP;
+
+      if (type === EVENTS.TOUR_END || terminalStatus || userDismiss) {
+        // A finish/skip/close is the user's doing (mark it seen). A bare
+        // TOUR_END with a non-terminal status and no dismiss action is a
+        // programmatic stop (scope change / unmount): do not mark it seen.
+        end(terminalStatus || userDismiss, index);
         return;
       }
 
-      if (data.type === EVENTS.STEP_AFTER) {
-        const direction = data.action === ACTIONS.PREV ? -1 : 1;
-        const next = data.index + direction;
+      if (type === EVENTS.STEP_AFTER) {
+        // Only real navigation moves the index. Never default an unhandled
+        // action to +1: that is exactly how a CLOSE used to advance the tour.
+        if (action !== ACTIONS.NEXT && action !== ACTIONS.PREV) return;
+        const direction = action === ACTIONS.PREV ? -1 : 1;
+        const next = index + direction;
         if (next < 0 || next >= steps.length) return;
-        const currentTab = steps[data.index]?.settingsTab ?? null;
+        const currentTab = steps[index]?.settingsTab ?? null;
         const nextTab = steps[next]?.settingsTab ?? null;
         setStepIndex(next);
         // Only the crossings that change the settings route need a navigate +
@@ -141,14 +166,13 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
         return;
       }
 
-      if (data.type === EVENTS.TARGET_NOT_FOUND) {
+      if (type === EVENTS.TARGET_NOT_FOUND) {
         // Should not happen given the suspend/poll, but never leave the user
         // stuck on a spotlight with no tooltip, or stranded in Settings.
-        if (steps[data.index]?.settingsTab) onNavigate(null);
-        onFinish(false);
+        end(false, index);
       }
     },
-    [steps, onFinish, onNavigate],
+    [steps, onNavigate, end],
   );
 
   if (suspended) return null;

--- a/web/src/components/tour/TourRunner.tsx
+++ b/web/src/components/tour/TourRunner.tsx
@@ -153,7 +153,15 @@ export default function TourRunner({ run, steps, onFinish, onNavigate }: TourRun
         if (action !== ACTIONS.NEXT && action !== ACTIONS.PREV) return;
         const direction = action === ACTIONS.PREV ? -1 : 1;
         const next = index + direction;
-        if (next < 0 || next >= steps.length) return;
+        // Advancing past the last step is the user finishing (clicking Done). We
+        // must end it ourselves: because each settings-tab crossing remounts a
+        // fresh Joyride, the engine does not emit its own TOUR_END on the last
+        // step in that flow, so relying on it strands the overlay (#2819).
+        if (next >= steps.length) {
+          end(true, index);
+          return;
+        }
+        if (next < 0) return;
         const currentTab = steps[index]?.settingsTab ?? null;
         const nextTab = steps[next]?.settingsTab ?? null;
         setStepIndex(next);

--- a/web/src/components/tour/tourRunnerStyles.ts
+++ b/web/src/components/tour/tourRunnerStyles.ts
@@ -14,6 +14,12 @@ export const TOUR_RUNNER_OPTIONS: Partial<Options> = {
   buttons: ["skip", "back", "primary"] as ButtonType[],
   showProgress: true,
   skipBeacon: true,
+  // Clicking the scrim is the only dismiss gesture react-joyride cannot report
+  // reliably in controlled mode: fired before a step settles (e.g. first paint
+  // under action=START, which skipBeacon keeps the overlay visible for), its
+  // close() emits no callback and leaves status=RUNNING, so the overlay strands
+  // with no event for us to end on (#2819). Make it inert; Skip and Escape stay.
+  overlayClickAction: false,
   primaryColor: "var(--color-brand-600)",
   overlayColor: "rgba(0, 0, 0, 0.65)",
   textColor: "var(--color-text-primary)",

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -126,7 +126,10 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     await expect.poll(() => new URL(page.url()).pathname).toBe("/");
     await page.getByRole("button", { name: /^Done/ }).click();
     await expect(page.getByText("Replay this tour any time")).toBeHidden();
-    // #2819: finishing on the last step tears the scrim down completely.
+    // #2819: finishing on the last step tears the scrim down completely. Because
+    // each settings-tab crossing remounts Joyride, the engine emits no TOUR_END
+    // on the last step here, so without ending on the past-last advance the
+    // overlay strands and blocks the page.
     await expect(page.locator(".react-joyride__overlay")).toHaveCount(0);
 
     // The flag stays set after a manual re-trigger, so the next reload is quiet.

--- a/web/tests/live/tutorial.spec.ts
+++ b/web/tests/live/tutorial.spec.ts
@@ -63,6 +63,9 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     const resp = await postSeen;
     expect(resp.status()).toBe(200);
     await expect(page.getByText(FIRST_STEP)).toBeHidden();
+    // #2819: the dim scrim must be gone, not just the tooltip. A stranded
+    // overlay blocks the whole page and forces a refresh.
+    await expect(page.locator(".react-joyride__overlay")).toHaveCount(0);
     // `mark_web_tour_seen` awaits its `save_config` in `spawn_blocking`
     // and `GET /api/settings` re-reads config on every call, so the flag
     // is committed by the time this poll starts. 20s (twice the 10s
@@ -123,6 +126,8 @@ base("first-run tutorial: auto-launch, skip, persist, re-trigger", async ({ page
     await expect.poll(() => new URL(page.url()).pathname).toBe("/");
     await page.getByRole("button", { name: /^Done/ }).click();
     await expect(page.getByText("Replay this tour any time")).toBeHidden();
+    // #2819: finishing on the last step tears the scrim down completely.
+    await expect(page.locator(".react-joyride__overlay")).toHaveCount(0);
 
     // The flag stays set after a manual re-trigger, so the next reload is quiet.
     expect(


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The first-run guided tour (react-joyride 3.1.0, driven in controlled mode) could leave its dark scrim overlay painted after the user finished or dismissed it, blocking the whole page until a browser refresh.

Root cause, confirmed against the react-joyride 3.1.0 dist source: the overlay renders only while the engine's internal status is `RUNNING`. In controlled mode `controls.close()` (the default action for both an overlay click and Escape) sets the next index and lifecycle `COMPLETE` but leaves status `RUNNING` on any non-last step; it only emits a `STEP_AFTER` callback when the previous lifecycle was `TOOLTIP`. So a dismiss fired before a step settled (for example an overlay click at first paint, which `skipBeacon: true` keeps the overlay visible for) produced no callback and no status change: the scrim stayed up with no event for us to end on. Separately, the dismiss callbacks that did fire arrived as `STEP_AFTER` with `action: CLOSE`, and the handler mapped any non-`PREV` action to `+1`, so a dismiss advanced the tour instead of ending it.

Two changes in the tour runner:

- Disable react-joyride's overlay-click dismiss (`overlayClickAction: false`). It is the one gesture the engine cannot report reliably in controlled mode, so clicking the scrim is now inert. Skip and Escape remain the dismiss affordances.
- Rewrite `handleEvent` to treat a `CLOSE` or `SKIP` action, and any terminal status, as a tour-end regardless of status, and to advance only on `NEXT`/`PREV`. A guarded `end()` helper latches the first terminal signal so a finish that reports twice (Escape on the last step fires both `STEP_AFTER(CLOSE)` and `TOUR_END(FINISHED)`) cannot double-fire `onFinish` or the "seen" write.

User-observable impact: no tour dismiss path can strand the overlay anymore, and Escape ends the tour instead of skipping ahead a step.

Closes #2819

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In a fresh browser profile (no `has_seen_web_tour`), open the web dashboard so the first-run tour auto-launches. Press Escape mid-tour and confirm the dark overlay disappears and the page is clickable, with no refresh.
- [ ] Re-trigger the tour (More options, then Show tutorial), click through to the last step, click Done, and confirm the overlay is gone and the dashboard is interactive.
- [ ] Re-trigger the tour and click the dim area outside the tooltip: confirm it does nothing (no advance, no stranded scrim), then dismiss with Skip or Escape.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Details: added real-browser scrim-removed assertions after both Skip and Done in `web/tests/live/tutorial.spec.ts`, plus prop-sink regression cases in `web/src/components/tour/TourRunner.transition.test.tsx` (close-ends-without-advancing, non-navigation-does-not-advance, `overlayClickAction === false`). The changed files already map to the existing `onboarding.first-run-tutorial` and `onboarding.tour-drift-guard` matrix entries, so no new matrix entry is needed; `validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the react-joyride dist trace, plan, and implementation were drafted by Claude under my direction, with a two-model design debate (gpt-5.5 and gemini) on how to handle the controlled-mode close semantics. I made the design calls, reviewed each change, and confirmed the reproduce-then-fix tests go red before the fix and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed the first-run guided tour so dismissing or completing it reliably removes the Joyride overlay/scrim (preventing a blocked dashboard).
- Updated tour termination logic to treat `CLOSE`, `SKIP`, and terminal Joyride statuses as ending the tour (not navigating forward).
- Ensured the tour ends when the user clicks **Next** past the final step, even in cases where Joyride may not emit the expected end event (e.g., remounts during tab transitions).
- Restricted step transitions so the tour advances only on **Next**/**Previous** (avoiding unintended advancement on other actions).
- Hardened “finish” handling to prevent duplicate completion callbacks and duplicate “tour seen” writes.
- Disabled scrim/overlay-click dismissal in controlled mode to avoid leaving the tour stranded.
- Added/expanded regression coverage:
  - Unit tests for controlled transition edge cases, termination reasons, and configuration.
  - Playwright tests that explicitly verify the overlay is fully removed after skip and after finishing.

## Benefits

Users can exit or complete the guided tour without the page becoming unusable due to a lingering Joyride overlay, and the added tests reduce the risk of future regressions in dismissal/finish behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->