### PR TITLE
feat: add sandbox.network config for container network isolation

### DIFF
--- a/aoe-settings-derive/src/lib.rs
+++ b/aoe-settings-derive/src/lib.rs
@@ -22,7 +22,7 @@
 //! `min`, `max`, `step`, `multiline`, `mono`, `options` ("v:Label,v2:Label2"),
 //! `web` ("allow" | "elevation:reason" | "local_only:reason"),
 //! `validate` ("none" | "range:min[:max]" | "nonempty" | "memory_limit" |
-//!   "volume_list" | "env_list" | "port_mapping_list"),
+//!   "volume_list" | "env_list" | "port_mapping_list" | "network"),
 //! `global_only` (flag: field is shown but not profile-overridable),
 //! `skip` (flag: exclude the field from the schema entirely).
 //! When `desc` is omitted, the field's doc comment is used.
@@ -308,6 +308,7 @@ fn build_validation(
         "volume_list" => quote!(ValidationKind::VolumeList),
         "env_list" => quote!(ValidationKind::EnvList),
         "port_mapping_list" => quote!(ValidationKind::PortMappingList),
+        "network" => quote!(ValidationKind::Network),
         range if range.starts_with("range:") => {
             let parts: Vec<&str> = range.trim_start_matches("range:").split(':').collect();
             if parts.is_empty() || parts.len() > 2 {

--- a/src/containers/container_interface.rs
+++ b/src/containers/container_interface.rs
@@ -93,6 +93,10 @@ pub struct ContainerConfig {
     pub cpu_limit: Option<String>,
     pub memory_limit: Option<String>,
     pub port_mappings: Vec<String>,
+    /// Container network mode passed to `--network`. `None` uses the runtime
+    /// default (bridge). Set from `sandbox.network`; `bridge` and the rejected
+    /// `host` value are normalized to `None` before reaching here.
+    pub network: Option<String>,
     /// Append the SELinux relabel flag (`:z`) to host bind mounts so the container
     /// can access them on SELinux-enforcing hosts (Fedora, RHEL). Set from
     /// `sandbox.selinux_relabel`; only emitted for runtimes that support it.

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -36,6 +36,11 @@ pub(crate) struct RuntimeBase {
     /// Whether this runtime supports the `:z`/`:Z` SELinux relabel volume flag
     /// (Docker and Podman do; Apple Container does not).
     pub supports_selinux_relabel: bool,
+    /// Whether this runtime supports Docker-style `--network <mode>` (`none`,
+    /// `bridge`, or a named network). Docker and Podman do; Apple Container's
+    /// `run` does not take these modes, so a configured `sandbox.network` is
+    /// skipped with a warning there rather than emitting a flag that fails.
+    pub supports_network_mode: bool,
     /// Case-insensitive stderr substrings that identify a "container does not
     /// exist" error for this runtime. Each runtime words it differently (Docker
     /// "No such container", Apple Container "notFound … not found"), so the
@@ -75,6 +80,7 @@ impl RuntimeBase {
         supports_remove_volumes: true,
         supports_named_volumes: true,
         supports_selinux_relabel: true,
+        supports_network_mode: true,
         not_found_markers: &["no such container"],
         // moby/moby client/errors.go connectionFailed() is the single source
         // of this message across every Docker OS variant (macOS Desktop, Linux
@@ -101,6 +107,7 @@ impl RuntimeBase {
         supports_remove_volumes: false,
         supports_named_volumes: false,
         supports_selinux_relabel: false,
+        supports_network_mode: false,
         // Apple Container reports a missing container as
         // `notFound: "container with ID <id> not found"`. The bare "not found"
         // substring would be dangerously broad; a plausible daemon-connectivity
@@ -136,6 +143,7 @@ impl RuntimeBase {
         supports_remove_volumes: true,
         supports_named_volumes: true,
         supports_selinux_relabel: true,
+        supports_network_mode: true,
         not_found_markers: &["no such container"],
         // Two distinct daemon-down wordings observed in real Podman output:
         // - "connect to Podman socket" fires on Linux socket mode
@@ -412,13 +420,25 @@ impl RuntimeBase {
         let (env_argv, _inherit) = docker_env_args(&config.environment);
         args.extend(env_argv);
 
-        let network_none = config
-            .network
-            .as_deref()
-            .is_some_and(|n| n.eq_ignore_ascii_case("none"));
-        if let Some(network) = &config.network {
+        // Apple Container's `run` doesn't take Docker-style `--network` modes,
+        // so a configured network is skipped there with a warning rather than
+        // emitting a flag that fails container creation.
+        let network = match config.network.as_deref() {
+            Some(n) if !self.supports_network_mode => {
+                tracing::warn!(
+                    target: "containers.runtime",
+                    "{} does not support --network modes; ignoring sandbox.network = {:?}",
+                    self.name,
+                    n
+                );
+                None
+            }
+            other => other,
+        };
+        let network_none = network.is_some_and(|n| n.eq_ignore_ascii_case("none"));
+        if let Some(network) = network {
             args.push("--network".to_string());
-            args.push(network.clone());
+            args.push(network.to_string());
         }
 
         // Publishing ports requires a network; the runtime errors out if `-p`
@@ -1045,6 +1065,24 @@ mod tests {
         assert_eq!(arg_after(&args, "--network"), Some("none"));
         // `-p` conflicts with `--network none`, so it must be dropped.
         assert!(!args.iter().any(|a| a == "-p"));
+    }
+
+    #[test]
+    fn test_build_create_args_network_skipped_on_unsupported_runtime() {
+        let base = RuntimeBase::APPLE_CONTAINER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            network: Some("none".to_string()),
+            port_mappings: vec!["3000:3000".to_string()],
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        // Apple Container gets no --network flag, and because it wasn't applied
+        // the port mappings are still emitted.
+        assert!(!args.iter().any(|a| a == "--network"));
+        assert_eq!(arg_after(&args, "-p"), Some("3000:3000"));
     }
 
     #[test]

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -412,9 +412,29 @@ impl RuntimeBase {
         let (env_argv, _inherit) = docker_env_args(&config.environment);
         args.extend(env_argv);
 
-        for port in &config.port_mappings {
-            args.push("-p".to_string());
-            args.push(port.clone());
+        let network_none = config
+            .network
+            .as_deref()
+            .is_some_and(|n| n.eq_ignore_ascii_case("none"));
+        if let Some(network) = &config.network {
+            args.push("--network".to_string());
+            args.push(network.clone());
+        }
+
+        // Publishing ports requires a network; the runtime errors out if `-p`
+        // is combined with `--network none`, so drop the mappings and warn
+        // rather than fail container creation.
+        if network_none && !config.port_mappings.is_empty() {
+            tracing::warn!(
+                target: "containers.runtime",
+                "Ignoring {} port mapping(s) because sandbox.network = \"none\"",
+                config.port_mappings.len()
+            );
+        } else {
+            for port in &config.port_mappings {
+                args.push("-p".to_string());
+                args.push(port.clone());
+            }
         }
 
         if let Some(cpu) = &config.cpu_limit {
@@ -973,6 +993,73 @@ mod tests {
         // Should NOT include :ro suffix (Apple Container doesn't support it)
         assert!(args.contains(&"/host/path:/container/path".to_string()));
         assert!(!args.iter().any(|a| a.ends_with(":ro")));
+    }
+
+    /// The value immediately following `flag` in an arg list, if present.
+    fn arg_after<'a>(args: &'a [String], flag: &str) -> Option<&'a str> {
+        args.iter()
+            .position(|a| a == flag)
+            .and_then(|i| args.get(i + 1))
+            .map(String::as_str)
+    }
+
+    #[test]
+    fn test_build_create_args_no_network_flag_by_default() {
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        assert!(!args.iter().any(|a| a == "--network"));
+    }
+
+    #[test]
+    fn test_build_create_args_named_network_emitted() {
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            network: Some("egress-proxy".to_string()),
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        assert_eq!(arg_after(&args, "--network"), Some("egress-proxy"));
+    }
+
+    #[test]
+    fn test_build_create_args_network_none_drops_port_mappings() {
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            network: Some("none".to_string()),
+            port_mappings: vec!["3000:3000".to_string()],
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        assert_eq!(arg_after(&args, "--network"), Some("none"));
+        // `-p` conflicts with `--network none`, so it must be dropped.
+        assert!(!args.iter().any(|a| a == "-p"));
+    }
+
+    #[test]
+    fn test_build_create_args_ports_kept_with_named_network() {
+        let base = RuntimeBase::DOCKER;
+        let config = ContainerConfig {
+            working_dir: "/workspace/project".to_string(),
+            network: Some("egress-proxy".to_string()),
+            port_mappings: vec!["3000:3000".to_string()],
+            ..Default::default()
+        };
+
+        let args = base.build_create_args("c", "alpine:latest", &config);
+
+        assert_eq!(arg_after(&args, "-p"), Some("3000:3000"));
     }
 
     #[test]

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2216,6 +2216,22 @@ pub struct SandboxConfig {
     )]
     pub port_mappings: Vec<String>,
 
+    /// Container network mode: unset or "bridge" for the default (full outbound
+    /// via the runtime's bridge), "none" for no network (isolates the agent but
+    /// also cuts off its own model API unless a proxy is routed in), or a named
+    /// network to attach a user-defined network with its own egress filtering.
+    /// "host" is rejected because sharing the host network namespace defeats
+    /// sandbox isolation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[setting(
+        label = "Network",
+        widget = "optional_text",
+        validate = "network",
+        web = "elevation:sandbox config affects host isolation",
+        advanced
+    )]
+    pub network: Option<String>,
+
     /// Default terminal for sandboxed sessions (toggle with 'c' key).
     #[serde(default)]
     #[setting(
@@ -2328,6 +2344,7 @@ impl Default for SandboxConfig {
             cpu_limit: None,
             memory_limit: None,
             port_mappings: Vec::new(),
+            network: None,
             default_terminal_mode: DefaultTerminalMode::default(),
             volume_ignores: Vec::new(),
             volume_ignores_strategy: VolumeIgnoresStrategy::default(),
@@ -3020,6 +3037,7 @@ mod tests {
         assert!(sb.cpu_limit.is_none());
         assert!(sb.memory_limit.is_none());
         assert!(sb.volume_ignores.is_empty());
+        assert!(sb.network.is_none());
     }
 
     #[test]
@@ -3033,6 +3051,7 @@ mod tests {
             cpu_limit = "2"
             memory_limit = "4g"
             port_mappings = ["3000:3000", "5432:5432"]
+            network = "none"
         "#;
         let sb: SandboxConfig = toml::from_str(toml).unwrap();
         assert!(sb.enabled_by_default);
@@ -3046,6 +3065,7 @@ mod tests {
             sb.port_mappings,
             vec!["3000:3000".to_string(), "5432:5432".to_string()]
         );
+        assert_eq!(sb.network, Some("none".to_string()));
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1719,8 +1719,31 @@ pub(crate) fn build_container_config(
         cpu_limit: sandbox_config.cpu_limit,
         memory_limit: sandbox_config.memory_limit,
         port_mappings: sandbox_config.port_mappings.clone(),
+        network: sanitize_network(sandbox_config.network.as_deref()),
         selinux_relabel: sandbox_config.selinux_relabel,
     })
+}
+
+/// Normalize the configured `sandbox.network` into the value passed to
+/// `--network`. Unset and `bridge` both map to `None` (runtime default, no
+/// flag). `host` is rejected here as defense in depth even though the settings
+/// validator already refuses it, because repo/profile TOML is only
+/// type-checked, not value-validated (a repo config could set it directly, the
+/// concern raised in #2706). Everything else (`none` or a named network) passes
+/// through verbatim.
+fn sanitize_network(network: Option<&str>) -> Option<String> {
+    let value = network.map(str::trim).filter(|v| !v.is_empty())?;
+    if value.eq_ignore_ascii_case("bridge") {
+        return None;
+    }
+    if value.eq_ignore_ascii_case("host") {
+        tracing::warn!(
+            target: "session.profile",
+            "Ignoring sandbox.network = \"host\": host network mode defeats sandbox isolation"
+        );
+        return None;
+    }
+    Some(value.to_string())
 }
 
 /// Find the longest common ancestor path of two absolute paths.
@@ -1743,6 +1766,30 @@ mod tests {
     use crate::hooks::test_support::BaseGuard;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn sanitize_network_defaults_to_none() {
+        assert_eq!(sanitize_network(None), None);
+        assert_eq!(sanitize_network(Some("")), None);
+        assert_eq!(sanitize_network(Some("  ")), None);
+        assert_eq!(sanitize_network(Some("bridge")), None);
+        assert_eq!(sanitize_network(Some("BRIDGE")), None);
+    }
+
+    #[test]
+    fn sanitize_network_rejects_host() {
+        assert_eq!(sanitize_network(Some("host")), None);
+        assert_eq!(sanitize_network(Some("Host")), None);
+    }
+
+    #[test]
+    fn sanitize_network_passes_through_none_and_named() {
+        assert_eq!(sanitize_network(Some("none")), Some("none".to_string()));
+        assert_eq!(
+            sanitize_network(Some(" egress-proxy ")),
+            Some("egress-proxy".to_string())
+        );
+    }
 
     // --- compute_volume_paths tests ---
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1743,6 +1743,13 @@ fn sanitize_network(network: Option<&str>) -> Option<String> {
         );
         return None;
     }
+    // Canonicalize the reserved keyword so a "None"/"NONE" config value still
+    // emits the runtime's lowercase `none` mode rather than a nonexistent
+    // network name. Named networks keep their original case (they are
+    // user-defined and case-sensitive).
+    if value.eq_ignore_ascii_case("none") {
+        return Some("none".to_string());
+    }
     Some(value.to_string())
 }
 
@@ -1789,6 +1796,12 @@ mod tests {
             sanitize_network(Some(" egress-proxy ")),
             Some("egress-proxy".to_string())
         );
+    }
+
+    #[test]
+    fn sanitize_network_canonicalizes_none_keyword() {
+        assert_eq!(sanitize_network(Some("None")), Some("none".to_string()));
+        assert_eq!(sanitize_network(Some("NONE")), Some("none".to_string()));
     }
 
     // --- compute_volume_paths tests ---

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -95,7 +95,7 @@ pub fn set_unread_enabled(on: bool) {
 pub use profile_config::{
     load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,
     save_profile_config, validate_check_interval, validate_env_format, validate_memory_limit,
-    validate_port_mapping_format, validate_volume_format, ProfileConfig,
+    validate_network_format, validate_port_mapping_format, validate_volume_format, ProfileConfig,
 };
 pub use projects::{Project, ProjectScope};
 pub use recovery::HookTimeoutScope;

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -182,6 +182,26 @@ pub fn validate_port_mapping_format(mapping: &str) -> Result<(), String> {
     }
 }
 
+/// Validate a container network mode (`sandbox.network`). Empty (unset),
+/// `none`, `bridge`, or a named network matching Docker's network-name grammar
+/// are accepted. `host` is rejected outright because sharing the host network
+/// namespace defeats sandbox isolation, and the `container:`/`ns:` namespace
+/// forms are rejected by the name grammar (they contain a colon).
+pub fn validate_network_format(network: &str) -> Result<(), String> {
+    if network.is_empty() {
+        return Ok(());
+    }
+    if network.eq_ignore_ascii_case("host") {
+        return Err("host network mode defeats sandbox isolation and is not allowed".to_string());
+    }
+    let re = regex::Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$").unwrap();
+    if re.is_match(network) {
+        Ok(())
+    } else {
+        Err("Must be 'none', 'bridge', or a network name".to_string())
+    }
+}
+
 /// Validate Docker memory limit format (e.g., "512m", "2g")
 pub fn validate_memory_limit(limit: &str) -> Result<(), String> {
     if limit.is_empty() {
@@ -217,6 +237,24 @@ mod tests {
     /// Build a `ProfileConfig` from a sparse override object (the on-disk shape).
     fn profile_from(overrides: serde_json::Value) -> ProfileConfig {
         serde_json::from_value(overrides).expect("profile override deserializes")
+    }
+
+    #[test]
+    fn validate_network_accepts_empty_none_bridge_and_named() {
+        assert!(validate_network_format("").is_ok());
+        assert!(validate_network_format("none").is_ok());
+        assert!(validate_network_format("bridge").is_ok());
+        assert!(validate_network_format("egress-proxy").is_ok());
+        assert!(validate_network_format("my_net.1").is_ok());
+    }
+
+    #[test]
+    fn validate_network_rejects_host_and_namespace_forms() {
+        assert!(validate_network_format("host").is_err());
+        assert!(validate_network_format("HOST").is_err());
+        assert!(validate_network_format("container:abc").is_err());
+        assert!(validate_network_format("ns:/var/run/netns/x").is_err());
+        assert!(validate_network_format("has space").is_err());
     }
 
     #[test]

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -130,6 +130,10 @@ pub enum ValidationKind {
     EnvList,
     /// Each list entry must be a `host:container` port mapping (digits only).
     PortMappingList,
+    /// A container network mode: empty, `none`, `bridge`, or a named network
+    /// (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`). `host` and other namespace-sharing
+    /// forms are rejected because they defeat sandbox isolation.
+    Network,
     /// Value must be one of a closed set of strings. Used by plugin `select`
     /// settings so an off-menu value cannot be persisted (core selects encode
     /// their options in the widget and need no separate rule).

--- a/src/session/settings_schema/validate.rs
+++ b/src/session/settings_schema/validate.rs
@@ -71,6 +71,12 @@ pub fn validate_value(kind: &ValidationKind, value: &Value) -> Result<(), Valida
         ValidationKind::PortMappingList => {
             validate_string_list(value, crate::session::validate_port_mapping_format)
         }
+        ValidationKind::Network => {
+            let s = value
+                .as_str()
+                .ok_or_else(|| ValidationError::new("expected a string"))?;
+            crate::session::validate_network_format(s).map_err(ValidationError::new)
+        }
         ValidationKind::OneOf { options } => {
             let s = value
                 .as_str()
@@ -173,5 +179,14 @@ mod tests {
         assert!(validate_value(&ValidationKind::PortMappingList, &json!(["8080:80"])).is_ok());
         assert!(validate_value(&ValidationKind::PortMappingList, &json!(["3000"])).is_err());
         assert!(validate_value(&ValidationKind::PortMappingList, &json!(["a:b"])).is_err());
+    }
+
+    #[test]
+    fn network_grammar() {
+        assert!(validate_value(&ValidationKind::Network, &json!("")).is_ok());
+        assert!(validate_value(&ValidationKind::Network, &json!("none")).is_ok());
+        assert!(validate_value(&ValidationKind::Network, &json!("egress-proxy")).is_ok());
+        assert!(validate_value(&ValidationKind::Network, &json!("host")).is_err());
+        assert!(validate_value(&ValidationKind::Network, &json!(42)).is_err());
     }
 }


### PR DESCRIPTION
## Description

Sandboxed sessions always landed on the runtime's default bridge network with full outbound access: `build_create_args` never emitted a `--network` flag and there was no config key to change it. For many sandbox use cases the whole point is limiting blast radius, so this adds a typed `sandbox.network` setting (global / profile / repo, like the other sandbox keys) that maps to `--network`:

- unset or `"bridge"` keeps the current default (no flag emitted, no change for existing users)
- `"none"` isolates the container (also drops conflicting port mappings with a warning, since `-p` conflicts with `--network none`)
- a named network attaches a user-defined network with its own egress filtering / proxy

`"host"` is rejected. Sharing the host network namespace defeats sandbox isolation, and because `sandbox` is repo-overridable, a cloned repo's config could otherwise silently weaken isolation. It is refused both by the settings validator and, as defense in depth, when the container config is assembled (repo/profile TOML is only type-checked, not value-validated), which is the trust-boundary concern raised in #2706.

Being a single-source setting, the one field declaration propagates to the TUI, web dashboard, and profile/repo overrides automatically.

Fixes #2705

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

<!-- No bespoke UI: the field renders via the generic schema-driven optional_text widget in both TUI and web. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

<!-- The setting is fully schema-driven: no web/src changes, no new custom widget. The web renders it through the existing generic optional_text SchemaSection path, so there is no new dashboard flow to cover. Server-side value validation is covered by Rust unit tests. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

<!-- No new TUI rendering or session-lifecycle behavior: the field is a schema-driven row. The new logic is arg assembly and value validation, covered by unit tests: build_create_args emission + port-mapping guard (src/containers/runtime_base.rs), sanitize_network normalization (src/session/container_config.rs), and validate_network_format grammar (src/session/profile_config.rs + settings_schema/validate.rs). -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Implemented via Claude Code through back-and-forth with @njbrake. The design decisions (typed key over a generic `extra_run_args` escape hatch, rejecting `host`, the defense-in-depth sanitization tied to the #2706 trust boundary) are his; the implementation and tests were drafted by Claude and reviewed by him.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Introduced a new configurable `sandbox.network` setting that can be applied globally, per-profile, and per-repository.
- Added validation and UI/schema support so only safe network modes are accepted (allows unset/`bridge`, `none`, and named networks; rejects `host`).
- Normalized network values before use: unset/`bridge` become the default, and `none` is handled case-insensitively.
- Updated container runtime argument generation to emit `--network ...` only for runtimes that support it (Docker/Podman), while unsupported runtimes skip the flag with a warning.
- For `none`, automatically removes conflicting port mappings and logs a warning about the ignored ports.
- Extended automated tests to cover validation, normalization, runtime argument emission, port-handling behavior, and runtime capability gating.

## Benefits

Gives sandbox sessions controlled network isolation (including fully isolated `none`) without changing existing behavior by default, and prevents unsafe configurations like `host` by design.

## Potential enhancements

Improve user-facing documentation/examples for `sandbox.network` across runtimes, including how port mappings behave under `none` and what happens on runtimes that don’t support network modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->