### PR TITLE
feat(tui): forward bare mouse motion to hover-capable agents in live preview

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -32,12 +32,13 @@ by default) skips the extra `Enter`/`Tab`/click when you switch into
 Terminal or Tool view: live-send starts as soon as the view switches,
 regardless of **Default Attach Mode**.
 
-Live-send only forwards keyboard input, not mouse events, so
-mouse-driven tool UIs like lazygit and yazi lose mouse interaction
-while you're live-sent to them; use their keyboard bindings instead, or
-exit live mode (`Ctrl+Q`) and then attach normally (`Enter`, depending
-on your Default Attach Mode) to get a full tmux attach with mouse
-support.
+Mouse input is forwarded too, when the pane on screen is a full-screen
+app that asked for it: clicks, drags, and the scroll wheel reach
+mouse-driven tool UIs like lazygit and yazi, and an agent that tracks
+the pointer (Claude Code highlights expandable content under your
+cursor) also receives hover motion. Hold `Shift` while clicking or
+dragging to bypass forwarding and use AoE's own text selection and
+copy instead.
 
 ## The leader menu
 

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -987,6 +987,7 @@ mod tests {
             alternate_on: false,
             mouse_tracking: false,
             mouse_sgr: false,
+            mouse_all: false,
             position_reliable: true,
         };
         let json = frame_json("hello\nworld", Some(&cursor));
