### PR TITLE
fix: disable trust-folder prompt for YOLO-mode sandboxed sessions

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1011,6 +1011,124 @@ pub fn uninstall_codex_hooks(config_path: &Path) -> Result<bool> {
     Ok(modified)
 }
 
+/// Disable Gemini's folder-trust confirmation by merging
+/// `security.folderTrust.enabled = false` into its `settings.json`.
+///
+/// In a YOLO-mode sandboxed session the container is ephemeral, so Gemini
+/// re-prompts to trust the working directory on every launch even though the
+/// user already opted out of approvals. Merging this flag suppresses the
+/// prompt (issue #472). Any other keys the user (or AoE's hook installer) has
+/// written to the same file are preserved, and an unwritable/malformed file is
+/// treated as empty rather than propagated as an error, mirroring the hook
+/// installers above.
+pub fn disable_gemini_folder_trust(settings_path: &Path) -> Result<()> {
+    with_config_lock(settings_path, "json.lock", || {
+        let mut settings: Value = if settings_path.exists() {
+            let content = std::fs::read_to_string(settings_path)?;
+            serde_json::from_str(&content).unwrap_or_else(|e| {
+                tracing::warn!(target: "hooks.install", "Failed to parse {}: {}", settings_path.display(), e);
+                serde_json::json!({})
+            })
+        } else {
+            serde_json::json!({})
+        };
+
+        let before = settings.clone();
+
+        let root = settings
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("Settings file root is not a JSON object"))?;
+        let security = root
+            .entry("security")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if !security.is_object() {
+            *security = Value::Object(serde_json::Map::new());
+        }
+        let folder_trust = security
+            .as_object_mut()
+            .expect("ensured object above")
+            .entry("folderTrust")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if !folder_trust.is_object() {
+            *folder_trust = Value::Object(serde_json::Map::new());
+        }
+        folder_trust
+            .as_object_mut()
+            .expect("ensured object above")
+            .insert("enabled".to_string(), Value::Bool(false));
+
+        if settings == before {
+            return Ok(());
+        }
+
+        if let Some(parent) = settings_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let formatted = serde_json::to_string_pretty(&settings)?;
+        crate::session::atomic_write_following_symlinks(settings_path, formatted.as_bytes())?;
+        tracing::info!(target: "hooks.install",
+            "Disabled Gemini folder trust in {}", settings_path.display());
+        Ok(())
+    })
+}
+
+/// Mark `project_path` as trusted in Codex's `config.toml` by merging
+/// `[projects."<project_path>"].trust_level = "trusted"`.
+///
+/// Codex keys folder trust on the absolute working directory, so
+/// `project_path` must be the path Codex sees as its cwd (inside a sandbox
+/// that is the in-container worktree path, not the host path). Used for
+/// YOLO-mode sandboxed sessions so the ephemeral container does not re-prompt
+/// for folder trust (issue #472). Runs under the same lock as the Codex hook
+/// installers so it cannot interleave with a concurrent hook rewrite, and
+/// preserves every other key in the file, including an existing `[projects.*]`
+/// block.
+pub fn trust_codex_project(config_path: &Path, project_path: &str) -> Result<()> {
+    with_codex_config_lock(config_path, || {
+        let mut config = read_codex_config(config_path)?;
+        let before = config.to_string();
+
+        let root = config.as_table_mut();
+        if !root.contains_key("projects") {
+            let mut projects = toml_edit::Table::new();
+            // Implicit so an empty `[projects]` header is never emitted; only
+            // the per-project `[projects."<path>"]` sub-table renders.
+            projects.set_implicit(true);
+            root.insert("projects", toml_edit::Item::Table(projects));
+        }
+        let projects = root
+            .get_mut("projects")
+            .and_then(|item| item.as_table_mut())
+            .ok_or_else(|| anyhow::anyhow!("Codex projects key is not a TOML table"))?;
+
+        if !projects
+            .get(project_path)
+            .is_some_and(|item| item.is_table())
+        {
+            projects.insert(
+                project_path,
+                toml_edit::Item::Table(toml_edit::Table::new()),
+            );
+        }
+        let project = projects
+            .get_mut(project_path)
+            .and_then(|item| item.as_table_mut())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Codex projects.{project_path} entry is not a TOML table")
+            })?;
+        project.insert("trust_level", toml_edit::value("trusted"));
+
+        if config.to_string() == before {
+            return Ok(());
+        }
+
+        write_codex_config(config_path, &config)?;
+        tracing::info!(target: "hooks.install",
+            "Marked {} trusted in Codex config {}", project_path, config_path.display());
+        Ok(())
+    })
+}
+
 /// Remove all AoE hooks from an agent's `settings.json` file.
 ///
 /// Strips AoE hook entries while preserving user-defined hooks. If an event
