### PR TITLE
fix(status): recover Claude sessions stuck on Running after a silent turn-end

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -351,12 +351,23 @@ pub struct PermissionResponse {
 ///
 /// `idle` has two sources, not just `Stop`. `Stop` does not fire on every
 /// turn-end path: a turn killed by an API error fires `StopFailure` instead,
-/// and a user interrupt fires nothing. Without a second idle signal the status
-/// file stays on the last `running` write and the session sticks on Running.
-/// `Notification` with matcher `idle_prompt` is Claude's explicit "done
-/// working, waiting for the user" signal and fires whenever Claude parks at the
-/// prompt regardless of why the turn ended, so it backstops `Stop`;
-/// `StopFailure` covers the API-error path deterministically.
+/// and a user interrupt fires nothing. Newer Claude Code has a further gap: a
+/// "silent tool stop" (a tool result followed by no text) parks at the prompt
+/// firing neither `Stop` nor `idle_prompt`. Without a second idle signal the
+/// status file stays on the last `running` write and the session sticks on
+/// Running. `Notification` with matcher `idle_prompt` is Claude's explicit
+/// "done working, waiting for the user" signal and fires whenever Claude parks
+/// at the prompt regardless of why the turn ended, so it backstops `Stop`;
+/// `StopFailure` covers the API-error path deterministically. The remaining
+/// gap (silent tool stop) has no hook, so it is recovered pane-side by
+/// `reconcile_claude_hook_status`.
+///
+/// The `Notification` matchers also carry the agent-view identifiers added in
+/// Claude Code 2.1.198: `agent_needs_input` (background session blocked on the
+/// user → Waiting) rides the permission group, and `agent_completed`
+/// (background session finished/failed → Idle) rides the `idle_prompt` group.
+/// They only fire while Claude's agent view is open, so they are best-effort
+/// extra coverage for that surface, not a substitute for the pane fallback.
 const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "SessionStart",
@@ -390,13 +401,13 @@ const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
     },
     HookEvent {
         name: "Notification",
-        matcher: Some("permission_prompt|elicitation_dialog"),
+        matcher: Some("permission_prompt|elicitation_dialog|agent_needs_input"),
         status: Some(HookStatus::Waiting),
         session_id_capture: false,
     },
     HookEvent {
         name: "Notification",
-        matcher: Some("idle_prompt"),
+        matcher: Some("idle_prompt|agent_completed"),
         status: Some(HookStatus::Idle),
         session_id_capture: false,
     },

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -28,7 +28,7 @@ pub(crate) use dir_guard::{
 };
 pub use status_file::{
     cleanup_hook_status_dir, hook_status_dir, read_hook_session_id, read_hook_status,
-    read_hook_urgent,
+    read_hook_status_age, read_hook_urgent,
 };
 pub(crate) use targets::{
     has_aoe_marker, iter_hook_targets, iter_hook_targets_in, HookTarget, HookTargetKind,
@@ -2994,6 +2994,8 @@ command = "echo user-hook"
         let waiting_matcher = waiting["matcher"].as_str().unwrap();
         assert!(waiting_matcher.contains("permission_prompt"));
         assert!(waiting_matcher.contains("elicitation_dialog"));
+        // Agent-view identifier (2.1.198) rides the permission/waiting group.
+        assert!(waiting_matcher.contains("agent_needs_input"));
         assert!(!waiting_matcher.contains("idle_prompt"));
         assert!(
             waiting["hooks"][0]["command"]
@@ -3005,8 +3007,17 @@ command = "echo user-hook"
 
         let idle = notification
             .iter()
-            .find(|g| g["matcher"].as_str() == Some("idle_prompt"))
+            .find(|g| {
+                g["matcher"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("idle_prompt"))
+            })
             .expect("idle_prompt matcher group present");
+        // Agent-view completion (2.1.198) rides the idle group.
+        assert!(idle["matcher"]
+            .as_str()
+            .unwrap()
+            .contains("agent_completed"));
         assert!(
             idle["hooks"][0]["command"]
                 .as_str()

--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -47,6 +47,22 @@ pub fn read_hook_status(instance_id: &str) -> Option<Status> {
     parse_status(&bytes)
 }
 
+/// Time since the hook status file was last written, i.e. how long the current
+/// value has been standing.
+///
+/// The running-mapped hooks (`PreToolUse`, `UserPromptSubmit`, `ElicitationResult`)
+/// rewrite the file on every fire, so a fresh mtime means the last write is
+/// recent. `reconcile_claude_hook_status` uses this to tell a genuinely fresh
+/// `running` (a turn that just started, spinner not yet rendered) from a stale
+/// one that a missed idle hook left standing after the turn ended.
+///
+/// Returns `None` when the file is absent or its mtime can't be read.
+pub fn read_hook_status_age(instance_id: &str) -> Option<std::time::Duration> {
+    let dir = dir_guard::open_instance_dir_read_only(instance_id).ok()??;
+    let meta = dir_guard::metadata_at(dir.as_fd(), "status").ok()??;
+    meta.modified().ok()?.elapsed().ok()
+}
+
 fn parse_status(bytes: &[u8]) -> Option<Status> {
     let trimmed = std::str::from_utf8(bytes).ok()?.trim();
     match trimmed {
@@ -183,6 +199,25 @@ mod tests {
     fn test_read_missing_file() {
         let (_g, _, _tmp) = BaseGuard::ready();
         assert_eq!(read_hook_status("nonexistent_instance_id"), None);
+    }
+
+    #[test]
+    #[serial_test::serial(hook_base)]
+    fn test_read_hook_status_age_fresh_after_write() {
+        let (_g, _, _tmp) = BaseGuard::ready();
+        write_status_via_guard("age_fresh", "running");
+        let age = read_hook_status_age("age_fresh").expect("age present after write");
+        assert!(
+            age < Duration::from_secs(5),
+            "just-written status should be fresh, got {age:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(hook_base)]
+    fn test_read_hook_status_age_none_when_absent() {
+        let (_g, _, _tmp) = BaseGuard::ready();
+        assert_eq!(read_hook_status_age("age_absent_instance"), None);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4645,7 +4645,12 @@ impl Instance {
                             if detection_tool == "codex" {
                                 tmux::reconcile_codex_hook_status(hook_status, &pane_content)
                             } else {
-                                tmux::reconcile_claude_hook_status(hook_status, &pane_content)
+                                let running_age = crate::hooks::read_hook_status_age(&self.id);
+                                tmux::reconcile_claude_hook_status(
+                                    hook_status,
+                                    &pane_content,
+                                    running_age,
+                                )
                             }
                         }
                         Err(e) => {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -272,6 +272,37 @@ fn claude_pane_shows_interrupted_turn(raw_content: &str) -> bool {
         && !claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower)
 }
 
+/// How long a `running` hook write must have been standing before a pane that
+/// looks parked at the idle prompt is trusted over it. The idle ready-prompt
+/// pane is identical whether Claude just finished a turn (the hook missed the
+/// idle write, file stuck on `running`) or the user just submitted a prompt and
+/// the spinner hasn't rendered yet. The two are told apart by age: the
+/// start-of-turn gap resolves within ~1s (a running-mapped hook just wrote the
+/// file), while a stuck value has been standing since the turn's last tool
+/// call. The threshold sits above the render gap with margin.
+const IDLE_RECONCILE_MIN_RUNNING_AGE: std::time::Duration = std::time::Duration::from_secs(6);
+
+/// Claude has finished a turn and parked at the idle ready prompt, but no idle
+/// hook fired (the "silent tool stop" path: a tool result followed by no text
+/// fires neither `Stop` nor `idle_prompt`), so the status file is stuck on
+/// `running`. The positive marker is Claude's empty input prompt (a bare `❯`
+/// line, distinct from a numbered `❯ 1.` menu) or its idle shortcuts footer,
+/// combined with the absence of any active-turn signal. Requiring a positive
+/// ready-prompt marker (not merely "no spinner") keeps a blank or mid-redraw
+/// capture from reading as Idle.
+fn claude_pane_shows_ready_prompt(raw_content: &str) -> bool {
+    let clean = strip_ansi(raw_content);
+    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
+    let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
+    let recent_joined = recent.join("\n");
+    let recent_lower = recent_joined.to_lowercase();
+
+    let has_empty_prompt = recent.iter().any(|line| line.trim() == "❯");
+    let has_idle_footer = recent_lower.contains("? for shortcuts");
+    (has_empty_prompt || has_idle_footer)
+        && !claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower)
+}
+
 /// When Claude's status hook reports Running, the pane is consulted to catch two
 /// cases the hook stream can't express on its own:
 ///
@@ -284,11 +315,24 @@ fn claude_pane_shows_interrupted_turn(raw_content: &str) -> bool {
 ///    `idle_prompt`, so the status file sticks on `running` indefinitely.
 ///    Downgrade to Idle when the pane shows the interrupt banner and no
 ///    active-turn signal.
+/// 3. A completed turn whose idle hook never fired (the "silent tool stop":
+///    a tool result with no following text fires neither `Stop` nor
+///    `idle_prompt`). The pane parks at the idle ready prompt with no
+///    active-turn signal, but that is also how a just-started turn looks
+///    before its spinner renders, so this downgrade is gated on the `running`
+///    write having been standing for `IDLE_RECONCILE_MIN_RUNNING_AGE`.
+///    `running_age` is how long ago the status file was last written (its mtime
+///    elapsed); `None` (age unavailable) is treated as not-yet-stale so we
+///    never downgrade on missing evidence.
 ///
 /// Otherwise trust the hook. Mirrors `reconcile_codex_hook_status`'s
 /// positive-evidence approach so an active turn whose pane hasn't rendered a
 /// spinner yet keeps Running rather than flickering Idle.
-pub(crate) fn reconcile_claude_hook_status(hook_status: Status, raw_content: &str) -> Status {
+pub(crate) fn reconcile_claude_hook_status(
+    hook_status: Status,
+    raw_content: &str,
+    running_age: Option<std::time::Duration>,
+) -> Status {
     if hook_status != Status::Running {
         return hook_status;
     }
@@ -296,6 +340,11 @@ pub(crate) fn reconcile_claude_hook_status(hook_status: Status, raw_content: &st
         return Status::Waiting;
     }
     if claude_pane_shows_interrupted_turn(raw_content) {
+        return Status::Idle;
+    }
+    if running_age.is_some_and(|age| age >= IDLE_RECONCILE_MIN_RUNNING_AGE)
+        && claude_pane_shows_ready_prompt(raw_content)
+    {
         return Status::Idle;
     }
     hook_status
@@ -1795,7 +1844,7 @@ enter to select · esc to cancel";
   ❯ 1. Yes\n    2. No\n\n  Esc to cancel · Tab to amend\n\
 \x1b[38;5;174m✶\x1b[0m Herding… (53s · ↓ 7.0k tokens)";
         assert_eq!(
-            reconcile_claude_hook_status(Status::Running, pane),
+            reconcile_claude_hook_status(Status::Running, pane, None),
             Status::Waiting
         );
     }
@@ -1804,7 +1853,7 @@ enter to select · esc to cancel";
     fn test_reconcile_claude_hook_status_keeps_running_without_prompt() {
         let pane = "✶ Working… (4s · ↓ 88 tokens)\n  esc to interrupt";
         assert_eq!(
-            reconcile_claude_hook_status(Status::Running, pane),
+            reconcile_claude_hook_status(Status::Running, pane, None),
             Status::Running
         );
     }
@@ -1815,11 +1864,11 @@ enter to select · esc to cancel";
         // Waiting directly; the reconciler must not second-guess it, and an
         // Idle/Waiting hook is trusted as-is even with no pane evidence.
         assert_eq!(
-            reconcile_claude_hook_status(Status::Waiting, ""),
+            reconcile_claude_hook_status(Status::Waiting, "", None),
             Status::Waiting
         );
         assert_eq!(
-            reconcile_claude_hook_status(Status::Idle, "Do you want to proceed?\n1. Yes"),
+            reconcile_claude_hook_status(Status::Idle, "Do you want to proceed?\n1. Yes", None),
             Status::Idle
         );
     }
@@ -1835,7 +1884,7 @@ enter to select · esc to cancel";
         let pane = "\x1b[2m  ⎿  Interrupted · What should Claude do instead?\x1b[0m\n\n\
 \x1b[1m❯ \x1b[0m\n\n  ? for shortcuts · ← for agents";
         assert_eq!(
-            reconcile_claude_hook_status(Status::Running, pane),
+            reconcile_claude_hook_status(Status::Running, pane, None),
             Status::Idle
         );
     }
@@ -1849,20 +1898,73 @@ enter to select · esc to cancel";
 ● Picking up where we left off\n\
 ✶ Herding… (3s · ↓ 42 tokens)\n  esc to interrupt";
         assert_eq!(
-            reconcile_claude_hook_status(Status::Running, pane),
+            reconcile_claude_hook_status(Status::Running, pane, None),
             Status::Running
         );
     }
 
     #[test]
-    fn test_reconcile_claude_hook_status_trusts_running_without_interrupt_banner() {
+    fn test_reconcile_claude_hook_status_trusts_fresh_running_at_idle_prompt() {
         // No interrupt banner and no active-turn signal yet: the gap right
-        // after UserPromptSubmit before the spinner renders. We trust the
-        // hook's Running rather than flickering Idle on missing pane evidence
-        // (mirrors the conservative codex reconciler).
+        // after UserPromptSubmit before the spinner renders. The `running`
+        // write is fresh (well under the stale threshold), so we trust the
+        // hook's Running rather than flickering Idle on the idle-looking pane.
         let pane = "❯ \n\n  ? for shortcuts · ← for agents";
         assert_eq!(
-            reconcile_claude_hook_status(Status::Running, pane),
+            reconcile_claude_hook_status(
+                Status::Running,
+                pane,
+                Some(std::time::Duration::from_secs(1))
+            ),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_idle_on_stale_running_at_idle_prompt() {
+        // The "silent tool stop": a tool result with no following text parked
+        // Claude at the idle prompt firing neither Stop nor idle_prompt, so the
+        // file is stuck on `running`. The pane shows the idle ready prompt with
+        // no active-turn signal and the write has been standing well past the
+        // threshold, so the reconciler recovers to Idle.
+        let pane = "\x1b[1m❯ \x1b[0m\n\n  ? for shortcuts · ← for agents";
+        assert_eq!(
+            reconcile_claude_hook_status(
+                Status::Running,
+                pane,
+                Some(std::time::Duration::from_secs(30))
+            ),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_stale_running_keeps_running_while_active() {
+        // A long tool run can leave the `running` write stale (mtime old)
+        // while the turn is genuinely active. The live active-turn signal must
+        // still win over the age gate; only an idle-looking pane downgrades.
+        let pane = "✶ Working… (90s · ↓ 4.1k tokens)\n  esc to interrupt";
+        assert_eq!(
+            reconcile_claude_hook_status(
+                Status::Running,
+                pane,
+                Some(std::time::Duration::from_secs(120))
+            ),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_stale_running_keeps_running_on_blank_pane() {
+        // Stale write but no positive idle marker (a blank / mid-redraw
+        // capture). Absence of a spinner is not enough; without the ready
+        // prompt we trust the hook rather than flicker Idle.
+        assert_eq!(
+            reconcile_claude_hook_status(
+                Status::Running,
+                "   \n\n  ",
+                Some(std::time::Duration::from_secs(30))
+            ),
             Status::Running
         );
     }


### PR DESCRIPTION
## Description

Sometimes a Claude session stays stuck on "working" (Running) after the turn has visibly completed, on newer Claude Code (2.1.211).

**Root cause.** aoe treats the hook-written status file as authoritative. In `session/instance.rs`, when the file says `Running` for Claude, the pane is captured and `reconcile_claude_hook_status` only downgrades on a positive approval-prompt or interrupt-banner match; the pure-pane detector (`detect_claude_status`, which would read a finished pane as Idle) is bypassed entirely whenever a hook file exists. So any turn-end path that fires no idle-writing hook leaves the file stuck on its last `running` write, and the session never falls back to Idle.

#2429 added `StopFailure` + `idle_prompt` to backstop `Stop`, but 2.1.211 has a further gap: a "silent tool stop" (a tool result followed by no text) parks Claude at the prompt firing none of `Stop` / `StopFailure` / `idle_prompt`. There is no hook for it, so it has to be recovered pane-side.

**Fix (two parts).**

1. **Age-gated idle-prompt recovery** in `reconcile_claude_hook_status`: when the hook says Running but the pane shows Claude's idle ready prompt (a bare `❯` line or the `? for shortcuts` footer) with no active-turn signal, AND the running write has been standing longer than `IDLE_RECONCILE_MIN_RUNNING_AGE` (6s), fall to Idle. The age gate is the anti-flicker guard: the idle-looking pane is identical to the sub-second gap after `UserPromptSubmit` before the spinner renders, and only age distinguishes a fresh `running` (turn just started, keep Running) from a stale one (turn finished, hook missed). A genuinely active turn always renders the spinner, so it is never downgraded regardless of age. New `read_hook_status_age` reads the status file mtime.

2. **New Notification matchers** (Claude 2.1.198, verified present in the 2.1.211 binary): `agent_needs_input` (-> Waiting) rides the permission group and `agent_completed` (-> Idle) rides the `idle_prompt` group. They only fire with the agent view open, so they are best-effort extra coverage, not a substitute for the pane fallback.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Covered by unit tests instead, alongside the code: four new `reconcile_claude_hook_status` cases (fresh running at idle prompt stays Running; stale running at idle prompt -> Idle; stale running with an active spinner stays Running; stale running on a blank pane stays Running) plus two `read_hook_status_age` tests. `cargo test` is green apart from one pre-existing failure on `states` (`restart_selected_session_surfaces_resume_failed_after_async_restart`), which fails without this change and is unrelated (restart/resume dialog).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigated and implemented via Claude Code. The reasoning and decisions are njbrake's; verified the 2.1.211 hook/notification identifiers against the installed Claude Code binary.

- [x] I am an AI Agent filling out this form (check box if true)
