### PR TITLE
perf(tui): cut live-mode input and echo latency to near-attach

### DIFF
--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -17,7 +17,7 @@ use std::io::Read;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
-use std::sync::{Arc, LazyLock, Mutex, Weak};
+use std::sync::{Arc, Condvar, LazyLock, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use crate::tmux::PaneCursor;
@@ -79,6 +79,30 @@ static REGISTRY: LazyLock<Mutex<HashMap<String, Weak<VtChannel>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static SOCK_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A `(Mutex, Condvar)` pair an in-process poller parks on. Registered via
+/// [`VtChannel::set_change_wakeup`]; the reader thread pokes it after every
+/// grid change (and on death) so the poller samples the moment output lands
+/// instead of after the remainder of a fixed poll interval. Web viewers use
+/// the tokio `watch` channel instead; this is the std-thread equivalent for
+/// the TUI capture worker.
+pub(crate) type ChangeWakeup = Arc<(Mutex<()>, Condvar)>;
+
+/// Poke a registered change wakeup, if any. The slot lock is held only to
+/// clone the pair; the pair's own mutex is then taken so the notify
+/// serializes with a parker between its `lock` and `wait` (otherwise the
+/// wake could fire into the gap and be lost).
+fn notify_change_wakeup(slot: &Mutex<Option<ChangeWakeup>>) {
+    let pair = match slot.lock() {
+        Ok(guard) => guard.clone(),
+        Err(_) => None,
+    };
+    if let Some(pair) = pair {
+        if let Ok(_g) = pair.0.lock() {
+            pair.1.notify_one();
+        }
+    }
+}
 
 /// Lines of scrollback the grid keeps, and how much history the seed pulls from
 /// the pane. Matches tmux's default `history-limit` so a freshly armed channel
@@ -482,6 +506,82 @@ fn grid_content(
     (content, total_sb)
 }
 
+/// Shared state the reader thread owns for a channel's lifetime. A named
+/// struct (rather than closure captures) so the reader loop is a plain
+/// function tests can drive against a raw socket without arming a real
+/// `pipe-pane`.
+struct ReaderCtx {
+    parser: Arc<Mutex<vt100::Parser>>,
+    stop: Arc<AtomicBool>,
+    seeded: Arc<AtomicBool>,
+    stream: Arc<Mutex<Option<UnixStream>>>,
+    app_cursor: Arc<AtomicBool>,
+    alive: Arc<AtomicBool>,
+    wakeup: Arc<Mutex<Option<ChangeWakeup>>>,
+    #[cfg(feature = "serve")]
+    changed_tx: Arc<tokio::sync::watch::Sender<()>>,
+}
+
+/// The channel's reader loop: accept the forwarder's connection, publish the
+/// writable half for input dispatch, then pump pane output into the vt100
+/// grid, waking viewers on every change. Runs on its own thread; exits on
+/// pipe EOF, socket error, or `stop`.
+fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
+    let Ok((conn, _)) = listener.accept() else {
+        return;
+    };
+    // Publish the writable half so input dispatch can reach the pane.
+    if let Ok(w) = conn.try_clone() {
+        *ctx.stream.lock().unwrap() = Some(w);
+    }
+    // The forwarder is connected: the channel is now the live
+    // single-writer. `acquire` is blocked until this flips.
+    ctx.alive.store(true, Ordering::Relaxed);
+    let mut conn = conn;
+    let _ = conn.set_read_timeout(Some(Duration::from_millis(200)));
+    let mut buf = [0u8; 8192];
+    while !ctx.stop.load(Ordering::Relaxed) {
+        match conn.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                // Hold stream bytes until the seed is applied so the
+                // seed can't clobber newer state.
+                while !ctx.seeded.load(Ordering::Relaxed) && !ctx.stop.load(Ordering::Relaxed) {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                if let Ok(mut p) = ctx.parser.lock() {
+                    p.process(&buf[..n]);
+                    ctx.app_cursor
+                        .store(p.screen().application_cursor(), Ordering::Relaxed);
+                }
+                // Wake the in-process poller (the TUI capture worker) so the
+                // just-landed output samples now, not after the remainder of
+                // its poll interval. This is the echo-latency path.
+                notify_change_wakeup(&ctx.wakeup);
+                // Wake every viewer waiting on output. The watch
+                // coalesces (a viewer that wasn't parked sees the
+                // bumped version on its next wait), so a chunk that
+                // lands between waits is not lost.
+                #[cfg(feature = "serve")]
+                ctx.changed_tx.send_modify(|_| {});
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(_) => break,
+        }
+    }
+    // Reader is exiting (pipe EOF / socket error / stop): the
+    // forwarder is gone, so the channel is no longer the live
+    // single-writer. Input dispatch and capture both fall back.
+    ctx.alive.store(false, Ordering::Relaxed);
+    // Wake parked viewers so they observe the death promptly
+    // instead of waiting out their heartbeat sleep.
+    notify_change_wakeup(&ctx.wakeup);
+    #[cfg(feature = "serve")]
+    ctx.changed_tx.send_modify(|_| {});
+}
+
 /// One shared pane channel: a vt100 grid fed by a `pipe-pane -IO` byte stream,
 /// plus the writable half of the same socket for keystroke injection. Methods
 /// take `&self` (interior mutability) so many viewers share one `Arc`.
