### PR TITLE
fix(test): skip chmod write-failure injection when running as root

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -815,6 +815,14 @@ mod tests {
         isolate_app_dir_at(temp)
     }
 
+    /// True when the effective uid is 0. Root bypasses the Unix DAC permission
+    /// bits, so a test that injects a write failure by making a dir read-only
+    /// cannot make the write fail and must skip rather than assert `is_err()`.
+    #[cfg(unix)]
+    fn running_as_root() -> bool {
+        nix::unistd::geteuid().is_root()
+    }
+
     fn parse_u64(s: &str) -> Result<u64> {
         Ok(s.trim().parse::<u64>()?)
     }
@@ -1928,6 +1936,14 @@ mod tests {
     #[serial]
     async fn test_update_write_failure_emits_no_notify() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
+
+        if running_as_root() {
+            eprintln!(
+                "test_update_write_failure_emits_no_notify: skipping (running as root; \
+                 uid 0 bypasses the read-only dir bit, so the write cannot be made to fail)"
+            );
+            return Ok(());
+        }
 
         let temp = tempdir()?;
         let _guard = setup_test_home(temp.path());

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -63,6 +63,14 @@ pub fn shim_ready() -> Result<(), String> {
     Ok(())
 }
 
+/// True when the effective uid is 0. Root bypasses the Unix DAC permission
+/// bits, so a test that injects a write failure by making a dir read-only
+/// cannot make the write fail and must skip rather than assert `is_err()`.
+#[cfg(unix)]
+pub fn running_as_root() -> bool {
+    nix::unistd::geteuid().is_root()
+}
+
 /// Set `HOME` (and `XDG_CONFIG_HOME` on Linux/macOS) to a fresh temp dir so
 /// tests read and write to isolated state. Returns the guard; drop it to clean
 /// up.

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -10,6 +10,8 @@ use anyhow::Result;
 use serial_test::serial;
 use std::sync::{Arc, Barrier};
 
+#[cfg(unix)]
+use crate::common::running_as_root;
 use crate::common::setup_temp_home;
 
 #[test]
@@ -202,6 +204,17 @@ fn test_concurrent_per_field_updates_no_clobber() -> Result<()> {
 fn test_update_propagates_disk_write_failure() -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
+    // Root bypasses the Unix DAC permission bits, so the read-only dir below
+    // would not make the write fail and this regression guard would falsely
+    // fail. Skip cleanly rather than assert a failure that cannot be injected.
+    if running_as_root() {
+        eprintln!(
+            "test_update_propagates_disk_write_failure: skipping (running as root; \
+             uid 0 bypasses the read-only dir bit, so the write cannot be made to fail)"
+        );
+        return Ok(());
+    }
+
     let _temp = setup_temp_home();
 
     let storage = Storage::new_unwatched("default")?;
@@ -218,20 +231,6 @@ fn test_update_propagates_disk_write_failure() -> Result<()> {
     let mut readonly_perms = original_perms.clone();
     readonly_perms.set_mode(0o555);
     std::fs::set_permissions(&profile_dir, readonly_perms)?;
-
-    // Root bypasses 0o555 on most Unixes, so the disk write would succeed
-    // and this regression guard would falsely fail. Probe the lock before
-    // running the real assertion and skip cleanly when we can still write.
-    let probe = profile_dir.join(".perm_probe");
-    if std::fs::write(&probe, b"x").is_ok() {
-        let _ = std::fs::remove_file(&probe);
-        std::fs::set_permissions(&profile_dir, original_perms)?;
-        eprintln!(
-            "test_update_propagates_disk_write_failure: skipping \
-             (parent dir writable despite 0o555; likely running as root)"
-        );
-        return Ok(());
-    }
 
     let result: Result<()> = storage.update(|instances, _groups| {
         instances.clear();


### PR DESCRIPTION
## Description

Two tests inject a disk-write failure by making a profile dir read-only, then assert the subsequent write returns `Err`:

- `src/session/storage.rs` (`session::storage::tests::test_update_write_failure_emits_no_notify`): `set_mode(0o500)` then `assert!(update_res.is_err())`.
- `tests/integration/storage_concurrency.rs` (`test_update_propagates_disk_write_failure`): `set_mode(0o555)`, same pattern.

Root (uid 0) bypasses the Unix DAC permission bits, so the write succeeds and the `is_err()` assertion falsely fails. Anyone running `cargo test` as root (a common container setup, and a likely one for an agent orchestration tool) sees these as hard failures on a clean checkout of `main`. CI runs as a normal user, so the chmod actually bites there and `main` stays green, which is why this is invisible in CI.

**What/why:** a test that cannot inject the failure it is checking for should skip, not assert. This PR adds a small `running_as_root()` helper (euid == 0 via `nix::unistd::geteuid`, already a dependency) and short-circuits both sites with a clean `eprintln!` skip, matching the existing "Skipping: ..." convention used elsewhere in the suite. The concurrency test's earlier ad-hoc write-probe skip is replaced by the same up-front euid check so both sites read the same way.

I inspected the other `set_mode`-based tests (`src/hooks/dir_guard.rs` setuid/setgid/sticky/mode rejection tests); those assert that stat-based mode inspection rejects a bad dir, which root does not bypass, so they are left unchanged.

Fixes #2861

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This is a test-only fix; no product code changes.

### Test evidence (run as root, `id -u` = 0)

Before, on this branch's base:

```
test session::storage::tests::test_update_write_failure_emits_no_notify ... FAILED
thread '...' panicked at src/session/storage.rs:1990:9:
write failure must surface as Err
test result: FAILED. 0 passed; 1 failed
```

After:

```
test session::storage::tests::test_update_write_failure_emits_no_notify ... ok
test result: ok. 1 passed; 0 failed

test storage_concurrency::test_update_propagates_disk_write_failure ... ok
test result: ok. 1 passed; 0 failed
```

`cargo fmt` and `cargo clippy --tests` are clean for the touched files (the two remaining clippy/dead-code warnings are pre-existing and in files this PR does not touch).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated two write-failure tests to skip when running as root, where permission changes cannot reliably trigger failures.
- Added reusable Unix-only root detection helpers for unit and integration tests.
- Removed the concurrency test’s temporary write-probe logic.
- No production code changes.

## Benefits

- Prevents false test failures in root-based environments such as containers.
- Preserves existing behavior for normal users while keeping failure-path coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->