### PR TITLE
test: serialize env-var mutation with a process-global lock in EnvGuard

### DIFF
--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -883,6 +883,12 @@ mod tests {
 
     impl Drop for ReloadRegistryOnDrop {
         fn drop(&mut self) {
+            // Re-acquire the process-global env lock (released when the sibling
+            // `_env` field dropped just before this) so the registry reload
+            // reads a HOME/XDG that no peer test is concurrently mutating.
+            // `reload_registry` resolves the app dir from those vars, so an
+            // unlocked reload here could otherwise read a racing test's dirs.
+            let _lock = crate::session::test_support::EnvGuard::unset(&[]);
             crate::plugin::reload_registry();
         }
     }

--- a/src/server/api/plugins.rs
+++ b/src/server/api/plugins.rs
@@ -876,45 +876,42 @@ mod tests {
         assert_eq!(content_type_for_icon(std::path::Path::new("a")), None);
     }
 
+    /// Reloads the process-global plugin registry on Drop. Ordered as a field
+    /// AFTER `AppDirEnvGuard::_env` so it runs once the env has been restored
+    /// (matching the pre-consolidation Drop, which reloaded after restoring).
+    struct ReloadRegistryOnDrop;
+
+    impl Drop for ReloadRegistryOnDrop {
+        fn drop(&mut self) {
+            crate::plugin::reload_registry();
+        }
+    }
+
     struct AppDirEnvGuard {
+        // Field drop order is load-bearing: `_env` restores HOME / XDG /
+        // USERPROFILE (and releases the shared env lock) first, then
+        // `_reload` reloads the registry against the restored dirs, then
+        // `_temp` deletes the tempdir. `_env` also holds the process-global
+        // env lock for the guard's whole lifetime (issues #2864, #2600).
+        _env: crate::session::test_support::EnvGuard,
+        _reload: ReloadRegistryOnDrop,
         _temp: tempfile::TempDir,
-        xdg_config_home: Option<std::ffi::OsString>,
-        home: Option<std::ffi::OsString>,
-        userprofile: Option<std::ffi::OsString>,
     }
 
     impl AppDirEnvGuard {
         fn new() -> Self {
             let temp = tempfile::tempdir().expect("tempdir");
-            let guard = Self {
-                xdg_config_home: std::env::var_os("XDG_CONFIG_HOME"),
-                home: std::env::var_os("HOME"),
-                userprofile: std::env::var_os("USERPROFILE"),
+            let env = crate::session::test_support::EnvGuard::set(&[
+                ("XDG_CONFIG_HOME", temp.path().to_path_buf()),
+                ("HOME", temp.path().to_path_buf()),
+                ("USERPROFILE", temp.path().to_path_buf()),
+            ]);
+            crate::plugin::reload_registry();
+            Self {
+                _env: env,
+                _reload: ReloadRegistryOnDrop,
                 _temp: temp,
-            };
-            std::env::set_var("XDG_CONFIG_HOME", guard._temp.path());
-            std::env::set_var("HOME", guard._temp.path());
-            std::env::set_var("USERPROFILE", guard._temp.path());
-            crate::plugin::reload_registry();
-            guard
-        }
-    }
-
-    impl Drop for AppDirEnvGuard {
-        fn drop(&mut self) {
-            match self.xdg_config_home.take() {
-                Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
-                None => std::env::remove_var("XDG_CONFIG_HOME"),
             }
-            match self.home.take() {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-            match self.userprofile.take() {
-                Some(value) => std::env::set_var("USERPROFILE", value),
-                None => std::env::remove_var("USERPROFILE"),
-            }
-            crate::plugin::reload_registry();
         }
     }
 

--- a/src/session/idle_reap.rs
+++ b/src/session/idle_reap.rs
@@ -362,47 +362,18 @@ mod tests {
         assert!(idle_reap_candidates(&[inst], n, &attached, |_| 60).is_empty());
     }
 
-    /// Saves and restores `HOME` / `XDG_CONFIG_HOME` so a test that points the
-    /// app dir at a tempdir does not leak that into sibling tests sharing the
-    /// process.
-    struct EnvGuard {
-        home: Option<std::ffi::OsString>,
-        xdg: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn capture() -> Self {
-            Self {
-                home: std::env::var_os("HOME"),
-                xdg: std::env::var_os("XDG_CONFIG_HOME"),
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-            match &self.xdg {
-                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-                None => std::env::remove_var("XDG_CONFIG_HOME"),
-            }
-        }
-    }
-
     #[test]
     #[serial_test::serial]
     fn claim_is_single_shot_under_storage_lock() {
         // The double-reap guard: the first claim wins and flips the on-disk
         // status to Stopped; a second claim (the peer reaper) sees a non-Idle
         // session and returns None, so the session is never stopped twice.
-        let _env = EnvGuard::capture();
+        //
+        // `isolate_home` points HOME/XDG_CONFIG_HOME at the tempdir, restores
+        // them on Drop, and holds the process-global env lock for the guard's
+        // lifetime so a peer test cannot leak this tempdir HOME into itself.
         let temp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", temp.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        let _env = crate::session::test_support::isolate_home(temp.path());
 
         let inst = idle_instance("claimable");
         let id = inst.id.clone();

--- a/src/session/test_support.rs
+++ b/src/session/test_support.rs
@@ -41,9 +41,54 @@
 //! different mechanism (e.g. a stub for the profile-folder lookup)
 //! rather than more env vars in this snapshot set.
 
+use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
 use tempfile::TempDir;
+
+/// Process-global lock that serializes every env-var mutation routed
+/// through [`EnvGuard`] (and therefore [`AppDirGuard`], [`isolate_home`],
+/// and the per-module home helpers that delegate to them).
+///
+/// `serial_test` only serializes tests that share the *same* group key, so
+/// a `#[serial]` test and a `#[serial_test::serial(shell_env)]` test run
+/// concurrently and yank each other's env mid-test (issues #2864, #2600).
+/// Holding this mutex for the guard's whole lifetime makes the exclusion
+/// structural rather than annotation-dependent: two guards can never be
+/// live at once across threads regardless of their serial group (or
+/// whether they carry `#[serial]` at all). A guard user no longer relies
+/// on every author remembering the right annotation, which is precisely
+/// the discipline that broke.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+thread_local! {
+    /// True while *this* thread already owns [`ENV_LOCK`] through an outer
+    /// guard. A nested guard on the same thread must not try to re-lock the
+    /// non-reentrant `Mutex` (that would deadlock the thread against
+    /// itself); it inherits the outer guard's exclusion instead and
+    /// acquires nothing. Same-thread nesting is race-free by construction,
+    /// so skipping the re-lock loses no safety.
+    static ENV_LOCK_HELD: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Acquire [`ENV_LOCK`] unless this thread already holds it. Returns the
+/// owned guard (dropping it releases the lock and clears the thread-local)
+/// or `None` for a re-entrant acquisition that owns nothing.
+///
+/// Poisoning is recovered via [`PoisonError::into_inner`]: several tests
+/// deliberately panic while a guard is live (see the `catch_unwind` cases
+/// below), which poisons the lock on unwind. The protected data is `()`,
+/// so a poisoned lock carries no corrupt state and is safe to keep using.
+fn acquire_env_lock() -> Option<MutexGuard<'static, ()>> {
+    if ENV_LOCK_HELD.with(Cell::get) {
+        None
+    } else {
+        let guard = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        ENV_LOCK_HELD.with(|held| held.set(true));
+        Some(guard)
+    }
+}
 
 /// RAII guard: snapshots an arbitrary set of env vars, applies the
 /// requested mutation, and restores the prior state on `Drop`
@@ -67,6 +112,14 @@ use tempfile::TempDir;
 #[must_use = "EnvGuard restores env vars on Drop; bind it to `_guard`, not `_`, or the override ends on the same line and the test body runs against the caller's real env"]
 pub(crate) struct EnvGuard {
     prev: Vec<(&'static str, Option<OsString>)>,
+    // Held for the guard's whole lifetime so the mutation and the test body
+    // that reads it are linearized against every other guard in the process
+    // (see [`ENV_LOCK`]). `None` when this guard is a same-thread re-entrant
+    // acquisition that inherited an outer guard's lock. The custom `Drop::drop`
+    // below restores the env before any field drops, so the lock (dropped as a
+    // field afterward) is only released once this guard's mutation is gone; no
+    // peer guard ever observes a half-restored env.
+    _lock: Option<MutexGuard<'static, ()>>,
 }
 
 impl EnvGuard {
@@ -84,8 +137,12 @@ impl EnvGuard {
     /// entry are still restored: the guard is built incrementally, so
     /// the partially-populated value drops during the unwind.
     pub(crate) fn set<V: AsRef<OsStr>>(pairs: &[(&'static str, V)]) -> Self {
+        // Take the process-global env lock before touching any env slot, so
+        // the snapshot / mutate / restore sequence is exclusive against every
+        // other guard (see [`ENV_LOCK`]).
         let mut guard = Self {
             prev: Vec::with_capacity(pairs.len()),
+            _lock: acquire_env_lock(),
         };
         for (key, value) in pairs {
             guard.snapshot(key);
@@ -100,6 +157,7 @@ impl EnvGuard {
     pub(crate) fn unset(keys: &[&'static str]) -> Self {
         let mut guard = Self {
             prev: Vec::with_capacity(keys.len()),
+            _lock: acquire_env_lock(),
         };
         for key in keys {
             guard.snapshot(key);
@@ -122,6 +180,14 @@ impl Drop for EnvGuard {
         // second write observed.
         for (key, prev) in self.prev.drain(..).rev() {
             restore_or_remove(key, prev);
+        }
+        // Clear the re-entrancy flag only for the outermost guard (the one
+        // that actually owns the lock). The `_lock` field drops right after
+        // this body, releasing [`ENV_LOCK`]; resetting the flag here keeps a
+        // later guard on this same thread from mistaking the lock as still
+        // held once it is released.
+        if self._lock.is_some() {
+            ENV_LOCK_HELD.with(|held| held.set(false));
         }
     }
 }
@@ -191,21 +257,28 @@ fn restore_or_remove(key: &str, prev: Option<OsString>) {
     // this function mutates a process-global env slot. It is sound to
     // call as long as no other thread is concurrently reading or writing
     // the same env key. The invariant is enforced by:
-    //   1. `EnvGuard` (and `AppDirGuard`, which delegates to it) is only
-    //      constructed from `#[serial]`-annotated tests, so the whole
-    //      call sequence (snapshot -> set_var -> test body -> Drop ->
-    //      restore_or_remove) is linearized against every other
-    //      `#[serial]` test in the crate. This is the load-bearing rule:
-    //      unlike `AppDirGuard`'s fixed `HOME` / `XDG_CONFIG_HOME` /
-    //      `XDG_DATA_HOME` set, `EnvGuard` shims a caller-chosen key
-    //      (today also `CODEX_HOME`, `VIBE_HOME`, `GEMINI_CLI_HOME`,
+    //   1. Every `EnvGuard` (and `AppDirGuard`, which delegates to it)
+    //      holds [`ENV_LOCK`] for its whole lifetime, so the whole call
+    //      sequence (snapshot -> set_var -> test body -> Drop ->
+    //      restore_or_remove) is linearized against every other guard in
+    //      the process. This is structural, not annotation-dependent: it
+    //      no longer matters whether a call site carries `#[serial]` or a
+    //      matching `serial_test::serial(...)` group, because the mutex
+    //      excludes guards across every group (and across un-annotated
+    //      tests). `EnvGuard` shims a caller-chosen key (today also
+    //      `CODEX_HOME`, `VIBE_HOME`, `GEMINI_CLI_HOME`,
     //      `CLAUDE_CONFIG_DIR`, the sibling `*_CONFIG_DIR` overrides, and
     //      `AOE_MOUSE_CAPTURE`), so no fixed grep list can bound which
-    //      readers might race. Every new call site must carry `#[serial]`
-    //      (or a `serial_test::serial(...)` group covering its key).
+    //      readers might race; routing every env mutation through the
+    //      guard is what keeps that open set safe.
     //   2. The `#[tokio::test]` sites that use this helper all run on
     //      the default single-threaded runtime; no worker task reads env
     //      concurrently with the mutation.
+    //   3. Raw `std::env::set_var` calls that bypass the guard entirely
+    //      (a peer thread, a not-yet-migrated test) are outside this
+    //      lock and can still race; the guard only protects code that
+    //      goes through it. Prefer `EnvGuard` / `isolate_home` for any
+    //      new env mutation in tests.
     match prev {
         Some(v) => std::env::set_var(key, v),
         None => std::env::remove_var(key),

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -485,10 +485,11 @@ mod tests {
     #[serial_test::serial]
     fn test_codex_agent_shows_profile_codex_home_config_path() {
         let tmp = TempDir::new().unwrap();
+        // Both guards route through the shared env lock; the second is a
+        // same-thread re-entrant acquisition. `isolate_home` restores
+        // HOME/XDG on Drop (the old bare `set_var` leaked them).
         let _guard = EnvGuard::unset(&["CODEX_HOME"]);
-        std::env::set_var("HOME", tmp.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        let _home = crate::session::test_support::isolate_home(tmp.path());
 
         let codex_home = tmp.path().join("profile-codex-home");
         let profile_dir = crate::session::get_profile_dir("codex-profile").unwrap();

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1159,13 +1159,12 @@ fn test_profile_included_in_submit() {
 #[serial_test::serial]
 fn test_profile_switch_reloads_sandbox_env_without_session_override() {
     let temp_home = tempfile::tempdir().expect("temp home");
-    let old_home = std::env::var_os("HOME");
-    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
-    std::env::set_var("HOME", temp_home.path());
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
-    std::env::set_var("OLD_THING", "1");
-    std::env::set_var("NEW_THING", "2");
+    // Both guards route through the shared env lock (`isolate_home` owns it;
+    // the second is a same-thread re-entrant acquisition) and restore their
+    // keys on Drop, so nothing leaks into sibling tests.
+    let _home = crate::session::test_support::isolate_home(temp_home.path());
+    let _extra_env =
+        crate::session::test_support::EnvGuard::set(&[("OLD_THING", "1"), ("NEW_THING", "2")]);
 
     let app_dir = crate::session::get_app_dir().expect("app dir");
     let profiles_dir = app_dir.join("profiles");
@@ -1217,28 +1216,15 @@ environment = ["THING=$NEW_THING"]
         }
         _ => panic!("Expected Submit"),
     }
-
-    std::env::remove_var("OLD_THING");
-    std::env::remove_var("NEW_THING");
-    match old_home {
-        Some(v) => std::env::set_var("HOME", v),
-        None => std::env::remove_var("HOME"),
-    }
-    match old_xdg {
-        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-        None => std::env::remove_var("XDG_CONFIG_HOME"),
-    }
 }
 
 #[test]
 #[serial_test::serial]
 fn test_set_path_reloads_repo_sandbox_env_without_session_override() {
     let temp_home = tempfile::tempdir().expect("temp home");
-    let old_home = std::env::var_os("HOME");
-    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
-    std::env::set_var("HOME", temp_home.path());
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+    // `isolate_home` restores HOME/XDG on Drop and holds the shared env lock
+    // for the test body.
+    let _home = crate::session::test_support::isolate_home(temp_home.path());
 
     let app_dir = crate::session::get_app_dir().expect("app dir");
     let profiles_dir = app_dir.join("profiles");
@@ -1284,26 +1270,15 @@ environment = ["THING=$REPO_THING"]
         }
         _ => panic!("Expected Submit"),
     }
-
-    match old_home {
-        Some(v) => std::env::set_var("HOME", v),
-        None => std::env::remove_var("HOME"),
-    }
-    match old_xdg {
-        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-        None => std::env::remove_var("XDG_CONFIG_HOME"),
-    }
 }
 
 #[test]
 #[serial_test::serial]
 fn test_sandbox_config_refreshes_typed_path_repo_env_without_session_override() {
     let temp_home = tempfile::tempdir().expect("temp home");
-    let old_home = std::env::var_os("HOME");
-    let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
-    std::env::set_var("HOME", temp_home.path());
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+    // `isolate_home` restores HOME/XDG on Drop and holds the shared env lock
+    // for the test body.
+    let _home = crate::session::test_support::isolate_home(temp_home.path());
 
     let app_dir = crate::session::get_app_dir().expect("app dir");
     let profiles_dir = app_dir.join("profiles");
@@ -1352,15 +1327,6 @@ environment = ["THING=$REPO_THING"]
             );
         }
         _ => panic!("Expected Submit"),
-    }
-
-    match old_home {
-        Some(v) => std::env::set_var("HOME", v),
-        None => std::env::remove_var("HOME"),
-    }
-    match old_xdg {
-        Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-        None => std::env::remove_var("XDG_CONFIG_HOME"),
     }
 }
 

--- a/src/tui/dialogs/projects.rs
+++ b/src/tui/dialogs/projects.rs
@@ -522,10 +522,15 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
-    fn isolate_home(temp: &std::path::Path) {
-        std::env::set_var("HOME", temp);
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    /// Point HOME/XDG_CONFIG_HOME at `temp` for the test body. Returns the
+    /// shared [`crate::session::test_support::HomeGuard`], which restores the
+    /// prior env on Drop and holds the process-global env lock for its
+    /// lifetime; the caller MUST bind it (`let _home = ...`) so the override
+    /// outlives the body instead of the previous fire-and-forget `set_var`
+    /// that leaked the tempdir HOME into sibling tests. The returned
+    /// `HomeGuard` is itself `#[must_use]`, so binding is enforced.
+    fn isolate_home(temp: &std::path::Path) -> crate::session::test_support::HomeGuard {
+        crate::session::test_support::isolate_home(temp)
     }
 
     /// Drive the dialog through an add of `dir`: enter add mode, set the path
@@ -541,7 +546,7 @@ mod tests {
     #[serial]
     fn non_git_add_shows_notice_once_then_latches() {
         let temp = tempdir().unwrap();
-        isolate_home(temp.path());
+        let _home = isolate_home(temp.path());
 
         let mut dialog = ProjectsDialog::new("test");
 
@@ -577,7 +582,7 @@ mod tests {
     #[serial]
     fn malformed_state_toml_is_not_clobbered_on_non_git_add() {
         let temp = tempdir().unwrap();
-        isolate_home(temp.path());
+        let _home = isolate_home(temp.path());
 
         // First add sets the latch, creating a real state.toml.
         let mut dialog = ProjectsDialog::new("test");
@@ -612,7 +617,7 @@ mod tests {
     #[serial]
     fn git_add_shows_no_notice() {
         let temp = tempdir().unwrap();
-        isolate_home(temp.path());
+        let _home = isolate_home(temp.path());
 
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -357,33 +357,11 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn s_key_toggles_split_view() {
-        // Restore HOME/XDG on drop (even on panic) so later serial tests don't
-        // inherit a temp HOME pointing at a since-deleted directory.
-        struct EnvGuard {
-            home: Option<std::ffi::OsString>,
-            xdg: Option<std::ffi::OsString>,
-        }
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                match self.home.take() {
-                    Some(v) => std::env::set_var("HOME", v),
-                    None => std::env::remove_var("HOME"),
-                }
-                match self.xdg.take() {
-                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-                    None => std::env::remove_var("XDG_CONFIG_HOME"),
-                }
-            }
-        }
-        let _env = EnvGuard {
-            home: std::env::var_os("HOME"),
-            xdg: std::env::var_os("XDG_CONFIG_HOME"),
-        };
-
+        // `isolate_home` snapshots HOME/XDG_CONFIG_HOME and restores them on
+        // Drop (even on panic), and holds the process-global env lock for the
+        // guard's lifetime so no peer test yanks the env mid-body.
         let temp_home = tempfile::TempDir::new().unwrap();
-        std::env::set_var("HOME", temp_home.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        let _env = crate::session::test_support::isolate_home(temp_home.path());
 
         let mut view = make_diff_view_no_warning();
         let before = view.split_view;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -6332,10 +6332,11 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn volume_ignores_glob_confirm_message_fires_only_on_globs() {
+        // `isolate_home` restores HOME/XDG on Drop (the old bare `set_var`
+        // leaked the deleted tempdir into later tests) and holds the
+        // process-global env lock for the guard's lifetime.
         let temp_home = tempfile::TempDir::new().unwrap();
-        std::env::set_var("HOME", temp_home.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        let _home = crate::session::test_support::isolate_home(temp_home.path());
 
         let project = tempfile::TempDir::new().unwrap();
         std::fs::create_dir_all(project.path().join("src/App/bin")).unwrap();

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -893,14 +893,21 @@ mod dirty_tracking_tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    fn fresh_view() -> (TempDir, SettingsView) {
+    /// Returns the `HomeGuard` first so it drops before the `TempDir`:
+    /// the env is restored before the tempdir is deleted, and the guard
+    /// holds the process-global env lock for the whole test body. The old
+    /// bare `set_var` never restored HOME, leaking a since-deleted tempdir
+    /// HOME into later tests (the #2600 failure mode).
+    fn fresh_view() -> (
+        crate::session::test_support::HomeGuard,
+        TempDir,
+        SettingsView,
+    ) {
         let temp = TempDir::new().unwrap();
-        std::env::set_var("HOME", temp.path());
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
-        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        let home = crate::session::test_support::isolate_home(temp.path());
         let _ = Storage::new_unwatched("test").unwrap();
         let view = SettingsView::new("test", None).unwrap();
-        (temp, view)
+        (home, temp, view)
     }
 
     /// Editing a setting and then reverting it to the saved value must not
@@ -909,7 +916,7 @@ mod dirty_tracking_tests {
     #[test]
     #[serial]
     fn reverting_an_edit_clears_unsaved_changes() {
-        let (_temp, mut view) = fresh_view();
+        let (_home, _temp, mut view) = fresh_view();
         assert!(!view.has_changes, "a freshly loaded view is clean");
 
         let original = view.global_config.default_profile.clone();
@@ -931,7 +938,7 @@ mod dirty_tracking_tests {
     #[test]
     #[serial]
     fn save_resets_the_baseline() {
-        let (_temp, mut view) = fresh_view();
+        let (_home, _temp, mut view) = fresh_view();
         view.scope = SettingsScope::Profile;
 
         view.profile_config.description = Some("from-save".to_string());
@@ -958,7 +965,7 @@ mod dirty_tracking_tests {
     #[test]
     #[serial]
     fn global_save_preserves_concurrent_external_edit() {
-        let (_temp, mut view) = fresh_view();
+        let (_home, _temp, mut view) = fresh_view();
         view.scope = SettingsScope::Global;
 
         // The user edits one field in the pane.
@@ -990,7 +997,7 @@ mod dirty_tracking_tests {
     #[test]
     #[serial]
     fn global_save_with_no_edits_preserves_concurrent_external_edit() {
-        let (_temp, mut view) = fresh_view();
+        let (_home, _temp, mut view) = fresh_view();
         view.scope = SettingsScope::Global;
 
         crate::session::config::update_config(|c| {


### PR DESCRIPTION
## Description

Fixes #2864 and Fixes #2600. Both are the same root cause: tests mutate a process-global env var to isolate state, but `serial_test` only serializes tests that share the same group key. A `#[serial]` test and a `#[serial_test::serial(shell_env)]` test therefore run concurrently and yank each other's environment mid-test.

- #2864: the migration tests clear `CLAUDE_CONFIG_DIR` under the `shell_env` group while the `session::instance` mtime-fallback tests read it under the default `#[serial]` group.
- #2600: the `tui::home::file_watch_tests` mutate `HOME` / `XDG_CONFIG_HOME` under `#[serial]` while other guard callers do the same outside that group. Triage also found non-serial `EnvGuard::unset` callers in `hooks` that raced everything.

**What changed.** The fix makes the exclusion structural instead of annotation-dependent, which is the approach both issues recommend as the durable option. `EnvGuard` (and therefore `AppDirGuard`, `isolate_home`, and every per-module home helper that delegates to them) now takes a process-global `Mutex` and holds it for the guard's whole lifetime. Two guards can never be live at once across threads regardless of their serial group, or whether they carry `#[serial]` at all, so correctness no longer depends on every author remembering the right annotation (the discipline that broke). Details:

- A thread-local flag makes same-thread nesting re-entrant, so a nested guard inherits the outer guard's exclusion instead of deadlocking the non-reentrant mutex.
- Lock poisoning from tests that deliberately panic while a guard is live is recovered via `PoisonError::into_inner`; the protected data is `()`, so a poisoned lock carries no corrupt state.
- The stale `restore_or_remove` SAFETY comment that claimed `#[serial]` was load-bearing is rewritten to describe the new structural guarantee.

I also consolidated the hand-rolled and leaking env guards named in the #2600 triage onto the shared guard so they participate in the lock: `tui/diff/input.rs` and `session/idle_reap.rs` (duplicate `EnvGuard` structs), `tui/dialogs/projects.rs`, `tui/settings/mod.rs`, and `tui/home/input.rs` (bare `set_var` that never restored `HOME`, leaking a since-deleted tempdir into later tests), `tui/dialogs/new_session/tests.rs` (hand-rolled snapshot/restore), `tui/dialogs/hooks_install.rs`, and `server/api/plugins.rs` (`AppDirEnvGuard`).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (module and SAFETY doc comments in `test_support.rs`)
- [ ] For UI changes: included screenshot or recording (N/A, test-infra only)

## Test Coverage Analysis

This is a test-infrastructure change with no product-code behavior change, so no new product test is warranted; the existing race-prone tests are the coverage. Evidence that the races are gone:

- The documented tests (`resume_fallback::verify_on_resume` mtime writers for #2864, `tui::home::file_watch_tests` for #2600), `migrations`, and the previously non-serial `hooks` `EnvGuard` tests pass 20 out of 20 under parallel `cargo test` (161 tests per iteration, 0 failures). On main, #2864 documents an 8-out-of-10 failure rate for `mtime_fallback_applies_without_sidecar` under the same conditions.
- The refactored modules pass 252 out of 252.
- `cargo fmt` and `cargo clippy --features serve --tests` are clean on the touched files.

One caveat on local verification: running the whole suite as root inside a Claude environment surfaces pre-existing, unrelated failures that are out of scope here (the chmod-as-root write-failure injection of #2861, tmux server contention, and `resume_intent_default_uses_observed`, which reads the real `~/.claude` and fails deterministically single-threaded because this container already has a `~/.claude/projects/-tmp-x` transcript). None of these are concurrency races and none are touched by this change.

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause analysis, the lock design, the call-site consolidation, and the loop-based verification were done via Claude Code under human direction.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Made test-time environment changes (`HOME`, `XDG_CONFIG_HOME`, `USERPROFILE`, and related paths like `CLAUDE_CONFIG_DIR`) safe under parallel execution by using a shared process-wide lock for the full lifetime of each environment guard.
- Improved the environment guard behavior to support nested use in the same thread and to recover cleanly if the lock is poisoned.
- Consolidated and standardized environment isolation across the test suite by switching multiple tests to shared helpers (so setup/cleanup happens automatically and consistently), including dialogs, session idle/claim logic, TUI home/settings, and plugin-related reload tests.
- Updated plugin registry handling to stay in sync with environment restoration: added a drop-time guard that re-locks environment access and reloads the registry when the guard is torn down.
- Refined existing TUI test helpers so environment isolation can’t leak—callers now keep the returned guard alive for the duration of each test.

## Benefits

- Prevents flaky/racy tests caused by concurrent or overlapping process-global environment mutations.
- Removes the need to rely on fragile combinations of `serial_test`/`#[serial]` annotations to keep tests from interfering with each other.
- Makes future test changes safer by centralizing environment setup and cleanup.

## Potential follow-up

- Continue migrating any remaining tests that still mutate process-wide environment variables manually to the shared isolation helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->