### PR TITLE
fix(tui): debounce live VT sampling across multi-chunk repaints

### DIFF
--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -80,6 +80,15 @@ static REGISTRY: LazyLock<Mutex<HashMap<String, Weak<VtChannel>>>> =
 
 static SOCK_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Monotonic base for chunk-arrival timestamps. The reader stamps each chunk's
+/// arrival against this (millis), and the TUI capture worker reads the deltas
+/// via [`VtChannel::chunk_timing`] to drive its repaint-quiescence debounce.
+static CHUNK_CLOCK: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+fn chunk_now_ms() -> u64 {
+    CHUNK_CLOCK.elapsed().as_millis() as u64
+}
+
 /// A `(Mutex, Condvar)` pair an in-process poller parks on. Registered via
 /// [`VtChannel::set_change_wakeup`]; the reader thread pokes it after every
 /// grid change (and on death) so the poller samples the moment output lands
@@ -518,6 +527,13 @@ struct ReaderCtx {
     app_cursor: Arc<AtomicBool>,
     alive: Arc<AtomicBool>,
     wakeup: Arc<Mutex<Option<ChangeWakeup>>>,
+    /// Chunk-arrival bookkeeping for the sample debounce (see the fields of the
+    /// same name on `VtChannel`): a chunk counter, the last chunk's arrival
+    /// (millis since `CHUNK_CLOCK`), and the gap between the two most recent
+    /// chunks.
+    chunk_seq: Arc<AtomicU64>,
+    last_chunk_ms: Arc<AtomicU64>,
+    prev_gap_ms: Arc<AtomicU64>,
     #[cfg(feature = "serve")]
     changed_tx: Arc<tokio::sync::watch::Sender<()>>,
 }
@@ -554,6 +570,22 @@ fn run_reader(listener: UnixListener, ctx: ReaderCtx) {
                     ctx.app_cursor
                         .store(p.screen().application_cursor(), Ordering::Relaxed);
                 }
+                // Stamp this chunk's arrival so the capture worker can tell a
+                // lone chunk (keystroke echo) from a back-to-back stream (a
+                // multi-chunk repaint) and hold the sample until the stream
+                // settles. Recorded before the wakeup so the woken worker reads
+                // fresh timing.
+                let seq = ctx.chunk_seq.fetch_add(1, Ordering::Relaxed);
+                let now = chunk_now_ms();
+                let prev = ctx.last_chunk_ms.swap(now, Ordering::Relaxed);
+                ctx.prev_gap_ms.store(
+                    if seq == 0 {
+                        u64::MAX
+                    } else {
+                        now.saturating_sub(prev)
+                    },
+                    Ordering::Relaxed,
+                );
                 // Wake the in-process poller (the TUI capture worker) so the
                 // just-landed output samples now, not after the remainder of
                 // its poll interval. This is the echo-latency path.
