### PR TITLE
feat: per-session color labels settable via CLI and web (#2383)

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -31,6 +31,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe session unsnooze`↴](#aoe-session-unsnooze)
 * [`aoe session favorite`↴](#aoe-session-favorite)
 * [`aoe session unfavorite`↴](#aoe-session-unfavorite)
+* [`aoe session color`↴](#aoe-session-color)
 * [`aoe session archive`↴](#aoe-session-archive)
 * [`aoe session unarchive`↴](#aoe-session-unarchive)
 * [`aoe session restore`↴](#aoe-session-restore)
@@ -351,6 +352,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `unsnooze` — Wake a snoozed session immediately
 * `favorite` — Mark a session as a favorite. Favorited rows pin to the top of their status tier in the Attention sort and render with a leading `* ` glyph plus bold + underline
 * `unfavorite` — Clear the favorite flag on a session
+* `color` — Set (or clear) a per-session color label, rendered as a colored dot in the web sidebar for at-a-glance status signaling. Intended for a running agent to flag its own state, e.g. `aoe session color $(aoe session current -q) red`. Colors: `red` (needs attention), `amber` (working), `green` (done); `none` clears it
 * `archive` — Archive a session: sink it in the Attention sort and tear down its tmux sessions. Worktree, branch, container preserved. `--no-kill` skips tmux teardown. See #1868
 * `unarchive` — Unarchive a session (restores it to its tier in the Attention sort)
 * `restore` — Restore a trashed session, returning it to its prior bucket with its transcript and metadata intact. See #2489
@@ -578,6 +580,19 @@ Clear the favorite flag on a session
 ###### **Arguments:**
 
 * `<IDENTIFIER>` — Session ID or title
+
+
+
+## `aoe session color`
+
+Set (or clear) a per-session color label, rendered as a colored dot in the web sidebar for at-a-glance status signaling. Intended for a running agent to flag its own state, e.g. `aoe session color $(aoe session current -q) red`. Colors: `red` (needs attention), `amber` (working), `green` (done); `none` clears it
+
+**Usage:** `aoe session color <IDENTIFIER> <COLOR>`
+
+###### **Arguments:**
+
+* `<IDENTIFIER>` — Session ID or title
+* `<COLOR>` — Color label: `red` (needs attention), `amber` (working), `green` (done), or `none`/`clear` to remove the label
 
 
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -63,6 +63,13 @@ pub enum SessionCommands {
     /// Clear the favorite flag on a session.
     Unfavorite(SessionIdArgs),
 
+    /// Set (or clear) a per-session color label, rendered as a colored dot in
+    /// the web sidebar for at-a-glance status signaling. Intended for a
+    /// running agent to flag its own state, e.g.
+    /// `aoe session color $(aoe session current -q) red`. Colors: `red`
+    /// (needs attention), `amber` (working), `green` (done); `none` clears it.
+    Color(SetColorArgs),
+
     /// Archive a session: sink it in the Attention sort and tear down its
     /// tmux sessions. Worktree, branch, container preserved. `--no-kill`
     /// skips tmux teardown. See #1868.
@@ -279,6 +286,15 @@ pub struct SetBaseArgs {
     pub clear: bool,
 }
 
+#[derive(Args)]
+pub struct SetColorArgs {
+    /// Session ID or title
+    pub identifier: String,
+    /// Color label: `red` (needs attention), `amber` (working), `green`
+    /// (done), or `none`/`clear` to remove the label.
+    pub color: String,
+}
+
 #[derive(Serialize)]
 struct SessionDetails {
     id: String,
@@ -311,6 +327,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
         SessionCommands::Unsnooze(args) => unsnooze_session(profile, args).await,
         SessionCommands::Favorite(args) => favorite_session(profile, args).await,
         SessionCommands::Unfavorite(args) => unfavorite_session(profile, args).await,
+        SessionCommands::Color(args) => set_color_session(profile, args).await,
         SessionCommands::Archive(args) => archive_session(profile, args).await,
         SessionCommands::Unarchive(args) => unarchive_session(profile, args).await,
         SessionCommands::Restore(args) => restore_session(profile, args).await,
@@ -341,6 +358,31 @@ async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
     })?;
     println!("Unfavorited: {}", title);
+    Ok(())
+}
+
+async fn set_color_session(profile: &str, args: SetColorArgs) -> Result<()> {
+    // `none`/`clear`/empty clears the label; anything else must be a palette
+    // member (validated inside `Instance::set_color`).
+    let normalized = args.color.trim().to_lowercase();
+    let new_color = match normalized.as_str() {
+        "none" | "clear" | "" => None,
+        other => Some(other.to_string()),
+    };
+
+    let storage = Storage::new_unwatched(profile)?;
+    let (title, color) = storage.update(|instances, _groups| {
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.set_color(new_color.clone())
+                .map_err(|e| anyhow::anyhow!(e))?;
+            Ok((inst.title.clone(), inst.color.clone()))
+        })
+    })?;
+
+    match color {
+        Some(c) => println!("✓ Set color for '{}': {}", title, c),
+        None => println!("✓ Cleared color for '{}'", title),
+    }
     Ok(())
 }
 
@@ -2144,6 +2186,93 @@ mod set_session_id_tests {
             ResumeIntent::Use("22222222-2222-2222-2222-222222222222".to_string())
         );
         assert_eq!(inst_disk.resume_probe_failed_sid, None);
+    }
+}
+
+#[cfg(test)]
+mod set_color_tests {
+    use super::{set_color_session, SetColorArgs};
+    use crate::session::{Instance, Storage};
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    async fn seed(profile: &str) -> (Storage, String) {
+        let storage = Storage::new_unwatched(profile).unwrap();
+        let inst = Instance::new("color_session", "/tmp/x");
+        let id = inst.id.clone();
+        let on_disk = inst.clone();
+        storage
+            .update(|i, g| {
+                *i = vec![on_disk.clone()];
+                *g =
+                    crate::session::GroupTree::new_with_groups(std::slice::from_ref(&on_disk), &[])
+                        .get_all_groups();
+                Ok(())
+            })
+            .unwrap();
+        (storage, id)
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn set_color_persists_palette_value_and_clears() {
+        let temp = tempdir().unwrap();
+        std::env::set_var("HOME", temp.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+        let (storage, id) = seed("set-color-ok").await;
+
+        set_color_session(
+            "set-color-ok",
+            SetColorArgs {
+                identifier: id.clone(),
+                color: "Red".to_string(), // case-insensitive
+            },
+        )
+        .await
+        .unwrap();
+        let loaded = storage.load().unwrap();
+        assert_eq!(
+            loaded.iter().find(|i| i.id == id).unwrap().color.as_deref(),
+            Some("red")
+        );
+
+        set_color_session(
+            "set-color-ok",
+            SetColorArgs {
+                identifier: id.clone(),
+                color: "none".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        let loaded = storage.load().unwrap();
+        assert_eq!(loaded.iter().find(|i| i.id == id).unwrap().color, None);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn set_color_rejects_unknown_color() {
+        let temp = tempdir().unwrap();
+        std::env::set_var("HOME", temp.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+        let (storage, id) = seed("set-color-bad").await;
+
+        let result = set_color_session(
+            "set-color-bad",
+            SetColorArgs {
+                identifier: id.clone(),
+                color: "chartreuse".to_string(),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "unknown color must error");
+        // The rejected write must not have touched disk.
+        let loaded = storage.load().unwrap();
+        assert_eq!(loaded.iter().find(|i| i.id == id).unwrap().color, None);
     }
 }
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -52,9 +52,9 @@ pub use sessions::{
     preview_volume_ignores_globs, read_output, rename_session, restore_session, search_sessions,
     send_message, serve_session_artifact, session_diff_file, session_diff_files, set_worktree_name,
     start_session, stop_session, summarize_session, trash_session, update_session_archive,
-    update_session_diff_base, update_session_group, update_session_notifications,
-    update_session_pin, update_session_snooze, update_session_unread, update_workspace_ordering,
-    CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
+    update_session_color, update_session_diff_base, update_session_group,
+    update_session_notifications, update_session_pin, update_session_snooze, update_session_unread,
+    update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };
 // Shared by the status poll loop's auto-unread persistence; not a route handler.
 pub(crate) use sessions::persist_session_update;
@@ -252,6 +252,7 @@ mod tests {
                     "update_session_notifications",
                     "update_session_diff_base",
                     "update_session_pin",
+                    "update_session_color",
                     "update_session_archive",
                     "update_session_snooze",
                     "trash_session",
@@ -449,6 +450,7 @@ mod tests {
                     "update_session_notifications",
                     "update_session_diff_base",
                     "update_session_pin",
+                    "update_session_color",
                     "update_session_archive",
                     "update_session_snooze",
                     "trash_session",

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -8906,6 +8906,7 @@ mod workspace_ordering_tests {
             monitor_active: false,
             monitor_description: None,
             favorited: false,
+            color: None,
             urgent: false,
             pinned_at: None,
             archived_at: None,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -64,6 +64,11 @@ pub struct SessionResponse {
     /// favorited rows and render the `*` marker without re-implementing
     /// the predicate. Cross-feature parity with the TUI's `f`/`F` keybind.
     pub favorited: bool,
+    /// Per-session color label (`red` / `amber` / `green`), or omitted when
+    /// unset. Rendered as a colored status dot in the web sidebar; set via the
+    /// sidebar context menu or `aoe session color`. See #2383.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
     /// True when the agent has flagged this session as urgent via the
     /// `attention-urgent` hook (read from `/tmp/aoe-hooks-<euid>/{id}/attention.json`
     /// by `Instance::is_urgent()`). The web sidebar's Attention sort floats
@@ -352,6 +357,7 @@ impl SessionResponse {
             is_sandboxed: inst.is_sandboxed(),
             scratch: inst.scratch,
             favorited: inst.is_favorited(),
+            color: inst.color.clone(),
             urgent: inst.is_urgent(),
             pinned_at: inst.pinned_at.map(|t| t.to_rfc3339()),
             archived_at: inst.archived_at.map(|t| t.to_rfc3339()),
@@ -1990,6 +1996,15 @@ pub struct UpdatePinBody {
 }
 
 #[derive(Deserialize)]
+pub struct UpdateColorBody {
+    /// A palette member (`red` / `amber` / `green`) sets the label; `null` (or
+    /// a missing field) clears it. Validated against
+    /// `crate::session::is_valid_session_color`, matching the CLI.
+    #[serde(default)]
+    pub color: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct UpdateArchiveBody {
     pub archived: bool,
     /// On archive, tear down every tmux session this instance owns. `false`
@@ -2106,6 +2121,81 @@ pub async fn update_session_pin(
     } else {
         inst.unpin();
     }
+
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
+    (StatusCode::OK, Json(serde_json::json!(response))).into_response()
+}
+
+pub async fn update_session_color(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Result<Json<UpdateColorBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return super::read_only_response();
+    }
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    // Validate up front so an unknown color never reaches disk. `None` clears
+    // the label. Mirrors the CLI's palette check.
+    let new_color = body.color.map(|c| c.trim().to_lowercase());
+    if let Some(c) = &new_color {
+        if !crate::session::is_valid_session_color(c) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("invalid color {c:?}; expected one of: red, amber, green, or null"),
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    let profile = {
+        let instances = state.instances.read().await;
+        let Some(inst) = instances.iter().find(|i| i.id == id) else {
+            return super::session_not_found();
+        };
+        inst.source_profile.clone()
+    };
+
+    // Persist first; only mutate memory once disk is durable. See #1589.
+    let persist_id = id.clone();
+    let persist_color = new_color.clone();
+    if persist_session_update(
+        profile,
+        "color update",
+        state.file_watch.clone(),
+        move |instances| {
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
+                // Pre-validated above, so this cannot fail.
+                let _ = inst.set_color(persist_color);
+            }
+        },
+    )
+    .await
+    .is_err()
+    {
+        return persist_failed_response();
+    }
+
+    let mut instances = state.instances.write().await;
+    let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+        tracing::warn!(
+            target: "http.api.sessions",
+            session = %id,
+            "color update: instance vanished after persist"
+        );
+        return super::session_gone_after_persist();
+    };
+    let _ = inst.set_color(new_color);
 
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1526,6 +1526,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             patch(api::set_worktree_name),
         )
         .route("/api/sessions/{id}/pin", patch(api::update_session_pin))
+        .route("/api/sessions/{id}/color", patch(api::update_session_color))
         .route(
             "/api/sessions/{id}/archive",
             patch(api::update_session_archive),

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -91,6 +91,18 @@ impl Status {
 pub const TMUX_SESSION_GONE_ERROR: &str =
     "tmux session is gone. The agent process may have exited or been killed.";
 
+/// The MVP palette for the per-session color label (#2383). Kept deliberately
+/// small and status-oriented: red = needs attention / blocked, amber =
+/// working / in progress, green = done / ready. `None`/absent clears the dot.
+/// Both the CLI (`aoe session color`) and the web PATCH endpoint validate
+/// against this list via [`is_valid_session_color`].
+pub const SESSION_COLORS: &[&str] = &["red", "amber", "green"];
+
+/// True when `color` is a member of the [`SESSION_COLORS`] palette.
+pub fn is_valid_session_color(color: &str) -> bool {
+    SESSION_COLORS.contains(&color)
+}
+
 /// Outcome of `start_with_resume_fallback`.
 ///
 /// Tmux/process failures propagate as `Err` so callers keep the existing
@@ -685,6 +697,18 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_branch_override: Option<String>,
 
+    /// Per-session color label for at-a-glance status signaling in the web
+    /// sidebar (a colored dot next to the title). Purely a decoration: it does
+    /// not re-rank the session. Settable from the web context menu and from the
+    /// CLI (`aoe session color <id> <color>`) so a running agent can flag its
+    /// own state (red = needs attention, amber = working, green = done) without
+    /// the user opening the session. `None` clears the dot. Constrained to the
+    /// [`SESSION_COLORS`] palette by [`is_valid_session_color`]. Additive:
+    /// absent in older `sessions.json` rows, so no migration is needed. See
+    /// #2383.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+
     /// How this session is rendered: `Structured` (ACP native rendering) or
     /// `Terminal` (raw tmux pane). When `Structured`, aoe spawns an ACP agent
     /// subprocess and renders structured events natively; tmux integration is
@@ -1160,6 +1184,7 @@ impl Instance {
             notify_on_idle: None,
             notify_on_error: None,
             base_branch_override: None,
+            color: None,
             view: View::Terminal,
             agent_name: None,
             agent_model: None,
@@ -1506,6 +1531,9 @@ impl Instance {
         if pre.base_branch_override != post.base_branch_override {
             self.base_branch_override = post.base_branch_override.clone();
         }
+        if pre.color != post.color {
+            self.color = post.color.clone();
+        }
         // Worktree workdir edit (move dir / rename branch) mutates these two;
         // both the TUI and the CLI can write them, so they go through the
         // same conditional-diff path as the triage fields. See #1723.
@@ -1718,6 +1746,27 @@ impl Instance {
 
     pub fn is_favorited(&self) -> bool {
         self.favorited_at.is_some()
+    }
+
+    /// Set (or clear, with `None`) the per-session color label. Only a value
+    /// in the [`SESSION_COLORS`] palette is accepted; anything else is
+    /// rejected so the sidebar never has to render an unknown swatch. See
+    /// #2383.
+    pub fn set_color(&mut self, color: Option<String>) -> Result<(), String> {
+        match color {
+            None => self.color = None,
+            Some(c) => {
+                if !is_valid_session_color(&c) {
+                    return Err(format!(
+                        "invalid color {:?}; expected one of: {}, or none",
+                        c,
+                        SESSION_COLORS.join(", ")
+                    ));
+                }
+                self.color = Some(c);
+            }
+        }
+        Ok(())
     }
 
     /// Read the agent-raised urgent flag from `attention.json`. Sourced
@@ -4822,6 +4871,46 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn set_color_accepts_palette_and_clears_with_none() {
+        let mut inst = Instance::new("color-test", "/tmp");
+        assert_eq!(inst.color, None);
+
+        for c in SESSION_COLORS {
+            inst.set_color(Some((*c).to_string())).unwrap();
+            assert_eq!(inst.color.as_deref(), Some(*c));
+        }
+
+        inst.set_color(None).unwrap();
+        assert_eq!(inst.color, None);
+    }
+
+    #[test]
+    fn set_color_rejects_unknown_color_and_leaves_prior_value() {
+        let mut inst = Instance::new("color-test", "/tmp");
+        inst.set_color(Some("green".to_string())).unwrap();
+
+        let err = inst
+            .set_color(Some("chartreuse".to_string()))
+            .expect_err("unknown color must be rejected");
+        assert!(
+            err.contains("chartreuse"),
+            "error should name the value: {err}"
+        );
+        // A rejected write must not clobber the previously stored color.
+        assert_eq!(inst.color.as_deref(), Some("green"));
+    }
+
+    #[test]
+    fn is_valid_session_color_matches_palette() {
+        assert!(is_valid_session_color("red"));
+        assert!(is_valid_session_color("amber"));
+        assert!(is_valid_session_color("green"));
+        assert!(!is_valid_session_color("blue"));
+        assert!(!is_valid_session_color(""));
+        assert!(!is_valid_session_color("Red"));
+    }
 
     #[test]
     fn container_terminal_autodetect_cmd_resolves_login_shell() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -65,12 +65,12 @@ pub use groups::{
 };
 #[cfg(feature = "serve")]
 pub(crate) use instance::ResumeAttemptPolicy;
-pub(crate) use instance::{persist_session_to_storage, PassiveStatusPatch, ResumeIntent, SidWrite};
 pub use instance::{
-    ClaimOp, EnsureReadyError, EnsureReadyOutcome, Instance, LaunchSidOutcome, SandboxInfo,
-    SessionBucket, StartOutcome, Status, TerminalInfo, View, WorkspaceInfo, WorkspaceRepo,
-    WorktreeInfo, TMUX_SESSION_GONE_ERROR,
+    is_valid_session_color, ClaimOp, EnsureReadyError, EnsureReadyOutcome, Instance,
+    LaunchSidOutcome, SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View,
+    WorkspaceInfo, WorkspaceRepo, WorktreeInfo, SESSION_COLORS, TMUX_SESSION_GONE_ERROR,
 };
+pub(crate) use instance::{persist_session_to_storage, PassiveStatusPatch, ResumeIntent, SidWrite};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -78,6 +78,7 @@ import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   createSession,
   renameSession,
+  setSessionColor,
   setSessionNotifications,
   setWorktreeName,
   smartRenameSession,
@@ -162,6 +163,21 @@ export interface RowBulkApi {
 
 const CTX_ITEM =
   "w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2";
+
+/** MVP per-session color palette (#2383). Mirrors the Rust `SESSION_COLORS`
+ *  list; each entry maps a palette key to its display label and the Tailwind
+ *  class for its status dot. Kept small and status-oriented on purpose. */
+const SESSION_COLOR_OPTIONS: { key: string; label: string; dotClass: string }[] = [
+  { key: "red", label: "Red · needs attention", dotClass: "bg-red-500" },
+  { key: "amber", label: "Amber · working", dotClass: "bg-amber-400" },
+  { key: "green", label: "Green · done", dotClass: "bg-green-500" },
+];
+
+/** Tailwind dot class for a stored color key, or null when unset / unknown. */
+function sessionColorDotClass(color: string | null | undefined): string | null {
+  if (!color) return null;
+  return SESSION_COLOR_OPTIONS.find((o) => o.key === color)?.dotClass ?? null;
+}
 
 /** Triage actions for the right-click menu when more than one row is selected.
  *  Reuses the same eligibility buckets as the old bulk bar so a mixed
@@ -959,6 +975,10 @@ export const SessionRow = memo(function SessionRow({
   // row visually so the user can find their starred work fast. Toggled
   // via TUI `f`/`F` or `aoe session favorite|unfavorite`.
   const isFavorited = workspace.sessions.some((s) => s.favorited);
+  // Per-session color label (#2383): the first session in the workspace that
+  // carries a color wins, mirroring how `snoozedUntil` picks the first match.
+  const sessionColor = workspace.sessions.map((s) => s.color).find((c) => c != null) ?? null;
+  const sessionColorDot = sessionColorDotClass(sessionColor);
   // Web-only triage signals. `pinned` floats the workspace to the top
   // of every sort mode; `archived` and `snoozedUntil` mark the row as
   // sunk (the parent splits sunk workspaces into a separate collapsible
@@ -1025,6 +1045,18 @@ export const SessionRow = memo(function SessionRow({
     setContextMenu(null);
     if (!sessionId || preset === notifyPreset) return;
     await setSessionNotifications(sessionId, preset);
+  };
+
+  // Set (or clear, with `null`) this row's color label. Fire-and-forget: the
+  // dot reflects on the next sessions poll (there is no optimistic overlay for
+  // color). A failed request surfaces a toast. See #2383.
+  const applyColor = async (color: string | null) => {
+    setContextMenu(null);
+    if (!sessionId || color === sessionColor) return;
+    const result = await setSessionColor(sessionId, color);
+    if (!result) {
+      reportError(color ? "Failed to set session color" : "Failed to clear session color");
+    }
   };
 
   // Triage actions (pin / archive / snooze). The optimistic overlay and the
@@ -1387,6 +1419,15 @@ export const SessionRow = memo(function SessionRow({
             <span
               className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${showUnreadGlyph ? "text-status-unread font-semibold" : isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited || effectivePinned ? "font-semibold" : ""} ${effectiveArchived || effectiveSnoozed ? "italic opacity-70" : ""}`}
             >
