### PR TITLE
refactor(test): consolidate env guards behind EnvGuard::set

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1897,6 +1897,7 @@ pub fn uninstall_all_hooks() {
 mod tests {
     use super::targets::collect_env_lists_from_session;
     use super::*;
+    use crate::session::test_support::EnvGuard;
     use tempfile::TempDir;
 
     fn claude_events() -> Vec<crate::agents::ResolvedHookEvent> {
@@ -1940,29 +1941,6 @@ mod tests {
             .events
     }
 
-    struct CodexHomeGuard(Option<String>);
-    impl CodexHomeGuard {
-        fn set(path: &Path) -> Self {
-            let prev = std::env::var("CODEX_HOME").ok();
-            std::env::set_var("CODEX_HOME", path);
-            Self(prev)
-        }
-
-        fn unset() -> Self {
-            let prev = std::env::var("CODEX_HOME").ok();
-            std::env::remove_var("CODEX_HOME");
-            Self(prev)
-        }
-    }
-    impl Drop for CodexHomeGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(v) => std::env::set_var("CODEX_HOME", v),
-                None => std::env::remove_var("CODEX_HOME"),
-            }
-        }
-    }
-
     fn claude_hook_config() -> &'static crate::agents::AgentHookConfig {
         crate::agents::get_agent("claude")
             .unwrap()
