### PR TITLE
fix(sandbox): send container workdir on session/new for sandboxed agents

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4769,6 +4769,21 @@ fn is_mode_advertised(
     }
 }
 
+/// The `cwd` to send on `session/new` / `session/load` / `session/fork`.
+///
+/// A sandboxed agent runs inside the container (via `docker exec`), so it
+/// must be given the container workdir, not the host project path; the host
+/// path does not exist in the container and the agent rejects it with
+/// "'cwd' does not exist on the machine running the agent" (#2871). The
+/// container workdir is the create-time-pinned value resolved by
+/// `SessionSandbox::from_info`. Non-sandbox sessions keep the host `cwd`.
+fn agent_request_cwd(
+    container_workdir: Option<&std::path::Path>,
+    host_cwd: &std::path::Path,
+) -> PathBuf {
+    container_workdir.unwrap_or(host_cwd).to_path_buf()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_connection_task<W, R>(
     transport: ByteStreams<W, R>,
@@ -4840,6 +4855,15 @@ async fn run_connection_task<W, R>(
     let res_term_wait = resources.clone();
     let res_term_kill = resources.clone();
     let res_term_release = resources.clone();
+    // Sandboxed agents run in-container: the session/new|load|fork request
+    // must carry the container workdir, not the host path (#2871).
+    let agent_cwd = agent_request_cwd(
+        resources
+            .sandbox
+            .as_ref()
+            .map(|s| s.container_workdir.as_path()),
+        &cwd,
+    );
 
     // After a successful `session/load`, claude-agent-acp re-emits the
     // full prior transcript as `session/update` notifications (each
@@ -5464,7 +5488,7 @@ async fn run_connection_task<W, R>(
                             parent_acp_id = %parent,
                             "structured fork via session/fork"
                         );
-                        let req = ForkSessionRequest::new(parent.clone(), cwd.clone())
+                        let req = ForkSessionRequest::new(parent.clone(), agent_cwd.clone())
                             .mcp_servers(mcp_servers.clone());
                         match connection.send_request(req).block_task().await {
                             Ok(resp) => {
@@ -5601,7 +5625,7 @@ async fn run_connection_task<W, R>(
                             if !seed_history_replay {
                                 suppress_for_block.store(true, Ordering::Relaxed);
                             }
-                            let req = LoadSessionRequest::new(stored.clone(), cwd.clone())
+                            let req = LoadSessionRequest::new(stored.clone(), agent_cwd.clone())
                                 .mcp_servers(mcp_servers.clone());
                             match connection.send_request(req).block_task().await {
                                 Ok(resp) => {
@@ -5707,7 +5731,9 @@ async fn run_connection_task<W, R>(
                             "creating fresh session via session/new"
                         );
                         let new_session = connection
-                            .send_request(NewSessionRequest::new(cwd).mcp_servers(mcp_servers))
+                            .send_request(
+                                NewSessionRequest::new(agent_cwd.clone()).mcp_servers(mcp_servers),
+                            )
                             .block_task()
                             .await?;
                         let id = new_session.session_id.clone();
@@ -8866,6 +8892,29 @@ mod tests {
         )
         .unwrap();
         assert_eq!(computed, "/workspace/feature");
+    }
+
+    /// #2871: a sandboxed agent runs in-container, so session/new|load|fork
+    /// must carry the container workdir, not the host path (which does not
+    /// exist inside the container, worktree `..` or not). Non-sandbox
+    /// sessions keep the host cwd.
+    #[test]
+    fn agent_request_cwd_prefers_container_workdir_when_sandboxed() {
+        let host = PathBuf::from(
+            "/Users/nbrake/scm/agent-of-empires/../agent-of-empires-worktrees/bohemians",
+        );
+        let container = PathBuf::from("/workspace/bohemians");
+
+        assert_eq!(
+            agent_request_cwd(Some(container.as_path()), &host),
+            container,
+            "sandboxed request must use the container workdir"
+        );
+        assert_eq!(
+            agent_request_cwd(None, &host),
+            host,
+            "non-sandbox request must use the host cwd unchanged"
+        );
     }
 
     /// Sandboxed structured view spawn must wrap the agent command in


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Structured view failed to start for any session using a Docker sandbox. The agent (`claude-agent-acp`) runs inside the container via `docker exec -w <container_workdir>`, but the `session/new`, `session/load`, and `session/fork` requests carried the host project path as `cwd`. The agent validated that path against the container filesystem, where it does not exist, and refused to start with `'cwd' does not exist on the machine running the agent`.

A git worktree made the failure visible: the reported path showed the literal `..` from the worktree template (`.../agent-of-empires/../agent-of-empires-worktrees/bohemians`). But this is not a worktree bug. A plain-repo sandbox session failed the same way, because the host repo path also does not exist inside the container. Non-sandbox structured view worked fine.

The correct container path was already computed and pinned on the sandbox handle at create time (`SessionSandbox::container_workdir`, e.g. `/workspace/bohemians`); it was used for the `docker exec -w` wrap but never for the ACP session request. This threads that value into the request `cwd` when a sandbox is present, and keeps the host path for non-sandbox sessions and for host-side uses (fs roots, non-sandbox `current_dir`).

Closes #2871

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Create a structured-view session with a Docker sandbox enabled on a plain repo; confirm the agent starts (no "cwd does not exist" error badge).
- [ ] Create a structured-view sandbox session on a git worktree (host path contains `..`); confirm it starts cleanly.
- [ ] Create a non-sandbox structured-view session; confirm it still starts as before (host cwd unchanged).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the fix is the cwd-selection decision, covered by a Rust unit test (`agent_request_cwd_prefers_container_workdir_when_sandboxed` in `src/acp/acp_client.rs`). Driving a real Docker-sandboxed agent end to end needs Docker and is out of scope for the standard e2e run.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls, reviewed the commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated ACP client behavior for Docker-sandboxed structured-view sessions to use the sandbox container work directory (`cwd`) for `session/new`, `session/load`, and `session/fork` requests.
- Kept the existing host-path behavior for non-sandbox sessions and for host-side filesystem operations.
- Added a Rust unit test to ensure sandboxed requests select the container workdir, while non-sandbox requests continue to use the host `cwd`.

## Benefits

- Structured-view sessions in Docker sandboxes start more reliably.
- Plain repositories and git worktrees continue to work without changing behavior for non-sandbox workflows, including cases involving tricky host paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->