@@ -509,6 +609,11 @@ pub(crate) struct VtChannel {
     /// bump that matters), so it is `()`.
     #[cfg(feature = "serve")]
     changed_tx: Arc<tokio::sync::watch::Sender<()>>,
+    /// Slot for one in-process poller's wakeup (the TUI capture worker).
+    /// The reader thread pokes it on each grid change and on death; last
+    /// registration wins (one capture worker per process, so a slot rather
+    /// than a list).
+    wakeup: Arc<Mutex<Option<ChangeWakeup>>>,
     /// Owner-only (0700) directory holding `sock_path`; removed on drop.
     sock_dir: PathBuf,
     sock_path: PathBuf,
@@ -581,65 +686,20 @@ impl VtChannel {
         let sock_path = sock_dir.join("s.sock");
         let listener = UnixListener::bind(&sock_path).ok()?;
 
+        let wakeup: Arc<Mutex<Option<ChangeWakeup>>> = Arc::new(Mutex::new(None));
         let reader = {
-            let parser = parser.clone();
-            let stop = stop.clone();
-            let seeded = seeded.clone();
-            let stream = stream.clone();
-            let app_cursor = app_cursor.clone();
-            let alive = alive.clone();
-            #[cfg(feature = "serve")]
-            let changed_tx = changed_tx.clone();
-            std::thread::spawn(move || {
-                let Ok((conn, _)) = listener.accept() else {
-                    return;
-                };
-                // Publish the writable half so input dispatch can reach the pane.
-                if let Ok(w) = conn.try_clone() {
-                    *stream.lock().unwrap() = Some(w);
-                }
-                // The forwarder is connected: the channel is now the live
-                // single-writer. `acquire` is blocked until this flips.
-                alive.store(true, Ordering::Relaxed);
-                let mut conn = conn;
-                let _ = conn.set_read_timeout(Some(Duration::from_millis(200)));
-                let mut buf = [0u8; 8192];
-                while !stop.load(Ordering::Relaxed) {
-                    match conn.read(&mut buf) {
-                        Ok(0) => break,
-                        Ok(n) => {
-                            // Hold stream bytes until the seed is applied so the
-                            // seed can't clobber newer state.
-                            while !seeded.load(Ordering::Relaxed) && !stop.load(Ordering::Relaxed) {
-                                std::thread::sleep(Duration::from_millis(1));
-                            }
-                            if let Ok(mut p) = parser.lock() {
-                                p.process(&buf[..n]);
-                                app_cursor
-                                    .store(p.screen().application_cursor(), Ordering::Relaxed);
-                            }
-                            // Wake every viewer waiting on output. The watch
-                            // coalesces (a viewer that wasn't parked sees the
-                            // bumped version on its next wait), so a chunk that
-                            // lands between waits is not lost.
-                            #[cfg(feature = "serve")]
-                            changed_tx.send_modify(|_| {});
-                        }
-                        Err(ref e)
-                            if e.kind() == std::io::ErrorKind::WouldBlock
-                                || e.kind() == std::io::ErrorKind::TimedOut => {}
-                        Err(_) => break,
-                    }
-                }
-                // Reader is exiting (pipe EOF / socket error / stop): the
-                // forwarder is gone, so the channel is no longer the live
-                // single-writer. Input dispatch and capture both fall back.
-                alive.store(false, Ordering::Relaxed);
-                // Wake parked viewers so they observe the death promptly
-                // instead of waiting out their heartbeat sleep.
+            let ctx = ReaderCtx {
+                parser: parser.clone(),
+                stop: stop.clone(),
+                seeded: seeded.clone(),
+                stream: stream.clone(),
+                app_cursor: app_cursor.clone(),
+                alive: alive.clone(),
+                wakeup: wakeup.clone(),
                 #[cfg(feature = "serve")]
-                changed_tx.send_modify(|_| {});
-            })
+                changed_tx: changed_tx.clone(),
+            };
+            std::thread::spawn(move || run_reader(listener, ctx))
         };
 
         let exe = std::env::current_exe().ok()?;
@@ -698,6 +758,7 @@ impl VtChannel {
             alive,
             #[cfg(feature = "serve")]
             changed_tx,
+            wakeup,
             sock_dir,
             sock_path,
             stop,
@@ -784,6 +845,17 @@ impl VtChannel {
     /// of writing into a dead socket or sampling a frozen grid.
     pub(crate) fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
+    }
+
+    /// Register the in-process poller wakeup this channel pokes on each grid
+    /// change (and on death). The TUI capture worker hands over the same
+    /// condvar pair its retarget/cadence nudges use, so pane output wakes it
+    /// into an immediate sample instead of letting the echo sit out the
+    /// remainder of a poll interval.
+    pub(crate) fn set_change_wakeup(&self, wakeup: ChangeWakeup) {
+        if let Ok(mut guard) = self.wakeup.lock() {
+            *guard = Some(wakeup);
+        }
     }
 
     /// A receiver that fires whenever the grid changes (output arrived) or the
@@ -945,6 +1017,74 @@ mod tests {
             first.matches(' ').count() >= 8,
             "trailing fill should keep its eight cells as spaces:\n{content:?}"
         );
+    }
+
+    #[test]
+    fn reader_pokes_registered_wakeup_on_grid_change() {
+        use std::io::Write;
+
+        // Drive run_reader against a raw socket pair (posing as the
+        // pipe-pane forwarder), no tmux needed. This pins the echo-latency
+        // wiring: pane output must poke the registered wakeup so the TUI
+        // capture worker samples immediately instead of waiting out its poll
+        // interval.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("s.sock");
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0)));
+        let stop = Arc::new(AtomicBool::new(false));
+        let stream: Arc<Mutex<Option<UnixStream>>> = Arc::new(Mutex::new(None));
+        let alive = Arc::new(AtomicBool::new(false));
+        let wakeup_slot: Arc<Mutex<Option<ChangeWakeup>>> = Arc::new(Mutex::new(None));
+        let ctx = ReaderCtx {
+            parser: parser.clone(),
+            stop: stop.clone(),
+            // Seeded upfront: this test has no capture-pane seed to wait for.
+            seeded: Arc::new(AtomicBool::new(true)),
+            stream,
+            app_cursor: Arc::new(AtomicBool::new(false)),
+            alive: alive.clone(),
+            wakeup: wakeup_slot.clone(),
+            #[cfg(feature = "serve")]
+            changed_tx: Arc::new(tokio::sync::watch::channel(()).0),
+        };
+        let reader = std::thread::spawn(move || run_reader(listener, ctx));
+        let mut conn = UnixStream::connect(&sock).expect("connect");
+
+        let pair: ChangeWakeup = Arc::new((Mutex::new(()), Condvar::new()));
+        *wakeup_slot.lock().unwrap() = Some(pair.clone());
+        // Hold the parker's mutex BEFORE writing: the reader's notify takes
+        // the same lock, so the wakeup cannot fire into the gap between this
+        // write and the wait below (i.e. the wait result is deterministic).
+        let guard = pair.0.lock().unwrap();
+        conn.write_all(b"echo-marker").expect("write pane output");
+        let (wake_guard, res) = pair
+            .1
+            .wait_timeout(guard, Duration::from_secs(5))
+            .expect("wait");
+        // Release the pair's mutex before joining: the reader's exit path
+        // notifies the wakeup one last time (death), and that notify takes
+        // this same lock. Holding it across `join` would deadlock.
+        drop(wake_guard);
+        assert!(
+            !res.timed_out(),
+            "a grid change must poke the registered wakeup"
+        );
+        // The wake postdates the parse (notify runs after the parser lock is
+        // released), so the change is already in the grid.
+        assert!(
+            parser
+                .lock()
+                .unwrap()
+                .screen()
+                .contents()
+                .contains("echo-marker"),
+            "pane bytes must land in the grid before the wakeup fires"
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        drop(conn);
+        let _ = reader.join();
     }
 
     #[test]

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -512,8 +512,15 @@ impl LiveSendWorker {
                         }
                     }
                     Err(RecvTimeoutError::Timeout) => {
-                        session.refresh_size_owner(&owner_id);
-                        last_owner_maintenance = std::time::Instant::now();
+                        // Only count a SUCCESSFUL refresh as maintenance: a
+                        // false return means another surface took (or freed)
+                        // the lock while we idled, and the stale timestamp
+                        // makes the next input batch re-steal right away,
+                        // matching the old steal-per-batch reclaim without
+                        // its per-keystroke cost.
+                        if session.refresh_size_owner(&owner_id) {
+                            last_owner_maintenance = std::time::Instant::now();
+                        }
                     }
                     Err(RecvTimeoutError::Disconnected) => break,
                 }