@@ -2634,6 +2752,134 @@ trust_level = "trusted"
             Some("trusted")
         );
         assert_eq!(config_text.matches("sh -c").count(), codex_events().len());
+    }
+
+    #[test]
+    fn test_disable_gemini_folder_trust_creates_nested_flag() {
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join(".gemini").join("settings.json");
+
+        disable_gemini_folder_trust(&settings_path).unwrap();
+
+        let settings: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(
+            settings["security"]["folderTrust"]["enabled"],
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_disable_gemini_folder_trust_preserves_existing_keys() {
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join("settings.json");
+        std::fs::write(
+            &settings_path,
+            r#"{"theme":"dark","security":{"auth":{"selectedType":"oauth"}}}"#,
+        )
+        .unwrap();
+
+        disable_gemini_folder_trust(&settings_path).unwrap();
+
+        let settings: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(settings["theme"], "dark");
+        assert_eq!(settings["security"]["auth"]["selectedType"], "oauth");
+        assert_eq!(
+            settings["security"]["folderTrust"]["enabled"],
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_disable_gemini_folder_trust_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let settings_path = tmp.path().join("settings.json");
+
+        disable_gemini_folder_trust(&settings_path).unwrap();
+        let first = std::fs::read_to_string(&settings_path).unwrap();
+        let mtime = std::fs::metadata(&settings_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        disable_gemini_folder_trust(&settings_path).unwrap();
+        let second = std::fs::read_to_string(&settings_path).unwrap();
+        assert_eq!(first, second);
+        // No-change second pass must not rewrite the file.
+        assert_eq!(
+            mtime,
+            std::fs::metadata(&settings_path)
+                .unwrap()
+                .modified()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_trust_codex_project_writes_project_table() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join(".codex").join("config.toml");
+
+        trust_codex_project(&config_path, "/workspace/my-worktree").unwrap();
+
+        let config_text = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            config_text.contains(r#"[projects."/workspace/my-worktree"]"#),
+            "unexpected config:\n{config_text}"
+        );
+        let config: toml::Value = toml::from_str(&config_text).unwrap();
+        assert_eq!(
+            config["projects"]["/workspace/my-worktree"]["trust_level"].as_str(),
+            Some("trusted")
+        );
+    }
+
+    #[test]
+    fn test_trust_codex_project_preserves_existing_config() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"model = "gpt-5.3-codex"
+
+[projects."/other/path"]
+trust_level = "trusted"
+"#,
+        )
+        .unwrap();
+
+        trust_codex_project(&config_path, "/workspace/my-worktree").unwrap();
+
+        let config: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(config["model"].as_str(), Some("gpt-5.3-codex"));
+        assert_eq!(
+            config["projects"]["/other/path"]["trust_level"].as_str(),
+            Some("trusted")
+        );
+        assert_eq!(
+            config["projects"]["/workspace/my-worktree"]["trust_level"].as_str(),
+            Some("trusted")
+        );
+    }
+
+    #[test]
+    fn test_trust_codex_project_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        trust_codex_project(&config_path, "/workspace/my-worktree").unwrap();
+        let first = std::fs::read_to_string(&config_path).unwrap();
+        let mtime = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+
+        trust_codex_project(&config_path, "/workspace/my-worktree").unwrap();
+        let second = std::fs::read_to_string(&config_path).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(
+            mtime,
+            std::fs::metadata(&config_path).unwrap().modified().unwrap()
+        );
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1617,6 +1617,36 @@ pub(crate) fn build_container_config(
                     value: value.to_string(),
                 });
             }
+
+            // Codex and Gemini re-prompt for folder trust on every launch, and
+            // in a sandbox the config dir is ephemeral so the prompt never
+            // "sticks". In YOLO mode the user has already opted out of
+            // approvals, so disable the trust confirmation in the staged
+            // sandbox config to match that intent (issue #472). The `.codex`
+            // /`.gemini` sandbox dirs were staged by the AGENT_CONFIG_MOUNTS
+            // loop above, so these merges land in files that get bind-mounted
+            // into the container.
+            match agent.name {
+                "codex" => {
+                    let config_file = home.join(".codex").join(SANDBOX_SUBDIR).join("config.toml");
+                    if let Err(e) = crate::hooks::trust_codex_project(&config_file, &workspace_path)
+                    {
+                        tracing::warn!(target: "session.profile",
+                            "Failed to mark project trusted in sandbox Codex config: {}", e);
+                    }
+                }
+                "gemini" => {
+                    let settings_file = home
+                        .join(".gemini")
+                        .join(SANDBOX_SUBDIR)
+                        .join("settings.json");
+                    if let Err(e) = crate::hooks::disable_gemini_folder_trust(&settings_file) {
+                        tracing::warn!(target: "session.profile",
+                            "Failed to disable folder trust in sandbox Gemini settings: {}", e);
+                    }
+                }
+                _ => {}
+            }
         }
     }
 
