### PR TITLE
fix(config): repair rustdoc private intra-doc link breaking main

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2679,7 +2679,7 @@ impl AppStateConfig {
 
 /// Atomically read-modify-write `state.toml`.
 ///
-/// Delegates to [`storage::locked_update`](super::storage::locked_update), the
+/// Delegates to `storage::locked_update`, the
 /// same serialised read-modify-write primitive `sessions.json` / `groups.json`
 /// go through: under a cross-process `flock` on `state.toml`'s sidecar it loads
 /// a *fresh* [`AppStateConfig`], applies `f`, and writes `state.toml` back out.


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

**main is currently red.** `cargo doc --no-deps --features serve` fails, so the `Docs` job fails on main and on every open PR that merges with it.

`update_app_state`'s docstring links to `storage::locked_update`, which is `pub(crate)` (`src/session/storage.rs:196`). That trips the `deny(rustdoc::private_intra_doc_links)` gate adopted in #2842:

```
error: public documentation for `update_app_state` links to private item `super::storage::locked_update`
    --> src/session/config.rs:2682:45
error: could not document `agent-of-empires`
```

### How this got in, given both PRs were green

A timing collision rather than a mistake by either author:

| Time (UTC) | Commit | What |
|---|---|---|
| 13:57 | `44b8aaaa` (#2842) | Added `#![deny(rustdoc::private_intra_doc_links)]` and fixed every violation existing at that moment |
| 14:36 | `4a3bdb28` (#2821) | Added `update_app_state`, whose docstring links to the `pub(crate)` `locked_update` |

#2821 branched before the gate existed, so its own CI never evaluated the lint. Both PRs passed independently; main went red the moment both were in. This is the classic "one PR adds a lint, another adds a violation" merge race, which per-PR CI cannot catch by construction.

### The fix

Demote the link to a plain code span, which is how #2842 handled the identical situation elsewhere (for example `is_local_trusted` in `src/server/auth.rs`):

```diff
-/// Delegates to [`storage::locked_update`](super::storage::locked_update), the
+/// Delegates to `storage::locked_update`, the
```

The prose is unchanged; only the link markup goes away. The reader still sees the function name, and the link would not have resolved for public-docs readers anyway, which is the point of the lint.

Worth noting the underlying gap is not closed by this PR: nothing stops the same race from recurring. If that is a concern, a merge queue or a required up-to-date-with-main branch would be the structural fix. Happy to file a follow-up issue if wanted.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (this change is itself a docstring repair)
- [ ] For UI changes: included screenshot or recording (N/A, not a visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

No test accompanies this because the `Docs` CI job is the regression test: the `deny` gate added in #2842 fails the build on any recurrence. Verified by reproducing CI's exact command locally. On unmodified main, `RUSTDOCFLAGS="-D warnings" AOE_WEB_DIST=... cargo doc --no-deps --features serve` exits 101 with the error above; with this change it exits 0. `cargo fmt --check` is clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any Additional AI Details you'd like to share:** Found while reviewing #2839, whose `Docs` check was red for this inherited reason rather than anything in that PR. Root cause, the timeline reconstruction, and the local before/after reproduction were done by Claude under @njbrake's direction.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the `update_app_state` documentation reference to use a plain code span instead of a private Rustdoc link.
- Restored successful documentation builds without changing runtime behavior, APIs, or data structures.
- Verified with the documentation build and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->