### PR TITLE
fix(sandbox): trust codex and gemini yolo workdirs

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1059,6 +1059,57 @@ fn refresh_codex_sandbox_hooks(
     }
 }
 
+fn apply_yolo_trust_config(
+    mount: &AgentConfigMount,
+    sandbox_dir: &Path,
+    container_workspace_path: &str,
+) -> Result<()> {
+    match (mount.tool_name, mount.host_rel) {
+        ("codex", ".codex") => crate::hooks::trust_codex_project(
+            &sandbox_dir.join("config.toml"),
+            container_workspace_path,
+        ),
+        ("gemini", ".gemini") => {
+            crate::hooks::disable_gemini_folder_trust(&sandbox_dir.join("settings.json"))
+        }
+        _ => Ok(()),
+    }
+}
+
+pub(crate) fn ensure_yolo_trust_config_for_active_agent(
+    tool: &str,
+    detect_as: Option<&str>,
+    profile: &str,
+    container_workspace_path: &str,
+) {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+
+    let resolved_profile = super::config::effective_profile(profile);
+    let session_config = super::profile_config::resolve_config_or_warn(&resolved_profile).session;
+    let active_agent = resolve_active_agent(tool, detect_as, &session_config);
+    let config_tool = active_agent.map_or(tool, |agent| agent.name);
+
+    for mount in AGENT_CONFIG_MOUNTS
+        .iter()
+        .filter(|m| m.tool_name == config_tool)
+    {
+        let sandbox_dir = home.join(mount.host_rel).join(SANDBOX_SUBDIR);
+        if let Err(e) = std::fs::create_dir_all(&sandbox_dir)
+            .with_context(|| format!("creating sandbox config dir {}", sandbox_dir.display()))
+            .and_then(|_| apply_yolo_trust_config(mount, &sandbox_dir, container_workspace_path))
+        {
+            tracing::warn!(target: "session.profile",
+                "Failed to apply sandbox YOLO trust config for {} at {}: {}",
+                mount.tool_name,
+                sandbox_dir.display(),
+                e
+            );
+        }
+    }
+}
+
 fn resolve_active_agent(
     tool: &str,
     detect_as: Option<&str>,
@@ -3656,6 +3707,84 @@ extra_volumes = ["/host/screenshots:/root/screenshots"]
         );
 
         crate::hooks::cleanup_hook_status_dir("gemini-yolo-trust-test");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_ensure_yolo_trust_config_restores_codex_after_refresh() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let codex_dir = temp_home.path().join(".codex");