@@ -3517,6 +3547,115 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
             "host (per-user) and container (fixed) paths MUST differ for the bind-mount remap"
         );
         crate::hooks::cleanup_hook_status_dir(instance_id);
+    }
+
+    // Issue #472: a YOLO-mode sandbox session must disable the agent's
+    // folder-trust prompt so the ephemeral container does not re-prompt on
+    // every launch.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_yolo_trusts_codex_project() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+        let config = build_container_config(
+            project_dir.path().to_str().unwrap(),
+            &sandbox_info,
+            ContainerAgentSelection::new("codex", None),
+            true,
+            "codex-yolo-trust-test",
+            None,
+            "",
+        )
+        .unwrap();
+
+        let codex_config = temp_home
+            .path()
+            .join(".codex")
+            .join(SANDBOX_SUBDIR)
+            .join("config.toml");
+        assert!(
+            codex_config.exists(),
+            "yolo codex sandbox must write config.toml"
+        );
+        let parsed: toml::Value =
+            toml::from_str(&fs::read_to_string(&codex_config).unwrap()).unwrap();
+        let projects = parsed["projects"].as_table().unwrap();
+        // The trust key is the in-container working dir, not the host path.
+        assert_eq!(
+            projects[&config.working_dir]["trust_level"].as_str(),
+            Some("trusted")
+        );
+
+        crate::hooks::cleanup_hook_status_dir("codex-yolo-trust-test");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_yolo_disables_gemini_folder_trust() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        };
+        build_container_config(
+            project_dir.path().to_str().unwrap(),
+            &sandbox_info,
+            ContainerAgentSelection::new("gemini", None),
+            true,
+            "gemini-yolo-trust-test",
+            None,
+            "",
+        )
+        .unwrap();
+
+        let gemini_settings = temp_home
+            .path()
+            .join(".gemini")
+            .join(SANDBOX_SUBDIR)
+            .join("settings.json");
+        assert!(
+            gemini_settings.exists(),
+            "yolo gemini sandbox must write settings.json"
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&gemini_settings).unwrap()).unwrap();
+        assert_eq!(
+            parsed["security"]["folderTrust"]["enabled"],
+            serde_json::Value::Bool(false)
+        );
+
+        crate::hooks::cleanup_hook_status_dir("gemini-yolo-trust-test");
     }
 
     // Regression guard for the trap in #958: a sidecar agent (settl TOML,


### PR DESCRIPTION
## Description

When a session is launched in a container in YOLO mode, `codex` and `gemini` still prompt to trust the working folder on every launch. In a sandbox the agent's config directory is ephemeral, so a folder-trust decision never sticks and the user is re-prompted each relaunch, even though YOLO mode means they have already opted out of approvals.

This wires the trust-disable settings into the staged sandbox config (the files that get bind-mounted into the container), gated on YOLO + sandbox:

- Gemini: merge `security.folderTrust.enabled = false` into `.gemini/settings.json`.
- Codex: merge `[projects."<in-container workdir>"].trust_level = "trusted"` into `.codex/config.toml`, keyed on the working directory Codex actually sees inside the container.

Both merges live in `src/hooks/mod.rs` (`disable_gemini_folder_trust`, `trust_codex_project`), reusing the existing locked/atomic JSON and TOML helpers. They are idempotent and preserve every other key, including AoE's own status hooks and any pre-existing Codex `[projects.*]` block. The wiring is in `build_container_config` next to the existing YOLO env-var injection, so it only fires for YOLO-mode sandboxed sessions.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

Added unit tests in `src/hooks/mod.rs` for both merge helpers (create, preserve-existing-keys, idempotent) and two integration tests in `src/session/container_config.rs` that drive `build_container_config` in YOLO mode and assert the trust settings land in the staged codex `config.toml` / gemini `settings.json`.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
  <!-- Backend-only change to container config staging; covered by the new lib unit + integration tests above. -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implementation drafted with Claude Code; reasoning and review by the PR author.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #472
