### PR TITLE
fix(web): preserve terminal key combos

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -203,6 +203,64 @@ function liveEnterSequence(e: { key: string; ctrlKey: boolean; shiftKey: boolean
   return "\r";
 }
 
+interface TerminalKeyLike {
+  key: string;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+function xtermModifierParam(e: Pick<TerminalKeyLike, "shiftKey" | "altKey" | "ctrlKey">): number | null {
+  const modifier = 1 + Number(e.shiftKey) + 2 * Number(e.altKey) + 4 * Number(e.ctrlKey);
+  return modifier === 1 ? null : modifier;
+}
+
+function navigationKeySequence(e: TerminalKeyLike): string | null {
+  if (e.metaKey) return null;
+
+  const modifier = xtermModifierParam(e);
+  switch (e.key) {
+    case "ArrowUp":
+      return modifier == null ? "\x1b[A" : `\x1b[1;${modifier}A`;
+    case "ArrowDown":
+      return modifier == null ? "\x1b[B" : `\x1b[1;${modifier}B`;
+    case "ArrowRight":
+      return modifier == null ? "\x1b[C" : `\x1b[1;${modifier}C`;
+    case "ArrowLeft":
+      return modifier == null ? "\x1b[D" : `\x1b[1;${modifier}D`;
+    case "Home":
+      return modifier == null ? "\x1b[H" : `\x1b[1;${modifier}H`;
+    case "End":
+      return modifier == null ? "\x1b[F" : `\x1b[1;${modifier}F`;
+    case "Insert":
+      return modifier == null ? "\x1b[2~" : `\x1b[2;${modifier}~`;
+    case "Delete":
+      return modifier == null ? "\x1b[3~" : `\x1b[3;${modifier}~`;
+    case "PageUp":
+      return modifier == null ? "\x1b[5~" : `\x1b[5;${modifier}~`;
+    case "PageDown":
+      return modifier == null ? "\x1b[6~" : `\x1b[6;${modifier}~`;
+    default:
+      return null;
+  }
+}
+
+function specialKeySequence(e: TerminalKeyLike): string | null {
+  switch (e.key) {
+    case "Enter":
+      return liveEnterSequence(e);
+    case "Backspace":
+      return e.altKey && !e.ctrlKey && !e.metaKey ? "\x1b\x7f" : "\x7f";
+    case "Tab":
+      return e.shiftKey ? "\x1b[Z" : "\t";
+    case "Escape":
+      return "\x1b";
+    default:
+      return navigationKeySequence(e);
+  }
+}
+
 // Wrap http(s) URLs in a segment's text as clickable anchors, so agent output
 // (PR links, localhost dev servers, docs) opens in one tap instead of a
 // manual select-copy-paste (#2685). Plain text returns as-is.
@@ -1115,44 +1173,10 @@ export function MobileLiveTerminal({
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (composingRef.current || e.nativeEvent.isComposing) return;
-      const enterSeq = liveEnterSequence(e);
-      if (enterSeq) {
-        e.preventDefault();
-        sendData(enterSeq);
-        return;
-      }
-      const seq = (() => {
-        switch (e.key) {
-          case "Backspace":
-            return "\x7f";
-          case "Tab":
-            return e.shiftKey ? "\x1b[Z" : "\t";
-          case "Escape":
-            return "\x1b";
-          case "ArrowUp":
-            return "\x1b[A";
-          case "ArrowDown":
-            return "\x1b[B";
-          case "ArrowRight":
-            return "\x1b[C";
-          case "ArrowLeft":
-            return "\x1b[D";
-          default:
-            return null;
-        }
-      })();
+      const seq = specialKeySequence(e);
       if (seq) {
         e.preventDefault();
-        const metaSpecial =
-          e.altKey &&
-          !e.ctrlKey &&
-          !e.metaKey &&
-          (e.key === "Backspace" ||
-            e.key === "ArrowUp" ||
-            e.key === "ArrowDown" ||
-            e.key === "ArrowRight" ||
-            e.key === "ArrowLeft");
-        sendData(metaSpecial ? `\x1b${seq}` : seq);
+        sendData(seq);
         return;
       }
       // Ctrl+Shift+C copies the current terminal selection (the terminal-

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -256,14 +256,55 @@ describe("MobileLiveTerminal paste", () => {
     expect(sendData).not.toHaveBeenCalled();
   });
 
-  it("prefixes supported Alt navigation keys with terminal Meta", () => {
+  it("encodes Backspace modifier chords", () => {
     const { input, sendData } = renderTerm();
 
     expect(fireEvent.keyDown(input, { key: "Backspace", altKey: true })).toBe(false);
     expect(sendData).toHaveBeenCalledWith("\x1b\x7f");
 
-    expect(fireEvent.keyDown(input, { key: "ArrowRight", altKey: true })).toBe(false);
-    expect(sendData).toHaveBeenCalledWith("\x1b\x1b[C");
+    expect(fireEvent.keyDown(input, { key: "Backspace", ctrlKey: true })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\x7f");
+  });
+
+  it("encodes unmodified navigation and edit keys", () => {
+    const { input, sendData } = renderTerm();
+
+    for (const { key, expected } of [
+      { key: "Insert", expected: "\x1b[2~" },
+      { key: "Delete", expected: "\x1b[3~" },
+      { key: "Home", expected: "\x1b[H" },
+      { key: "End", expected: "\x1b[F" },
+      { key: "PageUp", expected: "\x1b[5~" },
+      { key: "PageDown", expected: "\x1b[6~" },
+    ]) {
+      sendData.mockClear();
+      expect(fireEvent.keyDown(input, { key })).toBe(false);
+      expect(sendData).toHaveBeenCalledWith(expected);
+    }
+  });
+
+  it("encodes modified navigation and edit keys with xterm CSI modifier forms", () => {
+    const { input, sendData } = renderTerm();
+
+    for (const { key, init, expected } of [
+      { key: "ArrowUp", init: { shiftKey: true }, expected: "\x1b[1;2A" },
+      { key: "ArrowRight", init: { altKey: true }, expected: "\x1b[1;3C" },
+      { key: "ArrowLeft", init: { ctrlKey: true }, expected: "\x1b[1;5D" },
+      { key: "End", init: { ctrlKey: true, shiftKey: true }, expected: "\x1b[1;6F" },
+      { key: "PageDown", init: { altKey: true }, expected: "\x1b[6;3~" },
+      { key: "Delete", init: { ctrlKey: true }, expected: "\x1b[3;5~" },
+    ]) {
+      sendData.mockClear();
+      expect(fireEvent.keyDown(input, { key, ...init })).toBe(false);
+      expect(sendData).toHaveBeenCalledWith(expected);
+    }
+  });
+
+  it("leaves Meta navigation to the browser", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "ArrowLeft", metaKey: true })).toBe(true);
+    expect(sendData).not.toHaveBeenCalled();
   });
 
   it("leaves Ctrl+Alt printable chords alone for AltGr-style input", () => {

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -270,6 +270,10 @@ describe("MobileLiveTerminal paste", () => {
     const { input, sendData } = renderTerm();
 
     for (const { key, expected } of [
+      { key: "ArrowUp", expected: "\x1b[A" },
+      { key: "ArrowDown", expected: "\x1b[B" },
+      { key: "ArrowRight", expected: "\x1b[C" },
+      { key: "ArrowLeft", expected: "\x1b[D" },
       { key: "Insert", expected: "\x1b[2~" },
       { key: "Delete", expected: "\x1b[3~" },
       { key: "Home", expected: "\x1b[H" },
@@ -288,9 +292,13 @@ describe("MobileLiveTerminal paste", () => {
 
     for (const { key, init, expected } of [
       { key: "ArrowUp", init: { shiftKey: true }, expected: "\x1b[1;2A" },
+      { key: "ArrowDown", init: { altKey: true }, expected: "\x1b[1;3B" },
       { key: "ArrowRight", init: { altKey: true }, expected: "\x1b[1;3C" },
       { key: "ArrowLeft", init: { ctrlKey: true }, expected: "\x1b[1;5D" },
+      { key: "Home", init: { ctrlKey: true }, expected: "\x1b[1;5H" },
       { key: "End", init: { ctrlKey: true, shiftKey: true }, expected: "\x1b[1;6F" },
+      { key: "Insert", init: { shiftKey: true }, expected: "\x1b[2;2~" },
+      { key: "PageUp", init: { altKey: true }, expected: "\x1b[5;3~" },
       { key: "PageDown", init: { altKey: true }, expected: "\x1b[6;3~" },
       { key: "Delete", init: { ctrlKey: true }, expected: "\x1b[3;5~" },
     ]) {
@@ -305,6 +313,21 @@ describe("MobileLiveTerminal paste", () => {
 
     expect(fireEvent.keyDown(input, { key: "ArrowLeft", metaKey: true })).toBe(true);
     expect(sendData).not.toHaveBeenCalled();
+  });
+
+  it("encodes Tab and Escape keys", () => {
+    const { input, sendData } = renderTerm();
+
+    expect(fireEvent.keyDown(input, { key: "Tab" })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\t");
+
+    sendData.mockClear();
+    expect(fireEvent.keyDown(input, { key: "Tab", shiftKey: true })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\x1b[Z");
+
+    sendData.mockClear();
+    expect(fireEvent.keyDown(input, { key: "Escape" })).toBe(false);
+    expect(sendData).toHaveBeenCalledWith("\x1b");
   });
 
   it("leaves Ctrl+Alt printable chords alone for AltGr-style input", () => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes the web live terminal key encoder so terminal-owned hardware key combos reach tmux with the same byte shapes users expect from the TUI and native terminals.

The hidden live-terminal textarea now routes special keys through a small terminal encoder. Plain Enter still sends bare CR, while Shift+Enter, Alt+Enter, and Cmd+Enter send ESC+CR. Delete, Insert, Home, End, PageUp, and PageDown now send their standard escape sequences instead of falling through to the empty textarea. Modified navigation and edit keys now use xterm CSI modifier forms, so Ctrl/Alt/Shift arrows no longer collapse to unmodified arrows.

Printable Alt chords still stay in the existing capture-phase path from #2637, and Cmd+navigation intentionally falls through to the browser so OS/browser shortcuts are not stolen.

Closes #2628

Validation run:
- `cd web && npx vitest run src/components/__tests__/MobileLiveTerminal.paste.test.tsx`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `cd web && node tests/validate-coverage-matrix.mjs`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --features serve`
- `cargo test --features serve --test acp_runner_orphan`

Validation caveat: plain `cargo test` currently fails in `tests/acp_runner_orphan.rs` because that test invokes the serve-gated hidden `__acp-runner` command without `--features serve`; the same test passes with `--features serve`. A full `cargo test --features serve` run hit `storage_concurrency::test_cross_process_independent_profiles_do_not_serialise` twice on its 500 ms subprocess-duration assertion; this is unrelated to the web-only diff.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is deterministic DOM key translation covered by `web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx`; `web/tests/coverage-matrix.json` already maps `MobileLiveTerminal.tsx` through `terminal.clipboard-chords`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## How to test

- [ ] Open the web dashboard live terminal and press Shift+Enter in an agent prompt; observe that it inserts a newline instead of submitting.
- [ ] Press Alt+Enter or Cmd+Enter in the web live terminal; observe the same newline behavior rather than a bare submit.
- [ ] Press Delete, Home, End, PageUp, and PageDown in a terminal app inside the web live terminal; observe the app responds to those keys.
- [ ] Press Ctrl+Left, Alt+Right, and Shift+Up in a terminal app or shell inside the web live terminal; observe modified navigation reaches the app instead of plain arrow keys.
- [ ] Press Cmd+Arrow in the browser while the live terminal is focused; observe the terminal does not swallow the browser or OS navigation shortcut.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenCode with gpt-5.5, plus consult-llm debate with gemini-3.1-pro-preview and gpt-5.5.

**Any Additional AI Details you'd like to share:**

Investigation, debate synthesis, implementation, and PR prose were drafted by an AI coding agent under maintainer direction. The design choice was to mirror AoE's TUI live-mode xterm CSI modifier encoding while leaving printable Alt capture unchanged.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the web live terminal’s key handling to translate special keys into tmux/xterm-compatible escape sequences, fixing how modified Enter is represented (plain Enter vs modified Enter).
- Restored/kept the existing “soft newline” behavior for Ctrl+Enter instead of switching it to normal submission behavior.
- Added support for additional editing/navigation keys (Delete, Insert, Home, End, PageUp, PageDown).
- Improved handling of modified navigation/editing chords by encoding them as proper xterm “modifier form” sequences rather than falling back to unmodified key behavior.
- Refactored `MobileLiveTerminal` to use a centralized escape-sequence encoding layer (`specialKeySequence`) instead of inline keydown mapping, removing the older Alt/meta-prefix approach.
- Updated the key/paste-related test coverage to validate base vs modified encodings, ensure Meta+navigation is intentionally not forwarded to the terminal, and verify Tab/Escape encodings.

## Benefits

Browser key combinations now reach tmux with the expected byte sequences, improving reliability for modified Enter and a broader set of navigation/editing keys while keeping browser/OS shortcuts out of terminal handling.

## Potential enhancement

Add more automated coverage for rarer modifier combinations and verify behavior across platforms for Cmd/Ctrl/Alt interactions (especially around “Alt chord” handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->