### PR TITLE
test(session): per-tool verify-on-resume tests for opencode, vibe, codex, gemini, pi, hermes

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -9452,6 +9452,288 @@ mod tests {
                 assert_eq!(sid.as_deref(), Some(mine));
                 assert_eq!(inst.agent_session_id.as_deref(), Some(mine));
             }
+
+            // ── Per-tool bascule coverage (#2304) ────────────────────────────
+            //
+            // The Claude bascule above proves `acquire_session_id`'s Default arm
+            // supersedes a stale stored sid with a fresher live observation. The
+            // other six live-tracked agents inherit that behaviour through the
+            // same `try_retroactive_capture` dispatch, but a regression in an
+            // individual match arm (an accidental arm deletion or signature
+            // drift) would not be caught by the Claude test alone. Each test
+            // below seeds two on-disk sessions for one tool (older = stored,
+            // newer = fresh) and asserts acquire replaces the stored sid with
+            // the fresher one, exercising that tool's dispatch arm end-to-end.
+
+            /// Sets HOME (and XDG_CONFIG_HOME) to a temp dir for the test's
+            /// lifetime so the exclusion-set scan reads an empty storage rather
+            /// than the developer's real sessions.json. Restored on Drop.
+            struct StorageHomeGuard {
+                prev_home: Option<String>,
+                prev_xdg: Option<String>,
+            }
+
+            impl StorageHomeGuard {
+                fn set(temp: &TempDir) -> Self {
+                    let prev_home = std::env::var("HOME").ok();
+                    let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+                    std::env::set_var("HOME", temp.path());
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+                    Self {
+                        prev_home,
+                        prev_xdg,
+                    }
+                }
+            }
+
+            impl Drop for StorageHomeGuard {
+                fn drop(&mut self) {
+                    restore_or_remove("HOME", self.prev_home.take());
+                    restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
+                }
+            }
+
+            fn write_with_mtime(path: &std::path::Path, content: &str, mtime: SystemTime) {
+                fs::write(path, content).unwrap();
+                let f = fs::File::options().write(true).open(path).unwrap();
+                f.set_times(fs::FileTimes::new().set_modified(mtime))
+                    .unwrap();
+            }
+
+            #[test]
+            #[serial]
+            fn supersedes_stale_opencode_sid() {
+                let temp = tempdir().unwrap();
+                let _home = StorageHomeGuard::set(&temp);
+
+                let project_path = temp.path().join("opencode-project");
+                fs::create_dir_all(&project_path).unwrap();
+                let project_path = project_path.to_string_lossy().to_string();
+
+                let db_path = temp.path().join("opencode.db");
+                let stale = "ses_opencode_stored";
+                let fresh = "ses_opencode_fresh";
+                seed_opencode_db(&db_path, stale, &project_path);
+                let conn = rusqlite::Connection::open(&db_path).unwrap();
+                conn.execute(
+                    "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![fresh, project_path, 2_000_000_i64],
+                )
+                .unwrap();
+                drop(conn);
+                let _db = EnvVarGuard::set("OPENCODE_DB", &db_path);
+
+                let mut inst = Instance::new("verify-opencode-bascule", &project_path);
+                inst.tool = "opencode".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+            }
+
+            #[test]
+            #[serial]
+            fn supersedes_stale_vibe_sid() {
+                let temp = tempdir().unwrap();
+                let _home = StorageHomeGuard::set(&temp);
+                let _vibe = EnvVarGuard::set("VIBE_HOME", temp.path());
+
+                let project_path = temp.path().join("vibe-project");
+                fs::create_dir_all(&project_path).unwrap();
+                let project_path = project_path.to_string_lossy().to_string();
+
+                let sessions_dir = temp.path().join("logs").join("session");
+                let stale = "vibe-stored-sid";
+                let fresh = "vibe-fresh-sid";
+                let now = SystemTime::now();
+                for (sid, dir, age) in [(stale, "session-stale", 120), (fresh, "session-fresh", 10)]
+                {
+                    let sdir = sessions_dir.join(dir);
+                    fs::create_dir_all(&sdir).unwrap();
+                    let meta = serde_json::json!({
+                        "session_id": sid,
+                        "environment": {"working_directory": project_path},
+                    });
+                    write_with_mtime(
+                        &sdir.join("meta.json"),
+                        &meta.to_string(),
+                        now - Duration::from_secs(age),
+                    );
+                }
+
+                let mut inst = Instance::new("verify-vibe-bascule", &project_path);
+                inst.tool = "vibe".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+            }
+
+            #[test]
+            #[serial]
+            fn supersedes_stale_codex_sid() {
+                let temp = tempdir().unwrap();
+                let _home = StorageHomeGuard::set(&temp);
+                let _codex = EnvVarGuard::set("CODEX_HOME", temp.path());
+
+                let project_path = temp.path().join("codex-project");
+                fs::create_dir_all(&project_path).unwrap();
+                let project_path = project_path.to_string_lossy().to_string();
+
+                let sessions_dir = temp.path().join("sessions");
+                fs::create_dir_all(&sessions_dir).unwrap();
+                let stale = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+                let fresh = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb";
+                let now = SystemTime::now();
+                for (uuid, age) in [(stale, 120), (fresh, 10)] {
+                    let body = format!(
+                        r#"{{"type":"session_meta","payload":{{"cwd":"{project_path}"}}}}"#
+                    );
+                    write_with_mtime(
+                        &sessions_dir.join(format!("rollout-2025-03-06T10-30-00-{uuid}.jsonl")),
+                        &body,
+                        now - Duration::from_secs(age),
+                    );
+                }
+
+                let mut inst = Instance::new("verify-codex-bascule", &project_path);
+                inst.tool = "codex".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+            }
+
+            #[test]
+            #[serial]
+            fn supersedes_stale_gemini_sid() {
+                use sha2::{Digest, Sha256};
+
+                let temp = tempdir().unwrap();
+                let _home = StorageHomeGuard::set(&temp);
+                let _gemini = EnvVarGuard::set("GEMINI_CLI_HOME", temp.path());
+
+                let project_dir = temp.path().join("gemini-project");
+                fs::create_dir_all(&project_dir).unwrap();
+                let project_path = project_dir.to_string_lossy().to_string();
+
+                // Directory name is sha256 of the canonicalized cwd, matching the
+                // capture function's exact-match branch.
+                let canonical = fs::canonicalize(&project_dir).unwrap();
+                let hash = Sha256::digest(canonical.to_string_lossy().as_bytes())
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect::<String>();
+                let chats_dir = temp.path().join("tmp").join(&hash).join("chats");
+                fs::create_dir_all(&chats_dir).unwrap();
+
+                let stale = "gemini-stored-id";
+                let fresh = "gemini-fresh-id";
+                let now = SystemTime::now();
+                for (sid, age) in [(stale, 120), (fresh, 10)] {
+                    let body =
+                        format!(r#"{{"sessionId":"{sid}","projectHash":"{hash}","kind":"main"}}"#);
+                    write_with_mtime(
+                        &chats_dir.join(format!("session-{sid}.json")),
+                        &body,
+                        now - Duration::from_secs(age),
+                    );
+                }
+
+                let mut inst = Instance::new("verify-gemini-bascule", &project_path);
+                inst.tool = "gemini".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+            }
+
+            #[test]
+            #[serial]
+            fn supersedes_stale_pi_sid() {
+                use crate::session::capture::encode_pi_project_path;
+
+                let temp = tempdir().unwrap();
+                let _home = StorageHomeGuard::set(&temp);
+                let _pi = EnvVarGuard::set("PI_CODING_AGENT_DIR", temp.path());
+
+                let project_dir = temp.path().join("pi-project");
+                fs::create_dir_all(&project_dir).unwrap();
+                let project_path = project_dir.to_string_lossy().to_string();
+
+                let project_session_dir = temp
+                    .path()
+                    .join("sessions")
+                    .join(encode_pi_project_path(&project_path));
+                fs::create_dir_all(&project_session_dir).unwrap();
+
+                let stale = "cccccccc-3333-4333-8333-cccccccccccc";
+                let fresh = "dddddddd-4444-4444-8444-dddddddddddd";
+                let now = SystemTime::now();
+                for (sid, age) in [(stale, 120), (fresh, 10)] {
+                    let body =
+                        format!(r#"{{"type":"session","id":"{sid}","cwd":"{project_path}"}}"#);
+                    write_with_mtime(
+                        &project_session_dir.join(format!("20260101T000000_{sid}.jsonl")),
+                        &body,
+                        now - Duration::from_secs(age),
+                    );
+                }
+
+                let mut inst = Instance::new("verify-pi-bascule", &project_path);
+                inst.tool = "pi".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+            }
+
+            #[test]
+            #[serial]
+            fn supersedes_stale_hermes_sid() {
+                let temp = tempdir().unwrap();
+                let _home = StorageHomeGuard::set(&temp);
+                let _hermes = EnvVarGuard::set("HERMES_HOME", temp.path());
+
+                let db_path = temp.path().join("state.db");
+                let stale = "20260101_000000_stored";
+                let fresh = "20260101_000000_fresh";
+                let conn = rusqlite::Connection::open(&db_path).unwrap();
+                conn.execute_batch(&format!(
+                    "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL);
+                     INSERT INTO sessions VALUES ('{stale}','cli',1000.0,NULL);
+                     INSERT INTO sessions VALUES ('{fresh}','cli',2000.0,NULL);",
+                ))
+                .unwrap();
+                drop(conn);
+
+                // Hermes ignores the project path; it keys off the state.db rows.
+                let mut inst = Instance::new("verify-hermes-bascule", "/tmp/aoe-test-2304-hermes");
+                inst.tool = "hermes".to_string();
+                inst.agent_session_id = Some(stale.to_string());
+                inst.resume_intent = ResumeIntent::Default;
+
+                let (sid, is_existing) = inst.acquire_session_id();
+                assert_eq!(sid.as_deref(), Some(fresh));
+                assert!(is_existing);
+                assert_eq!(inst.agent_session_id.as_deref(), Some(fresh));
+            }
         }
 
         #[test]


### PR DESCRIPTION
## Description

Follow-up from #2298 (closes #2304).

`Instance::acquire_session_id`'s `Default` arm supersedes a stale stored session id with a fresher live observation, dispatched per tool through `try_retroactive_capture`. Only Claude had a direct integration test for this bascule (`supersedes_stale_claude_sid_after_clear`). The other six live-tracked agents (`opencode`, `vibe`, `codex`, `gemini`, `pi`, `hermes`) inherit the behaviour through the same dispatch but had no direct `acquire_session_id` coverage, so an accidental arm deletion or signature drift in one of them could regress without a failing test.

This PR adds one bascule test per tool in `tests::resume_fallback::verify_on_resume`, mirroring the Claude test. Each seeds two on-disk sessions in that tool's native store (older = stored, newer = fresh) and asserts `acquire_session_id` replaces the stored id with the fresher one, exercising that tool's dispatch arm end-to-end:

- opencode: two `session` rows in the `OPENCODE_DB` SQLite store, distinct `time_updated`.
- vibe: two `VIBE_HOME/logs/session/<dir>/meta.json` fixtures with mtime ordering.
- codex: two `CODEX_HOME/sessions/rollout-*-<UUID>.jsonl` files with mtime ordering.
- gemini: two `GEMINI_CLI_HOME/tmp/<sha256(cwd)>/chats/session-*.json` files.
- pi: two `PI_CODING_AGENT_DIR/sessions/<encoded>/<TS>_<UUID>.jsonl` files.
- hermes: two `cli` rows in `HERMES_HOME/state.db`, distinct `started_at`.

Adds a `StorageHomeGuard` (HOME/XDG isolation so the exclusion scan reads an empty storage) and a `write_with_mtime` helper. Test-only change; no production code touched.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR is itself test-only and adds unit coverage for existing session-lifecycle behaviour; no new runtime behaviour to e2e.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Tests authored by Claude Code, fixtures derived from each tool's existing capture unit tests in `src/session/capture.rs`. Ran `cargo fmt`, `cargo clippy`, and the new `cargo test` locally; all 17 `verify_on_resume` tests pass.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added integration tests covering resume-session verification for OpenCode, Vibe, Codex, Gemini, Pi, and Hermes.
- Each test uses the tool’s native session storage to simulate stale and newer sessions, confirming the newer session replaces the stored ID.
- Added storage-isolation and file-timestamp test helpers.
- No production behavior or public APIs changed.

## Benefits

- Expands regression coverage across all supported live-tracked agents.
- Verifies end-to-end stale-session recovery while keeping tests isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->