### PR TITLE
feat(tmux): settings-backed VT live toggle (replaces AOE_VT_LIVE)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -284,6 +284,7 @@ status_bar = "auto"
 mouse = "auto"
 clipboard = "auto"
 # socket_name = "aoe"
+vt_live = true
 ```
 
 | Option | Default | Description |
@@ -292,6 +293,7 @@ clipboard = "auto"
 | `mouse` | `"auto"` | Same modes as `status_bar`. Controls mouse support in aoe tmux sessions. |
 | `clipboard` | `"auto"` | Same modes. Forwards OSC 52 clipboard escape sequences from the wrapped agent (Claude Code, OpenCode, Codex, etc.) to your terminal. Without this, "select to copy" inside the agent silently fails. Sets `set-clipboard on` and `allow-passthrough on` on the aoe tmux session (the attached path), and in live-send aoe itself extracts the agent's OSC 52 from the pane stream and pushes it to your clipboard. Live-send forwarding is on for `"auto"` and `"enabled"` (your tmux config cannot affect aoe's in-process transport, so `"auto"` does not defer to it here); `"disabled"` turns it off. |
 | `socket_name` | unset | Run aoe's sessions on a private tmux server with this socket name (passed as `tmux -L <name>`), so your own `tmux ls` and hand-managed sessions stay separate from aoe's. Leave unset to share the default tmux server (the current behavior). Must be a bare name, not a path; a value with a `/` or `\` is ignored. Takes effect on the next aoe start. Global/profile only. |
+| `vt_live` | `true` | Render live views (the TUI live preview and the web/mobile live terminal) from a persistent VT channel: `tmux pipe-pane` streams the pane into an in-process terminal grid, and keystrokes go back over the same socket. Needs tmux 3.4+; panes that cannot arm a channel fall back to the polling `capture-pane` / `send-keys` path automatically. Disable only to troubleshoot the VT transport; the fallback is slower and loses agent clipboard forwarding in live-send. Applies in place: the TUI picks a change up on the next capture cycle, web connections on their next reconnect. |
 
 ## Diff
 

--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -95,6 +95,32 @@ kitty keyboard protocol (Apple Terminal, default iTerm2, Termius, Mosh),
 terminals, or configure the terminal to send `ESC+CR` for `Shift+Enter`
 as a fallback.
 
+## The VT live transport
+
+Live views (this TUI preview and the web/mobile live terminal) render
+through a persistent VT channel by default: `tmux pipe-pane` streams the
+agent's raw output into an in-process terminal grid, and your keystrokes
+travel back over the same socket. Compared to the older polling path
+(`capture-pane` scrapes plus a `send-keys` fork per keystroke), typing
+echo and streaming output land with near-attach latency, and agent
+copies (OSC 52) reach your clipboard in live-send.
+
+The channel needs tmux 3.4 or newer. A pane that cannot arm one, an
+older tmux, or a non-Unix host falls back to the polling path
+automatically; everything still works, just with more latency.
+
+To rule the VT transport in or out while troubleshooting, toggle "VT
+Live Transport" under Settings (Tmux tab, Advanced) or set it in
+`config.toml`:
+
+```toml
+[tmux]
+vt_live = false   # default true
+```
+
+The TUI applies a change on the next capture cycle; web connections pick
+it up when they reconnect.
+
 ## Configuration
 
 Both chords are editable under Settings, in the Interaction section, and

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,10 @@ fn is_serve_daemon_child(_cli: &Cli) -> bool {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Hidden internal helper for the `AOE_VT_LIVE` live-preview path (default
-    // on): `aoe __vt-pipe <socket>` forwards a tmux pipe-pane stream to a unix
-    // socket. Handled before clap so it never appears on the CLI/docs surface.
+    // Hidden internal helper for the VT live-preview path (`[tmux] vt_live`,
+    // default on): `aoe __vt-pipe <socket>` forwards a tmux pipe-pane stream to
+    // a unix socket. Handled before clap so it never appears on the CLI/docs
+    // surface.
     {
         let mut a = std::env::args();
         let _ = a.next();

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -370,10 +370,17 @@ async fn handle_live_ws(
     // Acquire the shared vt100 channel for this pane (armed once, shared with
     // the native TUI preview and any other web viewer). `Some` => render from
     // the in-process grid and inject input over the socket; `None` (tmux < 3.4,
-    // arm failure, or non-unix) => fall back to the capture-pane loop and
-    // send-keys. Held for the whole connection so the channel stays alive.
+    // arm failure, non-unix, or `[tmux] vt_live` off) => fall back to the
+    // capture-pane loop and send-keys. Held for the whole connection so the
+    // channel stays alive. The setting is read per connection: flipping it
+    // moves new connections; existing ones keep their transport until they
+    // reconnect.
     #[cfg(unix)]
-    let vt = crate::tmux::vt::VtChannel::acquire(&tmux_name);
+    let vt = if crate::session::config::vt_live_enabled() {
+        crate::tmux::vt::VtChannel::acquire(&tmux_name)
+    } else {
+        None
+    };
 
     let (mut ws_sender, mut ws_receiver) = socket.split();
 

--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -372,14 +372,16 @@ async fn handle_live_ws(
     // the in-process grid and inject input over the socket; `None` (tmux < 3.4,
     // arm failure, non-unix, or `[tmux] vt_live` off) => fall back to the
     // capture-pane loop and send-keys. Held for the whole connection so the
-    // channel stays alive. The setting is read per connection: flipping it
-    // moves new connections; existing ones keep their transport until they
-    // reconnect.
+    // channel stays alive. The setting is read per connection and gates
+    // *arming*, not *reuse*: while other holders keep a channel alive it is
+    // the pane's single input writer, so a new connection must join it (or
+    // its send-keys would race the socket); the fallback only becomes real
+    // once the last holder drops and the channel dies.
     #[cfg(unix)]
     let vt = if crate::session::config::vt_live_enabled() {
         crate::tmux::vt::VtChannel::acquire(&tmux_name)
     } else {
-        None
+        crate::tmux::vt::VtChannel::reuse(&tmux_name)
     };
 
     let (mut ws_sender, mut ws_receiver) = socket.split();
@@ -747,6 +749,15 @@ async fn handle_live_ws(
                             let bytes = data.to_vec();
                             // Off-runtime: send-keys forks a subprocess.
                             let _ = tokio::task::spawn_blocking(move || {
+                                // A live channel armed by another holder (the
+                                // TUI, an older connection) is the pane's
+                                // single input writer; route through it
+                                // rather than racing it with send-keys.
+                                // Mirrors the TUI's `dispatch_via_fork`.
+                                #[cfg(unix)]
+                                if crate::tmux::vt::try_send_input(&name, &bytes) {
+                                    return;
+                                }
                                 let session = crate::tmux::Session::from_name(&name);
                                 if let Err(e) = session.send_raw_bytes(&bytes) {
                                     warn!(target: "terminal.ws", tmux = %name, kind = "live", "send_raw_bytes failed: {}", e);

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -2477,6 +2477,16 @@ pub struct TmuxConfig {
         web = "local_only:changes which tmux server hosts your sessions on this machine"
     )]
     pub socket_name: Option<String>,
+
+    /// Render live views from a persistent VT channel (`tmux pipe-pane` into
+    /// an in-process terminal grid) instead of polling `capture-pane` and
+    /// forking `send-keys` per keystroke. Needs tmux 3.4+; panes that cannot
+    /// arm a channel fall back to the capture path automatically. Disable
+    /// only to troubleshoot the VT transport; the fallback is slower and
+    /// loses agent clipboard forwarding in live-send.
+    #[serde(default = "default_true")]
+    #[setting(label = "VT Live Transport", widget = "toggle", advanced, global_only)]
+    pub vt_live: bool,
 }
 
 impl Default for TmuxConfig {
@@ -2486,6 +2496,7 @@ impl Default for TmuxConfig {
             mouse: TmuxMouseMode::Auto,
             clipboard: TmuxClipboardMode::Auto,
             socket_name: None,
+            vt_live: true,
         }
     }
 }
@@ -2540,6 +2551,15 @@ pub fn should_apply_tmux_clipboard() -> bool {
         TmuxClipboardMode::Disabled => false,
         TmuxClipboardMode::Auto => !user_has_tmux_config(),
     }
+}
+
+/// Whether live views may use the VT transport (`[tmux] vt_live`, default
+/// on). Read from the global config at each gate: the TUI capture worker
+/// samples it through its config-refresh path, and the web live socket
+/// checks it per connection, so flipping the setting applies without a
+/// restart (existing web connections keep their transport until reconnect).
+pub fn vt_live_enabled() -> bool {
+    Config::load_or_warn().tmux.vt_live
 }
 
 pub(crate) fn config_path() -> Result<PathBuf> {
@@ -3409,6 +3429,30 @@ mod tests {
         assert_eq!(tmux.status_bar, TmuxStatusBarMode::Auto);
         assert_eq!(tmux.mouse, TmuxMouseMode::Auto);
         assert_eq!(tmux.clipboard, TmuxClipboardMode::Auto);
+        assert!(tmux.vt_live);
+    }
+
+    #[test]
+    fn test_tmux_config_vt_live_defaults_on_and_deserializes_off() {
+        // Absent from an existing config.toml => on (the pre-setting
+        // behavior; the AOE_VT_LIVE env hatch this replaces defaulted on).
+        let tmux: TmuxConfig = toml::from_str(r#""#).unwrap();
+        assert!(tmux.vt_live, "vt_live must default on when absent");
+        // Explicit off round-trips.
+        let tmux: TmuxConfig = toml::from_str(r#"vt_live = false"#).unwrap();
+        assert!(!tmux.vt_live);
+    }
+
+    #[test]
+    fn test_vt_live_in_settings_schema() {
+        // The single-source schema must expose the toggle so both the TUI
+        // and web settings render it (docs/development/adding-settings.md).
+        let schema = crate::session::settings_schema::schema();
+        let field = schema
+            .iter()
+            .find(|f| f.section == "tmux" && f.field == "vt_live")
+            .expect("vt_live field in tmux schema section");
+        assert!(field.advanced, "vt_live should sit under the Advanced fold");
     }
 
     #[test]

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -3453,6 +3453,11 @@ mod tests {
             .find(|f| f.section == "tmux" && f.field == "vt_live")
             .expect("vt_live field in tmux schema section");
         assert!(field.advanced, "vt_live should sit under the Advanced fold");
+        assert!(
+            !field.profile_overridable,
+            "vt_live is machine-level (the server reads global config); a \
+             profile override would desync the TUI and web transports"
+        );
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -904,6 +904,20 @@ pub(crate) struct VtChannel {
 }
 
 impl VtChannel {
+    /// The session's existing *live* channel, if any, WITHOUT arming a new
+    /// one. The `[tmux] vt_live = false` web gate uses this so a connection
+    /// opened after the toggle still joins a channel that other holders keep
+    /// alive: while that channel lives it is the pane's single input writer,
+    /// and a viewer that fell back to `send-keys` beside it would interleave
+    /// two writers on the one pty input stream. Once the last holder drops,
+    /// the channel dies and fallback becomes genuine. Server-only: the TUI
+    /// worker owns its channel lifecycle and its input path already routes
+    /// through the registry (`input_mode` / `try_send_input`).
+    #[cfg(feature = "serve")]
+    pub(crate) fn reuse(session: &str) -> Option<Arc<VtChannel>> {
+        lookup(session).filter(|c| c.is_alive())
+    }
+
     /// Get the shared channel for `session`, arming a new one if none is live.
     /// Returns `None` if tmux is too old or the pane is gone or any tmux/socket
     /// step fails; callers then use the legacy capture/send-keys path. The

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1212,7 +1212,7 @@ fn dispatch_batch(tmux_name: &str, batch: Vec<WorkerMsg>) {
 fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()> {
     use std::process::Stdio;
 
-    // Fast path (AOE_VT_LIVE): when a *live* input channel is armed for this
+    // Fast path (`[tmux] vt_live`): when a *live* input channel is armed for this
     // pane, ALL pane input goes through the socket, never `send-keys`. This is a
     // single-writer invariant: mixing the socket and `send-keys` would interleave
     // two writers on the one pty input stream and can corrupt multi-byte

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -709,6 +709,12 @@ pub(in crate::tui) struct LiveCaptureWorker {
     /// clipboard (#2420). Cleared on `set_target` so a copy from the old pane
     /// can't land after a retarget.
     clipboard: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    /// Whether the worker may render through a VT channel (`[tmux] vt_live`).
+    /// Pushed by the render reconcile at spawn and on config refresh
+    /// (`set_vt_enabled`), read by the worker each cycle: toggling off tears
+    /// down an armed channel (disabling its `pipe-pane`) and falls back to
+    /// the capture path in place, no restart needed.
+    vt_enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Drop for LiveCaptureWorker {
@@ -748,6 +754,10 @@ impl LiveCaptureWorker {
         let stop = Arc::new(AtomicBool::new(false));
         let cursor: Arc<Mutex<Option<crate::tmux::PaneCursor>>> = Arc::new(Mutex::new(None));
         let clipboard: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        // Spawned enabled; the render reconcile pushes the real
+        // `[tmux] vt_live` value right after spawn (and on every config
+        // refresh), so the worker itself never touches the config file.
+        let vt_enabled = Arc::new(AtomicBool::new(true));
         let lines_cell = capture_lines.clone();
         let target_cell = target.clone();
         let slot = latest.clone();
@@ -757,6 +767,8 @@ impl LiveCaptureWorker {
         let stop_flag = stop.clone();
         let cursor_cell = cursor.clone();
         let clipboard_cell = clipboard.clone();
+        #[cfg(unix)]
+        let vt_enabled_cell = vt_enabled.clone();
         std::thread::spawn(move || {
             let mut last_target = String::new();
             let mut last_captured: Option<String> = None;
@@ -771,15 +783,11 @@ impl LiveCaptureWorker {
             // Render the live preview from an in-process vt100 grid fed by
             // `tmux pipe-pane -IO` (and route input back through the same
             // socket), instead of scraping `capture-pane` and forking
-            // `send-keys` per keystroke. This is the default; set
-            // `AOE_VT_LIVE=0` to fall back to the legacy capture/send-keys path.
+            // `send-keys` per keystroke. This is the default; the
+            // `[tmux] vt_live` setting turns it off (`vt_enabled_cell`,
+            // re-read every cycle so a settings change applies in place).
             // When a pane can't arm a VT channel (tmux < 3.4, stopped pane), the
             // worker also falls back to capture for that pane.
-            #[cfg(unix)]
-            let vt_enabled = !matches!(
-                std::env::var("AOE_VT_LIVE").ok().as_deref(),
-                Some("0") | Some("false")
-            );
             #[cfg(unix)]
             let mut vt_source: Option<std::sync::Arc<crate::tmux::vt::VtChannel>> = None;
             // Whether we've already attempted (and possibly failed) to arm a VT
@@ -820,6 +828,17 @@ impl LiveCaptureWorker {
                         vt_source = None;
                         vt_arm_attempted = false;
                     }
+                }
+                // `[tmux] vt_live`, re-read every cycle. Toggling off while a
+                // channel is armed tears it down (disabling its `pipe-pane`);
+                // resetting the arm latch lets a later re-enable arm afresh
+                // for the same target instead of waiting for a retarget.
+                #[cfg(unix)]
+                let vt_enabled = vt_enabled_cell.load(Ordering::Relaxed);
+                #[cfg(unix)]
+                if !vt_enabled && vt_source.is_some() {
+                    vt_source = None;
+                    vt_arm_attempted = false;
                 }
                 if lines > 0 && !name.is_empty() {
                     let forward_empty = forward_empty_cell.load(Ordering::Relaxed);
@@ -1020,6 +1039,21 @@ impl LiveCaptureWorker {
             stop,
             cursor,
             clipboard,
+            vt_enabled,
+        }
+    }
+
+    /// Push the `[tmux] vt_live` setting into the worker. Cheap (one atomic
+    /// store); called right after spawn and on every config refresh, so a
+    /// toggle applies on the next capture cycle without a respawn. The nudge
+    /// makes that cycle run now (a disable mid-idle-sleep would otherwise
+    /// keep the armed channel for up to 250ms).
+    pub(in crate::tui) fn set_vt_enabled(&self, enabled: bool) {
+        let prev = self
+            .vt_enabled
+            .swap(enabled, std::sync::atomic::Ordering::Relaxed);
+        if prev != enabled {
+            self.nudge();
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -456,6 +456,10 @@ pub struct HomeView {
     /// is about tmux server options, which cannot influence this in-process
     /// path.
     pub(super) agent_clipboard_forward: bool,
+    /// Whether live previews may use the VT transport (`[tmux] vt_live`).
+    /// Cached at construction + config refresh and pushed into the capture
+    /// worker (`set_vt_enabled`), so a settings toggle applies in place.
+    pub(super) vt_live_enabled: bool,
     /// Active profile's `default_attach_mode`, cached at construction and
     /// refreshed by `refresh_from_config` / `switch_profile`. The help
     /// overlay falls back to this when no session row is selected so the
@@ -2045,6 +2049,7 @@ impl HomeView {
             row_tag_mode: resolved.session.row_tag,
             agent_clipboard_forward: resolved.tmux.clipboard
                 != crate::session::config::TmuxClipboardMode::Disabled,
+            vt_live_enabled: resolved.tmux.vt_live,
             profile_default_attach_mode: resolved.session.default_attach_mode,
             project_group_collapsed: user_config
                 .as_ref()
@@ -6343,6 +6348,10 @@ impl HomeView {
         self.row_tag_mode = config.session.row_tag;
         self.agent_clipboard_forward =
             config.tmux.clipboard != crate::session::config::TmuxClipboardMode::Disabled;
+        self.vt_live_enabled = config.tmux.vt_live;
+        if let Some(worker) = self.preview_capture_worker.as_ref() {
+            worker.set_vt_enabled(self.vt_live_enabled);
+        }
         self.profile_default_attach_mode = config.session.default_attach_mode;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1795,9 +1795,12 @@ impl HomeView {
             return;
         }
         if self.preview_capture_worker.is_none() {
-            self.preview_capture_worker = Some(live_send::LiveCaptureWorker::spawn(
-                self.preview_wake.clone(),
-            ));
+            let worker = live_send::LiveCaptureWorker::spawn(self.preview_wake.clone());
+            // The worker spawns VT-enabled; hand it the real `[tmux] vt_live`
+            // value (cached on the view, refreshed with the config) before it
+            // can arm a channel.
+            worker.set_vt_enabled(self.vt_live_enabled);
+            self.preview_capture_worker = Some(worker);
         }
         if self.preview_capture_target != desired {
             if let Some(worker) = self.preview_capture_worker.as_ref() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -26,9 +26,9 @@ mod worker;
 pub use app::*;
 
 /// Entry point for the hidden `aoe __vt-pipe <socket>` helper subprocess used
-/// by the `AOE_VT_LIVE` live-preview path (default on). Copies the pane's piped
-/// output (stdin) to the unix socket, unbuffered. Dispatched in `main` before
-/// clap so it stays off the CLI/docs surface.
+/// by the VT live-preview path (`[tmux] vt_live`, default on). Copies the
+/// pane's piped output (stdin) to the unix socket, unbuffered. Dispatched in
+/// `main` before clap so it stays off the CLI/docs surface.
 #[cfg(unix)]
 pub fn run_vt_pipe(socket: &str) -> std::io::Result<()> {
     crate::tmux::vt::run_pipe(socket)


### PR DESCRIPTION
_Note: this PR was implemented by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose and code are Claude's._

## Description

Part of #2438 (VT epic follow-ups): the settings-backed VT-live toggle and the VT transport user docs.

The VT live transport (persistent `tmux pipe-pane` into an in-process grid, #2433/#2435) was only controllable through the undocumented `AOE_VT_LIVE` env var, and only for the TUI; the web live socket acquired a channel unconditionally. This PR exposes it as `[tmux] vt_live` (default on, Advanced fold, global-only) through the single-source settings schema, so the TUI and web settings surfaces both render it from the one declaration.

- **TUI**: the capture worker re-reads the value each cycle through an atomic pushed at spawn and on config refresh. Toggling off mid-run tears down an armed channel (disabling its pipe-pane) and falls back to the capture path in place; re-enabling re-arms without a retarget. No restart needed.
- **Web**: the live socket reads the setting per connection; flipping it moves new connections while existing ones keep their transport until reconnect.
- The `AOE_VT_LIVE` env hatch is removed (nothing referenced it outside code comments; repo convention avoids compat shims).
- Docs: a new "The VT live transport" section in the live-mode guide plus a `vt_live` row in the configuration reference, covering the epic's user-docs checkbox.

Still open on #2438 after this: respawn-pane re-arm, scrollback/perf tuning, macOS reliability validation.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --all-targets`, `cargo test`, and `cargo build --features serve` are clean (the one failing lib test, `restart_selected_session_surfaces_resume_failed_after_async_restart`, fails identically on main in the dev sandbox; clippy warnings are the pre-existing ones).

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