@@ -564,7 +571,7 @@ const LIVE_CAPTURE_INTERVAL_FAST_MS: u64 = 25;
 /// given how long ago the previous frame published (`None` = never). Zero
 /// means publish now: the first change after a quiet gap always goes out
 /// immediately (this is the typed-echo case), while sustained streaming
-/// paces at the fast cadence exactly like the old fixed cycle. The floor
+/// paces at the fast cadence, matching the old fixed cycle. The floor
 /// keys off publishes, not samples, so a wasted pre-echo sample (the send
 /// worker's wake fires before the agent has echoed) can't push the real
 /// echo back a cycle.

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -406,6 +406,15 @@ pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
     out
 }
 
+/// Whether a drained batch must re-assert size ownership BEFORE dispatch.
+/// Only geometry changes need that ordering: a `resize-window` racing
+/// another surface's live grid is the flap the size-owner lock exists to
+/// kill. Plain keystrokes never read the lock, so they dispatch without
+/// waiting on the steal's tmux forks.
+pub(super) fn batch_needs_owner_first(batch: &[WorkerMsg]) -> bool {
+    batch.iter().any(|m| matches!(m, WorkerMsg::Resize { .. }))
+}
+
 /// One unit of work the worker can be asked to perform. Resizes don't
 /// coalesce with keys because they're sticky pane-level changes; a
 /// burst of keystrokes that brackets a resize must arrive on either
