### PR TITLE
docs: document #2697 passive-status behavior contracts

### DIFF
--- a/docs/development/internals/sessions.md
+++ b/docs/development/internals/sessions.md
@@ -29,6 +29,8 @@ Native agent MCP configs are re-read live at session start, so edits apply on th
 
 The passive-status pipeline is the daemon's + TUI's `status_poll_loop` shape that detects agent status transitions (Running / Idle / Waiting / Error / ...) via background polling, without any user action. The fix behind #2690 / #2697 / #2729 hardened its invariants; this section is the canonical entry point for a contributor arriving at any of the six touched files (`src/session/instance.rs`, `src/server/mod.rs`, `src/tui/status_poller.rs`, `src/tui/attached_status_hooks.rs`, `src/tui/home/mod.rs`, `src/tui/home/tests.rs`).
 
+The two user-observable behavior contracts this fix introduced (a blank activity column for fresh, never-touched Running sessions, and a briefly stale idle time on structured/ACP sessions after a daemon restart) are written up for users in the [next-release notes](../../releases/vNext.md#session-activity-column).
+
 The canonical glossary lives on `PassiveStatusPatch` in [`src/session/instance.rs`](../../../src/session/instance.rs) under the "Poller vocabulary" heading: `passive status`, `passive status patch`, `live status baseline`, `detected status`, `poller-authoritative status`. That rustdoc block is under a `pub(crate)` item and does not appear in `cargo doc --no-deps` output, so link from here rather than duplicate.
 
 Authority rule:

--- a/docs/releases/vNext.md
+++ b/docs/releases/vNext.md
@@ -1,0 +1,40 @@
+# Release notes (next version)
+
+Staging notes for behavior changes worth calling out to users in the next
+release. The generated [`CHANGELOG.md`](../../CHANGELOG.md) already lists every
+merged fix and feature by PR title; this page is for the subtle,
+user-observable behavior contracts that a one-line changelog entry cannot
+convey on its own.
+
+## Session activity column
+
+The activity-age fix in
+[#2697](https://github.com/agent-of-empires/agent-of-empires/pull/2697),
+hardened by
+[#2729](https://github.com/agent-of-empires/agent-of-empires/pull/2729) (see
+also [#2690](https://github.com/agent-of-empires/agent-of-empires/pull/2690)),
+stopped the activity column from resetting to `<1m` for every session on a TUI
+relaunch or a daemon restart. Sessions idle for hours now keep showing their
+real age instead of looking freshly touched.
+
+That fix comes with two behavior contracts that are intentional, not bugs:
+
+1. **Fresh, never-touched Running sessions show a blank activity column instead
+   of `<1m`.** A session's activity age now stays empty until the first real
+   user touch, rather than being stamped with the moment it was first polled.
+   Previously a brand-new session was given a fabricated "just now" timestamp;
+   that timestamp is what used to reset on every reload. A blank column for a
+   session you have not interacted with yet is expected.
+
+2. **Structured (ACP) sessions may briefly show a stale idle time after a
+   daemon restart.** For structured sessions the ACP event stream, not the
+   passive poller, owns the idle timestamp. Immediately after a daemon restart
+   the activity column (in both the web dashboard and the TUI) can display the
+   last durable value until the next ACP event re-emits the current state, at
+   which point it corrects itself. This stale window is bounded by the ACP
+   reconnect, not indefinite.
+
+For the technical rationale and the writer-authority rules behind both points,
+see the
+[Passive-status pipeline](../development/internals/sessions.md#passive-status-pipeline)
+section of the session internals reference.


### PR DESCRIPTION
## Description

The activity-age fix in #2697 (hardened by #2729) introduced two intentional, user-observable behavior contracts that the auto-generated `CHANGELOG.md` entry ("Activity age resets to <1m on TUI/daemon reload") does not convey:

1. Fresh, never-touched Running sessions now render a blank activity column instead of `<1m` (the first poll no longer fabricates a `last_accessed_at`).
2. Structured/ACP sessions can briefly show a stale idle time after a daemon restart, until the next ACP event re-emits.

This is the #2729 follow-up requested in #2761. Since the repo has no hand-authored release-notes file (`CHANGELOG.md` and the GitHub Release body are fully git-cliff-generated from conventional-commit titles, so hand edits are overwritten each release), this adds a staging notes page at `docs/releases/vNext.md` for the subtle behavior contracts a one-line changelog cannot carry, following the exact path the issue proposed. It is cross-linked both ways with the `## Passive-status pipeline` section of `docs/development/internals/sessions.md` (dev rationale <-> user-facing note).

Acceptance criteria from the issue:
- Release-notes entry lands (ships in-tree with the next version bump).
- Cross-linked from `docs/development/internals/sessions.md`'s Passive-status pipeline section.
- `grep -rn "#2690\|#2697" docs/` now returns hits outside the `docs/api.md` auto-generated section (`docs/releases/vNext.md` plus the existing `sessions.md`).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Docs-only change; author reviewed the wording and the inferred release-notes convention.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added next-release documentation for session activity status behavior:
  - Fresh running sessions show a blank activity value until user interaction.
  - Structured sessions may briefly show stale idle time after a daemon restart.
- Cross-linked the release notes with the session internals documentation.

## Benefits

Clarifies user-visible behavior and provides maintainers with a shared reference for the passive-status pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->