### PR TITLE
fix(web): present multi-session deletes as workspace actions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -886,41 +886,59 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, []);
 
   const deletingWorkspace = deletingWorkspaceId ? workspaces.find((w) => w.id === deletingWorkspaceId) : null;
+  const deletingSessions = deletingWorkspace?.sessions ?? [];
   const deletingSession = deletingWorkspace?.sessions[0] ?? null;
+  const deletingCleanupDefaults = deletingSession
+    ? {
+        ...deletingSession.cleanup_defaults,
+        delete_worktree: deletingSessions.some(
+          (session) => (session.has_cleanable_worktree ?? false) && session.cleanup_defaults.delete_worktree,
+        ),
+        delete_branch: deletingSessions.some(
+          (session) => (session.has_cleanable_worktree ?? false) && session.cleanup_defaults.delete_branch,
+        ),
+        delete_sandbox: deletingSessions.some(
+          (session) => session.is_sandboxed && session.cleanup_defaults.delete_sandbox,
+        ),
+      }
+    : null;
+  const deletingBranchName =
+    deletingSessions.find((session) => session.branch)?.branch ?? deletingSession?.branch ?? null;
+  const deletingDefaultToTrash =
+    deletingSession != null &&
+    !deletingSessions.every((session) => session.trashed_at) &&
+    deletingSession.cleanup_defaults.delete_to_trash;
 
   const handleDeleteSession = useCallback((workspaceId: string) => {
     setDeletingWorkspaceId(workspaceId);
   }, []);
 
-  const handleConfirmDelete = useCallback(
-    async (options: DeleteSessionOptions) => {
-      if (!deletingWorkspace) return;
-      const sessions = deletingWorkspace.sessions;
-      // Close the dialog immediately; the loop, ordering, and toast logic live
-      // in deleteWorkspaceSessions so they are unit-testable without the bundle.
-      setDeletingWorkspaceId(null);
-      await deleteWorkspaceSessions(sessions, options, activeSessionId, {
-        setStatus: setSessionStatus,
-        // Drop a deleted session's local-only state (#1358 acp cache + draft,
-        // #1842 diff comments). Cross-tab / cross-device deletes fall to the
-        // startup sweep.
-        purgeLocal: (id) => {
-          clearAcpCache(id);
-          clearDraft(id);
-          clearStoredComments(id);
-        },
-        navigateHome: () => navigate("/"),
-        notify: toastBus.handler,
-      });
-    },
-    [deletingWorkspace, activeSessionId, setSessionStatus, navigate],
-  );
+  const handleConfirmDelete = async (options: DeleteSessionOptions) => {
+    if (!deletingWorkspace) return;
+    const sessions = deletingWorkspace.sessions;
+    // Close the dialog immediately; the loop, ordering, and toast logic live
+    // in deleteWorkspaceSessions so they are unit-testable without the bundle.
+    setDeletingWorkspaceId(null);
+    await deleteWorkspaceSessions(sessions, options, activeSessionId, {
+      setStatus: setSessionStatus,
+      // Drop a deleted session's local-only state (#1358 acp cache + draft,
+      // #1842 diff comments). Cross-tab / cross-device deletes fall to the
+      // startup sweep.
+      purgeLocal: (id) => {
+        clearAcpCache(id);
+        clearDraft(id);
+        clearStoredComments(id);
+      },
+      navigateHome: () => navigate("/"),
+      notify: toastBus.handler,
+    });
+  };
 
   // Move-to-trash path (#2489): the safe default. Unlike permanent delete it
   // deliberately KEEPS the per-session acp cache, draft, and stored comments
   // so a restore is faithful; only purge clears them. Trashes every session
   // in the workspace so a multi-session workspace sinks as a whole.
-  const handleConfirmTrash = useCallback(async () => {
+  const handleConfirmTrash = async () => {
     if (!deletingWorkspace) return;
     const ids = deletingWorkspace.sessions.map((s) => s.id);
     if (ids.length === 0) return;
@@ -939,7 +957,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       onError: (id) => setSessionStatus(id, "Error"),
       notify: toastBus.handler,
     });
-  }, [deletingWorkspace, activeSessionId, setSessionStatus, applySession, navigate]);
+  };
 
   // Restore a trashed workspace from the sidebar Trash section (#2489).
   // Restores every session in the workspace (a workspace only lands in Trash
