### PR TITLE
chore: adopt `#![deny(rustdoc::private_intra_doc_links)]` and resolve pre-existing warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,13 @@ jobs:
           AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo xtask gen-docs
           git diff --exit-code docs/cli/reference.md \
             || (echo "::error::CLI docs are out of date. Run 'cargo xtask gen-docs' and commit." && exit 1)
+      - name: Check rustdoc is warning-clean
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          mkdir -p target/ci-web-dist
+          printf '<!doctype html><title>aoe docs placeholder</title>\n' > target/ci-web-dist/index.html
+          AOE_WEB_DIST="$PWD/target/ci-web-dist" cargo doc --no-deps --features serve
 
   skill:
     name: Skill Check

--- a/src/containers/error.rs
+++ b/src/containers/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// (`NotInstalled`, `DaemonNotRunning`, `PermissionDenied`) inline their
 /// actionable remediation on one line, and the string-carrying variants
 /// (`InspectFailed`, `RemoveFailed`, etc.) must be constructed via
-/// [`sanitize_stderr`] to normalize any embedded newlines from raw runtime
+/// `sanitize_stderr` to normalize any embedded newlines from raw runtime
 /// stderr. This lets `tracing::warn!(error = %e)` at gate sites emit one
 /// physical log line, keeping `grep target` correlation intact under the
 /// text-mode subscriber this project uses.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Agent of Empires library - Core functionality for the terminal session manager
 
+#![deny(rustdoc::private_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
 #[cfg(feature = "serve")]
 pub mod acp;
 pub mod agents;

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1054,7 +1054,7 @@ async fn probe_container_holds_worktree(id: &str, is_sandboxed: bool) -> bool {
 /// Rename a session's title (and, when tied, its worktree directory).
 ///
 /// The sandbox container probe runs on the blocking pool via
-/// [`probe_container_holds_worktree`], which fails closed on a
+/// `probe_container_holds_worktree`, which fails closed on a
 /// `spawn_blocking` panic or cancellation so the rename is rejected
 /// with `409 CONFLICT` rather than proceeding against a possibly-live
 /// container mount and hitting `EBUSY`.
@@ -1331,7 +1331,7 @@ fn worktree_edit_error_response(
 /// its git branch).
 ///
 /// The sandbox container probe runs on the blocking pool via
-/// [`probe_container_holds_worktree`], which fails closed on a
+/// `probe_container_holds_worktree`, which fails closed on a
 /// `spawn_blocking` panic or cancellation so the edit is rejected with
 /// `409 CONFLICT` rather than proceeding against a possibly-live container
 /// mount and hitting `EBUSY`.

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -490,14 +490,14 @@ pub struct AuthenticatedTokenHash(pub [u8; 32]);
 pub struct AuthenticatedSession(pub String);
 
 /// Request extension marking a request whose resolved client IP is
-/// loopback (see [`is_local_trusted`]). Inserted by `auth_middleware`
+/// loopback (see `is_local_trusted`). Inserted by `auth_middleware`
 /// right after client-IP resolution, before any auth branch, so every
 /// downstream consumer sees it regardless of which auth path ran. It is
 /// a server-internal fact derived from the socket peer plus trusted
 /// forwarding headers; clients cannot inject request extensions.
 ///
 /// Handler-side elevation gates treat it as elevated (see
-/// [`handler_elevated`]): the same-host caller already passes the
+/// `handler_elevated`): the same-host caller already passes the
 /// fs-perm trust boundary (#1168) and could run the equivalent CLI
 /// command with no passphrase, so a step-up prompt on loopback adds
 /// friction without strengthening anything. This mirrors the loopback

--- a/src/session/conversation_summary.rs
+++ b/src/session/conversation_summary.rs
@@ -127,7 +127,7 @@ pub fn last_summary(events: &[(u64, Event)]) -> (Option<String>, u64) {
 ///
 /// Tool output and thinking are dropped; tool calls are reduced to an
 /// intent-only line so a `grep` dump or a file read cannot bloat the input.
-/// If the rendered delta exceeds [`MAX_INPUT_BYTES`], the oldest content is
+/// If the rendered delta exceeds `MAX_INPUT_BYTES`, the oldest content is
 /// dropped (the tail is the most relevant for "so far") and a marker is
 /// prepended so the model knows the head was truncated.
 pub fn extract_transcript_delta(events: &[(u64, Event)], since_seq: u64) -> (String, u64, usize) {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1623,7 +1623,7 @@ impl Instance {
         self.trashed_at.is_some()
     }
 
-    /// TTL for an [`OpClaim`]. Longer than any realistic teardown or worktree
+    /// TTL for an `OpClaim`. Longer than any realistic teardown or worktree
     /// move so a live operation is never overridden mid-flight, short enough
     /// that a crash mid-operation self-heals promptly (the next purge/restore
     /// overrides the expired claim, and the load-time reconcile clears it). See


### PR DESCRIPTION
## Description

`cargo doc --no-deps --features serve` emitted `rustdoc::private_intra_doc_links` warnings: several public-item docstrings carried intra-doc links (`[`x`]`) to private items, which rustdoc renders as literal text rather than a link. This blocked adopting `#![deny(rustdoc::private_intra_doc_links)]` at the crate root.

Each offending reference is reworded to a plain code-span (`` `x` ``), keeping the docstring readable without claiming a link that cannot resolve. Fixed the 5 warnings called out in #2753 (`sanitize_stderr`, `probe_container_holds_worktree` x2, `is_local_trusted`, `handler_elevated`) plus 2 that landed since the issue was filed (`MAX_INPUT_BYTES` in `conversation_summary.rs`, `OpClaim` in `instance.rs`).

Added `#![deny(rustdoc::private_intra_doc_links)]` and `#![deny(rustdoc::broken_intra_doc_links)]` to `src/lib.rs` so any regression fails the build, and gated it in CI by adding a warning-clean `cargo doc --no-deps --features serve` step (`RUSTDOCFLAGS=-D warnings`) to the `docs` job, reusing the existing `AOE_WEB_DIST` placeholder so it needs no npm build.

Fixes #2753

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Skipped a test, because: doc-comment text plus two crate-level rustdoc `deny` attributes and a CI step; there is no runtime behavior to regression-test. The new CI `cargo doc` gate is itself the test that locks the cleanup in.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Docstring rewording, crate attributes, and the CI gate were drafted with Claude Code and reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)