@@ -1014,6 +1015,7 @@ mod tests {
             alternate_on: true,
             mouse_tracking: true,
             mouse_sgr: false,
+            mouse_all: false,
             position_reliable: true,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();
@@ -1034,6 +1036,7 @@ mod tests {
             alternate_on: false,
             mouse_tracking: false,
             mouse_sgr: false,
+            mouse_all: false,
             position_reliable: true,
         };
         let v: serde_json::Value = serde_json::from_str(&frame_json("x", Some(&cursor))).unwrap();

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -87,6 +87,11 @@ pub struct PaneCursor {
     /// can mean the legacy X10 encoding, which our SGR bytes would corrupt.
     /// Optional; parses as `false`.
     pub mouse_sgr: bool,
+    /// `#{mouse_all_flag}`: the app is in any-event tracking (DEC 1003), so
+    /// it wants bare mouse-motion reports even with no button held (hover).
+    /// Gates the live preview's motion forwarding: a 1000/1002 app never
+    /// expects bare-motion bytes. Optional; parses as `false`.
+    pub mouse_all: bool,
     /// Whether `x`/`y` can be trusted to index the captured content. The
     /// terminal-mode flags above (`alternate_on`, `mouse_tracking`,
     /// `mouse_sgr`) are always valid, but `capture_pane_with_cursor` probes
@@ -103,9 +108,9 @@ impl PaneCursor {
     /// Parse the single space-separated line emitted by the
     /// `#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height}
     /// #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag}
-    /// #{mouse_sgr_flag}` format. The trailing fields are optional so an
-    /// older four-field line still parses (numeric fields as 0, flag
-    /// fields as `false`).
+    /// #{mouse_sgr_flag} #{mouse_all_flag}` format. The trailing fields are
+    /// optional so an older four-field line still parses (numeric fields as
+    /// 0, flag fields as `false`).
     fn parse(line: &str) -> Option<Self> {
         let mut fields = line.split_whitespace();
         let x = fields.next()?.parse().ok()?;
@@ -117,6 +122,7 @@ impl PaneCursor {
         let alternate_on = fields.next().map(|f| f != "0").unwrap_or(false);
         let mouse_tracking = fields.next().map(|f| f != "0").unwrap_or(false);
         let mouse_sgr = fields.next().map(|f| f != "0").unwrap_or(false);
+        let mouse_all = fields.next().map(|f| f != "0").unwrap_or(false);
         Some(Self {
             x,
             y,
@@ -127,6 +133,7 @@ impl PaneCursor {
             alternate_on,
             mouse_tracking,
             mouse_sgr,
+            mouse_all,
             // A single probe's own position is self-consistent; the
             // cross-probe check in `capture_pane_with_cursor` is the only
             // thing that downgrades this.
@@ -496,7 +503,7 @@ impl Session {
         let target = format!("{}:^.0", self.name);
         let start = format!("-{}", lines);
         const HEADER_FMT: &str =
-            "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag}";
+            "#{cursor_x} #{cursor_y} #{cursor_flag} #{pane_height} #{history_size} #{pane_width} #{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag}";
         let output = crate::tmux::tmux_command()
             .args([
                 "display-message",
@@ -1151,7 +1158,7 @@ mod tests {
 
     #[test]
     fn pane_cursor_parses_format_line() {
-        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 1").expect("parses");
+        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 1 1").expect("parses");
         assert_eq!(
             c,
             PaneCursor {
@@ -1164,19 +1171,26 @@ mod tests {
                 alternate_on: true,
                 mouse_tracking: true,
                 mouse_sgr: true,
+                mouse_all: true,
                 position_reliable: true,
             }
         );
         // Legacy mouse (tracking on, SGR off) parses with mouse_sgr false.
-        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 0").expect("parses");
+        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 0 0").expect("parses");
         assert!(c.mouse_tracking);
         assert!(!c.mouse_sgr);
+        assert!(!c.mouse_all);
+        // Button-only tracking (1000/1002): any + SGR set, all-motion off.
+        let c = PaneCursor::parse("3 2 1 24 120 74 1 1 1 0").expect("parses");
+        assert!(c.mouse_tracking && c.mouse_sgr);
+        assert!(!c.mouse_all);
         // The six-field (pre-alternate/mouse) line still parses, the new
         // flags defaulting to false.
         let c = PaneCursor::parse("3 2 1 24 120 74").expect("parses");
         assert!(!c.alternate_on);
         assert!(!c.mouse_tracking);
         assert!(!c.mouse_sgr);
+        assert!(!c.mouse_all);
         // Four-field (pre-history) lines still parse, trailing fields 0.
         let c = PaneCursor::parse("3 2 0 24").expect("parses");
         assert!(!c.visible);

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -167,9 +167,9 @@ fn pane_size(target: &str) -> Option<(u16, u16)> {
 }
 
 /// Query the pane's terminal modes that the wheel-forward / scroll logic keys
-/// off: `(alternate_on, mouse_tracking, mouse_sgr)`. Used once at arm to seed
-/// the grid's modes, which the rendered-content seed can't carry.
-fn pane_modes(target: &str) -> Option<(bool, bool, bool)> {
+/// off: `(alternate_on, mouse_tracking, mouse_sgr, mouse_all)`. Used once at
+/// arm to seed the grid's modes, which the rendered-content seed can't carry.
+fn pane_modes(target: &str) -> Option<(bool, bool, bool, bool)> {
     let out = crate::tmux::tmux_command()
         .args([
             "display-message",
@@ -177,7 +177,7 @@ fn pane_modes(target: &str) -> Option<(bool, bool, bool)> {
             "-t",
             target,
             "-F",
-            "#{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag}",
+            "#{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag}",
         ])
         .output()
         .ok()?;
@@ -189,7 +189,8 @@ fn pane_modes(target: &str) -> Option<(bool, bool, bool)> {
     let alt = it.next().map(|f| f != "0").unwrap_or(false);
     let mouse = it.next().map(|f| f != "0").unwrap_or(false);
     let sgr = it.next().map(|f| f != "0").unwrap_or(false);
-    Some((alt, mouse, sgr))
+    let all = it.next().map(|f| f != "0").unwrap_or(false);
+    Some((alt, mouse, sgr, all))
 }
 
 /// Translate bare LF to CRLF so `capture-pane` seed rows (LF-separated) each
@@ -229,12 +230,17 @@ fn seed_parser(
     cols: u16,
     rows: u16,
 ) {
-    let (alt, mouse, mouse_sgr) = pane_modes(target).unwrap_or((false, false, false));
+    let (alt, mouse, mouse_sgr, mouse_all) =
+        pane_modes(target).unwrap_or((false, false, false, false));
     let mut prefix: Vec<u8> = Vec::new();
     if alt {
         prefix.extend_from_slice(b"\x1b[?1049h");
     }
-    if mouse {
+    // Any-event tracking (1003) subsumes plain button tracking (1000); replay
+    // whichever the app actually asked for so the grid's mode round-trips.
+    if mouse_all {
+        prefix.extend_from_slice(b"\x1b[?1003h");
+    } else if mouse {
         prefix.extend_from_slice(b"\x1b[?1000h");
     }
     if mouse_sgr {
@@ -318,6 +324,7 @@ fn cursor_from_screen(screen: &vt100::Screen, rows: u16, cols: u16) -> PaneCurso
         alternate_on: screen.alternate_screen(),
         mouse_tracking: screen.mouse_protocol_mode() != vt100::MouseProtocolMode::None,
         mouse_sgr: screen.mouse_protocol_encoding() == vt100::MouseProtocolEncoding::Sgr,
+        mouse_all: screen.mouse_protocol_mode() == vt100::MouseProtocolMode::AnyMotion,
         // Authoritative: the cursor is read straight from the owned grid, not
         // probed against a racing capture, so it is always trustworthy.
         position_reliable: true,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1309,6 +1309,16 @@ impl App {
                                 // cursor leaves the list, even when the new
                                 // position lands on the preview or border.
                                 MouseEventKind::Moved => {
+                                    // Bare motion over the preview is also
+                                    // reported to a hover-capable (any-event
+                                    // tracking) agent so its own hover UI
+                                    // works like a direct attach. It never
+                                    // consumes the event: aoe's hover below
+                                    // still runs, and no aoe redraw is
+                                    // needed (the capture worker picks up
+                                    // the agent's repaint).
+                                    self.home
+                                        .forward_hover_to_preview(mouse.column, mouse.row);
                                     // Route hover to the diff view's
                                     // file list when one is open AND
                                     // the mouse is over it; that's an

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -267,6 +267,25 @@ fn mouse_event_bytes(
     }
 }
 
+/// The bare mouse-motion (hover) bytes to forward to the previewed pane, or
+/// `None` when the app didn't ask for them. Only a full-screen app in
+/// any-event tracking (DEC 1003, tmux `#{mouse_all_flag}`) gets bare motion:
+/// a button-tracking (1000/1002) app never expects a no-button motion report.
+/// The report is the button-agnostic code 3 plus the motion bit (SGR `35`),
+/// which is what a real terminal emits for hover, so an app that highlights
+/// content under the pointer (Claude Code's expandable-block hover) reacts in
+/// the live preview the way it does over a direct tmux attach. Pure so the
+/// gate is asserted directly in tests, mirroring `wheel_forward_key`.
+fn hover_forward_bytes(
+    cursor: &crate::tmux::PaneCursor,
+    pane: ratatui::layout::Rect,
+    col: u16,
+    row: u16,
+) -> Option<Vec<u8>> {
+    (cursor.alternate_on && cursor.mouse_all)
+        .then(|| mouse_event_bytes(3, false, true, cursor.mouse_sgr, pane, col, row))
+}
+
 /// Page presses delivered per wheel notch for a no-mouse full-screen app.
 /// One page per notch: full-screen apps that scroll on `PageUp`/`PageDown`
 /// (Claude Code's fullscreen renderer is the motivating case) have no finer
@@ -3867,8 +3886,9 @@ impl HomeView {
     /// `Shift` is the escape hatch: a Shift-held event returns `false` so it
     /// falls through to aoe's own preview text-selection. Returns `true` when
     /// the event was forwarded (and should be consumed). Wheel and bare-motion
-    /// events are not handled here (the wheel has its own path; bare motion is
-    /// not forwarded).
+    /// events are not handled here; the wheel has its own path
+    /// (`forward_wheel_to_preview`) and so does bare motion
+    /// (`forward_hover_to_preview`).
     ///
     /// A button held down is tracked in `mouse_forward_btn` so its drag and
     /// release reach the agent even if the pointer leaves the preview rect
@@ -3926,6 +3946,42 @@ impl HomeView {
             col,
             row,
         );
+        self.send_to_preview_pane(live_send::TmuxKey::HexBytes(bytes))
+    }
+
+    /// Forward a bare mouse-motion event over the preview to a previewed
+    /// agent in any-event tracking (DEC 1003), so its hover-driven UI (e.g.
+    /// Claude Code highlighting an expandable block under the pointer) works
+    /// in the live preview like it does over a direct attach. Active in both
+    /// live-send and passive preview, mirroring the click/wheel forwards.
+    /// Deduped per mapped pane cell: crossterm can re-report a cell, and one
+    /// report per cell crossed is what a real terminal delivers anyway.
+    /// Unlike `forward_mouse_to_preview` this never consumes the event; the
+    /// caller still runs aoe's own hover handling (sidebar, dialogs) for the
+    /// same motion. Returns true when a report was sent.
+    pub fn forward_hover_to_preview(&mut self, col: u16, row: u16) -> bool {
+        if self.has_non_live_send_overlay() || !self.hit_preview(col, row) {
+            // Off-preview (or covered by a modal): drop the dedup cell so
+            // re-entering the preview on the same cell reports again.
+            self.hover_forward_cell = None;
+            return false;
+        }
+        let Some(cursor) = self
+            .preview_capture_worker
+            .as_ref()
+            .and_then(|w| w.current_cursor())
+        else {
+            return false;
+        };
+        let pane = self.preview_text_view.pane;
+        let Some(bytes) = hover_forward_bytes(&cursor, pane, col, row) else {
+            return false;
+        };
+        let cell = map_pane_cell(pane, col, row);
+        if self.hover_forward_cell == Some(cell) {
+            return false;
+        }
+        self.hover_forward_cell = Some(cell);
         self.send_to_preview_pane(live_send::TmuxKey::HexBytes(bytes))
     }
 
@@ -6053,8 +6109,42 @@ mod tests {
             alternate_on,
             mouse_tracking,
             mouse_sgr,
+            mouse_all: false,
             position_reliable: true,
         }
+    }
+
+    /// `hover_forward_bytes` only fires for a full-screen app in any-event
+    /// tracking (1003), and then emits the no-button motion report (SGR 35 /
+    /// the X10 equivalent) in the app's encoding. Everything else, including
+    /// a button-tracking (1000/1002) app that never expects bare motion,
+    /// gets `None`.
+    #[test]
+    fn hover_forward_bytes_requires_any_event_tracking() {
+        use ratatui::layout::Rect;
+        let pane = Rect::new(0, 0, 80, 24);
+        let mut all = cursor_for(true, true, true);
+        all.mouse_all = true;
+        // Cell (10,5) maps to 1-based (11,6); no-button motion is 3 + 32.
+        assert_eq!(
+            hover_forward_bytes(&all, pane, 10, 5).as_deref(),
+            Some(b"\x1b[<35;11;6M".as_slice())
+        );
+        // Legacy X10 encoding still gets the motion report.
+        all.mouse_sgr = false;
+        assert_eq!(
+            hover_forward_bytes(&all, pane, 10, 5),
+            Some(vec![0x1b, b'[', b'M', 35 + 32, 11 + 32, 6 + 32])
+        );
+        // Button-only tracking: no bare motion.
+        assert_eq!(
+            hover_forward_bytes(&cursor_for(true, true, true), pane, 10, 5),
+            None
+        );
+        // Normal screen: never forwarded, even with 1003 set.
+        let mut normal = cursor_for(false, true, true);
+        normal.mouse_all = true;
+        assert_eq!(hover_forward_bytes(&normal, pane, 10, 5), None);
     }
 
     /// The fix for #2407: a full-screen pane with no mouse tracking must

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -851,6 +851,13 @@ pub struct HomeView {
     /// preview rect. `None` when no forwarded button is held.
     pub(super) mouse_forward_btn: Option<u16>,
 
+    /// Last 1-based pane cell reported to the previewed agent as a bare
+    /// mouse-motion (hover) event, so `forward_hover_to_preview` reports each
+    /// cell once, the way a real terminal reports motion once per cell
+    /// crossed. Cleared when the pointer leaves the preview so re-entering
+    /// the same cell reports again.
+    pub(super) hover_forward_cell: Option<(u16, u16)>,
+
     /// Last pointer cell reported during a `PreviewSelect` drag, `None`
     /// outside one. The event-loop ticker reads it (`tick_preview_autoscroll`)
     /// to keep scrolling while the cursor is held at the pane edge:
@@ -2153,6 +2160,7 @@ impl HomeView {
             main_area_width: 0,
             drag_state: None,
             mouse_forward_btn: None,
+            hover_forward_cell: None,
             preview_drag_pos: None,
             preview_autoscroll_at: None,
             preview_selection: None,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -3341,6 +3341,7 @@ mod tests {
             alternate_on: false,
             mouse_tracking: false,
             mouse_sgr: false,
+            mouse_all: false,
             position_reliable: true,
         }
     }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1661,6 +1661,9 @@ impl HomeView {
                 worker.set_target(desired.clone().unwrap_or_default());
             }
             self.preview_capture_target = desired;
+            // New pane under the pointer: drop the hover dedup cell so a
+            // stationary pointer still reports its cell to the new agent.
+            self.hover_forward_cell = None;
         }
         // Fast cadence only when the displayed pane IS the live-send target.
         // Viewing the agent while live-send points at a terminal (or vice

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10295,6 +10295,7 @@ mod scroll_pane_isolation {
             alternate_on,
             mouse_tracking,
             mouse_sgr,
+            mouse_all: false,
             position_reliable: true,
         }
     }
@@ -10439,6 +10440,49 @@ mod scroll_pane_isolation {
         // Forwarding never starts an aoe text selection, even passively.
         assert!(env.view.drag_state.is_none());
         assert!(env.view.preview_selection.is_none());
+    }
+
+    /// Bare motion over the preview is forwarded to an any-event-tracking
+    /// (1003) agent so its hover UI (Claude Code's expandable-block
+    /// highlight) works in live mode, deduped per pane cell, and re-armed
+    /// when the pointer leaves the preview and comes back.
+    #[test]
+    #[serial]
+    fn forward_hover_to_preview_reports_once_per_cell() {
+        let mut cursor = alt_screen_cursor(true, true, true);
+        cursor.mouse_all = true;
+        let mut env = live_env_with_cursor(cursor);
+        // The forward maps cells against the previewed pane's rect; give it
+        // the preview area like a rendered frame would.
+        env.view.preview_text_view.pane = Rect::new(30, 0, 100, 40);
+
+        assert!(env.view.forward_hover_to_preview(50, 10));
+        assert_eq!(env.view.hover_forward_cell, Some((21, 11)));
+        // Same cell again: deduped, nothing sent.
+        assert!(!env.view.forward_hover_to_preview(50, 10));
+        // A different cell reports again.
+        assert!(env.view.forward_hover_to_preview(51, 10));
+        assert_eq!(env.view.hover_forward_cell, Some((22, 11)));
+        // Leaving the preview clears the dedup cell (and forwards nothing)...
+        assert!(!env.view.forward_hover_to_preview(1, 1));
+        assert_eq!(env.view.hover_forward_cell, None);
+        // ...so re-entering the same cell reports it to the agent again.
+        assert!(env.view.forward_hover_to_preview(51, 10));
+    }
+
+    /// A button-tracking (1000/1002) agent never gets bare motion: it didn't
+    /// ask for it and would misparse the report. Same for a non-mouse agent.
+    #[test]
+    #[serial]
+    fn forward_hover_to_preview_requires_any_event_tracking() {
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, true, true));
+        env.view.preview_text_view.pane = Rect::new(30, 0, 100, 40);
+        assert!(!env.view.forward_hover_to_preview(50, 10));
+        assert_eq!(env.view.hover_forward_cell, None);
+
+        let mut env = live_env_with_cursor(alt_screen_cursor(true, false, false));
+        env.view.preview_text_view.pane = Rect::new(30, 0, 100, 40);
+        assert!(!env.view.forward_hover_to_preview(50, 10));
     }
 
     /// Shift+press is NOT forwarded: it falls through so aoe's own preview


### PR DESCRIPTION
## Description

Claude Code's hover highlight (the expandable-content highlight under the pointer) works over a direct tmux attach but not in aoe's live mode. Hover needs any-event mouse tracking (DEC 1003), where the terminal reports bare pointer motion with no button held; the live preview forwarded clicks, drags, and wheel to the previewed agent but dropped bare `Moved` events, so the agent never saw the pointer.

This PR forwards bare motion to agents that asked for it:

- `PaneCursor` gains `mouse_all`, probed from tmux's `#{mouse_all_flag}` (set only when the app enabled 1003). The VT-grid path (`src/tmux/vt.rs`) probes, replays (`\e[?1003h` seed prefix), and detects (`MouseProtocolMode::AnyMotion`) the mode too.
- New `forward_hover_to_preview` (`src/tui/home/input.rs`): a bare `Moved` over the preview, with no modal in the way, is encoded as the no-button motion report (SGR `\e[<35;x;yM`, or the X10 equivalent when the app is in legacy encoding) and sent to the previewed pane. It rides the ordered live-send worker in live mode, or a one-shot send in passive preview, matching the click/wheel forwards.
- Reports are deduped per pane cell (a real terminal reports motion once per cell crossed), and the dedup cell clears when the pointer leaves the preview so re-entry re-reports.
- The forward never consumes the event: aoe's own sidebar/dialog hover handling still runs on the same motion.
- Gate: only 1003 apps get bare motion. A button-tracking (1000/1002) app never receives motion reports it didn't ask for.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: hover is pointer-motion driven and the e2e harness drives tmux `send-keys`, which can't synthesize terminal mouse-motion reports against the aoe binary. Coverage is unit-level instead: the encoding + 1003 gate (`hover_forward_bytes_requires_any_event_tracking`), per-cell dedup and off-preview re-arm (`forward_hover_to_preview_reports_once_per_cell`), button-only fallthrough (`forward_hover_to_preview_requires_any_event_tracking`), and `#{mouse_all_flag}` parsing (`pane_cursor_parses_format_line`).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**
Implemented via Claude Code from a user report; reviewed and tested by @njbrake. `cargo test --features serve`: 5226 passed (3 pre-existing failures in the sandbox from root-user permission fixtures, unrelated to this change; they fail identically on the branch tip without this diff).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds support for forwarding **mouse-hover (no-button motion) events** to full-screen previewed applications that explicitly opt into **full mouse-motion tracking** (DEC 1003 “any-event” / tmux “any-event tracking”).

### What changed
- Detects whether the preview target has enabled full motion tracking (via tmux/terminal probing) before forwarding hover events.
- Forwards bare motion reports using the appropriate terminal mouse encoding.
- Supports both **live** and **passive** preview modes.
- Avoids duplicate hover reports by remembering the last preview “cell” reported, and resets deduplication when:
  - the pointer leaves the preview, or
  - the preview target changes (so the new agent receives its first hover).
- Ensures aoe’s existing hover behavior still runs (the hover event is not consumed by aoe).
- Updates tmux cursor parsing and VT-mode seeding to carry the new “any-event” capability through the preview pipeline.
- Expands unit tests around encoding, forwarding gating, deduplication, re-entry, tmux flag parsing, and mode switching.
- Updates live-mode documentation to include mouse-forwarding behavior (including when Shift bypasses forwarding).

### Benefits
Previewed applications can react to pointer movement (hover) in real time, without breaking aoe’s own hover handling or spamming hover updates when the pointer stays in the same area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->