### PR TITLE
fix(tui): eliminate cursor flicker on terminals without synchronized-update support

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -235,6 +235,20 @@ fn theme_apply_needed(current: (&str, bool), next: (&str, bool)) -> bool {
     current != next
 }
 
+/// Whether `draw` should skip its explicit pre-render `cursor::Hide`.
+///
+/// The pre-draw Hide exists only to keep an IME candidate window from being
+/// dragged by the backend's transient cursor moves during the diff paint. In
+/// live-send with no overlay open, the only cursor is the remote preview-pane
+/// caret (no local IME), and the early Hide (flushed before the ~2-3ms widget
+/// build, while ratatui's trailing Show is flushed after it) is what straddles
+/// the vsync boundary and reads as ~30fps flicker on terminals without
+/// synchronized-update (Terminal.app). Skipping it there removes the blink;
+/// every other state keeps the Hide.
+fn skip_predraw_cursor_hide(live_send_active: bool, has_overlay: bool) -> bool {
+    live_send_active && !has_overlay
+}
+
 impl App {
     /// Is this key event a candidate for paste-burst accumulation?
     /// Printable ASCII Char or Enter, with no modifiers (or shift only).
@@ -438,13 +452,26 @@ impl App {
     /// frame's final cursor position is restored. Synchronized update batches
     /// the frame, and hiding the cursor before the batch keeps the only visible
     /// cursor transition at ratatui's final `Frame::set_cursor_position`.
+    ///
+    /// `skip_predraw_cursor_hide` skips that pre-draw Hide specifically in
+    /// live-send with no overlay open: that is the one state that visibly
+    /// flickers on terminals without synchronized-update support (Terminal.app),
+    /// because the only cursor set in that state is the remote live-preview
+    /// pane caret, not a local IME candidate window, so there's nothing for
+    /// the early Hide to protect.
     fn draw(&mut self, terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>) -> Result<()> {
+        let skip_hide = skip_predraw_cursor_hide(
+            self.home.live_send.is_some(),
+            self.home.has_non_live_send_overlay(),
+        );
         crossterm::execute!(
             terminal.backend_mut(),
             crossterm::terminal::BeginSynchronizedUpdate
         )?;
         let draw_result = (|| -> Result<()> {
-            crossterm::execute!(terminal.backend_mut(), crossterm::cursor::Hide)?;
+            if !skip_hide {
+                crossterm::execute!(terminal.backend_mut(), crossterm::cursor::Hide)?;
+            }
             terminal.draw(|f| self.render(f))?;
             Ok(())
         })();
@@ -3181,6 +3208,30 @@ mod tests {
         assert!(
             theme_apply_needed(("empire", false), ("empire", true)),
             "a different palette mode must re-apply even with the same name"
+        );
+    }
+
+    /// The pre-draw `cursor::Hide` is skipped only in the one state that
+    /// visibly flickers on non-synchronized-update terminals: live-send
+    /// active with no overlay on top of it. Any overlay (IME-relevant local
+    /// input) or a non-live-send state keeps the Hide.
+    #[test]
+    fn skip_predraw_cursor_hide_only_in_live_send_without_overlay() {
+        assert!(
+            skip_predraw_cursor_hide(true, false),
+            "live-send with no overlay must skip the pre-draw Hide (the fix)"
+        );
+        assert!(
+            !skip_predraw_cursor_hide(true, true),
+            "live-send with an overlay open must keep the Hide for IME protection"
+        );
+        assert!(
+            !skip_predraw_cursor_hide(false, false),
+            "outside live-send the Hide must stay unchanged"
+        );
+        assert!(
+            !skip_predraw_cursor_hide(false, true),
+            "outside live-send with an overlay the Hide must stay unchanged"
         );
     }
 


### PR DESCRIPTION
## Description

On terminals that don't support DECSET mode 2026 (synchronized-update) — notably macOS Terminal.app — the TUI cursor visibly blinks/flickers at an irregular ~30Hz cadence while attached to a live-send session. Terminals that do support mode 2026 (iTerm2, kitty, WezTerm) never showed this, because the whole hide/paint/show sequence lands inside one atomic sync-update batch.

Root cause: `App::draw()` unconditionally issued `crossterm::cursor::Hide` before `terminal.draw()`, while ratatui's own render always re-asserts the cursor (`Show` + `MoveTo`) at the end of every frame regardless of whether anything changed. During live-send, the 33ms refresh ticker calls `draw()` continuously, and the live-preview pane cursor is set on nearly every one of those frames. So each frame did: pre-draw `Hide` (flushed before the ~2-3ms widget diff) → paint → post-draw `Show` (flushed after). On Terminal.app those two flushes straddle its own vsync boundary and paint as two separate visible frames. On sync-update-capable terminals the whole sequence is buffered atomically, so it was invisible there.

Fix: skip the pre-draw `Hide` specifically in the one state that flickers — live-send active with no overlay open (`skip_predraw_cursor_hide` in `src/tui/app.rs`). In that state the only cursor ever set is the remote live-preview pane caret, not a local IME candidate window, so there's nothing for the early `Hide` to protect. Every other state (any dialog/picker/settings overlay open, or live-send inactive) keeps the `Hide` exactly as before — real cursor positioning for text inputs and IME safety are unaffected.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed for this internal fix)
- [ ] For UI changes: included screenshot or recording — flicker is a real-time timing artifact that doesn't show in a static screenshot, and a meaningful before/after recording would require side-by-side capture across two terminal emulators, which isn't produced by this PR. Manual verification on Terminal.app (fixed) and iTerm2/kitty (unaffected) is recommended before merge.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: added a focused unit test for the pure `skip_predraw_cursor_hide` predicate covering all four boolean combinations. A full e2e/screen-capture test isn't feasible here: the flicker is a real-terminal-emulator timing/vsync artifact the e2e harness's screen-capture can't observe, and `App::draw()` uses a real `CrosstermBackend<Stdout>` with no `TestBackend` wired through `App` to assert on emitted escape sequences.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Anthropic), model `anthropic/claude-sonnet-5`, via an OpenCode multi-agent pipeline — separate plan, build (TDD implementation), and verification agent passes.

**Any Additional AI Details you'd like to share:** Root cause was independently verified by reading the vendored ratatui/crossterm source (not just the app-level code) before any change was made; the fix's scope was reviewed in a dedicated design pass, weighing and rejecting three alternative approaches, before implementation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed cursor flicker during live-send sessions on terminals without synchronized-update support.
- Adjusted cursor hiding so it is skipped only during live-send without an open overlay.
- Preserved existing behavior for text input, IME handling, and overlay states.
- Added unit tests covering all live-send and overlay combinations.

## Benefits

Provides a smoother live-send experience on terminals such as macOS Terminal.app while minimizing changes to other cursor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->