### PR TITLE
fix(acp): skip lifecycle envelopes when no prompt is in flight

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -1289,6 +1289,36 @@ async fn send_lifecycle_signal(
     }
 }
 
+/// Forward a notification's watchdog signals to the per-prompt lifecycle
+/// channel, but only while a prompt is in flight.
+///
+/// The channel's sole consumer is the prompt loop: it drains during a
+/// `session/prompt` and flushes leftovers (discarding them by epoch) at
+/// the start of the next one. Between prompts nothing reads it, so a busy
+/// agent (a background Task subagent streaming child tool calls, or an
+/// agent-initiated turn) fills all slots and the next awaited send parks
+/// the notification handler until the next prompt; with dispatch
+/// serialized per connection, that freezes every subsequent notification
+/// and the session appears dead while the agent keeps working. Skipping
+/// the send loses nothing: a between-prompt envelope could only ever be
+/// flushed unread. The between-prompt watchdog is fed by atomics in the
+/// notification handler, not this channel. See #2888.
+async fn forward_lifecycle_signals(
+    prompt_active: bool,
+    tx: &mpsc::Sender<LifecycleEnvelope>,
+    epoch: u64,
+    lifecycle: Option<LifecycleSignal>,
+    wakeup: Option<LifecycleSignal>,
+    session_label: &str,
+) {
+    if !prompt_active {
+        return;
+    }
+    for signal in [lifecycle, wakeup].into_iter().flatten() {
+        send_lifecycle_signal(tx, LifecycleEnvelope { epoch, signal }, session_label).await;
+    }
+}
+
 /// Detect whether a `ToolCallUpdate` completion content array carries a
 /// Claude SDK marker that the underlying work continues off-protocol after
 /// the visible tool call completes. Two markers today:
@@ -5037,6 +5067,7 @@ async fn run_connection_task<W, R>(
                     if lifecycle_signal.is_some() || wakeup_signal.is_some() {
                         first_event_after_attach.store(true, Ordering::Relaxed);
                     }
+                    let prompt_active = prompt_in_flight.load(Ordering::Relaxed);
                     // Between-prompt idle tracking (#2325). Only while no
                     // aoe-issued prompt is in flight: a lifecycle signal here
                     // means the agent resumed itself (Monitor / scheduled
@@ -5044,7 +5075,7 @@ async fn run_connection_task<W, R>(
                     // its cost/progress/wake semantics so the outer loop's
                     // idle tick applies the same grace. During a real prompt
                     // the per-prompt watchdog owns this, so skip.
-                    if !prompt_in_flight.load(Ordering::Relaxed) {
+                    if !prompt_active {
                         let now = chrono::Utc::now().timestamp_millis();
                         if let Some(u) = between_prompt_signal_update(
                             lifecycle_signal.as_ref(),
@@ -5126,29 +5157,20 @@ async fn run_connection_task<W, R>(
                     // cancel a legitimate wait. Watchdog correctness
                     // wins; UI ordering is reconciled by the event
                     // store's monotonic seq anyway. See #1401 post-
-                    // impl review.
-                    if let Some(sig) = lifecycle_signal {
-                        send_lifecycle_signal(
-                            &lifecycle_signal_tx,
-                            LifecycleEnvelope {
-                                epoch: envelope_epoch,
-                                signal: sig,
-                            },
-                            &session_label,
-                        )
-                        .await;
-                    }
-                    if let Some(sig) = wakeup_signal {
-                        send_lifecycle_signal(
-                            &lifecycle_signal_tx,
-                            LifecycleEnvelope {
-                                epoch: envelope_epoch,
-                                signal: sig,
-                            },
-                            &session_label,
-                        )
-                        .await;
-                    }
+                    // impl review. Skipped entirely between prompts:
+                    // nothing drains the channel then, so at capacity
+                    // the awaited send would wedge this handler, and
+                    // every notification behind it, until the next
+                    // prompt (#2888).
+                    forward_lifecycle_signals(
+                        prompt_active,
+                        &lifecycle_signal_tx,
+                        envelope_epoch,
+                        lifecycle_signal,
+                        wakeup_signal,
+                        &session_label,
+                    )
+                    .await;
                     for event in mapped_events {
                         // An async sub-agent launch: spawn a tailer that
                         // follows the agent's on-disk transcript and emits
@@ -7559,6 +7581,71 @@ async fn handle_elicitation_request(
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    #[tokio::test]
+    async fn between_prompt_signals_do_not_block_on_a_full_lifecycle_channel() {
+        // Reproduces #2888: no prompt in flight means nothing drains the
+        // lifecycle channel; once it is full, an unguarded awaited send
+        // parks the notification handler forever and every notification
+        // behind it queues invisibly until the next prompt. The guard must
+        // skip the send entirely, so a between-prompt burst larger than
+        // the channel capacity completes without blocking.
+        let (tx, _rx) = mpsc::channel::<LifecycleEnvelope>(2);
+        for i in 0..2 {
+            tx.try_send(LifecycleEnvelope {
+                epoch: 0,
+                signal: LifecycleSignal::ToolStarted {
+                    id: format!("fill-{i}"),
+                    is_background_task: false,
+                },
+            })
+            .expect("pre-fill fits the channel");
+        }
+        let burst = async {
+            for i in 0..200 {
+                forward_lifecycle_signals(
+                    false,
+                    &tx,
+                    0,
+                    Some(LifecycleSignal::ToolStarted {
+                        id: i.to_string(),
+                        is_background_task: false,
+                    }),
+                    None,
+                    "test",
+                )
+                .await;
+            }
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), burst)
+            .await
+            .expect("between-prompt signals must not block on a full lifecycle channel");
+    }
+
+    #[tokio::test]
+    async fn active_prompt_signals_still_reach_the_lifecycle_channel() {
+        let (tx, mut rx) = mpsc::channel::<LifecycleEnvelope>(8);
+        forward_lifecycle_signals(
+            true,
+            &tx,
+            7,
+            Some(LifecycleSignal::Progress),
+            Some(LifecycleSignal::WakeupPending {
+                at: chrono::Utc::now(),
+            }),
+            "test",
+        )
+        .await;
+        let first = rx.try_recv().expect("lifecycle signal forwarded");
+        assert_eq!(first.epoch, 7);
+        assert!(matches!(first.signal, LifecycleSignal::Progress));
+        let second = rx.try_recv().expect("wakeup signal forwarded");
+        assert!(matches!(
+            second.signal,
+            LifecycleSignal::WakeupPending { .. }
+        ));
+        assert!(rx.try_recv().is_err(), "no extra envelopes");
+    }
 
     #[tokio::test]
     async fn fake_client_round_trips_events() {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes the between-prompt notification wedge from #2888. The per-prompt lifecycle channel (capacity 128) is drained only while a `session/prompt` is in flight and flushed at the next prompt start, so envelopes sent between prompts are never consumed. A background Task subagent that keeps streaming child tool calls after the main turn ends could fill all 128 slots; the next awaited send then parked the notification handler forever. Every later notification, including a whole agent-initiated turn, queued invisibly until the next user prompt, and the stuck `ToolStarted` kept the between-prompt watchdog permanently suppressed, so the session sat "running" with a frozen timeline. Live incident: session `8873630590ce48c2`, where the agent resumed itself, pushed a commit, and replied to a PR comment, none of it visible until a manual poke.

The fix extracts the two send sites into `forward_lifecycle_signals`, gated on `prompt_in_flight`. Between prompts the send is skipped entirely; nothing is lost because a between-prompt envelope could only ever be flushed unread, and the between-prompt watchdog is fed by atomics in the notification handler, not by this channel.

The reproducing test fails on the ungated code with a timeout (the exact production wedge: full channel, no drainer, awaited send never returns) and passes with the gate. A second test pins the active-prompt path so the per-prompt watchdog keeps receiving its signals.

Closes #2888

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view claude session and have it launch a long-running background Task subagent (`run_in_background`), then let the main turn end while the subagent keeps working. Watch the subagent's child tool calls keep appearing in the timeline well past 128 events; before the fix the timeline froze partway through.
- [ ] When the subagent completes and the agent resumes itself off the task notification, confirm the resumed turn's output streams in live, without sending a message first.
- [ ] After the agent finishes, confirm the session drops back to idle within the normal grace instead of showing "running" indefinitely.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: reproducing the wedge end-to-end needs a between-prompt notification burst the fake ACP agent cannot script today (it only emits during a turn). The wedge is regression-tested at the Rust unit layer instead, proven red on the ungated code and green on the fix; a post-turn script verb for the fake agent is noted as follow-up in #2888.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Claude Code, `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, root-cause analysis, fix, and tests drafted by Claude under my direction, including the live confirmation on the wedged session. I made the design calls and reviewed the diff.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents notification-handler freezes by forwarding lifecycle updates only while a prompt is active.
- Adds a helper to centralize lifecycle and wakeup signal forwarding.
- Adds regression tests covering full-channel bursts between prompts and signal delivery during active prompts.

## Benefits

- Prevents structured-view timelines from becoming stuck.
- Improves idle-state detection after background work completes.
- Preserves lifecycle monitoring during active prompts.

A future enhancement could add a timeout for tools that remain incomplete indefinitely between prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->