### PR TITLE
feat(tui): run background tool commands

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -335,7 +335,7 @@ Configs written for older `aoe` versions used a `check_enabled` boolean and an o
 
 ## Tools
 
-The `[tools.*]` block configures persistent dev tool sessions (lazygit, yazi, tig, etc.) tied to each agent session's working directory. Each entry has a required `command` and an optional `hotkey` in `Alt+<single-char>` format.
+The `[tools.*]` block configures dev tools tied to each agent session's working directory. Each entry has a required `command`, an optional `hotkey` in `Alt+<single-char>` format, and optional `background = true` for fire-and-forget commands that should not create a tmux tool session.
 
 ```toml
 [tools.lazygit]
@@ -345,6 +345,11 @@ hotkey = "Alt+g"
 [tools.yazi]
 command = "yazi"
 hotkey = "Alt+f"
+
+[tools.github]
+command = "gh repo view --web"
+hotkey = "Alt+o"
+background = true
 ```
 
 See [Tool Sessions](tool-sessions.md) for the full reference, hotkey rules, and lifecycle.

--- a/docs/guides/tool-sessions.md
+++ b/docs/guides/tool-sessions.md
@@ -2,9 +2,9 @@
 
 Tool sessions let you keep dev tools like `lazygit`, `yazi`, `tig`, or
 `gitui` running alongside each agent session, scoped to that session's
-working directory. Each tool runs in its own persistent tmux session, so
-re-attaching is instant and state (cursor position, staged hunks, browsed
-path) survives across detaches.
+working directory. By default each tool runs in its own persistent tmux
+session, so re-attaching is instant and state (cursor position, staged
+hunks, browsed path) survives across detaches.
 
 The UX mirrors the built-in terminal preview: press a hotkey to preview
 the tool in the home view, `Enter` to attach to it full-screen, and
@@ -20,7 +20,8 @@ Tool sessions are defined in your global `config.toml` under
   (defaults to `~/.config/agent-of-empires/config.toml`)
 - **macOS / Windows**: `~/.agent-of-empires/config.toml`
 
-Each entry has a required `command` and an optional `hotkey`:
+Each entry has a required `command`, an optional `hotkey`, and an
+optional `background` mode for fire-and-forget commands:
 
 ```toml
 [tools.lazygit]
@@ -34,14 +35,20 @@ hotkey = "Alt+f"
 [tools.tig]
 command = "tig --all"
 # no hotkey, reachable from the picker and palette only
+
+[tools.github]
+command = "gh repo view --web"
+hotkey = "Alt+o"
+background = true
 ```
 
 ### Field reference
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `command` | yes | Shell command to run inside the tmux session. The string is passed to `tmux new-session`, so pipes and `&&` work. |
+| `command` | yes | Shell command to run. Persistent tools pass it to `tmux new-session`; background tools pass it to the user's shell. Pipes and `&&` work in both modes. |
 | `hotkey` | no | Hotkey binding in `Alt+<single-char>` format (case-insensitive on the modifier, normalized to lowercase on the letter). Examples: `"Alt+g"`, `"Alt+1"`, `"Alt+/"`. |
+| `background` | no | When `true`, run the command fire-and-forget in the selected session's working directory instead of opening a persistent tmux tool session. Defaults to `false`. |
 
 Tool sessions are intentionally a config-file feature today; they are
 not editable from the settings TUI. Edit `config.toml` and reload from
@@ -70,7 +77,7 @@ so they shadow any built-in binding using the same combination.
 
 ## Using tools
 
-Three ways to open a tool, in roughly the order you'll grow into them:
+Three ways to open or run a tool, in roughly the order you'll grow into them:
 
 1. **Hotkey**. Select an agent session, press the configured hotkey
    (e.g. `Alt+g`). The home view switches to a live preview of that
@@ -79,7 +86,13 @@ Three ways to open a tool, in roughly the order you'll grow into them:
    configured tool with its command and hotkey. Pick one with arrow
    keys (or `j`/`k`) and `Enter`. `;` or `Esc` closes the picker.
 3. **Command palette**. Press `Ctrl+K`. Tool sessions appear as
-   "Open tool: \<name\>" entries you can fuzzy-search.
+   "Open tool: \<name\>" entries you can fuzzy-search. Background
+   tools appear as "Run: \<name\>".
+
+Tools with `background = true` skip tool preview mode and do not create a
+tmux session. They run with stdin, stdout, and stderr detached; redirect
+output in the command if you need a log. Non-zero exits are written to
+the debug log, not shown as an interactive dialog.
 
 Once you're in tool preview mode:
 
