### PR TITLE
fix(web): insert soft newline on Shift+Enter in live terminal

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -190,9 +190,16 @@ function altPrintableMetaKey(
   return e.shiftKey ? letter : letter.toLowerCase();
 }
 
+// Shift+Enter (and Ctrl+Enter) insert a soft newline instead of submitting,
+// matching native Claude Code and the standard macOS text-entry convention
+// (#2316). The browser can read the modifier here even though a bare terminal
+// can't, so we translate it to ESC+CR (\x1b\r), the same sequence Option/Alt+
+// Enter sends and that CLI agents read as "insert newline". Plain Enter and the
+// other chords still submit. Supersedes the Shift+Enter-submits mapping from
+// #2765.
 function liveEnterSequence(e: { key: string; ctrlKey: boolean; shiftKey: boolean; altKey: boolean; metaKey: boolean }) {
   if (e.key !== "Enter") return null;
-  if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) return "\x1b\r";
+  if ((e.shiftKey || e.ctrlKey) && !e.altKey && !e.metaKey) return "\x1b\r";
   return "\r";
 }
 

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -190,18 +190,18 @@ describe("MobileLiveTerminal paste", () => {
     expect(sendData).toHaveBeenCalledWith("\x1b\r");
   });
 
-  it("sends Shift+Enter as carriage return", () => {
+  it("sends Shift+Enter as terminal Meta Enter for agent line breaks", () => {
     const { input, sendData } = renderTerm();
 
     expect(fireEvent.keyDown(input, { key: "Enter", shiftKey: true })).toBe(false);
-    expect(sendData).toHaveBeenCalledWith("\r");
+    expect(sendData).toHaveBeenCalledWith("\x1b\r");
   });
 
-  it("sends Ctrl+Shift+Enter as carriage return", () => {
+  it("sends Ctrl+Shift+Enter as terminal Meta Enter for agent line breaks", () => {
     const { input, sendData } = renderTerm();
 
     expect(fireEvent.keyDown(input, { key: "Enter", ctrlKey: true, shiftKey: true })).toBe(false);
-    expect(sendData).toHaveBeenCalledWith("\r");
+    expect(sendData).toHaveBeenCalledWith("\x1b\r");
   });
 
   it("sends Alt+Enter as carriage return", () => {


### PR DESCRIPTION
## Description

The web dashboard's live terminal treated **Shift+Enter** the same as a plain Enter, submitting the prompt instead of inserting a soft newline. That breaks the convention users expect from native Claude Code (and virtually every macOS text surface): Shift+Enter is a soft line break, plain Enter submits. Reported in #2316 (and re-confirmed against the shipped web bundle in a later comment).

The browser can read the Shift modifier on the keydown even though a bare terminal cannot, so `liveEnterSequence` now translates Shift+Enter (and Ctrl+Enter, already handled) to ESC+CR (`\x1b\r`), the sequence Option/Alt+Enter sends and that CLI agents read as "insert newline". Plain Enter and Alt+Enter still submit.

This supersedes the Shift+Enter-submits mapping from #2765. That PR's rationale matched a terminal that can't distinguish the modifier, but the web view can, and should hand through the nicer sequence; it is also what Ghostty + the kitty keyboard protocol produce for a real attached terminal. Only the Shift+Enter / Ctrl+Shift+Enter mappings and their two tests change; the rest of #2765 stands.

Scope note: this resolves the web portion of #2316. The attached-TUI Shift+Enter path (needs the kitty keyboard protocol through tmux) is tracked separately in #2362, and web image paste already landed in #2678, so this uses `Refs #2316` rather than closing it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow in the coverage-matrix mandate list

Live-terminal Enter chords aren't in the mandated-flow list (same as #2765, which added no matrix entry). This is a request-payload permutation, does the Enter chord emit the right bytes, which the guidelines route to **Vitest + RTL**, not Playwright. Updated the two Shift+Enter assertions in `web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx`; verified they fail without the source change and pass with it.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Used to trace the byte-level Enter handling, implement the one-line fix, and update the tests. Reasoning and the decision to supersede #2765 were made in back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Updated the web live terminal so Shift+Enter and Ctrl+Shift+Enter insert a soft newline instead of submitting.
- Preserved submission behavior for regular Enter and Alt+Enter.
- Updated Vitest assertions to reflect the new terminal input sequences.

### Benefits
- Makes multiline prompt editing more intuitive in the web dashboard.
- Keeps existing Enter submission behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->