### PR TITLE
fix(profile): stop -p/--profile from lazily creating unknown profiles

### DIFF
--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -77,7 +77,7 @@ pub async fn run(profile: &str, command: GroupCommands) -> Result<()> {
 }
 
 async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, groups) = storage.load_with_groups()?;
 
     let group_tree = GroupTree::new_with_groups(&instances, &groups);
@@ -121,7 +121,7 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
 }
 
 async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     let name = args.name.trim().to_string();
     let group_path = if let Some(parent) = &args.parent {
@@ -145,7 +145,7 @@ async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
 }
 
 async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let name = args.name.trim().to_string();
     let force = args.force;
 
@@ -190,7 +190,7 @@ async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
 }
 
 async fn move_session(profile: &str, args: GroupMoveArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let identifier = args.identifier.trim().to_string();
     let group = args.group.trim().to_string();
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -135,7 +135,7 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
         return run_all_profiles(args.json).await;
     }
 
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _) = storage.load_with_groups()?;
 
     if instances.is_empty() {
@@ -175,7 +175,7 @@ async fn run_all_profiles(json: bool) -> Result<()> {
     if json {
         let mut all_sessions: Vec<SessionJson> = Vec::new();
         for profile_name in &profiles {
-            if let Ok(storage) = Storage::new_unwatched(profile_name) {
+            if let Ok(storage) = Storage::open_unwatched(profile_name) {
                 if let Ok((instances, _)) = storage.load_with_groups() {
                     for inst in &instances {
                         all_sessions.push(session_json(inst, profile_name));
@@ -189,7 +189,7 @@ async fn run_all_profiles(json: bool) -> Result<()> {
 
     let mut total_sessions = 0;
     for profile_name in &profiles {
-        if let Ok(storage) = Storage::new_unwatched(profile_name) {
+        if let Ok(storage) = Storage::open_unwatched(profile_name) {
             if let Ok((instances, _)) = storage.load_with_groups() {
                 if instances.is_empty() {
                     continue;

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -156,7 +156,7 @@ async fn show_profile_value(profile: &str, status_map: Option<&str>, json: bool)
     let Some(agent) = status_map else {
         bail!("nothing to show; pass --status-map <agent>");
     };
-    let effective_profile = session::config::effective_profile(profile);
+    let effective_profile = session::resolve_existing_profile(profile)?;
     let config = session::profile_config::resolve_config(&effective_profile)?;
     let map = crate::agents::effective_status_map(&config, agent)?;
 

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 use crate::session::projects;
-use crate::session::{Project, ProjectScope};
+use crate::session::{resolve_existing_profile, Project, ProjectScope};
 
 #[derive(Subcommand)]
 pub enum ProjectCommands {
@@ -120,6 +120,13 @@ fn resolve_default_scope(profile_explicit: bool) -> ProjectScope {
 }
 
 async fn list(profile: &str, args: ProjectListArgs) -> Result<()> {
+    // Global-only listing never touches profile-scoped storage, so it must
+    // not require a profile to exist (or resolve/bootstrap a default one).
+    let resolved_profile = match args.scope {
+        ScopeFilter::Global => None,
+        ScopeFilter::All | ScopeFilter::Profile => Some(resolve_existing_profile(profile)?),
+    };
+    let profile = resolved_profile.as_deref().unwrap_or(profile);
     let entries: Vec<Project> = match args.scope {
         ScopeFilter::All => projects::load_merged(profile)?,
         ScopeFilter::Global => projects::load_global()?,
@@ -168,6 +175,13 @@ async fn add(profile: &str, profile_explicit: bool, args: ProjectAddArgs) -> Res
         Some(ScopeArg::Profile) => ProjectScope::Profile,
         None => resolve_default_scope(profile_explicit),
     };
+    // Global-scope adds never touch profile-scoped storage, so they must
+    // not require a profile to exist.
+    let resolved_profile = match scope {
+        ProjectScope::Global => None,
+        ProjectScope::Profile => Some(resolve_existing_profile(profile)?),
+    };
+    let profile = resolved_profile.as_deref().unwrap_or(profile);
 
     let canonical = args
         .path
@@ -219,6 +233,13 @@ async fn remove(profile: &str, profile_explicit: bool, args: ProjectRemoveArgs) 
         Some(ScopeArg::Profile) => ProjectScope::Profile,
         None => resolve_default_scope(profile_explicit),
     };
+    // Global-scope removes never touch profile-scoped storage, so they must
+    // not require a profile to exist.
+    let resolved_profile = match scope {
+        ProjectScope::Global => None,
+        ProjectScope::Profile => Some(resolve_existing_profile(profile)?),
+    };
+    let profile = resolved_profile.as_deref().unwrap_or(profile);
     let removed = projects::remove(profile, scope, &args.name_or_path)?;
     println!(
         "✓ Removed project '{}' [{}] (was at {})",

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -64,7 +64,7 @@ fn should_delete_branch(
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): identify the target and run the slow deletion
     // side effects (worktree removal, branch deletion, container teardown,

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -22,7 +22,7 @@ pub struct SendArgs {
 
 #[tracing::instrument(target = "cli.send", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (mut instances, _) = storage.load_with_groups()?;
 
     if args.message.trim().is_empty() {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -338,7 +338,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
 }
 
 async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let title = storage.update(|instances, _groups| {
         super::patch_instance(instances, &args.identifier, |inst| {
             inst.favorite();
@@ -350,7 +350,7 @@ async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 }
 
 async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let title = storage.update(|instances, _groups| {
         super::patch_instance(instances, &args.identifier, |inst| {
             inst.unfavorite();
@@ -387,7 +387,7 @@ async fn set_color_session(profile: &str, args: SetColorArgs) -> Result<()> {
 }
 
 async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): resolve identifier.
     let (instances, _groups) = storage.load_with_groups()?;
@@ -426,7 +426,7 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
 }
 
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let title = storage.update(|instances, _groups| {
         super::patch_instance(instances, &args.identifier, |inst| {
             inst.unarchive();
@@ -438,7 +438,7 @@ async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 }
 
 async fn restore_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Resolve within the trashed subset only. The CLI advertises the argument
     // as an id OR title, and a live or archived session can share a title/path
@@ -525,7 +525,7 @@ fn release_restore_claim(storage: &Storage, restore_id: &str) {
 }
 
 async fn list_trash(profile: &str) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _groups) = storage.load_with_groups()?;
     let trashed: Vec<_> = instances.iter().filter(|i| i.is_trashed()).collect();
     if trashed.is_empty() {
@@ -544,7 +544,7 @@ async fn list_trash(profile: &str) -> Result<()> {
 }
 
 async fn empty_trash(profile: &str) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): snapshot the trashed sessions and run the slow
     // teardown for each. Purge is permanent; force removal so a dirty
@@ -709,7 +709,7 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     crate::session::validate_snooze_duration(raw_minutes).map_err(|e| anyhow::anyhow!("{}", e))?;
     let minutes = raw_minutes as u32;
 
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let title = storage.update(|instances, _groups| {
         super::patch_instance(instances, &args.identifier, |inst| {
             inst.snooze(minutes);
@@ -721,7 +721,7 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
 }
 
 async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let title = storage.update(|instances, _groups| {
         super::patch_instance(instances, &args.identifier, |inst| {
             inst.unsnooze();
@@ -733,7 +733,7 @@ async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 }
 
 async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): snapshot the target by identifier, rehydrate
     // `source_profile` so config resolution honors the right profile.
@@ -909,7 +909,7 @@ async fn import_sessions(profile: &str, args: ImportArgs) -> Result<()> {
         discovered.into_iter().partition(|s| s.cwd_exists);
 
     // Dedupe against sessions already imported into this profile.
-    let (existing, _groups) = Storage::new_unwatched(profile)?.load_with_groups()?;
+    let (existing, _groups) = Storage::open_unwatched(profile)?.load_with_groups()?;
     let candidate_count = candidates.len();
     let mut to_import: Vec<_> = candidates
         .into_iter()
@@ -974,7 +974,7 @@ async fn import_sessions(profile: &str, args: ImportArgs) -> Result<()> {
     }
 
     let group = args.group.clone().unwrap_or_default();
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let created_ids = storage.update(|all_instances, groups| {
         let mut ids = Vec::new();
         for s in &to_import {
@@ -1019,7 +1019,7 @@ async fn import_sessions(profile: &str, args: ImportArgs) -> Result<()> {
 /// `start_session`'s three-phase pattern; failures are reported per session and
 /// do not abort the rest.
 fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     for id in ids {
         let (instances, _groups) = storage.load_with_groups()?;
         let Some(inst) = instances.iter().find(|i| &i.id == id) else {
@@ -1051,7 +1051,7 @@ fn launch_imported(profile: &str, ids: &[String]) -> Result<()> {
 /// confirmed. The `warn!` for the Unknown case is emitted inside
 /// [`crate::session::Instance::stop`], so this call site does not re-warn.
 async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): resolve identifier, do tmux/container shutdown.
     // Loaded snapshot is read-only here; the persistence happens in phase 2.
@@ -1113,7 +1113,7 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
 }
 
 async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): snapshot the targets. We don't hold the flock
     // across the parallel restart fan-out below; phase 3 re-loads under
@@ -1285,7 +1285,7 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
 }
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): snapshot the target by identifier and
     // rehydrate `source_profile` for config resolution.
@@ -1401,7 +1401,7 @@ async fn wait_for_pane_ready(session_id: &str, title: &str, max_wait: std::time:
 }
 
 async fn attach_session(profile: &str, args: SessionIdArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _) = storage.load_with_groups()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;
@@ -1420,7 +1420,7 @@ async fn attach_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 }
 
 async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _) = storage.load_with_groups()?;
 
     let mut inst = if let Some(id) = &args.identifier {
@@ -1483,7 +1483,7 @@ async fn show_session(profile: &str, args: ShowArgs) -> Result<()> {
 }
 
 async fn capture_session(profile: &str, args: CaptureArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _) = storage.load_with_groups()?;
 
     let inst = if let Some(id) = &args.identifier {
@@ -1569,7 +1569,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         bail!("At least one of --title or --group must be specified");
     }
 
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
 
     // Phase 1 (unlocked): resolve the target id (auto-detect from tmux if
     // no identifier given) and the old/new title pair so we can do the
@@ -1741,7 +1741,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
 }
 
 async fn set_worktree_name(profile: &str, args: SetWorktreeNameArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _groups) = storage.load_with_groups()?;
     let inst = if let Some(id) = &args.identifier {
         super::resolve_session(id, &instances)?
@@ -1852,7 +1852,7 @@ async fn current_session(args: CurrentArgs) -> Result<()> {
     let profiles = crate::session::list_profiles()?;
 
     for profile_name in &profiles {
-        if let Ok(storage) = Storage::new_unwatched(profile_name) {
+        if let Ok(storage) = Storage::open_unwatched(profile_name) {
             if let Ok((instances, _)) = storage.load_with_groups() {
                 if let Some(inst) = instances.iter().find(|i| {
                     let tmux_name = crate::tmux::Session::generate_name(&i.id, &i.title);
@@ -1901,7 +1901,7 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         crate::session::ResumeIntent::Use(trimmed)
     };
 
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (title, tool) = storage.update(|instances, _groups| {
         super::patch_instance(instances, &args.identifier, |inst| {
             #[cfg(feature = "serve")]
@@ -1946,7 +1946,7 @@ async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
     if !args.clear && args.branch.is_none() {
         bail!("Provide a branch ref or pass --clear to remove the override.");
     }
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let instances = storage.load()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -43,7 +43,7 @@ struct StatusJson {
 
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: StatusArgs) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (mut instances, _) = storage.load_with_groups()?;
 
     if instances.is_empty() {

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -79,7 +79,7 @@ async fn list_worktrees() -> Result<()> {
 }
 
 async fn show_info(profile: &str, identifier: &str) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _) = storage.load_with_groups()?;
 
     let session = super::resolve_session(identifier, &instances)?;
@@ -154,7 +154,7 @@ async fn show_info(profile: &str, identifier: &str) -> Result<()> {
 }
 
 async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
-    let storage = Storage::new_unwatched(profile)?;
+    let storage = Storage::open_unwatched(profile)?;
     let (instances, _groups) = storage.load_with_groups()?;
 
     let mut orphaned_sessions = Vec::new();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -346,6 +346,28 @@ pub fn get_profile_dir_path(profile: &str) -> Result<PathBuf> {
     Ok(base.join("profiles").join(profile_name))
 }
 
+/// Resolve the effective profile name for a read/reference operation.
+///
+/// Never creates a profile directory. An empty `profile` resolves through
+/// [`config::resolve_default_profile`], including its bootstrap side effect
+/// on a genuine first run with zero profiles (that's intentional: AoE always
+/// needs somewhere to file sessions). An explicitly named profile, or a
+/// configured default whose directory has since been deleted, is an error
+/// rather than being silently revived on disk; only [`create_profile`] and
+/// the CLI's session-creation path are allowed to birth a profile directory.
+pub fn resolve_existing_profile(profile: &str) -> Result<String> {
+    let name = if profile.is_empty() {
+        config::resolve_default_profile()
+    } else {
+        profile.to_string()
+    };
+    let dir = get_profile_dir_path(&name)?;
+    if !dir.exists() {
+        anyhow::bail!("Profile '{name}' does not exist. Create it with: aoe profile create {name}");
+    }
+    Ok(name)
+}
+
 pub fn list_profiles() -> Result<Vec<String>> {
     // Test-only failure injection: when set, the next call returns
     // Err and the flag clears. Used by the file-watch regression test
@@ -1107,6 +1129,77 @@ mod tests {
         assert!(
             !unknown_dir.exists(),
             "load_profile_config must not create profiles/<unknown>/ as a side effect",
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_existing_profile_errors_on_unknown_name_without_creating_dir() {
+        // Core regression for the lazy-profile-creation bug: merely naming
+        // an unknown profile via -p must never leave a stub directory
+        // behind, whether the lookup succeeds or fails.
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        fs::create_dir_all(dir.join("profiles").join("real")).unwrap();
+        let unknown_dir = dir.join("profiles").join("ghost");
+        assert!(!unknown_dir.exists());
+
+        let err = resolve_existing_profile("ghost").expect_err("unknown profile must error");
+        let msg = err.to_string();
+        assert!(msg.contains("does not exist"), "unexpected message: {msg}");
+        assert!(
+            msg.contains("aoe profile create"),
+            "unexpected message: {msg}"
+        );
+        assert!(
+            !unknown_dir.exists(),
+            "resolve_existing_profile must not create profiles/<unknown>/ as a side effect",
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_existing_profile_succeeds_for_created_profile() {
+        let _temp = isolate_app_dir();
+        create_profile("newly-created").unwrap();
+
+        let resolved = resolve_existing_profile("newly-created").unwrap();
+        assert_eq!(resolved, "newly-created");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_existing_profile_empty_bootstraps_main_on_fresh_install() {
+        let _temp = isolate_app_dir();
+        assert!(list_profiles().unwrap().is_empty());
+
+        let resolved = resolve_existing_profile("").unwrap();
+        assert_eq!(resolved, "main");
+        assert_eq!(list_profiles().unwrap(), vec!["main".to_string()]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_existing_profile_empty_errors_on_stale_configured_default() {
+        // config.default_profile points at a name whose directory was
+        // deleted (or never existed). Resolving "" must not silently
+        // revive it on disk; it must error like any other unknown name.
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        fs::create_dir_all(dir.join("profiles").join("other")).unwrap();
+        fs::write(
+            dir.join("config.toml"),
+            r#"default_profile = "deleted-profile""#,
+        )
+        .unwrap();
+        let stale_dir = dir.join("profiles").join("deleted-profile");
+        assert!(!stale_dir.exists());
+
+        let err = resolve_existing_profile("").expect_err("stale default must error");
+        assert!(err.to_string().contains("does not exist"));
+        assert!(
+            !stale_dir.exists(),
+            "stale default_profile must not be silently revived on disk",
         );
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -361,6 +361,7 @@ pub fn resolve_existing_profile(profile: &str) -> Result<String> {
     } else {
         profile.to_string()
     };
+    validate_profile_name(&name)?;
     let dir = get_profile_dir_path(&name)?;
     if !dir.exists() {
         anyhow::bail!("Profile '{name}' does not exist. Create it with: aoe profile create {name}");
@@ -1200,6 +1201,27 @@ mod tests {
         assert!(
             !stale_dir.exists(),
             "stale default_profile must not be silently revived on disk",
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_existing_profile_rejects_path_traversal_name() {
+        // Security regression: an unvalidated name like "../etc" must not
+        // reach get_profile_dir_path and resolve to a path-traversal
+        // sibling directory that happens to exist.
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        fs::create_dir_all(dir.join("profiles").join("real")).unwrap();
+        // Sibling directory that a path-traversal name could resolve to:
+        // <app_dir>/profiles/../etc collapses to <app_dir>/etc.
+        fs::create_dir_all(dir.join("etc")).unwrap();
+
+        let err =
+            resolve_existing_profile("../etc").expect_err("path traversal name must be rejected");
+        assert!(
+            err.to_string().contains("path separators"),
+            "unexpected message: {err}"
         );
     }
 

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::warn;
 
-use super::{get_app_dir, get_profile_dir};
+use super::{get_app_dir, get_profile_dir_path};
 
 /// Distinct failure modes for registry mutations. The web layer maps these to
 /// HTTP status codes (Conflict → 409, NotFound → 404, Other → 500); CLI/TUI
@@ -144,7 +144,7 @@ fn global_path() -> Result<PathBuf> {
 }
 
 fn profile_path(profile: &str) -> Result<PathBuf> {
-    Ok(get_profile_dir(profile)?.join("projects.json"))
+    Ok(get_profile_dir_path(profile)?.join("projects.json"))
 }
 
 fn registry_path(profile: &str, scope: ProjectScope) -> Result<PathBuf> {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -75,7 +75,9 @@ use std::time::{Duration, Instant};
 
 use crate::file_watch::FileWatchService;
 
-use super::{get_app_dir, get_profile_dir, Group, Instance};
+use super::{
+    get_app_dir, get_profile_dir, get_profile_dir_path, resolve_existing_profile, Group, Instance,
+};
 
 /// Sidecar lock file name for per-profile storage. Lives next to
 /// `sessions.json` and `groups.json` and covers both: every code path that
@@ -417,6 +419,35 @@ impl Storage {
             save_lock: save_lock_for(profile),
             file_watch: FileWatchService::noop(),
         }
+    }
+
+    /// Construct a `Storage` for an existing profile, never creating it.
+    ///
+    /// Use this instead of [`Storage::new`] anywhere the caller is
+    /// referencing a profile rather than birthing one (every CLI read/write
+    /// path except the one that creates a brand-new session): resolving an
+    /// unknown `-p <name>` through `new`'s `get_profile_dir` silently
+    /// materializes an empty `profiles/<name>/` directory as a side effect
+    /// of the read.
+    pub fn open(profile: &str, file_watch: Arc<FileWatchService>) -> Result<Self> {
+        let profile_name = resolve_existing_profile(profile)?;
+        let profile_dir = get_profile_dir_path(&profile_name)?;
+        let sessions_path = profile_dir.join("sessions.json");
+        let save_lock = save_lock_for(&profile_name);
+
+        Ok(Self {
+            profile: profile_name,
+            sessions_path,
+            save_lock,
+            file_watch,
+        })
+    }
+
+    /// [`Storage::open`] wired to a noop `FileWatchService`. See
+    /// [`Storage::new_unwatched`] for why CLI subprocesses want the noop
+    /// watcher.
+    pub fn open_unwatched(profile: &str) -> Result<Self> {
+        Self::open(profile, FileWatchService::noop())
     }
 
     pub fn profile(&self) -> &str {
@@ -1050,6 +1081,37 @@ mod tests {
         assert_eq!(loaded[1].title, "test2");
 
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_open_unwatched_errors_on_unknown_profile_without_creating_dir() {
+        let temp = tempdir().unwrap();
+        let guard = setup_test_home(temp.path());
+        let profile_dir = guard.path().join("profiles").join("ghost");
+        assert!(!profile_dir.exists());
+
+        let result = Storage::open_unwatched("ghost");
+        let err = match result {
+            Ok(_) => panic!("unknown profile must error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("does not exist"), "got: {err}");
+        assert!(
+            !profile_dir.exists(),
+            "open_unwatched must not create profiles/<name>/ as a side effect",
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_open_unwatched_succeeds_for_created_profile() {
+        let temp = tempdir().unwrap();
+        let _guard = setup_test_home(temp.path());
+        crate::session::create_profile("known").unwrap();
+
+        let storage = Storage::open_unwatched("known").expect("known profile must open");
+        assert_eq!(storage.profile(), "known");
     }
 
     #[test]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -43,6 +43,7 @@ mod new_session;
 mod opencode_sandbox_resume;
 mod permission_response_e2e;
 mod plugins;
+mod profile_lazy_creation;
 mod profile_picker;
 mod project_registry;
 mod purge_restore_race;

--- a/tests/e2e/profile_lazy_creation.rs
+++ b/tests/e2e/profile_lazy_creation.rs
@@ -1,0 +1,64 @@
+//! Regression coverage for the lazy-profile-creation bug: naming an unknown
+//! profile via `-p`/`--profile` on a read-path command must error instead of
+//! silently birthing an empty `profiles/<name>/` directory. See
+//! `session::resolve_existing_profile`.
+
+use serial_test::serial;
+
+use crate::harness::{app_dir_in, TuiTestHarness};
+
+#[test]
+#[serial]
+fn test_list_with_unknown_profile_fails_without_creating_dir() {
+    let h = TuiTestHarness::new("profile_lazy_list_unknown");
+
+    let out = h.run_cli(&["list", "-p", "ghost-profile"]);
+    assert!(
+        !out.status.success(),
+        "aoe list -p <unknown profile> should fail"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does not exist") && stderr.contains("aoe profile create"),
+        "expected 'does not exist' + 'aoe profile create' guidance, got: {stderr}"
+    );
+
+    let ghost_dir = app_dir_in(h.home_path())
+        .join("profiles")
+        .join("ghost-profile");
+    assert!(
+        !ghost_dir.exists(),
+        "merely referencing an unknown profile must not create {}",
+        ghost_dir.display()
+    );
+}
+
+#[test]
+#[serial]
+fn test_profile_create_then_list_succeeds() {
+    let h = TuiTestHarness::new("profile_lazy_create_then_list");
+
+    let created = h.run_cli(&["profile", "create", "freshly-made"]);
+    assert!(
+        created.status.success(),
+        "aoe profile create should succeed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+
+    let profile_dir = app_dir_in(h.home_path())
+        .join("profiles")
+        .join("freshly-made");
+    assert!(
+        profile_dir.exists(),
+        "expected {} to exist after `aoe profile create`",
+        profile_dir.display()
+    );
+
+    let listed = h.run_cli(&["list", "-p", "freshly-made"]);
+    assert!(
+        listed.status.success(),
+        "aoe list -p <existing profile> should succeed: {}",
+        String::from_utf8_lossy(&listed.stderr)
+    );
+}


### PR DESCRIPTION
## Description
Passing `-p`/`--profile <name>` to any `aoe` CLI command — including read-only ones like `list`, `session show`, `session capture` — silently created a brand-new empty profile directory when the name didn't already exist. This let typos and e2e scenario names accumulate stray profile dirs, and let a stale `default_profile` value keep reviving itself on disk.

Added `session::resolve_existing_profile`, a non-creating resolver that errors clearly (`Profile '<name>' does not exist. Create it with: aoe profile create <name>`) instead of materializing a directory, plus `Storage::open`/`open_unwatched` built on it. Switched every CLI read/mutate path (`list`, `status`, `send`, `remove`, `worktree`, `group`, `session`, `project list/add/remove`, `profile show`) that isn't itself creating a profile over to the non-creating path. `aoe profile create` and the session-creation path in `aoe add` remain the only ways to birth a profile on disk; `project add` now also requires an existing profile when scoped to one, since it isn't a session-creating action either. Global-scoped `project` commands are untouched since they never read or write profile-scoped storage.

## PR Type
- [x] Bug Fix

## Checklist
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a — no user-facing docs describe the old behavior)
- [ ] For UI changes: included screenshot or recording (n/a, CLI-only)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (`tests/e2e/profile_lazy_creation.rs`: unknown `-p` name fails without creating a dir; `aoe profile create` then referencing that name succeeds)

## AI Usage
- [x] AI was used

**AI Model/Tool used:** anthropic/claude-sonnet-5 (via opencode, multi-agent plan/build pipeline)

**Any Additional AI Details you'd like to share:** Investigation, implementation, and test-writing were AI-driven under human direction; verification (cargo fmt/clippy/test, full e2e suite: 121 passed) was independently re-run and reviewed by the orchestrating agent before push.

- [ ] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `-p/--profile` so commands that *read* data no longer “lazy-create” an empty `profiles/<name>/` directory when the profile doesn’t exist.
- Added a non-creating profile resolver (`session::resolve_existing_profile`) that validates profile names (including blocking traversal-style names) before any filesystem access.
- Introduced new non-creating storage open paths (`Storage::open` / `Storage::open_unwatched`) that error clearly when the profile is missing, with instructions to run `aoe profile create`.
- Updated CLI flows to use the non-creating paths for read/mutation operations (across group, list, session, status, worktree, send, remove, etc.).
- Kept intentional profile-creation flows unchanged: `aoe profile create` and session creation via `aoe add` still create profiles as before.
- Adjusted profile-scoped `project` operations to require an existing profile, while global project operations remain unchanged.
- Added unit and end-to-end tests verifying:
  - unknown profiles fail without creating directories (and show the create-profile guidance)
  - explicitly created profiles succeed.

## Benefits

- Prevents clutter and accidental filesystem changes from typos or missing profiles.
- Makes “profile not found” failures more predictable and user-friendly.
- Improves safety by validating profile names before resolving paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->