@@ -106,6 +119,10 @@ is removed (`aoe remove <id>`, "Remove session" in the TUI, or delete
 in the web dashboard). Cleanup sweeps all of the agent's tool sessions
 even if you renamed or deleted the `[tools.*]` entry, so nothing is left
 orphaned.
+
+Background tools are not tmux sessions and are not managed by this
+cleanup path. Use them for short launch commands; if a command starts a
+daemon, its lifecycle is up to that command.
 
 ## Where the tool runs
 
@@ -163,6 +180,19 @@ hotkey = "Alt+d"
 command = "btm"
 # Reachable via `;` or `Ctrl+K`. No global hotkey.
 ```
+
+### Background launcher
+
+```toml
+[tools.github]
+command = "gh repo view --web"
+hotkey = "Alt+o"
+background = true
+```
+
+Now `Alt+o`, the picker, or the `Run: github` command palette entry opens
+the selected session's repository in the browser without switching to a
+tool preview.
 
 ## tmux session naming
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -176,6 +176,10 @@ fn default_enabled() -> bool {
     true
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 impl Default for PluginConfig {
     fn default() -> Self {
         Self {
@@ -199,6 +203,10 @@ pub struct ToolSessionConfig {
     /// Only Alt+ single-character bindings are supported.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hotkey: Option<String>,
+    /// Run fire-and-forget in the selected session's working directory instead
+    /// of opening a persistent tmux tool session.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub background: bool,
 }
 
 /// Persistent logging configuration. Drives the default tracing
@@ -3865,6 +3873,49 @@ mod tests {
             cfg.session.session_id_poller_max_threads, 1,
             "normalize() must clamp zero to 1 to keep config, UI, and runtime aligned"
         );
+    }
+
+    #[test]
+    fn test_tool_background_defaults_false_when_absent() {
+        let toml = r#"
+            [tools.github]
+            command = "gh repo view --web"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(!cfg.tools["github"].background);
+    }
+
+    #[test]
+    fn test_tool_background_roundtrips_when_enabled() {
+        let toml = r#"
+            [tools.github]
+            command = "gh repo view --web"
+            hotkey = "Alt+o"
+            background = true
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert!(cfg.tools["github"].background);
+
+        let serialized = toml::to_string_pretty(&cfg).unwrap();
+        assert!(serialized.contains("background = true"));
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert!(reparsed.tools["github"].background);
+    }
+
+    #[test]
+    fn test_tool_background_false_is_omitted() {
+        let mut cfg = Config::default();
+        cfg.tools.insert(
+            "lazygit".to_string(),
+            ToolSessionConfig {
+                command: "lazygit".to_string(),
+                hotkey: None,
+                background: false,
+            },
+        );
+
+        let serialized = toml::to_string_pretty(&cfg).unwrap();
+        assert!(!serialized.contains("background"));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3348,6 +3348,16 @@ fn spawn_background_tool(
         child_command.process_group(0);
     }
 
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
+        child_command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+
     let child = child_command.spawn().with_context(|| {
         format!(
             "spawn background tool '{}' with shell '{}'",

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,6 @@
 //! Main TUI application
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
     EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags,
@@ -9,6 +9,7 @@ use crossterm::event::{
 use futures_util::StreamExt;
 use ratatui::prelude::*;
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::time::Duration;
 
 use super::attached_status_hooks::AttachedStatusHookWatcher;
@@ -2819,6 +2820,9 @@ impl App {
             Action::AttachToolSession(id, tool_name) => {
                 self.attach_tool_session(&id, &tool_name, terminal)?;
             }
+            Action::RunBackgroundToolSession(id, tool_name) => {
+                self.run_background_tool_session(&id, &tool_name);
+            }
             #[cfg(feature = "serve")]
             Action::OpenStructuredView(id) => {
                 // Stash for the async main loop. The acp view needs
@@ -3211,6 +3215,50 @@ impl App {
         Ok(())
     }
 
+    fn run_background_tool_session(&mut self, session_id: &str, tool_name: &str) {
+        let instance = match self.home.get_instance(session_id) {
+            Some(inst) => inst.clone(),
+            None => {
+                self.update_status = Some(UpdateStatus::transient(format!(
+                    "Tool '{}' failed: session not found",
+                    tool_name
+                )));
+                return;
+            }
+        };
+
+        let tool_config = match self.home.tool_configs.get(tool_name) {
+            Some(tc) => tc.clone(),
+            None => {
+                self.update_status = Some(UpdateStatus::transient(format!(
+                    "Tool '{}' is not configured",
+                    tool_name
+                )));
+                return;
+            }
+        };
+
+        match spawn_background_tool(
+            session_id,
+            tool_name,
+            &instance.project_path,
+            &tool_config.command,
+        ) {
+            Ok(()) => {
+                self.update_status = Some(UpdateStatus::transient(format!(
+                    "Started background tool: {}",
+                    tool_name
+                )));
+            }
+            Err(e) => {
+                self.update_status = Some(UpdateStatus::transient(format!(
+                    "Failed to start background tool '{}': {}",
+                    tool_name, e
+                )));
+            }
+        }
+    }
+
     fn edit_file(
         &mut self,
         path: &std::path::Path,
@@ -3274,6 +3322,76 @@ impl App {
     }
 }
 
+fn spawn_background_tool(
+    session_id: &str,
+    tool_name: &str,
+    working_dir: &str,
+    command: &str,
+) -> Result<()> {
+    if command.trim().is_empty() {
+        anyhow::bail!("Tool '{}' has no command configured", tool_name);
+    }
+
+    let shell = crate::session::environment::user_shell();
+    let mut child_command = std::process::Command::new(&shell);
+    child_command
+        .arg("-c")
+        .arg(command)
+        .current_dir(working_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        child_command.process_group(0);
+    }
+
+    let child = child_command.spawn().with_context(|| {
+        format!(
+            "spawn background tool '{}' with shell '{}'",
+            tool_name, shell
+        )
+    })?;
+    wait_for_background_tool(session_id, tool_name, child);
+    Ok(())
+}
+
+fn wait_for_background_tool(session_id: &str, tool_name: &str, mut child: std::process::Child) {
+    let session_id = session_id.to_string();
+    let tool_name = tool_name.to_string();
+    std::thread::spawn(move || match child.wait() {
+        Ok(status) if status.success() => {
+            tracing::debug!(
+                target: "tui.tools",
+                session_id = %session_id,
+                tool = %tool_name,
+                status = %status,
+                "background tool exited"
+            );
+        }
+        Ok(status) => {
+            tracing::warn!(
+                target: "tui.tools",
+                session_id = %session_id,
+                tool = %tool_name,
+                status = %status,
+                "background tool exited unsuccessfully"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "tui.tools",
+                session_id = %session_id,
+                tool = %tool_name,
+                error = %e,
+                "failed waiting for background tool"
+            );
+        }
+    });
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Action {
     Quit,
@@ -3309,6 +3427,9 @@ pub enum Action {
     /// Attach to a tool session (lazygit, yazi, etc.) for the given agent
     /// session. The tool_name indexes into Config.tools.
     AttachToolSession(String, String),
+    /// Run a configured tool command without creating or attaching a tmux tool
+    /// session. The command runs in the selected agent session's workdir.
+    RunBackgroundToolSession(String, String),
     /// Open the native acp view for `session_id`. The action handler
     /// stashes the id in `pending_structured_view_open`; the main loop drains it
     /// after `execute_action` returns and runs the async acp loop

--- a/src/tui/dialogs/tool_picker.rs
+++ b/src/tui/dialogs/tool_picker.rs
@@ -19,6 +19,7 @@ struct ToolPickerEntry {
     name: String,
     command: String,
     hotkey: String,
+    background: bool,
 }
 
 impl ToolPickerDialog {
@@ -29,6 +30,7 @@ impl ToolPickerDialog {
                 name: name.clone(),
                 command: config.command.clone(),
                 hotkey: config.hotkey.clone().unwrap_or_default(),
+                background: config.background,
             })
             .collect();
         items.sort_by(|a, b| a.name.cmp(&b.name));
@@ -148,6 +150,7 @@ impl ToolPickerDialog {
                 } else {
                     format!("  [{}]", entry.hotkey)
                 };
+                let background_part = if entry.background { "  [bg]" } else { "" };
                 let line = Line::from(vec![
                     Span::styled(
                         &entry.name,
@@ -157,6 +160,7 @@ impl ToolPickerDialog {
                             theme.text
                         }),
                     ),
+                    Span::styled(background_part, Style::default().fg(theme.hint)),
                     Span::styled(
                         format!("  {}", entry.command),
                         Style::default().fg(theme.dimmed),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -442,15 +442,11 @@ impl HomeView {
     }
 
     fn activate_tool(&mut self, tool_name: String, toggle_current: bool) -> Option<Action> {
-        let Some(config) = self.tool_configs.get(&tool_name) else {
-            self.info_dialog = Some(InfoDialog::new(
-                "Tool not configured",
-                &format!("Tool '{}' is not configured", tool_name),
-            ));
-            return None;
-        };
-        let background = config.background;
-        let command_is_empty = config.command.trim().is_empty();
+        let (background, command_is_empty) = self
+            .tool_configs
+            .get(&tool_name)
+            .map(|config| (config.background, config.command.trim().is_empty()))
+            .unwrap_or((false, false));
 
         if !background {
             if toggle_current

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -441,6 +441,60 @@ impl HomeView {
         ));
     }
 
+    fn activate_tool(&mut self, tool_name: String, toggle_current: bool) -> Option<Action> {
+        let Some(config) = self.tool_configs.get(&tool_name) else {
+            self.info_dialog = Some(InfoDialog::new(
+                "Tool not configured",
+                &format!("Tool '{}' is not configured", tool_name),
+            ));
+            return None;
+        };
+        let background = config.background;
+        let command_is_empty = config.command.trim().is_empty();
+
+        if !background {
+            if toggle_current
+                && matches!(&self.view_mode, ViewMode::Tool(current) if current == &tool_name)
+            {
+                self.view_mode = ViewMode::Structured;
+                return None;
+            } else {
+                self.view_mode = ViewMode::Tool(tool_name);
+                self.preview_scroll_offset = 0;
+                self.tool_preview_cache = super::PreviewCache::default();
+            }
+            return self.maybe_auto_start_live_send();
+        }
+
+        if command_is_empty {
+            self.info_dialog = Some(InfoDialog::new(
+                "Tool command missing",
+                &format!("Tool '{}' has no command configured", tool_name),
+            ));
+            return None;
+        }
+
+        let Some(session_id) = self.selected_session.clone() else {
+            self.info_dialog = Some(InfoDialog::new(
+                "No session selected",
+                "Select a session before running a background tool.",
+            ));
+            return None;
+        };
+
+        if let Some(inst) = self.get_instance(&session_id) {
+            if matches!(inst.status, Status::Creating | Status::Deleting) {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Session not ready",
+                    "This session is still being created or deleted.",
+                ));
+                return None;
+            }
+        }
+
+        Some(Action::RunBackgroundToolSession(session_id, tool_name))
+    }
+
     /// Check if the key event matches any configured tool session hotkey.
     /// On duplicate hotkeys, the alphabetically-first tool name wins
     /// (the cache is built sorted by tool name).
@@ -1283,10 +1337,7 @@ impl HomeView {
                 }
                 DialogResult::Submit(tool_name) => {
                     self.tool_picker_dialog = None;
-                    self.view_mode = ViewMode::Tool(tool_name);
-                    self.preview_scroll_offset = 0;
-                    self.tool_preview_cache = super::PreviewCache::default();
-                    self.pending_dialog_click_action = self.maybe_auto_start_live_send();
+                    self.pending_dialog_click_action = self.activate_tool(tool_name, false);
                 }
             }
             return true;
@@ -1759,10 +1810,7 @@ impl HomeView {
                 }
                 DialogResult::Submit(tool_name) => {
                     self.tool_picker_dialog = None;
-                    self.view_mode = ViewMode::Tool(tool_name);
-                    self.preview_scroll_offset = 0;
-                    self.tool_preview_cache = super::PreviewCache::default();
-                    return self.maybe_auto_start_live_send();
+                    return self.activate_tool(tool_name, false);
                 }
             }
         }
@@ -2362,14 +2410,7 @@ impl HomeView {
     ) -> Option<Action> {
         // Dynamic tool session hotkeys (checked before everything else).
         if let Some(tool_name) = self.match_tool_hotkey(&key) {
-            if matches!(&self.view_mode, ViewMode::Tool(current) if current == &tool_name) {
-                self.view_mode = ViewMode::Structured;
-                return None;
-            }
-            self.view_mode = ViewMode::Tool(tool_name);
-            self.preview_scroll_offset = 0;
-            self.tool_preview_cache = super::PreviewCache::default();
-            return self.maybe_auto_start_live_send();
+            return self.activate_tool(tool_name, true);
         }
 
         // Context-dependent Esc handling (not a relocatable action).
@@ -3203,9 +3244,14 @@ impl HomeView {
                 .as_deref()
                 .map(|h| format!(" [{}]", h))
                 .unwrap_or_default();
+            let title = if config.background {
+                format!("Run: {}{}", name, hotkey_label)
+            } else {
+                format!("Open tool: {}{}", name, hotkey_label)
+            };
             entries.push(PaletteCommand {
                 id: "tool-session",
-                title: format!("Open tool: {}{}", name, hotkey_label),
+                title,
                 group: PaletteGroup::Actions,
                 keywords: vec!["tool", "session"],
                 hotkey: String::new(),
@@ -3258,12 +3304,7 @@ impl HomeView {
                 }
                 None
             }
-            PaletteAction::ToolSession(tool_name) => {
-                self.view_mode = ViewMode::Tool(tool_name);
-                self.preview_scroll_offset = 0;
-                self.tool_preview_cache = super::PreviewCache::default();
-                self.maybe_auto_start_live_send()
-            }
+            PaletteAction::ToolSession(tool_name) => self.activate_tool(tool_name, false),
             PaletteAction::Cheat(message) => Some(Action::SetTransientStatus(message)),
         }
     }
@@ -6195,6 +6236,7 @@ mod tests {
             ToolSessionConfig {
                 command: "lazygit".into(),
                 hotkey: Some("Alt+g".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6202,6 +6244,7 @@ mod tests {
             ToolSessionConfig {
                 command: "yazi".into(),
                 hotkey: Some("Ctrl+f".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6209,6 +6252,7 @@ mod tests {
             ToolSessionConfig {
                 command: "tig".into(),
                 hotkey: Some("Alt+too-long".into()),
+                background: false,
             },
         );
         let warnings = validate_tool_hotkeys(&tools);
@@ -6227,6 +6271,7 @@ mod tests {
             ToolSessionConfig {
                 command: "lazygit".into(),
                 hotkey: Some("Alt+g".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6234,6 +6279,7 @@ mod tests {
             ToolSessionConfig {
                 command: "rg --files".into(),
                 hotkey: None,
+                background: false,
             },
         );
         assert!(validate_tool_hotkeys(&tools).is_empty());
@@ -6247,6 +6293,7 @@ mod tests {
             ToolSessionConfig {
                 command: "z".into(),
                 hotkey: Some("Alt+z".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6254,6 +6301,7 @@ mod tests {
             ToolSessionConfig {
                 command: "lazygit".into(),
                 hotkey: Some("Alt+g".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6261,6 +6309,7 @@ mod tests {
             ToolSessionConfig {
                 command: "x".into(),
                 hotkey: Some("Ctrl+x".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6268,6 +6317,7 @@ mod tests {
             ToolSessionConfig {
                 command: "y".into(),
                 hotkey: None,
+                background: false,
             },
         );
 
@@ -6290,6 +6340,7 @@ mod tests {
             ToolSessionConfig {
                 command: "b".into(),
                 hotkey: Some("Alt+g".into()),
+                background: false,
             },
         );
         tools.insert(
@@ -6297,6 +6348,7 @@ mod tests {
             ToolSessionConfig {
                 command: "a".into(),
                 hotkey: Some("Alt+g".into()),
+                background: false,
             },
         );
         let cache = build_tool_hotkey_cache(&tools);

--- a/tests/acp_runner_orphan.rs
+++ b/tests/acp_runner_orphan.rs
@@ -15,6 +15,8 @@
 //! which is safe under the test's own process group, and is exactly the
 //! path where the superseded-delete bug lived.
 
+#![cfg(feature = "serve")]
+
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};

--- a/tests/e2e/tool_sessions.rs
+++ b/tests/e2e/tool_sessions.rs
@@ -4,8 +4,9 @@
 
 use serial_test::serial;
 use std::fs;
+use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::harness::{app_dir_in, require_tmux, TuiTestHarness};
 
@@ -46,6 +47,25 @@ fn kill_lingering_tool_sessions_on(socket: &std::path::Path, prefix_marker: &str
                 .args(["kill-session", "-t", &name])
                 .output();
         }
+    }
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
+}
+
+fn wait_for_file_contents(path: &Path, timeout: Duration) -> String {
+    let start = Instant::now();
+    loop {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if !contents.trim().is_empty() {
+                return contents;
+            }
+        }
+        if start.elapsed() >= timeout {
+            panic!("timed out waiting for {}", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(50));
     }
 }
 
@@ -120,6 +140,89 @@ hotkey = "Alt+g"
     h.type_text("lazyg");
     std::thread::sleep(Duration::from_millis(150));
     h.assert_screen_contains("Open tool: lazygit");
+}
+
+#[test]
+#[serial]
+fn test_background_tool_runs_without_tmux_session_or_preview_switch() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("tool_background_run");
+    let output_path = h.home_path().join("background-tool-pwd.txt");
+    append_tools_config(
+        &h,
+        &format!(
+            r#"
+[tools.bgpwd]
+command = "pwd > {}"
+hotkey = "Alt+b"
+background = true
+"#,
+            shell_quote_path(&output_path),
+        ),
+    );
+
+    let project = h.project_path();
+    let expected_project = fs::canonicalize(&project).expect("canonicalize project path");
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "BackgroundToolSession",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    let sessions_path = app_dir_in(h.home_path()).join("profiles/default/sessions.json");
+    let sessions_str = fs::read_to_string(&sessions_path).expect("read sessions.json");
+    let sessions: serde_json::Value =
+        serde_json::from_str(&sessions_str).expect("parse sessions.json");
+    let session_id = sessions[0]["id"]
+        .as_str()
+        .expect("session id present in sessions.json")
+        .to_string();
+    let id_suffix = &session_id[..session_id.len().min(8)];
+    let harness_sock = h.home_path().join("tmux.sock");
+    kill_lingering_tool_sessions_on(&harness_sock, id_suffix);
+
+    h.spawn_tui();
+    h.wait_for("BackgroundToolSession");
+
+    h.send_keys("C-k");
+    h.wait_for("Commands");
+    h.type_text("bgpwd");
+    h.wait_for("Run: bgpwd");
+    h.send_keys("Enter");
+    let contents = wait_for_file_contents(&output_path, Duration::from_secs(5));
+    assert_eq!(contents.trim(), expected_project.to_string_lossy());
+    h.assert_screen_not_contains("Tool: bgpwd");
+
+    fs::remove_file(&output_path).expect("remove palette output");
+    h.send_keys("M-b");
+    let contents = wait_for_file_contents(&output_path, Duration::from_secs(5));
+    assert_eq!(contents.trim(), expected_project.to_string_lossy());
+    h.assert_screen_not_contains("Tool: bgpwd");
+
+    fs::remove_file(&output_path).expect("remove hotkey output");
+    h.send_keys("\\;");
+    h.wait_for("Tool Sessions");
+    h.assert_screen_contains("[bg]");
+    h.send_keys("Enter");
+    let contents = wait_for_file_contents(&output_path, Duration::from_secs(5));
+    assert_eq!(contents.trim(), expected_project.to_string_lossy());
+    h.assert_screen_not_contains("Tool: bgpwd");
+
+    let sessions = list_tmux_sessions_on(&harness_sock);
+    assert!(
+        !sessions
+            .iter()
+            .any(|s| s.starts_with("aoe_dev_tool_") && s.contains(id_suffix)),
+        "background tool should not create a tmux tool session. sessions seen: {:?}",
+        sessions
+    );
 }
 
 #[test]

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -516,7 +516,10 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
     let id_a = s_a.load()?[0].id.clone();
     let id_b = s_b.load()?[0].id.clone();
 
+    // Debug CLI startup can exceed 500ms on loaded builders. Keep the hold
+    // long enough that startup overhead does not masquerade as lock contention.
     let hold = std::time::Duration::from_secs(5);
+    let independent_startup_budget = std::time::Duration::from_millis(4500);
     let storage_clone = Storage::new_unwatched("profile-a")?;
     let parent_held = Arc::new(Barrier::new(2));
     let parent_held_inner = parent_held.clone();
@@ -549,10 +552,10 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
     parent_handle.join().unwrap();
     assert!(status.success(), "profile-b favorite failed: {status:?}");
     assert!(
-        elapsed < hold,
+        elapsed < independent_startup_budget,
         "profile-b must not block on profile-a's flock; observed {:?} >= {:?}",
         elapsed,
-        hold
+        independent_startup_budget
     );
     let _ = id_a;
     Ok(())

--- a/web/tests/helpers/acp.ts
+++ b/web/tests/helpers/acp.ts
@@ -47,9 +47,10 @@ function readDebugLogTail(home: string | undefined, tailBytes = 8_000): string |
  *   1. Poll `/acp/replay` until any frame appears (proves the
  *      worker process is up and the supervisor finished `initialize`).
  *   2. Poll `/api/sessions` until the seeded session reports
- *      `acp_worker_state === "running"` (proves the ACP
- *      `session/new` handshake completed and the supervisor is ready
- *      to forward prompts).
+ *      `acp_worker_state === "running"` and a non-empty
+ *      `acp_session_id` (proves the ACP `session/new` or
+ *      `session/load` handshake completed, the server persisted the
+ *      assigned id, and the supervisor is ready to forward prompts).
  *
  * Without phase 2 the React client receives `acp_worker_state ===
  * "resuming"` from the initial `/api/sessions` fetch on navigation,
@@ -118,9 +119,12 @@ export async function waitForAcpReady(
       { cause: err },
     );
   }
-  // Phase 2: wait for the supervisor to reach "running". On failure
-  // dump everything we can about the session + replay frames so the
-  // root cause is visible without re-running with debug flags.
+  // Phase 2: wait for the supervisor to reach "running" and for the
+  // server-side AcpSessionAssigned listener to project acp_session_id.
+  // Sidebar fork affordances read that id from `/api/sessions`, so tests
+  // that navigate immediately after enable must wait for it too. On
+  // failure dump everything we can about the session + replay frames so
+  // the root cause is visible without re-running with debug flags.
   try {
     await expect
       .poll(
@@ -128,7 +132,9 @@ export async function waitForAcpReady(
           const res = await fetch(`${baseUrl}/api/sessions`);
           if (!res.ok) return "fetch-failed";
           const body = await res.json();
-          const sessions: Array<{ id: string; acp_worker_state?: string }> = Array.isArray(body)
+          const sessions: Array<{ id: string; acp_worker_state?: string; acp_session_id?: string }> = Array.isArray(
+            body,
+          )
             ? body
             : (body.sessions ?? []);
           const me = sessions.find((s) => s.id === sessionId);
@@ -140,11 +146,12 @@ export async function waitForAcpReady(
               throw new Error(`acp_enable spawn failed: ${startupErr} ` + `(frames=${frames.length})`);
             }
           }
-          return state;
+          if (state !== "running") return state;
+          return me?.acp_session_id ? "ready" : "running-without-acp-session-id";
         },
         { timeout: timeoutMs, intervals: [100, 200, 200, 500, 1000] },
       )
-      .toBe("running");
+      .toBe("ready");
   } catch (err) {
     // Augment the timeout error with the full replay + sessions
     // snapshot. expect.poll's default message is just the last polled

--- a/web/tests/helpers/acp.ts
+++ b/web/tests/helpers/acp.ts
@@ -47,10 +47,9 @@ function readDebugLogTail(home: string | undefined, tailBytes = 8_000): string |
  *   1. Poll `/acp/replay` until any frame appears (proves the
  *      worker process is up and the supervisor finished `initialize`).
  *   2. Poll `/api/sessions` until the seeded session reports
- *      `acp_worker_state === "running"` and a non-empty
- *      `acp_session_id` (proves the ACP `session/new` or
- *      `session/load` handshake completed, the server persisted the
- *      assigned id, and the supervisor is ready to forward prompts).
+ *      `acp_worker_state === "running"` (proves the ACP
+ *      `session/new` handshake completed and the supervisor is ready
+ *      to forward prompts).
  *
  * Without phase 2 the React client receives `acp_worker_state ===
  * "resuming"` from the initial `/api/sessions` fetch on navigation,
@@ -119,12 +118,9 @@ export async function waitForAcpReady(
       { cause: err },
     );
   }
-  // Phase 2: wait for the supervisor to reach "running" and for the
-  // server-side AcpSessionAssigned listener to project acp_session_id.
-  // Sidebar fork affordances read that id from `/api/sessions`, so tests
-  // that navigate immediately after enable must wait for it too. On
-  // failure dump everything we can about the session + replay frames so
-  // the root cause is visible without re-running with debug flags.
+  // Phase 2: wait for the supervisor to reach "running". On failure
+  // dump everything we can about the session + replay frames so the
+  // root cause is visible without re-running with debug flags.
   try {
     await expect
       .poll(
@@ -132,9 +128,7 @@ export async function waitForAcpReady(
           const res = await fetch(`${baseUrl}/api/sessions`);
           if (!res.ok) return "fetch-failed";
           const body = await res.json();
-          const sessions: Array<{ id: string; acp_worker_state?: string; acp_session_id?: string }> = Array.isArray(
-            body,
-          )
+          const sessions: Array<{ id: string; acp_worker_state?: string }> = Array.isArray(body)
             ? body
             : (body.sessions ?? []);
           const me = sessions.find((s) => s.id === sessionId);
@@ -146,12 +140,11 @@ export async function waitForAcpReady(
               throw new Error(`acp_enable spawn failed: ${startupErr} ` + `(frames=${frames.length})`);
             }
           }
-          if (state !== "running") return state;
-          return me?.acp_session_id ? "ready" : "running-without-acp-session-id";
+          return state;
         },
         { timeout: timeoutMs, intervals: [100, 200, 200, 500, 1000] },
       )
-      .toBe("ready");
+      .toBe("running");
   } catch (err) {
     // Augment the timeout error with the full replay + sessions
     // snapshot. expect.poll's default message is just the last polled

--- a/web/tests/live/session-fork.spec.ts
+++ b/web/tests/live/session-fork.spec.ts
@@ -62,6 +62,20 @@ base.describe("fork session via sidebar context menu", () => {
       const parentId = sessions[0]!.id as string;
 
       await enableStructuredViewAndWait(serve.baseUrl, parentId, 30_000, serve.home);
+      await expect
+        .poll(
+          async () => {
+            const parent = (await listSessions(serve.baseUrl)).find((s) => s.id === parentId);
+            const acpSessionId = parent?.acp_session_id;
+            return typeof acpSessionId === "string" && acpSessionId.length > 0;
+          },
+          {
+            timeout: 10_000,
+            intervals: [100, 200, 500, 1000],
+            message: "parent session should expose acp_session_id before sidebar fork",
+          },
+        )
+        .toBe(true);
 
       await page.goto(`${serve.baseUrl}/`);
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
<!-- Describe your changes and the problem they solve -->

Adds `background = true` to existing `[tools.*]` entries so one-shot launch commands can run from the TUI without creating a persistent tmux tool session. Background tools reuse the existing command palette, tool picker, hotkey parsing, and selected-session working-directory behavior, but route through a new app action that spawns the command on the host with detached stdio and no preview switch.

Persistent tools keep the existing `Open tool: <name>` palette label, preview mode, tmux attach path, and cleanup lifecycle. Background tools render as `Run: <name>` in the palette, show a `[bg]` marker in the picker, run in the selected session's `project_path`, and log non-zero exit status after the child is reaped.

The validation sweep also found two test-suite stability gaps: the ACP runner orphan tests were available to no-serve builds even though the hidden runner command is serve-gated, and one storage concurrency test used a 500ms CLI startup budget that was too tight on loaded debug builders. Those are corrected so the required no-feature validation passes reliably.

Closes #1970

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Configure a tool with `background = true`, for example `gh repo view --web`, select an existing session, open `Ctrl+K`, and confirm the entry reads `Run: <name>`.
- [ ] Activate that palette entry and confirm AoE stays on the home view without switching to `Tool: <name>` or creating a dead preview pane.
- [ ] Trigger the same background tool from its `Alt+<key>` hotkey and from the `;` tool picker, confirming each runs against the selected session's working directory.
- [ ] Configure a normal tool without `background = true` and confirm it still previews, attaches, and cleans up as before.

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** OpenCode with gpt-5.5, plus the agent-of-empires `/aoe-implement` workflow and a consult-llm design debate.

**Any Additional AI Details you'd like to share:**
Investigation, planning, implementation, validation, and PR prose were drafted by AI under my direction. I made the design calls, including keeping this as a `[tools.*]` mode instead of adding a separate commands surface.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an opt-in `background = true` flag to existing `[tools.*]` configurations so tools can run as fire-and-forget, one-shot commands.
- Background tools now run asynchronously from the currently selected session’s project directory, without creating/attaching a tmux tool session and without switching the UI to the tool preview.
- Updated the UI so background tools are still easy to discover and launch everywhere: tool picker, command palette, and tool hotkeys. They get a distinct `Run: <name>`-style label and show a `[bg]` marker in the picker.
- Centralized tool activation logic in the home view to preserve existing foreground tool behavior while routing background requests correctly.
- Extended configuration and serialization support for the new `background` field (it defaults off and is omitted from saved config when disabled), with added unit coverage.
- Added end-to-end coverage verifying background tools:
  - write expected output from the correct working directory,
  - do not appear in the tool preview,
  - are repeatable,
  - and do not create lingering tmux sessions.
- Improved overall test stability by tightening ACP readiness waiting (ensuring an `acp_session_id` is present), gating an ACP orphan-test behind the `serve` feature, and adjusting storage concurrency startup timing budgets.

## Benefits

Enables “run-and-continue” actions from within the current agent session context (e.g., opening a web view) without disrupting the existing tool workflow, preview, or tmux-based tool session model.

## Potential improvements

- Surface background command failures more directly in the UI (not only via logs/debug output) to make troubleshooting faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->