@@ -454,10 +463,11 @@ impl LiveSendWorker {
 
             // TUI live-send is an active take-over: own the session's size for
             // the lifetime of this worker so the web PTY relay and the mobile
-            // live view defer to it. Steal on entry and on each active input
-            // batch; refresh on a heartbeat so an idle-but-attached live
-            // session is not stolen from. Released (and `window-size latest`
-            // restored) when live mode exits and the channel closes.
+            // live view defer to it. Steal on entry, then maintain ownership
+            // at most once per heartbeat while input flows; refresh on the
+            // idle heartbeat so an idle-but-attached live session is not
+            // stolen from. Released (and `window-size latest` restored) when
+            // live mode exits and the channel closes.
             let owner_id = format!(
                 "tui-{}-{}",
                 std::process::id(),
@@ -471,6 +481,16 @@ impl LiveSendWorker {
             // paste-bursts and held-key autorepeat into one fork per literal
             // run, so typing a long sentence costs one `tmux send-keys -l`
             // invocation, not one per character.
+            //
+            // Owner bookkeeping stays OFF the keystroke critical path: a
+            // steal is ~5 tmux forks (3-13ms each on macOS) and used to run
+            // ahead of every batch's byte write, which made typing in live
+            // mode measurably laggier than a direct tmux attach. Keystrokes
+            // never read the size lock, so they dispatch first and ownership
+            // is re-asserted at most once per heartbeat afterwards. Resize
+            // batches are the exception: geometry must not race another
+            // owner's grid, so they keep the steal-before-dispatch ordering.
+            let mut last_owner_maintenance = std::time::Instant::now();
             loop {
                 match rx.recv_timeout(crate::tmux::SIZE_OWNER_HEARTBEAT) {
                     Ok(first) => {
@@ -478,14 +498,22 @@ impl LiveSendWorker {
                         while let Ok(msg) = rx.try_recv() {
                             batch.push(msg);
                         }
-                        session.steal_size_owner(&owner_id);
+                        if batch_needs_owner_first(&batch) {
+                            session.steal_size_owner(&owner_id);
+                            last_owner_maintenance = std::time::Instant::now();
+                        }
                         dispatch_batch(&tmux_name, batch);
                         if let Some(wake) = &capture_wake {
                             wake.wake();
                         }
+                        if last_owner_maintenance.elapsed() >= crate::tmux::SIZE_OWNER_HEARTBEAT {
+                            session.steal_size_owner(&owner_id);
+                            last_owner_maintenance = std::time::Instant::now();
+                        }
                     }
                     Err(RecvTimeoutError::Timeout) => {
                         session.refresh_size_owner(&owner_id);
+                        last_owner_maintenance = std::time::Instant::now();
                     }
                     Err(RecvTimeoutError::Disconnected) => break,
                 }
@@ -525,8 +553,27 @@ impl LiveSendWorker {
 /// tighter value buys little perceived freshness for a lot more idle
 /// forks, since the render only paints every ~33ms anyway).
 /// Capture cadence while live-send is attached to the displayed pane: tight
-/// so typed echo and agent output appear with near-attach latency.
+/// so typed echo and agent output appear with near-attach latency. On the VT
+/// path this is only the fallback wait: the channel's change wakeup ends the
+/// sleep the moment output lands, and this value doubles as the floor between
+/// *published* frames so change-driven sampling can't outpace the frame
+/// pacing the 33ms render ticker was calibrated against.
 const LIVE_CAPTURE_INTERVAL_FAST_MS: u64 = 25;
+
+/// Milliseconds a just-changed frame must still wait before it may publish,
+/// given how long ago the previous frame published (`None` = never). Zero
+/// means publish now: the first change after a quiet gap always goes out
+/// immediately (this is the typed-echo case), while sustained streaming
+/// paces at the fast cadence exactly like the old fixed cycle. The floor
+/// keys off publishes, not samples, so a wasted pre-echo sample (the send
+/// worker's wake fires before the agent has echoed) can't push the real
+/// echo back a cycle.
+pub(super) fn publish_floor_wait_ms(since_last_publish_ms: Option<u64>) -> u64 {
+    match since_last_publish_ms {
+        None => 0,
+        Some(elapsed) => LIVE_CAPTURE_INTERVAL_FAST_MS.saturating_sub(elapsed),
+    }
+}
 /// Capture cadence when the worker is just keeping the home-list preview warm
 /// (no live-send). Matches the old render-driven `PREVIEW_REFRESH_MS` throttle
 /// so moving the fork off the render thread doesn't raise the idle fork rate.
@@ -656,6 +703,9 @@ impl LiveCaptureWorker {
         std::thread::spawn(move || {
             let mut last_target = String::new();
             let mut last_captured: Option<String> = None;
+            // When the frame that is currently in the mailbox (or the last
+            // one consumed) was published, for the inter-publish floor.
+            let mut last_published_at: Option<std::time::Instant> = None;
             // Render the live preview from an in-process vt100 grid fed by
             // `tmux pipe-pane -IO` (and route input back through the same
             // socket), instead of scraping `capture-pane` and forking
@@ -684,12 +734,19 @@ impl LiveCaptureWorker {
                     .ok()
                     .map(|g| g.clone())
                     .unwrap_or_default();
+                // A frame deferred by the publish floor this iteration; the
+                // wait below shrinks to the floor's remainder so it goes out
+                // as soon as the floor reopens.
+                let mut deferred_publish = false;
                 // A retarget resets the dedup so the new pane's first frame
                 // always publishes, even if its bytes happen to match the
                 // previous pane's last capture.
                 if name != last_target {
                     last_target = name.clone();
                     last_captured = None;
+                    // The new pane's first frame must not inherit the old
+                    // pane's floor.
+                    last_published_at = None;
                     // Tear down a VT source armed for the old target (also fires
                     // on retarget-to-empty), disabling its `pipe-pane`, and allow
                     // a fresh arm attempt for the new target.
@@ -716,6 +773,13 @@ impl LiveCaptureWorker {
                         if vt_source.is_none() && !vt_arm_attempted {
                             vt_arm_attempted = true;
                             vt_source = crate::tmux::vt::VtChannel::acquire(&name);
+                            // Event-driven echo: the channel pokes our nudge
+                            // condvar on every grid change, so the wait below
+                            // ends the moment output lands instead of after
+                            // the remainder of a poll interval.
+                            if let Some(v) = vt_source.as_ref() {
+                                v.set_change_wakeup(nudge_thread.clone());
+                            }
                         }
                         // A channel whose forwarder has disconnected stops
                         // updating its grid; drop it and fall back to capture
@@ -759,19 +823,35 @@ impl LiveCaptureWorker {
                                 *guard = cursor_now;
                             }
                             if (forward_empty || !content.is_empty()) && changed {
-                                if let Ok(mut guard) = slot.lock() {
-                                    *guard = Some(content.clone());
+                                let since =
+                                    last_published_at.map(|t| t.elapsed().as_millis() as u64);
+                                if publish_floor_wait_ms(since) == 0 {
+                                    if let Ok(mut guard) = slot.lock() {
+                                        *guard = Some(content.clone());
+                                    }
+                                    last_captured = Some(content);
+                                    last_published_at = Some(std::time::Instant::now());
+                                    wake.notify_one();
+                                } else {
+                                    // Inside the floor: defer, don't drop.
+                                    // `last_captured` stays stale, so the next
+                                    // cycle re-detects this frame and publishes
+                                    // it once the floor reopens.
+                                    deferred_publish = true;
                                 }
-                                last_captured = Some(content);
-                                wake.notify_one();
                             }
                         }
                     }
                 }
                 // Interruptible wait: `set_live` / `set_target` notify the
                 // condvar so a cadence or target change is picked up at once
-                // rather than after the current sleep. Spurious wakeups just
-                // run an extra capture cycle, which the dedup makes harmless.
+                // rather than after the current sleep, and on the VT path the
+                // channel's reader thread notifies it on every grid change,
+                // so fresh output samples immediately instead of waiting out
+                // the interval (the interval is then only the fallback for a
+                // notify that fired while this thread wasn't parked). Spurious
+                // wakeups just run an extra capture cycle, which the dedup
+                // makes harmless.
                 //
                 // A live in-process vt channel samples the grid cheaply (no
                 // `capture-pane` fork) and dedups unchanged frames, so the idle
@@ -788,6 +868,14 @@ impl LiveCaptureWorker {
                     LIVE_CAPTURE_INTERVAL_FAST_MS
                 } else {
                     interval_cell.load(Ordering::Relaxed)
+                };
+                // A frame deferred by the publish floor goes out as soon as
+                // the floor reopens, not after a full interval.
+                let ms = if deferred_publish {
+                    let since = last_published_at.map(|t| t.elapsed().as_millis() as u64);
+                    ms.min(publish_floor_wait_ms(since).max(1))
+                } else {
+                    ms
                 };
                 if let Ok(guard) = nudge_thread.0.lock() {
                     let _ = nudge_thread
@@ -2284,6 +2372,58 @@ mod tests {
             worker.take_latest().is_none(),
             "retarget must drop the previous pane's queued capture",
         );
+    }
+
+    #[test]
+    fn publish_floor_first_change_after_quiet_publishes_immediately() {
+        // The typed-echo case: no prior publish (or one long past) must never
+        // wait. Reintroducing a wait here re-creates the live-mode echo lag
+        // the event-driven wakeup exists to kill.
+        assert_eq!(publish_floor_wait_ms(None), 0);
+        assert_eq!(
+            publish_floor_wait_ms(Some(LIVE_CAPTURE_INTERVAL_FAST_MS)),
+            0
+        );
+        assert_eq!(publish_floor_wait_ms(Some(1_000)), 0);
+    }
+
+    #[test]
+    fn publish_floor_paces_sustained_streaming_at_fast_cadence() {
+        // Back-to-back changes must not publish faster than the fast
+        // interval: the 33ms render ticker and its cooldown were calibrated
+        // against that pacing, and faster publishes tear on terminals
+        // without synchronized updates.
+        assert_eq!(
+            publish_floor_wait_ms(Some(0)),
+            LIVE_CAPTURE_INTERVAL_FAST_MS
+        );
+        assert_eq!(
+            publish_floor_wait_ms(Some(5)),
+            LIVE_CAPTURE_INTERVAL_FAST_MS - 5
+        );
+    }
+
+    #[test]
+    fn only_resize_batches_reassert_ownership_before_dispatch() {
+        // Keystroke batches must dispatch without waiting on the size-owner
+        // steal (~5 tmux forks); putting the steal back ahead of plain input
+        // re-creates the per-keystroke latency this classifier exists to
+        // avoid. Resizes keep steal-first so geometry never races another
+        // owner's grid.
+        assert!(batch_needs_owner_first(&[WorkerMsg::Resize {
+            cols: 80,
+            rows: 24
+        }]));
+        assert!(batch_needs_owner_first(&[
+            WorkerMsg::Send(TmuxKey::Literal("a".into())),
+            WorkerMsg::Resize { cols: 80, rows: 24 },
+        ]));
+        assert!(!batch_needs_owner_first(&[
+            WorkerMsg::Send(TmuxKey::Literal("abc".into())),
+            WorkerMsg::Send(TmuxKey::Named("Enter".into())),
+            WorkerMsg::Send(TmuxKey::HexBytes(vec![0x1b])),
+        ]));
+        assert!(!batch_needs_owner_first(&[]));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Live mode has always felt a bit laggier than attaching to the tmux session directly, even after #1829, #1775, #1824, #2433, and #2435 each shaved a layer. This PR removes the two delays that were left. Nothing docker- or worktree-specific; the delta was in the transport itself.

**1. Input: ~5 tmux forks serialized ahead of every keystroke.** `LiveSendWorker` ran `steal_size_owner` (has-session, 2x set-option, 2x show-options) before dispatching each input batch, so every keystroke paid ~5.5ms of forks on Linux and an estimated 15-65ms on macOS (where a fork is 3-13ms) before its byte even reached the pane. Keystrokes never read the size lock, so they now dispatch first; ownership is re-asserted at most once per `SIZE_OWNER_HEARTBEAT` (1.5s, well inside the 4s TTL). Resize batches keep the steal-before-dispatch ordering, since geometry must not race another owner's grid (`batch_needs_owner_first`).

**2. Echo: the TUI polled the vt100 grid at 25ms.** #2435 made the web viewer event-driven off the shared `VtChannel`, but the change signal (`changed_tx`) was serve-only; the native TUI's `LiveCaptureWorker` kept sampling on a 25ms cadence, so every echo sat out the remainder of a poll cycle. The reader thread now pokes a registered `ChangeWakeup` (the capture worker's own nudge condvar) on every grid change and on death, so output samples the moment it lands. A 25ms floor between published frames keeps sustained streaming at the old pacing (the 33ms render ticker and its cooldown were calibrated against it); the floor keys off publishes, not samples, so the send worker's pre-echo wake cannot push real echo back a cycle, and a deferred frame re-publishes the instant the floor reopens.

The reader loop moved out of the `arm()` closure into `run_reader` with a `ReaderCtx`, so the notify wiring has a deterministic unit test driven over a raw unix socket, no tmux required.

**Measured** end-to-end echo latency (nested-tmux harness, instant-echo fake agent, 24 keystrokes per run, roughly 3-5ms of measurement overhead included):

| build | median | p90 |
|---|---|---|
| baseline (2 runs) | 48.4ms / 49.1ms | ~53ms |
| fixed (3 runs) | 19.0ms / 19.6ms / 19.0ms | ~23ms |

2.5x faster on Linux; the macOS gain should be larger since the removed forks cost more there.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy`, `cargo test` clean (3818 passed; the 3 failures in my sandbox also fail on a clean checkout of main there: one reads fixtures a non-isolated test leaks into the real `~/.claude/projects/-tmp-x/`, one chmods a dir and expects EACCES which cannot work as root, one is the restart resume-cascade dialog. All environmental, none touch this diff. The fixture leak deserves its own issue.)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior change is latency, and a timing-threshold e2e would be flaky in CI. The regression coverage is deterministic unit tests instead: `reader_pokes_registered_wakeup_on_grid_change` (vt.rs, drives `run_reader` over a raw socket and asserts the wakeup fires), `publish_floor_*` (floor semantics), and `only_resize_batches_reassert_ownership_before_dispatch` (steal ordering). Existing live-send e2e-adjacent worker tests still pass.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:** Investigated, fixed, and measured via Claude Code in a sandbox, directed by @njbrake. The before/after latency numbers come from a scripted nested-tmux harness driving the real binary.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Lowered live-mode TUI latency by changing the order in which input batches are handled: keystrokes are sent before reasserting the tmux size ownership, while resize batches keep a steal-before-dispatch sequence so resizing stays correct.
- Made the live VT capture more efficient by switching from frequent polling to an event-driven wakeup that triggers when the terminal grid changes (with a small 25ms floor to keep sustained output feeling smooth).
- Refactored the socket reader into a dedicated `run_reader` flow with a context object to make the behavior deterministic and easier to unit test.
- Updated/added unit tests to cover wakeup behavior, the 25ms publishing cadence, and the resize-vs-keystroke ownership ordering.

## Benefits

- Linux echo latency improved from roughly 48–49ms median to ~19ms median.
- p90 latency improved from about ~53ms to ~23ms.
- Less polling work and faster responsiveness for live previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->