No web source changed; the field renders through the schema-driven `SchemaSection`, which the existing `settings.schema-renderer` (Vitest) and `settings.schema-persistence` (live Playwright) matrix entries already cover.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the setting itself is covered by three new unit tests in `src/session/config.rs` (default-on when absent, explicit-off round-trip, schema exposure with the Advanced flag), and the TUI row renders through the schema-driven settings surface that existing tests exercise generically. The worker-level toggle path reuses the existing arm/teardown machinery already covered by the VT channel tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**
Implemented via the /fix-github-issue workflow, directed and approved by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new settings-backed `tmux.vt_live` toggle to control the VT live transport (default: enabled), exposed in the shared Settings UI under Advanced settings and restricted to global scope.
- Removed support for the old, undocumented `AOE_VT_LIVE` environment variable.
- Updated the TUI live preview so the toggle applies immediately (no restart) by reconfiguring the live transport on the fly.
- Updated the web socket behavior so each new web connection reads the current `tmux.vt_live` setting, while existing connections keep their current transport until reconnecting.
- Added/expanded documentation for VT live mode, including tmux version requirements and the automatic fallback behavior when live VT piping can’t be used.
- Added unit tests covering the default value, settings persistence/exposure, and settings-schema behavior.

## Benefits

- Makes VT live transport behavior explicit, configurable, and discoverable (instead of relying on an undocumented environment variable).
- Provides smoother runtime control in the TUI and safer/consistent behavior for web clients through connection-based transport gating.
- Maintains compatibility via automatic fallback when tmux VT live piping isn’t available.

## Validation

- Formatting, clippy, tests, and serve-feature builds are clean aside from a pre-existing failing library test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->