@@ -1918,16 +1936,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         {showAbout && <AboutModal onClose={() => setShowAbout(false)} sessionId={activeSessionId} />}
         {telemetryConsentNeeded && <TelemetryConsentModal onChoose={handleTelemetryConsent} />}
 
-        {deletingSession && (
+        {deletingSession && deletingCleanupDefaults && (
           <DeleteSessionDialog
             sessionTitle={deletingSession.title}
-            branchName={deletingSession.branch}
-            hasManagedWorktree={deletingSession.has_cleanable_worktree ?? false}
-            isSandboxed={deletingSession.is_sandboxed}
-            isScratch={deletingSession.scratch}
-            cleanupDefaults={deletingSession.cleanup_defaults}
-            defaultToTrash={!deletingSession.trashed_at && deletingSession.cleanup_defaults.delete_to_trash}
-            extraSessionCount={deletingWorkspace ? deletingWorkspace.sessions.length - 1 : 0}
+            branchName={deletingBranchName}
+            hasManagedWorktree={deletingSessions.some((session) => session.has_cleanable_worktree ?? false)}
+            isSandboxed={deletingSessions.some((session) => session.is_sandboxed)}
+            isScratch={deletingSessions.some((session) => session.scratch)}
+            cleanupDefaults={deletingCleanupDefaults}
+            defaultToTrash={deletingDefaultToTrash}
+            affectedSessions={deletingSessions.map((session) => ({
+              id: session.id,
+              title: session.title,
+              isSandboxed: session.is_sandboxed,
+            }))}
             onConfirm={handleConfirmDelete}
             onTrash={handleConfirmTrash}
             onCancel={() => setDeletingWorkspaceId(null)}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -887,10 +887,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const deletingWorkspace = deletingWorkspaceId ? workspaces.find((w) => w.id === deletingWorkspaceId) : null;
   const deletingSessions = deletingWorkspace?.sessions ?? [];
+  const liveDeletingSessions = deletingSessions.filter((session) => !session.trashed_at);
   const deletingSession = deletingWorkspace?.sessions[0] ?? null;
+  const deletingDefaultToTrash = liveDeletingSessions.some((session) => session.cleanup_defaults.delete_to_trash);
   const deletingCleanupDefaults = deletingSession
     ? {
-        ...deletingSession.cleanup_defaults,
+        delete_to_trash: deletingDefaultToTrash,
         delete_worktree: deletingSessions.some(
           (session) => (session.has_cleanable_worktree ?? false) && session.cleanup_defaults.delete_worktree,
         ),
@@ -904,10 +906,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     : null;
   const deletingBranchName =
     deletingSessions.find((session) => session.branch)?.branch ?? deletingSession?.branch ?? null;
-  const deletingDefaultToTrash =
-    deletingSession != null &&
-    !deletingSessions.every((session) => session.trashed_at) &&
-    deletingSession.cleanup_defaults.delete_to_trash;
 
   const handleDeleteSession = useCallback((workspaceId: string) => {
     setDeletingWorkspaceId(workspaceId);

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -72,9 +72,7 @@ export function DeleteSessionDialog({
     ? isWorkspaceDelete
       ? `Removes the workspace branch "${branchName}"`
       : `Removes branch "${branchName}"`
-    : isWorkspaceDelete
-      ? "Removes the workspace branch"
-      : undefined;
+    : undefined;
   const sandboxDetail = isWorkspaceDelete
     ? sandboxedSessionCount > 0 && sandboxedSessionCount < sessions.length
       ? `Removes Docker sandbox containers for ${sandboxedSessionCount} sandboxed ${sandboxedSessionLabel} in this workspace`

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -2,6 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { DeleteSessionOptions } from "../lib/api";
 import type { CleanupDefaults } from "../lib/types";
 
+interface AffectedSession {
+  id: string;
+  title: string;
+  isSandboxed: boolean;
+}
+
 interface Props {
   sessionTitle: string;
   branchName: string | null;
@@ -13,11 +19,10 @@ interface Props {
    *  Trash" with a "Delete permanently" disclosure; when false it goes
    *  straight to the permanent-delete options. See #2489. */
   defaultToTrash: boolean;
-  /** Number of sibling sessions in the workspace beyond the one named above.
-   *  A workspace shares one worktree across all its sessions, and delete acts
-   *  on the whole workspace, so when this is >0 the dialog discloses that more
-   *  than the named session will be removed. See #2530. */
-  extraSessionCount?: number;
+  /** A workspace shares one worktree across all its sessions, and delete acts
+   *  on the whole workspace. When this has more than one item the dialog uses
+   *  workspace-shaped copy instead of presenting the action as single-session. */
+  affectedSessions?: AffectedSession[];
   onConfirm: (options: DeleteSessionOptions) => Promise<void>;
   onTrash: () => Promise<void>;
   onCancel: () => void;
@@ -31,7 +36,7 @@ export function DeleteSessionDialog({
   isScratch,
   cleanupDefaults,
   defaultToTrash,
-  extraSessionCount = 0,
+  affectedSessions,
   onConfirm,
   onTrash,
   onCancel,
@@ -52,6 +57,32 @@ export function DeleteSessionDialog({
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const hasOptions = hasManagedWorktree || isSandboxed || isScratch;
+  const sessions = affectedSessions?.length ? affectedSessions : [{ id: "primary", title: sessionTitle, isSandboxed }];
+  const isWorkspaceDelete = sessions.length > 1;
+  const sandboxedSessionCount = sessions.filter((session) => session.isSandboxed).length;
+  const sandboxedSessionLabel = sandboxedSessionCount === 1 ? "session" : "sessions";
+  const worktreeDetail = branchName
+    ? isWorkspaceDelete
+      ? `Removes the workspace worktree for branch "${branchName}"`
+      : `Removes worktree for branch "${branchName}"`
+    : isWorkspaceDelete
+      ? "Removes the workspace worktree"
+      : undefined;
+  const branchDetail = branchName
+    ? isWorkspaceDelete
+      ? `Removes the workspace branch "${branchName}"`
+      : `Removes branch "${branchName}"`
+    : isWorkspaceDelete
+      ? "Removes the workspace branch"
+      : undefined;
+  const sandboxDetail = isWorkspaceDelete
+    ? sandboxedSessionCount > 0 && sandboxedSessionCount < sessions.length
+      ? `Removes Docker sandbox containers for ${sandboxedSessionCount} sandboxed ${sandboxedSessionLabel} in this workspace`
+      : "Removes Docker sandbox containers for all sessions in this workspace"
+    : "Removes the Docker sandbox container";
+  const scratchDetail = isWorkspaceDelete
+    ? "Leaves scratch directories on disk; session records are still removed"
+    : "Leaves the scratch directory on disk; session record is still removed";
 
   const handleConfirm = useCallback(async () => {
     setDeleting(true);
@@ -127,25 +158,38 @@ export function DeleteSessionDialog({
         {/* Header */}
         <div className="px-5 py-4 border-b border-surface-700">
           <h2 id="delete-session-dialog-title" className="text-sm font-semibold text-status-error">
-            Delete Session
+            {isWorkspaceDelete ? "Delete Workspace" : "Delete Session"}
           </h2>
         </div>
 
         {/* Body */}
         <div className="px-5 py-4 space-y-3">
-          <p className="text-[13px] text-text-secondary">
-            Delete <span className="font-mono text-text-primary break-all">{sessionTitle}</span>?
-          </p>
-
-          {extraSessionCount > 0 && (
-            <p className="text-[12px] text-text-dim" data-testid="delete-session-extra-count">
-              {permanent
-                ? `This permanently deletes all ${extraSessionCount + 1} sessions in this workspace.`
-                : `This moves all ${extraSessionCount + 1} sessions in this workspace to Trash.`}
+          {isWorkspaceDelete ? (
+            <div className="space-y-2">
+              <p className="text-[13px] text-text-secondary">
+                {permanent ? "Permanently delete this workspace?" : "Move this workspace to Trash?"}
+              </p>
+              <p className="text-[12px] text-text-dim" data-testid="delete-session-affected-count">
+                This affects all {sessions.length} sessions in this workspace.
+              </p>
+              <ul
+                className="max-h-32 overflow-y-auto rounded-md border border-surface-700/60 bg-surface-900/40 p-2 space-y-1"
+                data-testid="delete-session-affected-list"
+              >
+                {sessions.map((session) => (
+                  <li key={session.id} className="font-mono text-[12px] text-text-secondary break-all">
+                    {session.title}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="text-[13px] text-text-secondary">
+              Delete <span className="font-mono text-text-primary break-all">{sessionTitle}</span>?
             </p>
           )}
 
-          {/* When trash is the default, deleting moves the session to the
+          {/* When trash is the default, deleting moves the target to the
               Trash (restore later); this checkbox opts into erasing it now.
               When trash-first is off (or the session is already trashed),
               there is no checkbox and delete is always permanent. See #2489. */}
@@ -154,7 +198,11 @@ export function DeleteSessionDialog({
               checked={permanent}
               onChange={setPermanent}
               label="Delete permanently"
-              detail="Skip the trash and erase now, including the transcript. Off: move to Trash, restore later."
+              detail={
+                isWorkspaceDelete
+                  ? "Skip the trash and erase now, including all transcripts. Off: move to Trash, restore later."
+                  : "Skip the trash and erase now, including the transcript. Off: move to Trash, restore later."
+              }
               testId="delete-session-permanent"
             />
           )}
@@ -167,7 +215,7 @@ export function DeleteSessionDialog({
                     checked={deleteWorktree}
                     onChange={setDeleteWorktree}
                     label="Delete worktree"
-                    detail={branchName ? `Removes worktree for branch "${branchName}"` : undefined}
+                    detail={worktreeDetail}
                     testId="delete-session-checkbox-worktree"
                   />
                   {deleteWorktree && (
@@ -185,7 +233,7 @@ export function DeleteSessionDialog({
                     checked={deleteBranch}
                     onChange={setDeleteBranch}
                     label="Delete branch"
-                    detail={branchName ? `Removes branch "${branchName}"` : undefined}
+                    detail={branchDetail}
                     testId="delete-session-checkbox-branch"
                   />
                 </>
@@ -194,8 +242,8 @@ export function DeleteSessionDialog({
                 <Checkbox
                   checked={deleteSandbox}
                   onChange={setDeleteSandbox}
-                  label="Delete container"
-                  detail="Removes the Docker sandbox container"
+                  label={isWorkspaceDelete ? "Delete containers" : "Delete container"}
+                  detail={sandboxDetail}
                   testId="delete-session-checkbox-sandbox"
                 />
               )}
@@ -203,8 +251,8 @@ export function DeleteSessionDialog({
                 <Checkbox
                   checked={keepScratch}
                   onChange={setKeepScratch}
-                  label="Keep scratch directory"
-                  detail="Leaves the scratch directory on disk; session record is still removed"
+                  label={isWorkspaceDelete ? "Keep scratch directories" : "Keep scratch directory"}
+                  detail={scratchDetail}
                   testId="delete-session-checkbox-keep-scratch"
                 />
               )}

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -24,6 +24,7 @@ function setup(overrides?: {
   onConfirm?: () => Promise<void>;
   onTrash?: () => Promise<void>;
   onCancel?: () => void;
+  branchName?: string | null;
   hasManagedWorktree?: boolean;
   isSandboxed?: boolean;
   isScratch?: boolean;
@@ -37,7 +38,7 @@ function setup(overrides?: {
   const utils = render(
     <DeleteSessionDialog
       sessionTitle="my-session"
-      branchName="feature/foo"
+      branchName={overrides?.branchName === undefined ? "feature/foo" : overrides.branchName}
       hasManagedWorktree={overrides?.hasManagedWorktree ?? true}
       isSandboxed={overrides?.isSandboxed ?? false}
       isScratch={overrides?.isScratch ?? false}
@@ -198,6 +199,20 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     expect(container.textContent).toMatch(
       /Removes Docker sandbox containers for 1 sandboxed session in this workspace/,
     );
+  });
+
+  it("does not invent branch cleanup detail when a workspace branch name is unavailable", () => {
+    const { container } = setup({
+      branchName: null,
+      affectedSessions: [
+        { id: "sess-a", title: "agent-alpha", isSandboxed: false },
+        { id: "sess-b", title: "agent-beta", isSandboxed: false },
+      ],
+    });
+
+    const branchBox = container.querySelector('[data-testid="delete-session-checkbox-branch"]');
+    expect(branchBox).toBeTruthy();
+    expect(branchBox?.textContent).toBe("Delete branch");
   });
 
   it("trash-first workspace copy switches when Delete permanently is checked", () => {

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -20,6 +20,7 @@ const cleanupDefaults: CleanupDefaults = {
 };
 
 function setup(overrides?: {
+  affectedSessions?: Array<{ id: string; title: string; isSandboxed: boolean }>;
   onConfirm?: () => Promise<void>;
   onTrash?: () => Promise<void>;
   onCancel?: () => void;
@@ -42,6 +43,7 @@ function setup(overrides?: {
       isScratch={overrides?.isScratch ?? false}
       cleanupDefaults={cleanupDefaults}
       defaultToTrash={overrides?.defaultToTrash ?? false}
+      affectedSessions={overrides?.affectedSessions}
       onConfirm={onConfirm}
       onTrash={onTrash}
       onCancel={onCancel}
@@ -144,6 +146,84 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     expect(labelId).toBeTruthy();
     const titleEl = container.querySelector(`#${labelId}`);
     expect(titleEl?.textContent).toMatch(/Delete Session/);
+  });
+
+  it("keeps the single-session presentation for one affected session", () => {
+    const { container } = setup({
+      affectedSessions: [{ id: "sess-a", title: "my-session", isSandboxed: false }],
+    });
+
+    expect(container.querySelector("#delete-session-dialog-title")?.textContent).toMatch(/Delete Session/);
+    expect(container.textContent).toMatch(/Delete my-session\?/);
+    expect(container.querySelector('[data-testid="delete-session-affected-count"]')).toBeNull();
+    expect(container.querySelector('[data-testid="delete-session-affected-list"]')).toBeNull();
+  });
+
+  it("renders a workspace-shaped presentation for multi-session workspaces", () => {
+    const { container } = setup({
+      affectedSessions: [
+        { id: "sess-a", title: "agent-alpha", isSandboxed: true },
+        { id: "sess-b", title: "agent-beta", isSandboxed: true },
+      ],
+      isSandboxed: true,
+      isScratch: true,
+    });
+
+    expect(container.querySelector("#delete-session-dialog-title")?.textContent).toMatch(/Delete Workspace/);
+    expect(container.textContent).toMatch(/Permanently delete this workspace\?/);
+    expect(container.querySelector('[data-testid="delete-session-affected-count"]')?.textContent).toMatch(
+      /all 2 sessions/,
+    );
+    const affectedList = container.querySelector('[data-testid="delete-session-affected-list"]');
+    expect(affectedList?.textContent).toMatch(/agent-alpha/);
+    expect(affectedList?.textContent).toMatch(/agent-beta/);
+    expect(container.textContent).not.toMatch(/Delete my-session\?/);
+    expect(container.textContent).toMatch(/Removes the workspace worktree for branch "feature\/foo"/);
+    expect(container.textContent).toMatch(/Removes the workspace branch "feature\/foo"/);
+    expect(container.textContent).toMatch(/Delete containers/);
+    expect(container.textContent).toMatch(/Removes Docker sandbox containers for all sessions in this workspace/);
+    expect(container.textContent).toMatch(/Keep scratch directories/);
+    expect(container.textContent).toMatch(/Leaves scratch directories on disk; session records are still removed/);
+  });
+
+  it("describes mixed workspace sandbox cleanup by sandboxed session count", () => {
+    const { container } = setup({
+      affectedSessions: [
+        { id: "sess-a", title: "agent-alpha", isSandboxed: true },
+        { id: "sess-b", title: "agent-beta", isSandboxed: false },
+      ],
+      isSandboxed: true,
+    });
+
+    expect(container.textContent).toMatch(
+      /Removes Docker sandbox containers for 1 sandboxed session in this workspace/,
+    );
+  });
+
+  it("trash-first workspace copy switches when Delete permanently is checked", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onTrash = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({
+      onConfirm,
+      onTrash,
+      defaultToTrash: true,
+      affectedSessions: [
+        { id: "sess-a", title: "agent-alpha", isSandboxed: false },
+        { id: "sess-b", title: "agent-beta", isSandboxed: false },
+      ],
+    });
+
+    expect(container.textContent).toMatch(/Move this workspace to Trash\?/);
+    expect(container.querySelectorAll('[data-testid^="delete-session-checkbox-"]')).toHaveLength(0);
+
+    const permanentBox = container.querySelector<HTMLLabelElement>('[data-testid="delete-session-permanent"]');
+    fireEvent.click(permanentBox!.querySelector("span")!);
+    expect(container.textContent).toMatch(/Permanently delete this workspace\?/);
+    expect(container.querySelector('[data-testid="delete-session-checkbox-worktree"]')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onTrash).not.toHaveBeenCalled();
   });
 
   it("toggling delete-worktree off hides the force checkbox and sends a worktree=false body", () => {

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -227,7 +227,7 @@ interface MultiHandle {
   restoredIds: string[];
 }
 
-function multiPayload(id: string, groupPath: string, trashed: boolean) {
+function multiPayload(id: string, groupPath: string, trashed: boolean, deleteToTrash = true) {
   return {
     id,
     title: id,
@@ -247,14 +247,14 @@ function multiPayload(id: string, groupPath: string, trashed: boolean) {
     has_terminal: true,
     profile: "default",
     trashed_at: trashed ? new Date().toISOString() : null,
-    cleanup_defaults: { delete_to_trash: true },
+    cleanup_defaults: { delete_to_trash: deleteToTrash },
     workspace_repos: [],
   };
 }
 
 async function mockMultiApis(
   page: Page,
-  sessions: Array<{ id: string; groupPath: string; trashed: boolean }>,
+  sessions: Array<{ id: string; groupPath: string; trashed: boolean; deleteToTrash?: boolean }>,
   opts: { failDeleteIds?: string[] } = {},
 ): Promise<MultiHandle> {
   const handle: MultiHandle = { trashedIds: [], deletedIds: [], deleteOptions: {}, restoredIds: [] };
@@ -278,7 +278,7 @@ async function mockMultiApis(
     if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
     const live = sessions
       .filter((s) => !handle.deletedIds.includes(s.id))
-      .map((s) => multiPayload(s.id, s.groupPath, trashedState.get(s.id) ?? false));
+      .map((s) => multiPayload(s.id, s.groupPath, trashedState.get(s.id) ?? false, s.deleteToTrash));
     return r.fulfill({ json: { sessions: live, workspace_ordering: [] } });
   });
   for (const s of sessions) {
@@ -286,13 +286,13 @@ async function mockMultiApis(
       if (r.request().method() !== "POST") return r.fulfill({ status: 400 });
       handle.trashedIds.push(s.id);
       trashedState.set(s.id, true);
-      return r.fulfill({ json: multiPayload(s.id, s.groupPath, true) });
+      return r.fulfill({ json: multiPayload(s.id, s.groupPath, true, s.deleteToTrash) });
     });
     await page.route(`**/api/sessions/${s.id}/restore`, (r) => {
       if (r.request().method() !== "POST") return r.fulfill({ status: 400 });
       handle.restoredIds.push(s.id);
       trashedState.set(s.id, false);
-      return r.fulfill({ json: multiPayload(s.id, s.groupPath, false) });
+      return r.fulfill({ json: multiPayload(s.id, s.groupPath, false, s.deleteToTrash) });
     });
     await page.route(`**/api/sessions/${s.id}`, (r) => {
       if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
@@ -339,6 +339,24 @@ test.describe("Multi-session workspace trash", () => {
 
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
     await expect.poll(() => [...handle.trashedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
+  });
+
+  test("workspace Delete uses trash-first when any live session defaults to Trash (#2538)", async ({ page }) => {
+    await mockMultiApis(page, [
+      { id: "sess-a", groupPath: "alpha", trashed: false, deleteToTrash: false },
+      { id: "sess-b", groupPath: "alpha", trashed: false, deleteToTrash: true },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    const row = page.locator('[data-testid="sidebar-session-row"]').first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.click({ button: "right" });
+    await page.locator('[data-testid="sidebar-context-menu-delete"]').click();
+
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toContainText("Move this workspace to Trash?", { timeout: 5_000 });
+    await expect(dialog.locator('[data-testid="delete-session-permanent"]')).toBeVisible();
   });
 
   test("a workspace trashed in only one group slice does not appear in Trash (#2533)", async ({ page }) => {

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -217,6 +217,8 @@ test.describe("Session trash flow", () => {
 // act on the whole workspace, not on whichever slice survives dedupe.
 
 interface MultiHandle {
+  /** Session ids that received a trash POST, in call order. */
+  trashedIds: string[];
   /** Session ids that received a DELETE, in call order. */
   deletedIds: string[];
   /** Last DELETE option body keyed by session id. */
@@ -255,7 +257,7 @@ async function mockMultiApis(
   sessions: Array<{ id: string; groupPath: string; trashed: boolean }>,
   opts: { failDeleteIds?: string[] } = {},
 ): Promise<MultiHandle> {
-  const handle: MultiHandle = { deletedIds: [], deleteOptions: {}, restoredIds: [] };
+  const handle: MultiHandle = { trashedIds: [], deletedIds: [], deleteOptions: {}, restoredIds: [] };
   const trashedState = new Map(sessions.map((s) => [s.id, s.trashed]));
   const failDelete = new Set(opts.failDeleteIds ?? []);
 
@@ -280,6 +282,12 @@ async function mockMultiApis(
     return r.fulfill({ json: { sessions: live, workspace_ordering: [] } });
   });
   for (const s of sessions) {
+    await page.route(`**/api/sessions/${s.id}/trash`, (r) => {
+      if (r.request().method() !== "POST") return r.fulfill({ status: 400 });
+      handle.trashedIds.push(s.id);
+      trashedState.set(s.id, true);
+      return r.fulfill({ json: multiPayload(s.id, s.groupPath, true) });
+    });
     await page.route(`**/api/sessions/${s.id}/restore`, (r) => {
       if (r.request().method() !== "POST") return r.fulfill({ status: 400 });
       handle.restoredIds.push(s.id);
@@ -308,6 +316,31 @@ async function mockMultiApis(
 }
 
 test.describe("Multi-session workspace trash", () => {
+  test("live workspace Delete presents workspace trash scope (#2538)", async ({ page }) => {
+    const handle = await mockMultiApis(page, [
+      { id: "sess-a", groupPath: "alpha", trashed: false },
+      { id: "sess-b", groupPath: "alpha", trashed: false },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+
+    await page.goto("/");
+    const row = page.locator('[data-testid="sidebar-session-row"]').first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.click({ button: "right" });
+    await page.locator('[data-testid="sidebar-context-menu-delete"]').click();
+
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await expect(dialog.locator("#delete-session-dialog-title")).toContainText("Delete Workspace");
+    await expect(dialog).toContainText("Move this workspace to Trash?");
+    await expect(dialog.locator('[data-testid="delete-session-affected-count"]')).toContainText("all 2 sessions");
+    await expect(dialog.locator('[data-testid="delete-session-affected-list"]')).toContainText("sess-a");
+    await expect(dialog.locator('[data-testid="delete-session-affected-list"]')).toContainText("sess-b");
+
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+    await expect.poll(() => [...handle.trashedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
+  });
+
   test("a workspace trashed in only one group slice does not appear in Trash (#2533)", async ({ page }) => {
     await mockMultiApis(page, [
       { id: "sess-a", groupPath: "alpha", trashed: true },
@@ -354,8 +387,12 @@ test.describe("Multi-session workspace trash", () => {
     await trashRow.locator('[data-testid="sidebar-trash-purge"]').click();
     const dialog = page.locator('[data-testid="delete-session-dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5_000 });
-    // The dialog discloses the workspace-wide scope (#2530).
-    await expect(dialog.locator('[data-testid="delete-session-extra-count"]')).toContainText("all 2 sessions");
+    // The dialog presents the whole workspace scope (#2530, #2538).
+    await expect(dialog.locator("#delete-session-dialog-title")).toContainText("Delete Workspace");
+    await expect(dialog).toContainText("Permanently delete this workspace?");
+    await expect(dialog.locator('[data-testid="delete-session-affected-count"]')).toContainText("all 2 sessions");
+    await expect(dialog.locator('[data-testid="delete-session-affected-list"]')).toContainText("sess-a");
+    await expect(dialog.locator('[data-testid="delete-session-affected-list"]')).toContainText("sess-b");
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
 
     await expect.poll(() => [...handle.deletedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`DeleteSessionDialog` now switches to a workspace-shaped presentation when the delete target contains multiple sessions. The multi-session dialog is titled `Delete Workspace`, uses trash/permanent wording for the whole workspace, shows the affected session count, and lists the affected session titles in a bounded panel.

The dialog inputs now come from the whole workspace instead of only `sessions[0]`: worktree, branch, sandbox, scratch, and trash-default state are aggregated from every affected session. The cleanup option copy also describes shared workspace resources and plural sandbox/scratch cleanup where relevant, while the single-session layout remains unchanged.

Regression coverage was added to the dialog Vitest suite and the mocked Playwright trash-flow spec so both live-workspace trash and already-trashed permanent delete paths prove the workspace-shaped copy and session list reach the UI.

Closes #2538

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a workspace with two sessions on the same branch, choose Delete from the live sidebar row, and confirm the dialog says `Delete Workspace`, `Move this workspace to Trash?`, and lists both sessions.
- [ ] Confirm the live workspace delete without checking `Delete permanently`; both sessions move into Trash together.
- [ ] From Trash, choose Delete on that workspace and confirm the dialog says `Permanently delete this workspace?`, lists both sessions, and permanent delete removes both sessions.
- [ ] Open a one-session workspace and choose Delete; the dialog still says `Delete Session` and uses the original single-session prompt.

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Note: docs were not changed because this is discoverable dialog UI. The local full Rust suite hit an unrelated timing-sensitive storage-concurrency integration test; see validation notes below.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/`; existing `web/tests/coverage-matrix.json` entry covers it
- [ ] Skipped a test, because:

Added `web/tests/session-trash-flow.spec.ts` coverage for the workspace-shaped live delete dialog, sibling-driven trash defaults, and the already-trashed permanent-delete workspace dialog. The existing `session.trash.flow` coverage-matrix entry already maps this component and spec, and `node tests/validate-coverage-matrix.mjs` passes.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation Notes

Passing locally:

- `cargo fmt --all -- --check`
- `cargo clippy --features serve --all-targets -- -D warnings`
- `cargo build --features serve`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `cd web && node tests/validate-coverage-matrix.mjs`
- `cd web && npx vitest run src/components/__tests__/DeleteSessionDialog.test.tsx`
- `cd web && npx playwright test --config=playwright.config.ts tests/session-trash-flow.spec.ts`

`cargo test --features serve` was rerun twice. The lib suite passed on the second run (`4859 passed; 0 failed; 2 ignored`), but the integration target failed on `storage_concurrency::test_cross_process_independent_profiles_do_not_serialise` with `profile-b must not block on profile-a's flock; observed ~5s >= 500ms`. The exact test also fails in this worktree and does not touch the web dialog files.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, two-model design debate, implementation, and PR prose drafted by Claude under my direction. I reviewed the plan and commits, accepted one post-implementation review fix for workspace cleanup defaults, and ran the validation commands above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated delete confirmations to use workspace-level wording when multiple sessions are affected.
- Added affected-session counts and titles, plus aggregated cleanup options for worktrees, branches, sandboxes, scratch directories, and trash settings.
- Preserved the existing single-session dialog experience.
- Added component, Vitest, and Playwright coverage for workspace trash and permanent-deletion flows.

## Benefits

Users now receive clearer context and safer cleanup controls when deleting workspaces with multiple sessions.

Validation passes except for an unrelated storage-concurrency integration test failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->