### PR TITLE
fix(tui): forward sandboxed agent's OSC 52 copy to the host clipboard in live-send

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -290,7 +290,7 @@ clipboard = "auto"
 |--------|---------|-------------|
 | `status_bar` | `"auto"` | `"auto"`: apply if no `~/.tmux.conf`; `"enabled"`: always apply; `"disabled"`: never apply |
 | `mouse` | `"auto"` | Same modes as `status_bar`. Controls mouse support in aoe tmux sessions. |
-| `clipboard` | `"auto"` | Same modes. Forwards OSC 52 clipboard escape sequences from the wrapped agent (Claude Code, OpenCode, Codex, etc.) through tmux to your terminal. Without this, "select to copy" inside the agent silently fails. Sets `set-clipboard on` and `allow-passthrough on` on the aoe tmux session. |
+| `clipboard` | `"auto"` | Same modes. Forwards OSC 52 clipboard escape sequences from the wrapped agent (Claude Code, OpenCode, Codex, etc.) to your terminal. Without this, "select to copy" inside the agent silently fails. Sets `set-clipboard on` and `allow-passthrough on` on the aoe tmux session (the attached path), and in live-send aoe itself extracts the agent's OSC 52 from the pane stream and pushes it to your clipboard. Live-send forwarding is on for `"auto"` and `"enabled"` (your tmux config cannot affect aoe's in-process transport, so `"auto"` does not defer to it here); `"disabled"` turns it off. |
 | `socket_name` | unset | Run aoe's sessions on a private tmux server with this socket name (passed as `tmux -L <name>`), so your own `tmux ls` and hand-managed sessions stay separate from aoe's. Leave unset to share the default tmux server (the current behavior). Must be a bare name, not a path; a value with a `/` or `\` is ignored. Takes effect on the next aoe start. Global/profile only. |
 
 ## Diff

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2455,7 +2455,8 @@ pub struct TmuxConfig {
 
     /// Forward OSC 52 clipboard from agents to your terminal (Auto respects
     /// your tmux config). Controls `set-clipboard on` and `allow-passthrough
-    /// on` so OSC 52 from the wrapped agent reaches the terminal.
+    /// on` so OSC 52 from the wrapped agent reaches the terminal, and (unless
+    /// Disabled) live-send's own copy forwarding to the host clipboard.
     #[serde(default)]
     #[setting(
         label = "Clipboard Pass-through",

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -20,7 +20,158 @@ use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, LazyLock, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use base64::Engine;
+
 use crate::tmux::PaneCursor;
