### PR TITLE
fix(tui): honor repo config sandbox.default_image in new-session dialog

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -498,9 +498,7 @@ impl NewSessionDialog {
             worktree_config_mode: false,
             worktree_config_focused_field: 0,
             sandbox_enabled,
-            sandbox_image: Input::new(
-                containers::get_container_runtime().effective_default_image(),
-            ),
+            sandbox_image: Input::new(config.sandbox.default_image.clone()),
             docker_available,
             yolo_mode,
             yolo_mode_default: yolo_mode,
@@ -839,9 +837,7 @@ impl NewSessionDialog {
             worktree_config_mode: false,
             worktree_config_focused_field: 0,
             sandbox_enabled: false,
-            sandbox_image: Input::new(
-                containers::get_container_runtime().effective_default_image(),
-            ),
+            sandbox_image: Input::new(config.sandbox.default_image.clone()),
             docker_available: false,
             yolo_mode: false,
             yolo_mode_default: false,

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -636,6 +636,17 @@ fn test_worktree_enabled_from_config() {
 }
 
 #[test]
+fn test_sandbox_image_from_config() {
+    let mut config = Config::default();
+    config.sandbox.default_image = "my-custom-sandbox:local".to_string();
+
+    let dialog =
+        NewSessionDialog::new_with_config(vec!["claude"], "/tmp/project".to_string(), config);
+
+    assert_eq!(dialog.sandbox_image.value(), "my-custom-sandbox:local");
+}
+
+#[test]
 fn test_worktree_toggle_submit_without_name() {
     let mut dialog = single_tool_dialog();
     dialog.focused_field = 3; // worktree field


### PR DESCRIPTION
## Description

Follow-up to #1651. That issue fixed `default_image` resolution for `aoe add` on the CLI, but the TUI new-session dialog still ignored the repo config's `sandbox.default_image` and used the global default. On a repo with a custom sandbox image, sessions created via the TUI (`n`) launched with the wrong image, so `on_create` hooks depending on tooling in the custom image failed.

`NewSessionDialog::new()` and `new_with_config()` already resolve the full repo-aware `config` (used for `default_tool`, `sandbox.enabled_by_default`, `worktree.enabled`, etc.), but for the image field they bypassed it and called the global-only `effective_default_image()` (which reads `Config::load()`, global config only). This change reads the image from the already-resolved `config.sandbox.default_image`, mirroring what `reload_config_defaults()` already does. `new_with_tools()` (test-only, no `config`) keeps the global fallback.

Fixes #2763

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Added `test_sandbox_image_from_config` unit test in `src/tui/dialogs/new_session/tests.rs` verifying the dialog initializes the sandbox image from repo config. A lighter unit test rather than a full e2e since the fix is a pure config-wiring change at dialog construction.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** AI drafted the fix and test under human direction; the root cause and fix approach come from the issue report.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the TUI new-session dialog to use the repository’s configured sandbox image.
- Preserved the global default for test-only paths without repository configuration.
- Added a unit test covering repository-specific sandbox image settings.

This ensures TUI-created sessions use the same sandbox configuration as other repository operations, enabling dependent hooks and tooling to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->