### PR TITLE
fix(web): cap context menus with dvh so mobile Delete stays reachable

### DIFF
--- a/web/src/components/ProjectsSection.tsx
+++ b/web/src/components/ProjectsSection.tsx
@@ -263,7 +263,7 @@ const ProjectRow = memo(function ProjectRow({
             ref={menuRef}
             data-testid="sidebar-project-context-menu"
             className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[190px] overflow-y-auto"
-            style={{ left: contextMenu.x, top: contextMenu.y, maxHeight: "calc(100vh - 16px)" }}
+            style={{ left: contextMenu.x, top: contextMenu.y, maxHeight: "calc(100dvh - 16px)" }}
           >
             {project.registeredProjects.map((reg) => (
               <button

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -621,7 +621,7 @@ function TrashMenu({
             role="region"
             aria-label="Trash"
             data-testid="sidebar-trash-menu"
-            className="fixed z-40 flex max-h-[min(520px,calc(100vh-5rem))] flex-col overflow-hidden rounded-lg border border-surface-700/60 bg-surface-800 shadow-2xl animate-fade-in"
+            className="fixed z-40 flex max-h-[min(520px,calc(100dvh-5rem))] flex-col overflow-hidden rounded-lg border border-surface-700/60 bg-surface-800 shadow-2xl animate-fade-in"
             style={{ left: panelPosition.left, bottom: panelPosition.bottom, width: panelPosition.width }}
           >
             <div className="flex items-start justify-between gap-3 border-b border-surface-700/60 px-4 py-3">
@@ -1575,7 +1575,7 @@ export const SessionRow = memo(function SessionRow({
             style={{
               left: contextMenu.x,
               top: contextMenu.y,
-              maxHeight: "calc(100vh - 16px)",
+              maxHeight: "calc(100dvh - 16px)",
             }}
           >
             {contextMenu.scope.kind === "bulk" ? (
@@ -2516,7 +2516,7 @@ export const SidebarGroupHeader = memo(function SidebarGroupHeader({
             style={{
               left: contextMenu.x,
               top: contextMenu.y,
-              maxHeight: "calc(100vh - 16px)",
+              maxHeight: "calc(100dvh - 16px)",
             }}
           >
             {canPin && (

--- a/web/src/components/__tests__/ProjectsSection.test.tsx
+++ b/web/src/components/__tests__/ProjectsSection.test.tsx
@@ -94,6 +94,17 @@ describe("ProjectsSection", () => {
     expect(h.onRemoveProject).toHaveBeenCalledWith(expect.objectContaining({ repoPath: "/work/alpha" }));
   });
 
+  it("caps the context menu with the dynamic viewport so its tail scrolls on iOS (#2870)", () => {
+    renderSection();
+    fireEvent.contextMenu(screen.getByTestId("sidebar-project-row"));
+    const menu = screen.getByTestId("sidebar-project-context-menu");
+    // `100vh` overshoots iOS Safari's visible viewport (dynamic toolbar),
+    // so the menu would never exceed its own max-height and overflow-y-auto
+    // would never engage. `dvh` matches the visible viewport.
+    expect(menu.style.maxHeight).toContain("dvh");
+    expect(menu.className).toContain("overflow-y-auto");
+  });
+
   it("opens the context menu via Shift+F10 keyboard path", () => {
     const h = renderSection();
     const row = screen.getByTestId("sidebar-project-row");

--- a/web/tests/sidebar-context-menu-clamp.spec.ts
+++ b/web/tests/sidebar-context-menu-clamp.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./helpers/mockedTest";
-import { Page } from "@playwright/test";
+import { Page, Locator } from "@playwright/test";
 
 // Regression for #1601: the session-row and repo-group context menus
 // must clamp inside the viewport when opened near the bottom or right
@@ -66,6 +66,18 @@ async function menuFitsViewport(page: Page, locator: string) {
     .toBe(true);
 }
 
+async function expectDvhCap(menu: Locator) {
+  // Regression for #2870: the cap must use the dynamic viewport height.
+  // On iOS Safari `100vh` overshoots the visible viewport (dynamic
+  // toolbar), so a menu taller than the visible area never exceeds its
+  // own max-height and `overflow-y-auto` never engages, leaving Delete
+  // behind the toolbar with no way to scroll to it. `dvh` shrinks with
+  // the toolbar and matches the `window.innerHeight` the clamp measures.
+  const maxHeight = await menu.evaluate((el) => el.style.maxHeight);
+  expect(maxHeight).toContain("dvh");
+  await expect(menu).toHaveClass(/overflow-y-auto/);
+}
+
 test.describe("Sidebar context-menu viewport clamp (#1601)", () => {
   test("right-click on the bottom session row keeps the menu inside the viewport", async ({ page }) => {
     await mockApis(page, [
@@ -86,6 +98,7 @@ test.describe("Sidebar context-menu viewport clamp (#1601)", () => {
     const menu = page.locator("[data-testid='sidebar-context-menu']");
     await expect(menu).toBeVisible();
     await menuFitsViewport(page, "[data-testid='sidebar-context-menu']");
+    await expectDvhCap(menu);
   });
 
   test("right-click on a repo group header near the bottom clamps the menu", async ({ page }) => {
@@ -107,5 +120,6 @@ test.describe("Sidebar context-menu viewport clamp (#1601)", () => {
     const menu = page.locator("[data-testid='sidebar-group-context-menu']");
     await expect(menu).toBeVisible();
     await menuFitsViewport(page, "[data-testid='sidebar-group-context-menu']");
+    await expectDvhCap(menu);
   });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

On mobile (iPhone / iOS Safari), long-pressing a session row opened the context menu but its bottom items, including Delete, sat off-screen behind Safari's toolbar with no way to scroll to them.

Root cause: the sidebar session, repo-group, and project context menus (plus the pinned multi-select panel) capped their height with CSS `100vh`, while the viewport clamp (`useClampedMenuPosition`) measures `window.innerHeight`. On iOS Safari `100vh` is pinned to the largest viewport (dynamic toolbar hidden), so it overshoots the currently visible area. A menu taller than the visible viewport but shorter than `100vh - 16px` never exceeded its own `max-height`, so `overflow-y-auto` never produced a scrollbar and the tail landed behind the toolbar with nothing to scroll.

Fix: swap the caps to `100dvh`, which shrinks with the dynamic toolbar and matches the `window.innerHeight` the clamp already uses. `dvh` is already the established convention in this codebase (`web/src/index.css`, `web/src/App.tsx`, `web/src/components/LiveTerminalView.tsx`). The clamp algorithm itself was already correct; only the CSS cap was wrong.

Test note: headless Chromium cannot reproduce the iOS dynamic-toolbar gap (there `100vh == innerHeight`), so the regression guard asserts the CSS unit (`dvh`) and the presence of `overflow-y-auto`, which are the two conditions the fix depends on, rather than pixel behavior.

Closes #2870

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] On an iPhone (Safari), open the web dashboard with enough sessions to fill the sidebar; long-press a session row near the bottom and confirm the context menu scrolls and Delete is reachable.
- [ ] Repeat on a repo-group header (long-press) and on a project row context menu; confirm the menu scrolls to its last item.
- [ ] On desktop, right-click a session row near the bottom edge and confirm the menu still clamps inside the viewport (no #1601 regression).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

<!-- Extended web/tests/sidebar-context-menu-clamp.spec.ts (mapped by the existing sidebar.context-menu-clamp matrix entry) and web/src/components/__tests__/ProjectsSection.test.tsx to assert the dvh cap. No new matrix entry needed: both changed components already appear in coverage-matrix.json. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Updated mobile sidebar context menus (session and repo-group/project menus, plus the pinned/bulk multi-select menu) to cap their height using the dynamic viewport unit (`100dvh`) instead of `100vh`, so items at the bottom remain accessible on iOS Safari.
- Updated the sidebar “Trash” menu panel to use the same `100dvh`-based sizing.
- Ensured menus can scroll when their contents exceed the capped height (`overflow-y-auto`).
- Added regression coverage: a new ProjectsSection iOS-focused test and Playwright assertions that verify `dvh`-based max-height and scrollability.

### Benefits
- Prevents critical actions (like **Delete**) from being hidden behind the iOS Safari toolbar.
- Makes menu sizing more robust to mobile browser viewport changes (e.g., dynamic toolbars).

### Notes / follow-ups
- Touch behavior and the clamp algorithm itself remain unchanged/out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->