+        let codex_sandbox = codex_dir.join(SANDBOX_SUBDIR);
+        fs::create_dir_all(&codex_sandbox).unwrap();
+        fs::write(codex_dir.join("config.toml"), r#"model = "host""#).unwrap();
+        fs::write(
+            codex_sandbox.join("config.toml"),
+            r#"[projects."/workspace/project"]
+trust_level = "trusted"
+"#,
+        )
+        .unwrap();
+
+        refresh_agent_configs_for_profile(&crate::session::config::effective_profile(""));
+        let refreshed: toml::Value =
+            toml::from_str(&fs::read_to_string(codex_sandbox.join("config.toml")).unwrap())
+                .unwrap();
+        assert_eq!(refreshed["model"].as_str(), Some("host"));
+        assert!(refreshed.get("projects").is_none());
+
+        ensure_yolo_trust_config_for_active_agent("codex", None, "", "/workspace/project");
+        let restored: toml::Value =
+            toml::from_str(&fs::read_to_string(codex_sandbox.join("config.toml")).unwrap())
+                .unwrap();
+        assert_eq!(restored["model"].as_str(), Some("host"));
+        assert_eq!(
+            restored["projects"]["/workspace/project"]["trust_level"].as_str(),
+            Some("trusted")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_ensure_yolo_trust_config_restores_gemini_after_refresh() {
+        let (_hg, _, _tmp_base) = BaseGuard::ready();
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let gemini_dir = temp_home.path().join(".gemini");
+        let gemini_sandbox = gemini_dir.join(SANDBOX_SUBDIR);
+        fs::create_dir_all(&gemini_sandbox).unwrap();
+        fs::write(gemini_dir.join("settings.json"), r#"{"theme":"host"}"#).unwrap();
+        fs::write(
+            gemini_sandbox.join("settings.json"),
+            r#"{"security":{"folderTrust":{"enabled":false}}}"#,
+        )
+        .unwrap();
+
+        refresh_agent_configs_for_profile(&crate::session::config::effective_profile(""));
+        let refreshed: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(gemini_sandbox.join("settings.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(refreshed["theme"].as_str(), Some("host"));
+        assert!(refreshed["security"]["folderTrust"]["enabled"].is_null());
+
+        ensure_yolo_trust_config_for_active_agent("gemini", None, "", "/workspace/project");
+        let restored: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(gemini_sandbox.join("settings.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(restored["theme"].as_str(), Some("host"));
+        assert_eq!(
+            restored["security"]["folderTrust"]["enabled"].as_bool(),
+            Some(false)
+        );
     }
 
     // Regression guard for the trap in #958: a sidecar agent (settl TOML,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3400,6 +3400,14 @@ impl Instance {
             self.ensure_before_start_env(false)?;
             container_config::refresh_agent_configs_for_profile(&self.effective_profile());
             self.backfill_container_workdir(&container);
+            if self.is_yolo_mode() {
+                container_config::ensure_yolo_trust_config_for_active_agent(
+                    &self.tool,
+                    Some(&self.detect_as),
+                    &self.source_profile,
+                    &self.container_workdir(),
+                );
+            }
             return Ok(container);
         }
 
@@ -3410,6 +3418,14 @@ impl Instance {
             container_config::refresh_agent_configs_for_profile(&self.effective_profile());
             container.start()?;
             self.backfill_container_workdir(&container);
+            if self.is_yolo_mode() {
+                container_config::ensure_yolo_trust_config_for_active_agent(
+                    &self.tool,
+                    Some(&self.detect_as),
+                    &self.source_profile,
+                    &self.container_workdir(),
+                );
+            }
             return Ok(container);
         }
 


### PR DESCRIPTION
**Note:** OpenCode handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine.

## Description
<!-- Describe your changes and the problem they solve -->

YOLO sandboxed sessions can start Gemini or Codex inside a container workdir that the agent has not trusted before. Gemini and Codex can then stop for their own folder or project trust prompts, which defeats the expected no-prompt YOLO startup path.

This PR writes agent-specific trust config into the sandboxed agent config area whenever a YOLO sandbox is prepared. Gemini gets `security.folderTrust.enabled = false`, while Codex gets a trusted project entry for the container workdir. The same helper is rerun for reused containers after agent config refresh, so persisted agent config cannot reintroduce the trust prompt.

The config updates use the existing locked hook-config write path and keep non-YOLO sessions untouched.

Closes #472

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a YOLO sandboxed Gemini session in a repo Gemini has not previously trusted and confirm it reaches the agent prompt without a folder trust confirmation.
- [ ] Start a YOLO sandboxed Codex session in a repo Codex has not previously trusted and confirm it reaches the agent prompt without a project trust confirmation.
- [ ] Reuse an existing YOLO sandboxed container after agent config refresh and confirm Gemini and Codex still do not ask to trust the workdir.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: an end-to-end reproduction would require live Gemini/Codex binaries plus Docker trust-prompt behavior; deterministic unit tests assert the exact sandbox config written for fresh and reused containers.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** OpenCode (GPT-5.5)


**Any Additional AI Details you'd like to share:**

OpenCode investigated, implemented, and drafted this PR under my direction. I reviewed the behavior and validation results.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevented Gemini and Codex from prompting for project or folder trust in YOLO sandbox sessions.
- Centralized trust configuration and reapplied it when reused containers refresh their agent settings.
- Added coverage confirming Codex trust and Gemini folder-trust settings are restored.
- Non-YOLO sessions remain unchanged.

## Benefits

Users can start sandboxed Gemini and Codex sessions without extra trust confirmations, including when containers are reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->