### PR TITLE
fix(tui): keep the live preview from desyncing by a row (#2742)

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1114,15 +1114,16 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
             return crate::tmux::Session::from_name(tmux_name).send_raw_bytes(bytes);
         }
         TmuxAction::Resize { cols, rows } => {
-            cmd.args([
-                "resize-window",
-                "-t",
-                tmux_name,
-                "-x",
-                &cols.to_string(),
-                "-y",
-                &rows.to_string(),
-            ]);
+            // Size the window through `Session::resize_window` so the pane lands
+            // at exactly `rows` after tmux's status-bar chrome, the same math the
+            // passive / serve preview sync uses (#2766). A raw `resize-window -y
+            // rows` leaves a `rows - chrome` pane whenever a client is attached
+            // (or a tmux that reserves the status row while detached), one row
+            // shorter than the preview output area the cursor overlay and the
+            // bottom-anchored capture assume, so the live preview desyncs by a
+            // row (#2742).
+            crate::tmux::Session::from_name(tmux_name).resize_window(*cols, *rows);
+            return Ok(());
         }
     }
     let status = cmd

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5207,25 +5207,19 @@ impl HomeView {
         if pane.width == 0 || pane.height == 0 {
             return;
         }
-        let resize_status = crate::tmux::tmux_command()
-            .args([
-                "resize-window",
-                "-t",
-                &tmux_name,
-                "-x",
-                &pane.width.to_string(),
-                "-y",
-                &pane.height.to_string(),
-            ])
-            .stderr(std::process::Stdio::null())
-            .status();
-        // Only register the dedup if the resize subprocess actually
-        // succeeded. If tmux failed (session died between our state
-        // install and now, tmux binary missing, etc.), leaving
-        // `live_send_last_resize` as None lets the next
-        // `refresh_preview_cache_if_needed` try the resize again
-        // through the worker.
-        if matches!(&resize_status, Ok(s) if s.success()) {
+        // Size through `Session::resize_window` so the pane lands at exactly
+        // `pane.height` after tmux's status-bar chrome (#2766), matching the
+        // worker's Resize arm and the passive preview sync. A raw
+        // `resize-window -y pane.height` leaves a `pane.height - chrome` pane
+        // one row shorter than the preview output area, desyncing the live
+        // preview by a row (#2742).
+        let session = crate::tmux::Session::from_name(&tmux_name);
+        // Only register the dedup if the session still exists (so the resize was
+        // actually attempted). If it died between our state install and now,
+        // leaving `live_send_last_resize` as None lets the next
+        // `refresh_preview_cache_if_needed` retry through the worker.
+        if session.exists() {
+            session.resize_window(pane.width, pane.height);
             self.live_send_last_resize = Some((pane.width, pane.height));
         }
         // Give the agent ~50ms to handle SIGWINCH and re-lay out

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -132,24 +132,31 @@ fn truncate_to_width(text: &str, max_width: usize) -> String {
 /// Map a tmux pane cursor onto the preview's output rect for live-send.
 ///
 /// `output` is the rect the captured pane text paints into; `visible_rows` is
-/// its height in rows; `cursor` carries the pane's `(x, y)` (counted from the
-/// top of the visible screen) plus `pane_height`. Assumes the preview is at
-/// the live tail, where the bottom captured line pins to the bottom of
-/// `output`, so a screen row maps to `output.y + (visible_rows - pane_height)
-/// + cursor.y`. When the pane is sized to the output area (the live-send
-/// resize) the delta is zero and this is just `output.y + cursor.y`; the delta
-/// only bites for the frame or two after a resize. A hidden cursor, or one
-/// that maps outside `output` (e.g. a pane taller than the output area clips
-/// its top rows), yields `None` so nothing is painted.
+/// its height in rows; `line_count` is the parsed capture's line count (the
+/// same value the renderer feeds to `compute_scroll`); `cursor` carries the
+/// pane's `(x, y)` (counted from the top of the visible screen) plus
+/// `pane_height`. The renderer bottom-anchors the capture ONLY when it
+/// overflows `output`; a capture shorter than `output` paints from the top
+/// (`compute_scroll` returns 0). Anchor the cursor the same way so it tracks
+/// the text: a screen row maps to `output.y + (min(line_count, visible_rows) -
+/// pane_height) + cursor.y`. With the pane sized to the output area and a
+/// full-height capture the delta is zero and this is just `output.y +
+/// cursor.y`. When the pane is a row or more shorter than `output` and the
+/// capture doesn't overflow (an alt-screen prompt, or the frame after a
+/// resize), using the bare `visible_rows` here would paint the cursor a row
+/// BELOW the text the user typed (#2742); clamping to `line_count` keeps them
+/// aligned. A hidden cursor, or one that maps outside `output`, yields `None`.
 fn map_live_preview_cursor(
     output: Rect,
     visible_rows: usize,
+    line_count: usize,
     cursor: crate::tmux::PaneCursor,
 ) -> Option<Position> {
     if !cursor.visible {
         return None;
     }
-    let row = output.y as i32 + (visible_rows as i32 - cursor.pane_height as i32) + cursor.y as i32;
+    let anchor = line_count.min(visible_rows) as i32;
+    let row = output.y as i32 + (anchor - cursor.pane_height as i32) + cursor.y as i32;
     let col = output.x as i32 + cursor.x as i32;
     if row < output.y as i32
         || row >= output.y as i32 + output.height as i32
@@ -2495,7 +2502,16 @@ impl HomeView {
         if !cursor.position_reliable {
             return None;
         }
-        map_live_preview_cursor(self.preview_pane_area, self.preview_visible_rows, cursor)
+        // `total_lines` is the parsed line count of the capture painted this
+        // frame (set by `set_preview_text_view` right before this), matching
+        // what the renderer fed to `compute_scroll`, so the cursor anchors the
+        // same way the text did.
+        map_live_preview_cursor(
+            self.preview_pane_area,
+            self.preview_visible_rows,
+            self.preview_text_view.total_lines,
+            cursor,
+        )
     }
 
     /// Apply the drag-select highlight to cells inside the preview
@@ -3306,25 +3322,56 @@ mod tests {
     #[test]
     fn live_cursor_maps_directly_when_pane_matches_output() {
         // Pane sized to the output area (the steady-state live-send case): the
-        // delta is zero, so cursor (x, y) maps onto output.{x,y} + (x, y).
+        // delta is zero, so cursor (x, y) maps onto output.{x,y} + (x, y). A
+        // full-height capture (line_count >= visible_rows) bottom-anchors.
         let output = Rect::new(40, 5, 80, 24);
-        let pos = map_live_preview_cursor(output, 24, pane_cursor(3, 2, true, 24));
+        let pos = map_live_preview_cursor(output, 24, 200, pane_cursor(3, 2, true, 24));
         assert_eq!(pos, Some(Position::new(43, 7)));
     }
 
     #[test]
     fn live_cursor_anchored_to_bottom_when_pane_taller_than_output() {
-        // Pane is 24 rows but only 10 are visible (top clipped). The bottom 10
-        // pin to the output, so a cursor on the last screen row (y=23) lands on
-        // the output's last row; a cursor in the clipped top maps out and drops.
+        // Pane is 24 rows but only 10 are visible (top clipped). The capture
+        // overflows the output, so the bottom 10 pin to the output: a cursor on
+        // the last screen row (y=23) lands on the output's last row; a cursor in
+        // the clipped top maps out and drops.
         let output = Rect::new(0, 0, 80, 10);
         assert_eq!(
-            map_live_preview_cursor(output, 10, pane_cursor(0, 23, true, 24)),
+            map_live_preview_cursor(output, 10, 100, pane_cursor(0, 23, true, 24)),
             Some(Position::new(0, 9)),
         );
         assert_eq!(
-            map_live_preview_cursor(output, 10, pane_cursor(0, 5, true, 24)),
+            map_live_preview_cursor(output, 10, 100, pane_cursor(0, 5, true, 24)),
             None,
+        );
+    }
+
+    #[test]
+    fn live_cursor_tracks_top_anchored_short_capture() {
+        // #2742: the pane is a row shorter than the output (status-bar chrome, or
+        // the frame after a resize) and its capture does not overflow, so the
+        // renderer paints from the top (`compute_scroll` returns 0). The cursor
+        // must anchor to the same top, not to `visible_rows` as if the capture
+        // filled the output; otherwise it paints one row below the typed text.
+        let output = Rect::new(0, 0, 80, 24);
+        // 23-row alt-screen pane, capture is exactly its 23 lines (no scrollback
+        // to overflow the 24-row output). Cursor on the pane's last row (y=22).
+        let short = pane_cursor(5, 22, true, 23);
+        assert_eq!(
+            map_live_preview_cursor(output, 24, 23, short),
+            Some(Position::new(5, 22)),
+            "top-anchored capture must not drift the cursor down a row",
+        );
+        // The buggy formula (`visible_rows - pane_height`) would place it at
+        // row 23; assert the fix does not.
+        assert_ne!(
+            map_live_preview_cursor(output, 24, 23, short),
+            Some(Position::new(5, 23)),
+        );
+        // Cursor on the pane's top row lands on the output's top row.
+        assert_eq!(
+            map_live_preview_cursor(output, 24, 23, pane_cursor(0, 0, true, 23)),
+            Some(Position::new(0, 0)),
         );
     }
 
@@ -3333,12 +3380,12 @@ mod tests {
         let output = Rect::new(0, 0, 80, 24);
         // DECTCEM-hidden cursor: nothing to paint.
         assert_eq!(
-            map_live_preview_cursor(output, 24, pane_cursor(3, 2, false, 24)),
+            map_live_preview_cursor(output, 24, 200, pane_cursor(3, 2, false, 24)),
             None,
         );
         // Column past the output width is dropped rather than clamped.
         assert_eq!(
-            map_live_preview_cursor(output, 24, pane_cursor(80, 2, true, 24)),
+            map_live_preview_cursor(output, 24, 200, pane_cursor(80, 2, true, 24)),
             None,
         );
     }

--- a/tests/integration/tui_attach_detach.rs
+++ b/tests/integration/tui_attach_detach.rs
@@ -117,6 +117,44 @@ fn test_session_name_format() {
     assert!(!session_name.contains('.'));
 }
 
+/// The TUI live-send resize path must size the pane through
+/// `Session::resize_window` (which adds the status-bar chrome back so the pane
+/// lands at exactly the requested rows, #2766), not a raw `resize-window` that
+/// ignores chrome. A raw resize leaves the live pane a row short of the preview
+/// output area whenever a client reserves the status row, desyncing the live
+/// preview by a row (#2742). Behavioral coverage is unreliable here because
+/// `resize-window` is a no-op / reports chrome 0 on a detached, client-less
+/// tmux on some builds (see the dropped convergence test in #2766); the
+/// chrome math itself is unit-tested by `chrome_rows_*`. This guards the
+/// wiring so it can't silently regress to the raw path.
+#[test]
+fn test_live_send_resize_uses_chrome_aware_resize_window() {
+    // Worker dispatch (the `TmuxAction::Resize` arm).
+    let dispatch =
+        std::fs::read_to_string("src/tui/home/live_send.rs").expect("Failed to read live_send.rs");
+    let body = app_method_body(&dispatch, "dispatch_via_fork");
+    assert!(
+        body.contains("resize_window("),
+        "dispatch_via_fork must resize through Session::resize_window (chrome-aware, #2766)"
+    );
+    assert!(
+        !body.contains("\"resize-window\""),
+        "dispatch_via_fork must not run a raw `resize-window`, which ignores status-bar chrome (#2742)"
+    );
+
+    // Live-send entry sync (`finalize_live_send_resize`).
+    let home = std::fs::read_to_string("src/tui/home/mod.rs").expect("Failed to read home/mod.rs");
+    let finalize = app_method_body(&home, "finalize_live_send_resize");
+    assert!(
+        finalize.contains("resize_window("),
+        "finalize_live_send_resize must resize through Session::resize_window (chrome-aware, #2766)"
+    );
+    assert!(
+        !finalize.contains("\"resize-window\""),
+        "finalize_live_send_resize must not run a raw `resize-window` (#2742)"
+    );
+}
+
 /// Test terminal mode switching sequence
 ///
 /// This guards the production sequence around the attach closure:


### PR DESCRIPTION
## Description

Fixes #2742.

The TUI live-preview pane could sit a row out of sync: typed text landed one line above the rendered cursor, the pane bounced up and down by a line while the agent worked, and it got worse around interactive prompts. A full attach never showed it.

Two independent causes, both about the live preview being a row taller than the pane it mirrors:

**1. The live-send resize path ignored status-bar chrome.** `finalize_live_send_resize` and the worker's `TmuxAction::Resize` dispatch ran a raw `resize-window -y rows`, which sizes the tmux *window*. When a client reserves the status row, the pane lands at `rows - chrome`, a row short of the preview output area the cursor overlay and bottom-anchored capture assume. The passive / serve preview sync already routes through `Session::resize_window`, which measures the chrome and adds it back so the pane lands at exactly `rows` (#2766); the live-send path was the last raw resize. Both live-send resize sites now go through `resize_window`, so the two paths can't disagree by the status row.

**2. The cursor overlay assumed bottom-anchoring unconditionally.** `map_live_preview_cursor` mapped a screen row with `visible_rows - pane_height`, but the renderer only bottom-anchors a capture that *overflows* the output; a shorter capture (an alt-screen prompt, or the frame right after a resize) paints from the top (`compute_scroll` returns 0). The cursor then drifted a row below the text. It now anchors with `min(line_count, visible_rows)`, threading in the same parsed line count the renderer feeds to `compute_scroll`, so it tracks the text in both cases.

### Note on coverage for cause 1
A behavioral test is unreliable here: `resize-window` is a no-op / reports chrome 0 on a detached, client-less tmux on some builds (see the convergence test dropped in #2766). The chrome math is already unit-tested by `chrome_rows_*`; this PR adds a source-inspection guard so the live-send resize can't silently regress to the raw path. Cause 2 is version-independent and has a direct unit test.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

<!-- The change is a one-row alignment correction in the live preview; there is no new UI surface to screenshot, and the desync is timing/geometry dependent. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test (unit + integration under `tests/`)

Added `live_cursor_tracks_top_anchored_short_capture` (verified it fails without the anchoring fix and passes with it) and `test_live_send_resize_uses_chrome_aware_resize_window` (guards the chrome-aware delegation). Existing `map_live_preview_cursor` tests updated for the new `line_count` parameter. `cargo fmt` and `cargo clippy --features serve` are clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude investigated the issue, traced the root causes, and drafted the fix and tests via back-and-forth with @njbrake. The reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed live-preview vertical alignment issues by using chrome-aware session resizing.
- Improved cursor positioning for both short captures and interactive prompts.
- Added unit and integration tests covering cursor tracking and resize behavior.

## Benefits

- Keeps typed input and rendered content synchronized in the live preview.
- Prevents vertical cursor drift and improves reliability during agent activity.
- Allows resize operations to be retried when the session is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->