### PR TITLE
fix(tui): drop the pin/unpin confirmation popups

### DIFF
--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -121,22 +121,13 @@ impl HomeView {
                 return;
             };
             let target = existing.path.clone();
-            match self.set_project_pinned_all_scopes(&target, &profile, false) {
-                Ok(_) => {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Project Unpinned",
-                        &format!(
-                            "'{}' is no longer pinned. It stays a saved project; its header drops from project view once it has no sessions.",
-                            label
-                        ),
-                    ));
-                }
-                Err(e) => {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Unpin Failed",
-                        &format!("Could not unpin: {}", e),
-                    ));
-                }
+            // On success stay quiet: the header's pin icon flips, which is
+            // feedback enough. Only surface a dialog when the toggle fails.
+            if let Err(e) = self.set_project_pinned_all_scopes(&target, &profile, false) {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Unpin Failed",
+                    &format!("Could not unpin: {}", e),
+                ));
             }
         } else {
             // Pin the repo backing this header. An unpinned header always has at
@@ -162,22 +153,13 @@ impl HomeView {
                 )
                 .map(|_| ())
             };
-            match result {
-                Ok(_) => {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Project Pinned",
-                        &format!(
-                            "'{}' is pinned. It will stay in project view even with no sessions.",
-                            label
-                        ),
-                    ));
-                }
-                Err(e) => {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Pin Failed",
-                        &format!("Could not pin: {}", e),
-                    ));
-                }
+            // On success stay quiet: the header's pin icon appears, which is
+            // feedback enough. Only surface a dialog when the toggle fails.
+            if let Err(e) = result {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Pin Failed",
+                    &format!("Could not pin: {}", e),
+                ));
             }
         }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8747,12 +8747,23 @@ fn p_key_pins_project_on_header() {
     );
     // The pin path must not open the projects dialog (the chord is shared).
     assert!(env.view.projects_dialog.is_none());
+    // A successful pin stays quiet: the header's pin icon is feedback enough,
+    // so there is no dialog to dismiss.
+    assert!(
+        env.view.info_dialog.is_none(),
+        "a successful pin must not raise an info dialog"
+    );
 
     // Unpinning (a second toggle) clears the pin but KEEPS the saved project,
     // so the entry stays in the registry (only an explicit remove deletes it).
     // See #2208.
     env.view.toggle_project_pin_at_cursor();
     assert!(!env.view.is_project_label_pinned("alpha"));
+    // A successful unpin is likewise quiet.
+    assert!(
+        env.view.info_dialog.is_none(),
+        "a successful unpin must not raise an info dialog"
+    );
     // The specific entry is kept (not just "registry non-empty") with its pin
     // flag cleared: unpin keeps the saved project, only Remove deletes it.
     let after = crate::session::projects::load_global().unwrap();


### PR DESCRIPTION
## Description

Pinning a project from its header in the TUI raised a "Project Pinned" info dialog that had to be dismissed (and unpinning raised the symmetric "Project Unpinned" dialog). The header's pin icon already appears/flips on success, so the dialog was pure noise. Now a successful pin/unpin stays quiet; a dialog is only surfaced when the toggle actually fails ("Pin Failed" / "Unpin Failed" are kept so real I/O errors still show).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

<!-- No screenshot: the change removes a popup; the visible behavior is the absence of a dialog. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the pin/unpin toggle is already covered by the lib test `p_key_pins_project_on_header` (`src/tui/home/tests.rs`), which I extended to assert `info_dialog.is_none()` after a successful pin and unpin. A full-binary e2e is overkill for the absence of a dialog.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code with review by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed success confirmation dialogs when pinning or unpinning projects from the TUI header.
- Kept failure dialogs for unsuccessful pin state updates.
- Updated tests to verify both successful pinning and unpinning remain silent.

## Benefits

The TUI is less disruptive while still providing feedback when an operation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->