@@ -614,6 +646,17 @@ pub(crate) struct VtChannel {
     /// registration wins (one capture worker per process, so a slot rather
     /// than a list).
     wakeup: Arc<Mutex<Option<ChangeWakeup>>>,
+    /// Number of chunks the reader has parsed. `0` means none yet, so
+    /// `chunk_timing` reports `None` and the caller leaves pacing untouched.
+    chunk_seq: Arc<AtomicU64>,
+    /// Arrival of the most recent chunk (millis since `CHUNK_CLOCK`), stamped
+    /// by the reader thread on every chunk.
+    last_chunk_ms: Arc<AtomicU64>,
+    /// Interval between the two most recent chunks (millis). Large when the
+    /// latest chunk followed a quiet gap (a lone keystroke echo); small during
+    /// a back-to-back stream (a multi-chunk repaint). The sample debounce keys
+    /// off this to tell the two apart.
+    prev_gap_ms: Arc<AtomicU64>,
     /// Owner-only (0700) directory holding `sock_path`; removed on drop.
     sock_dir: PathBuf,
     sock_path: PathBuf,
@@ -687,6 +730,9 @@ impl VtChannel {
         let listener = UnixListener::bind(&sock_path).ok()?;
 
         let wakeup: Arc<Mutex<Option<ChangeWakeup>>> = Arc::new(Mutex::new(None));
+        let chunk_seq = Arc::new(AtomicU64::new(0));
+        let last_chunk_ms = Arc::new(AtomicU64::new(0));
+        let prev_gap_ms = Arc::new(AtomicU64::new(u64::MAX));
         let reader = {
             let ctx = ReaderCtx {
                 parser: parser.clone(),
@@ -696,6 +742,9 @@ impl VtChannel {
                 app_cursor: app_cursor.clone(),
                 alive: alive.clone(),
                 wakeup: wakeup.clone(),
+                chunk_seq: chunk_seq.clone(),
+                last_chunk_ms: last_chunk_ms.clone(),
+                prev_gap_ms: prev_gap_ms.clone(),
                 #[cfg(feature = "serve")]
                 changed_tx: changed_tx.clone(),
             };
@@ -759,6 +808,9 @@ impl VtChannel {
             #[cfg(feature = "serve")]
             changed_tx,
             wakeup,
+            chunk_seq,
+            last_chunk_ms,
+            prev_gap_ms,
             sock_dir,
             sock_path,
             stop,
@@ -856,6 +908,21 @@ impl VtChannel {
         if let Ok(mut guard) = self.wakeup.lock() {
             *guard = Some(wakeup);
         }
+    }
+
+    /// Chunk-arrival timing for the capture worker's repaint-quiescence
+    /// debounce: `(since_last_chunk_ms, prev_gap_ms)`. The first is how long ago
+    /// the most recent chunk landed; the second is the interval between the two
+    /// most recent chunks, large when the latest chunk followed a quiet gap (a
+    /// lone keystroke echo) and small during a back-to-back stream (a
+    /// multi-chunk repaint). `None` until the first chunk arrives, so the caller
+    /// leaves frame pacing untouched.
+    pub(crate) fn chunk_timing(&self) -> Option<(u64, u64)> {
+        if self.chunk_seq.load(Ordering::Relaxed) == 0 {
+            return None;
+        }
+        let since_last = chunk_now_ms().saturating_sub(self.last_chunk_ms.load(Ordering::Relaxed));
+        Some((since_last, self.prev_gap_ms.load(Ordering::Relaxed)))
     }
 
     /// A receiver that fires whenever the grid changes (output arrived) or the
@@ -1045,6 +1112,9 @@ mod tests {
             app_cursor: Arc::new(AtomicBool::new(false)),
             alive: alive.clone(),
             wakeup: wakeup_slot.clone(),
+            chunk_seq: Arc::new(AtomicU64::new(0)),
+            last_chunk_ms: Arc::new(AtomicU64::new(0)),
+            prev_gap_ms: Arc::new(AtomicU64::new(u64::MAX)),
             #[cfg(feature = "serve")]
             changed_tx: Arc::new(tokio::sync::watch::channel(()).0),
         };
@@ -1080,6 +1150,95 @@ mod tests {
                 .contents()
                 .contains("echo-marker"),
             "pane bytes must land in the grid before the wakeup fires"
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        drop(conn);
+        let _ = reader.join();
+    }
+
+    #[test]
+    fn reader_chunk_timing_distinguishes_stream_from_lone_chunk() {
+        use std::io::Write;
+
+        // Drive run_reader against a raw socket (posing as the pipe-pane
+        // forwarder), no tmux needed. The reader stamps each chunk's arrival;
+        // `chunk_timing` feeds the capture worker's repaint-quiescence debounce,
+        // which must tell a lone chunk (a keystroke echo, wide inter-chunk gap)
+        // from a back-to-back stream (a multi-chunk repaint, small gap). Without
+        // that distinction the worker samples half-repainted grids and the
+        // paired terminal flashes (#2903).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("s.sock");
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0)));
+        let stop = Arc::new(AtomicBool::new(false));
+        let chunk_seq = Arc::new(AtomicU64::new(0));
+        let last_chunk_ms = Arc::new(AtomicU64::new(0));
+        let prev_gap_ms = Arc::new(AtomicU64::new(u64::MAX));
+        let ctx = ReaderCtx {
+            parser,
+            stop: stop.clone(),
+            // Seeded upfront: this test has no capture-pane seed to wait for.
+            seeded: Arc::new(AtomicBool::new(true)),
+            stream: Arc::new(Mutex::new(None)),
+            app_cursor: Arc::new(AtomicBool::new(false)),
+            alive: Arc::new(AtomicBool::new(false)),
+            wakeup: Arc::new(Mutex::new(None)),
+            chunk_seq: chunk_seq.clone(),
+            last_chunk_ms: last_chunk_ms.clone(),
+            prev_gap_ms: prev_gap_ms.clone(),
+            #[cfg(feature = "serve")]
+            changed_tx: Arc::new(tokio::sync::watch::channel(()).0),
+        };
+        let reader = std::thread::spawn(move || run_reader(listener, ctx));
+        let mut conn = UnixStream::connect(&sock).expect("connect");
+
+        // Wait for the reader to finish processing the `n`th chunk. Writing the
+        // next chunk only after the previous is consumed keeps them separate
+        // reads (a unix stream is a byte stream, so two pending writes could
+        // otherwise coalesce into one chunk).
+        let wait_seq = |n: u64| {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while chunk_seq.load(Ordering::Relaxed) < n {
+                assert!(
+                    Instant::now() < deadline,
+                    "reader did not process {n} chunks"
+                );
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        };
+
+        // First chunk (the repaint's clear): no prior chunk, so the gap is
+        // "infinite" and it classifies as lone, never streaming.
+        conn.write_all(b"\x1b[2J").expect("write clear");
+        wait_seq(1);
+        assert_eq!(
+            prev_gap_ms.load(Ordering::Relaxed),
+            u64::MAX,
+            "the first chunk after arming is lone, not streaming"
+        );
+
+        // Two back-to-back reprint chunks: the reader records a real, small gap.
+        conn.write_all(b"partial").expect("write partial");
+        wait_seq(2);
+        conn.write_all(b" repaint").expect("write rest");
+        wait_seq(3);
+        let stream_gap = prev_gap_ms.load(Ordering::Relaxed);
+        assert!(
+            stream_gap < 20,
+            "back-to-back chunks record a small gap, got {stream_gap}"
+        );
+
+        // A chunk after a quiet pause records a much wider gap, so it reads as a
+        // lone chunk and samples immediately rather than debouncing.
+        std::thread::sleep(Duration::from_millis(40));
+        conn.write_all(b"!").expect("write lone");
+        wait_seq(4);
+        let quiet_gap = prev_gap_ms.load(Ordering::Relaxed);
+        assert!(
+            quiet_gap >= 20 && quiet_gap > stream_gap,
+            "a chunk after a 40ms pause is lone (gap {quiet_gap}) vs streamed (gap {stream_gap})"
         );
 
         stop.store(true, Ordering::Relaxed);

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -756,7 +756,8 @@ impl LiveCaptureWorker {
             let mut last_published_at: Option<std::time::Instant> = None;
             // When the current unpublished change first started being held by
             // the repaint-quiescence debounce, for its latency cap. `None`
-            // whenever nothing is pending. Cleared on publish and on retarget.
+            // whenever nothing is pending. Cleared on publish, on retarget, and
+            // whenever a cycle ends with nothing deferred.
             let mut pending_since: Option<std::time::Instant> = None;
             // Render the live preview from an in-process vt100 grid fed by
             // `tmux pipe-pane -IO` (and route input back through the same
@@ -932,6 +933,16 @@ impl LiveCaptureWorker {
                             }
                         }
                     }
+                }
+                // Nothing deferred this cycle means no frame is being held, so
+                // clear the debounce hold and let the next repaint's latency cap
+                // start fresh. Covers both a publish (already cleared above) and
+                // a mid-repaint change that evaporated back to the last
+                // published content without ever publishing, which would
+                // otherwise leave a stale `pending_since` that makes the next
+                // repaint hit the cap immediately and skip the debounce.
+                if defer_wait_ms.is_none() {
+                    pending_since = None;
                 }
                 // Interruptible wait: `set_live` / `set_target` notify the
                 // condvar so a cadence or target change is picked up at once

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -581,6 +581,47 @@ pub(super) fn publish_floor_wait_ms(since_last_publish_ms: Option<u64>) -> u64 {
         Some(elapsed) => LIVE_CAPTURE_INTERVAL_FAST_MS.saturating_sub(elapsed),
     }
 }
+
+/// Quiescence window for the VT sample debounce: while output is streaming in
+/// back-to-back chunks, a changed frame waits until the stream has been silent
+/// for this long before it may publish, so a clear-then-reprint that spans
+/// several chunks publishes once it settles instead of mid-repaint (the flash
+/// in #2903). Small enough that the settled frame still lands promptly once
+/// output stops.
+const SAMPLE_QUIESCENCE_MS: u64 = 6;
+
+/// Hard cap on how long the sample debounce may hold a changed frame. Sustained
+/// output (a stream that never goes quiet) hits this and publishes anyway, so
+/// heavy streaming still renders at a bounded cadence rather than stalling
+/// until it happens to pause.
+const SAMPLE_LATENCY_CAP_MS: u64 = 40;
+
+/// How long a just-changed VT frame must wait before it may sample/publish,
+/// given whether output is currently `streaming` (chunks arriving back-to-back
+/// within [`SAMPLE_QUIESCENCE_MS`]), `since_last_chunk_ms` (how long ago the
+/// most recent chunk landed), and `since_pending_ms` (how long this pending
+/// change has been held). Zero means publish now.
+///
+/// A lone chunk (a keystroke echo, or the first chunk after a quiet gap)
+/// reports `streaming == false` and never waits, so the #2822 echo-latency path
+/// is untouched. Only a live stream defers, and only until it goes quiet
+/// (`since_last_chunk_ms >= SAMPLE_QUIESCENCE_MS`) or the latency cap fires.
+pub(super) fn sample_debounce_wait_ms(
+    streaming: bool,
+    since_last_chunk_ms: u64,
+    since_pending_ms: u64,
+) -> u64 {
+    if !streaming || since_pending_ms >= SAMPLE_LATENCY_CAP_MS {
+        return 0;
+    }
+    let quiescence_remaining = SAMPLE_QUIESCENCE_MS.saturating_sub(since_last_chunk_ms);
+    if quiescence_remaining == 0 {
+        return 0;
+    }
+    quiescence_remaining
+        .min(SAMPLE_LATENCY_CAP_MS.saturating_sub(since_pending_ms))
+        .max(1)
+}
 /// Capture cadence when the worker is just keeping the home-list preview warm
 /// (no live-send). Matches the old render-driven `PREVIEW_REFRESH_MS` throttle
 /// so moving the fork off the render thread doesn't raise the idle fork rate.
@@ -713,6 +754,10 @@ impl LiveCaptureWorker {
             // When the frame that is currently in the mailbox (or the last
             // one consumed) was published, for the inter-publish floor.
             let mut last_published_at: Option<std::time::Instant> = None;
+            // When the current unpublished change first started being held by
+            // the repaint-quiescence debounce, for its latency cap. `None`
+            // whenever nothing is pending. Cleared on publish and on retarget.
+            let mut pending_since: Option<std::time::Instant> = None;
             // Render the live preview from an in-process vt100 grid fed by
             // `tmux pipe-pane -IO` (and route input back through the same
             // socket), instead of scraping `capture-pane` and forking
@@ -741,10 +786,12 @@ impl LiveCaptureWorker {
                     .ok()
                     .map(|g| g.clone())
                     .unwrap_or_default();
-                // A frame deferred by the publish floor this iteration; the
-                // wait below shrinks to the floor's remainder so it goes out
-                // as soon as the floor reopens.
-                let mut deferred_publish = false;
+                // How long a change deferred this iteration must wait before
+                // re-checking (the sooner of the publish-floor and debounce
+                // remainders). `Some` shrinks the wait below so the held frame
+                // goes out as soon as its blockers reopen; `None` means nothing
+                // was deferred.
+                let mut defer_wait_ms: Option<u64> = None;
                 // A retarget resets the dedup so the new pane's first frame
                 // always publishes, even if its bytes happen to match the
                 // previous pane's last capture.
@@ -752,8 +799,9 @@ impl LiveCaptureWorker {
                     last_target = name.clone();
                     last_captured = None;
                     // The new pane's first frame must not inherit the old
-                    // pane's floor.
+                    // pane's floor or debounce hold.
                     last_published_at = None;
+                    pending_since = None;
                     // Tear down a VT source armed for the old target (also fires
                     // on retarget-to-empty), disabling its `pipe-pane`, and allow
                     // a fresh arm attempt for the new target.
@@ -807,6 +855,14 @@ impl LiveCaptureWorker {
                     };
                     #[cfg(not(unix))]
                     let (capture, cursor_now) = capture_via_tmux(&name, lines, forward_empty);
+                    // Chunk-arrival timing for the repaint-quiescence debounce,
+                    // only when sampling a live VT grid. `None` on the
+                    // capture-pane fallback and non-unix, which leaves pacing to
+                    // the publish floor alone.
+                    #[cfg(unix)]
+                    let vt_timing = vt_source.as_ref().and_then(|v| v.chunk_timing());
+                    #[cfg(not(unix))]
+                    let vt_timing: Option<(u64, u64)> = None;
                     if let Some(content) = capture {
                         // Skip unchanged frames (no point waking a re-parse).
                         // Empties are skipped too unless this pane forwards
@@ -832,19 +888,46 @@ impl LiveCaptureWorker {
                             if (forward_empty || !content.is_empty()) && changed {
                                 let since =
                                     last_published_at.map(|t| t.elapsed().as_millis() as u64);
-                                if publish_floor_wait_ms(since) == 0 {
+                                let floor = publish_floor_wait_ms(since);
+                                // Repaint-quiescence debounce (VT path only):
+                                // hold a changed frame while output streams in
+                                // back-to-back chunks so a multi-chunk
+                                // clear-then-reprint publishes once it settles,
+                                // not mid-repaint (#2903). A lone chunk (a
+                                // keystroke echo) reports not-streaming and
+                                // never waits, preserving the #2822 echo path.
+                                let debounce = match vt_timing {
+                                    Some((since_last_chunk, gap)) => {
+                                        let streaming = gap < SAMPLE_QUIESCENCE_MS;
+                                        let held = pending_since
+                                            .map(|t| t.elapsed().as_millis() as u64)
+                                            .unwrap_or(0);
+                                        sample_debounce_wait_ms(streaming, since_last_chunk, held)
+                                    }
+                                    None => 0,
+                                };
+                                if floor == 0 && debounce == 0 {
                                     if let Ok(mut guard) = slot.lock() {
                                         *guard = Some(content.clone());
                                     }
                                     last_captured = Some(content);
                                     last_published_at = Some(std::time::Instant::now());
+                                    pending_since = None;
                                     wake.notify_one();
                                 } else {
-                                    // Inside the floor: defer, don't drop.
-                                    // `last_captured` stays stale, so the next
-                                    // cycle re-detects this frame and publishes
-                                    // it once the floor reopens.
-                                    deferred_publish = true;
+                                    // Held by the floor and/or the debounce:
+                                    // defer, don't drop. `last_captured` stays
+                                    // stale so the next cycle re-detects this
+                                    // frame and publishes it once both reopen.
+                                    if pending_since.is_none() {
+                                        pending_since = Some(std::time::Instant::now());
+                                    }
+                                    let wait = match (floor, debounce) {
+                                        (0, d) => d,
+                                        (f, 0) => f,
+                                        (f, d) => f.min(d),
+                                    };
+                                    defer_wait_ms = Some(wait.max(1));
                                 }
                             }
                         }
@@ -876,13 +959,11 @@ impl LiveCaptureWorker {
                 } else {
                     interval_cell.load(Ordering::Relaxed)
                 };
-                // A frame deferred by the publish floor goes out as soon as
-                // the floor reopens, not after a full interval.
-                let ms = if deferred_publish {
-                    let since = last_published_at.map(|t| t.elapsed().as_millis() as u64);
-                    ms.min(publish_floor_wait_ms(since).max(1))
-                } else {
-                    ms
+                // A deferred frame goes out as soon as its blockers (publish
+                // floor and/or debounce) reopen, not after a full interval.
+                let ms = match defer_wait_ms {
+                    Some(wait) => ms.min(wait),
+                    None => ms,
                 };
                 if let Ok(guard) = nudge_thread.0.lock() {
                     let _ = nudge_thread
@@ -2426,6 +2507,65 @@ mod tests {
         assert_eq!(
             publish_floor_wait_ms(Some(5)),
             LIVE_CAPTURE_INTERVAL_FAST_MS - 5
+        );
+    }
+
+    #[test]
+    fn sample_debounce_lone_chunk_never_waits() {
+        // A lone chunk (a keystroke echo, or the first chunk after a quiet gap)
+        // reports `streaming == false`, so it must sample with zero added delay
+        // regardless of how recently it landed. Adding a wait here re-creates
+        // the live-mode echo lag the #2822 event-driven wakeup exists to kill.
+        assert_eq!(sample_debounce_wait_ms(false, 0, 0), 0);
+        assert_eq!(sample_debounce_wait_ms(false, 0, 100), 0);
+        assert_eq!(sample_debounce_wait_ms(false, 3, 0), 0);
+    }
+
+    #[test]
+    fn sample_debounce_holds_active_stream_until_quiescent() {
+        // While chunks are arriving back-to-back and the stream has not gone
+        // quiet, a changed frame is held so a multi-chunk repaint publishes once
+        // it settles instead of mid-repaint. The wait is the remaining
+        // quiescence window.
+        assert_eq!(
+            sample_debounce_wait_ms(true, 0, 0),
+            SAMPLE_QUIESCENCE_MS,
+            "a fresh stream chunk waits the full quiescence window",
+        );
+        assert_eq!(
+            sample_debounce_wait_ms(true, SAMPLE_QUIESCENCE_MS - 2, 10),
+            2,
+            "the wait shrinks to the quiescence remainder",
+        );
+    }
+
+    #[test]
+    fn sample_debounce_publishes_once_stream_goes_quiet() {
+        // Once the stream has been silent for the quiescence window, the
+        // settled frame publishes immediately (this is the repaint's final
+        // frame arriving right after output stops).
+        assert_eq!(sample_debounce_wait_ms(true, SAMPLE_QUIESCENCE_MS, 10), 0);
+        assert_eq!(
+            sample_debounce_wait_ms(true, SAMPLE_QUIESCENCE_MS + 5, 10),
+            0
+        );
+    }
+
+    #[test]
+    fn sample_debounce_latency_cap_bounds_sustained_streaming() {
+        // A stream that never goes quiet must still render: once a held frame
+        // has waited out the latency cap it publishes regardless of how
+        // recently the last chunk landed, so heavy output paces at the cap
+        // rather than stalling until it happens to pause.
+        assert_eq!(sample_debounce_wait_ms(true, 0, SAMPLE_LATENCY_CAP_MS), 0);
+        assert_eq!(
+            sample_debounce_wait_ms(true, 0, SAMPLE_LATENCY_CAP_MS + 100),
+            0
+        );
+        // Just under the cap, the wait is clamped so it can never overshoot it.
+        assert_eq!(
+            sample_debounce_wait_ms(true, 0, SAMPLE_LATENCY_CAP_MS - 1),
+            1,
         );
     }
 


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Viewing a session's paired bash terminal in TUI live mode while a chatty process runs in it (a vite dev server) made the pane flash and shift during redraws.

Root cause: the `pipe-pane` reader thread (`VtChannel::run_reader`) pokes the capture worker's change wakeup after every read chunk. A full-screen redraw (clear region, then reprint) frequently spans several 8KB chunks, so `LiveCaptureWorker` sampled and published half-repainted grids. The 25ms publish floor paced frames but did not align them to logical repaint boundaries.

The fix adds a repaint-quiescence debounce to the VT sample path:

- The reader now stamps each chunk's arrival (a chunk counter, the last chunk's time, and the gap between the two most recent chunks). This lets the capture worker tell a lone chunk (a keystroke echo, wide inter-chunk gap) from a back-to-back stream (a multi-chunk repaint, small gap).
- A changed frame produced while output is streaming is held until the stream has been silent for a short quiescence window (6ms), so a multi-chunk clear-then-reprint publishes once it settles instead of mid-repaint. A hard latency cap (40ms) keeps sustained output rendering at a bounded cadence rather than stalling until it happens to pause.
- A lone chunk reports not-streaming and never waits, so the #2822 event-driven echo path (19ms median on Linux) is preserved. The debounce only engages when a subsequent chunk actually arrived back-to-back.

The debounce decision is a small pure function (`sample_debounce_wait_ms`) so it is unit-testable. Scope is limited to reader/wakeup/sample pacing: the capture-pane fallback and non-unix paths report no timing (leaving pacing to the publish floor alone), `forward_empty` semantics are untouched, and none of the resize / size-owner / `reconcile_size` machinery is changed (all noted out of scope in the issue).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The change is a timing/pacing fix with no static UI surface; the effect (no mid-repaint flash) is only observable as motion under a live chatty stream, so a still screenshot would not convey it. Regression coverage is via the added tests below.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test (unit-level, alongside the code it covers)

New tests:

- `src/tmux/vt.rs::reader_chunk_timing_distinguishes_stream_from_lone_chunk`: drives `run_reader` against a raw socket and asserts the reader records a wide gap for the first / post-pause chunk (lone) and a small gap for back-to-back chunks (streaming). Fails to compile against the pre-fix reader, which has no chunk-timing.
- `src/tui/home/live_send.rs::sample_debounce_*` (four tests): pin the debounce decision. `sample_debounce_holds_active_stream_until_quiescent` is the core regression: a streaming frame returns a non-zero hold, where the pre-fix behavior published immediately (mid-repaint). The others assert a lone chunk never waits (echo path preserved), the settled frame publishes once quiet, and the latency cap bounds sustained streaming.

Verification: `cargo fmt`, `cargo clippy`, and `cargo check --features serve` are clean; the new and existing `tmux::vt` (9) and `live_send` (126) module tests pass. Two unrelated tests fail on this branch and on a clean `origin/main` alike (`restart_selected_session_surfaces_resume_failed_after_async_restart`, and a flaky tmux split-panes status check that passes in isolation), so they are pre-existing and not introduced here.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude implemented the fix and tests from a diagnosis and fix direction written up in the issue by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed TUI live-mode flashing/shifting caused by rapidly changing terminal output.
- The VT live reader now measures when output chunks arrive, so the capture worker can tell “one-off” chunks apart from continuous back-to-back repaint streams.
- Live preview updates are now held briefly to wait for a short quiet period during active output, with a hard cap to prevent noticeable lag during sustained streaming.
- Lone chunks still update immediately to preserve event-driven terminal echo.
- Added unit tests for chunk timing classification and the debounce/latency-cap behavior.
- The change is limited to the VT reader/wakeup path and live sample pacing; capture fallback, non-Unix behavior, `forward_empty`, and resize handling are unchanged.

## Benefits

- Smoother, more stable live previews with fewer distracting intermediate redraws.
- Better responsiveness under heavy output by keeping delays bounded.
- Preserves the fast “immediate echo” feel when output is sporadic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->