+
+/// Largest base64 payload an OSC 52 sequence may carry before the scanner
+/// abandons it (the TUI-side `copy_to_clipboard` truncates at 1 MiB of raw
+/// bytes anyway, and an unbounded accumulator would let a malformed stream
+/// grow it forever).
+const OSC52_MAX_PAYLOAD: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Copy, PartialEq)]
+enum Osc52State {
+    /// Searching for the next ESC.
+    Idle,
+    /// Seen `ESC`.
+    Esc,
+    /// Seen `ESC ]`.
+    OscStart,
+    /// Seen `ESC ] 5`.
+    Five,
+    /// Seen `ESC ] 5 2`.
+    Two,
+    /// Inside the selection-target params (`c`, `p`, ...), up to the `;`
+    /// that opens the payload.
+    Params,
+    /// Accumulating the base64 payload.
+    Payload,
+    /// Seen `ESC` inside the payload: either the opening of an ST
+    /// terminator (`ESC \`) or, in a tmux-passthrough-wrapped sequence,
+    /// the first half of a doubled `ESC ESC \`.
+    PayloadEsc,
+}
+
+/// Incremental OSC 52 clipboard-write extractor for the raw pane stream.
+///
+/// The wrapped agent's "copy" comes out of the pane as
+/// `ESC ] 52 ; <targets> ; <base64> BEL|ST` (possibly tmux-passthrough
+/// wrapped, which doubles the inner ESCs). The stream arrives in arbitrary
+/// read-sized chunks, so the scanner is a per-byte state machine that
+/// carries its state across `feed` calls; a sequence split at any byte
+/// boundary still extracts.
+///
+/// Query (`?`) and empty payloads are skipped: a query is a read request,
+/// and forwarding an empty write would *clear* the host clipboard, which is
+/// never what a dropped or malformed copy should do.
+struct Osc52Scanner {
+    state: Osc52State,
+    params_len: usize,
+    payload: Vec<u8>,
+}
+
+impl Osc52Scanner {
+    fn new() -> Self {
+        Self {
+            state: Osc52State::Idle,
+            params_len: 0,
+            payload: Vec::new(),
+        }
+    }
+
+    /// Scan one chunk; returns the decoded text of the last complete
+    /// non-empty clipboard write it contains, if any.
+    fn feed(&mut self, chunk: &[u8]) -> Option<String> {
+        use Osc52State::*;
+        let mut found = None;
+        for &b in chunk {
+            self.state = match (self.state, b) {
+                (Idle, 0x1b) => Esc,
+                (Idle, _) => Idle,
+                (Esc, b']') => OscStart,
+                (OscStart, b'5') => Five,
+                (Five, b'2') => Two,
+                (Two, b';') => {
+                    self.params_len = 0;
+                    Params
+                }
+                (Params, b';') => {
+                    self.payload.clear();
+                    Payload
+                }
+                (Params, 0x07) => Idle,
+                (Params, 0x1b) => Esc,
+                (Params, _) => {
+                    // The targets field is a handful of selection letters;
+                    // anything longer is not an OSC 52 we understand.
+                    self.params_len += 1;
+                    if self.params_len > 16 {
+                        Idle
+                    } else {
+                        Params
+                    }
+                }
+                (Payload, 0x07) => {
+                    if let Some(text) = self.complete() {
+                        found = Some(text);
+                    }
+                    Idle
+                }
+                (Payload, 0x1b) => PayloadEsc,
+                (Payload, c) if is_payload_byte(c) => {
+                    if self.payload.len() >= OSC52_MAX_PAYLOAD {
+                        Idle
+                    } else {
+                        self.payload.push(c);
+                        Payload
+                    }
+                }
+                (Payload, _) => Idle,
+                (PayloadEsc, b'\\') => {
+                    if let Some(text) = self.complete() {
+                        found = Some(text);
+                    }
+                    Idle
+                }
+                // A tmux-passthrough-wrapped sequence doubles inner ESCs,
+                // so its ST arrives as `ESC ESC \`.
+                (PayloadEsc, 0x1b) => PayloadEsc,
+                (PayloadEsc, _) => Idle,
+                // Any non-matching byte after a bare ESC: restart if it is
+                // itself an ESC (`ESC ESC ]` from tmux passthrough doubling),
+                // else fall back to searching.
+                (Esc | OscStart | Five | Two, 0x1b) => Esc,
+                (Esc | OscStart | Five | Two, _) => Idle,
+            };
+        }
+        found
+    }
+
+    /// Decode the accumulated payload; `None` for queries, empty writes,
+    /// and undecodable base64.
+    fn complete(&mut self) -> Option<String> {
+        let payload = std::mem::take(&mut self.payload);
+        if payload.is_empty() || payload.contains(&b'?') {
+            return None;
+        }
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&payload)
+            .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(&payload))
+            .ok()?;
+        if decoded.is_empty() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&decoded).into_owned())
+    }
+}
+
+/// Bytes legal inside the OSC 52 payload: base64 plus `?` (a clipboard
+/// query, recognised so the sequence parses to completion and is then
+/// skipped rather than aborting mid-sequence).
+fn is_payload_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'+' | b'/' | b'=' | b'?')
+}
 
 /// `aoe __vt-pipe <socket>`: the bidirectional `pipe-pane -IO` forwarder. tmux
 /// connects the pane's OUTPUT to this process's stdin and the pane's INPUT to
