### PR TITLE
feat(scheduling): cron-scheduled sessions across CLI, TUI, and web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "croner",
  "crossterm",
  "dirs",
  "flate2",
@@ -902,6 +903,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "croner"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "crossbeam-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ anyhow = "1.0"
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
+# Cron expression parsing for scheduled sessions (#2886)
+croner = "2"
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4"] }

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -43,6 +43,12 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe group create`↴](#aoe-group-create)
 * [`aoe group delete`↴](#aoe-group-delete)
 * [`aoe group move`↴](#aoe-group-move)
+* [`aoe schedule`↴](#aoe-schedule)
+* [`aoe schedule list`↴](#aoe-schedule-list)
+* [`aoe schedule add`↴](#aoe-schedule-add)
+* [`aoe schedule remove`↴](#aoe-schedule-remove)
+* [`aoe schedule enable`↴](#aoe-schedule-enable)
+* [`aoe schedule disable`↴](#aoe-schedule-disable)
 * [`aoe plugin`↴](#aoe-plugin)
 * [`aoe plugin list`↴](#aoe-plugin-list)
 * [`aoe plugin info`↴](#aoe-plugin-info)
@@ -132,6 +138,7 @@ Run without arguments to launch the TUI dashboard.
 * `killall` — Force-stop everything aoe is running: the serve daemon, all agent workers, and all aoe tmux sessions. Destructive and unprompted
 * `session` — Manage session lifecycle (start, stop, attach, etc.)
 * `group` — Manage groups for organizing sessions
+* `schedule` — Manage cron-scheduled sessions
 * `plugin` — Manage plugins (list, info, enable, disable, install, update, uninstall)
 * `profile` — Manage profiles (separate workspaces)
 * `project` — Manage the project registry used by multi-repo session pickers
@@ -742,6 +749,95 @@ Move session to group
 
 * `<IDENTIFIER>` — Session ID or title
 * `<GROUP>` — Target group
+
+
+
+## `aoe schedule`
+
+Manage cron-scheduled sessions
+
+**Usage:** `aoe schedule <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List scheduled jobs
+* `add` — Add a scheduled job
+* `remove` — Remove a scheduled job by id or name
+* `enable` — Enable a scheduled job by id or name
+* `disable` — Disable a scheduled job by id or name
+
+
+
+## `aoe schedule list`
+
+List scheduled jobs
+
+**Usage:** `aoe schedule list [OPTIONS]`
+
+###### **Options:**
+
+* `--json` — Emit JSON instead of a table
+
+
+
+## `aoe schedule add`
+
+Add a scheduled job
+
+**Usage:** `aoe schedule add [OPTIONS] --name <NAME> --cron <CRON> --prompt <PROMPT>`
+
+###### **Options:**
+
+* `--name <NAME>` — Display name for the job (also titles the spawned session)
+* `--cron <CRON>` — Cron expression, host-local time (e.g. "0 8 * * *" for 8am daily)
+* `--prompt <PROMPT>` — The prompt delivered to the session when it starts
+* `--tool <TOOL>` — Tool / built-in agent key
+
+  Default value: `claude`
+* `--agent <AGENT>` — Structured-view agent name, when different from the tool
+* `--model <MODEL>` — Model override
+* `--approval-mode <APPROVAL_MODE>` — ACP session-mode applied post-spawn (e.g. a read-only / plan mode) so the unattended run does not block on approvals. Omit to use the agent's default bypass mode
+* `--project <PROJECT>` — Project path to run in. Omit for a scratch (project-less) session
+* `--group <GROUP>` — Group the spawned session is filed under
+
+  Default value: `Scheduled`
+* `--disabled` — Add the job disabled (does not fire until enabled)
+
+
+
+## `aoe schedule remove`
+
+Remove a scheduled job by id or name
+
+**Usage:** `aoe schedule remove <TARGET>`
+
+###### **Arguments:**
+
+* `<TARGET>` — Job id or unique name
+
+
+
+## `aoe schedule enable`
+
+Enable a scheduled job by id or name
+
+**Usage:** `aoe schedule enable <TARGET>`
+
+###### **Arguments:**
+
+* `<TARGET>` — Job id or unique name
+
+
+
+## `aoe schedule disable`
+
+Disable a scheduled job by id or name
+
+**Usage:** `aoe schedule disable <TARGET>`
+
+###### **Arguments:**
+
+* `<TARGET>` — Job id or unique name
 
 
 

--- a/docs/guides/scheduled-sessions.md
+++ b/docs/guides/scheduled-sessions.md
@@ -1,0 +1,93 @@
+# Scheduled Sessions
+
+Scheduled sessions run a preset prompt against an agent on a cron schedule,
+unattended. A job says "at this time, spawn a session with this agent/model in
+this project and send it this prompt." Spawned sessions are filed under a
+`Scheduled` group so they do not muddle with your interactive ones.
+
+A common use is a daily check: every morning, spin up an agent to review open
+PRs, summarize what changed overnight, or run a triage prompt.
+
+## Requirements
+
+The `aoe serve` daemon must be running for jobs to fire; the scheduler lives in
+the daemon. If the daemon is stopped, nothing fires.
+
+Scheduling is available only for structured-view agents (the ones that run over
+ACP), since an unattended run has no terminal for you to type into.
+
+## Managing jobs from the CLI
+
+```sh
+# Add a job: 8am every day, Claude reviews open PRs in this repo.
+aoe schedule add \
+  --name "morning pr review" \
+  --cron "0 8 * * *" \
+  --tool claude \
+  --project /path/to/repo \
+  --prompt "Review open PRs. Flag anything ready to merge or with unanswered reviews."
+
+# List jobs (add --json for machine-readable output).
+aoe schedule list
+
+# Disable / enable without deleting.
+aoe schedule disable "morning pr review"
+aoe schedule enable "morning pr review"
+
+# Remove a job by name or id.
+aoe schedule remove "morning pr review"
+```
+
+Add flags:
+
+- `--name` label for the job; also titles the spawned session.
+- `--cron` a standard 5-field cron expression, `min hour day-of-month month day-of-week`.
+- `--prompt` the prompt delivered once the session starts.
+- `--tool` the agent to run (default `claude`).
+- `--agent`, `--model` optional agent-name and model overrides.
+- `--project` the project path to run in. Omit for a scratch (project-less) session.
+- `--approval-mode` the agent session mode applied so the run does not stall on
+  approvals (see below).
+- `--group` the group to file the session under (default `Scheduled`).
+- `--disabled` add the job without enabling it yet.
+
+Jobs are stored in the global config under `[scheduling]`, one `[[scheduling.jobs]]`
+table each. You can also manage them from the settings screen in the TUI and the
+web dashboard, which offer a picker for building the cron expression.
+
+## Cron syntax and timezone
+
+Expressions are standard 5-field cron, interpreted in the daemon host's local
+time. `0 8 * * *` is 8:00 every day; `*/15 * * * *` is every 15 minutes;
+`0 9 * * 1` is 9:00 every Monday. Moving the daemon to a machine in another
+timezone changes when a job fires; daylight-saving transitions are handled by
+the host clock.
+
+## Missed runs
+
+If the daemon is down when a job was due, that occurrence is skipped. The
+scheduler does not catch up on restart, so a machine that was asleep overnight
+does not fire a burst of backlogged sessions when it wakes. The next future
+match fires normally.
+
+## Unattended approvals
+
+An unattended run cannot answer an approval prompt, so a job applies an agent
+session mode when it starts. With no `--approval-mode`, the job uses the agent's
+default bypass ("yolo") mode so it can act without prompting. Set
+`--approval-mode` to a more restricted mode the agent advertises (for example a
+read-only or plan mode) when you want the scheduled run to act safely without
+full write access.
+
+## Trust
+
+A scheduled run against a repository whose lifecycle hooks have never been
+trusted is refused (the daemon logs it and skips the job), the same gate that
+protects interactive sessions. Trust the repo once via an interactive session
+first, or point the job at a project-less scratch session, before relying on it
+to fire.
+
+## Multiple profiles
+
+Each job records the profile that owns it, and only that profile's daemon fires
+it. Running daemons for several profiles will not double-fire a shared job.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -22,6 +22,7 @@ use super::plugin::PluginCommands;
 use super::profile::ProfileCommands;
 use super::project::ProjectCommands;
 use super::remove::RemoveArgs;
+use super::schedule::ScheduleCommands;
 use super::send::SendArgs;
 #[cfg(feature = "serve")]
 use super::serve::ServeArgs;