@@ -1971,36 +1949,10 @@ mod tests {
             .unwrap()
     }
 
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<String>,
-    }
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            std::env::set_var(key, value);
-            Self { key, prev }
-        }
-
-        fn unset(key: &'static str) -> Self {
-            let prev = std::env::var(key).ok();
-            std::env::remove_var(key);
-            Self { key, prev }
-        }
-    }
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.prev {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_agent_settings_path_defaults_to_home_relative() {
-        let _guard = EnvGuard::unset("CLAUDE_CONFIG_DIR");
+        let _guard = EnvGuard::unset(&["CLAUDE_CONFIG_DIR"]);
         let path = agent_settings_path_for_host_environment(claude_hook_config(), &[]).unwrap();
         let expected = dirs::home_dir().unwrap().join(".claude/settings.json");
         assert_eq!(path, expected);
@@ -2009,7 +1961,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_agent_settings_path_honors_host_env_override() {
-        let _guard = EnvGuard::unset("CLAUDE_CONFIG_DIR");
+        let _guard = EnvGuard::unset(&["CLAUDE_CONFIG_DIR"]);
         let host_env = vec!["CLAUDE_CONFIG_DIR=/home/me/.claude-work".to_string()];
         let path =
             agent_settings_path_for_host_environment(claude_hook_config(), &host_env).unwrap();
@@ -2022,7 +1974,7 @@ mod tests {
     #[serial_test::serial(shell_env)]
     fn test_agent_settings_path_host_env_takes_precedence_over_process_env() {
         // When both are set, the session's profile env wins over AoE's own env.
-        let _guard = EnvGuard::set("CLAUDE_CONFIG_DIR", "/from/process/env");
+        let _guard = EnvGuard::set(&[("CLAUDE_CONFIG_DIR", "/from/process/env")]);
         let host_env = vec!["CLAUDE_CONFIG_DIR=/from/host/env".to_string()];
         let path =
             agent_settings_path_for_host_environment(claude_hook_config(), &host_env).unwrap();
@@ -2034,7 +1986,7 @@ mod tests {
     fn test_agent_settings_path_falls_back_to_process_env() {
         // Not present in the host env list at all, but set in AoE's own env:
         // the launched agent inherits it, so hooks must follow.
-        let _guard = EnvGuard::set("CLAUDE_CONFIG_DIR", "/tmp/claude-proc");
+        let _guard = EnvGuard::set(&[("CLAUDE_CONFIG_DIR", "/tmp/claude-proc")]);
         let path = agent_settings_path_for_host_environment(claude_hook_config(), &[]).unwrap();
         assert_eq!(path, PathBuf::from("/tmp/claude-proc/settings.json"));
     }
@@ -2042,7 +1994,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_agent_settings_path_display_matches_resolution() {
-        let _guard = EnvGuard::unset("CLAUDE_CONFIG_DIR");
+        let _guard = EnvGuard::unset(&["CLAUDE_CONFIG_DIR"]);
 
         // Default: tilde-relative, matching how the path is shown elsewhere.
         assert_eq!(
@@ -2061,7 +2013,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn test_agent_settings_path_empty_override_is_ignored() {
-        let _guard = EnvGuard::unset("CLAUDE_CONFIG_DIR");
+        let _guard = EnvGuard::unset(&["CLAUDE_CONFIG_DIR"]);
         let host_env = vec!["CLAUDE_CONFIG_DIR=".to_string()];
         let path =
             agent_settings_path_for_host_environment(claude_hook_config(), &host_env).unwrap();
@@ -2420,7 +2372,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_config_path_respects_codex_home() {
         let tmp = TempDir::new().unwrap();
-        let _guard = CodexHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("CODEX_HOME", tmp.path())]);
 
         assert_eq!(codex_config_path().unwrap(), tmp.path().join("config.toml"));
         assert_eq!(
@@ -2433,7 +2385,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_config_path_for_host_environment_ignores_empty_codex_home() {
         let tmp = TempDir::new().unwrap();
-        let _guard = CodexHomeGuard::unset();
+        let _guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
 
         // An empty `CODEX_HOME=` must not resolve to a bare relative
@@ -2457,7 +2409,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         // An empty `CODEX_HOME` in AoE's own process env must fall back to the
         // home-relative default rather than a bare relative `config.toml`.
-        let _guard = CodexHomeGuard::set(Path::new(""));
+        let _guard = EnvGuard::set(&[("CODEX_HOME", Path::new(""))]);
         std::env::set_var("HOME", tmp.path());
 
         let path = codex_config_path().unwrap();
@@ -2472,7 +2424,7 @@ mod tests {
     #[serial_test::serial]
     fn test_iter_hook_targets_includes_profile_codex_home() {
         let tmp = TempDir::new().unwrap();
-        let _guard = CodexHomeGuard::unset();
+        let _guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
@@ -4811,13 +4763,10 @@ hooks_auto_accept: false
     #[serial_test::serial(shell_env)]
     fn collect_env_lists_warns_on_corrupt_global_config_but_not_on_missing() {
         let tmp = TempDir::new().unwrap();
-        let _codex = CodexHomeGuard::unset();
-        let _home = EnvGuard::set("HOME", tmp.path().to_str().unwrap());
+        let _codex = EnvGuard::unset(&["CODEX_HOME"]);
+        let _home = EnvGuard::set(&[("HOME", tmp.path())]);
         #[cfg(any(target_os = "linux", target_os = "macos"))]
-        let _xdg = EnvGuard::set(
-            "XDG_CONFIG_HOME",
-            tmp.path().join(".config").to_str().unwrap(),
-        );
+        let _xdg = EnvGuard::set(&[("XDG_CONFIG_HOME", tmp.path().join(".config"))]);
 
         let app_dir = crate::session::get_app_dir().unwrap();
         let config_path = app_dir.join("config.toml");

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -218,6 +218,7 @@ fn read_environment_from_toml(path: &Path) -> Option<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::EnvGuard;
     use serde_json::Value;
     use std::fs;
     use tempfile::TempDir;
@@ -228,41 +229,17 @@ mod tests {
         mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID && \
         printf running > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status'";
 
-    /// `EnvGuard` clears CODEX_HOME, CLAUDE_CONFIG_DIR, etc. for the test
-    /// duration so the migration's path resolution sees only the explicit
-    /// fixtures in `home` / `app_dir`.
-    struct EnvGuard {
-        saved: Vec<(&'static str, Option<String>)>,
-    }
-    impl EnvGuard {
-        fn unset_all() -> Self {
-            let keys = [
-                "CODEX_HOME",
-                "CLAUDE_CONFIG_DIR",
-                "CURSOR_CONFIG_DIR",
-                "GEMINI_CONFIG_DIR",
-                "QWEN_CONFIG_DIR",
-            ];
-            let saved = keys
-                .iter()
-                .map(|k| {
-                    let prev = std::env::var(k).ok();
-                    std::env::remove_var(k);
-                    (*k, prev)
-                })
-                .collect();
-            Self { saved }
-        }
-    }
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.saved {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
+    /// Clears CODEX_HOME, CLAUDE_CONFIG_DIR, etc. for the test duration so
+    /// the migration's path resolution sees only the explicit fixtures in
+    /// `home` / `app_dir`.
+    fn unset_agent_home_env() -> EnvGuard {
+        EnvGuard::unset(&[
+            "CODEX_HOME",
+            "CLAUDE_CONFIG_DIR",
+            "CURSOR_CONFIG_DIR",
+            "GEMINI_CONFIG_DIR",
+            "QWEN_CONFIG_DIR",
+        ])
     }
 
     fn setup_dirs() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
@@ -353,7 +330,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn claude_legacy_settings_rewritten_user_preserved() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude/settings.json");
         write_json(
@@ -392,7 +369,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn claude_no_marker_untouched() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude/settings.json");
         write_json(
@@ -419,7 +396,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn claude_idempotent_byte_identical_and_canonical() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude/settings.json");
         write_json(
@@ -460,7 +437,7 @@ mod tests {
         // group. Both fire per event; the legacy command stays unhardened.
         // Defense-in-depth gap bounded by PR #1803's host-side
         // `AOE_INSTANCE_ID` validator.
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude/settings.json");
         write_json(
@@ -526,7 +503,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn settl_marker_only_rewrites_aoe_lines() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let settl = home.join(".settl/config.toml");
         fs::create_dir_all(settl.parent().unwrap()).unwrap();
@@ -567,7 +544,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn hermes_config_and_allowlist_both_rewritten() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let cfg = home.join(".hermes/config.yaml");
         fs::create_dir_all(cfg.parent().unwrap()).unwrap();
@@ -600,7 +577,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn hermes_allowlist_approved_at_preserved_on_idempotency() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let cfg = home.join(".hermes/config.yaml");
         let allow_path = home.join(".hermes/shell-hooks-allowlist.json");
@@ -667,7 +644,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn kiro_rewrite_preserves_extra_keys() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let kiro = home.join(".kiro/agents/aoe-hooks.json");
         write_json(
@@ -708,7 +685,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn missing_files_noop() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
 
         run_in(&home, &app_dir).unwrap();
@@ -725,7 +702,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn malformed_json_gate_fails_closed_silently() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude/settings.json");
         fs::create_dir_all(claude.parent().unwrap()).unwrap();
@@ -743,7 +720,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn malformed_toml_gate_fails_closed_silently() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let settl = home.join(".settl/config.toml");
         fs::create_dir_all(settl.parent().unwrap()).unwrap();
@@ -761,7 +738,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn profile_codex_home_path_is_rewritten() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex_override = home.join("work-codex");
         fs::create_dir_all(&codex_override).unwrap();
@@ -808,7 +785,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn profile_claude_config_dir_path_is_rewritten() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         // CLAUDE_CONFIG_DIR replaces the whole `~/.claude` dir, so the
         // override file lands at `<override>/settings.json` (basename of
@@ -859,7 +836,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn malformed_yaml_gate_fails_closed_silently() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let hermes = home.join(".hermes/config.yaml");
         fs::create_dir_all(hermes.parent().unwrap()).unwrap();

--- a/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
+++ b/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
@@ -475,6 +475,7 @@ fn read_environment_from_toml(path: &Path) -> Option<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::EnvGuard;
     use serde_json::Value;
     use std::fs;
     use tempfile::TempDir;
@@ -488,38 +489,17 @@ mod tests {
         printf running > \"/tmp/aoe-hooks/$AOE_INSTANCE_ID/status\" 2>/dev/null; \
         exit 0'";
 
-    struct EnvGuard {
-        saved: Vec<(&'static str, Option<String>)>,
-    }
-    impl EnvGuard {
-        fn unset_all() -> Self {
-            let keys = [
-                "CODEX_HOME",
-                "CLAUDE_CONFIG_DIR",
-                "CURSOR_CONFIG_DIR",
-                "GEMINI_CONFIG_DIR",
-                "QWEN_CONFIG_DIR",
-            ];
-            let saved = keys
-                .iter()
-                .map(|k| {
-                    let prev = std::env::var(k).ok();
-                    std::env::remove_var(k);
-                    (*k, prev)
-                })
-                .collect();
-            Self { saved }
-        }
-    }
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.saved {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
+    /// Clears CODEX_HOME, CLAUDE_CONFIG_DIR, etc. for the test duration so
+    /// the migration's path resolution sees only the explicit fixtures in
+    /// `home` / `app_dir`.
+    fn unset_agent_home_env() -> EnvGuard {
+        EnvGuard::unset(&[
+            "CODEX_HOME",
+            "CLAUDE_CONFIG_DIR",
+            "CURSOR_CONFIG_DIR",
+            "GEMINI_CONFIG_DIR",
+            "QWEN_CONFIG_DIR",
+        ])
     }
 
     fn setup_dirs() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
@@ -601,7 +581,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn rewrites_pre_v017_claude_settings_to_per_user_base() {
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude").join("settings.json");
         write_json(&claude, &pre_v017_claude_settings());
@@ -614,7 +594,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn skips_files_without_aoe_marker() {
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude").join("settings.json");
         let user_settings = serde_json::json!({
@@ -641,7 +621,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn idempotent_byte_identical_on_second_run() {
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let claude = home.join(".claude").join("settings.json");
         write_json(&claude, &pre_v017_claude_settings());
@@ -658,7 +638,7 @@ mod tests {
     #[serial_test::serial(shell_env)]
     fn rewrite_failure_keeps_legacy_dir_intact_for_manual_recovery() {
         use std::os::unix::fs::PermissionsExt;
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
 
         let claude = home.join(".claude").join("settings.json");
@@ -692,7 +672,7 @@ mod tests {
     #[serial_test::serial(shell_env)]
     fn legacy_sweep_full_success_removes_owned_dir() {
         use std::os::unix::fs::PermissionsExt;
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
 
         let claude = home.join(".claude").join("settings.json");
@@ -721,7 +701,7 @@ mod tests {
     #[serial_test::serial(shell_env)]
     fn legacy_sweep_handles_symlink_at_legacy_path() {
         use std::os::unix::fs::PermissionsExt;
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
 
         let canary = _tmp.path().join("canary");
@@ -749,7 +729,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn sandbox_baked_hooks_under_aoe_sandbox_subpath_are_untouched() {
-        let _env = EnvGuard::unset_all();
+        let _env = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
 
         let claude = home.join(".claude").join("settings.json");

--- a/src/migrations/v018_strip_codex_config_toml_hooks.rs
+++ b/src/migrations/v018_strip_codex_config_toml_hooks.rs
@@ -199,44 +199,21 @@ fn read_environment_from_toml(path: &Path) -> Option<Vec<String>> {
 mod tests {
     use super::*;
     use crate::hooks::{canonical_status_command, HookInstallTarget};
+    use crate::session::test_support::EnvGuard;
     use std::fs;
     use tempfile::TempDir;
 
-    /// `EnvGuard` clears `CODEX_HOME` (and the sibling agent overrides v015
-    /// also scrubs) for the test duration so the migration's path
-    /// resolution sees only the explicit fixtures in `home` / `app_dir`.
-    struct EnvGuard {
-        saved: Vec<(&'static str, Option<String>)>,
-    }
-    impl EnvGuard {
-        fn unset_all() -> Self {
-            let keys = [
-                "CODEX_HOME",
-                "CLAUDE_CONFIG_DIR",
-                "CURSOR_CONFIG_DIR",
-                "GEMINI_CONFIG_DIR",
-                "QWEN_CONFIG_DIR",
-            ];
-            let saved = keys
-                .iter()
-                .map(|k| {
-                    let prev = std::env::var(k).ok();
-                    std::env::remove_var(k);
-                    (*k, prev)
-                })
-                .collect();
-            Self { saved }
-        }
-    }
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.saved {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
+    /// Clears CODEX_HOME, CLAUDE_CONFIG_DIR, etc. for the test duration so
+    /// the migration's path resolution sees only the explicit fixtures in
+    /// `home` / `app_dir`.
+    fn unset_agent_home_env() -> EnvGuard {
+        EnvGuard::unset(&[
+            "CODEX_HOME",
+            "CLAUDE_CONFIG_DIR",
+            "CURSOR_CONFIG_DIR",
+            "GEMINI_CONFIG_DIR",
+            "QWEN_CONFIG_DIR",
+        ])
     }
 
     fn setup_dirs() -> (TempDir, PathBuf, PathBuf) {
@@ -265,7 +242,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn missing_config_is_noop() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
 
         run_in(&home, &app_dir).unwrap();
@@ -283,7 +260,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn user_only_config_byte_identical() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex = home.join(".codex/config.toml");
         fs::create_dir_all(codex.parent().unwrap()).unwrap();
@@ -306,7 +283,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn aoe_only_strips_and_preserves_state() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex = home.join(".codex/config.toml");
         fs::create_dir_all(codex.parent().unwrap()).unwrap();
@@ -347,7 +324,7 @@ mod tests {
         // preserved byte-for-byte. v018 still treats this as success
         // (returns Ok); the only observable side effect is the debug
         // "marker present but no all-AoE group" log.
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex = home.join(".codex/config.toml");
         fs::create_dir_all(codex.parent().unwrap()).unwrap();
@@ -377,7 +354,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn profile_codex_home_visited() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex_override = home.join("work-codex");
         fs::create_dir_all(&codex_override).unwrap();
@@ -414,7 +391,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn symlinked_config_resolved_and_stripped() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let real = home.join("real-codex.toml");
         fs::write(&real, aoe_session_start_block()).unwrap();
@@ -441,7 +418,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn idempotent_byte_identical_on_second_run() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex = home.join(".codex/config.toml");
         fs::create_dir_all(codex.parent().unwrap()).unwrap();
@@ -469,7 +446,7 @@ mod tests {
     #[test]
     #[serial_test::serial(shell_env)]
     fn malformed_toml_skipped_silently() {
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex = home.join(".codex/config.toml");
         fs::create_dir_all(codex.parent().unwrap()).unwrap();
@@ -492,7 +469,7 @@ mod tests {
         // when `[features].hooks = false`. The feature flag controls
         // execution; v018 is about file presence (the dual-source
         // warning). See module-level "Divergence from v015".
-        let _g = EnvGuard::unset_all();
+        let _g = unset_agent_home_env();
         let (_tmp, home, app_dir) = setup_dirs();
         let codex = home.join(".codex/config.toml");
         fs::create_dir_all(codex.parent().unwrap()).unwrap();

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2278,6 +2278,7 @@ pub(crate) fn hermes_poll_fn_sandboxed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::EnvGuard;
     use serial_test::serial;
 
     #[test]
@@ -3060,29 +3061,6 @@ mod tests {
         }
     }
 
-    /// Sets `VIBE_HOME` for the test's lifetime and restores it on Drop, so a
-    /// panicking assertion can't leak the override into later serial tests.
-    struct VibeHomeGuard {
-        previous: Option<String>,
-    }
-
-    impl VibeHomeGuard {
-        fn set(value: &Path) -> Self {
-            let previous = std::env::var("VIBE_HOME").ok();
-            std::env::set_var("VIBE_HOME", value);
-            Self { previous }
-        }
-    }
-
-    impl Drop for VibeHomeGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(v) => std::env::set_var("VIBE_HOME", v),
-                None => std::env::remove_var("VIBE_HOME"),
-            }
-        }
-    }
-
     #[test]
     fn test_extract_vibe_meta_nested() {
         let tmp = tempfile::tempdir().unwrap();
@@ -3143,7 +3121,7 @@ mod tests {
         });
         std::fs::write(s2_dir.join("meta.json"), s2_meta.to_string()).unwrap();
 
-        let _guard = VibeHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("VIBE_HOME", tmp.path())]);
 
         let exclusion = HashSet::new();
         let result = capture_vibe_session_id(project_dir.to_str().unwrap(), &exclusion);
@@ -3168,7 +3146,7 @@ mod tests {
         });
         std::fs::write(s1_dir.join("meta.json"), s1_meta.to_string()).unwrap();
 
-        let _guard = VibeHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("VIBE_HOME", tmp.path())]);
 
         let exclusion = HashSet::new();
         let result = capture_vibe_session_id(project_dir.to_str().unwrap(), &exclusion);
@@ -3200,7 +3178,7 @@ mod tests {
         });
         std::fs::write(s1_dir.join("meta.json"), s1_meta.to_string()).unwrap();
 
-        let _guard = VibeHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("VIBE_HOME", tmp.path())]);
 
         let mut extra = HashSet::new();
         extra.insert("stale-sid-cleared-by-cascade".to_string());
@@ -3575,23 +3553,6 @@ mod tests {
         assert_eq!(selected, uuid_new);
     }
 
-    struct CodexHomeGuard(Option<String>);
-    impl CodexHomeGuard {
-        fn set(path: &str) -> Self {
-            let prev = std::env::var("CODEX_HOME").ok();
-            std::env::set_var("CODEX_HOME", path);
-            Self(prev)
-        }
-    }
-    impl Drop for CodexHomeGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(v) => std::env::set_var("CODEX_HOME", v),
-                None => std::env::remove_var("CODEX_HOME"),
-            }
-        }
-    }
-
     #[test]
     #[serial]
     fn test_codex_respects_codex_home_env() {
@@ -3612,7 +3573,7 @@ mod tests {
         )
         .unwrap();
 
-        let _guard = CodexHomeGuard::set(tmp.path().to_str().unwrap());
+        let _guard = EnvGuard::set(&[("CODEX_HOME", tmp.path())]);
 
         let result = capture_codex_session_id(project_dir.to_str().unwrap(), &HashSet::new());
         assert!(result.is_ok());
@@ -3626,7 +3587,7 @@ mod tests {
         let sessions_dir = tmp.path().join("sessions");
         std::fs::create_dir_all(&sessions_dir).unwrap();
 
-        let _guard = CodexHomeGuard::set(tmp.path().to_str().unwrap());
+        let _guard = EnvGuard::set(&[("CODEX_HOME", tmp.path())]);
 
         let result = capture_codex_session_id("/tmp/some-project", &HashSet::new());
         assert!(result.is_err(), "Empty sessions dir should return error");
@@ -3786,7 +3747,7 @@ mod tests {
         )
         .unwrap();
 
-        let _guard = GeminiHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("GEMINI_CLI_HOME", tmp.path())]);
 
         let result = capture_gemini_session_id(project_path, &HashSet::new());
         assert_eq!(result.unwrap(), "new-id-222");
@@ -3829,7 +3790,7 @@ mod tests {
             .set_times(std::fs::FileTimes::new().set_modified(older))
             .unwrap();
 
-        let _guard = GeminiHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("GEMINI_CLI_HOME", tmp.path())]);
 
         let mut exclusion = HashSet::new();
         exclusion.insert("json-id-AAA".to_string());
@@ -3850,27 +3811,6 @@ mod tests {
             "json-id-AAA",
             "Filename stem in exclusion should have no effect"
         );
-    }
-
-    struct GeminiHomeGuard {
-        previous: Option<String>,
-    }
-
-    impl GeminiHomeGuard {
-        fn set(value: &Path) -> Self {
-            let previous = std::env::var("GEMINI_CLI_HOME").ok();
-            std::env::set_var("GEMINI_CLI_HOME", value);
-            Self { previous }
-        }
-    }
-
-    impl Drop for GeminiHomeGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(v) => std::env::set_var("GEMINI_CLI_HOME", v),
-                None => std::env::remove_var("GEMINI_CLI_HOME"),
-            }
-        }
     }
 
     #[test]
@@ -3964,7 +3904,7 @@ mod tests {
         );
         std::fs::write(&session_file, body).unwrap();
 
-        let _guard = GeminiHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("GEMINI_CLI_HOME", tmp.path())]);
 
         let result = capture_gemini_session_id(project_path, &HashSet::new());
         assert_eq!(result.unwrap(), "jsonl-session-id");

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4822,6 +4822,7 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::EnvGuard;
 
     #[test]
     fn container_terminal_autodetect_cmd_resolves_login_shell() {
@@ -4841,23 +4842,6 @@ mod tests {
         // Single-quoted body: the embedded command substitution is evaluated by
         // the container's sh, not the host shell tmux spawns the session with.
         assert!(cmd.starts_with("sh -c '"));
-    }
-
-    struct CodexHomeGuard(Option<String>);
-    impl CodexHomeGuard {
-        fn unset() -> Self {
-            let prev = std::env::var("CODEX_HOME").ok();
-            std::env::remove_var("CODEX_HOME");
-            Self(prev)
-        }
-    }
-    impl Drop for CodexHomeGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(v) => std::env::set_var("CODEX_HOME", v),
-                None => std::env::remove_var("CODEX_HOME"),
-            }
-        }
     }
 
     /// Regression for issue #2414: a sandboxed worktree session's
@@ -4931,7 +4915,7 @@ mod tests {
     #[serial_test::serial]
     fn test_custom_codex_detected_agent_uses_codex_hook_installer() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let _codex_home_guard = CodexHomeGuard::unset();
+        let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
@@ -4953,7 +4937,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_hook_installer_uses_profile_codex_home() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let _codex_home_guard = CodexHomeGuard::unset();
+        let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
@@ -4984,7 +4968,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_hook_installer_respects_profile_hooks_disabled() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let _codex_home_guard = CodexHomeGuard::unset();
+        let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
@@ -5009,7 +4993,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_hook_installer_respects_profile_hooks_enabled() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let _codex_home_guard = CodexHomeGuard::unset();
+        let _codex_home_guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
@@ -7988,30 +7972,9 @@ mod tests {
             should_attempt_resume, Instance, LaunchSidOutcome, ResumeAttemptPolicy, ResumeIntent,
             SidPersistOutcome, StartOutcome, Status,
         };
+        use crate::session::test_support::EnvGuard;
         use serial_test::serial;
         use tempfile::tempdir;
-
-        struct EnvVarGuard {
-            key: &'static str,
-            prev: Option<std::ffi::OsString>,
-        }
-
-        impl EnvVarGuard {
-            fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-                let prev = std::env::var_os(key);
-                std::env::set_var(key, value);
-                Self { key, prev }
-            }
-        }
-
-        impl Drop for EnvVarGuard {
-            fn drop(&mut self) {
-                match self.prev.take() {
-                    Some(value) => std::env::set_var(self.key, value),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
 
         struct TmuxSessionGuard(String);
 
@@ -8919,7 +8882,7 @@ mod tests {
             let db_path = temp.path().join("opencode.db");
             let captured_sid = "ses_retroactive_capture";
             seed_opencode_db(&db_path, captured_sid, &project_path);
-            let _opencode_db = EnvVarGuard::set("OPENCODE_DB", &db_path);
+            let _opencode_db = EnvGuard::set(&[("OPENCODE_DB", &db_path)]);
 
             let mut inst = Instance::new("retroactive-opencode", &project_path);
             inst.tool = "opencode".to_string();
@@ -8939,46 +8902,24 @@ mod tests {
         mod verify_on_resume {
             use super::*;
             use crate::session::capture::encode_claude_project_path;
+            use crate::session::test_support::isolate_app_dir_at;
             use std::fs;
+            use std::path::PathBuf;
             use std::time::{Duration, SystemTime};
             use tempfile::{tempdir, TempDir};
 
-            struct ClaudeHomeGuard {
-                prev_home: Option<String>,
-                prev_xdg: Option<String>,
-                prev_claude: Option<String>,
-            }
-
-            impl ClaudeHomeGuard {
-                fn set(temp: &TempDir) -> Self {
-                    let prev_home = std::env::var("HOME").ok();
-                    let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-                    let prev_claude = std::env::var("CLAUDE_CONFIG_DIR").ok();
-                    std::env::set_var("HOME", temp.path());
-                    #[cfg(any(target_os = "linux", target_os = "macos"))]
-                    std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-                    std::env::set_var("CLAUDE_CONFIG_DIR", temp.path().join(".claude"));
-                    Self {
-                        prev_home,
-                        prev_xdg,
-                        prev_claude,
-                    }
-                }
-            }
-
-            impl Drop for ClaudeHomeGuard {
-                fn drop(&mut self) {
-                    restore_or_remove("HOME", self.prev_home.take());
-                    restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-                    restore_or_remove("CLAUDE_CONFIG_DIR", self.prev_claude.take());
-                }
-            }
-
-            fn restore_or_remove(key: &str, prev: Option<String>) {
-                match prev {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
+            /// Points `HOME`, `CLAUDE_CONFIG_DIR` (and, on Linux/macOS,
+            /// `XDG_CONFIG_HOME`) at `temp` for the current test body.
+            /// See [`crate::session::test_support`]: the snapshot/restore
+            /// is `EnvGuard`'s, so a non-UTF-8 prior value round-trips
+            /// instead of being dropped (#2751).
+            fn claude_home_guard(temp: &TempDir) -> EnvGuard {
+                let mut pairs: Vec<(&'static str, PathBuf)> =
+                    vec![("HOME", temp.path().to_path_buf())];
+                #[cfg(any(target_os = "linux", target_os = "macos"))]
+                pairs.push(("XDG_CONFIG_HOME", temp.path().join(".config")));
+                pairs.push(("CLAUDE_CONFIG_DIR", temp.path().join(".claude")));
+                EnvGuard::set(&pairs)
             }
 
             fn write_jsonl_with_mtime(path: &std::path::Path, mtime: SystemTime) {
@@ -8992,7 +8933,7 @@ mod tests {
             #[serial]
             fn supersedes_stale_claude_sid_after_clear() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2291-claude-bascule";
                 let claude_dir = temp
@@ -9029,7 +8970,7 @@ mod tests {
             #[serial]
             fn no_bascule_when_claude_stored_matches_freshest() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2291-claude-steady";
                 let claude_dir = temp
@@ -9067,7 +9008,7 @@ mod tests {
             #[serial]
             fn stored_sid_without_transcript_launches_fresh_pinned() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2291-no-jsonl";
                 let stored = "12121212-3434-5656-7878-9a9a9a9a9a9a";
@@ -9095,7 +9036,7 @@ mod tests {
             #[serial]
             fn stored_sid_with_stale_transcript_still_resumes() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-stale-transcript";
                 let claude_dir = temp
@@ -9129,7 +9070,7 @@ mod tests {
             #[serial]
             fn unaffected_for_unsupported_tool() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let mut inst = Instance::new("verify-cursor", "/tmp/aoe-test-2291-cursor");
                 inst.tool = "cursor".to_string();
@@ -9153,7 +9094,7 @@ mod tests {
             #[serial]
             fn sidecar_wins_over_fresher_peer_jsonl() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2344-shared-cwd";
                 let claude_dir = temp
@@ -9208,7 +9149,7 @@ mod tests {
             #[serial]
             fn sidecar_consulted_for_sandboxed_claude() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2344-sandbox";
                 let claude_dir = temp
@@ -9268,7 +9209,7 @@ mod tests {
             #[serial]
             fn mtime_fallback_applies_without_sidecar() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2344-no-sidecar";
                 let claude_dir = temp
@@ -9310,7 +9251,7 @@ mod tests {
             #[serial]
             fn mtime_fallback_skips_stopped_peer_sid() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2355-stopped-peer";
                 let claude_dir = temp
@@ -9358,7 +9299,7 @@ mod tests {
             #[serial]
             fn mtime_fallback_skips_archived_peer_sid() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2355-archived-peer";
                 let claude_dir = temp
@@ -9409,7 +9350,7 @@ mod tests {
             #[serial]
             fn mtime_fallback_skips_pane_less_peer_sid() {
                 let temp = tempdir().unwrap();
-                let _guard = ClaudeHomeGuard::set(&temp);
+                let _guard = claude_home_guard(&temp);
 
                 let project_path = "/tmp/aoe-test-2355-paneless-peer";
                 let claude_dir = temp
@@ -9464,35 +9405,12 @@ mod tests {
             // below seeds two on-disk sessions for one tool (older = stored,
             // newer = fresh) and asserts acquire replaces the stored sid with
             // the fresher one, exercising that tool's dispatch arm end-to-end.
-
-            /// Sets HOME (and XDG_CONFIG_HOME) to a temp dir for the test's
-            /// lifetime so the exclusion-set scan reads an empty storage rather
-            /// than the developer's real sessions.json. Restored on Drop.
-            struct StorageHomeGuard {
-                prev_home: Option<String>,
-                prev_xdg: Option<String>,
-            }
-
-            impl StorageHomeGuard {
-                fn set(temp: &TempDir) -> Self {
-                    let prev_home = std::env::var("HOME").ok();
-                    let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-                    std::env::set_var("HOME", temp.path());
-                    #[cfg(any(target_os = "linux", target_os = "macos"))]
-                    std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-                    Self {
-                        prev_home,
-                        prev_xdg,
-                    }
-                }
-            }
-
-            impl Drop for StorageHomeGuard {
-                fn drop(&mut self) {
-                    restore_or_remove("HOME", self.prev_home.take());
-                    restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-                }
-            }
+            //
+            // Each points `HOME` at a tempdir via `isolate_app_dir_at` so the
+            // exclusion-set scan reads an empty storage rather than the
+            // developer's real sessions.json. The tempdir is declared before
+            // the guard so the guard drops first, restoring the env before the
+            // directory `HOME` points at is removed.
 
             fn write_with_mtime(path: &std::path::Path, content: &str, mtime: SystemTime) {
                 fs::write(path, content).unwrap();
@@ -9505,7 +9423,7 @@ mod tests {
             #[serial]
             fn supersedes_stale_opencode_sid() {
                 let temp = tempdir().unwrap();
-                let _home = StorageHomeGuard::set(&temp);
+                let _home = isolate_app_dir_at(temp.path());
 
                 let project_path = temp.path().join("opencode-project");
                 fs::create_dir_all(&project_path).unwrap();
@@ -9522,7 +9440,7 @@ mod tests {
                 )
                 .unwrap();
                 drop(conn);
-                let _db = EnvVarGuard::set("OPENCODE_DB", &db_path);
+                let _db = EnvGuard::set(&[("OPENCODE_DB", &db_path)]);
 
                 let mut inst = Instance::new("verify-opencode-bascule", &project_path);
                 inst.tool = "opencode".to_string();
@@ -9539,8 +9457,8 @@ mod tests {
             #[serial]
             fn supersedes_stale_vibe_sid() {
                 let temp = tempdir().unwrap();
-                let _home = StorageHomeGuard::set(&temp);
-                let _vibe = EnvVarGuard::set("VIBE_HOME", temp.path());
+                let _home = isolate_app_dir_at(temp.path());
+                let _vibe = EnvGuard::set(&[("VIBE_HOME", temp.path())]);
 
                 let project_path = temp.path().join("vibe-project");
                 fs::create_dir_all(&project_path).unwrap();
@@ -9580,8 +9498,8 @@ mod tests {
             #[serial]
             fn supersedes_stale_codex_sid() {
                 let temp = tempdir().unwrap();
-                let _home = StorageHomeGuard::set(&temp);
-                let _codex = EnvVarGuard::set("CODEX_HOME", temp.path());
+                let _home = isolate_app_dir_at(temp.path());
+                let _codex = EnvGuard::set(&[("CODEX_HOME", temp.path())]);
 
                 let project_path = temp.path().join("codex-project");
                 fs::create_dir_all(&project_path).unwrap();
@@ -9620,8 +9538,8 @@ mod tests {
                 use sha2::{Digest, Sha256};
 
                 let temp = tempdir().unwrap();
-                let _home = StorageHomeGuard::set(&temp);
-                let _gemini = EnvVarGuard::set("GEMINI_CLI_HOME", temp.path());
+                let _home = isolate_app_dir_at(temp.path());
+                let _gemini = EnvGuard::set(&[("GEMINI_CLI_HOME", temp.path())]);
 
                 let project_dir = temp.path().join("gemini-project");
                 fs::create_dir_all(&project_dir).unwrap();
@@ -9667,8 +9585,8 @@ mod tests {
                 use crate::session::capture::encode_pi_project_path;
 
                 let temp = tempdir().unwrap();
-                let _home = StorageHomeGuard::set(&temp);
-                let _pi = EnvVarGuard::set("PI_CODING_AGENT_DIR", temp.path());
+                let _home = isolate_app_dir_at(temp.path());
+                let _pi = EnvGuard::set(&[("PI_CODING_AGENT_DIR", temp.path())]);
 
                 let project_dir = temp.path().join("pi-project");
                 fs::create_dir_all(&project_dir).unwrap();
@@ -9708,8 +9626,8 @@ mod tests {
             #[serial]
             fn supersedes_stale_hermes_sid() {
                 let temp = tempdir().unwrap();
-                let _home = StorageHomeGuard::set(&temp);
-                let _hermes = EnvVarGuard::set("HERMES_HOME", temp.path());
+                let _home = isolate_app_dir_at(temp.path());
+                let _hermes = EnvGuard::set(&[("HERMES_HOME", temp.path())]);
 
                 let db_path = temp.path().join("state.db");
                 let stale = "20260101_000000_stored";

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -335,8 +335,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     /// Restores `SESSION_ID_POLLER_MAX_THREADS` to its original value on drop,
-    /// even if the test panics. Mirrors the `VibeHomeGuard` / `TmuxCleanup`
-    /// pattern used elsewhere in the test suite.
+    /// even if the test panics. Mirrors the `EnvGuard` / `TmuxCleanup`
+    /// pattern used elsewhere in the test suite. Not an `EnvGuard` itself:
+    /// the cap is a process-global atomic, not an env var.
     struct CapRestorer(u32);
     impl Drop for CapRestorer {
         fn drop(&mut self) {

--- a/src/session/sync.rs
+++ b/src/session/sync.rs
@@ -338,42 +338,23 @@ mod tests {
     use crate::file_watch::FileWatchService;
     use crate::session::poller::SessionPoller;
     use crate::session::storage::Storage;
+    use crate::session::test_support::EnvGuard;
     use crate::session::{GroupTree, Instance};
     use serial_test::serial;
+    use std::path::PathBuf;
     use std::sync::Mutex;
     use tempfile::{tempdir, TempDir};
 
-    struct StorageHomeGuard {
-        prev_home: Option<String>,
-        prev_xdg: Option<String>,
-    }
-
-    impl StorageHomeGuard {
-        fn set(temp: &TempDir) -> Self {
-            let prev_home = std::env::var("HOME").ok();
-            let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
-            std::env::set_var("HOME", temp.path());
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
-            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
-            Self {
-                prev_home,
-                prev_xdg,
-            }
-        }
-    }
-
-    impl Drop for StorageHomeGuard {
-        fn drop(&mut self) {
-            restore_or_remove("HOME", self.prev_home.take());
-            restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-        }
-    }
-
-    fn restore_or_remove(key: &str, prev: Option<String>) {
-        match prev {
-            Some(v) => std::env::set_var(key, v),
-            None => std::env::remove_var(key),
-        }
+    /// Points `HOME` (and, on Linux/macOS, `XDG_CONFIG_HOME`) at `temp`
+    /// for the current test body. See [`crate::session::test_support`]:
+    /// the snapshot/restore is `EnvGuard`'s, so a non-UTF-8 prior value
+    /// round-trips instead of being dropped (#2751).
+    fn storage_home_guard(temp: &TempDir) -> EnvGuard {
+        #[allow(unused_mut)]
+        let mut pairs: Vec<(&'static str, PathBuf)> = vec![("HOME", temp.path().to_path_buf())];
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        pairs.push(("XDG_CONFIG_HOME", temp.path().join(".config")));
+        EnvGuard::set(&pairs)
     }
 
     fn seed_instance_on_disk(profile: &str, inst: &Instance) {
@@ -411,7 +392,7 @@ mod tests {
     #[serial]
     fn drain_applied_updates_memory_and_clears_failed_sid() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let profile = "sync-applied";
         let mut inst = Instance::new("sync-applied-title", "/tmp/x");
@@ -443,7 +424,7 @@ mod tests {
     #[serial]
     fn drain_filters_invalid_sid_and_leaves_state_unchanged() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let profile = "sync-filtered-validation";
         let mut inst = Instance::new("sync-validation-title", "/tmp/x");
@@ -470,7 +451,7 @@ mod tests {
     #[serial]
     fn drain_filters_sid_present_in_retroactive_capture_excludes() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let profile = "sync-filtered-excludes";
         let excluded = "019342ab-1234-7def-8901-abcdef012345";
@@ -501,7 +482,7 @@ mod tests {
     #[serial]
     fn drain_rejects_observed_sid_for_stopped_session() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let own = "019342ab-1234-7def-8901-aaaaaaaaaaaa";
         let peer = "019342ab-1234-7def-8901-bbbbbbbbbbbb";
@@ -526,7 +507,7 @@ mod tests {
     #[serial]
     fn drain_rejects_observed_sid_contradicting_use_pin() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let pin = "019342ab-1234-7def-8901-aaaaaaaaaaaa";
         let peer = "019342ab-1234-7def-8901-bbbbbbbbbbbb";
@@ -553,7 +534,7 @@ mod tests {
     #[serial]
     fn drain_rejects_sid_owned_by_another_instance() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let owned = "019342ab-1234-7def-8901-cccccccccccc";
         let mut owner = Instance::new("owner-title", "/tmp/x");
@@ -580,7 +561,7 @@ mod tests {
     #[serial]
     fn drain_rejects_all_claimants_of_same_batch_duplicate_sid() {
         let temp = tempdir().unwrap();
-        let _guard = StorageHomeGuard::set(&temp);
+        let _guard = storage_home_guard(&temp);
 
         let contested = "019342ab-1234-7def-8901-dddddddddddd";
         let mut a = Instance::new("peer-a-title", "/tmp/x");

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -9,14 +9,18 @@
 //! but the env vars leaked into the process for the rest of the test
 //! run, poisoning any later test that read them. See issue #2306.
 //!
-//! `AppDirGuard` snapshots the previous env values, so its `Drop`
-//! closes the leak: env vars are restored to their prior state (or
-//! removed if they were previously unset) even if the test panics.
-//! The `Drop` restore-or-remove pattern is similar to
-//! `StorageHomeGuard` at [`crate::session::sync`], with the deliberate
-//! divergence that `AppDirGuard` snapshots `OsString` via `env::var_os`
-//! rather than `String` via `env::var`, so a non-UTF-8 prior value
-//! round-trips faithfully instead of coercing to `None`.
+//! [`EnvGuard`] is the one helper every test reaches for when it needs
+//! to shim an env var: it snapshots the previous values, so its `Drop`
+//! closes the leak by restoring them to their prior state (or removing
+//! them if they were previously unset) even if the test panics. It
+//! snapshots `OsString` via `env::var_os` rather than `String` via
+//! `env::var`, so a non-UTF-8 prior value round-trips faithfully
+//! instead of coercing to `None` and being removed (issue #2751).
+//!
+//! [`AppDirGuard`] layers tempdir ownership on top of an inner
+//! `EnvGuard`; issue #2716 folded the per-agent `StorageHomeGuard` /
+//! `VibeHomeGuard` / `GeminiHomeGuard` / `ClaudeHomeGuard` /
+//! `CodexHomeGuard` copies scattered across the crate into it.
 //!
 //! Two constructors are offered. [`isolate_app_dir`] creates and owns
 //! a fresh tempdir; reach for it when the caller has no directory to
@@ -37,9 +41,90 @@
 //! different mechanism (e.g. a stub for the profile-folder lookup)
 //! rather than more env vars in this snapshot set.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+/// RAII guard: snapshots an arbitrary set of env vars, applies the
+/// requested mutation, and restores the prior state on `Drop`
+/// (`set_var` when the var was previously set, `remove_var` when it was
+/// previously unset). See issue #2716: every test in the crate that
+/// needs to shim an env var reaches for this instead of hand-rolling
+/// another snapshot/restore struct.
+///
+/// Snapshots are typed `Option<OsString>` and read via
+/// [`std::env::var_os`], never `String` / [`std::env::var`]. A
+/// non-UTF-8 prior value makes `env::var` return `Err(NotUnicode(_))`,
+/// so a `var(...).ok()` snapshot would collapse to `None` and `Drop`
+/// would *remove* the var rather than restore its bytes, leaking the
+/// removal into every later `#[serial]` test in the process. See issue
+/// #2751.
+///
+/// `Debug` is intentionally not derived: the snapshot carries the
+/// caller's real env values (`$HOME` and friends), which are often
+/// personally identifying, and a derived impl would print them verbatim
+/// in test-failure output. Same reasoning as [`AppDirGuard`] below.
+#[must_use = "EnvGuard restores env vars on Drop; bind it to `_guard`, not `_`, or the override ends on the same line and the test body runs against the caller's real env"]
+pub(crate) struct EnvGuard {
+    prev: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    /// Set each `key` to `value` for the rest of the current scope.
+    ///
+    /// Values are `impl AsRef<OsStr>`, so call sites pass `&str`,
+    /// `&Path`, `PathBuf`, or `OsString` without converting. All values
+    /// in one call share a type; build a `Vec<(&'static str, PathBuf)>`
+    /// when a call site mixes shapes.
+    ///
+    /// # Panics
+    ///
+    /// `std::env::set_var` panics on a key or value containing a NUL
+    /// byte or an `=` in the key. Vars snapshotted before the panicking
+    /// entry are still restored: the guard is built incrementally, so
+    /// the partially-populated value drops during the unwind.
+    pub(crate) fn set<V: AsRef<OsStr>>(pairs: &[(&'static str, V)]) -> Self {
+        let mut guard = Self {
+            prev: Vec::with_capacity(pairs.len()),
+        };
+        for (key, value) in pairs {
+            guard.snapshot(key);
+            // SAFETY (staged for Rust 2024 edition migration): same
+            // invariant as [`restore_or_remove`] below.
+            std::env::set_var(key, value.as_ref());
+        }
+        guard
+    }
+
+    /// Remove each `key` for the rest of the current scope.
+    pub(crate) fn unset(keys: &[&'static str]) -> Self {
+        let mut guard = Self {
+            prev: Vec::with_capacity(keys.len()),
+        };
+        for key in keys {
+            guard.snapshot(key);
+            // SAFETY (staged for Rust 2024 edition migration): same
+            // invariant as [`restore_or_remove`] below.
+            std::env::remove_var(key);
+        }
+        guard
+    }
+
+    fn snapshot(&mut self, key: &'static str) {
+        self.prev.push((key, std::env::var_os(key)));
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // Reverse order so a key listed twice in one call round-trips to
+        // its pre-guard value rather than to the intermediate one the
+        // second write observed.
+        for (key, prev) in self.prev.drain(..).rev() {
+            restore_or_remove(key, prev);
+        }
+    }
+}
 
 /// RAII guard: isolates `HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME`
 /// for one test; restores them on `Drop`. See the
@@ -63,13 +148,18 @@ use tempfile::TempDir;
 /// avoid the log entirely.
 #[must_use = "AppDirGuard restores env vars on Drop; bind it to `_tmp` or `_guard`, not `_`, or the isolation ends on the same line and the test body runs against the caller's real env"]
 pub(crate) struct AppDirGuard {
-    // `None` when the caller retains ownership via `isolate_app_dir_at`.
-    temp: Option<TempDir>,
+    // Field order is load-bearing: fields drop in declaration order, so
+    // the env restore runs before the owned tempdir is deleted and
+    // `HOME` never points at a directory being removed.
+    //
+    // Both are underscore-prefixed because they exist purely for their
+    // `Drop`: nothing reads them, and the names keep `dead_code` quiet
+    // without an `#[allow]`.
+    _env: EnvGuard,
     // Snapshotted at construction so `path()` works whether we own the tempdir or not.
     path: PathBuf,
-    prev_home: Option<OsString>,
-    prev_xdg: Option<OsString>,
-    prev_xdg_data: Option<OsString>,
+    // `None` when the caller retains ownership via `isolate_app_dir_at`.
+    _temp: Option<TempDir>,
 }
 
 impl AppDirGuard {
@@ -91,24 +181,9 @@ impl AsRef<Path> for AppDirGuard {
     }
 }
 
-impl Drop for AppDirGuard {
-    fn drop(&mut self) {
-        // `prev_xdg` and `prev_xdg_data` are snapshotted unconditionally at
-        // construction, while the constructor only mutates `XDG_CONFIG_HOME`
-        // and `XDG_DATA_HOME` under `cfg(any(target_os = "linux", target_os
-        // = "macos"))`. On other targets the restore writes back the same
-        // value the constructor observed (a no-op on the ambient env); the
-        // asymmetry is deliberate so a future target that starts consulting
-        // these vars inherits the restore path automatically without a
-        // matching cfg edit here.
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-        restore_or_remove("XDG_DATA_HOME", self.prev_xdg_data.take());
-        // Env vars are restored; only now release the owned tempdir (if
-        // any) so `HOME` no longer points at a directory being deleted.
-        let _ = self.temp.take();
-    }
-}
+// No hand-written `Drop` impl: the inner `EnvGuard` restores the env and
+// the declaration order of `AppDirGuard`'s fields (env, then path, then
+// temp) sequences that restore ahead of the owned tempdir's deletion.
 
 fn restore_or_remove(key: &str, prev: Option<OsString>) {
     // SAFETY (staged for Rust 2024 edition migration, at which point
@@ -188,60 +263,40 @@ pub(crate) fn isolate_app_dir_at(path: &Path) -> AppDirGuard {
 }
 
 fn install_env_vars(path: PathBuf, temp: Option<TempDir>) -> AppDirGuard {
-    let prev_home = std::env::var_os("HOME");
-    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-    let prev_xdg_data = std::env::var_os("XDG_DATA_HOME");
-    // SAFETY (staged for Rust 2024 edition migration): same invariant
-    // as [`restore_or_remove`] above. Callers are `#[serial]`-annotated
-    // tests; no other thread reads or writes `HOME` / `XDG_CONFIG_HOME`
-    // / `XDG_DATA_HOME` while this function runs.
-    std::env::set_var("HOME", &path);
+    // Only the vars this target actually mutates are handed to the guard;
+    // a var that is never written needs no restore. A future target that
+    // starts consulting `XDG_CONFIG_HOME` / `XDG_DATA_HOME` adds them to
+    // this list and inherits the snapshot-and-restore automatically.
+    #[allow(unused_mut)]
+    let mut pairs: Vec<(&'static str, PathBuf)> = vec![("HOME", path.clone())];
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
-        std::env::set_var("XDG_CONFIG_HOME", path.join(".config"));
-        std::env::set_var("XDG_DATA_HOME", path.join(".local/share"));
+        pairs.push(("XDG_CONFIG_HOME", path.join(".config")));
+        pairs.push(("XDG_DATA_HOME", path.join(".local/share")));
     }
     AppDirGuard {
-        temp,
+        _env: EnvGuard::set(&pairs),
         path,
-        prev_home,
-        prev_xdg,
-        prev_xdg_data,
+        _temp: temp,
     }
 }
 
-/// RAII guard: like [`isolate_app_dir`], but for callers that already own
-/// their tempdir and just need `HOME`/`XDG_CONFIG_HOME` pointed at an
-/// existing path rather than one this helper creates and owns. Sets
-/// `XDG_CONFIG_HOME` unconditionally (not gated to Linux/macOS): see
-/// issue #1948, the fix this branch lands.
-#[must_use = "HomeGuard restores env vars on Drop; bind it to `_home` or `_guard`, not `_`, or the isolation ends on the same line and the test body runs against the caller's real env"]
-pub(crate) struct HomeGuard {
-    prev_home: Option<OsString>,
-    prev_xdg: Option<OsString>,
-}
-
-impl Drop for HomeGuard {
-    fn drop(&mut self) {
-        restore_or_remove("HOME", self.prev_home.take());
-        restore_or_remove("XDG_CONFIG_HOME", self.prev_xdg.take());
-    }
-}
+/// The guard returned by [`isolate_home`]. Retained as a named alias so
+/// call sites that spell the return type keep reading as intent
+/// ("a guard over `HOME`") rather than as the generic [`EnvGuard`].
+pub(crate) type HomeGuard = EnvGuard;
 
 /// Points `HOME`/`XDG_CONFIG_HOME` at `temp` for the current test body,
 /// restoring the prior values on `Drop`. Unlike [`isolate_app_dir`], the
 /// caller supplies (and owns) the tempdir.
+///
+/// Sets `XDG_CONFIG_HOME` unconditionally (not gated to Linux/macOS):
+/// see issue #1948.
 pub(crate) fn isolate_home(temp: &Path) -> HomeGuard {
-    let prev_home = std::env::var_os("HOME");
-    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
-    // SAFETY (staged for Rust 2024 edition migration): same invariant
-    // as [`restore_or_remove`] above.
-    std::env::set_var("HOME", temp);
-    std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
-    HomeGuard {
-        prev_home,
-        prev_xdg,
-    }
+    EnvGuard::set(&[
+        ("HOME", temp.to_path_buf()),
+        ("XDG_CONFIG_HOME", temp.join(".config")),
+    ])
 }
 
 #[cfg(test)]
@@ -249,6 +304,150 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::panic::AssertUnwindSafe;
+
+    /// Restores one ambient env key on `Drop` so a panicking assertion
+    /// mid-test cannot leak a seeded value into the next `#[serial]`
+    /// test in the process.
+    struct AmbientEnvRestore(&'static str, Option<OsString>);
+    impl Drop for AmbientEnvRestore {
+        fn drop(&mut self) {
+            restore_or_remove(self.0, self.1.take());
+        }
+    }
+    impl AmbientEnvRestore {
+        fn capture(key: &'static str) -> Self {
+            Self(key, std::env::var_os(key))
+        }
+    }
+
+    /// Locks #2751: a non-UTF-8 prior value MUST round-trip through the
+    /// guard byte-for-byte. `std::env::var` returns `Err(NotUnicode(_))`
+    /// for such a value, so the pre-consolidation `Option<String>`
+    /// snapshot built from `var(...).ok()` collapsed it to `None` and
+    /// `Drop` called `remove_var` instead of restoring the bytes,
+    /// leaking the removal into every later `#[serial]` test.
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn env_guard_drop_restores_non_utf8_prior_value() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let _restore = AmbientEnvRestore::capture("HOME");
+
+        // A lone 0xFF byte can never appear in valid UTF-8, so this
+        // value is exactly the shape `env::var` rejects.
+        let non_utf8 = OsString::from(OsStr::from_bytes(b"/tmp/aoe-\xFF\xFE-home"));
+        assert!(
+            non_utf8.to_str().is_none(),
+            "precondition: the seeded value must not be valid UTF-8"
+        );
+        std::env::set_var("HOME", &non_utf8);
+        assert!(
+            std::env::var("HOME").is_err(),
+            "precondition: env::var must surface NotUnicode, the error the old \
+             Option<String> snapshot swallowed via .ok()"
+        );
+
+        {
+            let _guard = EnvGuard::set(&[("HOME", "/tmp/aoe-envguard-scoped")]);
+            assert_eq!(
+                std::env::var_os("HOME"),
+                Some(OsString::from("/tmp/aoe-envguard-scoped")),
+                "guard must apply its override while live"
+            );
+        }
+
+        assert_eq!(
+            std::env::var_os("HOME"),
+            Some(non_utf8),
+            "Drop must restore the non-UTF-8 prior value byte-for-byte rather than remove it (#2751)"
+        );
+    }
+
+    /// An empty prior value is `Some("")`, not `None`: `Drop` must
+    /// restore it as an empty string rather than unsetting the var.
+    /// `env::var_os` is what preserves the distinction.
+    #[test]
+    #[serial]
+    fn env_guard_drop_preserves_empty_versus_unset() {
+        let _restore_set = AmbientEnvRestore::capture("AOE_ENVGUARD_EMPTY");
+        let _restore_unset = AmbientEnvRestore::capture("AOE_ENVGUARD_UNSET");
+
+        std::env::set_var("AOE_ENVGUARD_EMPTY", "");
+        std::env::remove_var("AOE_ENVGUARD_UNSET");
+
+        {
+            let _guard = EnvGuard::set(&[
+                ("AOE_ENVGUARD_EMPTY", "populated"),
+                ("AOE_ENVGUARD_UNSET", "populated"),
+            ]);
+        }
+
+        assert_eq!(
+            std::env::var_os("AOE_ENVGUARD_EMPTY"),
+            Some(OsString::new()),
+            "an empty prior value must be restored as empty, not removed"
+        );
+        assert_eq!(
+            std::env::var_os("AOE_ENVGUARD_UNSET"),
+            None,
+            "a previously-unset var must be removed on Drop, not set to empty"
+        );
+    }
+
+    /// `EnvGuard::unset` removes the key for the scope and restores the
+    /// prior value on `Drop`.
+    #[test]
+    #[serial]
+    fn env_guard_unset_removes_then_restores() {
+        let _restore = AmbientEnvRestore::capture("AOE_ENVGUARD_UNSET_ME");
+
+        std::env::set_var("AOE_ENVGUARD_UNSET_ME", "original");
+
+        {
+            let _guard = EnvGuard::unset(&["AOE_ENVGUARD_UNSET_ME"]);
+            assert_eq!(
+                std::env::var_os("AOE_ENVGUARD_UNSET_ME"),
+                None,
+                "unset must remove the var while the guard is live"
+            );
+        }
+
+        assert_eq!(
+            std::env::var_os("AOE_ENVGUARD_UNSET_ME"),
+            Some(OsString::from("original")),
+            "Drop must restore the value unset removed"
+        );
+    }
+
+    /// A key listed twice in one `set` call must round-trip to its
+    /// pre-guard value, not to the intermediate write. This is what the
+    /// reverse-order restore in `Drop` buys.
+    #[test]
+    #[serial]
+    fn env_guard_drop_restores_duplicate_key_to_pre_guard_value() {
+        let _restore = AmbientEnvRestore::capture("AOE_ENVGUARD_DUP");
+
+        std::env::set_var("AOE_ENVGUARD_DUP", "original");
+
+        {
+            let _guard = EnvGuard::set(&[
+                ("AOE_ENVGUARD_DUP", "first"),
+                ("AOE_ENVGUARD_DUP", "second"),
+            ]);
+            assert_eq!(
+                std::env::var_os("AOE_ENVGUARD_DUP"),
+                Some(OsString::from("second")),
+                "the last write in the pair list wins while the guard is live"
+            );
+        }
+
+        assert_eq!(
+            std::env::var_os("AOE_ENVGUARD_DUP"),
+            Some(OsString::from("original")),
+            "Drop must restore the pre-guard value, not the intermediate 'first'"
+        );
+    }
 
     /// Locks the fix for #2306: `Drop` MUST restore `HOME` and (on
     /// Linux/macOS) `XDG_CONFIG_HOME` plus `XDG_DATA_HOME` to their
@@ -318,24 +517,10 @@ mod tests {
     #[test]
     #[serial]
     fn app_dir_guard_drop_removes_env_vars_when_unset() {
-        struct AmbientEnvRestore {
-            home: Option<OsString>,
-            xdg: Option<OsString>,
-            xdg_data: Option<OsString>,
-        }
-        impl Drop for AmbientEnvRestore {
-            fn drop(&mut self) {
-                restore_or_remove("HOME", self.home.take());
-                restore_or_remove("XDG_CONFIG_HOME", self.xdg.take());
-                restore_or_remove("XDG_DATA_HOME", self.xdg_data.take());
-            }
-        }
+        let _restore_home = AmbientEnvRestore::capture("HOME");
+        let _restore_xdg = AmbientEnvRestore::capture("XDG_CONFIG_HOME");
+        let _restore_xdg_data = AmbientEnvRestore::capture("XDG_DATA_HOME");
 
-        let _restore = AmbientEnvRestore {
-            home: std::env::var_os("HOME"),
-            xdg: std::env::var_os("XDG_CONFIG_HOME"),
-            xdg_data: std::env::var_os("XDG_DATA_HOME"),
-        };
         std::env::remove_var("HOME");
         std::env::remove_var("XDG_CONFIG_HOME");
         std::env::remove_var("XDG_DATA_HOME");

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -191,14 +191,19 @@ fn restore_or_remove(key: &str, prev: Option<OsString>) {
     // this function mutates a process-global env slot. It is sound to
     // call as long as no other thread is concurrently reading or writing
     // the same env key. The invariant is enforced by:
-    //   1. `AppDirGuard` is only constructed from `#[serial]`-annotated
-    //      tests, so the whole call sequence (snapshot -> set_var ->
-    //      test body -> Drop -> restore_or_remove) is linearized against
-    //      every other `#[serial]` test in the crate.
-    //   2. Non-`#[serial]` tests in the crate do not read `HOME`,
-    //      `XDG_CONFIG_HOME`, or `XDG_DATA_HOME` (grep-verified; see
-    //      the module doc).
-    //   3. The `#[tokio::test]` sites that use this helper all run on
+    //   1. `EnvGuard` (and `AppDirGuard`, which delegates to it) is only
+    //      constructed from `#[serial]`-annotated tests, so the whole
+    //      call sequence (snapshot -> set_var -> test body -> Drop ->
+    //      restore_or_remove) is linearized against every other
+    //      `#[serial]` test in the crate. This is the load-bearing rule:
+    //      unlike `AppDirGuard`'s fixed `HOME` / `XDG_CONFIG_HOME` /
+    //      `XDG_DATA_HOME` set, `EnvGuard` shims a caller-chosen key
+    //      (today also `CODEX_HOME`, `VIBE_HOME`, `GEMINI_CLI_HOME`,
+    //      `CLAUDE_CONFIG_DIR`, the sibling `*_CONFIG_DIR` overrides, and
+    //      `AOE_MOUSE_CAPTURE`), so no fixed grep list can bound which
+    //      readers might race. Every new call site must carry `#[serial]`
+    //      (or a `serial_test::serial(...)` group covering its key).
+    //   2. The `#[tokio::test]` sites that use this helper all run on
     //      the default single-threaded runtime; no worker task reads env
     //      concurrently with the mutation.
     match prev {

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -296,6 +296,7 @@ impl HooksInstallDialog {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::EnvGuard;
     use crossterm::event::KeyModifiers;
     use tempfile::TempDir;
 
@@ -310,29 +311,6 @@ mod tests {
             .map(|l| l.to_string())
             .collect::<Vec<_>>()
             .join("\n")
-    }
-
-    struct CodexHomeGuard(Option<String>);
-    impl CodexHomeGuard {
-        fn set(path: &std::path::Path) -> Self {
-            let prev = std::env::var("CODEX_HOME").ok();
-            std::env::set_var("CODEX_HOME", path);
-            Self(prev)
-        }
-
-        fn unset() -> Self {
-            let prev = std::env::var("CODEX_HOME").ok();
-            std::env::remove_var("CODEX_HOME");
-            Self(prev)
-        }
-    }
-    impl Drop for CodexHomeGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(v) => std::env::set_var("CODEX_HOME", v),
-                None => std::env::remove_var("CODEX_HOME"),
-            }
-        }
     }
 
     #[test]
@@ -476,7 +454,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_codex_agent_shows_hooks_and_config_paths() {
-        let _guard = CodexHomeGuard::unset();
+        let _guard = EnvGuard::unset(&["CODEX_HOME"]);
         let dialog = HooksInstallDialog::new("codex");
         let lines = dialog.build_content_lines();
         let text: String = lines
@@ -494,7 +472,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_agent_shows_codex_home_config_path() {
         let tmp = TempDir::new().unwrap();
-        let _guard = CodexHomeGuard::set(tmp.path());
+        let _guard = EnvGuard::set(&[("CODEX_HOME", tmp.path())]);
 
         let dialog = HooksInstallDialog::new("codex");
         let text = content_text(&dialog);
@@ -507,7 +485,7 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_agent_shows_profile_codex_home_config_path() {
         let tmp = TempDir::new().unwrap();
-        let _guard = CodexHomeGuard::unset();
+        let _guard = EnvGuard::unset(&["CODEX_HOME"]);
         std::env::set_var("HOME", tmp.path());
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -416,32 +416,8 @@ mod clear_terminal_tests {
 mod mouse_capture_tests {
     use super::mouse_capture_requested;
     use crate::session::config::SessionConfig;
+    use crate::session::test_support::EnvGuard;
     use serial_test::serial;
-
-    /// Restores `AOE_MOUSE_CAPTURE` to its prior value on drop so the
-    /// process-global env var doesn't leak between serial tests.
-    struct EnvGuard(Option<String>);
-
-    impl EnvGuard {
-        fn set(val: Option<&str>) -> Self {
-            let prev = std::env::var("AOE_MOUSE_CAPTURE").ok();
-            apply(val);
-            EnvGuard(prev)
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            apply(self.0.as_deref());
-        }
-    }
-
-    fn apply(val: Option<&str>) {
-        match val {
-            Some(v) => std::env::set_var("AOE_MOUSE_CAPTURE", v),
-            None => std::env::remove_var("AOE_MOUSE_CAPTURE"),
-        }
-    }
 
     fn session_with(mouse_capture: bool) -> SessionConfig {
         SessionConfig {
@@ -453,14 +429,14 @@ mod mouse_capture_tests {
     #[test]
     #[serial]
     fn enabled_config_without_env_requests_capture() {
-        let _g = EnvGuard::set(None);
+        let _g = EnvGuard::unset(&["AOE_MOUSE_CAPTURE"]);
         assert!(mouse_capture_requested(&session_with(true)));
     }
 
     #[test]
     #[serial]
     fn disabled_config_opts_out_even_without_env() {
-        let _g = EnvGuard::set(None);
+        let _g = EnvGuard::unset(&["AOE_MOUSE_CAPTURE"]);
         assert!(!mouse_capture_requested(&session_with(false)));
     }
 
@@ -469,14 +445,14 @@ mod mouse_capture_tests {
     fn env_zero_still_wins_over_enabled_config() {
         // The pre-existing AOE_MOUSE_CAPTURE=0 escape hatch keeps working
         // even though the config defaults to enabled (#1346).
-        let _g = EnvGuard::set(Some("0"));
+        let _g = EnvGuard::set(&[("AOE_MOUSE_CAPTURE", "0")]);
         assert!(!mouse_capture_requested(&session_with(true)));
     }
 
     #[test]
     #[serial]
     fn env_true_does_not_re_enable_disabled_config() {
-        let _g = EnvGuard::set(Some("1"));
+        let _g = EnvGuard::set(&[("AOE_MOUSE_CAPTURE", "1")]);
         assert!(!mouse_capture_requested(&session_with(false)));
     }
 }

--- a/tests/filewatch_degradation.rs
+++ b/tests/filewatch_degradation.rs
@@ -22,14 +22,25 @@ const NEG_WAIT: Duration = Duration::from_millis(300);
 /// Set `AOE_FILE_WATCH` for the duration of the test, restoring the
 /// previous value on drop. Wraps the unsafe env mutation in a single
 /// place so the test body stays clear.
+///
+/// The crate's own `session::test_support::EnvGuard` is `pub(crate)` and
+/// so out of reach from this integration-test crate; the snapshot logic
+/// is duplicated here rather than widening that helper's visibility.
+///
+/// The snapshot is `Option<OsString>` read via [`std::env::var_os`], not
+/// `Option<String>` via `env::var(..).ok()`. `env::var` returns
+/// `Err(NotUnicode(_))` for a non-UTF-8 prior value, which `.ok()` would
+/// collapse to `None`, making `Drop` *remove* the var instead of
+/// restoring its bytes and leaking the removal into every later
+/// `#[serial]` test in this binary. See issue #2751.
 struct EnvGuard {
     key: &'static str,
-    prev: Option<String>,
+    prev: Option<std::ffi::OsString>,
 }
 
 impl EnvGuard {
     fn set(key: &'static str, value: &str) -> Self {
-        let prev = std::env::var(key).ok();
+        let prev = std::env::var_os(key);
         // SAFETY: 2024-edition `set_var` is unsafe because env is process
         // global and racy across threads. The `#[serial]` annotation
         // serialises this test against any other test that mutates env.

--- a/tests/integration/acp_silent_orphan.rs
+++ b/tests/integration/acp_silent_orphan.rs
@@ -36,15 +36,26 @@ use crate::common::{shim_path, shim_ready};
 /// env mutations leak across test order regardless; the guard keeps
 /// each test hermetic so adding or reordering cases can't break the
 /// next one. See #1401 and CodeRabbit feedback on PR #1364.
+///
+/// The crate's own `session::test_support::EnvGuard` is `pub(crate)` and
+/// so out of reach from this integration-test crate; the snapshot logic
+/// is duplicated here rather than widening that helper's visibility.
+///
+/// Snapshots are `Option<OsString>` read via [`std::env::var_os`], not
+/// `Option<String>` via `env::var(..).ok()`. `env::var` returns
+/// `Err(NotUnicode(_))` for a non-UTF-8 prior value, which `.ok()` would
+/// collapse to `None`, making `Drop` *remove* the var instead of
+/// restoring its bytes and leaking the removal into every later
+/// `#[serial]` test in this binary. See issue #2751.
 struct EnvGuard {
-    vars: Vec<(&'static str, Option<String>)>,
+    vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
 }
 
 impl EnvGuard {
     fn set(pairs: &[(&'static str, &'static str)]) -> Self {
         let vars: Vec<_> = pairs
             .iter()
-            .map(|(k, _)| (*k, std::env::var(k).ok()))
+            .map(|(k, _)| (*k, std::env::var_os(k)))
             .collect();
         for (k, v) in pairs {
             std::env::set_var(k, v);


### PR DESCRIPTION
## Description

The crate carried **nine** hand-written env-restoration guard structs across six files, all the same shape: snapshot the prior value, `set_var` the new one, restore-or-remove on `Drop`. Four of the `CodexHomeGuard` copies were byte-for-byte identical.

This replaces them with a single `EnvGuard` in `src/session/test_support.rs`:

```rust
let _guard = EnvGuard::set(&[("CODEX_HOME", tmp.path())]);
let _guard = EnvGuard::unset(&["CODEX_HOME"]);
```

Guards folded in (the 8 from #2716, plus one extra found on the way):

| Struct | Location |
| --- | --- |
| `StorageHomeGuard` | `src/session/sync.rs` |
| `VibeHomeGuard` / `GeminiHomeGuard` / `CodexHomeGuard` | `src/session/capture.rs` |
| `ClaudeHomeGuard` / `CodexHomeGuard` | `src/session/instance.rs` |
| `StorageHomeGuard` / `EnvVarGuard` (added by #2837) | `src/session/instance.rs` |
| `CodexHomeGuard` + a local `Option<String>` `EnvGuard` | `src/hooks/mod.rs` |
| `CodexHomeGuard` | `src/tui/dialogs/hooks_install.rs` |

The local `EnvGuard` in `src/hooks/mod.rs` was not in #2716's table; it collided by name with the new helper and carried the same pre-fix shape, so it is folded in here. It is one of the sites #2751's status comment flagged.

`AppDirGuard` keeps its `TempDir` ownership and `path()` accessor and delegates the env work to an inner `EnvGuard`. Its hand-written `Drop` is gone: field declaration order (`_env`, `path`, `_temp`) already sequences the env restore ahead of the tempdir's deletion, which is the invariant the old `Drop` enforced by hand. `HomeGuard` becomes an alias for `EnvGuard`.

The `restore_or_remove` SAFETY comment is re-scoped to match. It previously named `AppDirGuard` as the only constructor and grep-claimed that non-`#[serial]` tests do not read `HOME` / `XDG_CONFIG_HOME` / `XDG_DATA_HOME`. `EnvGuard` widened that to `CODEX_HOME` / `VIBE_HOME` / `GEMINI_CLI_HOME` / `CLAUDE_CONFIG_DIR` / `AOE_MOUSE_CAPTURE` plus any caller-chosen key, so no fixed grep list can bound which readers might race; the comment now states the `#[serial]` obligation on every call site as the load-bearing rule.

### Closes #2751: `Option<OsString>`, not `Option<String>`

Snapshots are typed `Option<OsString>` and read via `std::env::var_os`, never `env::var(...).ok()`. A non-UTF-8 prior value makes `env::var` return `Err(NotUnicode(_))`; the old `.ok()` snapshot collapsed that to `None`, so `Drop` called `remove_var` instead of restoring the original bytes, leaking the removal into every later `#[serial]` test in the same process.

Two smaller semantics that fall out of the consolidation and are now pinned by tests:

- **empty vs unset**: `var_os` returns `Some("")` for an empty value, so `Drop` restores it as empty rather than unsetting it.
- **duplicate keys**: `Drop` restores in reverse, so a key listed twice in one `set` call round-trips to its pre-guard value rather than to the intermediate write.

Behaviour and every `#[serial]` annotation are unchanged; this is test-support only, with no production-code changes.

### All 8 of #2751's sites are covered

#2751's status comment enumerates 8 leaking `Option<String>` guard sites. The consolidation above covers 2 of them (`src/session/sync.rs`, `src/hooks/mod.rs`); the second commit covers the remaining 6, so `Closes #2751` is accurate rather than aspirational.

| #2751 site | Treatment |
| --- | --- |
| `src/session/sync.rs` | folded into `EnvGuard` (consolidation commit) |
| `src/hooks/mod.rs` | folded into `EnvGuard` (consolidation commit) |
| `src/tui/mod.rs` | migrated to `EnvGuard` |
| `src/migrations/v015_rewrite_hook_strings.rs` | migrated to `EnvGuard` |
| `src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs` | migrated to `EnvGuard` |
| `src/migrations/v018_strip_codex_config_toml_hooks.rs` | migrated to `EnvGuard` |
| `tests/filewatch_degradation.rs` | fixed in place (`var_os`) |
| `tests/integration/acp_silent_orphan.rs` | fixed in place (`var_os`) |

**The `unset_all()`-shaped guards** (`v015` / `v017` / `v018`) were three byte-identical structs unsetting the same 5 keys. Each collapses to a local `unset_agent_home_env()` returning `EnvGuard::unset` over that key list, preserving the "unset these 5, restore on drop" semantics. The keys are distinct, so `EnvGuard`'s reverse-order restore is equivalent to the old forward-order loop. `src/tui/mod.rs`'s guard is a set-or-unset shape over `AOE_MOUSE_CAPTURE`: `set(None)` becomes `EnvGuard::unset`, `set(Some(v))` becomes `EnvGuard::set`.

**The two integration-test crates** are separate crates and cannot reach `pub(crate)` `test_support`. Rather than widen `EnvGuard` to `pub` purely to reach test code, or add a shared crate for two call sites, their guards are fixed in place: they now snapshot `Option<OsString>` via `env::var_os` and restore unset-as-unset. That resolves the #2751 bug at both sites without the consolidation, which is the part of #2751 that is actually a bug. Each carries a comment recording why it is duplicated rather than shared.

### Rebased onto #2837: its new guard is absorbed, not left behind

#2837 (per-tool verify-on-resume tests for the six live agents) merged to main
while this PR was open. It hand-rolled a **new** `StorageHomeGuard` in
`src/session/instance.rs` that snapshots `Option<String>` via `env::var`, which
is precisely the #2751 bug this PR closes. Rebasing produced no textual
conflict, so that guard would have survived silently and #2751 would have closed
with a fresh copy of its own bug in the tree. It is folded in here instead:

| #2837 site | Treatment |
| --- | --- |
| `StorageHomeGuard` (6 call sites) | replaced by `test_support::isolate_app_dir_at` |
| `EnvVarGuard` (7 call sites, pre-existing, `var_os`-based) | collapsed into `EnvGuard::set` |
| local `fn restore_or_remove(_, Option<String>)` | deleted with its last caller |

Notes on the absorption:

- **`XDG_DATA_HOME`**: `StorageHomeGuard` set only `HOME` and `XDG_CONFIG_HOME`;
  `isolate_app_dir_at` also sets `XDG_DATA_HOME`, which is the stricter
  isolation. All six tests pass with it: the opencode test resolves `OPENCODE_DB`
  before `XDG_DATA_HOME` (`capture.rs` checks the explicit override first), and
  the other five key off their own tool-specific home var, so none of them reads
  `XDG_DATA_HOME`.
- **Drop order preserved**: each test still declares its `TempDir` before the
  guard, so the guard drops first (env restore) and only then is the tempdir
  removed. `HOME` never points at a directory being deleted.
- **No test weakened**: all six tests (opencode, vibe, codex, gemini, pi, hermes)
  keep their assertions byte-for-byte; only the env-guard plumbing changed.
- **`#[serial]` unchanged**: `src/session/instance.rs` carries 78 annotations on
  both main and this branch, so all of #2837's are intact.

### Out of scope

- Inline `let old = env::var(..).ok(); ... restore` blocks in test bodies (`src/file_watch.rs`, `src/update/install.rs`, `src/acp/acp_client.rs`, `src/session/capture.rs`). These are not guard structs, are not in #2716's table, and are not in #2751's enumeration; they carry the same snapshot-type bug in miniature and are a clean follow-up.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Docs: the `test_support` module doc is rewritten to describe `EnvGuard` as the single entry point and to record the `var_os` rationale. No user-facing docs are affected.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Five new unit tests in `src/session/test_support.rs` cover the new helper:

- `env_guard_drop_restores_non_utf8_prior_value` (the #2751 acceptance test; `#[cfg(unix)]`, seeds `HOME` via `OsStr::from_bytes(b"/tmp/aoe-\xFF\xFE-home")`, asserts byte-identical restoration and asserts as a precondition that `env::var` really does error on it)
- `env_guard_drop_preserves_empty_versus_unset`
- `env_guard_unset_removes_then_restores`
- `env_guard_drop_restores_duplicate_key_to_pre_guard_value`
- plus the pre-existing `AppDirGuard` suite, which now exercises the delegated path

### How I tested

- `cargo fmt`: clean (no-op).
- `cargo clippy --lib --tests`: no warnings from any file in this diff. The three that remain (`src/session/config.rs`, `src/tui/home/mod.rs`, and the `inject_test_update` dead-code warning in `src/session/poller.rs`) are pre-existing on `main` and untouched here. `cargo clippy --features serve --test integration` is also clean, which is the run that actually compiles `tests/integration/acp_silent_orphan.rs` (it is gated behind `cfg(all(feature = "serve", debug_assertions))`).
- Scoped tests for the second commit, all green: `--lib test_support:: mouse_capture_tests::` (15 passed), `--lib migrations::v015 migrations::v017 migrations::v018` (31 passed), `--test filewatch_degradation` (1 passed), `--features serve --test integration -- acp_silent_orphan` (6 passed).
- Every `#[serial]` / `#[serial_test::serial(...)]` annotation is unchanged. Verified mechanically per-file against the base: the second commit's net delta across `src/` and `tests/` is 0. The only annotation change in the whole PR is the +4 from the consolidation commit's own new `EnvGuard` unit tests. Env mutation is process-global, so dropping one would reintroduce the #2600 race class.
- `cargo test --lib`: **3862 passed, 3 failed**. The 3 failures (`resume_intent_default_uses_observed`, `test_update_write_failure_emits_no_notify`, `restart_selected_session_surfaces_resume_failed_after_async_restart`) reproduce identically on a clean checkout of `origin/main` at `3f0ee18`, both in a full run and in isolation, so they are pre-existing and unrelated to this change. Worth a look independently of this PR.
- After rebasing onto #2837: `cargo fmt` clean, `cargo clippy --lib --tests` clean (same three pre-existing warnings, none from this diff). Re-ran the affected scopes green: `verify_on_resume` (17 passed, includes #2837's six), `test_support::` (18 passed), and `migrations::v015 v017 v018`, for 59 passed / 0 failed over the combined set.
- **Pre-existing flaky race found while verifying, not introduced here.** Running `--lib verify_on_resume migrations::v015 v017 v018` in one process makes `verify_on_resume::mtime_fallback_applies_without_sidecar` fail intermittently. The migration tests are `#[serial_test::serial(shell_env)]` (a named group) while the instance tests are plain `#[serial]` (the default group); serial_test does not serialise a named group against the default one, so the migration tests `remove_var("CLAUDE_CONFIG_DIR")` while the Claude test is mid-scan, and the scan then finds no fresher jsonl. It reproduces on a clean `origin/main` checkout at `faf5ce0e` (8 of 10 runs failed) and disappears entirely under `--test-threads=1` (3 of 3 clean), on main and on this branch alike. Out of scope here since fixing it means changing `#[serial]` groups, which this PR deliberately leaves untouched; worth its own issue.

- The `--features serve` matrix is left to CI; this diff is TUI/session test-support only and touches no serve-gated code.

Closes #2716
Closes #2751

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:**

Claude did the mechanical sweep across the six files and drafted the helper, its docs, and the new tests. The compiler caught missed call sites; the pre-existing-failure claim above was verified by re-running the three tests against a clean `origin/main`.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests / test utilities**
  * Consolidated nine duplicated, hand-written environment restoration guards into a single shared `EnvGuard` helper in `src/session/test_support.rs`, with new `EnvGuard::set` and `EnvGuard::unset` APIs.
  * Refactored test callers across hooks/session/tui and multiple migration test suites to use the shared helper and removed the local guard implementations they replaced.
* **Env snapshot correctness**
  * Updated environment snapshots to store `Option<OsString>` via `env::var_os`, preserving non-UTF-8 values and distinguishing empty values from unset variables.
  * Ensured scoped restoration is correct even when the same key is provided multiple times in a single `set` call (restores the pre-guard value).
  * Added/expanded tests covering non-UTF-8 round-tripping, empty-vs-unset behavior, unset round-tripping, and duplicate-key handling.
* **App dir / home isolation**
  * Updated `AppDirGuard` to delegate env handling to `EnvGuard` while retaining its temp directory ownership/lifetime behavior and `path()` accessor.
  * Simplified `HomeGuard` by making it an alias of `EnvGuard`.

* **Behavioral impact**
  * No production logic or user-facing behavior changes; the refactor is limited to test helpers and test behavior around env isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

