### PR TITLE
test(serve): pin daemon session id drain

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3368,51 +3368,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
             )
             .await;
 
-            // Drain poller observations into sessions.json so daemon-only
-            // sessions (no attached TUI) persist post-`/clear` sids (#2291).
-            // Snapshot + spawn_blocking + reapply, never holding AppState
-            // across the flock or tmux exec, per storage.rs:46.
-            let snapshot = state.instances.read().await.clone();
-            let drain_state = state.clone();
-            match tokio::task::spawn_blocking(move || {
-                let mut snapshot = snapshot;
-                let outcome = crate::session::sync::drain_and_persist_session_ids(
-                    &mut snapshot,
-                    &drain_state.file_watch,
-                );
-                (outcome, snapshot)
-            })
-            .await
-            {
-                Ok((outcome, mutated)) if outcome.touched() => {
-                    // Reapply only for ids the helper actually touched, so a
-                    // peer that wrote `agent_session_id` (e.g. the restart-
-                    // completion path) on the live state during the
-                    // spawn_blocking window is not silently reverted.
-                    let touched: std::collections::HashSet<&str> = outcome
-                        .applied
-                        .iter()
-                        .chain(outcome.rolled_back.iter())
-                        .map(String::as_str)
-                        .collect();
-                    if !touched.is_empty() {
-                        let mut guard = state.instances.write().await;
-                        for src in mutated.iter().filter(|i| touched.contains(i.id.as_str())) {
-                            if let Some(dst) = guard.iter_mut().find(|i| i.id == src.id) {
-                                dst.agent_session_id = src.agent_session_id.clone();
-                                dst.resume_probe_failed_sid = src.resume_probe_failed_sid.clone();
-                            }
-                        }
-                    }
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::error!(
-                        target: "session.sync",
-                        "drain_and_persist task failed: {e}",
-                    );
-                }
-            }
+            drain_session_id_updates_in_state(&state).await;
 
             #[cfg(feature = "serve")]
             acp_reconciler::reconcile_acp_workers(
@@ -4492,6 +4448,50 @@ pub(crate) fn derive_acp_status(event: &crate::acp::Event) -> Option<StatusInten
     }
 }
 
+async fn drain_session_id_updates_in_state(state: &Arc<AppState>) {
+    // Drain poller observations into sessions.json so daemon-only sessions
+    // persist post-`/clear` sids (#2291). Snapshot + spawn_blocking + reapply,
+    // never holding AppState across the flock or tmux exec, per storage.rs:46.
+    let snapshot = state.instances.read().await.clone();
+    let file_watch = state.file_watch.clone();
+    match tokio::task::spawn_blocking(move || {
+        let mut snapshot = snapshot;
+        let outcome =
+            crate::session::sync::drain_and_persist_session_ids(&mut snapshot, &file_watch);
+        (outcome, snapshot)
+    })
+    .await
+    {
+        Ok((outcome, mutated)) if outcome.touched() => {
+            // Reapply only for ids the helper actually touched, so a peer that
+            // wrote `agent_session_id` on the live state during spawn_blocking
+            // is not silently reverted.
+            let touched: std::collections::HashSet<&str> = outcome
+                .applied
+                .iter()
+                .chain(outcome.rolled_back.iter())
+                .map(String::as_str)
+                .collect();
+            if !touched.is_empty() {
+                let mut guard = state.instances.write().await;
+                for src in mutated.iter().filter(|i| touched.contains(i.id.as_str())) {
+                    if let Some(dst) = guard.iter_mut().find(|i| i.id == src.id) {
+                        dst.agent_session_id = src.agent_session_id.clone();
+                        dst.resume_probe_failed_sid = src.resume_probe_failed_sid.clone();
+                    }
+                }
+            }
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::error!(
+                target: "session.sync",
+                "drain_and_persist task failed: {e}",
+            );
+        }
+    }
+}
+
 /// Test-only constructors that integration tests in `tests/` need to drive
 /// `reload_state_instances_from_disk` and the dynamic-profile-rewire helpers
 /// without going through the full daemon. Mirrors the pattern at
