### PR TITLE
fix(web): preserve right dock tabs on collapse

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,7 +36,7 @@ import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useIsCoarsePointer } from "./hooks/useIsCoarsePointer";
 import { useIsWideViewport } from "./hooks/useIsWideViewport";
 import type { RightPanelView } from "./lib/rightPanelView";
-import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab } from "./lib/paneLayout";
+import { usePaneLayout, dockTabs, dockGroups, dockOf, isActiveTab, isDockCollapsed } from "./lib/paneLayout";
 import { isPluginPaneId, resolvePaneIcon, usePluginPanes, type PluginPane } from "./lib/pluginPanes";
 import { PluginPaneBody } from "./components/plugin/PluginSlots";
 import { TOUR_ANCHORS, tourAnchor } from "./lib/tourSteps";
@@ -439,6 +439,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     toggleKind,
     togglePlugin,
     syncPlugins,
+    setDockCollapsed,
   } = usePaneLayout(activeSessionId);
   const pluginPanes = usePluginPanes(activeSessionId);
   const pluginPaneById = useMemo(() => {
@@ -516,8 +517,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     [paneLayout, tabAvailable],
   );
 
-  const rightGroups = renderGroups("right");
-  const bottomGroups = renderGroups("bottom");
+  const availableRightGroups = useMemo(() => renderGroups("right"), [renderGroups]);
+  const rightDockExplicitlyCollapsed = isDockCollapsed(paneLayout, "right");
+  const rightDockCollapsed = rightDockExplicitlyCollapsed || availableRightGroups.length === 0;
+  const rightGroups = useMemo(
+    () => (rightDockExplicitlyCollapsed ? [] : availableRightGroups),
+    [rightDockExplicitlyCollapsed, availableRightGroups],
+  );
+  const bottomGroups = useMemo(() => renderGroups("bottom"), [renderGroups]);
   const groupsByDock = useMemo(
     () => ({
       right: rightGroups.map((g) => ({ group: g.group, tabs: g.tabs })),
@@ -525,16 +532,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }),
     [rightGroups, bottomGroups],
   );
-  const rightDockCollapsed = rightGroups.length === 0;
-  const terminalOpen = (["right", "bottom"] as DockLocation[]).some((d) =>
-    dockTabs(paneLayout, d).some(isTerminalTabId),
+  const terminalOpen = (["right", "bottom"] as DockLocation[]).some(
+    (d) => !isDockCollapsed(paneLayout, d) && dockTabs(paneLayout, d).some(isTerminalTabId),
   );
 
   // Activity-bar entries are pane KINDS (diff, terminal, each plugin), not
   // individual tabs; the strip's +/x manage terminal instances.
   const isPaneOpen = (kind: string): boolean => {
     if (kind === "terminal") return terminalOpen;
-    return dockOf(paneLayout, kind) !== null;
+    const dock = dockOf(paneLayout, kind);
+    return dock !== null && !isDockCollapsed(paneLayout, dock);
   };
   const togglePaneAny = useCallback(
     (kind: string) => {
@@ -1088,24 +1095,23 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, [isMdUp, toggleKind]);
 
   // Collapse or restore the whole right dock (the "toggle right panel"
-  // shortcut). Collapse closes every pane docked right; restore reopens the
-  // built-in diff + terminal that live there. ponytail: restore reopens the
-  // defaults rather than remembering the exact pre-collapse set, which is a
-  // fine approximation for a collapse/expand toggle.
+  // shortcut). Collapse hides the dock without removing its tabs so expanding
+  // restores the active session's previous pane set.
   const toggleRightDock = useCallback(() => {
     if (!isMdUp) {
       setPickerOpen((o) => !o);
       return;
     }
     if (rightDockCollapsed) {
-      // Restore the built-in defaults into the right dock.
-      openTab("diff", "right");
-      openTab(terminalTabId(0), "right");
+      setDockCollapsed("right", false);
+      if (availableRightGroups.length === 0) {
+        openTab("diff", "right");
+        openTab(terminalTabId(0), "right");
+      }
     } else {
-      // Collapse: close every tab currently in the right dock.
-      for (const id of dockTabs(paneLayout, "right")) closeTab(id);
+      setDockCollapsed("right", true);
     }
-  }, [isMdUp, rightDockCollapsed, paneLayout, openTab, closeTab]);
+  }, [isMdUp, rightDockCollapsed, setDockCollapsed, availableRightGroups.length, openTab]);
 
   const handlePickView = useCallback((view: RightPanelView) => {
     setRightPanelView(view);
@@ -1551,7 +1557,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         <PaneDndController groupsByDock={groupsByDock} descriptorFor={paneDescriptor} onPlaceTab={placeVisibleTab}>
           <ContentSplit
             collapsed={rightDockCollapsed}
-            onToggleCollapse={toggleDiff}
+            onToggleCollapse={toggleRightDock}
             left={
               <div className="flex-1 flex flex-col min-h-0 overflow-hidden relative">
                 <div className={selectedFilePath ? "hidden" : "flex-1 flex flex-col min-h-0 overflow-hidden"}>

--- a/web/src/lib/__tests__/paneLayout.test.ts
+++ b/web/src/lib/__tests__/paneLayout.test.ts
@@ -7,12 +7,14 @@ import {
   addTerminal,
   dockOf,
   dockTabs,
+  isDockCollapsed,
   isActiveTab,
   moveTab,
   placeTab,
   removeAllTerminals,
   removeTab,
   setActive,
+  setDockCollapsed,
   syncPluginTabs,
   usePaneLayout,
   type DockLayout,
@@ -22,7 +24,7 @@ beforeEach(() => localStorage.clear());
 afterEach(() => localStorage.clear());
 
 function emptyLayout(): DockLayout {
-  return { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [] };
+  return { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [], collapsed: { right: false, bottom: false } };
 }
 
 describe("pane layout pure ops", () => {
@@ -183,6 +185,25 @@ describe("pane layout pure ops", () => {
     l = syncPluginTabs(l, [{ id: "plugin:p:b", defaultDock: "bottom" }]);
     expect(dockOf(l, "plugin:p:b")).toBe("bottom");
   });
+
+  it("setDockCollapsed preserves tabs, active tab, and plugin close intent", () => {
+    let l = addTab(emptyLayout(), "right", "diff");
+    l = addTab(l, "right", "plugin:p:a");
+    l = setActive(l, "right", "plugin:p:a");
+
+    l = setDockCollapsed(l, "right", true);
+
+    expect(isDockCollapsed(l, "right")).toBe(true);
+    expect(dockTabs(l, "right")).toEqual(["diff", "plugin:p:a"]);
+    expect(l.right[0]!.active).toBe("plugin:p:a");
+    expect(l.closedPlugins).not.toContain("plugin:p:a");
+
+    l = setDockCollapsed(l, "right", false);
+
+    expect(isDockCollapsed(l, "right")).toBe(false);
+    expect(dockTabs(l, "right")).toEqual(["diff", "plugin:p:a"]);
+    expect(l.right[0]!.active).toBe("plugin:p:a");
+  });
 });
 
 describe("usePaneLayout migration + persistence", () => {
@@ -215,6 +236,47 @@ describe("usePaneLayout migration + persistence", () => {
     // s1's addition round-trips through localStorage.
     const reloaded = renderHook(() => usePaneLayout("s1"));
     expect(dockTabs(reloaded.result.current.layout, "right")).toContain("terminal:1");
+  });
+
+  it("persists dock collapse state per session", () => {
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    act(() => result.current.setDockCollapsed("right", true));
+    expect(isDockCollapsed(result.current.layout, "right")).toBe(true);
+
+    const other = renderHook(() => usePaneLayout("s2"));
+    expect(isDockCollapsed(other.result.current.layout, "right")).toBe(false);
+
+    const reloaded = renderHook(() => usePaneLayout("s1"));
+    expect(isDockCollapsed(reloaded.result.current.layout, "right")).toBe(true);
+  });
+
+  it("syncPlugins adds plugin tabs without revealing a collapsed dock", () => {
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    act(() => result.current.setDockCollapsed("right", true));
+    act(() => result.current.syncPlugins([{ id: "plugin:p:a", defaultDock: "right" }]));
+
+    expect(dockOf(result.current.layout, "plugin:p:a")).toBe("right");
+    expect(isDockCollapsed(result.current.layout, "right")).toBe(true);
+  });
+
+  it("openTab reveals a collapsed target dock", () => {
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    act(() => result.current.setDockCollapsed("right", true));
+    act(() => result.current.openTab("diff", "right"));
+
+    expect(dockOf(result.current.layout, "diff")).toBe("right");
+    expect(isDockCollapsed(result.current.layout, "right")).toBe(false);
+  });
+
+  it("togglePlugin reveals an open plugin in a collapsed dock instead of closing it", () => {
+    const { result } = renderHook(() => usePaneLayout("s1"));
+    act(() => result.current.openTab("plugin:p:a", "right"));
+    act(() => result.current.setDockCollapsed("right", true));
+    act(() => result.current.togglePlugin("plugin:p:a", "right"));
+
+    expect(dockOf(result.current.layout, "plugin:p:a")).toBe("right");
+    expect(isDockCollapsed(result.current.layout, "right")).toBe(false);
+    expect(result.current.layout.closedPlugins).not.toContain("plugin:p:a");
   });
 
   it("drops a tab id duplicated across docks on load (keeps the first dock)", () => {

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -35,6 +35,9 @@ export interface DockLayout {
   // Plugin tabs the user explicitly closed, so the auto-add pass does not
   // immediately re-add them on the next render.
   closedPlugins: TabId[];
+  // Per-dock visibility. Collapsed docks keep their tabs so expand restores
+  // the same pane set, tab order, and active tab.
+  collapsed: Record<DockLocation, boolean>;
 }
 
 interface LayoutStore {
@@ -46,7 +49,7 @@ interface LayoutStore {
 const DOCKS: DockLocation[] = ["right", "bottom"];
 
 function emptyDockLayout(): DockLayout {
-  return { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [] };
+  return { right: [], bottom: [], nextTerminalIndex: 1, closedPlugins: [], collapsed: { right: false, bottom: false } };
 }
 
 /** All groups in a dock, in render order. */
@@ -90,13 +93,25 @@ export function dockOf(layout: DockLayout, tabId: TabId): DockLocation | null {
   return findTab(layout, tabId)?.dock ?? null;
 }
 
+export function isDockCollapsed(layout: DockLayout, dock: DockLocation): boolean {
+  return layout.collapsed[dock] === true;
+}
+
 function clone(layout: DockLayout): DockLayout {
   return {
     right: layout.right.map((g) => ({ tabs: [...g.tabs], active: g.active })),
     bottom: layout.bottom.map((g) => ({ tabs: [...g.tabs], active: g.active })),
     nextTerminalIndex: layout.nextTerminalIndex,
     closedPlugins: [...layout.closedPlugins],
+    collapsed: { ...layout.collapsed },
   };
+}
+
+export function setDockCollapsed(layout: DockLayout, dock: DockLocation, collapsed: boolean): DockLayout {
+  if (isDockCollapsed(layout, dock) === collapsed) return layout;
+  const next = clone(layout);
+  next.collapsed[dock] = collapsed;
+  return next;
 }
 
 function ensureGroup(layout: DockLayout, dock: DockLocation): PaneGroup {
@@ -345,6 +360,7 @@ function dropDuplicates(group: PaneGroup[], seen: Set<TabId>): PaneGroup[] {
 function normalizeDock(v: unknown): DockLayout {
   const o = (v && typeof v === "object" ? v : {}) as Record<string, unknown>;
   const seen = new Set<TabId>();
+  const collapsed = (o.collapsed && typeof o.collapsed === "object" ? o.collapsed : {}) as Record<string, unknown>;
   return {
     right: dropDuplicates(normalizeGroups(o.right), seen),
     bottom: dropDuplicates(normalizeGroups(o.bottom), seen),
@@ -353,6 +369,10 @@ function normalizeDock(v: unknown): DockLayout {
     closedPlugins: Array.isArray(o.closedPlugins)
       ? o.closedPlugins.filter((t): t is string => typeof t === "string")
       : [],
+    collapsed: {
+      right: collapsed.right === true,
+      bottom: collapsed.bottom === true,
+    },
   };
 }
 
@@ -392,6 +412,30 @@ export interface PaneLayoutApi {
   /** Add/remove a plugin pane tab (activity-bar toggle). */
   togglePlugin: (id: TabId, defaultDock: DockLocation) => void;
   syncPlugins: (available: { id: TabId; defaultDock: DockLocation }[]) => void;
+  setDockCollapsed: (dock: DockLocation, collapsed: boolean) => void;
+}
+
+function revealDock(layout: DockLayout, dock: DockLocation): DockLayout {
+  return setDockCollapsed(layout, dock, false);
+}
+
+function openOrRevealTab(layout: DockLayout, tabId: TabId, defaultDock: DockLocation): DockLayout {
+  const at = findTab(layout, tabId);
+  if (at) return revealDock(setActive(layout, at.dock, tabId), at.dock);
+  return revealDock(addTab(layout, defaultDock, tabId), defaultDock);
+}
+
+function activateOrRevealTab(layout: DockLayout, dock: DockLocation, tabId: TabId): DockLayout {
+  if (!layout[dock].some((g) => g.tabs.includes(tabId))) return layout;
+  return revealDock(setActive(layout, dock, tabId), dock);
+}
+
+function terminalTabs(layout: DockLayout): { id: TabId; dock: DockLocation }[] {
+  return DOCKS.flatMap((dock) =>
+    dockTabs(layout, dock)
+      .filter(isTerminalTabId)
+      .map((id) => ({ id, dock })),
+  );
 }
 
 export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
@@ -420,19 +464,33 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     [sessionId],
   );
 
-  const openTab = useCallback((tabId: TabId, dock: DockLocation) => mutate((l) => addTab(l, dock, tabId)), [mutate]);
-  const addTerminalCb = useCallback((dock: DockLocation) => mutate((l) => addTerminal(l, dock).layout), [mutate]);
+  const openTab = useCallback(
+    (tabId: TabId, dock: DockLocation) => mutate((l) => openOrRevealTab(l, tabId, dock)),
+    [mutate],
+  );
+  const addTerminalCb = useCallback(
+    (dock: DockLocation) => mutate((l) => revealDock(addTerminal(l, dock).layout, dock)),
+    [mutate],
+  );
   const closeTab = useCallback((tabId: TabId) => mutate((l) => removeTab(l, tabId)), [mutate]);
   const activateTab = useCallback(
-    (dock: DockLocation, tabId: TabId) => mutate((l) => setActive(l, dock, tabId)),
+    (dock: DockLocation, tabId: TabId) => mutate((l) => activateOrRevealTab(l, dock, tabId)),
     [mutate],
   );
   const moveTabCb = useCallback(
-    (tabId: TabId, toDock: DockLocation) => mutate((l) => moveTab(l, tabId, toDock)),
+    (tabId: TabId, toDock: DockLocation) =>
+      mutate((l) => {
+        const next = moveTab(l, tabId, toDock);
+        return dockOf(next, tabId) === toDock ? revealDock(next, toDock) : next;
+      }),
     [mutate],
   );
   const placeTabCb = useCallback(
-    (tabId: TabId, target: PlaceTarget) => mutate((l) => placeTab(l, tabId, target)),
+    (tabId: TabId, target: PlaceTarget) =>
+      mutate((l) => {
+        const next = placeTab(l, tabId, target);
+        return dockOf(next, tabId) === target.dock ? revealDock(next, target.dock) : next;
+      }),
     [mutate],
   );
   const toggleKind = useCallback(
@@ -441,20 +499,34 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
         // Single-instance panes (diff, agents) toggle their one tab; the
         // terminal kind is multi-instance and toggles the whole group.
         if (kind === "diff" || kind === "agents") {
-          return dockOf(l, kind) ? removeTab(l, kind) : addTab(l, defaultDock, kind);
+          const at = findTab(l, kind);
+          if (at) return isDockCollapsed(l, at.dock) ? openOrRevealTab(l, kind, defaultDock) : removeTab(l, kind);
+          return openOrRevealTab(l, kind, defaultDock);
         }
-        const hasTerminal = DOCKS.some((d) => dockTabs(l, d).some(isTerminalTabId));
-        return hasTerminal ? removeAllTerminals(l) : addTab(l, defaultDock, terminalTabId(0));
+        const terminals = terminalTabs(l);
+        if (terminals.length === 0) return openOrRevealTab(l, terminalTabId(0), defaultDock);
+        const visibleTerminal = terminals.find(({ dock }) => !isDockCollapsed(l, dock));
+        if (visibleTerminal) return removeAllTerminals(l);
+        const first = terminals[0]!;
+        return activateOrRevealTab(l, first.dock, first.id);
       }),
     [mutate],
   );
   const togglePlugin = useCallback(
     (id: TabId, defaultDock: DockLocation) =>
-      mutate((l) => (dockOf(l, id) ? removeTab(l, id) : addTab(l, defaultDock, id))),
+      mutate((l) => {
+        const at = findTab(l, id);
+        if (at) return isDockCollapsed(l, at.dock) ? openOrRevealTab(l, id, defaultDock) : removeTab(l, id);
+        return openOrRevealTab(l, id, defaultDock);
+      }),
     [mutate],
   );
   const syncPlugins = useCallback(
     (available: { id: TabId; defaultDock: DockLocation }[]) => mutate((l) => syncPluginTabs(l, available)),
+    [mutate],
+  );
+  const setDockCollapsedCb = useCallback(
+    (dock: DockLocation, collapsed: boolean) => mutate((l) => setDockCollapsed(l, dock, collapsed)),
     [mutate],
   );
 
@@ -469,5 +541,6 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     toggleKind,
     togglePlugin,
     syncPlugins,
+    setDockCollapsed: setDockCollapsedCb,
   };
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2115,7 +2115,12 @@
       "kind": "mocked-playwright",
       "risk": "low",
       "specs": ["tests/shortcuts.spec.ts"],
-      "components": ["web/src/components/ContentSplit.tsx", "web/src/hooks/useKeyboardShortcuts.ts"]
+      "components": [
+        "web/src/App.tsx",
+        "web/src/lib/paneLayout.ts",
+        "web/src/components/ContentSplit.tsx",
+        "web/src/hooks/useKeyboardShortcuts.ts"
+      ]
     },
     {
       "id": "story.shortcut-escape-closes-palette",

--- a/web/tests/pane-docking.spec.ts
+++ b/web/tests/pane-docking.spec.ts
@@ -134,6 +134,46 @@ test.describe("Dockable pane system", () => {
     await expect.poll(() => actionBody?.method).toBe("demo.reload");
   });
 
+  test("right-dock collapse shortcut preserves an active plugin pane", async ({ page }) => {
+    await openSession(page);
+
+    await page.route("**/api/plugins/ui-state", (route) =>
+      route.fulfill({
+        json: {
+          entries: [
+            {
+              plugin_id: "acme.demo",
+              slot: "pane",
+              id: "demo_pane",
+              session_id: SESSION,
+              payload: {
+                title: "Demo",
+                default_location: "right",
+                blocks: [{ kind: "heading", text: "Demo" }],
+              },
+            },
+          ],
+          notifications: [],
+        },
+      }),
+    );
+
+    await page.goto(`/session/${SESSION}`);
+
+    const paneId = "plugin:acme.demo:demo_pane";
+    await page.getByTestId(`pane-tab-${paneId}`).click();
+    await expect(page.locator('[data-testid="plugin-pane-body"][data-plugin-id="acme.demo"]')).toBeVisible();
+
+    const handle = page.getByTestId("content-split-resize-handle");
+    await page.keyboard.press("ControlOrMeta+Alt+b");
+    await expect(handle).toBeHidden();
+
+    await page.keyboard.press("ControlOrMeta+Alt+b");
+    await expect(handle).toBeVisible();
+    await expect(page.getByTestId(`pane-tab-${paneId}`)).toBeVisible();
+    await expect(page.locator('[data-testid="plugin-pane-body"][data-plugin-id="acme.demo"]')).toBeVisible();
+  });
+
   test("dragging a tab reorders it within a dock and the order persists across reload", async ({ page }) => {
     await openSession(page);
     await page.goto(`/session/${SESSION}`);

--- a/web/tests/shortcuts.spec.ts
+++ b/web/tests/shortcuts.spec.ts
@@ -15,6 +15,29 @@ import type { Page } from "@playwright/test";
 import { installSidebarMocks, threeSessionsInOneRepo } from "./helpers/sidebarMocks";
 import { mockTerminalApis } from "./helpers/terminal-mocks";
 
+const SESSION = "pinch-test";
+const PANE_LAYOUT_KEY = "aoe-pane-layout-v2";
+
+async function rightDockState(page: Page): Promise<{ tabs: string[]; collapsed: boolean } | null> {
+  return page.evaluate(
+    ({ key, session }) => {
+      const raw = localStorage.getItem(key);
+      if (!raw) return null;
+      const store = JSON.parse(raw) as {
+        template?: { right?: { tabs?: string[] }[]; collapsed?: { right?: boolean } };
+        sessions?: Record<string, { right?: { tabs?: string[] }[]; collapsed?: { right?: boolean } }>;
+      };
+      const layout = store.sessions?.[session] ?? store.template;
+      if (!layout) return null;
+      return {
+        tabs: (layout.right ?? []).flatMap((g) => g.tabs ?? []),
+        collapsed: layout.collapsed?.right === true,
+      };
+    },
+    { key: PANE_LAYOUT_KEY, session: SESSION },
+  );
+}
+
 // Force focus onto <body> before pressing a single-key shortcut.
 // xterm.js's helper textarea steals focus when the terminal mounts or
 // re-layouts; a focused textarea makes the input-gated shortcuts
@@ -64,7 +87,7 @@ test("Cmd/Ctrl+B toggles the workspace sidebar", async ({ page }) => {
 test("Shift+D toggles the diff pane on a session view", async ({ page }) => {
   await mockTerminalApis(page);
   await page.setViewportSize({ width: 1280, height: 720 });
-  await page.goto("/session/pinch-test");
+  await page.goto(`/session/${SESSION}`);
 
   // Shift+D toggles the diff pane specifically (not the whole dock); the
   // activity-bar toggle's pressed state reflects whether diff is open.
@@ -89,10 +112,13 @@ test("Cmd/Ctrl+Alt+B toggles the right panel on a session view", async ({ page }
 
   const handle = page.locator('[data-testid="content-split-resize-handle"]');
   await expect(handle).toBeVisible();
+  expect(await rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: false });
 
   await page.keyboard.press("ControlOrMeta+Alt+b");
   await expect(handle).toBeHidden();
+  expect(await rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: true });
 
   await page.keyboard.press("ControlOrMeta+Alt+b");
   await expect(handle).toBeVisible();
+  expect(await rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: false });
 });

--- a/web/tests/shortcuts.spec.ts
+++ b/web/tests/shortcuts.spec.ts
@@ -112,13 +112,13 @@ test("Cmd/Ctrl+Alt+B toggles the right panel on a session view", async ({ page }
 
   const handle = page.locator('[data-testid="content-split-resize-handle"]');
   await expect(handle).toBeVisible();
-  expect(await rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: false });
+  await expect.poll(() => rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: false });
 
   await page.keyboard.press("ControlOrMeta+Alt+b");
   await expect(handle).toBeHidden();
-  expect(await rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: true });
+  await expect.poll(() => rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: true });
 
   await page.keyboard.press("ControlOrMeta+Alt+b");
   await expect(handle).toBeVisible();
-  expect(await rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: false });
+  await expect.poll(() => rightDockState(page)).toEqual({ tabs: ["diff", "terminal:0"], collapsed: false });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes the desktop right-dock collapse toggle so it hides the dock without removing the active session's right-dock tabs. The pane layout now stores per-dock collapsed visibility inside each session layout, while preserving the existing tab groups, tab order, active tab, terminal instances, and plugin pane ids.

This keeps plugin pane intent intact. Collapsing the dock no longer routes plugin tabs through `removeTab()`, so `closedPlugins` is only updated when the user explicitly closes a plugin pane. Explicit pane actions still reveal a collapsed dock, while plugin auto-sync can add available pane tabs without expanding the dock unexpectedly.

Closes #2488

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a desktop web dashboard session with `diff`, `terminal`, and a plugin pane in the right dock, activate the plugin pane, press `Ctrl/Cmd+Alt+B` twice, and confirm the plugin pane is still the active right-dock tab.
- [ ] Collapse the right dock in session A, switch to session B, and confirm session B does not inherit session A's collapsed state.
- [ ] Collapse the right dock with a plugin pane open, reload the session, and confirm the plugin pane is not treated as explicitly closed.

## Checklist

- [ ] New and existing tests pass, see validation note for one unrelated local timing failure
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, implementation, and PR prose were drafted by Claude under my direction. I reviewed the approach, approved the plan, and validated the implementation with the commands below.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- [x] `cd web && npx vitest run src/lib/__tests__/paneLayout.test.ts`
- [x] `cd web && npx playwright test --config=playwright.config.ts tests/pane-docking.spec.ts tests/shortcuts.spec.ts tests/right-panel-persistence.spec.ts`
- [x] `cd web && npm run format:check`
- [x] `cd web && npm run lint`
- [x] `cd web && npx tsc -b`
- [x] `cd web && node tests/validate-coverage-matrix.mjs`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --features serve`
- [x] `cargo test --features serve --test acp_runner_orphan`
- [x] `cargo test --features serve` passed all except `storage_concurrency::test_cross_process_independent_profiles_do_not_serialise`, which failed locally on a timing threshold while spawning the debug `aoe` subprocess. The same test also failed without `--features serve`, so it is unrelated to this web dashboard change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed the desktop right-dock “collapse” so it only hides the dock while keeping the exact same tabs, grouping, and active content (including terminals and plugin panes) instead of closing/removing them.
- Introduced per-dock, per-session persistence for the collapsed/expanded state, preventing layout/collapse state from leaking across sessions or after reloads.
- Updated plugin handling so collapsing a dock doesn’t mark plugin panes as explicitly closed; plugin auto-sync can add available panes without unintentionally expanding the dock.
- Switched the right-panel UI wiring to use the new dock-collapse state (and ensured expanding into an empty right area opens a sensible default).
- Added/expanded coverage: updated unit tests for the pane layout model, and Playwright tests for dock shortcut behavior and session-aware right-dock state. Also updated coverage metadata.

## Benefits

- Users can collapse/restore the right dock without losing their current workspace arrangement or plugin/terminal context.
- Plugin panes remain stable and correctly reflect “explicit close” vs “dock hidden,” reducing surprising reopen/close behavior.
- More reliable regression protection for session-specific persistence and shortcut-driven collapse/expand behavior.

## Notes

- An unrelated localStorage concurrency test failed due to a timing threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->