### PR TITLE
fix(tui): fall back to send-keys when VT socket write fails

### DIFF
--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -958,16 +958,34 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
     // bytes here using the pane's cursor-key mode (DECCKM) from the grid, since
     // we bypass tmux's own key translation. `Resize` is not pane input (it's
     // `resize-window`), so it still forks below.
+    //
+    // The invariant only forbids *concurrent* writers, not a sequential
+    // fallback. `try_send_input`'s `write_all` on a blocking `UnixStream` fails
+    // only on a broken pipe / EOF, never a transient WouldBlock, so `false`
+    // reliably means the forwarder already died between the `input_mode` check
+    // above and this write (a TOCTOU race), not that it's merely busy. At that
+    // point the socket has no live writer left, so forking `send-keys` for this
+    // one action is safe and delivers the keystroke instead of dropping it
+    // silently. An empty-bytes encoding (a key we can't represent while the
+    // channel is genuinely alive) still drops without forking: there is no
+    // failure to prove the writer is dead, so falling back here could race a
+    // still-live socket writer.
     #[cfg(unix)]
     if let Some(app_cursor) = crate::tmux::vt::input_mode(tmux_name) {
         if !matches!(action, TmuxAction::Resize { .. }) {
             let bytes = encode_action_bytes(action, app_cursor);
-            if !bytes.is_empty() {
-                let _ = crate::tmux::vt::try_send_input(tmux_name, &bytes);
+            if bytes.is_empty() {
+                return Ok(());
             }
-            // Single-writer: never fall back to a fork for pane input while
-            // armed, even if encoding produced nothing (drop the rare key).
-            return Ok(());
+            if crate::tmux::vt::try_send_input(tmux_name, &bytes) {
+                return Ok(());
+            }
+            tracing::warn!(
+                target: "tui.live_send",
+                action = ?action,
+                "vt socket write failed; falling back to send-keys fork",
+            );
+            // Fall through to the send-keys fork below.
         }
     }
 


### PR DESCRIPTION
## Description
In the TUI's "live" mode (raw tmux-pane passthrough to the agent's own CLI), keystrokes — including Escape — could be silently dropped, requiring a variable number of retries before they landed. Root cause: `dispatch_via_fork`'s VT-armed fast path discarded a failed socket write (`let _ = try_send_input(...)`) and unconditionally returned `Ok(())`, with zero logging, whenever the pipe-pane forwarder died between the `input_mode` liveness check and the write itself (a TOCTOU race). This fix logs a warning and falls back to the existing `send-keys` fork for that one action when the write is confirmed to have failed, since a failed write on a blocking socket is a terminal signal that the writer is dead (not merely busy) — falling back sequentially at that point doesn't violate the single-writer invariant, which only forbids concurrent writers. The empty-bytes case (unencodable key on a genuinely live channel) is unchanged.

## PR Type
- [x] Bug Fix

## Checklist
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the VT-armed branch of `dispatch_via_fork` has no existing test seam — it calls free functions in `src/tmux/vt.rs` requiring a live tmux pane and pipe-pane socket, and deterministically reaching the TOCTOU race would need a test hook in `vt.rs`, out of scope for this targeted fix (this branch is untested pre-existing code regardless).

## AI Usage
- [x] AI was used

**AI Model/Tool used:** anthropic/claude-sonnet-5

**Any Additional AI Details you'd like to share:** Root cause found via debug-log analysis (VT-channel arm/re-arm churn correlated with the drop window) plus source review; fix design reviewed for single-writer-invariant safety before implementation.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed a TUI live-mode issue that could silently drop keystrokes when the VT socket forwarder stopped unexpectedly.
- Added a warning and fallback to the existing `send-keys` path when socket delivery fails.
- Preserved the existing behavior for keys that cannot be encoded.
- Existing tests pass; an end-to-end test was not added because the affected flow requires a live tmux pane and socket.

## Benefit

Keystrokes are now delivered more reliably during VT live-mode failures, with clearer warning visibility and graceful recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->