### PR TITLE
feat(web): add mobile sidebar-toggle FAB to terminal view

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1624,6 +1624,8 @@ function AppContent({
                       sessions={sessions.filter((session) => session.view !== "structured")}
                       persistent={webSettings.persistentTerminals}
                       maxPersistentTerminals={webSettings.maxPersistentTerminals}
+                      sidebarOpen={sidebarOpen}
+                      onToggleSidebar={handleToggleSidebar}
                     />
                   )}
                 </div>

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -5,6 +5,7 @@ import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
 import { MobileLiveTerminal } from "./MobileLiveTerminal";
 import { KeyboardFab } from "./KeyboardFab";
+import { SidebarFab } from "./SidebarFab";
 import { TerminalConnectionBanners } from "./TerminalConnectionBanners";
 import { ensureSession, ensureTerminal, pasteImage } from "../lib/api";
 import type { SessionResponse } from "../lib/types";
@@ -25,6 +26,11 @@ interface Props {
   /** Paired-terminal instance index for the tabbed terminal groups (#2437).
    *  Ignored for the agent surface; 0 is the primary paired shell. */
   terminalIndex?: number;
+  /** Mobile sidebar-toggle FAB wiring (#2245). Present only on the primary
+   *  agent surface; when both are supplied the FAB renders on coarse pointers
+   *  next to the keyboard FAB. */
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
 }
 
 const SURFACES = {
@@ -48,7 +54,14 @@ const SURFACES = {
  * not shrink. The pane re-pins itself to the bottom when its container
  * resizes, which is all a bottom-anchored chat-style surface needs.
  */
-export function LiveTerminalView({ session, active = true, surface = "agent", terminalIndex = 0 }: Props) {
+export function LiveTerminalView({
+  session,
+  active = true,
+  surface = "agent",
+  terminalIndex = 0,
+  sidebarOpen,
+  onToggleSidebar,
+}: Props) {
   const base = SURFACES[surface];
   const { focusTarget, dataTerm } = base;
   // Paired terminals carry their instance index as a query param so the
@@ -291,6 +304,9 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
           bottomAlign={surface === "agent"}
         />
         {coarse && live.state.connected && <KeyboardFab keyboardOpen={inputFocused} onToggle={toggleKeyboard} />}
+        {coarse && live.state.connected && onToggleSidebar && (
+          <SidebarFab sidebarOpen={sidebarOpen ?? false} onToggle={onToggleSidebar} />
+        )}
       </div>
 
       {coarse && live.state.connected && (

--- a/web/src/components/SidebarFab.tsx
+++ b/web/src/components/SidebarFab.tsx
@@ -1,0 +1,38 @@
+interface Props {
+  sidebarOpen: boolean;
+  onToggle: () => void;
+}
+
+/** Mobile shortcut for the session sidebar, mirroring the keyboard FAB so a
+ *  deep-in-a-session thumb can reach the sidebar without stretching to the
+ *  top-bar toggle (#2245). Sits bottom-left, opposite the keyboard FAB. */
+export function SidebarFab({ sidebarOpen, onToggle }: Props) {
+  return (
+    <button
+      type="button"
+      aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+      onClick={onToggle}
+      // Same reason as the keyboard FAB: a button steals focus on pointer-down,
+      // which would blur the terminal input and drop the soft keyboard before
+      // onClick runs. Preventing the default keeps the keyboard up so the
+      // sidebar can be toggled while typing. onClick still fires.
+      onMouseDown={(e) => e.preventDefault()}
+      className="absolute left-3 bottom-3 z-10 w-10 h-10 rounded-full bg-surface-800/90 border border-surface-700/30 text-text-secondary flex items-center justify-center shadow-lg backdrop-blur-sm active:scale-95"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <line x1="9" y1="3" x2="9" y2="21" />
+      </svg>
+    </button>
+  );
+}

--- a/web/src/components/TerminalSessionStack.tsx
+++ b/web/src/components/TerminalSessionStack.tsx
@@ -8,6 +8,9 @@ interface Props {
   sessions: SessionResponse[];
   persistent: boolean;
   maxPersistentTerminals?: number;
+  /** Sidebar-toggle FAB wiring, forwarded to the active terminal only (#2245). */
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
 }
 
 export function TerminalSessionStack({
@@ -15,6 +18,8 @@ export function TerminalSessionStack({
   sessions,
   persistent,
   maxPersistentTerminals = DEFAULT_PERSISTENT_TERMINALS,
+  sidebarOpen,
+  onToggleSidebar,
 }: Props) {
   const [recentIds, setRecentIds] = useState<string[]>([]);
   const limit = normalizePersistentTerminalLimit(maxPersistentTerminals);
@@ -66,7 +71,12 @@ export function TerminalSessionStack({
                 : "absolute inset-0 flex flex-col min-h-0 invisible pointer-events-none"
             }
           >
-            <TerminalView session={session} active={active} />
+            <TerminalView
+              session={session}
+              active={active}
+              sidebarOpen={active ? sidebarOpen : undefined}
+              onToggleSidebar={active ? onToggleSidebar : undefined}
+            />
           </div>
         );
       })}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -4,12 +4,19 @@ import type { SessionResponse } from "../lib/types";
 interface Props {
   session: SessionResponse;
   active?: boolean;
+  /** Mobile sidebar-toggle FAB wiring; forwarded to the live view so a
+   *  deep-in-a-session thumb can open the session list without reaching the
+   *  top bar (#2245). Only the primary agent surface receives these. */
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
 }
 
 /** Agent terminal: the capture-snapshot live view (the TUI's live-mode
  *  architecture, native scroll, send-keys input, no PTY attach), on every
  *  device. The xterm.js PTY relay was removed in favor of this single
  *  renderer so desktop, mobile, and the TUI all show the pane the same way. */
-export function TerminalView({ session, active = true }: Props) {
-  return <LiveTerminalView session={session} active={active} />;
+export function TerminalView({ session, active = true, sidebarOpen, onToggleSidebar }: Props) {
+  return (
+    <LiveTerminalView session={session} active={active} sidebarOpen={sidebarOpen} onToggleSidebar={onToggleSidebar} />
+  );
 }

--- a/web/src/components/__tests__/SidebarFab.test.tsx
+++ b/web/src/components/__tests__/SidebarFab.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+//
+// Unit tests for the mobile sidebar-toggle FAB (#2245). It mirrors the
+// keyboard FAB: an aria-label that flips with sidebar state and an
+// onMouseDown preventDefault so tapping it does not blur the terminal input
+// (which would drop the soft keyboard before the sidebar toggles).
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { SidebarFab } from "../SidebarFab";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SidebarFab", () => {
+  it("labels itself 'Open sidebar' when the sidebar is closed", () => {
+    render(<SidebarFab sidebarOpen={false} onToggle={vi.fn()} />);
+    expect(screen.getByLabelText("Open sidebar")).toBeTruthy();
+  });
+
+  it("labels itself 'Close sidebar' when the sidebar is open", () => {
+    render(<SidebarFab sidebarOpen={true} onToggle={vi.fn()} />);
+    expect(screen.getByLabelText("Close sidebar")).toBeTruthy();
+  });
+
+  it("fires onToggle when clicked", () => {
+    const onToggle = vi.fn();
+    render(<SidebarFab sidebarOpen={false} onToggle={onToggle} />);
+    fireEvent.click(screen.getByLabelText("Open sidebar"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents the default on mousedown so it does not steal focus from the terminal", () => {
+    render(<SidebarFab sidebarOpen={false} onToggle={vi.fn()} />);
+    const button = screen.getByLabelText("Open sidebar");
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    const prevented = !button.dispatchEvent(event);
+    expect(prevented).toBe(true);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -85,6 +85,13 @@
       "components": ["web/src/components/DashboardUpdateBanner.tsx"]
     },
     {
+      "id": "terminal.mobile-sidebar-fab",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/SidebarFab.test.tsx"],
+      "components": ["web/src/components/SidebarFab.tsx"]
+    },
+    {
       "id": "terminal.mobile-live-view",
       "kind": "mocked-playwright",
       "risk": "high",


### PR DESCRIPTION
## Description

On mobile, the only way to open the session sidebar from inside a terminal session was the small icon in the top-left corner of the top bar, which means reaching all the way to the top of the screen while deep in a session (#2245).

This adds a small circular sidebar-toggle FAB rendered in the terminal pane, styled to match the existing keyboard FAB.

- Sits **bottom-left** (`left-3 bottom-3`), opposite the keyboard FAB on the right.
- Appears only on coarse-pointer devices while a terminal session is connected, the same condition as the keyboard FAB.
- Flips its `aria-label` between "Open sidebar" and "Close sidebar" with the sidebar state.
- Uses `onMouseDown` `preventDefault()` (same trick as the keyboard FAB) so tapping it does not blur the terminal input and drop the soft keyboard, i.e. the sidebar is openable while the keyboard is up.
- The existing top-bar toggle and swipe-to-open both continue to work; this is an additional shortcut, not a replacement.

Sidebar open state and the toggle handler are threaded from `App` through `TerminalSessionStack` to the active agent surface only, so paired shells do not render the FAB.

> Note: the issue thread includes a maintainer preference for refining swipe-to-open over adding a FAB. That swipe already exists and is untouched here; this PR adds the FAB per the issue's stated desired behavior. Happy to close if the swipe-only direction is preferred.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added a Vitest + RTL spec `web/src/components/__tests__/SidebarFab.test.tsx` covering the aria-label toggle, the click handler, and the `onMouseDown` preventDefault focus guard, and registered the new component in `web/tests/coverage-matrix.json` (`terminal.mobile-sidebar-fab`).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Implemented via Claude Code under human direction. Reasoning and decisions were reviewed by the author.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a mobile floating button for opening and closing the terminal sidebar.
- Connected sidebar state and toggle behavior through the terminal view components.
- Limited the button to connected, active agent sessions on coarse-pointer devices.
- Preserved keyboard focus and existing sidebar interactions.
- Added tests for accessibility labels, toggling, and focus protection.
- Registered the new coverage area in the test matrix.

## Benefits

Improves mobile terminal navigation while preserving the existing keyboard and swipe-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->