### PR TITLE
test(session): lock Use variant of promote_one_shot arm

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9628,6 +9628,58 @@ mod tests {
 
         #[test]
         #[serial]
+        fn use_intent_promotes_to_default_after_launch() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let profile = "use-promote";
+            let storage = crate::session::storage::Storage::new_unwatched(profile).unwrap();
+            let pinned = "019342ab-1234-7def-8901-abcdef012345";
+
+            let mut inst = Instance::new("Pinned", "/tmp/x");
+            inst.tool = "claude".into();
+            inst.source_profile = profile.into();
+            inst.agent_session_id = Some(pinned.into());
+            inst.resume_intent = ResumeIntent::Use(pinned.into());
+
+            let on_disk = inst.clone();
+            storage
+                .update(|i, g| {
+                    *i = vec![on_disk.clone()];
+                    *g = crate::session::GroupTree::new_with_groups(
+                        std::slice::from_ref(&on_disk),
+                        &[],
+                    )
+                    .get_all_groups();
+                    Ok(())
+                })
+                .unwrap();
+
+            // Simulate the post-launch persist: expected_prior_intent is the Use
+            // we launched with; the pinned id is already in agent_session_id.
+            let expected_prior = inst.resume_intent.clone();
+            let expected_sid = inst.agent_session_id.clone();
+            let _ = inst.persist_session_id(profile, expected_sid.as_deref(), expected_prior);
+
+            let reloaded = storage.load().unwrap();
+            let disk = reloaded.iter().find(|i| i.id == inst.id).unwrap();
+            assert_eq!(
+                disk.resume_intent,
+                ResumeIntent::Default,
+                "Use must auto-promote to Default after the launch consumes the pin so the drain adopts subsequent post-launch captures (#2708)",
+            );
+            assert_eq!(
+                inst.resume_intent,
+                ResumeIntent::Default,
+                "In-memory resume_intent must also promote so the drain PIN guard stops firing on the same tick",
+            );
+            assert_eq!(disk.agent_session_id.as_deref(), Some(pinned));
+        }
+
+        #[test]
+        #[serial]
         fn persist_session_id_writes_sid_only_on_default_intent() {
             let temp = tempdir().unwrap();
             std::env::set_var("HOME", temp.path());


### PR DESCRIPTION
## Description

The `promote_one_shot` match arm in `persist_session_id` (`src/session/instance.rs`) collapses three variants into a single `matches!` expression: `ResumeIntent::Cleared | Fork { .. } | Use(_)`. PR #2709 added the `Use(_)` term so a launched `Use(pin)` promotes to `Default` on disk and in memory, letting subsequent drain ticks (the PIN guard at `sync.rs:113`) adopt post-launch captures instead of freezing the pinned sid forever (the #2708 regression).

The Cleared and Fork branches are each locked by a test, but nothing drove `Use(_)` through `persist_session_id`. A refactor that split the arm and dropped `Use(_)` would leave every existing test green while re-introducing #2708.

This adds `use_intent_promotes_to_default_after_launch` next to `fork_intent_promotes_to_default_after_launch`. It launches with `ResumeIntent::Use(pin)`, calls `persist_session_id`, and asserts BOTH the on-disk (`storage.load()`) and in-memory (`inst.resume_intent`) state promote to `Default`, plus that the pinned sid is preserved. The in-memory assertion guards the memory-coherence invariant the drain PIN guard depends on.

Test-only. No production code change, no migration, no change to the `Use(pin)` semantics PR #2709 established.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI
- [x] Test coverage

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This PR IS the test; it locks a session-storage invariant via a unit test in `src/session/instance.rs`. No coverage-matrix entry is required (Rust-only, no web surface).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Test authored per the fully specified test in issue #2714, verified against the neighboring `fork_intent_promotes_to_default_after_launch` test and the `persist_session_id` signature.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #2714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a unit test covering promotion of a pinned resume intent to the default intent after launch.
- Verifies the change is saved to storage and reflected in memory while preserving the pinned session ID.
- Improves regression coverage without changing production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->