+              {sessionColorDot && (
+                <span
+                  title={`Color: ${sessionColor}`}
+                  aria-label={`Color: ${sessionColor}`}
+                  data-testid="sidebar-session-color-dot"
+                  data-color={sessionColor ?? undefined}
+                  className={`shrink-0 inline-block h-2 w-2 rounded-full ${sessionColorDot}`}
+                />
+              )}
               {effectivePinned && (
                 <span title="Pinned" aria-label="Pinned" className="shrink-0 inline-flex text-brand-400">
                   <Pin className="h-3 w-3 -rotate-45" />
@@ -1663,6 +1704,41 @@ export const SessionRow = memo(function SessionRow({
                     </button>
                   );
                 })}
+                {!readOnly && (
+                  <>
+                    <div className="border-t border-surface-700/20 my-1" />
+                    <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+                      Color
+                    </div>
+                    {SESSION_COLOR_OPTIONS.map((opt) => {
+                      const selected = sessionColor === opt.key;
+                      return (
+                        <button
+                          key={opt.key}
+                          onClick={() => void applyColor(opt.key)}
+                          data-testid={`sidebar-context-menu-color-${opt.key}`}
+                          className={`w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2 ${
+                            selected ? "text-text-primary" : "text-text-secondary"
+                          }`}
+                        >
+                          <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${opt.dotClass}`} />
+                          {opt.label}
+                          {selected && <span className="ml-auto text-brand-500">✓</span>}
+                        </button>
+                      );
+                    })}
+                    {sessionColor && (
+                      <button
+                        onClick={() => void applyColor(null)}
+                        data-testid="sidebar-context-menu-color-clear"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <span className="h-2.5 w-2.5 shrink-0 rounded-full border border-surface-600" />
+                        Clear color
+                      </button>
+                    )}
+                  </>
+                )}
                 {!readOnly && (
                   <>
                     <div className="border-t border-surface-700/20 my-1" />

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -779,3 +779,91 @@ describe("SessionRow unread", () => {
     expect(screen.queryByTestId("sidebar-context-menu-unread")).toBeNull();
   });
 });
+
+describe("SessionRow color label (#2383)", () => {
+  it("renders the color dot when a session carries a color", () => {
+    const ws = workspace("w-color", [session({ id: "s-color", color: "red" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    const dot = screen.getByTestId("sidebar-session-color-dot");
+    expect(dot.getAttribute("data-color")).toBe("red");
+    expect(dot.className).toContain("bg-red-500");
+  });
+
+  it("renders no color dot when color is unset", () => {
+    const ws = workspace("w-nocolor", [session({ id: "s-nocolor" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByTestId("sidebar-session-color-dot")).toBeNull();
+  });
+
+  it("renders no color dot for an unknown color value", () => {
+    const ws = workspace("w-badcolor", [session({ id: "s-bad", color: "chartreuse" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByTestId("sidebar-session-color-dot")).toBeNull();
+  });
+
+  it("Color swatch click fires PATCH /api/sessions/:id/color with { color: 'red' }", async () => {
+    const ws = workspace("w-live", [session({ id: "sess-color-it" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-color-red"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-color-it/color");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(init!.body as string)).toEqual({ color: "red" });
+  });
+
+  it("shows a Clear color item on a colored row that fires { color: null }", async () => {
+    const ws = workspace("w-colored", [session({ id: "sess-clear-it", color: "green" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-color-clear"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-clear-it/color");
+    expect(JSON.parse(init!.body as string)).toEqual({ color: null });
+  });
+
+  it("hides the Clear color item when no color is set", () => {
+    const ws = workspace("w-nocolor", [session({ id: "sess-noclear" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    expect(screen.queryByTestId("sidebar-context-menu-color-clear")).toBeNull();
+  });
+
+  it("hides the color section in read-only mode", () => {
+    const ws = workspace("w-ro", [session({ id: "sess-ro-color", color: "amber" })]);
+    render(
+      <Wrap>
+        <Row ws={ws} readOnly />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    expect(screen.queryByTestId("sidebar-context-menu-color-red")).toBeNull();
+    expect(screen.queryByTestId("sidebar-context-menu-color-clear")).toBeNull();
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2109,6 +2109,23 @@ export async function setSessionPin(id: string, pinned: boolean): Promise<Sessio
   }
 }
 
+/** Set (or clear, with `null`) a session's color label. Rendered as a colored
+ *  status dot in the sidebar; the palette is `red` / `amber` / `green`. Also
+ *  settable from the CLI via `aoe session color`. See #2383. */
+export async function setSessionColor(id: string, color: string | null): Promise<SessionResponse | null> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/color`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ color }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as SessionResponse;
+  } catch {
+    return null;
+  }
+}
+
 /** Archive or unarchive a session. On archive (with `killPane` true or
  *  omitted), the server tears down all tmux sessions and shuts down the
  *  ACP worker for acp-mode sessions. Sending a message auto-unarchives.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -45,6 +45,11 @@ export interface SessionResponse {
    *  rows and prepends a `*` marker. Toggled via the TUI `f`/`F` keybind
    *  or `aoe session favorite|unfavorite`. */
   favorited: boolean;
+  /** Per-session color label (`red` / `amber` / `green`), or null / undefined
+   *  when unset. Rendered as a colored status dot in the sidebar for
+   *  at-a-glance agent status signaling. Set via the sidebar context menu or
+   *  `aoe session color <id> <color>`. See #2383. */
+  color?: string | null;
   /** True when the agent has flagged this session as urgent via the
    *  `attention-urgent` hook. Mirrors `Instance::is_urgent()` server-side
    *  (false for archived / snoozed sessions). The sidebar's Attention sort

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -932,6 +932,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.session-color",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/SessionRowTriage.test.tsx"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sessions.fork.round-trip",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
## Description

Adds a per-session **color label** (red / amber / green) for at-a-glance agent status signaling in the web sidebar, implementing the MVP path proposed in #2383.

When running a fleet of sessions there was no way to tell at a glance which need attention, which are working, and which are done. A running agent can now flag its own state programmatically, e.g. `aoe session color $(aoe session current -q) red`, so the sidebar acts as a lightweight fleet status board without opening each session. Suggested convention: red = needs attention / blocked, amber = working, green = done.

Scope is deliberately the MVP palette (red / amber / green + clear); no full color picker.

**What changed**

- **Model** (`src/session/instance.rs`): additive `Instance.color: Option<String>`, constrained to the new `SESSION_COLORS` palette by `is_valid_session_color`; a `set_color` setter; the field participates in the concurrent-writer merge (`merge_user_action_diff`). Additive field, so no data migration.
- **CLI** (`src/cli/session.rs`): `aoe session color <id> <color>` where color is `red` / `amber` / `green`, or `none` / `clear` to remove the label. CLI reference regenerated via `cargo xtask gen-docs`.
- **Server** (`src/server/api/sessions.rs`, `src/server/mod.rs`): `color` on `SessionResponse` and a `PATCH /api/sessions/{id}/color` handler mirroring the existing pin endpoint (read-only guard, persist-first, palette validation returning 400 on an unknown color). Change reaches connected clients through the existing file-watch broadcast path.
- **Web** (`web/src/lib/types.ts`, `web/src/lib/api.ts`, `web/src/components/WorkspaceSidebar.tsx`): `color` on the session type + a `setSessionColor` client; a colored status dot on the sidebar row and a "Color" section (swatches + Clear color) in the row context menu, hidden in read-only mode.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

<!-- Screenshot deferred: this sandbox cannot render the dashboard; the sidebar dot and context-menu Color section are covered by the Vitest cases below. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`

Added Vitest RTL cases in `web/src/components/__tests__/SessionRowTriage.test.tsx` covering the sidebar color dot (rendered for a palette color, hidden when unset or unknown) and the context-menu actions (swatch click PATCHes `{ color: "red" }`, Clear color PATCHes `{ color: null }`, section hidden in read-only). New matrix entry `sidebar.session-color`.

**TUI / CLI (e2e test)**
- [x] Added or updated a test

Added Rust unit tests for `Instance::set_color` / `is_valid_session_color` and for the CLI `set_color_session` handler (valid, case-insensitive, clear, and reject-unknown-without-touching-disk).

## How I tested

- Rust: `cargo fmt`, `cargo check --features serve`, `cargo clippy --lib`, and the new unit tests (`cargo test --lib set_color`, 4 passed). `cargo xtask gen-docs` clean.
- Web: `npm run format:check`, `npm run lint`, `npx tsc -b`, and `npx vitest run SessionRowTriage.test.tsx` (48 passed).
- Full `cargo test --features serve,e2e-tests` is delegated to CI (local memory limits make the full serve link impractical here).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #2383