@@ -4566,6 +4566,33 @@ pub mod test_support {
             disk_changed: Arc::new(tokio::sync::Notify::new()),
             disk_watch_handles: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         })
+    }
+
+    pub async fn drain_session_id_updates_for_test(state: &Arc<AppState>) {
+        super::drain_session_id_updates_in_state(state).await;
+    }
+
+    pub fn attach_session_id_update_for_test(inst: &mut Instance, sid: &str) {
+        let poller = crate::session::poller::SessionPoller::new(format!("test-tmux-{}", inst.id));
+        poller.inject_test_update(&inst.id, sid);
+        inst.session_id_poller = Some(Arc::new(std::sync::Mutex::new(poller)));
+    }
+
+    pub fn seed_instances_on_disk_for_test(profile: &str, insts: Vec<Instance>) {
+        let storage = Storage::new_unwatched(profile).expect("storage");
+        storage
+            .update(move |instances, _groups| {
+                *instances = insts;
+                Ok(())
+            })
+            .expect("seed sessions.json");
+    }
+
+    pub fn load_instances_from_disk_for_test(profile: &str) -> Vec<Instance> {
+        Storage::new_unwatched(profile)
+            .expect("storage")
+            .load()
+            .expect("load sessions.json")
     }
 
     pub async fn has_disk_watch_handle(state: &Arc<AppState>, profile: &str) -> bool {

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -296,7 +296,7 @@ impl SessionPoller {
         self.result_rx.as_ref()?.try_recv().ok()
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) fn inject_test_update(&self, instance_id: &str, session_id: &str) {
         self.result_tx
             .send((instance_id.to_string(), session_id.to_string()))

--- a/tests/serve_daemon_session_id_drain.rs
+++ b/tests/serve_daemon_session_id_drain.rs
@@ -20,6 +20,9 @@ impl EnvGuard {
     fn set(path: &Path) -> Self {
         let prev_home = std::env::var("HOME").ok();
         let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        // SAFETY: 2024-edition `set_var` is unsafe because env is process
+        // global and racy across threads. The `#[serial]` annotation
+        // serialises this test against any other test that mutates env.
         unsafe {
             std::env::set_var("HOME", path);
             std::env::set_var("XDG_CONFIG_HOME", path.join(".config"));
@@ -33,6 +36,7 @@ impl EnvGuard {
 
 impl Drop for EnvGuard {
     fn drop(&mut self) {
+        // SAFETY: see `set` above.
         unsafe {
             match self.prev_home.take() {
                 Some(value) => std::env::set_var("HOME", value),

--- a/tests/serve_daemon_session_id_drain.rs
+++ b/tests/serve_daemon_session_id_drain.rs
@@ -1,0 +1,108 @@
+//! Integration coverage for the daemon-side session-id drain wiring.
+
+#![cfg(feature = "serve")]
+
+use std::path::Path;
+
+use agent_of_empires::server::test_support::{
+    attach_session_id_update_for_test, build_test_app_state, drain_session_id_updates_for_test,
+    load_instances_from_disk_for_test, seed_instances_on_disk_for_test,
+};
+use agent_of_empires::session::Instance;
+use serial_test::serial;
+
+struct EnvGuard {
+    prev_home: Option<String>,
+    prev_xdg: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(path: &Path) -> Self {
+        let prev_home = std::env::var("HOME").ok();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("HOME", path);
+            std::env::set_var("XDG_CONFIG_HOME", path.join(".config"));
+        }
+        Self {
+            prev_home,
+            prev_xdg,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match self.prev_home.take() {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.prev_xdg.take() {
+                Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn daemon_session_id_drain_updates_state_and_sessions_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let _guard = EnvGuard::set(temp.path());
+
+    let profile = "daemon-sid-drain";
+    let fresh_sid = "019342ab-1234-7def-8901-abcdef012345";
+    let untouched_sid = "keep-me";
+
+    let mut target = Instance::new("daemon sid drain", "/tmp/daemon-sid-drain");
+    target.source_profile = profile.to_string();
+    let target_id = target.id.clone();
+
+    let mut untouched = Instance::new("daemon sid untouched", "/tmp/daemon-sid-untouched");
+    untouched.source_profile = profile.to_string();
+    untouched.agent_session_id = Some(untouched_sid.to_string());
+    let untouched_id = untouched.id.clone();
+
+    seed_instances_on_disk_for_test(profile, vec![target.clone(), untouched.clone()]);
+    attach_session_id_update_for_test(&mut target, fresh_sid);
+
+    let state = build_test_app_state(vec![target, untouched]);
+
+    drain_session_id_updates_for_test(&state).await;
+
+    {
+        let instances = state.instances.read().await;
+        let target_row = instances
+            .iter()
+            .find(|inst| inst.id == target_id)
+            .expect("target row in state");
+        assert_eq!(target_row.agent_session_id.as_deref(), Some(fresh_sid));
+
+        let untouched_row = instances
+            .iter()
+            .find(|inst| inst.id == untouched_id)
+            .expect("untouched row in state");
+        assert_eq!(
+            untouched_row.agent_session_id.as_deref(),
+            Some(untouched_sid)
+        );
+    }
+
+    let persisted = load_instances_from_disk_for_test(profile);
+    let target_row = persisted
+        .iter()
+        .find(|inst| inst.id == target_id)
+        .expect("target row on disk");
+    assert_eq!(target_row.agent_session_id.as_deref(), Some(fresh_sid));
+
+    let untouched_row = persisted
+        .iter()
+        .find(|inst| inst.id == untouched_id)
+        .expect("untouched row on disk");
+    assert_eq!(
+        untouched_row.agent_session_id.as_deref(),
+        Some(untouched_sid)
+    );
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds serve-feature integration coverage for the daemon-only session-id drain path introduced by #2298. The production drain block is now a private one-shot helper that `status_poll_loop` calls, which lets the integration test exercise the same snapshot, `spawn_blocking`, and touched-id reapply logic without running the infinite poll loop.

The new test builds an isolated `AppState` with a synthetic `SessionPoller` observation, runs one daemon drain iteration, and asserts the fresh session id lands in both memory and `sessions.json`. It also keeps a second untouched row in the state and on disk so a future full-snapshot overwrite is easier to catch.

Closes #2303

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Start `aoe serve` without an attached TUI, run `/clear` in a live Claude session, wait for one daemon poll tick, and confirm `sessions.json` records the fresh session id.
- [ ] Keep another session in the same profile while the daemon drain runs, and confirm its stored session id is not overwritten.
- [ ] Temporarily disable the daemon drain helper locally and confirm the new `serve_daemon_session_id_drain` regression test fails before restoring it.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: deterministic integration coverage now drives the daemon drain helper directly; a full e2e would need a live Claude `/clear` cycle and would be less reliable than the isolated regression test.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Claude investigated the linked issue and PR context, drafted the private helper extraction and integration test, ran validation, and performed the mutation-style red check under my direction.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refactored the daemon “session ID drain” work into a single private helper (`drain_session_id_updates_in_state`) that performs the snapshot + persistence step, then carefully updates only the sessions whose session IDs were actually touched.
- Added test-only wiring utilities to make the drain flow directly triggerable from integration tests:
  - `drain_session_id_updates_for_test` to run one drain iteration without looping
  - `attach_session_id_update_for_test` to inject a synthetic session poller update
  - `seed_instances_on_disk_for_test` / `load_instances_from_disk_for_test` to set up and verify `sessions.json`
- Added an integration test `tests/serve_daemon_session_id_drain.rs` (guarded by the `serve` feature) that:
  - runs under `#[serial]` with temporary `HOME` / `XDG_CONFIG_HOME` to isolate disk writes
  - seeds two session rows (one should update, one should remain unchanged)
  - runs one drain iteration and verifies the updated `agent_session_id` is persisted to both in-memory state and disk, without overwriting the untouched row.
- Expanded `SessionPoller::inject_test_update` availability to include the `test-support` feature (not just `#[cfg(test)]`), so the new test utilities work in the intended build modes.

## Benefits

- Closes the daemon-side session ID persistence regression gap by explicitly testing the “drain once, persist, and reapply only touched IDs” path.
- Protects against subtle failures where the test suite could previously pass even if the drain block was removed or if touched tracking was effectively disabled (e.g., by changing `outcome.touched()` behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->