### PR TITLE
fix(test): isolate HOME in resume_intent_default_uses_observed

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -8541,17 +8541,33 @@ mod tests {
         #[test]
         #[serial]
         fn resume_intent_default_uses_observed() {
+            // Isolate HOME and CLAUDE_CONFIG_DIR at an empty tempdir so
+            // `acquire_session_id`'s freshest-observation probe reads scratch
+            // state, never the caller's real `~/.claude`. Without this the
+            // probe scans `~/.claude/projects/-tmp-x`, and any live transcript
+            // there (present in a Claude dev environment) supersedes the stored
+            // sid, so the assertion below fails deterministically. Mirrors the
+            // `verify_on_resume` submodule's `claude_home_guard`.
+            let temp = tempdir().unwrap();
+            let mut pairs: Vec<(&'static str, std::path::PathBuf)> =
+                vec![("HOME", temp.path().to_path_buf())];
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            pairs.push(("XDG_CONFIG_HOME", temp.path().join(".config")));
+            pairs.push(("CLAUDE_CONFIG_DIR", temp.path().join(".claude")));
+            let _home = EnvGuard::set(&pairs);
+
             let mut inst = Instance::new("intent-default", "/tmp/x");
             inst.tool = "claude".to_string();
             inst.agent_session_id = Some("observed".to_string());
             inst.resume_intent = ResumeIntent::Default;
 
-            // Default intent returns the observed sid as the owned session. The
-            // is_existing flag is transcript-dependent for Claude (covered in
-            // `verify_on_resume`); asserting it here would read the real
-            // `~/.claude`.
-            let (sid, _is_existing) = inst.acquire_session_id();
+            // Default intent keeps the observed sid as the owned session. With
+            // the isolated home holding no transcript for it, the empty thread
+            // launches fresh-pinned (`is_existing = false`, `--session-id`)
+            // rather than a certain-to-fail `--resume`.
+            let (sid, is_existing) = inst.acquire_session_id();
             assert_eq!(sid.as_deref(), Some("observed"));
+            assert!(!is_existing);
         }
 
         #[test]


### PR DESCRIPTION
## Description

`session::instance::tests::resume_fallback::resume_intent_default_uses_observed` failed deterministically (5/5 single-threaded) in a Claude dev environment because it read live user home state.

The test drives `acquire_session_id` with `ResumeIntent::Default` and a stored `agent_session_id` for a Claude instance. That path reaches the freshest-observation probe (`capture_freshest_session_id`), which scans `~/.claude/projects/-tmp-x` on the real home. When that directory already holds a live transcript (routine in a Claude environment, and reproducible for any developer whose real `~/.claude` has matching state), the probe returns that sid instead of the stored `"observed"` one, so `assert_eq!(sid.as_deref(), Some("observed"))` fails. A unit test must never read live user home state.

The prior code sidestepped only part of the leak: it stopped asserting `is_existing` (whose value is transcript dependent) but still let `acquire_session_id` read the real `~/.claude`, so the `sid` value itself remained at the mercy of ambient state.

Fix: point `HOME`, `XDG_CONFIG_HOME`, and `CLAUDE_CONFIG_DIR` at an empty tempdir via the existing `EnvGuard` helper, mirroring the `verify_on_resume` submodule's `claude_home_guard`. The probe now reads scratch state and deterministically returns the stored sid. With no transcript on disk, the empty thread launches fresh pinned, so the test now also asserts `is_existing == false`, tightening the coverage the old comment had abandoned.

Surfaced while verifying #2878; it is a pre-existing test-isolation bug, not caused by that PR, and this fix is based off `origin/main` independently of it. No filed issue exists yet.

Scope: I grepped the whole `resume_fallback` module and the nearby `instance` acquire tests. This is the only test with the real `~/.claude` leak. The other acquire tests use `Use` / `Cleared` intents (early return before any disk read), pass `agent_session_id = None` (skip the probe), or already isolate via `claude_home_guard` / `isolate_app_dir_at` in the `verify_on_resume` submodule.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Before** (fresh transcript present under `~/.claude/projects/-tmp-x`):

```
test session::instance::tests::resume_fallback::resume_intent_default_uses_observed ... FAILED
assertion `left == right` failed
  left: Some("66666666-6666-6666-6666-666666666666")
 right: Some("observed")
```

**After** (same condition, transcripts freshly touched):

```
running 1 test
test session::instance::tests::resume_fallback::resume_intent_default_uses_observed ... ok
test result: ok. 1 passed; 0 failed
```

Full `resume_fallback` module, three parallel runs plus one single threaded, all `64 passed; 0 failed`. Target test run three more times single threaded, all pass. `cargo fmt` clean; `cargo clippy --tests` introduces no new warnings (the two remaining warnings are pre-existing and in untouched files: `src/session/poller.rs:300` and `src/tui/home/mod.rs:4866`).

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root cause traced and fix implemented via Claude Code; reasoning and decisions reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Isolated `resume_intent_default_uses_observed` from the developer’s local Claude configuration and transcripts.
- Added coverage confirming the stored session ID is used and marked as non-existing when no transcript is available.
- Improves test determinism and prevents environment-dependent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->