@@ -126,6 +127,12 @@ pub enum Commands {
     Group {
         #[command(subcommand)]
         command: GroupCommands,
+    },
+
+    /// Manage cron-scheduled sessions
+    Schedule {
+        #[command(subcommand)]
+        command: ScheduleCommands,
     },
 
     /// Manage plugins (list, info, enable, disable, install, update, uninstall)
@@ -297,6 +304,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Stop { .. } => return None,
         Commands::Session { .. } => "session",
         Commands::Group { .. } => "group",
+        Commands::Schedule { .. } => "schedule",
         Commands::Plugin { .. } => "plugin",
         Commands::Profile { .. } => "profile",
         Commands::Project { .. } => "project",

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -259,6 +259,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "killall",
     "session",
     "group",
+    "schedule",
     "plugin",
     "profile",
     "project",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,7 @@ pub mod plugin;
 pub mod profile;
 pub mod project;
 pub mod remove;
+pub mod schedule;
 pub mod send;
 #[cfg(feature = "serve")]
 pub mod serve;

--- a/src/cli/schedule.rs
+++ b/src/cli/schedule.rs
@@ -1,0 +1,241 @@
+//! `aoe schedule` CLI: manage cron-scheduled sessions (#2886).
+//!
+//! Jobs are stored in the global config `[scheduling]` section, each tagged with
+//! the profile that owns it so only that profile's daemon fires it. The daemon
+//! (`aoe serve`) must be running for jobs to actually fire.
+
+use anyhow::{bail, Result};
+use clap::{Args, Subcommand};
+
+use crate::session::config::update_config;
+use crate::session::schedule::{validate_cron, ScheduledJob, DEFAULT_SCHEDULE_GROUP};
+
+#[derive(Subcommand)]
+pub enum ScheduleCommands {
+    /// List scheduled jobs
+    #[command(alias = "ls")]
+    List(ScheduleListArgs),
+    /// Add a scheduled job
+    Add(ScheduleAddArgs),
+    /// Remove a scheduled job by id or name
+    #[command(alias = "rm")]
+    Remove(ScheduleTargetArgs),
+    /// Enable a scheduled job by id or name
+    Enable(ScheduleTargetArgs),
+    /// Disable a scheduled job by id or name
+    Disable(ScheduleTargetArgs),
+}
+
+#[derive(Args)]
+pub struct ScheduleListArgs {
+    /// Emit JSON instead of a table
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct ScheduleAddArgs {
+    /// Display name for the job (also titles the spawned session)
+    #[arg(long)]
+    pub name: String,
+
+    /// Cron expression, host-local time (e.g. "0 8 * * *" for 8am daily)
+    #[arg(long)]
+    pub cron: String,
+
+    /// The prompt delivered to the session when it starts
+    #[arg(long)]
+    pub prompt: String,
+
+    /// Tool / built-in agent key
+    #[arg(long, default_value = "claude")]
+    pub tool: String,
+
+    /// Structured-view agent name, when different from the tool
+    #[arg(long)]
+    pub agent: Option<String>,
+
+    /// Model override
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// ACP session-mode applied post-spawn (e.g. a read-only / plan mode) so the
+    /// unattended run does not block on approvals. Omit to use the agent's
+    /// default bypass mode.
+    #[arg(long)]
+    pub approval_mode: Option<String>,
+
+    /// Project path to run in. Omit for a scratch (project-less) session.
+    #[arg(long)]
+    pub project: Option<String>,
+
+    /// Group the spawned session is filed under
+    #[arg(long, default_value = DEFAULT_SCHEDULE_GROUP)]
+    pub group: String,
+
+    /// Add the job disabled (does not fire until enabled)
+    #[arg(long)]
+    pub disabled: bool,
+}
+
+#[derive(Args)]
+pub struct ScheduleTargetArgs {
+    /// Job id or unique name
+    pub target: String,
+}
+
+pub async fn run(profile: &str, command: ScheduleCommands) -> Result<()> {
+    match command {
+        ScheduleCommands::List(args) => list(profile, args),
+        ScheduleCommands::Add(args) => add(profile, args),
+        ScheduleCommands::Remove(args) => remove(args),
+        ScheduleCommands::Enable(args) => set_enabled(args, true),
+        ScheduleCommands::Disable(args) => set_enabled(args, false),
+    }
+}
+
+/// A job matches `target` when it equals the id exactly, or the name exactly and
+/// uniquely. Returns the index or an error explaining the miss/ambiguity.
+fn find_index(jobs: &[ScheduledJob], target: &str) -> Result<usize> {
+    if let Some(i) = jobs.iter().position(|j| j.id == target) {
+        return Ok(i);
+    }
+    let matches: Vec<usize> = jobs
+        .iter()
+        .enumerate()
+        .filter(|(_, j)| j.name == target)
+        .map(|(i, _)| i)
+        .collect();
+    match matches.as_slice() {
+        [] => bail!("no scheduled job with id or name '{target}'"),
+        [i] => Ok(*i),
+        _ => bail!("name '{target}' is ambiguous; remove/enable by id instead"),
+    }
+}
+
+fn add(profile: &str, args: ScheduleAddArgs) -> Result<()> {
+    validate_cron(&args.cron).map_err(|e| anyhow::anyhow!("invalid cron '{}': {e}", args.cron))?;
+
+    let job = ScheduledJob {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: args.name,
+        schedule: args.cron,
+        enabled: !args.disabled,
+        tool: args.tool,
+        agent: args.agent,
+        model: args.model,
+        approval_mode: args.approval_mode,
+        project: args.project,
+        prompt: args.prompt,
+        group: args.group,
+        owner_profile: profile.to_string(),
+    };
+    job.validate().map_err(|e| anyhow::anyhow!(e))?;
+    let id = job.id.clone();
+
+    update_config(|c| c.scheduling.jobs.push(job))?;
+    println!("Added scheduled job {id}");
+    println!("Note: the daemon (`aoe serve`) must be running for jobs to fire.");
+    Ok(())
+}
+
+fn remove(args: ScheduleTargetArgs) -> Result<()> {
+    let removed = update_config(|c| {
+        let i = find_index(&c.scheduling.jobs, &args.target)?;
+        Ok::<_, anyhow::Error>(c.scheduling.jobs.remove(i))
+    })??;
+    println!("Removed scheduled job {} ({})", removed.id, removed.name);
+    Ok(())
+}
+
+fn set_enabled(args: ScheduleTargetArgs, enabled: bool) -> Result<()> {
+    let (id, name) = update_config(|c| {
+        let i = find_index(&c.scheduling.jobs, &args.target)?;
+        c.scheduling.jobs[i].enabled = enabled;
+        Ok::<_, anyhow::Error>((
+            c.scheduling.jobs[i].id.clone(),
+            c.scheduling.jobs[i].name.clone(),
+        ))
+    })??;
+    println!(
+        "{} scheduled job {id} ({name})",
+        if enabled { "Enabled" } else { "Disabled" }
+    );
+    Ok(())
+}
+
+fn list(profile: &str, args: ScheduleListArgs) -> Result<()> {
+    let config = crate::session::config::Config::load()?;
+    let jobs = &config.scheduling.jobs;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(jobs)?);
+        return Ok(());
+    }
+
+    if jobs.is_empty() {
+        println!("No scheduled jobs. Add one with `aoe schedule add`.");
+        return Ok(());
+    }
+
+    for job in jobs {
+        let owner = if job.owner_profile.is_empty() || job.owner_profile == profile {
+            String::new()
+        } else {
+            format!("  [profile: {}]", job.owner_profile)
+        };
+        println!(
+            "{}  {}  {:>3}  {}  {}{}",
+            job.id,
+            if job.enabled { "on " } else { "off" },
+            job.tool,
+            job.schedule,
+            job.name,
+            owner,
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(id: &str, name: &str) -> ScheduledJob {
+        ScheduledJob {
+            id: id.to_string(),
+            name: name.to_string(),
+            schedule: "0 8 * * *".to_string(),
+            enabled: true,
+            tool: "claude".to_string(),
+            agent: None,
+            model: None,
+            approval_mode: None,
+            project: None,
+            prompt: "x".to_string(),
+            group: DEFAULT_SCHEDULE_GROUP.to_string(),
+            owner_profile: "default".to_string(),
+        }
+    }
+
+    #[test]
+    fn find_by_id_and_unique_name() {
+        let jobs = vec![job("id-a", "morning"), job("id-b", "evening")];
+        assert_eq!(find_index(&jobs, "id-a").unwrap(), 0);
+        assert_eq!(find_index(&jobs, "evening").unwrap(), 1);
+    }
+
+    #[test]
+    fn find_missing_errors() {
+        let jobs = vec![job("id-a", "morning")];
+        assert!(find_index(&jobs, "nope").is_err());
+    }
+
+    #[test]
+    fn find_ambiguous_name_errors() {
+        let jobs = vec![job("id-a", "dup"), job("id-b", "dup")];
+        assert!(find_index(&jobs, "dup").is_err());
+        // But the id is still unambiguous.
+        assert_eq!(find_index(&jobs, "id-b").unwrap(), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,7 @@ async fn main() -> Result<()> {
         Some(Commands::Killall(args)) => cli::killall::run(args).await,
         Some(Commands::Session { command }) => cli::session::run(&profile, command).await,
         Some(Commands::Group { command }) => cli::group::run(&profile, command).await,
+        Some(Commands::Schedule { command }) => cli::schedule::run(&profile, command).await,
         Some(Commands::Plugin { command }) => cli::plugin::run(command).await,
         Some(Commands::Profile { command }) => cli::profile::run(&profile, command).await,
         Some(Commands::Project { command }) => {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -19,7 +19,7 @@ mod log_level;
 mod mcp;
 pub mod plugins;
 mod projects;
-mod sessions;
+pub(crate) mod sessions;
 pub(crate) mod system;
 mod telemetry;
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4026,7 +4026,7 @@ fn validate_session_tool_identity(
 /// row, and inserts it first. A blind `push` would then leave two entries
 /// with the same id in `state.instances` until the next poll tick collapses
 /// them, and `GET /api/sessions` would briefly return the session twice.
-fn upsert_instance(
+pub(crate) fn upsert_instance(
     instances: &mut Vec<crate::session::Instance>,
     instance: crate::session::Instance,
 ) {
@@ -4072,7 +4072,7 @@ impl std::error::Error for HooksNeedTrust {}
 /// without leaving an orphan worktree; executed after the build once the
 /// session directory exists.
 #[derive(Debug)]
-struct CreateHookPlan {
+pub(crate) struct CreateHookPlan {
     /// Commands to run, already merged (repo overrides global/profile per type).
     on_create: Vec<String>,
     /// `(hooks_hash, mcp_hash)` to persist into `trusted_repos.toml` when the
@@ -4086,7 +4086,7 @@ struct CreateHookPlan {
 /// caller did not pass `trust_hooks: true`; the surrounding handler maps that to
 /// a structured `hooks_need_trust` response. Mirrors the CLI `--trust-hooks`
 /// path in `src/cli/add.rs`, adapted for the API's non-interactive context.
-fn resolve_create_hook_plan(
+pub(crate) fn resolve_create_hook_plan(
     profile: &str,
     project_path: &std::path::Path,
     scratch: bool,
@@ -4191,7 +4191,7 @@ fn resolve_create_hook_plan(
 /// streamed to a discarded channel so the shared streamed executor's
 /// terminal-detach (credential-prompt suppression) applies; failures surface
 /// through the returned `Result` with a captured output tail.
-fn run_create_hooks(
+pub(crate) fn run_create_hooks(
     instance: &mut Instance,
     plan: &CreateHookPlan,
     project_path: &std::path::Path,
@@ -4506,453 +4506,86 @@ pub async fn create_session(
     };
 
     let profile = body.profile.unwrap_or_else(|| state.profile.clone());
-    let instances = state.instances.read().await;
-    let existing_titles: Vec<String> = instances.iter().map(|i| i.title.clone()).collect();
-    let existing_branches: Vec<String> = instances
-        .iter()
-        .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.clone()))
-        .collect();
-    drop(instances);
 
-    let file_watch_for_create = state.file_watch.clone();
-
-    let result = tokio::task::spawn_blocking(move || {
-        use crate::session::builder::{self, InstanceParams};
-        use crate::session::Config;
-
-        let config = Config::load_or_warn();
-        let sandbox_image = body.sandbox_image.unwrap_or_else(|| {
-            if config.sandbox.default_image.is_empty() {
-                "ubuntu:latest".to_string()
-            } else {
-                config.sandbox.default_image.clone()
-            }
-        });
-
-        let title_refs: Vec<&str> = existing_titles.iter().map(|s| s.as_str()).collect();
-        let branch_refs: Vec<&str> = existing_branches.iter().map(|s| s.as_str()).collect();
-        let extra_repo_paths: Vec<String> = body
-            .extra_repo_paths
-            .into_iter()
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        // Resolve repo hook trust BEFORE building the worktree (#2066): a repo
-        // whose hooks need approval and that was not sent `trust_hooks: true`
-        // is refused here, so the handler never leaves an orphan worktree on
-        // disk. The original `path` is the trust anchor (the same source the
-        // CLI/TUI use); `check_repo_trust` resolves a worktree path to its main
-        // repo, so a worktree created from an already-trusted repo inherits its
-        // trust without a separate prompt.
-        let original_path = body.path.clone();
-        let hook_plan = resolve_create_hook_plan(
-            &profile,
-            std::path::Path::new(&original_path),
-            body.scratch,
-            body.trust_hooks.unwrap_or(false),
-        )?;
-
-        let title = body.title.unwrap_or_default();
-        let worktree_branch = body
-            .worktree_branch
-            .map(|b| b.trim().to_string())
-            .filter(|b| !b.is_empty());
-
-        let params = InstanceParams {
-            title,
-            path: body.path,
-            group: body.group,
-            tool: body.tool,
-            worktree_enabled,
-            worktree_branch,
-            create_new_branch: body.create_new_branch,
-            base_branch: if body.create_new_branch {
-                body.base_branch
-                    .as_ref()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-            } else {
-                None
-            },
-            sandbox: body.sandbox,
-            sandbox_image,
-            yolo_mode: body.yolo_mode,
-            extra_env: body.extra_env,
-            extra_args: body.extra_args,
-            command_override: body.command_override,
-            extra_repo_paths,
-            scratch: body.scratch,
-            #[cfg(feature = "serve")]
-            fork_seed,
-            #[cfg(not(feature = "serve"))]
-            fork_seed: None,
-        };
-
-        let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
-        let mut instance = build_result.instance;
-        instance.source_profile = profile.clone();
-        let build_warnings = build_result.warnings;
-        let created_worktree = build_result.created_worktree;
-        let created_workspace_worktrees = build_result.created_workspace_worktrees;
-
-        // Apply per-session sandbox overrides from the request body.
-        if let Some(ref mut sandbox) = instance.sandbox_info {
-            if body.custom_instruction.is_some() {
-                sandbox.custom_instruction = body.custom_instruction;
-            }
-        }
-
-        // Apply structured-view fields from the request body. structured_view is
-        // re-validated below against real ACP capability; non-ACP tools
-        // fall back to terminal view rather than erroring at spawn time.
+    let spec = crate::server::session_spawn::StructuredSessionSpec {
+        title: body.title,
+        path: body.path,
+        group: body.group,
+        tool: body.tool,
+        worktree_enabled,
+        worktree_branch: body.worktree_branch,
+        create_new_branch: body.create_new_branch,
+        base_branch: body.base_branch,
+        sandbox: body.sandbox,
+        sandbox_image: body.sandbox_image,
+        yolo_mode: body.yolo_mode,
+        extra_env: body.extra_env,
+        extra_args: body.extra_args,
+        command_override: body.command_override,
+        extra_repo_paths: body.extra_repo_paths,
+        scratch: body.scratch,
+        trust_hooks: body.trust_hooks,
+        custom_instruction: body.custom_instruction,
+        profile,
         #[cfg(feature = "serve")]
-        let agent_effort = {
-            instance.view = body.view;
-            // #2276: importing an existing Claude session forces the
-            // structured view and adopts the on-disk session id, so the
-            // structured spawn resumes it via session/load and seeds the
-            // transcript from the agent's history replay. `path` is the
-            // session's original cwd (the wizard prefills it).
-            if let Some(import_id) = body
-                .import_acp_session_id
-                .clone()
-                .filter(|s| !s.trim().is_empty())
-            {
-                instance.view = crate::session::View::Structured;
-                instance.acp_session_id = Some(import_id);
-                instance.import_pending = Some(true);
-            }
-            instance.agent_name = body.agent_name;
-            let agent_key = instance
-                .agent_name
-                .as_deref()
-                .filter(|s| !s.is_empty())
-                .unwrap_or(instance.tool.as_str())
-                .to_string();
-            let resolved_config = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                &instance.source_profile,
-                std::path::Path::new(&instance.project_path),
+        view: body.view,
+        #[cfg(feature = "serve")]
+        agent_name: body.agent_name,
+        #[cfg(feature = "serve")]
+        agent_model: body.agent_model,
+        #[cfg(feature = "serve")]
+        agent_effort: body.agent_effort,
+        #[cfg(feature = "serve")]
+        import_acp_session_id: body.import_acp_session_id,
+        #[cfg(feature = "serve")]
+        fork_seed,
+    };
+
+    match crate::server::session_spawn::spawn_structured_session(&state, spec).await {
+        Ok(outcome) => {
+            let instance = outcome.instance;
+            let mut resp = SessionResponse::from_instance(
+                &instance,
+                crate::claude_settings::read_tui_fullscreen(),
             );
-            let defaults = resolved_config.acp.acp_defaults_for(&agent_key);
-            // Preserve the explicit request model separately (trimmed to match
-            // the resolver's normalization) so a terminal fallback below can
-            // keep it while dropping any ACP-derived default; agent_model is
-            // ACP-only.
-            let explicit_model = body
-                .agent_model
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string);
-            // Explicit request wins, else the per-agent default; effort is keyed
-            // on the resolved model. Same single-source resolver the spawn path
-            // uses; persist the model here so the composer shows it and the
-            // session stays pinned to it. See resolve_spawn_model_effort.
-            let (resolved_model, mut agent_effort) =
-                crate::session::config::resolve_spawn_model_effort(
-                    defaults,
-                    explicit_model.clone(),
-                    body.agent_effort,
-                );
-            instance.agent_model = resolved_model;
-            // Don't trust the client's capability decision. Re-resolve
-            // whether this agent can actually run in structured view; a custom
-            // agent without an `agent_acp_cmd` (or any non-ACP tool)
-            // falls back to tmux here rather than erroring at spawn time.
-            if instance.is_structured() {
-                let acp_registry = crate::acp::AgentRegistry::with_defaults();
-                let resolved = instance
-                    .agent_name
-                    .as_deref()
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or(instance.tool.as_str());
-                let capable = acp_registry.get(resolved).is_some()
-                    || crate::session::repo_config::resolve_config_with_repo_or_warn(
+            resp.warnings = outcome.warnings;
+            // Carry the resolved tie value (#1927); list_sessions' overlay does
+            // not run on this create response, so a managed worktree would
+            // otherwise report untied until the next list refresh.
+            #[cfg(feature = "serve")]
+            {
+                if resp.has_managed_worktree {
+                    resp.tie_workdir_to_name =
+                        crate::session::profile_config::resolve_config_or_warn(
+                            &instance.source_profile,
+                        )
+                        .session
+                        .tie_workdir_to_name;
+                }
+                if !resp.acp_capable {
+                    let acp_cmd = crate::session::repo_config::resolve_config_with_repo_or_warn(
                         &instance.source_profile,
                         std::path::Path::new(&instance.project_path),
                     )
                     .session
-                    .agent_acp_cmd
-                    .get(&instance.tool)
-                    .is_some_and(|cmd| {
-                        crate::acp::AgentSpec::from_acp_cmd(&instance.tool, cmd).is_ok()
-                    });
-                if capable {
-                    instance.view = crate::session::View::Structured;
-                } else {
-                    instance.view = crate::session::View::Terminal;
-                    // A non-ACP tool cannot run the structured session/fork
-                    // handshake. If a malformed request seeded a structured
-                    // fork (fork_pending/import_pending set by the builder),
-                    // drop those markers so a later switch-to-structured does
-                    // not fire an unexpected session/fork against the parent.
-                    instance.fork_pending = None;
-                    instance.import_pending = None;
+                    .agent_acp_cmd;
+                    resp.acp_capable = custom_agent_acp_capable(&acp_cmd, &instance.tool);
                 }
             }
-
-            if !instance.is_structured() {
-                agent_effort = None;
-                // Terminal sessions keep only an explicitly requested model,
-                // never an ACP-derived default (agent_model is ACP-only).
-                instance.agent_model = explicit_model;
-            }
-
-            agent_effort
-        };
-
-        // Run on_create hooks now that the worktree exists, before the session
-        // is persisted or started (#2066). Mirrors the TUI/CLI ordering so the
-        // worktree is bootstrapped (`.env` copies, venv symlinks, DB seeds)
-        // before the agent launches. On failure, tear down the just-built
-        // worktree/container so a broken hook doesn't leave an orphan.
-        if let Err(e) = run_create_hooks(
-            &mut instance,
-            &hook_plan,
-            std::path::Path::new(&original_path),
-        ) {
-            builder::cleanup_instance(
-                &instance,
-                created_worktree.as_ref(),
-                &created_workspace_worktrees,
-            );
-            return Err(anyhow::anyhow!("on_create hook failed: {e:#}"));
+            (StatusCode::CREATED, Json(resp)).into_response()
         }
-
-        // Anything that fails between here and the final `Ok(..)`
-        // would otherwise orphan the scratch directory `build_instance`
-        // already provisioned (Storage::new, storage.update,
-        // instance.start). Wrap the tail in an IIFE-equivalent closure
-        // so we can run cleanup on Err once, regardless of which step
-        // tripped. Matches the CLI cleanup path in
-        // `cleanup_partial_session(... scratch_dir: Some(...))`.
-        let mut persist_and_start = || -> anyhow::Result<()> {
-            let storage = Storage::new(&profile, file_watch_for_create.clone())?;
-            let to_persist = instance.clone();
-            storage.update(|all, _groups| {
-                all.push(to_persist);
-                Ok(())
-            })?;
-
-            // Acp-mode sessions are not backed by tmux; the structured view
-            // supervisor spawns the ACP agent on demand. Skip the tmux
-            // `start()` to avoid creating an empty pane that no one will
-            // attach to.
-            #[cfg(feature = "serve")]
-            let skip_tmux_start = instance.is_structured();
-            #[cfg(not(feature = "serve"))]
-            let skip_tmux_start = false;
-            if !skip_tmux_start {
-                instance.start()?;
-            }
-            Ok(())
-        };
-
-        if let Err(e) = persist_and_start() {
-            // Guarded the same way as the deletion path: only remove a
-            // path that `is_scratch_path` blesses, so a corrupted
-            // `project_path` cannot trick us into wiping unrelated
-            // state.
-            if instance.scratch {
-                let scratch_path = std::path::PathBuf::from(&instance.project_path);
-                if crate::session::scratch::is_scratch_path(&scratch_path) {
-                    if let Err(rm_err) = std::fs::remove_dir_all(&scratch_path) {
-                        tracing::warn!(
-                            target: "http.api.sessions",
-                            "Failed to clean up orphan scratch dir {} after create failure: {}",
-                            scratch_path.display(),
-                            rm_err
-                        );
-                    }
-                }
-            }
-            return Err(e);
-        }
-
-        #[cfg(feature = "serve")]
-        return Ok::<(Instance, Vec<String>, Option<String>), anyhow::Error>((
-            instance,
-            build_warnings,
-            agent_effort,
-        ));
-
-        #[cfg(not(feature = "serve"))]
-        Ok::<(Instance, Vec<String>), anyhow::Error>((instance, build_warnings))
-    })
-    .await;
-
-    match result {
-        #[cfg(feature = "serve")]
-        Ok(Ok((instance, warnings, agent_effort))) => {
-            let mut resp = SessionResponse::from_instance(
-                &instance,
-                crate::claude_settings::read_tui_fullscreen(),
-            );
-            resp.warnings = warnings;
-            // Carry the resolved tie value (#1927); list_sessions' overlay does
-            // not run on this create response, so a managed worktree would
-            // otherwise report untied until the next list refresh.
-            if resp.has_managed_worktree {
-                resp.tie_workdir_to_name = crate::session::profile_config::resolve_config_or_warn(
-                    &instance.source_profile,
-                )
-                .session
-                .tie_workdir_to_name;
-            }
-            if !resp.acp_capable {
-                let acp_cmd = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                    &instance.source_profile,
-                    std::path::Path::new(&instance.project_path),
-                )
-                .session
-                .agent_acp_cmd;
-                resp.acp_capable = custom_agent_acp_capable(&acp_cmd, &instance.tool);
-            }
-            let acp_spawn_target = if instance.is_structured() {
-                Some((
-                    instance.id.clone(),
-                    instance.tool.clone(),
-                    instance.agent_name.clone(),
-                    instance.agent_model.clone(),
-                    agent_effort,
-                    instance.project_path.clone(),
-                    instance.acp_session_id.clone(),
-                    instance.source_profile.clone(),
-                    instance.yolo_mode,
-                    instance.command.clone(),
-                    instance.import_pending == Some(true),
-                    instance.fork_pending.clone(),
-                ))
-            } else {
-                None
-            };
-            let mut instances = state.instances.write().await;
-            upsert_instance(&mut instances, instance);
-            drop(instances);
-
-            // Count the create for the opt-in telemetry trend counter. Bounded
-            // accumulator, read-and-decremented by the snapshot loop; no-op for
-            // opted-out installs (the snapshot is never built / sent).
-            state
-                .telemetry_session_creates
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-            if let Some((
-                id,
-                tool,
-                agent_override,
-                model,
-                effort,
-                project_path,
-                stored_acp_session_id,
-                source_profile,
-                yolo_mode,
-                command,
-                seed_history_replay,
-                fork_from,
-            )) = acp_spawn_target
+        Err(e) => {
+            // A build-task panic keeps its 500; a plain build failure is a 400.
+            if let Some(panicked) =
+                e.downcast_ref::<crate::server::session_spawn::SessionBuildPanicked>()
             {
-                let agent = state
-                    .acp_supervisor
-                    .pick_agent_for_tool(
-                        &tool,
-                        agent_override.as_deref(),
-                        &source_profile,
-                        std::path::Path::new(&project_path),
-                    )
-                    .await;
-                let command_override =
-                    crate::server::acp_reconciler::command_override_for_spawn(&tool, &command);
-                let cwd = std::path::PathBuf::from(project_path);
-                let supervisor = state.acp_supervisor.clone();
-                let state_for_check = state.clone();
-                tokio::spawn(async move {
-                    let inst_lock = state_for_check.instance_lock(&id).await;
-                    let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
-                        &state_for_check.instances,
-                        &inst_lock,
-                        &id,
-                        true,
-                    )
-                    .await
-                    {
-                        Ok(info) => info,
-                        Err(e) => {
-                            let message = format!("sandbox container ensure failed: {e}");
-                            tracing::warn!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create failed: {message}"
-                            );
-                            supervisor.publish_startup_error(&id, message);
-                            return;
-                        }
-                    };
-                    let source_profile_for_spawn = Some(source_profile.clone());
-                    if let Err(e) = supervisor
-                        .spawn(crate::acp::supervisor::SpawnRequest {
-                            session_id: id.clone(),
-                            agent: agent.clone(),
-                            cwd,
-                            additional_dirs: vec![],
-                            provider_env: vec![],
-                            model,
-                            effort,
-                            stored_acp_session_id,
-                            fork_from,
-                            sandbox_info,
-                            source_profile: source_profile_for_spawn,
-                            yolo_mode,
-                            agent_command_override: command_override,
-                            seed_history_replay,
-                        })
-                        .await
-                    {
-                        let still_present = state_for_check
-                            .instances
-                            .read()
-                            .await
-                            .iter()
-                            .any(|i| i.id == id);
-                        // Capacity-aware banner selection (and the benign
-                        // first-tick duplicate) is documented on
-                        // `structured_spawn_error_message`.
-                        let message =
-                            crate::server::api::structured_spawn_error_message(&e, &agent);
-                        if still_present {
-                            tracing::warn!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create failed: {message}"
-                            );
-                            supervisor.publish_startup_error(&id, message);
-                        } else {
-                            tracing::debug!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create error after session removed (ignored): {message}"
-                            );
-                        }
-                    }
-                });
+                tracing::error!(target: "http.api.sessions", "Session creation panicked: {}", panicked.0);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+                )
+                    .into_response();
             }
-
-            (StatusCode::CREATED, Json(resp)).into_response()
-        }
-        #[cfg(not(feature = "serve"))]
-        Ok(Ok((instance, warnings))) => {
-            let mut resp = SessionResponse::from_instance(
-                &instance,
-                crate::claude_settings::read_tui_fullscreen(),
-            );
-            resp.warnings = warnings;
-            let mut instances = state.instances.write().await;
-            instances.push(instance);
-            drop(instances);
-
-            (StatusCode::CREATED, Json(resp)).into_response()
-        }
-        Ok(Err(e)) => {
             // A repo whose hooks need approval gets a distinct, structured
             // response so the caller can surface the commands and resubmit with
             // `trust_hooks: true` (#2066), rather than the opaque create_failed.
@@ -4974,14 +4607,6 @@ pub async fn create_session(
             (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({"error": "create_failed", "message": public_create_session_error(&e)})),
-            )
-                .into_response()
-        }
-        Err(e) => {
-            tracing::error!(target: "http.api.sessions", "Session creation panicked: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
             )
                 .into_response()
         }

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -244,11 +244,14 @@ pub async fn update_settings(
     // (`plugins.<id>.settings.*`) before the generic merge.
     rewrite_plugin_sections(&mut body);
 
-    // Scheduled jobs: stamp the owning profile onto any job that arrived without
-    // one (the web widget cannot know the serving profile) and validate the set
-    // server-side. The generic merge does not re-check cron, so without this a
-    // malformed job would persist and then silently never fire; reject it with a
-    // 400 instead.
+    // Scheduled jobs (#2886). Jobs live in one global list keyed by owning
+    // profile, but this PATCH is served by a single profile's daemon, so it may
+    // only manage its own jobs. Rebuild the list as every other profile's jobs
+    // preserved exactly as stored, plus the incoming jobs this profile owns (an
+    // empty owner is stamped to the serving profile; a job claiming a different
+    // owner is dropped, so a client on profile A cannot write or spoof profile
+    // B's jobs). Then validate the full set server-side, since the generic merge
+    // does not re-check cron and a malformed job would persist yet never fire.
     if let Some(jobs_val) = body
         .get_mut("scheduling")
         .and_then(|s| s.get_mut("jobs"))
@@ -257,12 +260,27 @@ pub async fn update_settings(
         match serde_json::from_value::<Vec<crate::session::schedule::ScheduledJob>>(
             jobs_val.clone(),
         ) {
-            Ok(mut jobs) => {
-                for j in &mut jobs {
-                    if j.owner_profile.trim().is_empty() {
-                        j.owner_profile = state.profile.clone();
-                    }
-                }
+            Ok(incoming) => {
+                let profile = state.profile.clone();
+                let mut own: Vec<crate::session::schedule::ScheduledJob> = incoming
+                    .into_iter()
+                    .filter_map(|mut j| {
+                        if j.owner_profile.trim().is_empty() {
+                            j.owner_profile = profile.clone();
+                        }
+                        (j.owner_profile == profile).then_some(j)
+                    })
+                    .collect();
+                let mut jobs: Vec<crate::session::schedule::ScheduledJob> =
+                    crate::session::Config::load()
+                        .map(|c| c.scheduling.jobs)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|j| {
+                            !j.owner_profile.trim().is_empty() && j.owner_profile != profile
+                        })
+                        .collect();
+                jobs.append(&mut own);
                 let cfg = crate::session::schedule::SchedulingConfig { jobs };
                 if let Err(e) = cfg.validate() {
                     return (

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -244,6 +244,49 @@ pub async fn update_settings(
     // (`plugins.<id>.settings.*`) before the generic merge.
     rewrite_plugin_sections(&mut body);
 
+    // Scheduled jobs: stamp the owning profile onto any job that arrived without
+    // one (the web widget cannot know the serving profile) and validate the set
+    // server-side. The generic merge does not re-check cron, so without this a
+    // malformed job would persist and then silently never fire; reject it with a
+    // 400 instead.
+    if let Some(jobs_val) = body
+        .get_mut("scheduling")
+        .and_then(|s| s.get_mut("jobs"))
+        .filter(|v| v.is_array())
+    {
+        match serde_json::from_value::<Vec<crate::session::schedule::ScheduledJob>>(
+            jobs_val.clone(),
+        ) {
+            Ok(mut jobs) => {
+                for j in &mut jobs {
+                    if j.owner_profile.trim().is_empty() {
+                        j.owner_profile = state.profile.clone();
+                    }
+                }
+                let cfg = crate::session::schedule::SchedulingConfig { jobs };
+                if let Err(e) = cfg.validate() {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({"error": "invalid_scheduling", "message": e})),
+                    )
+                        .into_response();
+                }
+                if let Ok(v) = serde_json::to_value(&cfg.jobs) {
+                    *jobs_val = v;
+                }
+            }
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(
+                        serde_json::json!({"error": "invalid_scheduling", "message": format!("{e}")}),
+                    ),
+                )
+                    .into_response();
+            }
+        }
+    }
+
     let result = tokio::task::spawn_blocking(move || {
         crate::session::update_config(|config| -> anyhow::Result<()> {
             let mut current = serde_json::to_value(&*config)?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,8 @@ mod pane;
 pub mod push;
 pub mod push_send;
 pub mod rate_limit;
+#[cfg(feature = "serve")]
+pub mod scheduler;
 pub(crate) mod session_spawn;
 pub mod tunnel;
 
@@ -1202,6 +1204,19 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             status_poll_loop(poll_state).await;
         },
     );
+
+    // Scheduled-session cron loop (#2886): fires the profile's scheduled jobs.
+    #[cfg(feature = "serve")]
+    {
+        let schedule_state = state.clone();
+        crate::task_util::spawn_supervised(
+            "server.schedule_loop",
+            crate::task_util::PanicPolicy::Log,
+            async move {
+                scheduler::schedule_loop(schedule_state).await;
+            },
+        );
+    }
 
     // File-watch wire-up: register the initial per-profile subscriptions
     // BEFORE the server starts serving requests so cold-start writes do not

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1206,8 +1206,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     );
 
     // Scheduled-session cron loop (#2886): fires the profile's scheduled jobs.
+    // Skipped in read-only mode; the loop persists sessions and launches agents,
+    // which would bypass the server's read-only guarantee.
     #[cfg(feature = "serve")]
-    {
+    if !state.read_only {
         let schedule_state = state.clone();
         crate::task_util::spawn_supervised(
             "server.schedule_loop",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,7 @@ mod pane;
 pub mod push;
 pub mod push_send;
 pub mod rate_limit;
+pub(crate) mod session_spawn;
 pub mod tunnel;
 
 use std::net::SocketAddr;

--- a/src/server/scheduler.rs
+++ b/src/server/scheduler.rs
@@ -11,10 +11,13 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
+use crate::acp::state::Event;
 use crate::server::session_spawn::{spawn_structured_session, StructuredSessionSpec};
+use crate::server::AcpBroadcastFrame;
 use crate::session::schedule::{plan_tick, Cursors, ScheduledJob, DEFAULT_SCHEDULE_GROUP};
 
 use super::AppState;
@@ -23,6 +26,12 @@ use super::AppState;
 /// prompt before we give up, so a worker that never starts cannot wedge the
 /// per-job task forever.
 const PROMPT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Upper bound on how long a single fired run is held in flight while waiting
+/// for its turn to complete. Prevents a session that never emits `Stopped` (a
+/// crashed worker, a dropped broadcast) from pinning the in-flight guard and
+/// silently disabling the job forever.
+const RUN_MAX_LIFETIME: Duration = Duration::from_secs(30 * 60);
 
 /// The supervised tick loop. Runs until `state.shutdown` is cancelled.
 pub async fn schedule_loop(state: Arc<AppState>) {
@@ -59,15 +68,16 @@ pub async fn schedule_loop(state: Arc<AppState>) {
         // Only run jobs this daemon owns, that individually validate, and whose
         // id is unique. A malformed job (e.g. a cron typo added via the settings
         // UI, which does not re-validate cron server-side) is skipped and logged
-        // rather than halting every job. An empty owner is a job added without a
-        // profile; run it. A job owned by another profile is left to that
-        // profile's daemon so multiple daemons do not double-fire.
+        // rather than halting every job. Ownership is an exact match on the
+        // profile: a job with no owner never fires (the CLI and the save path
+        // both stamp a concrete owner), so multiple profile daemons can never
+        // double-fire the same job.
         let mut seen_ids = std::collections::HashSet::new();
         let owned: Vec<ScheduledJob> = cfg
             .scheduling
             .jobs
             .into_iter()
-            .filter(|j| j.owner_profile.is_empty() || j.owner_profile == state.profile)
+            .filter(|j| j.owner_profile == state.profile)
             .filter(|j| match j.validate() {
                 Ok(()) => true,
                 Err(e) => {
@@ -176,13 +186,33 @@ async fn run_job(state: &Arc<AppState>, job: &ScheduledJob) {
             return;
         }
     };
-    let id = outcome.instance.id;
+    let id = outcome.instance.id.clone();
+
+    // The spawn core downgrades a tool that cannot run over ACP to a terminal
+    // session. Delivering an ACP prompt to it would never reach the agent and
+    // would leave an idle session, so stop here (the session is still visible in
+    // the Scheduled group for the user to inspect and delete).
+    if !outcome.instance.is_structured() {
+        warn!(
+            target: "server.scheduler",
+            job = %job.id,
+            session = %id,
+            "tool '{}' is not structured-view capable; created the session but did not deliver the prompt",
+            job.tool
+        );
+        return;
+    }
+
     info!(
         target: "server.scheduler",
         job = %job.id,
         session = %id,
         "fired scheduled session"
     );
+
+    // Subscribe before sending so the turn-end wait below cannot miss a fast
+    // `Stopped`.
+    let mut events = state.acp_events_tx.subscribe();
 
     // Apply the session mode before the prompt so approvals are handled per the
     // job's policy. An explicit approval_mode wins; otherwise fall back to the
@@ -201,11 +231,24 @@ async fn run_job(state: &Arc<AppState>, job: &ScheduledJob) {
     };
     if let Some(mode_id) = mode_id {
         if let Err(e) = state.acp_supervisor.set_mode(&id, &mode_id).await {
+            // An explicit mode that fails to apply must not be silently ignored:
+            // the run would proceed under an unverified permission mode. Abort
+            // prompt delivery instead. A failed fallback reassert (None case) is
+            // non-fatal since the spawn already requested the bypass mode.
+            if job.approval_mode.is_some() {
+                warn!(
+                    target: "server.scheduler",
+                    job = %job.id,
+                    session = %id,
+                    "explicit approval mode '{mode_id}' failed to apply; not delivering the prompt: {e}"
+                );
+                return;
+            }
             warn!(
                 target: "server.scheduler",
                 job = %job.id,
                 session = %id,
-                "set_mode({mode_id}) failed: {e}"
+                "default mode reassert failed (continuing): {e}"
             );
         }
     }
@@ -223,19 +266,64 @@ async fn run_job(state: &Arc<AppState>, job: &ScheduledJob) {
     .await
     {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => warn!(
-            target: "server.scheduler",
-            job = %job.id,
-            session = %id,
-            "send_prompt failed: {e}"
-        ),
-        Err(_) => warn!(
-            target: "server.scheduler",
-            job = %job.id,
-            session = %id,
-            "send_prompt timed out after {}s",
-            PROMPT_TIMEOUT.as_secs()
-        ),
+        Ok(Err(e)) => {
+            warn!(
+                target: "server.scheduler",
+                job = %job.id,
+                session = %id,
+                "send_prompt failed: {e}"
+            );
+            return;
+        }
+        Err(_) => {
+            warn!(
+                target: "server.scheduler",
+                job = %job.id,
+                session = %id,
+                "send_prompt timed out after {}s",
+                PROMPT_TIMEOUT.as_secs()
+            );
+            return;
+        }
+    }
+
+    // Hold the job in flight until the turn it just started actually completes,
+    // so a later cron occurrence cannot spawn an overlapping run. Bounded by
+    // RUN_MAX_LIFETIME so a session that never emits `Stopped` cannot pin the
+    // guard forever.
+    wait_for_turn_end(&mut events, &id).await;
+}
+
+/// Block until the session emits a terminal turn signal (`Stopped` or a startup
+/// failure), the broadcast closes, or `RUN_MAX_LIFETIME` elapses.
+async fn wait_for_turn_end(
+    events: &mut tokio::sync::broadcast::Receiver<AcpBroadcastFrame>,
+    id: &str,
+) {
+    let deadline = tokio::time::sleep(RUN_MAX_LIFETIME);
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            _ = &mut deadline => {
+                warn!(
+                    target: "server.scheduler",
+                    session = %id,
+                    "run exceeded {}s without a turn-end signal; releasing the in-flight guard",
+                    RUN_MAX_LIFETIME.as_secs()
+                );
+                return;
+            }
+            recv = events.recv() => match recv {
+                Ok(frame) if frame.session_id == id => {
+                    if matches!(&*frame.event, Event::Stopped { .. } | Event::AgentStartupError { .. }) {
+                        return;
+                    }
+                }
+                Ok(_) => {}
+                Err(RecvError::Lagged(_)) => {}
+                Err(RecvError::Closed) => return,
+            },
+        }
     }
 }
 

--- a/src/server/scheduler.rs
+++ b/src/server/scheduler.rs
@@ -56,23 +56,33 @@ pub async fn schedule_loop(state: Arc<AppState>) {
                 continue;
             }
         };
-        if let Err(e) = cfg.scheduling.validate() {
-            warn!(
-                target: "server.scheduler",
-                profile = %state.profile,
-                "skipping tick: invalid scheduling config: {e}"
-            );
-            continue;
-        }
-
-        // Only run jobs this daemon owns. An empty owner is a job added without
-        // a profile; run it. A job owned by another profile is left to that
+        // Only run jobs this daemon owns, that individually validate, and whose
+        // id is unique. A malformed job (e.g. a cron typo added via the settings
+        // UI, which does not re-validate cron server-side) is skipped and logged
+        // rather than halting every job. An empty owner is a job added without a
+        // profile; run it. A job owned by another profile is left to that
         // profile's daemon so multiple daemons do not double-fire.
+        let mut seen_ids = std::collections::HashSet::new();
         let owned: Vec<ScheduledJob> = cfg
             .scheduling
             .jobs
             .into_iter()
             .filter(|j| j.owner_profile.is_empty() || j.owner_profile == state.profile)
+            .filter(|j| match j.validate() {
+                Ok(()) => true,
+                Err(e) => {
+                    warn!(target: "server.scheduler", job = %j.id, "skipping invalid job: {e}");
+                    false
+                }
+            })
+            .filter(|j| {
+                if seen_ids.insert(j.id.clone()) {
+                    true
+                } else {
+                    warn!(target: "server.scheduler", job = %j.id, "skipping duplicate job id");
+                    false
+                }
+            })
             .collect();
 
         let now = chrono::Local::now();

--- a/src/server/scheduler.rs
+++ b/src/server/scheduler.rs
@@ -291,12 +291,13 @@ async fn run_job(state: &Arc<AppState>, job: &ScheduledJob) {
     // so a later cron occurrence cannot spawn an overlapping run. Bounded by
     // RUN_MAX_LIFETIME so a session that never emits `Stopped` cannot pin the
     // guard forever.
-    wait_for_turn_end(&mut events, &id).await;
+    wait_for_turn_end(state, &mut events, &id).await;
 }
 
 /// Block until the session emits a terminal turn signal (`Stopped` or a startup
 /// failure), the broadcast closes, or `RUN_MAX_LIFETIME` elapses.
 async fn wait_for_turn_end(
+    state: &Arc<AppState>,
     events: &mut tokio::sync::broadcast::Receiver<AcpBroadcastFrame>,
     id: &str,
 ) {
@@ -320,7 +321,16 @@ async fn wait_for_turn_end(
                     }
                 }
                 Ok(_) => {}
-                Err(RecvError::Lagged(_)) => {}
+                // A lagged receiver may have dropped this session's terminal
+                // frame. Reconcile against the event store: if no turn is in
+                // flight the run already finished, so release the guard rather
+                // than blocking out the full lifetime on a signal that will
+                // never arrive.
+                Err(RecvError::Lagged(_)) => {
+                    if !state.acp_event_store.has_in_flight_turn(id) {
+                        return;
+                    }
+                }
                 Err(RecvError::Closed) => return,
             },
         }

--- a/src/server/scheduler.rs
+++ b/src/server/scheduler.rs
@@ -1,0 +1,304 @@
+//! Daemon-side cron scheduler for scheduled sessions (#2886).
+//!
+//! A supervised background task ticks every 30s, evaluates the profile's
+//! scheduled jobs through the pure [`plan_tick`] step, and for each job that
+//! fires it spawns a structured-view session and delivers the job's prompt.
+//! The runtime cursors live only in memory: seeding them to "now" every startup
+//! is what makes the skip-missed policy discard downtime rather than firing a
+//! backlog of elapsed occurrences.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use crate::server::session_spawn::{spawn_structured_session, StructuredSessionSpec};
+use crate::session::schedule::{plan_tick, Cursors, ScheduledJob, DEFAULT_SCHEDULE_GROUP};
+
+use super::AppState;
+
+/// How long a fired job waits for its worker to become ready and accept the
+/// prompt before we give up, so a worker that never starts cannot wedge the
+/// per-job task forever.
+const PROMPT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The supervised tick loop. Runs until `state.shutdown` is cancelled.
+pub async fn schedule_loop(state: Arc<AppState>) {
+    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    // Runtime cursors, held across ticks (never persisted).
+    let mut cursors: Cursors<chrono::Local> = Cursors::new();
+    // Ids of jobs whose per-job task is still running, so a job that fires again
+    // before its previous run finishes is skipped rather than overlapped.
+    let in_flight: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {}
+            _ = state.shutdown.cancelled() => break,
+        }
+
+        // Fail closed: a config load or validation error skips the tick WITHOUT
+        // touching cursors, so a transient read failure is never mistaken for
+        // "all jobs removed" (which would drop the cursors and let a later
+        // recovery refire).
+        let cfg = match crate::session::profile_config::resolve_config(&state.profile) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                warn!(
+                    target: "server.scheduler",
+                    profile = %state.profile,
+                    "skipping tick: failed to load config: {e}"
+                );
+                continue;
+            }
+        };
+        if let Err(e) = cfg.scheduling.validate() {
+            warn!(
+                target: "server.scheduler",
+                profile = %state.profile,
+                "skipping tick: invalid scheduling config: {e}"
+            );
+            continue;
+        }
+
+        // Only run jobs this daemon owns. An empty owner is a job added without
+        // a profile; run it. A job owned by another profile is left to that
+        // profile's daemon so multiple daemons do not double-fire.
+        let owned: Vec<ScheduledJob> = cfg
+            .scheduling
+            .jobs
+            .into_iter()
+            .filter(|j| j.owner_profile.is_empty() || j.owner_profile == state.profile)
+            .collect();
+
+        let now = chrono::Local::now();
+        let (fire_ids, next_cursors) = plan_tick(&owned, &cursors, &now);
+        cursors = next_cursors;
+
+        for id in fire_ids {
+            let Some(job) = owned.iter().find(|j| j.id == id).cloned() else {
+                continue;
+            };
+
+            {
+                let mut guard = in_flight.lock().await;
+                if !guard.insert(id.clone()) {
+                    info!(
+                        target: "server.scheduler",
+                        job = %id,
+                        "skipping fire: previous run of this job is still in flight"
+                    );
+                    continue;
+                }
+            }
+
+            let state = state.clone();
+            let in_flight = in_flight.clone();
+            tokio::spawn(async move {
+                run_job(&state, &job).await;
+                in_flight.lock().await.remove(&job.id);
+            });
+        }
+    }
+}
+
+/// Pure mapping from a scheduled job to the create-core spec. A job with a
+/// `project` runs there; a project-less job runs as a scratch session. When the
+/// job has no explicit `approval_mode` the spawn requests the agent's default
+/// bypass ("yolo") mode so the unattended run does not stall on approvals; a
+/// specific mode is applied post-spawn instead.
+fn job_to_spec(job: &ScheduledJob, profile: &str) -> StructuredSessionSpec {
+    let group = if job.group.trim().is_empty() {
+        DEFAULT_SCHEDULE_GROUP.to_string()
+    } else {
+        job.group.clone()
+    };
+    let (path, scratch) = match &job.project {
+        Some(p) => (p.clone(), false),
+        None => (String::new(), true),
+    };
+    StructuredSessionSpec {
+        title: Some(job.name.clone()),
+        path,
+        group,
+        tool: job.tool.clone(),
+        worktree_enabled: false,
+        worktree_branch: None,
+        create_new_branch: false,
+        base_branch: None,
+        sandbox: false,
+        sandbox_image: None,
+        yolo_mode: job.approval_mode.is_none(),
+        extra_env: vec![],
+        extra_args: String::new(),
+        command_override: String::new(),
+        extra_repo_paths: vec![],
+        scratch,
+        trust_hooks: None,
+        custom_instruction: None,
+        profile: profile.to_string(),
+        view: crate::session::View::Structured,
+        agent_name: job.agent.clone(),
+        agent_model: job.model.clone(),
+        agent_effort: None,
+        import_acp_session_id: None,
+        fork_seed: None,
+    }
+}
+
+/// Spawn the session for a fired job, apply its approval mode, and deliver its
+/// prompt. Best-effort: every failure is logged and swallowed so one bad job
+/// never affects the tick loop or other jobs.
+async fn run_job(state: &Arc<AppState>, job: &ScheduledJob) {
+    let spec = job_to_spec(job, &state.profile);
+    let outcome = match spawn_structured_session(state, spec).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            warn!(
+                target: "server.scheduler",
+                job = %job.id,
+                "failed to spawn scheduled session: {e:#}"
+            );
+            return;
+        }
+    };
+    let id = outcome.instance.id;
+    info!(
+        target: "server.scheduler",
+        job = %job.id,
+        session = %id,
+        "fired scheduled session"
+    );
+
+    // Apply the session mode before the prompt so approvals are handled per the
+    // job's policy. An explicit approval_mode wins; otherwise fall back to the
+    // agent's default bypass mode (the spawn already requests it via
+    // `yolo_mode`, so this is a belt-and-suspenders reassert for the None case).
+    let agent_key = job
+        .agent
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(job.tool.as_str());
+    let mode_id = match &job.approval_mode {
+        Some(mode) => Some(mode.clone()),
+        None => crate::acp::agent_profiles::resolve(agent_key)
+            .yolo_mode_id
+            .map(str::to_string),
+    };
+    if let Some(mode_id) = mode_id {
+        if let Err(e) = state.acp_supervisor.set_mode(&id, &mode_id).await {
+            warn!(
+                target: "server.scheduler",
+                job = %job.id,
+                session = %id,
+                "set_mode({mode_id}) failed: {e}"
+            );
+        }
+    }
+
+    // Record the prompt in the transcript, then send it. A worker that never
+    // becomes ready is bounded by the timeout rather than hanging the task.
+    state
+        .acp_supervisor
+        .publish_user_prompt_with_attachments(&id, job.prompt.clone(), &[])
+        .await;
+    match tokio::time::timeout(
+        PROMPT_TIMEOUT,
+        state.acp_supervisor.send_prompt(&id, &job.prompt, &[]),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!(
+            target: "server.scheduler",
+            job = %job.id,
+            session = %id,
+            "send_prompt failed: {e}"
+        ),
+        Err(_) => warn!(
+            target: "server.scheduler",
+            job = %job.id,
+            session = %id,
+            "send_prompt timed out after {}s",
+            PROMPT_TIMEOUT.as_secs()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(id: &str) -> ScheduledJob {
+        ScheduledJob {
+            id: id.to_string(),
+            name: "nightly build".to_string(),
+            schedule: "0 2 * * *".to_string(),
+            enabled: true,
+            tool: "claude".to_string(),
+            agent: None,
+            model: None,
+            approval_mode: None,
+            project: None,
+            prompt: "run the build".to_string(),
+            group: DEFAULT_SCHEDULE_GROUP.to_string(),
+            owner_profile: String::new(),
+        }
+    }
+
+    #[test]
+    fn job_to_spec_scratch_when_no_project() {
+        let spec = job_to_spec(&job("a"), "default");
+        assert!(spec.scratch);
+        assert!(spec.path.is_empty());
+        assert_eq!(spec.group, DEFAULT_SCHEDULE_GROUP);
+        assert_eq!(spec.title.as_deref(), Some("nightly build"));
+        assert_eq!(spec.profile, "default");
+        // No explicit approval mode requests the default bypass at spawn.
+        assert!(spec.yolo_mode);
+        assert!(!spec.worktree_enabled);
+        assert!(!spec.sandbox);
+    }
+
+    #[test]
+    fn job_to_spec_uses_project_when_set() {
+        let mut j = job("b");
+        j.project = Some("/home/me/repo".to_string());
+        let spec = job_to_spec(&j, "work");
+        assert!(!spec.scratch);
+        assert_eq!(spec.path, "/home/me/repo");
+        assert_eq!(spec.profile, "work");
+    }
+
+    #[test]
+    fn job_to_spec_passes_through_agent_and_model() {
+        let mut j = job("c");
+        j.agent = Some("codex".to_string());
+        j.model = Some("gpt-5".to_string());
+        j.group = "Reports".to_string();
+        let spec = job_to_spec(&j, "default");
+        assert_eq!(spec.agent_name.as_deref(), Some("codex"));
+        assert_eq!(spec.agent_model.as_deref(), Some("gpt-5"));
+        assert_eq!(spec.group, "Reports");
+    }
+
+    #[test]
+    fn job_to_spec_explicit_mode_disables_yolo() {
+        let mut j = job("d");
+        j.approval_mode = Some("plan".to_string());
+        let spec = job_to_spec(&j, "default");
+        assert!(!spec.yolo_mode);
+    }
+
+    #[test]
+    fn job_to_spec_empty_group_defaults() {
+        let mut j = job("e");
+        j.group = "  ".to_string();
+        let spec = job_to_spec(&j, "default");
+        assert_eq!(spec.group, DEFAULT_SCHEDULE_GROUP);
+    }
+}

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -1,0 +1,544 @@
+//! Domain core for creating a session: build the instance, persist it, upsert
+//! it into the live state, and (for a structured session) spawn its ACP worker.
+//!
+//! Extracted from the `create_session` HTTP handler so a non-HTTP caller (for
+//! example a scheduler) can create a structured-view ACP session without
+//! duplicating the build/persist/spawn logic. The handler keeps all request
+//! decoding, validation, and response construction; it decodes a request into a
+//! [`StructuredSessionSpec`], calls [`spawn_structured_session`], and builds its
+//! HTTP response from the returned [`SpawnOutcome`].
+
+use std::sync::Arc;
+
+use crate::session::Instance;
+
+use super::AppState;
+
+/// Already-decoded, already-validated inputs the create core needs. The HTTP
+/// handler fills this in after it has finished request parsing, auth, and
+/// validation; a future non-HTTP caller builds it directly.
+pub(crate) struct StructuredSessionSpec {
+    pub title: Option<String>,
+    pub path: String,
+    pub group: String,
+    pub tool: String,
+    pub worktree_enabled: bool,
+    pub worktree_branch: Option<String>,
+    pub create_new_branch: bool,
+    pub base_branch: Option<String>,
+    pub sandbox: bool,
+    pub sandbox_image: Option<String>,
+    pub yolo_mode: bool,
+    pub extra_env: Vec<String>,
+    pub extra_args: String,
+    pub command_override: String,
+    pub extra_repo_paths: Vec<String>,
+    pub scratch: bool,
+    pub trust_hooks: Option<bool>,
+    pub custom_instruction: Option<String>,
+    /// Resolved source profile (request profile, else the server default).
+    pub profile: String,
+    #[cfg(feature = "serve")]
+    pub view: crate::session::View,
+    #[cfg(feature = "serve")]
+    pub agent_name: Option<String>,
+    #[cfg(feature = "serve")]
+    pub agent_model: Option<String>,
+    #[cfg(feature = "serve")]
+    pub agent_effort: Option<String>,
+    #[cfg(feature = "serve")]
+    pub import_acp_session_id: Option<String>,
+    #[cfg(feature = "serve")]
+    pub fork_seed: Option<crate::session::ForkSeed>,
+}
+
+/// What the create core returns to its caller once the session exists in state.
+/// The HTTP handler builds its `SessionResponse` from `instance` and threads
+/// `warnings` onto it exactly as the inline handler did.
+pub(crate) struct SpawnOutcome {
+    pub instance: Instance,
+    pub warnings: Vec<String>,
+}
+
+/// Marker error the core returns when the blocking build task panicked, so the
+/// HTTP handler can keep answering `500 Internal Server Error` for that case
+/// while a plain build failure stays `400`. Mirrors the existing
+/// `HooksNeedTrust` downcast pattern in the handler.
+#[derive(Debug)]
+pub(crate) struct SessionBuildPanicked(pub String);
+
+impl std::fmt::Display for SessionBuildPanicked {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for SessionBuildPanicked {}
+
+/// Build, persist, and register a session, spawning its ACP worker when the
+/// resolved view is structured. Returns the created instance and any build
+/// warnings; a build-time panic is surfaced as a [`SessionBuildPanicked`] error
+/// and a repo-trust refusal propagates as-is so the caller can map it.
+pub(crate) async fn spawn_structured_session(
+    state: &Arc<AppState>,
+    spec: StructuredSessionSpec,
+) -> anyhow::Result<SpawnOutcome> {
+    let instances = state.instances.read().await;
+    let existing_titles: Vec<String> = instances.iter().map(|i| i.title.clone()).collect();
+    let existing_branches: Vec<String> = instances
+        .iter()
+        .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.clone()))
+        .collect();
+    drop(instances);
+
+    let file_watch_for_create = state.file_watch.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        use crate::session::builder::{self, InstanceParams};
+        use crate::session::Config;
+        use crate::session::Storage;
+
+        let StructuredSessionSpec {
+            title,
+            path,
+            group,
+            tool,
+            worktree_enabled,
+            worktree_branch,
+            create_new_branch,
+            base_branch,
+            sandbox,
+            sandbox_image,
+            yolo_mode,
+            extra_env,
+            extra_args,
+            command_override,
+            extra_repo_paths,
+            scratch,
+            trust_hooks,
+            custom_instruction,
+            profile,
+            #[cfg(feature = "serve")]
+            view,
+            #[cfg(feature = "serve")]
+            agent_name,
+            #[cfg(feature = "serve")]
+            agent_model,
+            #[cfg(feature = "serve")]
+            agent_effort,
+            #[cfg(feature = "serve")]
+            import_acp_session_id,
+            #[cfg(feature = "serve")]
+            fork_seed,
+        } = spec;
+
+        let config = Config::load_or_warn();
+        let sandbox_image = sandbox_image.unwrap_or_else(|| {
+            if config.sandbox.default_image.is_empty() {
+                "ubuntu:latest".to_string()
+            } else {
+                config.sandbox.default_image.clone()
+            }
+        });
+
+        let title_refs: Vec<&str> = existing_titles.iter().map(|s| s.as_str()).collect();
+        let branch_refs: Vec<&str> = existing_branches.iter().map(|s| s.as_str()).collect();
+        let extra_repo_paths: Vec<String> = extra_repo_paths
+            .into_iter()
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        // Resolve repo hook trust BEFORE building the worktree (#2066): a repo
+        // whose hooks need approval and that was not sent `trust_hooks: true`
+        // is refused here, so the handler never leaves an orphan worktree on
+        // disk. The original `path` is the trust anchor (the same source the
+        // CLI/TUI use); `check_repo_trust` resolves a worktree path to its main
+        // repo, so a worktree created from an already-trusted repo inherits its
+        // trust without a separate prompt.
+        let original_path = path.clone();
+        let hook_plan = crate::server::api::sessions::resolve_create_hook_plan(
+            &profile,
+            std::path::Path::new(&original_path),
+            scratch,
+            trust_hooks.unwrap_or(false),
+        )?;
+
+        let title = title.unwrap_or_default();
+        let worktree_branch = worktree_branch
+            .map(|b| b.trim().to_string())
+            .filter(|b| !b.is_empty());
+
+        let params = InstanceParams {
+            title,
+            path,
+            group,
+            tool,
+            worktree_enabled,
+            worktree_branch,
+            create_new_branch,
+            base_branch: if create_new_branch {
+                base_branch
+                    .as_ref()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            } else {
+                None
+            },
+            sandbox,
+            sandbox_image,
+            yolo_mode,
+            extra_env,
+            extra_args,
+            command_override,
+            extra_repo_paths,
+            scratch,
+            #[cfg(feature = "serve")]
+            fork_seed,
+            #[cfg(not(feature = "serve"))]
+            fork_seed: None,
+        };
+
+        let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
+        let mut instance = build_result.instance;
+        instance.source_profile = profile.clone();
+        let build_warnings = build_result.warnings;
+        let created_worktree = build_result.created_worktree;
+        let created_workspace_worktrees = build_result.created_workspace_worktrees;
+
+        // Apply per-session sandbox overrides from the request body.
+        if let Some(ref mut sandbox) = instance.sandbox_info {
+            if custom_instruction.is_some() {
+                sandbox.custom_instruction = custom_instruction;
+            }
+        }
+
+        // Apply structured-view fields from the request body. structured_view is
+        // re-validated below against real ACP capability; non-ACP tools
+        // fall back to terminal view rather than erroring at spawn time.
+        #[cfg(feature = "serve")]
+        let agent_effort = {
+            instance.view = view;
+            // #2276: importing an existing Claude session forces the
+            // structured view and adopts the on-disk session id, so the
+            // structured spawn resumes it via session/load and seeds the
+            // transcript from the agent's history replay. `path` is the
+            // session's original cwd (the wizard prefills it).
+            if let Some(import_id) = import_acp_session_id
+                .clone()
+                .filter(|s| !s.trim().is_empty())
+            {
+                instance.view = crate::session::View::Structured;
+                instance.acp_session_id = Some(import_id);
+                instance.import_pending = Some(true);
+            }
+            instance.agent_name = agent_name;
+            let agent_key = instance
+                .agent_name
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(instance.tool.as_str())
+                .to_string();
+            let resolved_config = crate::session::repo_config::resolve_config_with_repo_or_warn(
+                &instance.source_profile,
+                std::path::Path::new(&instance.project_path),
+            );
+            let defaults = resolved_config.acp.acp_defaults_for(&agent_key);
+            // Preserve the explicit request model separately (trimmed to match
+            // the resolver's normalization) so a terminal fallback below can
+            // keep it while dropping any ACP-derived default; agent_model is
+            // ACP-only.
+            let explicit_model = agent_model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            // Explicit request wins, else the per-agent default; effort is keyed
+            // on the resolved model. Same single-source resolver the spawn path
+            // uses; persist the model here so the composer shows it and the
+            // session stays pinned to it. See resolve_spawn_model_effort.
+            let (resolved_model, mut agent_effort) =
+                crate::session::config::resolve_spawn_model_effort(
+                    defaults,
+                    explicit_model.clone(),
+                    agent_effort,
+                );
+            instance.agent_model = resolved_model;
+            // Don't trust the client's capability decision. Re-resolve
+            // whether this agent can actually run in structured view; a custom
+            // agent without an `agent_acp_cmd` (or any non-ACP tool)
+            // falls back to tmux here rather than erroring at spawn time.
+            if instance.is_structured() {
+                let acp_registry = crate::acp::AgentRegistry::with_defaults();
+                let resolved = instance
+                    .agent_name
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(instance.tool.as_str());
+                let capable = acp_registry.get(resolved).is_some()
+                    || crate::session::repo_config::resolve_config_with_repo_or_warn(
+                        &instance.source_profile,
+                        std::path::Path::new(&instance.project_path),
+                    )
+                    .session
+                    .agent_acp_cmd
+                    .get(&instance.tool)
+                    .is_some_and(|cmd| {
+                        crate::acp::AgentSpec::from_acp_cmd(&instance.tool, cmd).is_ok()
+                    });
+                if capable {
+                    instance.view = crate::session::View::Structured;
+                } else {
+                    instance.view = crate::session::View::Terminal;
+                    // A non-ACP tool cannot run the structured session/fork
+                    // handshake. If a malformed request seeded a structured
+                    // fork (fork_pending/import_pending set by the builder),
+                    // drop those markers so a later switch-to-structured does
+                    // not fire an unexpected session/fork against the parent.
+                    instance.fork_pending = None;
+                    instance.import_pending = None;
+                }
+            }
+
+            if !instance.is_structured() {
+                agent_effort = None;
+                // Terminal sessions keep only an explicitly requested model,
+                // never an ACP-derived default (agent_model is ACP-only).
+                instance.agent_model = explicit_model;
+            }
+
+            agent_effort
+        };
+
+        // Run on_create hooks now that the worktree exists, before the session
+        // is persisted or started (#2066). Mirrors the TUI/CLI ordering so the
+        // worktree is bootstrapped (`.env` copies, venv symlinks, DB seeds)
+        // before the agent launches. On failure, tear down the just-built
+        // worktree/container so a broken hook doesn't leave an orphan.
+        if let Err(e) = crate::server::api::sessions::run_create_hooks(
+            &mut instance,
+            &hook_plan,
+            std::path::Path::new(&original_path),
+        ) {
+            builder::cleanup_instance(
+                &instance,
+                created_worktree.as_ref(),
+                &created_workspace_worktrees,
+            );
+            return Err(anyhow::anyhow!("on_create hook failed: {e:#}"));
+        }
+
+        // Anything that fails between here and the final `Ok(..)`
+        // would otherwise orphan the scratch directory `build_instance`
+        // already provisioned (Storage::new, storage.update,
+        // instance.start). Wrap the tail in an IIFE-equivalent closure
+        // so we can run cleanup on Err once, regardless of which step
+        // tripped. Matches the CLI cleanup path in
+        // `cleanup_partial_session(... scratch_dir: Some(...))`.
+        let mut persist_and_start = || -> anyhow::Result<()> {
+            let storage = Storage::new(&profile, file_watch_for_create.clone())?;
+            let to_persist = instance.clone();
+            storage.update(|all, _groups| {
+                all.push(to_persist);
+                Ok(())
+            })?;
+
+            // Acp-mode sessions are not backed by tmux; the structured view
+            // supervisor spawns the ACP agent on demand. Skip the tmux
+            // `start()` to avoid creating an empty pane that no one will
+            // attach to.
+            #[cfg(feature = "serve")]
+            let skip_tmux_start = instance.is_structured();
+            #[cfg(not(feature = "serve"))]
+            let skip_tmux_start = false;
+            if !skip_tmux_start {
+                instance.start()?;
+            }
+            Ok(())
+        };
+
+        if let Err(e) = persist_and_start() {
+            // Guarded the same way as the deletion path: only remove a
+            // path that `is_scratch_path` blesses, so a corrupted
+            // `project_path` cannot trick us into wiping unrelated
+            // state.
+            if instance.scratch {
+                let scratch_path = std::path::PathBuf::from(&instance.project_path);
+                if crate::session::scratch::is_scratch_path(&scratch_path) {
+                    if let Err(rm_err) = std::fs::remove_dir_all(&scratch_path) {
+                        tracing::warn!(
+                            target: "http.api.sessions",
+                            "Failed to clean up orphan scratch dir {} after create failure: {}",
+                            scratch_path.display(),
+                            rm_err
+                        );
+                    }
+                }
+            }
+            return Err(e);
+        }
+
+        #[cfg(feature = "serve")]
+        return Ok::<(Instance, Vec<String>, Option<String>), anyhow::Error>((
+            instance,
+            build_warnings,
+            agent_effort,
+        ));
+
+        #[cfg(not(feature = "serve"))]
+        Ok::<(Instance, Vec<String>), anyhow::Error>((instance, build_warnings))
+    })
+    .await;
+
+    match result {
+        #[cfg(feature = "serve")]
+        Ok(Ok((instance, warnings, agent_effort))) => {
+            let response_instance = instance.clone();
+            let acp_spawn_target = if instance.is_structured() {
+                Some((
+                    instance.id.clone(),
+                    instance.tool.clone(),
+                    instance.agent_name.clone(),
+                    instance.agent_model.clone(),
+                    agent_effort,
+                    instance.project_path.clone(),
+                    instance.acp_session_id.clone(),
+                    instance.source_profile.clone(),
+                    instance.yolo_mode,
+                    instance.command.clone(),
+                    instance.import_pending == Some(true),
+                    instance.fork_pending.clone(),
+                ))
+            } else {
+                None
+            };
+            let mut instances = state.instances.write().await;
+            crate::server::api::sessions::upsert_instance(&mut instances, instance);
+            drop(instances);
+
+            // Count the create for the opt-in telemetry trend counter. Bounded
+            // accumulator, read-and-decremented by the snapshot loop; no-op for
+            // opted-out installs (the snapshot is never built / sent).
+            state
+                .telemetry_session_creates
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+            if let Some((
+                id,
+                tool,
+                agent_override,
+                model,
+                effort,
+                project_path,
+                stored_acp_session_id,
+                source_profile,
+                yolo_mode,
+                command,
+                seed_history_replay,
+                fork_from,
+            )) = acp_spawn_target
+            {
+                let agent = state
+                    .acp_supervisor
+                    .pick_agent_for_tool(
+                        &tool,
+                        agent_override.as_deref(),
+                        &source_profile,
+                        std::path::Path::new(&project_path),
+                    )
+                    .await;
+                let command_override =
+                    crate::server::acp_reconciler::command_override_for_spawn(&tool, &command);
+                let cwd = std::path::PathBuf::from(project_path);
+                let supervisor = state.acp_supervisor.clone();
+                let state_for_check = state.clone();
+                tokio::spawn(async move {
+                    let inst_lock = state_for_check.instance_lock(&id).await;
+                    let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
+                        &state_for_check.instances,
+                        &inst_lock,
+                        &id,
+                        true,
+                    )
+                    .await
+                    {
+                        Ok(info) => info,
+                        Err(e) => {
+                            let message = format!("sandbox container ensure failed: {e}");
+                            tracing::warn!(
+                                target: "acp.supervisor",
+                                session = %id,
+                                "auto-spawn after create failed: {message}"
+                            );
+                            supervisor.publish_startup_error(&id, message);
+                            return;
+                        }
+                    };
+                    let source_profile_for_spawn = Some(source_profile.clone());
+                    if let Err(e) = supervisor
+                        .spawn(crate::acp::supervisor::SpawnRequest {
+                            session_id: id.clone(),
+                            agent: agent.clone(),
+                            cwd,
+                            additional_dirs: vec![],
+                            provider_env: vec![],
+                            model,
+                            effort,
+                            stored_acp_session_id,
+                            fork_from,
+                            sandbox_info,
+                            source_profile: source_profile_for_spawn,
+                            yolo_mode,
+                            agent_command_override: command_override,
+                            seed_history_replay,
+                        })
+                        .await
+                    {
+                        let still_present = state_for_check
+                            .instances
+                            .read()
+                            .await
+                            .iter()
+                            .any(|i| i.id == id);
+                        // Capacity-aware banner selection (and the benign
+                        // first-tick duplicate) is documented on
+                        // `structured_spawn_error_message`.
+                        let message =
+                            crate::server::api::structured_spawn_error_message(&e, &agent);
+                        if still_present {
+                            tracing::warn!(
+                                target: "acp.supervisor",
+                                session = %id,
+                                "auto-spawn after create failed: {message}"
+                            );
+                            supervisor.publish_startup_error(&id, message);
+                        } else {
+                            tracing::debug!(
+                                target: "acp.supervisor",
+                                session = %id,
+                                "auto-spawn after create error after session removed (ignored): {message}"
+                            );
+                        }
+                    }
+                });
+            }
+
+            Ok(SpawnOutcome {
+                instance: response_instance,
+                warnings,
+            })
+        }
+        #[cfg(not(feature = "serve"))]
+        Ok(Ok((instance, warnings))) => {
+            let response_instance = instance.clone();
+            let mut instances = state.instances.write().await;
+            instances.push(instance);
+            drop(instances);
+            Ok(SpawnOutcome {
+                instance: response_instance,
+                warnings,
+            })
+        }
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(anyhow::Error::new(SessionBuildPanicked(e.to_string()))),
+    }
+}

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -68,6 +68,15 @@ pub struct Config {
     #[serde(default)]
     pub logging: LoggingConfig,
 
+    /// Cron-scheduled sessions (#2886). Profile/global only; never honored from
+    /// a repo's `.agent-of-empires/config.toml` (jobs run unattended host-side
+    /// work), so `scheduling` is omitted from `REPO_OVERRIDABLE_SECTIONS`.
+    #[serde(
+        default,
+        skip_serializing_if = "super::schedule::SchedulingConfig::is_empty"
+    )]
+    pub scheduling: super::schedule::SchedulingConfig,
+
     /// Trusted global/profile agent runtime overrides. Repo config does not
     /// merge this section, because hook installation writes durable agent files.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -31,6 +31,7 @@ pub mod projects;
 pub(crate) mod recovery;
 pub mod repo_config;
 pub mod restart;
+pub mod schedule;
 pub mod scratch;
 pub(crate) mod serde_helpers;
 pub mod settings_schema;

--- a/src/session/schedule.rs
+++ b/src/session/schedule.rs
@@ -142,6 +142,98 @@ pub fn validate_cron(expr: &str) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+/// The occurrence to fire if `schedule` has a match in the half-open window
+/// `(last_check, now]`, else `None`. Returns at most one occurrence (the
+/// earliest in the window), so a delayed tick that spans several matches fires
+/// only once rather than bursting. Occurrences are interpreted in the timezone
+/// of the supplied timestamps; the scheduler passes host-local time.
+///
+/// This is the pure core of the skip-missed policy: seeding `last_check` to
+/// "now" at startup means occurrences that elapsed while the daemon was down are
+/// never in a future window and so are skipped.
+pub fn next_due<Tz: chrono::TimeZone>(
+    schedule: &str,
+    last_check: &chrono::DateTime<Tz>,
+    now: &chrono::DateTime<Tz>,
+) -> Option<chrono::DateTime<Tz>> {
+    let cron = croner::Cron::new(schedule).parse().ok()?;
+    let next = cron.find_next_occurrence(last_check, false).ok()?;
+    if next <= *now {
+        Some(next)
+    } else {
+        None
+    }
+}
+
+/// Per-job runtime cursor. Held in memory only (never persisted): the
+/// skip-missed policy relies on cursors seeding to "now" every startup so
+/// downtime is discarded.
+#[derive(Debug, Clone)]
+pub struct JobCursor<Tz: chrono::TimeZone> {
+    /// `(enabled, schedule)` when the cursor was last seeded. A change means the
+    /// job was enabled/disabled or rescheduled, so we reseed rather than fire
+    /// retroactively.
+    fingerprint: (bool, String),
+    /// Upper bound of the last evaluated window. Advances only when the job
+    /// fires, so an occurrence is caught even if it lands between ticks.
+    last_check: chrono::DateTime<Tz>,
+}
+
+/// Cursors keyed by job id.
+pub type Cursors<Tz> = std::collections::HashMap<String, JobCursor<Tz>>;
+
+/// Pure scheduler step: given the current jobs, the prior cursors, and `now`,
+/// return the ids to fire and the updated cursor map.
+///
+/// Rules (the debate's converged semantics):
+/// - A job absent from `prev` is seeded to `now` and does NOT fire (new job /
+///   fresh daemon skips past occurrences).
+/// - A job whose `(enabled, schedule)` fingerprint changed is reseeded to `now`
+///   and does NOT fire (an edit never retroactively fires).
+/// - An unchanged enabled job fires at most once if an occurrence falls in
+///   `(last_check, now]`; on fire its cursor advances to `now`.
+/// - Disabled jobs never fire.
+/// - Cursors for jobs no longer present are dropped (only current jobs are
+///   carried forward).
+pub fn plan_tick<Tz: chrono::TimeZone>(
+    jobs: &[ScheduledJob],
+    prev: &Cursors<Tz>,
+    now: &chrono::DateTime<Tz>,
+) -> (Vec<String>, Cursors<Tz>) {
+    let mut fires = Vec::new();
+    let mut next: Cursors<Tz> = std::collections::HashMap::with_capacity(jobs.len());
+
+    for job in jobs {
+        let fp = (job.enabled, job.schedule.clone());
+        let cursor = match prev.get(&job.id) {
+            // New job or changed fingerprint: reseed to now, do not fire.
+            None => JobCursor {
+                fingerprint: fp,
+                last_check: now.clone(),
+            },
+            Some(c) if c.fingerprint != fp => JobCursor {
+                fingerprint: fp,
+                last_check: now.clone(),
+            },
+            // Unchanged: evaluate the window.
+            Some(c) => {
+                let mut last_check = c.last_check.clone();
+                if job.enabled && next_due(&job.schedule, &c.last_check, now).is_some() {
+                    fires.push(job.id.clone());
+                    last_check = now.clone();
+                }
+                JobCursor {
+                    fingerprint: fp,
+                    last_check,
+                }
+            }
+        };
+        next.insert(job.id.clone(), cursor);
+    }
+
+    (fires, next)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,6 +303,62 @@ mod tests {
         assert_eq!(cfg.jobs, back.jobs);
     }
 
+    fn utc(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> chrono::DateTime<chrono::Utc> {
+        use chrono::TimeZone;
+        chrono::Utc.with_ymd_and_hms(y, mo, d, h, mi, 0).unwrap()
+    }
+
+    #[test]
+    fn next_due_fires_when_occurrence_in_window() {
+        // daily at 08:00; window (07:00, 08:30] contains 08:00.
+        let got = next_due(
+            "0 8 * * *",
+            &utc(2026, 7, 16, 7, 0),
+            &utc(2026, 7, 16, 8, 30),
+        );
+        assert_eq!(got, Some(utc(2026, 7, 16, 8, 0)));
+    }
+
+    #[test]
+    fn next_due_none_when_no_occurrence_in_window() {
+        // window (08:30, 09:00] has no daily-08:00 occurrence.
+        let got = next_due(
+            "0 8 * * *",
+            &utc(2026, 7, 16, 8, 30),
+            &utc(2026, 7, 16, 9, 0),
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn next_due_collapses_multiple_occurrences_to_one() {
+        // every 10 min; window (08:00, 08:35] has 08:10/08:20/08:30 -> only 08:10.
+        let got = next_due(
+            "*/10 * * * *",
+            &utc(2026, 7, 16, 8, 0),
+            &utc(2026, 7, 16, 8, 35),
+        );
+        assert_eq!(got, Some(utc(2026, 7, 16, 8, 10)));
+    }
+
+    #[test]
+    fn next_due_includes_occurrence_exactly_at_now() {
+        let got = next_due(
+            "0 8 * * *",
+            &utc(2026, 7, 16, 7, 59),
+            &utc(2026, 7, 16, 8, 0),
+        );
+        assert_eq!(got, Some(utc(2026, 7, 16, 8, 0)));
+    }
+
+    #[test]
+    fn next_due_invalid_cron_is_none() {
+        assert_eq!(
+            next_due("nonsense", &utc(2026, 7, 16, 7, 0), &utc(2026, 7, 16, 9, 0)),
+            None
+        );
+    }
+
     #[test]
     fn fingerprint_ignores_prompt_edits() {
         let a = job("a", "0 8 * * *");
@@ -219,5 +367,82 @@ mod tests {
         assert_eq!(a.schedule_fingerprint(), b.schedule_fingerprint());
         b.schedule = "0 9 * * *".to_string();
         assert_ne!(a.schedule_fingerprint(), b.schedule_fingerprint());
+    }
+
+    #[test]
+    fn plan_tick_seeds_new_job_without_firing() {
+        let jobs = vec![job("a", "0 8 * * *")];
+        let (fires, cursors) = plan_tick(&jobs, &Cursors::new(), &utc(2026, 7, 16, 9, 0));
+        assert!(
+            fires.is_empty(),
+            "a fresh job must not fire on its seed tick"
+        );
+        assert!(cursors.contains_key("a"));
+    }
+
+    #[test]
+    fn plan_tick_fires_once_when_due() {
+        let jobs = vec![job("a", "0 8 * * *")];
+        let (_, c0) = plan_tick(&jobs, &Cursors::new(), &utc(2026, 7, 16, 7, 0));
+        let (fires, c1) = plan_tick(&jobs, &c0, &utc(2026, 7, 16, 8, 30));
+        assert_eq!(fires, vec!["a".to_string()]);
+        // Next tick in the same day does not refire.
+        let (fires2, _) = plan_tick(&jobs, &c1, &utc(2026, 7, 16, 8, 31));
+        assert!(fires2.is_empty());
+    }
+
+    #[test]
+    fn plan_tick_skips_missed_occurrences_after_reseed() {
+        // Seed at 09:00 (after the 08:00 occurrence). It must never fire for the
+        // already-elapsed 08:00: this is the daemon-was-down case.
+        let jobs = vec![job("a", "0 8 * * *")];
+        let (_, c0) = plan_tick(&jobs, &Cursors::new(), &utc(2026, 7, 16, 9, 0));
+        let (fires, _) = plan_tick(&jobs, &c0, &utc(2026, 7, 16, 9, 30));
+        assert!(fires.is_empty());
+    }
+
+    #[test]
+    fn plan_tick_disabled_job_never_fires() {
+        let mut j = job("a", "0 8 * * *");
+        j.enabled = false;
+        let jobs = vec![j];
+        let (_, c0) = plan_tick(&jobs, &Cursors::new(), &utc(2026, 7, 16, 7, 0));
+        let (fires, _) = plan_tick(&jobs, &c0, &utc(2026, 7, 16, 8, 30));
+        assert!(fires.is_empty());
+    }
+
+    #[test]
+    fn plan_tick_reenable_does_not_catch_up() {
+        // Enabled then disabled then re-enabled around the occurrence: no catch-up.
+        let mut disabled = job("a", "0 8 * * *");
+        disabled.enabled = false;
+        let enabled = job("a", "0 8 * * *");
+        let (_, c0) = plan_tick(
+            std::slice::from_ref(&enabled),
+            &Cursors::new(),
+            &utc(2026, 7, 16, 7, 0),
+        );
+        // Disable before the occurrence (fingerprint change reseeds).
+        let (_, c1) = plan_tick(
+            std::slice::from_ref(&disabled),
+            &c0,
+            &utc(2026, 7, 16, 7, 30),
+        );
+        // Re-enable after the occurrence: fingerprint change reseeds to 08:30, no fire.
+        let (fires, _) = plan_tick(
+            std::slice::from_ref(&enabled),
+            &c1,
+            &utc(2026, 7, 16, 8, 30),
+        );
+        assert!(fires.is_empty());
+    }
+
+    #[test]
+    fn plan_tick_drops_removed_job_cursor() {
+        let jobs = vec![job("a", "0 8 * * *")];
+        let (_, c0) = plan_tick(&jobs, &Cursors::new(), &utc(2026, 7, 16, 7, 0));
+        assert!(c0.contains_key("a"));
+        let (_, c1) = plan_tick(&[], &c0, &utc(2026, 7, 16, 7, 30));
+        assert!(!c1.contains_key("a"), "removed job cursor must be dropped");
     }
 }

--- a/src/session/schedule.rs
+++ b/src/session/schedule.rs
@@ -10,6 +10,7 @@
 //! Cron expressions are interpreted in the daemon host's local time. Moving the
 //! daemon to a machine in another timezone changes when a job fires.
 
+use aoe_settings_derive::SettingsSection;
 use serde::{Deserialize, Serialize};
 
 /// Group scheduled sessions land in by default, so they do not muddle with
@@ -105,9 +106,18 @@ impl ScheduledJob {
 }
 
 /// The `[scheduling]` config section: the list of jobs for this scope.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, SettingsSection)]
+#[setting_section(name = "scheduling", category = "Scheduling")]
 pub struct SchedulingConfig {
+    /// The scheduled jobs. Edited through a dedicated cron-job widget on every
+    /// surface; global-only since jobs are stored at global scope and tagged
+    /// with their owning profile.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[setting(
+        label = "Scheduled Jobs",
+        widget = "custom:scheduled-jobs",
+        global_only
+    )]
     pub jobs: Vec<ScheduledJob>,
 }
 

--- a/src/session/schedule.rs
+++ b/src/session/schedule.rs
@@ -1,0 +1,223 @@
+//! Scheduled-session job definitions (#2886).
+//!
+//! A [`ScheduledJob`] is a preset prompt the daemon fires against an agent on a
+//! cron schedule. Jobs live in the global/profile config (`[scheduling]`), never
+//! in a repo's `.agent-of-empires/config.toml` (they run unattended host-side
+//! work, so `scheduling` is omitted from `REPO_OVERRIDABLE_SECTIONS`). Each job
+//! records the profile that owns it so only that profile's daemon runs it; a
+//! shared list would otherwise fire once per running daemon.
+//!
+//! Cron expressions are interpreted in the daemon host's local time. Moving the
+//! daemon to a machine in another timezone changes when a job fires.
+
+use serde::{Deserialize, Serialize};
+
+/// Group scheduled sessions land in by default, so they do not muddle with
+/// interactive ones.
+pub const DEFAULT_SCHEDULE_GROUP: &str = "Scheduled";
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_group() -> String {
+    DEFAULT_SCHEDULE_GROUP.to_string()
+}
+
+/// One scheduled job: what to run, when, and as whom.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduledJob {
+    /// Stable identity (uuid v4). Generated on add; required. Enable/disable and
+    /// the runtime cursor key on this, so it must survive renames and edits.
+    pub id: String,
+
+    /// Human-readable label. Also used to title spawned sessions.
+    pub name: String,
+
+    /// Cron expression, host-local time. Standard 5-field (min hour dom mon dow).
+    pub schedule: String,
+
+    /// Whether the scheduler fires this job. Disabled jobs are kept but skipped.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Tool / built-in agent key (e.g. `claude`), same as `aoe add --tool`.
+    pub tool: String,
+
+    /// Structured-view agent name, when different from `tool`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+
+    /// Model override for the spawned session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// ACP session-mode id applied after the worker spawns, so an unattended run
+    /// does not block forever on an approval prompt. `None` means the agent's
+    /// default bypass ("yolo") mode; set a read-only / plan mode for a safe
+    /// unattended run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_mode: Option<String>,
+
+    /// Working project path. `None` runs a scratch (project-less) session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+
+    /// The prompt delivered to the session once it starts.
+    pub prompt: String,
+
+    /// Group the spawned session is filed under.
+    #[serde(default = "default_group")]
+    pub group: String,
+
+    /// Profile that owns this job. Only that profile's daemon fires it.
+    #[serde(default)]
+    pub owner_profile: String,
+}
+
+impl ScheduledJob {
+    /// The value whose change should reset the runtime cursor (re-seed to now so
+    /// a schedule edit does not retroactively fire). Prompt/model/name edits do
+    /// not reset firing; only the schedule and enabled-state matter.
+    pub fn schedule_fingerprint(&self) -> (bool, &str) {
+        (self.enabled, self.schedule.as_str())
+    }
+
+    /// Validate a single job in isolation (does not check id uniqueness across a
+    /// set; see [`SchedulingConfig::validate`]).
+    pub fn validate(&self) -> Result<(), String> {
+        if self.id.trim().is_empty() {
+            return Err("job id is empty".to_string());
+        }
+        if self.name.trim().is_empty() {
+            return Err(format!("job {}: name is empty", self.id));
+        }
+        if self.tool.trim().is_empty() {
+            return Err(format!("job {}: tool is empty", self.id));
+        }
+        if self.prompt.trim().is_empty() {
+            return Err(format!("job {}: prompt is empty", self.id));
+        }
+        validate_cron(&self.schedule)
+            .map_err(|e| format!("job {}: invalid cron '{}': {e}", self.id, self.schedule))?;
+        Ok(())
+    }
+}
+
+/// The `[scheduling]` config section: the list of jobs for this scope.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SchedulingConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub jobs: Vec<ScheduledJob>,
+}
+
+impl SchedulingConfig {
+    pub fn is_empty(&self) -> bool {
+        self.jobs.is_empty()
+    }
+
+    /// Validate the whole set: each job is well-formed and ids are unique.
+    /// Duplicate or missing ids are a hard error rather than a silent drop, so a
+    /// hand-edited config that copy-pasted a job block fails loudly instead of
+    /// clobbering the runtime cursor or double-firing.
+    pub fn validate(&self) -> Result<(), String> {
+        let mut seen = std::collections::HashSet::new();
+        for job in &self.jobs {
+            job.validate()?;
+            if !seen.insert(job.id.as_str()) {
+                return Err(format!("duplicate job id: {}", job.id));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate a cron expression, returning a human-readable error on failure.
+/// Host-local interpretation; the scheduler evaluates occurrences against the
+/// local clock.
+pub fn validate_cron(expr: &str) -> Result<(), String> {
+    croner::Cron::new(expr)
+        .parse()
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(id: &str, schedule: &str) -> ScheduledJob {
+        ScheduledJob {
+            id: id.to_string(),
+            name: "daily pr check".to_string(),
+            schedule: schedule.to_string(),
+            enabled: true,
+            tool: "claude".to_string(),
+            agent: None,
+            model: None,
+            approval_mode: None,
+            project: None,
+            prompt: "check open PRs".to_string(),
+            group: DEFAULT_SCHEDULE_GROUP.to_string(),
+            owner_profile: "default".to_string(),
+        }
+    }
+
+    #[test]
+    fn valid_job_passes() {
+        assert!(job("a", "0 8 * * *").validate().is_ok());
+    }
+
+    #[test]
+    fn invalid_cron_rejected() {
+        assert!(job("a", "not a cron").validate().is_err());
+        assert!(validate_cron("0 8 * * *").is_ok());
+        assert!(validate_cron("77 8 * * *").is_err());
+    }
+
+    #[test]
+    fn empty_fields_rejected() {
+        let mut j = job("a", "0 8 * * *");
+        j.prompt = "  ".to_string();
+        assert!(j.validate().is_err());
+        let mut j = job("", "0 8 * * *");
+        j.prompt = "x".to_string();
+        assert!(j.validate().is_err());
+    }
+
+    #[test]
+    fn duplicate_ids_rejected() {
+        let cfg = SchedulingConfig {
+            jobs: vec![job("dup", "0 8 * * *"), job("dup", "0 9 * * *")],
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn unique_ids_pass() {
+        let cfg = SchedulingConfig {
+            jobs: vec![job("a", "0 8 * * *"), job("b", "0 9 * * *")],
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn round_trips_through_toml() {
+        let cfg = SchedulingConfig {
+            jobs: vec![job("a", "*/5 * * * *")],
+        };
+        let toml = toml::to_string_pretty(&cfg).unwrap();
+        let back: SchedulingConfig = toml::from_str(&toml).unwrap();
+        assert_eq!(cfg.jobs, back.jobs);
+    }
+
+    #[test]
+    fn fingerprint_ignores_prompt_edits() {
+        let a = job("a", "0 8 * * *");
+        let mut b = a.clone();
+        b.prompt = "different prompt".to_string();
+        assert_eq!(a.schedule_fingerprint(), b.schedule_fingerprint());
+        b.schedule = "0 9 * * *".to_string();
+        assert_ne!(a.schedule_fingerprint(), b.schedule_fingerprint());
+    }
+}

--- a/src/session/settings_schema/registry.rs
+++ b/src/session/settings_schema/registry.rs
@@ -7,6 +7,7 @@ use crate::session::config::{
     AcpConfig, AuthConfig, DiffConfig, LoggingConfig, SandboxConfig, SessionConfig,
     TelemetryConfig, ThemeConfig, TmuxConfig, UpdatesConfig, WebConfig, WorktreeConfig,
 };
+use crate::session::schedule::SchedulingConfig;
 use crate::sound::SoundConfig;
 use crate::status_hooks::StatusHookConfig;
 
@@ -27,6 +28,7 @@ pub fn schema() -> Vec<FieldDescriptor> {
     out.extend(AcpConfig::settings_descriptors());
     out.extend(DiffConfig::settings_descriptors());
     out.extend(LoggingConfig::settings_descriptors());
+    out.extend(SchedulingConfig::settings_descriptors());
     out
 }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -52,6 +52,7 @@ pub enum SettingsCategory {
     Acp,
     Diff,
     Logging,
+    Scheduling,
     Plugins,
 }
 
@@ -74,6 +75,7 @@ impl SettingsCategory {
             Self::Acp => "Acp",
             Self::Diff => "Diff",
             Self::Logging => "Logging",
+            Self::Scheduling => "Scheduling",
             Self::Plugins => "Plugins",
         }
     }
@@ -99,6 +101,7 @@ impl SettingsCategory {
             Self::Diff => "Diff",
             Self::Telemetry => "Telemetry",
             Self::Logging => "Logging",
+            Self::Scheduling => "Scheduling",
             Self::Plugins => "Plugins",
         }
     }
@@ -527,6 +530,17 @@ fn custom_value_from_json(id: &str, current: &Value) -> FieldValue {
             };
             FieldValue::Text(text)
         }
+        "scheduled-jobs" => {
+            // The web widget offers the rich cron picker; the TUI keeps parity
+            // by editing the job list as raw JSON (an array of job objects),
+            // validated on commit so a typo cannot wipe the list.
+            let text = if current.is_null() {
+                "[]".to_string()
+            } else {
+                serde_json::to_string(current).unwrap_or_else(|_| "[]".to_string())
+            };
+            FieldValue::Text(text)
+        }
         // logging-targets is expanded into per-target rows during build and
         // never lands here.
         _ => FieldValue::Text(String::new()),
@@ -646,6 +660,16 @@ fn custom_value_to_json(id: &str, value: &FieldValue) -> Value {
             match serde_json::from_str::<Value>(trimmed) {
                 Ok(v) if v.is_object() => v,
                 _ => json!({}),
+            }
+        }
+        ("scheduled-jobs", FieldValue::Text(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return json!([]);
+            }
+            match serde_json::from_str::<Value>(trimmed) {
+                Ok(v) if v.is_array() => v,
+                _ => json!([]),
             }
         }
         _ => Value::Null,

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -390,6 +390,11 @@ impl SettingsView {
             push_tab(&mut rows, SettingsCategory::Telemetry);
         }
         push_tab(&mut rows, SettingsCategory::Logging);
+        // Scheduled jobs live in the global config (tagged with their owning
+        // profile), so the tab only appears under Global scope.
+        if scope == SettingsScope::Global {
+            push_tab(&mut rows, SettingsCategory::Scheduling);
+        }
         // Plugin enable/disable is stored in the global config, so the manager
         // tab (which stages toggles into it) only appears under Global scope.
         if scope == SettingsScope::Global {

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -44,6 +44,7 @@ export type TabId =
   | "structured-view"
   | "mcp"
   | "logging"
+  | "scheduling"
   | "plugins";
 
 type SidebarItem = { kind: "tab"; id: TabId; label: string; icon?: ReactNode } | { kind: "divider"; label: string };
@@ -106,6 +107,7 @@ export function buildSidebar(): SidebarItem[] {
     { kind: "tab", id: "updates", label: "Updates" },
     { kind: "tab", id: "telemetry", label: "Telemetry" },
     { kind: "tab", id: "logging", label: "Logging" },
+    { kind: "tab", id: "scheduling", label: "Scheduling" },
     { kind: "tab", id: "plugins", label: "Plugins" },
   ];
 }
@@ -144,6 +146,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "structured-view",
   "mcp",
   "logging",
+  "scheduling",
   "plugins",
 ]);
 
@@ -167,6 +170,7 @@ const SCHEMA_BACKED_TABS = new Set<TabId>([
   "logging",
   "notifications",
   "structured-view",
+  "scheduling",
 ]);
 
 /// Resolves the value `selectedProfile` should take when the mount-time
@@ -549,6 +553,16 @@ export function SettingsView({
             values={(settings?.logging ?? {}) as Record<string, unknown>}
             onSaveField={saveSubField}
             advancedSubtitle="Sink and rotation; some fields require restarting aoe to take effect."
+          />
+        );
+      case "scheduling":
+        return (
+          <SchemaSection
+            section="scheduling"
+            schema={schema}
+            focusRequest={focusRequest}
+            values={(settings?.scheduling ?? {}) as Record<string, unknown>}
+            onSaveField={saveSubField}
           />
         );
 

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -47,6 +47,7 @@ describe("buildSidebar", () => {
       { kind: "tab", id: "updates", label: "Updates" },
       { kind: "tab", id: "telemetry", label: "Telemetry" },
       { kind: "tab", id: "logging", label: "Logging" },
+      { kind: "tab", id: "scheduling", label: "Scheduling" },
       { kind: "tab", id: "plugins", label: "Plugins" },
     ]);
   });

--- a/web/src/components/settings/ScheduledJobsWidget.tsx
+++ b/web/src/components/settings/ScheduledJobsWidget.tsx
@@ -134,7 +134,6 @@ interface JobDraft {
   schedule: string;
   enabled: boolean;
   tool: string;
-  agent: string;
   model: string;
   approval_mode: string;
   project: string;
@@ -149,7 +148,6 @@ function emptyDraft(): JobDraft {
     schedule: "0 8 * * *",
     enabled: true,
     tool: "claude",
-    agent: "",
     model: "",
     approval_mode: "",
     project: "",
@@ -165,7 +163,6 @@ function draftFromJob(job: ScheduledJob): JobDraft {
     schedule: job.schedule,
     enabled: job.enabled,
     tool: job.tool || "claude",
-    agent: job.agent ?? "",
     model: job.model ?? "",
     approval_mode: job.approval_mode ?? "",
     project: job.project ?? "",
@@ -511,10 +508,9 @@ function JobForm({
   const [error, setError] = useState<string | null>(null);
   const set = (patch: Partial<JobDraft>) => setLocal((prev) => ({ ...prev, ...patch }));
 
-  // Models and approval modes are looked up against the agent the run resolves
-  // to: an explicit structured-view agent wins, else the tool (matches the
-  // scheduler's `job.agent ?? job.tool`).
-  const agentKey = (local.agent || local.tool).trim();
+  // Models and approval modes are looked up against the tool, which already
+  // selects the runtime (built-in binaries and custom ACP agents alike).
+  const agentKey = local.tool.trim();
   const entry = catalog[agentKey];
   const modelDesc = optionByCategory(entry, "model");
   const modeDesc = optionByCategory(entry, "mode");
@@ -574,13 +570,6 @@ function JobForm({
           value={local.tool}
           onChange={(v) => set({ tool: v })}
           options={agentOptions(agents, local.tool, "Select a tool…")}
-        />
-        <SelectRow
-          label="Agent (optional)"
-          ariaLabel="Agent"
-          value={local.agent}
-          onChange={(v) => set({ agent: v })}
-          options={agentOptions(agents, local.agent, "Same as tool")}
         />
         <CapabilityRow
           label="Model (optional)"
@@ -732,7 +721,6 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
       schedule: draft.schedule.trim(),
       enabled: draft.enabled,
       tool: draft.tool.trim(),
-      agent: draft.agent.trim() || undefined,
       model: draft.model.trim() || undefined,
       approval_mode: draft.approval_mode.trim() || undefined,
       project: draft.project.trim() || undefined,

--- a/web/src/components/settings/ScheduledJobsWidget.tsx
+++ b/web/src/components/settings/ScheduledJobsWidget.tsx
@@ -493,9 +493,9 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
   // null = no form open; "new" = adding; otherwise the id being edited.
   const [editing, setEditing] = useState<string | null>(null);
 
-  const persist = (next: ScheduledJob[]) => void save(next);
+  const persist = async (next: ScheduledJob[]) => (await save(next)) !== false;
 
-  const submitDraft = (draft: JobDraft) => {
+  const submitDraft = async (draft: JobDraft) => {
     const base = {
       name: draft.name.trim(),
       schedule: draft.schedule.trim(),
@@ -510,7 +510,7 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
     };
     if (draft.id === null) {
       const job: ScheduledJob = { id: crypto.randomUUID(), owner_profile: "", ...base };
-      persist([...jobs, job]);
+      if (await persist([...jobs, job])) setEditing(null);
     } else {
       const existing = jobs.find((j) => j.id === draft.id);
       const job: ScheduledJob = {
@@ -518,9 +518,8 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
         owner_profile: existing?.owner_profile ?? "",
         ...base,
       };
-      persist(jobs.map((j) => (j.id === draft.id ? job : j)));
+      if (await persist(jobs.map((j) => (j.id === draft.id ? job : j)))) setEditing(null);
     }
-    setEditing(null);
   };
 
   const toggle = (id: string) => persist(jobs.map((j) => (j.id === id ? { ...j, enabled: !j.enabled } : j)));

--- a/web/src/components/settings/ScheduledJobsWidget.tsx
+++ b/web/src/components/settings/ScheduledJobsWidget.tsx
@@ -68,6 +68,37 @@ function parseTime(time: string): { h: number; m: number } {
   return { h: Number(hh) || 0, m: Number(mm) || 0 };
 }
 
+/** Derive the picker state that produced `schedule`, so editing an existing job
+ *  opens on its real frequency instead of the default Daily. Recognizes the
+ *  same shapes `buildCron` emits; anything else falls back to `custom` with the
+ *  raw expression left untouched. */
+function parsePicker(schedule: string): PickerState {
+  const fields = schedule.trim().split(/\s+/);
+  const [min, hour, dom, mon, dow] = fields;
+  if (fields.length === 5 && min && hour && dom && mon && dow) {
+    const everyN = /^\*\/(\d+)$/.exec(min);
+    if (everyN && hour === "*" && dom === "*" && mon === "*" && dow === "*") {
+      const n = Number(everyN[1]);
+      if (n >= 1 && n <= 59) return { ...DEFAULT_PICKER, frequency: "minutes", everyN: n };
+    }
+    if (dom === "*" && mon === "*") {
+      const m = Number(min);
+      const minuteOk = /^\d+$/.test(min) && m >= 0 && m <= 59;
+      if (minuteOk && hour === "*" && dow === "*") {
+        return { ...DEFAULT_PICKER, frequency: "hourly", minute: m };
+      }
+      const h = Number(hour);
+      const hourOk = /^\d+$/.test(hour) && h >= 0 && h <= 23;
+      if (minuteOk && hourOk) {
+        const time = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+        if (dow === "*") return { ...DEFAULT_PICKER, frequency: "daily", time };
+        if (/^[0-6]$/.test(dow)) return { ...DEFAULT_PICKER, frequency: "weekly", time, weekday: dow };
+      }
+    }
+  }
+  return { ...DEFAULT_PICKER, frequency: "custom" };
+}
+
 /** Build the 5-field cron string a preset describes. `custom` returns null so
  *  the caller leaves the raw field alone. */
 function buildCron(p: PickerState): string | null {
@@ -149,7 +180,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 
 function CronPicker({ schedule, onScheduleChange }: { schedule: string; onScheduleChange: (next: string) => void }) {
-  const [picker, setPicker] = useState<PickerState>(DEFAULT_PICKER);
+  const [picker, setPicker] = useState<PickerState>(() => parsePicker(schedule));
 
   const apply = (next: PickerState) => {
     setPicker(next);

--- a/web/src/components/settings/ScheduledJobsWidget.tsx
+++ b/web/src/components/settings/ScheduledJobsWidget.tsx
@@ -1,0 +1,541 @@
+// Cron-scheduled sessions editor (#2886).
+//
+// Edits the global `scheduling.jobs` array: a list of jobs, each with a friendly
+// cron picker (frequency presets that generate a 5-field expression) plus a raw
+// cron escape hatch. The raw field is the source of truth on save; presets just
+// fill it. The whole array is persisted wholesale through `save(nextJobs)`.
+//
+// Cron is validated client-side before save (see cronValidation.ts) because the
+// server does not re-validate it: an invalid expression would silently never
+// fire.
+
+import { useState } from "react";
+
+import { validateCron } from "./cronValidation";
+import type { CustomWidgetProps } from "./customWidgets";
+
+interface ScheduledJob {
+  id: string;
+  name: string;
+  schedule: string;
+  enabled: boolean;
+  tool: string;
+  agent?: string;
+  model?: string;
+  approval_mode?: string;
+  project?: string;
+  prompt: string;
+  group: string;
+  owner_profile: string;
+}
+
+function asJobs(value: unknown): ScheduledJob[] {
+  return Array.isArray(value) ? (value as ScheduledJob[]) : [];
+}
+
+type Frequency = "minutes" | "hourly" | "daily" | "weekly" | "custom";
+
+const WEEKDAYS = [
+  { value: "1", label: "Monday" },
+  { value: "2", label: "Tuesday" },
+  { value: "3", label: "Wednesday" },
+  { value: "4", label: "Thursday" },
+  { value: "5", label: "Friday" },
+  { value: "6", label: "Saturday" },
+  { value: "0", label: "Sunday" },
+];
+
+interface PickerState {
+  frequency: Frequency;
+  everyN: number; // minutes for "Every N minutes"
+  minute: number; // minute-of-hour for "Hourly"
+  time: string; // "HH:MM" for daily / weekly
+  weekday: string; // dow for weekly
+}
+
+const DEFAULT_PICKER: PickerState = {
+  frequency: "daily",
+  everyN: 30,
+  minute: 0,
+  time: "08:00",
+  weekday: "1",
+};
+
+/** Parse an "HH:MM" time input into numeric hour/minute (leading zeros
+ *  stripped so the cron reads "0 8 * * *", not "00 08 * * *"). */
+function parseTime(time: string): { h: number; m: number } {
+  const [hh, mm] = time.split(":");
+  return { h: Number(hh) || 0, m: Number(mm) || 0 };
+}
+
+/** Build the 5-field cron string a preset describes. `custom` returns null so
+ *  the caller leaves the raw field alone. */
+function buildCron(p: PickerState): string | null {
+  switch (p.frequency) {
+    case "minutes":
+      return `*/${p.everyN} * * * *`;
+    case "hourly":
+      return `${p.minute} * * * *`;
+    case "daily": {
+      const { h, m } = parseTime(p.time);
+      return `${m} ${h} * * *`;
+    }
+    case "weekly": {
+      const { h, m } = parseTime(p.time);
+      return `${m} ${h} * * ${p.weekday}`;
+    }
+    case "custom":
+      return null;
+  }
+}
+
+interface JobDraft {
+  id: string | null;
+  name: string;
+  schedule: string;
+  enabled: boolean;
+  tool: string;
+  agent: string;
+  model: string;
+  approval_mode: string;
+  project: string;
+  prompt: string;
+  group: string;
+}
+
+function emptyDraft(): JobDraft {
+  return {
+    id: null,
+    name: "",
+    schedule: "0 8 * * *",
+    enabled: true,
+    tool: "claude",
+    agent: "",
+    model: "",
+    approval_mode: "",
+    project: "",
+    prompt: "",
+    group: "Scheduled",
+  };
+}
+
+function draftFromJob(job: ScheduledJob): JobDraft {
+  return {
+    id: job.id,
+    name: job.name,
+    schedule: job.schedule,
+    enabled: job.enabled,
+    tool: job.tool || "claude",
+    agent: job.agent ?? "",
+    model: job.model ?? "",
+    approval_mode: job.approval_mode ?? "",
+    project: job.project ?? "",
+    prompt: job.prompt,
+    group: job.group || "Scheduled",
+  };
+}
+
+const inputCls =
+  "w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none";
+const labelCls = "block text-sm text-text-bright mb-1";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className={labelCls}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function CronPicker({ schedule, onScheduleChange }: { schedule: string; onScheduleChange: (next: string) => void }) {
+  const [picker, setPicker] = useState<PickerState>(DEFAULT_PICKER);
+
+  const apply = (next: PickerState) => {
+    setPicker(next);
+    const cron = buildCron(next);
+    if (cron !== null) onScheduleChange(cron);
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border border-surface-700 bg-surface-900/50 p-3">
+      <Field label="Frequency">
+        <select
+          aria-label="Frequency"
+          value={picker.frequency}
+          onChange={(e) => apply({ ...picker, frequency: e.target.value as Frequency })}
+          className={inputCls}
+        >
+          <option value="minutes">Every N minutes</option>
+          <option value="hourly">Hourly</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="custom">Custom (raw cron)</option>
+        </select>
+      </Field>
+
+      {picker.frequency === "minutes" && (
+        <Field label="Every (minutes)">
+          <input
+            type="number"
+            aria-label="Every N minutes"
+            min={1}
+            max={59}
+            value={picker.everyN}
+            onChange={(e) => apply({ ...picker, everyN: Math.max(1, Math.min(59, Number(e.target.value) || 1)) })}
+            className={inputCls}
+          />
+        </Field>
+      )}
+
+      {picker.frequency === "hourly" && (
+        <Field label="At minute">
+          <input
+            type="number"
+            aria-label="At minute"
+            min={0}
+            max={59}
+            value={picker.minute}
+            onChange={(e) => apply({ ...picker, minute: Math.max(0, Math.min(59, Number(e.target.value) || 0)) })}
+            className={inputCls}
+          />
+        </Field>
+      )}
+
+      {(picker.frequency === "daily" || picker.frequency === "weekly") && (
+        <Field label="Time">
+          <input
+            type="time"
+            aria-label="Time"
+            value={picker.time}
+            onChange={(e) => apply({ ...picker, time: e.target.value || "00:00" })}
+            className={inputCls}
+          />
+        </Field>
+      )}
+
+      {picker.frequency === "weekly" && (
+        <Field label="Day of week">
+          <select
+            aria-label="Day of week"
+            value={picker.weekday}
+            onChange={(e) => apply({ ...picker, weekday: e.target.value })}
+            className={inputCls}
+          >
+            {WEEKDAYS.map((d) => (
+              <option key={d.value} value={d.value}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+      )}
+
+      <Field label="Cron expression">
+        <input
+          type="text"
+          aria-label="Cron expression"
+          value={schedule}
+          onChange={(e) => onScheduleChange(e.target.value)}
+          placeholder="min hour day month weekday"
+          className={inputCls + " font-mono"}
+        />
+      </Field>
+      <p className="text-xs text-text-dim">
+        5-field cron, host-local time. Presets fill this in; edit it directly for anything custom.
+      </p>
+    </div>
+  );
+}
+
+function JobForm({
+  draft,
+  onCancel,
+  onSubmit,
+}: {
+  draft: JobDraft;
+  onCancel: () => void;
+  onSubmit: (draft: JobDraft) => void;
+}) {
+  const [local, setLocal] = useState<JobDraft>(draft);
+  const [error, setError] = useState<string | null>(null);
+  const set = (patch: Partial<JobDraft>) => setLocal((prev) => ({ ...prev, ...patch }));
+
+  const submit = () => {
+    if (!local.name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    if (!local.prompt.trim()) {
+      setError("Prompt is required.");
+      return;
+    }
+    if (!local.tool.trim()) {
+      setError("Tool is required.");
+      return;
+    }
+    const cronError = validateCron(local.schedule);
+    if (cronError) {
+      setError(cronError);
+      return;
+    }
+    setError(null);
+    onSubmit(local);
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-brand-600/40 bg-surface-850 p-3">
+      <Field label="Name">
+        <input
+          type="text"
+          aria-label="Name"
+          value={local.name}
+          onChange={(e) => set({ name: e.target.value })}
+          placeholder="Daily PR triage"
+          className={inputCls}
+        />
+      </Field>
+
+      <CronPicker schedule={local.schedule} onScheduleChange={(schedule) => set({ schedule })} />
+
+      <Field label="Prompt">
+        <textarea
+          aria-label="Prompt"
+          value={local.prompt}
+          onChange={(e) => set({ prompt: e.target.value })}
+          rows={3}
+          placeholder="What should the session do?"
+          className={inputCls + " resize-y"}
+        />
+      </Field>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label="Tool">
+          <input
+            type="text"
+            aria-label="Tool"
+            value={local.tool}
+            onChange={(e) => set({ tool: e.target.value })}
+            placeholder="claude"
+            className={inputCls + " font-mono"}
+          />
+        </Field>
+        <Field label="Agent (optional)">
+          <input
+            type="text"
+            aria-label="Agent"
+            value={local.agent}
+            onChange={(e) => set({ agent: e.target.value })}
+            placeholder="Same as tool"
+            className={inputCls + " font-mono"}
+          />
+        </Field>
+        <Field label="Model (optional)">
+          <input
+            type="text"
+            aria-label="Model"
+            value={local.model}
+            onChange={(e) => set({ model: e.target.value })}
+            placeholder="Agent default"
+            className={inputCls + " font-mono"}
+          />
+        </Field>
+        <Field label="Approval mode (optional)">
+          <input
+            type="text"
+            aria-label="Approval mode"
+            value={local.approval_mode}
+            onChange={(e) => set({ approval_mode: e.target.value })}
+            placeholder="Bypass (yolo)"
+            className={inputCls + " font-mono"}
+          />
+        </Field>
+        <Field label="Project (optional)">
+          <input
+            type="text"
+            aria-label="Project"
+            value={local.project}
+            onChange={(e) => set({ project: e.target.value })}
+            placeholder="Scratch (project-less)"
+            className={inputCls + " font-mono"}
+          />
+        </Field>
+        <Field label="Group">
+          <input
+            type="text"
+            aria-label="Group"
+            value={local.group}
+            onChange={(e) => set({ group: e.target.value })}
+            placeholder="Scheduled"
+            className={inputCls}
+          />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-text-primary">
+        <input
+          type="checkbox"
+          aria-label="Enabled"
+          checked={local.enabled}
+          onChange={(e) => set({ enabled: e.target.checked })}
+          className="accent-brand-600"
+        />
+        Enabled
+      </label>
+
+      {error && <div className="text-xs text-status-error">{error}</div>}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={submit}
+          className="rounded-md bg-brand-600 px-3 py-1.5 text-sm font-medium text-surface-950 hover:bg-brand-500"
+        >
+          Save job
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md px-3 py-1.5 text-sm text-text-dim hover:text-text-primary"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function JobRow({
+  job,
+  onToggle,
+  onEdit,
+  onRemove,
+}: {
+  job: ScheduledJob;
+  onToggle: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-surface-700 bg-surface-850 p-3">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={job.enabled}
+        aria-label={`Enable ${job.name}`}
+        onClick={onToggle}
+        className={`relative inline-flex h-6 w-10 shrink-0 items-center rounded-full transition-colors ${job.enabled ? "bg-brand-600" : "bg-surface-700"}`}
+      >
+        <span
+          className={`inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${job.enabled ? "translate-x-5" : "translate-x-1"}`}
+        />
+      </button>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm text-text-primary">{job.name}</div>
+        <div className="truncate text-xs text-text-dim">
+          <span className="font-mono">{job.schedule}</span>
+          {" · "}
+          <span className="font-mono">{job.tool}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="rounded px-2 py-1 text-xs text-text-dim hover:text-text-primary"
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        aria-label={`Remove ${job.name}`}
+        onClick={onRemove}
+        className="rounded px-2 py-1 text-xs text-text-dim hover:text-status-error"
+      >
+        Remove
+      </button>
+    </div>
+  );
+}
+
+export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetProps) {
+  const jobs = asJobs(value);
+  // null = no form open; "new" = adding; otherwise the id being edited.
+  const [editing, setEditing] = useState<string | null>(null);
+
+  const persist = (next: ScheduledJob[]) => void save(next);
+
+  const submitDraft = (draft: JobDraft) => {
+    const base = {
+      name: draft.name.trim(),
+      schedule: draft.schedule.trim(),
+      enabled: draft.enabled,
+      tool: draft.tool.trim(),
+      agent: draft.agent.trim() || undefined,
+      model: draft.model.trim() || undefined,
+      approval_mode: draft.approval_mode.trim() || undefined,
+      project: draft.project.trim() || undefined,
+      prompt: draft.prompt.trim(),
+      group: draft.group.trim() || "Scheduled",
+    };
+    if (draft.id === null) {
+      const job: ScheduledJob = { id: crypto.randomUUID(), owner_profile: "", ...base };
+      persist([...jobs, job]);
+    } else {
+      const existing = jobs.find((j) => j.id === draft.id);
+      const job: ScheduledJob = {
+        id: draft.id,
+        owner_profile: existing?.owner_profile ?? "",
+        ...base,
+      };
+      persist(jobs.map((j) => (j.id === draft.id ? job : j)));
+    }
+    setEditing(null);
+  };
+
+  const toggle = (id: string) => persist(jobs.map((j) => (j.id === id ? { ...j, enabled: !j.enabled } : j)));
+  const remove = (id: string) => {
+    persist(jobs.filter((j) => j.id !== id));
+    if (editing === id) setEditing(null);
+  };
+
+  const editingJob = editing && editing !== "new" ? jobs.find((j) => j.id === editing) : undefined;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-sm text-text-bright">{descriptor.label}</label>
+        {descriptor.description && <div className="mt-0.5 text-xs text-text-dim">{descriptor.description}</div>}
+      </div>
+
+      {jobs.length === 0 && editing !== "new" && <p className="text-xs text-text-dim">No scheduled jobs yet.</p>}
+
+      {jobs.map((job) =>
+        editing === job.id ? (
+          <JobForm key={job.id} draft={draftFromJob(job)} onCancel={() => setEditing(null)} onSubmit={submitDraft} />
+        ) : (
+          <JobRow
+            key={job.id}
+            job={job}
+            onToggle={() => toggle(job.id)}
+            onEdit={() => setEditing(job.id)}
+            onRemove={() => remove(job.id)}
+          />
+        ),
+      )}
+
+      {editing === "new" ? (
+        <JobForm draft={emptyDraft()} onCancel={() => setEditing(null)} onSubmit={submitDraft} />
+      ) : (
+        !editingJob && (
+          <button
+            type="button"
+            onClick={() => setEditing("new")}
+            className="rounded-md border border-surface-700 px-3 py-1.5 text-sm text-brand-500 hover:text-brand-400"
+          >
+            + Add scheduled job
+          </button>
+        )
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/ScheduledJobsWidget.tsx
+++ b/web/src/components/settings/ScheduledJobsWidget.tsx
@@ -9,10 +9,18 @@
 // server does not re-validate it: an invalid expression would silently never
 // fire.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { DirectoryBrowser } from "../DirectoryBrowser";
+import { fetchAcpOptionCatalog, fetchAgents, fetchGroups, fetchProjects } from "../../lib/api";
+import type { AgentOptionEntry } from "../../lib/api";
+import type { ConfigOptionCategory, ConfigOptionDescriptor } from "../../lib/acpTypes";
+import type { AgentInfo, GroupInfo, ProjectInfo } from "../../lib/types";
 import { validateCron } from "./cronValidation";
 import type { CustomWidgetProps } from "./customWidgets";
+
+/** Recall catalog keyed by agent name (`fetchAcpOptionCatalog().agents`). */
+type OptionCatalog = Record<string, AgentOptionEntry>;
 
 interface ScheduledJob {
   id: string;
@@ -179,6 +187,209 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
+/** Agents the wizard treats as selectable: installed built-ins plus any custom
+ *  agent (defined by config, not a resolvable binary). Mirrors
+ *  AgentPickerEssentials. */
+function selectableAgents(agents: AgentInfo[]): AgentInfo[] {
+  return agents.filter((a) => a.kind === "custom" || a.installed);
+}
+
+/** `<select>` options for the tool/agent pickers: an empty choice, the
+ *  selectable agents, and, when the saved value is not among them, an
+ *  "(unverified)" entry so a stale or hand-entered name stays selected. */
+function agentOptions(agents: AgentInfo[], current: string, emptyLabel: string): { value: string; label: string }[] {
+  const opts = [{ value: "", label: emptyLabel }];
+  const selectable = selectableAgents(agents);
+  for (const a of selectable) opts.push({ value: a.name, label: a.name });
+  if (current && !selectable.some((a) => a.name === current)) {
+    opts.push({ value: current, label: `${current} (unverified)` });
+  }
+  return opts;
+}
+
+function optionByCategory(
+  entry: AgentOptionEntry | undefined,
+  category: ConfigOptionCategory,
+): ConfigOptionDescriptor | undefined {
+  return entry?.options.find((o) => o.category === category);
+}
+
+/** `<select>` options for a capability field (model / approval mode): the
+ *  "default" empty choice, the advertised choices, and an "(unverified)" entry
+ *  preserving a saved value the agent no longer advertises. */
+function capabilityOptions(
+  descriptor: ConfigOptionDescriptor | undefined,
+  saved: string,
+  defaultLabel: string,
+): { value: string; label: string }[] {
+  const opts = [{ value: "", label: defaultLabel }];
+  const choices = descriptor?.options ?? [];
+  for (const c of choices) opts.push({ value: c.value, label: c.name || c.value });
+  if (saved && !choices.some((c) => c.value === saved)) {
+    opts.push({ value: saved, label: `${saved} (unverified)` });
+  }
+  return opts;
+}
+
+function SelectRow({
+  label,
+  ariaLabel,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  ariaLabel: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  return (
+    <Field label={label}>
+      <select aria-label={ariaLabel} value={value} onChange={(e) => onChange(e.target.value)} className={inputCls}>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </Field>
+  );
+}
+
+/** A capability field is a dropdown when the agent advertised choices for the
+ *  category, else a free-text input. Falls back to text when no catalog entry
+ *  exists yet (no structured session has run for the agent) so the value stays
+ *  editable. */
+function CapabilityRow({
+  label,
+  ariaLabel,
+  descriptor,
+  value,
+  onChange,
+  defaultLabel,
+  placeholder,
+}: {
+  label: string;
+  ariaLabel: string;
+  descriptor: ConfigOptionDescriptor | undefined;
+  value: string;
+  onChange: (v: string) => void;
+  defaultLabel: string;
+  placeholder: string;
+}) {
+  if (descriptor && descriptor.options.length > 0) {
+    return (
+      <SelectRow
+        label={label}
+        ariaLabel={ariaLabel}
+        value={value}
+        onChange={onChange}
+        options={capabilityOptions(descriptor, value, defaultLabel)}
+      />
+    );
+  }
+  return (
+    <Field label={label}>
+      <input
+        type="text"
+        aria-label={ariaLabel}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={inputCls + " font-mono"}
+      />
+    </Field>
+  );
+}
+
+function GroupRow({ value, onChange, groups }: { value: string; onChange: (v: string) => void; groups: GroupInfo[] }) {
+  const names = Array.from(new Set(groups.map((g) => g.path).filter(Boolean)));
+  return (
+    <Field label="Group">
+      <input
+        type="text"
+        aria-label="Group"
+        list="scheduled-job-groups"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Scheduled"
+        className={inputCls}
+      />
+      <datalist id="scheduled-job-groups">
+        {names.map((n) => (
+          <option key={n} value={n} />
+        ))}
+      </datalist>
+    </Field>
+  );
+}
+
+const BROWSE_SENTINEL = "__browse__";
+
+/** Project picker: scratch (project-less), the registered projects, an
+ *  "(unverified)" entry keeping a hand-picked path selected, and a sentinel that
+ *  opens the same directory browser the wizard uses. */
+function ProjectRow({
+  projects,
+  value,
+  onChange,
+}: {
+  projects: ProjectInfo[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [browsing, setBrowsing] = useState(false);
+  const known = projects.some((p) => p.path === value);
+  const options = [{ value: "", label: "Scratch (project-less)" }];
+  for (const p of projects) options.push({ value: p.path, label: p.name ? `${p.name} (${p.path})` : p.path });
+  if (value && !known) options.push({ value, label: value });
+  options.push({ value: BROWSE_SENTINEL, label: "Browse filesystem…" });
+
+  return (
+    <Field label="Project (optional)">
+      <select
+        aria-label="Project"
+        value={browsing ? BROWSE_SENTINEL : value}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (v === BROWSE_SENTINEL) {
+            setBrowsing(true);
+          } else {
+            setBrowsing(false);
+            onChange(v);
+          }
+        }}
+        className={inputCls}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      {browsing && (
+        <div className="mt-2 rounded-md border border-surface-700 bg-surface-900/50 p-2">
+          <DirectoryBrowser
+            initialPath={value || undefined}
+            onSelect={(path) => {
+              onChange(path);
+              setBrowsing(false);
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => setBrowsing(false)}
+            className="mt-2 text-xs text-text-dim hover:text-text-primary"
+          >
+            Cancel browse
+          </button>
+        </div>
+      )}
+    </Field>
+  );
+}
+
 function CronPicker({ schedule, onScheduleChange }: { schedule: string; onScheduleChange: (next: string) => void }) {
   const [picker, setPicker] = useState<PickerState>(() => parsePicker(schedule));
 
@@ -281,16 +492,32 @@ function CronPicker({ schedule, onScheduleChange }: { schedule: string; onSchedu
 
 function JobForm({
   draft,
+  agents,
+  catalog,
+  projects,
+  groups,
   onCancel,
   onSubmit,
 }: {
   draft: JobDraft;
+  agents: AgentInfo[];
+  catalog: OptionCatalog;
+  projects: ProjectInfo[];
+  groups: GroupInfo[];
   onCancel: () => void;
   onSubmit: (draft: JobDraft) => void;
 }) {
   const [local, setLocal] = useState<JobDraft>(draft);
   const [error, setError] = useState<string | null>(null);
   const set = (patch: Partial<JobDraft>) => setLocal((prev) => ({ ...prev, ...patch }));
+
+  // Models and approval modes are looked up against the agent the run resolves
+  // to: an explicit structured-view agent wins, else the tool (matches the
+  // scheduler's `job.agent ?? job.tool`).
+  const agentKey = (local.agent || local.tool).trim();
+  const entry = catalog[agentKey];
+  const modelDesc = optionByCategory(entry, "model");
+  const modeDesc = optionByCategory(entry, "mode");
 
   const submit = () => {
     if (!local.name.trim()) {
@@ -341,67 +568,42 @@ function JobForm({
       </Field>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <Field label="Tool">
-          <input
-            type="text"
-            aria-label="Tool"
-            value={local.tool}
-            onChange={(e) => set({ tool: e.target.value })}
-            placeholder="claude"
-            className={inputCls + " font-mono"}
-          />
-        </Field>
-        <Field label="Agent (optional)">
-          <input
-            type="text"
-            aria-label="Agent"
-            value={local.agent}
-            onChange={(e) => set({ agent: e.target.value })}
-            placeholder="Same as tool"
-            className={inputCls + " font-mono"}
-          />
-        </Field>
-        <Field label="Model (optional)">
-          <input
-            type="text"
-            aria-label="Model"
-            value={local.model}
-            onChange={(e) => set({ model: e.target.value })}
-            placeholder="Agent default"
-            className={inputCls + " font-mono"}
-          />
-        </Field>
-        <Field label="Approval mode (optional)">
-          <input
-            type="text"
-            aria-label="Approval mode"
-            value={local.approval_mode}
-            onChange={(e) => set({ approval_mode: e.target.value })}
-            placeholder="Bypass (yolo)"
-            className={inputCls + " font-mono"}
-          />
-        </Field>
-        <Field label="Project (optional)">
-          <input
-            type="text"
-            aria-label="Project"
-            value={local.project}
-            onChange={(e) => set({ project: e.target.value })}
-            placeholder="Scratch (project-less)"
-            className={inputCls + " font-mono"}
-          />
-        </Field>
-        <Field label="Group">
-          <input
-            type="text"
-            aria-label="Group"
-            value={local.group}
-            onChange={(e) => set({ group: e.target.value })}
-            placeholder="Scheduled"
-            className={inputCls}
-          />
-        </Field>
+        <SelectRow
+          label="Tool"
+          ariaLabel="Tool"
+          value={local.tool}
+          onChange={(v) => set({ tool: v })}
+          options={agentOptions(agents, local.tool, "Select a tool…")}
+        />
+        <SelectRow
+          label="Agent (optional)"
+          ariaLabel="Agent"
+          value={local.agent}
+          onChange={(v) => set({ agent: v })}
+          options={agentOptions(agents, local.agent, "Same as tool")}
+        />
+        <CapabilityRow
+          label="Model (optional)"
+          ariaLabel="Model"
+          descriptor={modelDesc}
+          value={local.model}
+          onChange={(v) => set({ model: v })}
+          defaultLabel="Agent default"
+          placeholder="Agent default"
+        />
+        <CapabilityRow
+          label="Approval mode (optional)"
+          ariaLabel="Approval mode"
+          descriptor={modeDesc}
+          value={local.approval_mode}
+          onChange={(v) => set({ approval_mode: v })}
+          defaultLabel="Default (agent bypass)"
+          placeholder="Bypass (yolo)"
+        />
+        <GroupRow value={local.group} onChange={(v) => set({ group: v })} groups={groups} />
       </div>
+
+      <ProjectRow projects={projects} value={local.project} onChange={(v) => set({ project: v })} />
 
       <label className="flex items-center gap-2 text-sm text-text-primary">
         <input
@@ -493,6 +695,35 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
   // null = no form open; "new" = adding; otherwise the id being edited.
   const [editing, setEditing] = useState<string | null>(null);
 
+  // Picker sources, loaded once: the wizard's agent list (tool/agent), the
+  // recall catalog of advertised models/modes per agent, the project registry,
+  // and the existing group names. Each degrades gracefully to an empty list so
+  // a fetch failure leaves the form usable (text fallbacks / free-typed group).
+  const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const [catalog, setCatalog] = useState<OptionCatalog>({});
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [groups, setGroups] = useState<GroupInfo[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      const [a, c, p, g] = await Promise.all([
+        fetchAgents().catch(() => [] as AgentInfo[]),
+        fetchAcpOptionCatalog().catch(() => ({ version: 1, agents: {} as OptionCatalog })),
+        fetchProjects().catch(() => [] as ProjectInfo[]),
+        fetchGroups().catch(() => [] as GroupInfo[]),
+      ]);
+      if (!alive) return;
+      setAgents(a);
+      setCatalog(c.agents ?? {});
+      setProjects(p);
+      setGroups(g);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
   const persist = async (next: ScheduledJob[]) => (await save(next)) !== false;
 
   const submitDraft = async (draft: JobDraft) => {
@@ -541,7 +772,16 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
 
       {jobs.map((job) =>
         editing === job.id ? (
-          <JobForm key={job.id} draft={draftFromJob(job)} onCancel={() => setEditing(null)} onSubmit={submitDraft} />
+          <JobForm
+            key={job.id}
+            draft={draftFromJob(job)}
+            agents={agents}
+            catalog={catalog}
+            projects={projects}
+            groups={groups}
+            onCancel={() => setEditing(null)}
+            onSubmit={submitDraft}
+          />
         ) : (
           <JobRow
             key={job.id}
@@ -554,7 +794,15 @@ export function ScheduledJobsWidget({ descriptor, value, save }: CustomWidgetPro
       )}
 
       {editing === "new" ? (
-        <JobForm draft={emptyDraft()} onCancel={() => setEditing(null)} onSubmit={submitDraft} />
+        <JobForm
+          draft={emptyDraft()}
+          agents={agents}
+          catalog={catalog}
+          projects={projects}
+          groups={groups}
+          onCancel={() => setEditing(null)}
+          onSubmit={submitDraft}
+        />
       ) : (
         !editingJob && (
           <button

--- a/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
+++ b/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+//
+// Behavioral coverage for the scheduled-jobs settings widget (#2886): the cron
+// picker generates a 5-field expression from a preset, adding a job persists the
+// full array with a generated id and the built cron, and an invalid raw cron
+// blocks the save with an inline error.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ScheduledJobsWidget } from "../ScheduledJobsWidget";
+import { validateCron } from "../cronValidation";
+
+const DESCRIPTOR = {
+  section: "scheduling",
+  field: "jobs",
+  category: "Scheduling",
+  label: "Scheduled Jobs",
+  description: "",
+  widget: { kind: "custom" as const, id: "scheduled-jobs" },
+  web_write: { policy: "allow" as const },
+  profile_overridable: false,
+  validation: { rule: "none" as const },
+  advanced: false,
+};
+
+beforeEach(() => {
+  vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-0000-0000-000000000000");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("validateCron", () => {
+  it("accepts picker-generated expressions", () => {
+    expect(validateCron("0 8 * * *")).toBeNull();
+    expect(validateCron("*/30 * * * *")).toBeNull();
+    expect(validateCron("30 9 * * 1")).toBeNull();
+  });
+
+  it("rejects wrong field count and out-of-range values", () => {
+    expect(validateCron("0 8 * *")).toMatch(/exactly 5 fields/);
+    expect(validateCron("99 8 * * *")).toMatch(/minute/);
+    expect(validateCron("0 25 * * *")).toMatch(/hour/);
+  });
+});
+
+it("cron picker generates the cron string for the Daily preset", () => {
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  const cron = screen.getByLabelText("Cron expression") as HTMLInputElement;
+  const time = screen.getByLabelText("Time") as HTMLInputElement;
+
+  // Prove the picker drives the raw field, not just the seed default.
+  fireEvent.change(time, { target: { value: "23:59" } });
+  expect(cron.value).toBe("59 23 * * *");
+
+  fireEvent.change(time, { target: { value: "08:00" } });
+  expect(cron.value).toBe("0 8 * * *");
+});
+
+it("Weekly preset generates a day-of-week cron", () => {
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Frequency"), { target: { value: "weekly" } });
+  fireEvent.change(screen.getByLabelText("Time"), { target: { value: "09:30" } });
+  fireEvent.change(screen.getByLabelText("Day of week"), { target: { value: "1" } });
+
+  expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("30 9 * * 1");
+});
+
+it("adds a job and saves the full array with a generated id and built cron", () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Daily triage" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "Review open PRs" } });
+  fireEvent.change(screen.getByLabelText("Time"), { target: { value: "08:00" } });
+
+  fireEvent.click(screen.getByText("Save job"));
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(save).toHaveBeenCalledWith([
+    {
+      id: "00000000-0000-0000-0000-000000000000",
+      owner_profile: "",
+      name: "Daily triage",
+      schedule: "0 8 * * *",
+      enabled: true,
+      tool: "claude",
+      prompt: "Review open PRs",
+      group: "Scheduled",
+    },
+  ]);
+});
+
+it("blocks save and shows an error for an invalid raw cron", () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Broken" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "do it" } });
+  fireEvent.change(screen.getByLabelText("Cron expression"), { target: { value: "99 8 * * *" } });
+
+  fireEvent.click(screen.getByText("Save job"));
+
+  expect(save).not.toHaveBeenCalled();
+  expect(screen.getByText(/Invalid minute field/)).toBeTruthy();
+});
+
+it("toggles a job's enabled flag and persists the whole array", () => {
+  const save = vi.fn();
+  const job = {
+    id: "job-1",
+    owner_profile: "",
+    name: "Nightly",
+    schedule: "0 3 * * *",
+    enabled: true,
+    tool: "claude",
+    prompt: "run",
+    group: "Scheduled",
+  };
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[job]} save={save} />);
+
+  fireEvent.click(screen.getByLabelText("Enable Nightly"));
+  expect(save).toHaveBeenCalledWith([{ ...job, enabled: false }]);
+});

--- a/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
+++ b/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
@@ -180,3 +180,207 @@ it("toggles a job's enabled flag and persists the whole array", () => {
   fireEvent.click(screen.getByLabelText("Enable Nightly"));
   expect(save).toHaveBeenCalledWith([{ ...job, enabled: false }]);
 });
+
+it("Every-N-minutes preset generates a step cron and reflects the input", () => {
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Frequency"), { target: { value: "minutes" } });
+  const everyN = screen.getByLabelText("Every N minutes") as HTMLInputElement;
+  fireEvent.change(everyN, { target: { value: "15" } });
+
+  expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("*/15 * * * *");
+});
+
+it("Hourly preset generates a minute-of-hour cron and reflects the input", () => {
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Frequency"), { target: { value: "hourly" } });
+  fireEvent.change(screen.getByLabelText("At minute"), { target: { value: "45" } });
+
+  expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("45 * * * *");
+});
+
+it("opens an existing every-N-minutes job on the minutes frequency", () => {
+  const job = {
+    id: "job-1",
+    owner_profile: "",
+    name: "Poll",
+    schedule: "*/10 * * * *",
+    enabled: true,
+    tool: "claude",
+    prompt: "poll",
+    group: "Scheduled",
+  };
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[job]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("Edit"));
+
+  expect((screen.getByLabelText("Frequency") as HTMLSelectElement).value).toBe("minutes");
+  expect((screen.getByLabelText("Every N minutes") as HTMLInputElement).value).toBe("10");
+});
+
+it("opens an existing hourly job on the hourly frequency", () => {
+  const job = {
+    id: "job-1",
+    owner_profile: "",
+    name: "Hourly",
+    schedule: "20 * * * *",
+    enabled: true,
+    tool: "claude",
+    prompt: "run",
+    group: "Scheduled",
+  };
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[job]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("Edit"));
+
+  expect((screen.getByLabelText("Frequency") as HTMLSelectElement).value).toBe("hourly");
+  expect((screen.getByLabelText("At minute") as HTMLInputElement).value).toBe("20");
+});
+
+it("falls back to custom for an unrecognized cron and leaves the raw field untouched", () => {
+  const job = {
+    id: "job-1",
+    owner_profile: "",
+    name: "Monthly",
+    schedule: "0 8 1 * *",
+    enabled: true,
+    tool: "claude",
+    prompt: "run",
+    group: "Scheduled",
+  };
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[job]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("Edit"));
+
+  expect((screen.getByLabelText("Frequency") as HTMLSelectElement).value).toBe("custom");
+  expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("0 8 1 * *");
+
+  // Re-selecting "custom" runs buildCron's custom arm, which returns null so the
+  // raw expression is deliberately left as-is.
+  fireEvent.change(screen.getByLabelText("Frequency"), { target: { value: "custom" } });
+  expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("0 8 1 * *");
+});
+
+it("requires name, prompt, and tool before saving", () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.click(screen.getByText("Save job"));
+  expect(screen.getByText("Name is required.")).toBeTruthy();
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Job" } });
+  fireEvent.click(screen.getByText("Save job"));
+  expect(screen.getByText("Prompt is required.")).toBeTruthy();
+
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "do it" } });
+  fireEvent.change(screen.getByLabelText("Tool"), { target: { value: "" } });
+  fireEvent.click(screen.getByText("Save job"));
+  expect(screen.getByText("Tool is required.")).toBeTruthy();
+
+  expect(save).not.toHaveBeenCalled();
+});
+
+it("persists every optional field and the in-form enabled toggle", () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Full job" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "work" } });
+  fireEvent.change(screen.getByLabelText("Tool"), { target: { value: "codex" } });
+  fireEvent.change(screen.getByLabelText("Agent"), { target: { value: "codex-agent" } });
+  fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5" } });
+  fireEvent.change(screen.getByLabelText("Approval mode"), { target: { value: "yolo" } });
+  fireEvent.change(screen.getByLabelText("Project"), { target: { value: "/repo" } });
+  fireEvent.change(screen.getByLabelText("Group"), { target: { value: "Nightly" } });
+  fireEvent.click(screen.getByLabelText("Enabled"));
+
+  fireEvent.click(screen.getByText("Save job"));
+
+  expect(save).toHaveBeenCalledWith([
+    {
+      id: "00000000-0000-0000-0000-000000000000",
+      owner_profile: "",
+      name: "Full job",
+      schedule: "0 8 * * *",
+      enabled: false,
+      tool: "codex",
+      agent: "codex-agent",
+      model: "gpt-5",
+      approval_mode: "yolo",
+      project: "/repo",
+      prompt: "work",
+      group: "Nightly",
+    },
+  ]);
+});
+
+it("omits blank optional fields and defaults the group when project is left empty", () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Minimal" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "go" } });
+  fireEvent.change(screen.getByLabelText("Group"), { target: { value: "" } });
+
+  fireEvent.click(screen.getByText("Save job"));
+
+  const [[persisted]] = save.mock.calls;
+  const job = persisted[0];
+  expect(job.project).toBeUndefined();
+  expect(job.agent).toBeUndefined();
+  expect(job.group).toBe("Scheduled");
+});
+
+it("edits an existing job and persists the update in place", () => {
+  const save = vi.fn();
+  const job = {
+    id: "job-1",
+    owner_profile: "profile-a",
+    name: "Old name",
+    schedule: "0 8 * * *",
+    enabled: true,
+    tool: "claude",
+    prompt: "old prompt",
+    group: "Scheduled",
+  };
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[job]} save={save} />);
+
+  fireEvent.click(screen.getByText("Edit"));
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "new prompt" } });
+  fireEvent.click(screen.getByText("Save job"));
+
+  expect(save).toHaveBeenCalledWith([{ ...job, prompt: "new prompt" }]);
+});
+
+it("removes a job and persists the array without it", () => {
+  const save = vi.fn();
+  const jobs = [
+    {
+      id: "job-1",
+      owner_profile: "",
+      name: "First",
+      schedule: "0 8 * * *",
+      enabled: true,
+      tool: "claude",
+      prompt: "a",
+      group: "Scheduled",
+    },
+    {
+      id: "job-2",
+      owner_profile: "",
+      name: "Second",
+      schedule: "0 9 * * *",
+      enabled: true,
+      tool: "claude",
+      prompt: "b",
+      group: "Scheduled",
+    },
+  ];
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={jobs} save={save} />);
+
+  fireEvent.click(screen.getByLabelText("Remove First"));
+  expect(save).toHaveBeenCalledWith([jobs[1]]);
+});

--- a/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
+++ b/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
@@ -72,6 +72,35 @@ it("Weekly preset generates a day-of-week cron", () => {
   expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("30 9 * * 1");
 });
 
+it("opens an existing weekly job on its own frequency and preserves the schedule", () => {
+  const save = vi.fn();
+  const job = {
+    id: "job-1",
+    owner_profile: "",
+    name: "Weekly report",
+    schedule: "30 9 * * 1",
+    enabled: true,
+    tool: "claude",
+    prompt: "summarize",
+    group: "Scheduled",
+  };
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[job]} save={save} />);
+
+  fireEvent.click(screen.getByText("Edit"));
+
+  // The picker opens on Weekly (not the default Daily), so weekly-only controls
+  // are present and the raw cron is untouched.
+  expect((screen.getByLabelText("Frequency") as HTMLSelectElement).value).toBe("weekly");
+  expect((screen.getByLabelText("Day of week") as HTMLSelectElement).value).toBe("1");
+  expect((screen.getByLabelText("Cron expression") as HTMLInputElement).value).toBe("30 9 * * 1");
+
+  // Editing an unrelated field does not silently rewrite the schedule as daily.
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Renamed" } });
+  fireEvent.click(screen.getByText("Save job"));
+
+  expect(save).toHaveBeenCalledWith([{ ...job, name: "Renamed" }]);
+});
+
 it("adds a job and saves the full array with a generated id and built cron", () => {
   const save = vi.fn();
   render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);

--- a/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
+++ b/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
@@ -4,11 +4,78 @@
 // picker generates a 5-field expression from a preset, adding a job persists the
 // full array with a generated id and the built cron, and an invalid raw cron
 // blocks the save with an inline error.
+//
+// The tool / agent / model / approval-mode / project fields are capability-driven
+// pickers (#2887): tool and agent come from the wizard's agent list
+// (GET /api/agents), model and approval mode from the recall catalog each agent
+// advertised (GET /api/acp/option-catalog), the project from the registry
+// (GET /api/projects) plus the shared directory browser, and the group from a
+// datalist of existing groups (GET /api/groups) that still accepts a new name.
+// All four sources are mocked here the way the sibling AcpDefaultsWidget test
+// mocks the api module.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { ScheduledJobsWidget } from "../ScheduledJobsWidget";
 import { validateCron } from "../cronValidation";
+import * as api from "../../../lib/api";
+import type { AgentInfo } from "../../../lib/types";
+
+vi.mock("../../../lib/api", () => ({
+  fetchAgents: vi.fn(),
+  fetchAcpOptionCatalog: vi.fn(),
+  fetchProjects: vi.fn(),
+  fetchGroups: vi.fn(),
+  getHomePath: vi.fn(),
+  browseFilesystem: vi.fn(),
+}));
+
+function agent(name: string, over: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    name,
+    kind: "builtin",
+    binary: name,
+    host_only: false,
+    installed: true,
+    install_hint: "",
+    acp_capable: true,
+    acp_installed: true,
+    ...over,
+  };
+}
+
+// codex advertises model + mode choices; claude has no catalog entry, so its
+// model / approval-mode fields degrade to free text.
+const CATALOG = {
+  version: 1,
+  agents: {
+    codex: {
+      updated_at: "2026-01-01T00:00:00Z",
+      options: [
+        {
+          id: "model",
+          name: "Model",
+          category: "model" as const,
+          current_value: "",
+          options: [
+            { value: "gpt-5", name: "GPT-5" },
+            { value: "gpt-5-mini", name: "GPT-5 mini" },
+          ],
+        },
+        {
+          id: "mode",
+          name: "Mode",
+          category: "mode" as const,
+          current_value: "",
+          options: [
+            { value: "plan", name: "Plan" },
+            { value: "yolo", name: "Yolo" },
+          ],
+        },
+      ],
+    },
+  },
+};
 
 const DESCRIPTOR = {
   section: "scheduling",
@@ -25,6 +92,23 @@ const DESCRIPTOR = {
 
 beforeEach(() => {
   vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-0000-0000-000000000000");
+  vi.mocked(api.fetchAgents).mockResolvedValue([
+    agent("claude"),
+    agent("codex"),
+    agent("gemini", { installed: false }),
+  ]);
+  vi.mocked(api.fetchAcpOptionCatalog).mockResolvedValue(CATALOG);
+  vi.mocked(api.fetchProjects).mockResolvedValue([{ name: "repo", path: "/repo", scope: "global", pinned: false }]);
+  vi.mocked(api.fetchGroups).mockResolvedValue([
+    { path: "Nightly", session_count: 2 },
+    { path: "Scheduled", session_count: 1 },
+  ]);
+  vi.mocked(api.getHomePath).mockResolvedValue("/home");
+  vi.mocked(api.browseFilesystem).mockResolvedValue({
+    entries: [{ name: "myrepo", path: "/home/myrepo", is_dir: true, is_git_repo: true }],
+    has_more: false,
+    ok: true,
+  });
 });
 
 afterEach(() => {
@@ -274,6 +358,8 @@ it("requires name, prompt, and tool before saving", () => {
   expect(screen.getByText("Prompt is required.")).toBeTruthy();
 
   fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "do it" } });
+  // The tool picker always carries the empty "Select a tool…" choice, so a user
+  // can clear it and the required-field guard still fires.
   fireEvent.change(screen.getByLabelText("Tool"), { target: { value: "" } });
   fireEvent.click(screen.getByText("Save job"));
   expect(screen.getByText("Tool is required.")).toBeTruthy();
@@ -281,18 +367,47 @@ it("requires name, prompt, and tool before saving", () => {
   expect(save).not.toHaveBeenCalled();
 });
 
-it("persists every optional field and the in-form enabled toggle", () => {
+it("selecting an agent swaps its capability fields to catalog-driven dropdowns", async () => {
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={vi.fn()} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  // claude has no cached options, so model/approval start as free-text inputs.
+  await waitFor(() => expect((screen.getByLabelText("Tool") as HTMLSelectElement).value).toBe("claude"));
+  expect((screen.getByLabelText("Model") as HTMLElement).tagName).toBe("INPUT");
+  expect((screen.getByLabelText("Approval mode") as HTMLElement).tagName).toBe("INPUT");
+
+  // Switching to codex (which advertised choices) turns them into dropdowns.
+  fireEvent.change(screen.getByLabelText("Tool"), { target: { value: "codex" } });
+
+  const model = screen.getByLabelText("Model") as HTMLSelectElement;
+  const mode = screen.getByLabelText("Approval mode") as HTMLSelectElement;
+  expect(model.tagName).toBe("SELECT");
+  expect(mode.tagName).toBe("SELECT");
+  expect(within(model).getByRole("option", { name: "GPT-5" })).toBeTruthy();
+  expect(within(model).getByRole("option", { name: "Agent default" })).toBeTruthy();
+  expect(within(mode).getByRole("option", { name: "Plan" })).toBeTruthy();
+  expect(within(mode).getByRole("option", { name: "Default (agent bypass)" })).toBeTruthy();
+});
+
+it("persists an advertised model/mode, a registered project, and a chosen group", async () => {
   const save = vi.fn();
   render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
   fireEvent.click(screen.getByText("+ Add scheduled job"));
 
   fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Full job" } });
   fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "work" } });
+
+  // Wait for the agent list to load, then drive the capability pickers.
+  await waitFor(() =>
+    expect(within(screen.getByLabelText("Tool") as HTMLElement).getByRole("option", { name: "codex" })).toBeTruthy(),
+  );
   fireEvent.change(screen.getByLabelText("Tool"), { target: { value: "codex" } });
-  fireEvent.change(screen.getByLabelText("Agent"), { target: { value: "codex-agent" } });
   fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5" } });
-  fireEvent.change(screen.getByLabelText("Approval mode"), { target: { value: "yolo" } });
+  fireEvent.change(screen.getByLabelText("Approval mode"), { target: { value: "plan" } });
+
+  await screen.findByRole("option", { name: "repo (/repo)" });
   fireEvent.change(screen.getByLabelText("Project"), { target: { value: "/repo" } });
+
   fireEvent.change(screen.getByLabelText("Group"), { target: { value: "Nightly" } });
   fireEvent.click(screen.getByLabelText("Enabled"));
 
@@ -306,9 +421,8 @@ it("persists every optional field and the in-form enabled toggle", () => {
       schedule: "0 8 * * *",
       enabled: false,
       tool: "codex",
-      agent: "codex-agent",
       model: "gpt-5",
-      approval_mode: "yolo",
+      approval_mode: "plan",
       project: "/repo",
       prompt: "work",
       group: "Nightly",
@@ -316,7 +430,7 @@ it("persists every optional field and the in-form enabled toggle", () => {
   ]);
 });
 
-it("omits blank optional fields and defaults the group when project is left empty", () => {
+it("omits blank optional fields and defaults the group when project is left as scratch", () => {
   const save = vi.fn();
   render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
   fireEvent.click(screen.getByText("+ Add scheduled job"));
@@ -331,7 +445,55 @@ it("omits blank optional fields and defaults the group when project is left empt
   const job = persisted[0];
   expect(job.project).toBeUndefined();
   expect(job.agent).toBeUndefined();
+  expect(job.model).toBeUndefined();
+  expect(job.approval_mode).toBeUndefined();
   expect(job.group).toBe("Scheduled");
+});
+
+it("suggests existing groups in a datalist while still accepting a new name", async () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  // The datalist offers the existing group names once /api/groups resolves.
+  await waitFor(() => {
+    const opts = Array.from(document.querySelectorAll("#scheduled-job-groups option")).map(
+      (o) => (o as HTMLOptionElement).value,
+    );
+    expect(opts).toContain("Nightly");
+    expect(opts).toContain("Scheduled");
+  });
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Custom group job" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "go" } });
+  // A brand-new name that is not in the suggestions is still accepted.
+  fireEvent.change(screen.getByLabelText("Group"), { target: { value: "Brand New" } });
+
+  fireEvent.click(screen.getByText("Save job"));
+
+  const [[persisted]] = save.mock.calls;
+  expect(persisted[0].group).toBe("Brand New");
+});
+
+it("browses the filesystem to select a project directory", async () => {
+  const save = vi.fn();
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Browsed" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "go" } });
+
+  // Opening the browse sentinel mounts the shared directory browser.
+  fireEvent.change(screen.getByLabelText("Project"), { target: { value: "__browse__" } });
+  const repo = await screen.findByText("myrepo");
+  fireEvent.click(repo);
+
+  // Selecting a repo closes the browser and stamps the path onto the job.
+  await waitFor(() => expect(screen.queryByText("myrepo")).toBeNull());
+  fireEvent.click(screen.getByText("Save job"));
+
+  const [[persisted]] = save.mock.calls;
+  expect(persisted[0].project).toBe("/home/myrepo");
 });
 
 it("edits an existing job and persists the update in place", () => {

--- a/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
+++ b/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
@@ -5,10 +5,11 @@
 // full array with a generated id and the built cron, and an invalid raw cron
 // blocks the save with an inline error.
 //
-// The tool / agent / model / approval-mode / project fields are capability-driven
-// pickers (#2887): tool and agent come from the wizard's agent list
-// (GET /api/agents), model and approval mode from the recall catalog each agent
-// advertised (GET /api/acp/option-catalog), the project from the registry
+// The tool / model / approval-mode / project fields are capability-driven
+// pickers (#2887): the tool comes from the wizard's agent list
+// (GET /api/agents) and already selects the runtime (built-in binaries and
+// custom ACP agents alike), model and approval mode from the recall catalog the
+// tool advertised (GET /api/acp/option-catalog), the project from the registry
 // (GET /api/projects) plus the shared directory browser, and the group from a
 // datalist of existing groups (GET /api/groups) that still accepts a new name.
 // All four sources are mocked here the way the sibling AcpDefaultsWidget test
@@ -367,7 +368,7 @@ it("requires name, prompt, and tool before saving", () => {
   expect(save).not.toHaveBeenCalled();
 });
 
-it("selecting an agent swaps its capability fields to catalog-driven dropdowns", async () => {
+it("selecting a tool swaps its capability fields to catalog-driven dropdowns", async () => {
   render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={vi.fn()} />);
   fireEvent.click(screen.getByText("+ Add scheduled job"));
 
@@ -444,7 +445,6 @@ it("omits blank optional fields and defaults the group when project is left as s
   const [[persisted]] = save.mock.calls;
   const job = persisted[0];
   expect(job.project).toBeUndefined();
-  expect(job.agent).toBeUndefined();
   expect(job.model).toBeUndefined();
   expect(job.approval_mode).toBeUndefined();
   expect(job.group).toBe("Scheduled");

--- a/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
+++ b/web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx
@@ -6,7 +6,7 @@
 // blocks the save with an inline error.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ScheduledJobsWidget } from "../ScheduledJobsWidget";
 import { validateCron } from "../cronValidation";
 
@@ -125,6 +125,27 @@ it("adds a job and saves the full array with a generated id and built cron", () 
       group: "Scheduled",
     },
   ]);
+});
+
+it("keeps the editor open when save is rejected and closes it once save succeeds", async () => {
+  const save = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+  render(<ScheduledJobsWidget descriptor={DESCRIPTOR} value={[]} save={save} />);
+  fireEvent.click(screen.getByText("+ Add scheduled job"));
+
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Daily triage" } });
+  fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "Review open PRs" } });
+
+  // A rejected save keeps the form open with the draft intact, so the entry is
+  // not lost.
+  fireEvent.click(screen.getByText("Save job"));
+  await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+  expect(screen.getByText("Save job")).toBeTruthy();
+  expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("Daily triage");
+
+  // A successful save closes the editor back to the list.
+  fireEvent.click(screen.getByText("Save job"));
+  await waitFor(() => expect(screen.queryByText("Save job")).toBeNull());
+  expect(screen.getByText("+ Add scheduled job")).toBeTruthy();
 });
 
 it("blocks save and shows an error for an invalid raw cron", () => {

--- a/web/src/components/settings/__tests__/cronValidation.test.ts
+++ b/web/src/components/settings/__tests__/cronValidation.test.ts
@@ -1,0 +1,98 @@
+// Branch coverage for the client-side cron validator (#2886). Each field has a
+// distinct range, and the validator supports wildcards, lists, ranges, and
+// steps; every one of those forms has an accept and a reject case here.
+
+import { describe, expect, it } from "vitest";
+import { validateCron } from "../cronValidation";
+
+describe("validateCron field count", () => {
+  it("rejects too few fields", () => {
+    expect(validateCron("0 8 * *")).toMatch(/exactly 5 fields/);
+  });
+
+  it("rejects too many fields", () => {
+    expect(validateCron("0 8 * * * *")).toMatch(/exactly 5 fields/);
+  });
+
+  it("accepts the all-wildcard expression", () => {
+    expect(validateCron("* * * * *")).toBeNull();
+  });
+});
+
+describe("validateCron per-field ranges", () => {
+  // [expr, valid?, fieldName]
+  const cases: [string, boolean, string][] = [
+    // minute 0-59
+    ["0 * * * *", true, "minute low"],
+    ["59 * * * *", true, "minute high"],
+    ["60 * * * *", false, "minute over"],
+    // hour 0-23
+    ["0 0 * * *", true, "hour low"],
+    ["0 23 * * *", true, "hour high"],
+    ["0 24 * * *", false, "hour over"],
+    // day-of-month 1-31
+    ["0 0 1 * *", true, "dom low"],
+    ["0 0 31 * *", true, "dom high"],
+    ["0 0 0 * *", false, "dom under"],
+    ["0 0 32 * *", false, "dom over"],
+    // month 1-12
+    ["0 0 1 1 *", true, "month low"],
+    ["0 0 1 12 *", true, "month high"],
+    ["0 0 1 0 *", false, "month under"],
+    ["0 0 1 13 *", false, "month over"],
+    // day-of-week 0-7 (0 and 7 both Sunday)
+    ["0 0 * * 0", true, "dow low"],
+    ["0 0 * * 7", true, "dow high"],
+    ["0 0 * * 8", false, "dow over"],
+  ];
+
+  it.each(cases)("%s -> %s (%s)", (expr, valid) => {
+    const result = validateCron(expr);
+    if (valid) expect(result).toBeNull();
+    else expect(result).not.toBeNull();
+  });
+});
+
+describe("validateCron token forms", () => {
+  it("accepts comma lists", () => {
+    expect(validateCron("0,15,30,45 * * * *")).toBeNull();
+  });
+
+  it("rejects a list with an out-of-range member", () => {
+    expect(validateCron("0,15,99 * * * *")).toMatch(/minute/);
+  });
+
+  it("accepts ranges", () => {
+    expect(validateCron("0 9-17 * * *")).toBeNull();
+  });
+
+  it("rejects a range whose endpoint is out of range", () => {
+    expect(validateCron("0 9-25 * * *")).toMatch(/hour/);
+  });
+
+  it("rejects a malformed 3-part range", () => {
+    expect(validateCron("0 1-2-3 * * *")).toMatch(/hour/);
+  });
+
+  it("accepts step values", () => {
+    expect(validateCron("*/15 * * * *")).toBeNull();
+    expect(validateCron("0 */2 * * *")).toBeNull();
+  });
+
+  it("rejects a zero step", () => {
+    expect(validateCron("*/0 * * * *")).toMatch(/minute/);
+  });
+
+  it("rejects a non-numeric step", () => {
+    expect(validateCron("*/x * * * *")).toMatch(/minute/);
+  });
+
+  it("rejects more than one slash", () => {
+    expect(validateCron("*/2/3 * * * *")).toMatch(/minute/);
+  });
+
+  it("rejects non-numeric tokens", () => {
+    expect(validateCron("abc * * * *")).toMatch(/minute/);
+    expect(validateCron("0 xyz * * *")).toMatch(/hour/);
+  });
+});

--- a/web/src/components/settings/cronValidation.ts
+++ b/web/src/components/settings/cronValidation.ts
@@ -1,0 +1,55 @@
+// Small client-side 5-field cron validator for the scheduled-jobs widget
+// (#2886). The server does not re-validate cron, so an invalid expression would
+// silently never fire; this catches the obvious mistakes (wrong field count,
+// out-of-range values) before save. It is intentionally minimal: numeric fields
+// with `*`, `,`, `-`, `/`, matching the ranges croner enforces server-side and
+// covering everything the picker generates. Named tokens (JAN/MON) are not
+// accepted here; advanced users wanting those edit via the TUI or config.toml.
+
+const FIELD_RANGES: [number, number][] = [
+  [0, 59], // minute
+  [0, 23], // hour
+  [1, 31], // day of month
+  [1, 12], // month
+  [0, 7], // day of week (0 and 7 are both Sunday)
+];
+const FIELD_NAMES = ["minute", "hour", "day-of-month", "month", "day-of-week"];
+
+function inRange(token: string, min: number, max: number): boolean {
+  if (!/^\d+$/.test(token)) return false;
+  const n = Number(token);
+  return n >= min && n <= max;
+}
+
+function validItem(item: string, min: number, max: number): boolean {
+  const slash = item.split("/");
+  if (slash.length > 2) return false;
+  const base = slash[0] ?? "";
+  if (slash.length === 2) {
+    const step = slash[1] ?? "";
+    if (!/^\d+$/.test(step) || Number(step) < 1) return false;
+  }
+  if (base === "*") return true;
+  const dash = base.split("-");
+  if (dash.length === 1) return inRange(dash[0] ?? "", min, max);
+  if (dash.length === 2) return inRange(dash[0] ?? "", min, max) && inRange(dash[1] ?? "", min, max);
+  return false;
+}
+
+/** Return an error string for an invalid 5-field cron, or null when it is
+ *  acceptable. Purely a UX gate; the picker only ever produces valid output. */
+export function validateCron(expr: string): string | null {
+  const parts = expr.trim().split(/\s+/).filter(Boolean);
+  if (parts.length !== 5) {
+    return "Cron must have exactly 5 fields: minute hour day-of-month month day-of-week.";
+  }
+  for (let i = 0; i < 5; i++) {
+    const range = FIELD_RANGES[i];
+    const field = parts[i];
+    if (!range || field === undefined) continue;
+    const [min, max] = range;
+    const ok = field.split(",").every((item) => validItem(item, min, max));
+    if (!ok) return `Invalid ${FIELD_NAMES[i]} field: "${field}".`;
+  }
+  return null;
+}

--- a/web/src/components/settings/customWidgetRegistry.ts
+++ b/web/src/components/settings/customWidgetRegistry.ts
@@ -1,4 +1,5 @@
 import { AcpDefaultsWidget } from "./AcpDefaultsWidget";
+import { ScheduledJobsWidget } from "./ScheduledJobsWidget";
 import type { CustomSettingsWidget } from "./customWidgets";
 import {
   DefaultToolWidget,
@@ -21,4 +22,5 @@ export const CUSTOM_SETTINGS_WIDGETS: Record<string, CustomSettingsWidget> = {
   "sound-volume": SoundVolumeWidget,
   "logging-targets": LoggingTargetsWidget,
   "acp-defaults": AcpDefaultsWidget,
+  "scheduled-jobs": ScheduledJobsWidget,
 };

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -390,7 +390,10 @@
       "id": "settings.scheduled-jobs",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/settings/__tests__/ScheduledJobsWidget.test.tsx"],
+      "specs": [
+        "src/components/settings/__tests__/ScheduledJobsWidget.test.tsx",
+        "src/components/settings/__tests__/cronValidation.test.ts"
+      ],
       "components": [
         "web/src/components/settings/ScheduledJobsWidget.tsx",
         "web/src/components/settings/cronValidation.ts",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -387,6 +387,18 @@
       ]
     },
     {
+      "id": "settings.scheduled-jobs",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/settings/__tests__/ScheduledJobsWidget.test.tsx"],
+      "components": [
+        "web/src/components/settings/ScheduledJobsWidget.tsx",
+        "web/src/components/settings/cronValidation.ts",
+        "web/src/components/settings/customWidgetRegistry.ts",
+        "web/src/components/SettingsView.tsx"
+      ]
+    },
+    {
       "id": "settings.schema-persistence",
       "kind": "live-playwright",
       "risk": "medium",

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -153,6 +153,13 @@ const PAGES = [
       "Launch a session in a fresh scratch directory under ~/.agent-of-empires/scratch/ with no project path. The directory is removed when the session is deleted.",
   },
   {
+    source: "docs/guides/scheduled-sessions.md",
+    dest: "guides/scheduled-sessions.md",
+    title: "Scheduled Sessions",
+    description:
+      "Run a preset prompt against an agent on a cron schedule, unattended and auto-grouped, managed from the CLI, TUI, or web dashboard.",
+  },
+  {
     source: "docs/guides/live-mode.md",
     dest: "guides/live-mode.md",
     title: "Live Mode",
@@ -438,6 +445,7 @@ const URL_MAP = {
   "docs/guides/session-fork.md": "/guides/session-fork/",
   "docs/guides/multi-repo-workspaces.md": "/guides/multi-repo-workspaces/",
   "docs/guides/scratch-sessions.md": "/guides/scratch-sessions/",
+  "docs/guides/scheduled-sessions.md": "/guides/scheduled-sessions/",
   "docs/guides/live-mode.md": "/guides/live-mode/",
   "docs/guides/tool-sessions.md": "/guides/tool-sessions/",
   "docs/guides/podman.md": "/guides/podman/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -31,6 +31,7 @@ export const docsNav: NavSection[] = [
       { title: "Git Worktrees", href: "/guides/worktrees/", description: "How AoE creates and cleans up a git worktree per session." },
       { title: "Multi-Repo Workspaces", href: "/guides/multi-repo-workspaces/", description: "Drive one session across several git repositories at once." },
       { title: "Scratch Sessions", href: "/guides/scratch-sessions/", description: "Throwaway sessions for quick experiments without a worktree." },
+      { title: "Scheduled Sessions", href: "/guides/scheduled-sessions/", description: "Run a preset prompt against an agent on a cron schedule, unattended." },
       { title: "Diff View", href: "/guides/diff-view/", description: "Review git changes and edit files from the TUI." },
       { title: "tmux Status Bar", href: "/guides/tmux-status-bar/", description: "Show live session status in your tmux status bar." },
       { title: "Agent Command Overrides", href: "/guides/agent-override/", description: "Customize the command used to launch each agent." },


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds host-side cron-scheduled sessions (#2886). A scheduled job runs a preset prompt against an agent on a cron schedule, unattended, and files the spawned session under a `Scheduled` group so it does not muddle with interactive ones. Manageable from the CLI, the TUI settings screen, and the web dashboard.

How it works:

- **Config**: a new `[scheduling]` section holds `jobs` (id, name, cron, enabled, tool/agent/model, approval mode, project, prompt, group, owning profile). Global/profile only; excluded from repo overrides so a checked-out repo cannot inject unattended host work.
- **Scheduler**: a supervised daemon loop (`server.schedule_loop`) ticks every 30s and drives a pure `plan_tick` step (in-memory cursors seeded to now at startup). Missed occurrences while the daemon was down are skipped, so a machine that slept overnight does not fire a burst on wake. Each fired job dispatches in its own task (one hung worker never blocks the others) with per-job overlap suppression.
- **Execution**: a fired job creates a structured-view session via the extracted `spawn_structured_session` helper, applies an ACP session mode so the unattended run does not stall on approvals, then delivers the prompt with a readiness timeout.
- **Cron**: standard 5-field expressions via the new `croner` dependency, interpreted in the daemon host's local time.
- **Surfaces**: `aoe schedule add|list|remove|enable|disable`; a global-only Scheduling tab in the TUI (jobs edited as inline JSON, mirroring the acp-defaults widget); a web settings widget with a friendly cron picker (frequency presets that generate the cron string, plus a raw-cron escape hatch and client-side validation).

The first refactor commit extracts `spawn_structured_session` out of the 700-line `create_session` HTTP handler with no behavior change, so the scheduler reuses the exact session-creation invariants instead of duplicating them.

Closes agent-of-empires/plugin-cron#2

## PR Type

- [x] New Feature
- [x] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cargo build --features serve` succeeds.
- [ ] `aoe schedule add --name test --cron "*/1 * * * *" --tool claude --project <a-trusted-repo> --prompt "list open PRs"`, then `aoe schedule list` shows the job.
- [ ] Start `aoe serve`; within about a minute a new session appears under the `Scheduled` group and receives the prompt.
- [ ] `aoe schedule disable test` stops it firing; `aoe schedule enable test` resumes; `aoe schedule remove test` deletes it.
- [ ] Project-less: `aoe schedule add --name scratch --cron "*/1 * * * *" --prompt "hi"` (no `--project`) fires a scratch session.
- [ ] Web dashboard -> Settings -> Scheduling: add a job with the picker (Daily at 08:00 produces `0 8 * * *`), save, reload, confirm it persists and shows in `aoe schedule list`.
- [ ] Typing an invalid raw cron (e.g. `99 8 * * *`) in the web picker is rejected with an inline error and does not save.
- [ ] TUI settings at Global scope -> Scheduling tab lists the jobs as editable JSON.
- [ ] Stop the daemon, wait past a scheduled minute, restart: no burst of backlogged sessions fires (skip-missed).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`
  - Vitest + RTL spec `web/src/components/settings/__tests__/ScheduledJobsWidget.test.tsx` (cron-picker output, add-job save payload, invalid-cron rejection, enable toggle); matrix entry `settings.scheduled-jobs`. Used Vitest rather than Playwright per the repo guidance that request-payload permutations belong in Vitest.

**TUI / CLI (e2e test)**
- [x] Skipped a full e2e, because: the CLI and scheduler are covered by unit tests (`aoe schedule` matching + validation, config round-trip, `next_due` and `plan_tick` semantics including skip-missed / disable / re-enable-no-catch-up, `job_to_spec` mapping). A tmux+daemon e2e that waits for an unattended fire is timing-heavy and was left out of scope; the fire path reuses the already-tested `spawn_structured_session`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a multi-model architecture debate, plan, and implementation drafted by Claude under my direction. I made the design calls (one PR with ordered commits, per-job approval mode, host-local time, skip-missed policy), reviewed each commit, and will run the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added host-side, daemon-resident cron scheduling for “structured-view” sessions, interpreted with a five-field cron expression in the server’s local time.
- Introduced persistent global scheduling configuration ([scheduling]) with profile-owned jobs, including:
  - prompt delivery to a structured-view session
  - selectable tool/runtime, with model + approval-mode derived from the tool’s advertised capabilities
  - optional project scoping (including project-less runs)
  - configurable target group placement (auto-defaulted when blank) and an enable/disable flag
- Implemented safe scheduling runtime behavior:
  - the daemon ticks every 30 seconds
  - missed occurrences are skipped after downtime (no backlog catch-up)
  - jobs dispatch independently
  - overlapping runs of the same job are suppressed
- Refactored structured-session creation into shared server-side logic so scheduled executions follow the same constraints/behavior as interactive structured sessions.
- Added scheduling management in three surfaces:
  - **CLI:** new `aoe schedule` command family (`add`, `list`, `remove`, `enable`, `disable`)
  - **TUI:** global-only **Scheduling** tab (inline JSON editing)
  - **Web:** scheduling settings + presets and raw cron input, with validation and capability-driven pickers (tool → model/approval-mode), plus inline add/edit/enable/disable/remove for scheduled jobs
- Added server-side normalization/validation for incoming scheduling settings (ensuring only jobs owned by the serving profile are accepted).
- Added documentation/website navigation for “Scheduled Sessions.”
- Added/expanded tests for cron parsing/validation, scheduling tick planning/missed-run behavior, widget UX/persistence (including project-less runs), and CLI scheduling management.

## Benefits

Users can set up recurring, unattended prompt-based sessions that run from the host daemon without interactive input or agent-side wakeup tools, consistently across CLI, TUI, and the web UI—while safely handling downtime, preventing overlaps, and keeping scheduled jobs organized in a dedicated **Scheduled** grouping.

## Potential Enhancements

- Expand cron preset/validation coverage for additional cron edge cases and formatting variants.
- Add more end-to-end coverage for daemon restarts across long downtime, approval-mode corner cases, and high-concurrency scheduling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->