### PR TITLE
fix(git): make cleanup running-state probe warn runtime-neutral

### DIFF
--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -447,7 +447,7 @@ pub fn cleanup_sandbox_worktree(instance: &Instance) -> bool {
                 target: "containers.runtime",
                 session = %instance.id,
                 error = %e,
-                "container running-state probe failed while probing sandbox container for worktree cleanup; attempting container start (safe if already running)"
+                "container running-state probe failed during worktree cleanup; attempting container start (safe if already running)"
             );
             true
         }

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -447,7 +447,7 @@ pub fn cleanup_sandbox_worktree(instance: &Instance) -> bool {
                 target: "containers.runtime",
                 session = %instance.id,
                 error = %e,
-                "docker inspect failed while probing sandbox container for worktree cleanup; attempting container start (safe if already running)"
+                "container running-state probe failed while probing sandbox container for worktree cleanup; attempting container start (safe if already running)"
             );
             true
         }


### PR DESCRIPTION
## Description

Follow-up to #2654 / #2719. The `Probe::Unknown(e)` warn in
`cleanup_sandbox_worktree` (`src/git/cleanup.rs`) read "docker inspect failed
while probing sandbox container for worktree cleanup...", which is factually
wrong on non-Docker runtimes: Podman uses `podman container inspect` and Apple
uses `container inspect`. This aligns the warn with the sibling existence-probe
warn fixed in #2719 by describing the probe by its intent rather than a
runtime-specific CLI, while preserving the actionable tail ("attempting
container start (safe if already running)").

New wording:

> container running-state probe failed while probing sandbox container for worktree cleanup; attempting container start (safe if already running)

Scoped narrowly to this one cleanup.rs warn, as the issue requests. The sibling
`docker inspect failed` literals in `src/session/instance.rs` and
`src/session/worktree_edit.rs` are intentionally left for a separate
runtime-neutrality sweep.

Fixes #2720

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: this changes only the text of a `tracing::warn!` log message; no code path, control flow, or user-facing behavior changes, and no test asserts on this string. Existing `git::cleanup` unit tests (25) still pass.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Drafted via back-and-forth with @njbrake; the one-line wording change and scope decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated a single warning log in `src/git/cleanup.rs` to remove Docker-specific wording and make it runtime-neutral.
- Aligned the warning’s phrasing with the adjacent existence-probe warning, while keeping the same actionable guidance to attempt starting the container when the running-state probe fails.
- No cleanup logic, control flow, or error-handling behavior was changed—only the log text was revised.

## Benefits

- Improves log clarity and consistency across container runtimes (e.g., Podman and Apple environments) without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->