### PR TITLE
refactor(session): drop PassiveStatusPatch.id, thread id through merge_passive_status_patch

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3285,10 +3285,9 @@ fn decide_passive_transition(
 #[derive(Default)]
 struct PassiveTransitionWrites {
     /// Keyed by instance id for O(1) lookup inside the persist closure.
-    /// [`crate::session::PassiveStatusPatch::from_instance`] keeps
-    /// `patch.id == inst.id`, so the map key and the value's `id` field
-    /// stay in sync by construction; the redundancy is intentional and
-    /// used by the closure's `.get(&inst.id)` at the flush site below.
+    /// The patch value carries no id of its own; the flush site reads the
+    /// map key (via `get_key_value`) and threads it into
+    /// [`crate::session::Instance::merge_passive_status_patch`].
     patches: std::collections::HashMap<String, crate::session::PassiveStatusPatch>,
     unread_ids: Vec<String>,
 }
@@ -3331,13 +3330,8 @@ async fn flush_passive_transition_writes(
             file_watch.clone(),
             move |insts| {
                 for inst in insts.iter_mut() {
-                    if let Some(patch) = patches.get(&inst.id) {
-                        debug_assert_eq!(
-                            patch.id, inst.id,
-                            "PassiveStatusPatch::from_instance keeps `patch.id == inst.id`; \
-                             if this fires, the map key or the patch's `id` field has drifted"
-                        );
-                        inst.merge_passive_status_patch(patch);
+                    if let Some((id, patch)) = patches.get_key_value(&inst.id) {
+                        inst.merge_passive_status_patch(id, patch);
                     }
                     if unread_ids.contains(&inst.id) {
                         inst.mark_unread();
@@ -3484,7 +3478,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 }
                 let bundle = bundles.entry(inst.source_profile.clone()).or_default();
                 if let Some(patch) = decision.patch {
-                    bundle.patches.insert(patch.id.clone(), patch);
+                    bundle.patches.insert(inst.id.clone(), patch);
                 }
                 if decision.mark_unread {
                     // Record the id only; the in-memory mark on `instances`
@@ -4880,7 +4874,6 @@ mod tests {
         let decision = decide_passive_transition(&inst, Status::Running, false);
 
         let patch = decision.patch.expect("plain tmux session must get a patch");
-        assert_eq!(patch.id, inst.id);
         assert_eq!(patch.status, Status::Idle);
         assert_eq!(patch.idle_entered_at, inst.idle_entered_at);
         assert_eq!(patch.last_accessed_at, inst.last_accessed_at);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1116,7 +1116,6 @@ fn publish_session_to_tmux_env(tmux_session_name: &str, instance_id: &str, sessi
 ///   `apply_acp_overlay_inplace` is the authority; see its docstring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PassiveStatusPatch {
-    pub id: String,
     pub status: Status,
     pub idle_entered_at: Option<DateTime<Utc>>,
     /// `None` when the source `Instance` was never touched by a user
@@ -1134,7 +1133,6 @@ impl PassiveStatusPatch {
     /// contract is on [`Self::last_accessed_at`].
     pub(crate) fn from_instance(inst: &Instance) -> Self {
         Self {
-            id: inst.id.clone(),
             status: inst.status,
             idle_entered_at: inst.idle_entered_at,
             last_accessed_at: inst.last_accessed_at,
@@ -1469,7 +1467,7 @@ impl Instance {
     /// while `status` and `idle_entered_at` still apply unconditionally.
     /// Callers relying on the observable `last_accessed_at` change must
     /// re-read the field after `merge_passive_status_patch` returns.
-    pub(crate) fn merge_passive_status_patch(&mut self, patch: &PassiveStatusPatch) {
+    pub(crate) fn merge_passive_status_patch(&mut self, id: &str, patch: &PassiveStatusPatch) {
         self.status = patch.status;
         self.idle_entered_at = patch.idle_entered_at;
         let Some(incoming) = patch.last_accessed_at else {
@@ -1478,7 +1476,7 @@ impl Instance {
         if self.last_accessed_at.is_some_and(|disk| disk >= incoming) {
             tracing::debug!(
                 target: "session.store",
-                session_id = %patch.id,
+                session_id = %id,
                 disk_ts = ?self.last_accessed_at,
                 patch_ts = %incoming,
                 "dropped passive status patch's last_accessed_at as a no-op (disk value is at least as recent; status/idle_entered_at still applied)"
@@ -6014,12 +6012,11 @@ mod tests {
 
         let now = Utc::now();
         let patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: Some(now),
             last_accessed_at: Some(now),
         };
-        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
         assert_eq!(disk.status, Status::Idle);
         assert_eq!(disk.idle_entered_at, Some(now));
@@ -6044,12 +6041,11 @@ mod tests {
         disk.last_accessed_at = None;
 
         let patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: Some(Utc::now()),
             last_accessed_at: None,
         };
-        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
         assert_eq!(disk.status, Status::Idle, "status must still apply");
         assert_eq!(
@@ -6072,12 +6068,11 @@ mod tests {
         disk.idle_entered_at = None;
 
         let stale_patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: Some(peer_touch - chrono::Duration::minutes(5)),
             last_accessed_at: Some(peer_touch - chrono::Duration::minutes(5)),
         };
-        disk.merge_passive_status_patch(&stale_patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &stale_patch);
 
         assert_eq!(
             disk.status,
@@ -6103,12 +6098,11 @@ mod tests {
         disk.last_accessed_at = Some(ts);
 
         let patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: None,
             last_accessed_at: Some(ts),
         };
-        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
         // Guard is `>=`: equal timestamps are not a real advance, so the
         // patch's last_accessed_at is dropped. The observable value stays
@@ -6125,12 +6119,11 @@ mod tests {
 
         let newer = Utc::now();
         let patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: None,
             last_accessed_at: Some(newer),
         };
-        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
         assert_eq!(disk.last_accessed_at, Some(newer));
     }
@@ -6144,12 +6137,11 @@ mod tests {
 
         let ts = Utc::now();
         let patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: None,
             last_accessed_at: Some(ts),
         };
-        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
         assert_eq!(disk.last_accessed_at, Some(ts));
     }
@@ -6159,13 +6151,12 @@ mod tests {
         let mut disk = Instance::new("session", "/tmp/test");
         let ts = Utc::now();
         let patch = PassiveStatusPatch {
-            id: disk.id.clone(),
             status: Status::Idle,
             idle_entered_at: Some(ts),
             last_accessed_at: Some(ts),
         };
-        disk.merge_passive_status_patch(&patch);
-        disk.merge_passive_status_patch(&patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
         assert_eq!(disk.status, Status::Idle);
         assert_eq!(disk.idle_entered_at, Some(ts));
@@ -6178,18 +6169,22 @@ mod tests {
         let t0 = Utc::now() - chrono::Duration::minutes(1);
         let t1 = Utc::now();
 
-        disk.merge_passive_status_patch(&PassiveStatusPatch {
-            id: disk.id.clone(),
-            status: Status::Running,
-            idle_entered_at: None,
-            last_accessed_at: Some(t0),
-        });
-        disk.merge_passive_status_patch(&PassiveStatusPatch {
-            id: disk.id.clone(),
-            status: Status::Idle,
-            idle_entered_at: Some(t1),
-            last_accessed_at: Some(t1),
-        });
+        disk.merge_passive_status_patch(
+            &disk.id.clone(),
+            &PassiveStatusPatch {
+                status: Status::Running,
+                idle_entered_at: None,
+                last_accessed_at: Some(t0),
+            },
+        );
+        disk.merge_passive_status_patch(
+            &disk.id.clone(),
+            &PassiveStatusPatch {
+                status: Status::Idle,
+                idle_entered_at: Some(t1),
+                last_accessed_at: Some(t1),
+            },
+        );
 
         assert_eq!(disk.status, Status::Idle);
         assert_eq!(disk.idle_entered_at, Some(t1));

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5551,8 +5551,8 @@ impl HomeView {
         };
         let patch = crate::session::PassiveStatusPatch::from_instance(inst);
         if let Err(e) = storage.update(|insts, _groups| {
-            if let Some(disk) = insts.iter_mut().find(|i| i.id == patch.id) {
-                disk.merge_passive_status_patch(&patch);
+            if let Some(disk) = insts.iter_mut().find(|i| i.id == id) {
+                disk.merge_passive_status_patch(id, &patch);
                 if mark_unread {
                     disk.mark_unread();
                 }
@@ -5569,7 +5569,7 @@ impl HomeView {
             // `AOE_LOG_LEVEL=debug`.
             tracing::warn!(
                 target: "session.store",
-                session_id = %patch.id,
+                session_id = %id,
                 "persist_passive_status_transition failed: {e}"
             );
         }


### PR DESCRIPTION
## Description

`PassiveTransitionWrites.patches` is a `HashMap<String, PassiveStatusPatch>` keyed by instance id, yet each `PassiveStatusPatch` value also carried its own `id: String`. `PassiveStatusPatch::from_instance` kept the two in sync by construction, and a `debug_assert_eq!(patch.id, inst.id)` at the daemon flush site locked the invariant in debug builds. The field was pure redundancy against the map key and added one `String` clone per detected transition.

This drops the `id` field and threads the id explicitly:

- `Instance::merge_passive_status_patch` now takes `id: &str`; callers pass the map key.
- The daemon flush site reads the key via `HashMap::get_key_value` (avoids a receiver borrow conflict) and drops the now-redundant `debug_assert_eq!`.
- The daemon insert keys the map on `inst.id` directly.
- The TUI `persist_passive_status_transition` passes its own `id` parameter and finds the disk row by it.
- Tracing sites log the threaded `id` instead of `patch.id`.

No behavior change. Cleared to proceed now that #2727 has landed (the issue asked to defer pending a broader `PassiveStatusPatch` shape change).

Fixes #2762

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: internal wire-format refactor with no observable behavior change; covered by the existing `merge_passive_status_patch` and `decide_passive_transition` unit tests, which were updated.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Mechanical refactor following the issue's proposed direction. Verified `cargo fmt`, `cargo clippy --lib --features serve`, and the affected unit tests (`merge_passive_status_patch*`, `decide_passive_transition*`) locally; full build/test matrix left to CI.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed redundant instance ID storage from `PassiveStatusPatch`.
- Passed the instance ID explicitly through status merging, persistence, logging, and tests.
- Used the map key as the authoritative ID when flushing passive status updates.
- Removed the redundant consistency assertion.

## Benefits

This simplifies the data model, avoids unnecessary ID cloning, and preserves the existing map-key behavior without changing functionality. Formatting, clippy, and affected tests were run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->