@@ -518,6 +669,11 @@ struct ReaderCtx {
     app_cursor: Arc<AtomicBool>,
     alive: Arc<AtomicBool>,
     wakeup: Arc<Mutex<Option<ChangeWakeup>>>,
+    /// Latest decoded OSC 52 clipboard write from the pane, awaiting a
+    /// consumer (see [`VtChannel::take_clipboard`]). Single-slot: a newer
+    /// copy overwrites an unconsumed older one, matching clipboard
+    /// semantics (only the last copy matters).
+    clipboard: Arc<Mutex<Option<String>>>,
     #[cfg(feature = "serve")]
     changed_tx: Arc<tokio::sync::watch::Sender<()>>,
 }
@@ -540,6 +696,7 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
     let mut conn = conn;
     let _ = conn.set_read_timeout(Some(Duration::from_millis(200)));
     let mut buf = [0u8; 8192];
+    let mut osc52 = Osc52Scanner::new();
     while !ctx.stop.load(Ordering::Relaxed) {
         match conn.read(&mut buf) {
             Ok(0) => break,
@@ -548,6 +705,15 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
                 // seed can't clobber newer state.
                 while !ctx.seeded.load(Ordering::Relaxed) && !ctx.stop.load(Ordering::Relaxed) {
                     std::thread::sleep(Duration::from_millis(1));
+                }
+                // The vt100 parser below silently drops OSC 52, and in
+                // live-send no tmux client is attached for `set-clipboard`
+                // to forward to, so this tap is the ONLY path an agent's
+                // copy has to the host clipboard (#2420).
+                if let Some(text) = osc52.feed(&buf[..n]) {
+                    if let Ok(mut guard) = ctx.clipboard.lock() {
+                        *guard = Some(text);
+                    }
                 }
                 if let Ok(mut p) = ctx.parser.lock() {
                     p.process(&buf[..n]);
@@ -614,6 +780,9 @@ pub(crate) struct VtChannel {
     /// registration wins (one capture worker per process, so a slot rather
     /// than a list).
     wakeup: Arc<Mutex<Option<ChangeWakeup>>>,
+    /// Latest decoded OSC 52 clipboard write from the pane, filled by the
+    /// reader thread, drained by [`Self::take_clipboard`].
+    clipboard: Arc<Mutex<Option<String>>>,
     /// Owner-only (0700) directory holding `sock_path`; removed on drop.
     sock_dir: PathBuf,
     sock_path: PathBuf,
@@ -660,6 +829,7 @@ impl VtChannel {
         let stream: Arc<Mutex<Option<UnixStream>>> = Arc::new(Mutex::new(None));
         let app_cursor = Arc::new(AtomicBool::new(false));
         let alive = Arc::new(AtomicBool::new(false));
+        let clipboard: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         // Bumped by the reader thread on every grid change (and on death) so
         // a web viewer can render on output instead of polling on a cadence.
         // A watch so all viewers wake, not just one. Server-only; the TUI
@@ -696,6 +866,7 @@ impl VtChannel {
                 app_cursor: app_cursor.clone(),
                 alive: alive.clone(),
                 wakeup: wakeup.clone(),
+                clipboard: clipboard.clone(),
                 #[cfg(feature = "serve")]
                 changed_tx: changed_tx.clone(),
             };
@@ -759,6 +930,7 @@ impl VtChannel {
             #[cfg(feature = "serve")]
             changed_tx,
             wakeup,
+            clipboard,
             sock_dir,
             sock_path,
             stop,
@@ -845,6 +1017,19 @@ impl VtChannel {
     /// of writing into a dead socket or sampling a frozen grid.
     pub(crate) fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
+    }
+
+    /// Take the newest OSC 52 clipboard write the pane has emitted since the
+    /// last call, if any. Consuming and single-slot (a newer copy overwrites
+    /// an unconsumed older one), so exactly one consumer should drain it: the
+    /// TUI capture worker, which forwards it to the host clipboard. Queries
+    /// and empty writes are filtered out at the scanner, so a taken value is
+    /// always non-empty text.
+    pub(crate) fn take_clipboard(&self) -> Option<String> {
+        self.clipboard
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take())
     }
 
     /// Register the in-process poller wakeup this channel pokes on each grid
@@ -1045,6 +1230,7 @@ mod tests {
             app_cursor: Arc::new(AtomicBool::new(false)),
             alive: alive.clone(),
             wakeup: wakeup_slot.clone(),
+            clipboard: Arc::new(Mutex::new(None)),
             #[cfg(feature = "serve")]
             changed_tx: Arc::new(tokio::sync::watch::channel(()).0),
         };
@@ -1080,6 +1266,153 @@ mod tests {
                 .contents()
                 .contains("echo-marker"),
             "pane bytes must land in the grid before the wakeup fires"
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        drop(conn);
+        let _ = reader.join();
+    }
+
+    #[test]
+    fn osc52_scanner_extracts_bel_and_st_terminated_writes() {
+        // "hello" = aGVsbG8=
+        let mut s = Osc52Scanner::new();
+        assert_eq!(
+            s.feed(b"before\x1b]52;c;aGVsbG8=\x07after"),
+            Some("hello".to_string())
+        );
+        let mut s = Osc52Scanner::new();
+        assert_eq!(
+            s.feed(b"\x1b]52;c;aGVsbG8=\x1b\\"),
+            Some("hello".to_string())
+        );
+        // Unpadded base64 ("hi" = aGk) must decode too.
+        let mut s = Osc52Scanner::new();
+        assert_eq!(s.feed(b"\x1b]52;c;aGk\x07"), Some("hi".to_string()));
+        // Empty targets field (`52;;`) is the spec's shorthand for `c`.
+        let mut s = Osc52Scanner::new();
+        assert_eq!(s.feed(b"\x1b]52;;aGVsbG8=\x07"), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn osc52_scanner_survives_arbitrary_chunk_splits() {
+        // pipe-pane delivers reads at arbitrary boundaries; a copy split at
+        // every byte position must still extract.
+        let seq = b"noise\x1b]52;c;aGVsbG8=\x07more";
+        for split in 1..seq.len() {
+            let mut s = Osc52Scanner::new();
+            let first = s.feed(&seq[..split]);
+            let second = s.feed(&seq[split..]);
+            assert_eq!(
+                first.or(second),
+                Some("hello".to_string()),
+                "split at byte {split} lost the copy"
+            );
+        }
+    }
+
+    #[test]
+    fn osc52_scanner_skips_queries_and_empty_writes() {
+        // A query asks the terminal to REPLY with the clipboard; forwarding
+        // it as a write (empty pbcopy/xclip input) would CLEAR the host
+        // clipboard. Same for an explicit empty payload.
+        let mut s = Osc52Scanner::new();
+        assert_eq!(s.feed(b"\x1b]52;c;?\x07"), None);
+        let mut s = Osc52Scanner::new();
+        assert_eq!(s.feed(b"\x1b]52;c;\x07"), None);
+        // Undecodable payloads are dropped, not forwarded as garbage.
+        let mut s = Osc52Scanner::new();
+        assert_eq!(s.feed(b"\x1b]52;c;=====\x07"), None);
+    }
+
+    #[test]
+    fn osc52_scanner_ignores_other_sequences_and_recovers() {
+        let mut s = Osc52Scanner::new();
+        // Title OSC, a CSI, an OSC 5-something that is not 52, then a real
+        // copy: only the copy comes out, and prior garbage doesn't wedge
+        // the state machine.
+        assert_eq!(
+            s.feed(b"\x1b]0;title\x07\x1b[31m\x1b]521;x\x07\x1b]52;c;aGVsbG8=\x07"),
+            Some("hello".to_string())
+        );
+        // The last complete write in a chunk wins (clipboard semantics).
+        let mut s = Osc52Scanner::new();
+        assert_eq!(
+            s.feed(b"\x1b]52;c;aGVsbG8=\x07\x1b]52;c;aGk=\x07"),
+            Some("hi".to_string())
+        );
+    }
+
+    #[test]
+    fn osc52_scanner_unwraps_tmux_passthrough_wrapped_writes() {
+        // An agent that wraps its OSC 52 in tmux DCS passthrough doubles the
+        // inner ESCs: `ESC P tmux; ESC ESC ] 52 ... ESC \`. The scanner must
+        // still find the copy (BEL-terminated inner form, as emitted by our
+        // own clipboard.rs and by OpenCode).
+        let mut s = Osc52Scanner::new();
+        assert_eq!(
+            s.feed(b"\x1bPtmux;\x1b\x1b]52;c;aGVsbG8=\x07\x1b\\"),
+            Some("hello".to_string())
+        );
+        // ST-terminated inner form: the terminator arrives ESC-doubled.
+        let mut s = Osc52Scanner::new();
+        assert_eq!(
+            s.feed(b"\x1bPtmux;\x1b\x1b]52;c;aGVsbG8=\x1b\x1b\\\x1b\\"),
+            Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn reader_publishes_osc52_clipboard_from_pane_stream() {
+        use std::io::Write;
+
+        // Drive run_reader against a raw socket (posing as the pipe-pane
+        // forwarder): an OSC 52 write in the pane stream must land in the
+        // channel's clipboard slot (#2420), while the surrounding bytes
+        // still reach the grid.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("s.sock");
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0)));
+        let stop = Arc::new(AtomicBool::new(false));
+        let alive = Arc::new(AtomicBool::new(false));
+        let clipboard: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let ctx = ReaderCtx {
+            parser: parser.clone(),
+            stop: stop.clone(),
+            seeded: Arc::new(AtomicBool::new(true)),
+            stream: Arc::new(Mutex::new(None)),
+            app_cursor: Arc::new(AtomicBool::new(false)),
+            alive: alive.clone(),
+            wakeup: Arc::new(Mutex::new(None)),
+            clipboard: clipboard.clone(),
+            #[cfg(feature = "serve")]
+            changed_tx: Arc::new(tokio::sync::watch::channel(()).0),
+        };
+        let reader = std::thread::spawn(move || run_reader(listener, ctx));
+        let mut conn = UnixStream::connect(&sock).expect("connect");
+        conn.write_all(b"visible\x1b]52;c;aGVsbG8=\x07")
+            .expect("write pane output");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let copied = loop {
+            if let Some(text) = clipboard.lock().unwrap().take() {
+                break Some(text);
+            }
+            if Instant::now() >= deadline {
+                break None;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        };
+        assert_eq!(copied.as_deref(), Some("hello"));
+        assert!(
+            parser
+                .lock()
+                .unwrap()
+                .screen()
+                .contents()
+                .contains("visible"),
+            "non-clipboard bytes must still reach the grid"
         );
 
         stop.store(true, Ordering::Relaxed);

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -661,6 +661,13 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// cursor query (a one-line `display-message` folded into the capture
     /// fork) runs every cycle, not just live ones.
     cursor: std::sync::Arc<std::sync::Mutex<Option<crate::tmux::PaneCursor>>>,
+    /// Newest OSC 52 clipboard write the displayed pane's agent has emitted
+    /// (VT path only; `capture-pane` returns rendered cells, so the fallback
+    /// path never sees the escape). Single-slot like `latest`; drained by the
+    /// render loop via `take_agent_clipboard`, which forwards it to the host
+    /// clipboard (#2420). Cleared on `set_target` so a copy from the old pane
+    /// can't land after a retarget.
+    clipboard: std::sync::Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl Drop for LiveCaptureWorker {
@@ -699,6 +706,7 @@ impl LiveCaptureWorker {
         let nudge: Arc<(Mutex<()>, Condvar)> = Arc::new((Mutex::new(()), Condvar::new()));
         let stop = Arc::new(AtomicBool::new(false));
         let cursor: Arc<Mutex<Option<crate::tmux::PaneCursor>>> = Arc::new(Mutex::new(None));
+        let clipboard: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
         let slot = latest.clone();
@@ -707,6 +715,7 @@ impl LiveCaptureWorker {
         let nudge_thread = nudge.clone();
         let stop_flag = stop.clone();
         let cursor_cell = cursor.clone();
+        let clipboard_cell = clipboard.clone();
         std::thread::spawn(move || {
             let mut last_target = String::new();
             let mut last_captured: Option<String> = None;
@@ -765,6 +774,13 @@ impl LiveCaptureWorker {
                 }
                 if lines > 0 && !name.is_empty() {
                     let forward_empty = forward_empty_cell.load(Ordering::Relaxed);
+                    // An OSC 52 clipboard write the displayed agent emitted
+                    // since the last cycle (VT path only). Published below
+                    // under the same retarget guard as the cursor.
+                    #[cfg(unix)]
+                    let mut clipboard_now: Option<String> = None;
+                    #[cfg(not(unix))]
+                    let clipboard_now: Option<String> = None;
                     // Acquire one frame + cursor. Default: sample the in-process
                     // vt100 grid, arming a `pipe-pane -IO` channel on first use
                     // for this target (cursor and alt/mouse flags come
@@ -798,6 +814,7 @@ impl LiveCaptureWorker {
                         match vt_source.as_ref() {
                             Some(v) => {
                                 let (content, cur) = v.sample(lines);
+                                clipboard_now = v.take_clipboard();
                                 (Some(content), cur)
                             }
                             None => capture_via_tmux(&name, lines, forward_empty),
@@ -828,6 +845,16 @@ impl LiveCaptureWorker {
                             // the wheel forward reads it in passive preview too).
                             if let Ok(mut guard) = cursor_cell.lock() {
                                 *guard = cursor_now;
+                            }
+                            // Publish an agent clipboard write and wake the
+                            // render loop even if the frame itself dedups: a
+                            // copy must reach the host clipboard promptly
+                            // whether or not the grid changed visibly.
+                            if let Some(text) = clipboard_now {
+                                if let Ok(mut guard) = clipboard_cell.lock() {
+                                    *guard = Some(text);
+                                }
+                                wake.notify_one();
                             }
                             if (forward_empty || !content.is_empty()) && changed {
                                 let since =
@@ -900,6 +927,7 @@ impl LiveCaptureWorker {
             nudge,
             stop,
             cursor,
+            clipboard,
         }
     }
 
@@ -947,6 +975,12 @@ impl LiveCaptureWorker {
                 // new pane's first frame before the next live capture lands.
                 if let Ok(mut cursor) = self.cursor.lock() {
                     *cursor = None;
+                }
+                // And an unconsumed clipboard write: a copy from the old
+                // pane must not land on the host clipboard under the new
+                // view.
+                if let Ok(mut clipboard) = self.clipboard.lock() {
+                    *clipboard = None;
                 }
                 true
             } else {
@@ -1005,6 +1039,16 @@ impl LiveCaptureWorker {
     /// it. The render loop maps this onto the preview output rect.
     pub(in crate::tui) fn current_cursor(&self) -> Option<crate::tmux::PaneCursor> {
         self.cursor.lock().ok().and_then(|guard| *guard)
+    }
+
+    /// Take the newest OSC 52 clipboard write the displayed pane's agent has
+    /// emitted since the last call, if any. Consuming: the render loop drains
+    /// this each frame and forwards the text to the host clipboard (#2420).
+    pub(in crate::tui) fn take_agent_clipboard(&self) -> Option<String> {
+        self.clipboard
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take())
     }
 
     /// Inject a cursor without running a capture cycle, so scroll-routing

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -443,6 +443,13 @@ pub struct HomeView {
     /// the render layer reads this rather than re-resolving the config on
     /// every paint.
     pub(super) row_tag_mode: crate::session::config::RowTagMode,
+    /// Whether an agent's OSC 52 clipboard write (surfaced by the VT capture
+    /// worker) is forwarded to the host clipboard (#2420). Cached from
+    /// `[tmux] clipboard != disabled` at construction + config refresh. Auto
+    /// forwards too: that mode's "respect the user's tmux config" rationale
+    /// is about tmux server options, which cannot influence this in-process
+    /// path.
+    pub(super) agent_clipboard_forward: bool,
     /// Active profile's `default_attach_mode`, cached at construction and
     /// refreshed by `refresh_from_config` / `switch_profile`. The help
     /// overlay falls back to this when no session row is selected so the
@@ -2016,6 +2023,8 @@ impl HomeView {
             sort_order,
             group_by,
             row_tag_mode: resolved.session.row_tag,
+            agent_clipboard_forward: resolved.tmux.clipboard
+                != crate::session::config::TmuxClipboardMode::Disabled,
             profile_default_attach_mode: resolved.session.default_attach_mode,
             project_group_collapsed: user_config
                 .as_ref()
@@ -6292,6 +6301,8 @@ impl HomeView {
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.confirm_before_quit = config.session.confirm_before_quit;
         self.row_tag_mode = config.session.row_tag;
+        self.agent_clipboard_forward =
+            config.tmux.clipboard != crate::session::config::TmuxClipboardMode::Disabled;
         self.profile_default_attach_mode = config.session.default_attach_mode;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1730,13 +1730,16 @@ impl HomeView {
         // `copy_to_clipboard` delivers it the same way preview drag-select
         // copies do: platform helper + OSC 52 re-emitted to the user's real
         // terminal. Applied on the render thread so the re-emitted escape
-        // can't interleave with a frame flush.
-        if self.agent_clipboard_forward {
-            if let Some(text) = self
-                .preview_capture_worker
-                .as_ref()
-                .and_then(|worker| worker.take_agent_clipboard())
-            {
+        // can't interleave with a frame flush. Drained unconditionally and
+        // gated at the forward: a copy that arrives while the setting is
+        // disabled must be discarded, not parked in the slot to clobber the
+        // user's clipboard whenever the setting is later re-enabled.
+        if let Some(text) = self
+            .preview_capture_worker
+            .as_ref()
+            .and_then(|worker| worker.take_agent_clipboard())
+        {
+            if self.agent_clipboard_forward {
                 crate::tui::clipboard::copy_to_clipboard(&text);
             }
         }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1723,6 +1723,23 @@ impl HomeView {
     }
 
     pub(super) fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
+        // Forward an agent's OSC 52 copy to the host clipboard (#2420). The
+        // VT reader extracts it from the raw pane stream (the vt100 grid
+        // drops the escape, and with no attached tmux client `set-clipboard`
+        // has nobody to forward to), the capture worker relays it here, and
+        // `copy_to_clipboard` delivers it the same way preview drag-select
+        // copies do: platform helper + OSC 52 re-emitted to the user's real
+        // terminal. Applied on the render thread so the re-emitted escape
+        // can't interleave with a frame flush.
+        if self.agent_clipboard_forward {
+            if let Some(text) = self
+                .preview_capture_worker
+                .as_ref()
+                .and_then(|worker| worker.take_agent_clipboard())
+            {
+                crate::tui::clipboard::copy_to_clipboard(&text);
+            }
+        }
         // The off-thread `LiveCaptureWorker` (retargeted to this pane by
         // `sync_preview_capture_worker` in `render_preview`) keeps fresh
         // content flowing on its own thread; `apply_worker_capture` below


### PR DESCRIPTION
_Note: this PR was implemented by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose and code are Claude's._

## Description

Fixes #2420: copying inside a sandboxed agent (e.g. drag-select in Claude Code, which copies via OSC 52) never reached the host clipboard in live-send.

**Root cause.** In live-send the pane's raw output feeds the in-process vt100 grid (`run_reader` in `src/tmux/vt.rs`), and the vt100 crate silently discards OSC sequences it does not model. With no attached tmux client, `set-clipboard on` has no terminal to forward to, and the `capture-pane` fallback only ever sees rendered cells. The agent's copy died inside the grid parser.

**Fix.**
- `Osc52Scanner` (`src/tmux/vt.rs`): an incremental, chunk-split-safe state machine that taps the raw pipe-pane stream before the vt100 parse. Handles BEL and ST terminators plus tmux-passthrough-doubled forms. Queries (`?`) and empty payloads are skipped, so a malformed or dropped copy can never clear the host clipboard (an empty `pbcopy` stdin clears it).
- `VtChannel::take_clipboard()` exposes the decoded text; `LiveCaptureWorker` relays it in a single-slot mailbox next to the cursor, under the same retarget guard, so a copy from the old pane cannot land after switching sessions.
- The render thread drains it and delivers through the existing `copy_to_clipboard()` (platform helper plus OSC 52 re-emitted to the user's real terminal), the same mechanism preview drag-select copies (#1502) already use. Deliberately not built on `pbcopy` alone; the abandoned relay prototype showed `pbcopy` exiting 0 without the paste landing.
- Gated on `[tmux] clipboard != disabled`. Auto forwards too: that mode's "respect the user's tmux config" rationale is about tmux server options, which cannot influence this in-process path.

**Follow-ups (not in this PR):** attached mode still depends on the outer terminal's terminfo advertising `Ms` (fails under e.g. iTerm2's xterm-256color without an override), and the web live terminal does not yet forward agent copies to the browser clipboard.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets`, and `cargo test` are clean (the one failing lib test, `restart_selected_session_surfaces_resume_failed_after_async_restart`, fails identically on main in the dev sandbox). `cargo check --features serve` compiles. Manually verified on macOS: drag-select in a sandboxed Claude Code under live-send now pastes on the host.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is covered by six new unit tests in `src/tmux/vt.rs`, including a reader-level test that drives `run_reader` over a real unix socket (posing as the pipe-pane forwarder) and asserts the copy lands in the clipboard slot while other bytes still reach the grid, plus every-byte-position chunk-split coverage. The remaining hop (host clipboard write) shells out to `pbcopy`/`xclip`, which the e2e environment cannot observe; it was verified manually on macOS.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**
Investigation, implementation, and tests by Claude via the /investigate workflow, directed and manually verified by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed live-send clipboard forwarding so OSC 52 clipboard writes made inside sandboxed agents reach the host clipboard.
- Added an incremental OSC 52 “clipboard scanner” that can handle partial/chunked output and tmux passthrough wrapping, extracting only real clipboard writes.
- Wired the decoded clipboard value from pane capture → live preview worker → render thread → host clipboard, with safeguards to prevent cross-pane leakage.
- Made forwarding behavior explicitly depend on `tmux.clipboard` being enabled (and ignore OSC 52 queries or empty payloads).
- Updated documentation/config comments and added unit tests for scanner behavior, chunk splitting, and end-to-end reader/VT integration.

## Benefits

- Users get reliable clipboard updates during live-send from sandboxed agents.
- Reduces incorrect/stale clipboard overwrites by draining/discarding clipboard data when forwarding is disabled and only forwarding the latest valid value.

## Potential follow-ups

- Clarify or extend behavior for “attached mode” terminfo limitations and any missing web clipboard forwarding (both called out as out-of-scope for this change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->