### PR TITLE
fix(tui): surface delete failures and live status on trashed/archived rows

### DIFF
--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -285,9 +285,11 @@ impl HomeView {
     /// Guards (apply to bare `e` / `E` / `F5` and dialog-submitted restarts):
     /// - No selection: no-op.
     /// - Transient lifecycle (`Creating` / `Deleting`): drop.
-    /// - Sunk rows: archived and pane-dead always drop (archive's contract
-    ///   is "do not auto-revive"; dead panes have a dedicated revive path).
-    ///   Snoozed rows drop only when `sort_order == Attention`; in other
+    /// - Sunk rows: archived and trashed rows refuse with an info dialog
+    ///   pointing at the restore key (archive's contract is "do not
+    ///   auto-revive", but a silent drop read as a swallowed failure);
+    ///   pane-dead rows still drop silently (they have a dedicated revive
+    ///   path). Snoozed rows drop only when `sort_order == Attention`; in other
     ///   sort modes the snooze surface is hidden, so silently swallowing
     ///   the press would leave the user staring at a row that looks
     ///   restartable but isn't. Outside Attention we clear the snooze flag
@@ -339,15 +341,34 @@ impl HomeView {
             return Ok(());
         }
 
-        // Skip transient + sunk rows. Snoozed rows only skip when the user is
+        // A trashed/archived row's refusal must be visible: its agent was
+        // deliberately stopped, so a silent no-op here read as a swallowed
+        // failure (the row just sits there). Point at the restore key instead.
+        let shelved = self.get_instance(&id).and_then(|inst| {
+            if inst.is_trashed() {
+                Some(("Session in trash", "in the trash", "restore"))
+            } else if inst.is_archived() {
+                Some(("Session archived", "archived", "unarchive"))
+            } else {
+                None
+            }
+        });
+        if let Some((dialog_title, state, verb)) = shelved {
+            let key = if self.strict_hotkeys { "Z" } else { "z" };
+            self.info_dialog = Some(InfoDialog::new(
+                dialog_title,
+                &format!("This session is {state}; its agent stays stopped. Press {key} to {verb} it first."),
+            ));
+            return Ok(());
+        }
+
+        // Skip transient rows. Snoozed rows only skip when the user is
         // in Attention sort; see method doc.
         let in_attention = self.sort_order == crate::session::config::SortOrder::Attention;
         let (skip, wake_snooze) = match self.get_instance(&id) {
             Some(inst) => {
                 let snoozed = inst.is_snoozed();
                 let skip = matches!(inst.status, Status::Creating | Status::Deleting)
-                    || inst.is_archived()
-                    || inst.is_trashed()
                     || (snoozed && in_attention)
                     || inst.pane_dead_observed;
                 let wake_snooze = snoozed && !in_attention;

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -345,7 +345,13 @@ impl HomeView {
         // deliberately stopped, so a silent no-op here read as a swallowed
         // failure (the row just sits there). Point at the restore key instead.
         let shelved = self.get_instance(&id).and_then(|inst| {
-            if inst.is_trashed() {
+            // A row mid-purge gets no restore/unarchive hint: same rationale
+            // as `render_shelf_deleting_preview`, which drops those hints so
+            // they don't race the in-flight delete. Falls through to the
+            // transient skip below, which drops Deleting silently.
+            if inst.status == Status::Deleting {
+                None
+            } else if inst.is_trashed() {
                 Some(("Session in trash", "in the trash", "restore"))
             } else if inst.is_archived() {
                 Some(("Session archived", "archived", "unarchive"))

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2229,13 +2229,14 @@ impl HomeView {
                     let idle_age = inst.idle_age();
                     let is_fresh_idle =
                         matches!(idle_age, Some(age) if age < self.idle_decay_window);
-                    // An archived row is parked; its preview body renders the
-                    // "Archived" placeholder. Force the compact title icon to
-                    // the stopped glyph so the hoisted title can't show a live
-                    // spinner from a stale (pre-poll) status and contradict it.
-                    // Error/Deleting are live delete-operation states (the
-                    // placeholder surfaces them too), so they keep their icon.
-                    let (icon, icon_color) = if inst.is_archived()
+                    // An archived/trashed row is parked; its preview body
+                    // renders the "Archived" / "Trash" placeholder. Force the
+                    // compact title icon to the stopped glyph so the hoisted
+                    // title can't show a live spinner from a stale (pre-poll)
+                    // status and contradict it. Error/Deleting are live
+                    // delete-operation states (the placeholder surfaces them
+                    // too), so they keep their icon.
+                    let (icon, icon_color) = if (inst.is_archived() || inst.is_trashed())
                         && !matches!(inst.status, Status::Error | Status::Deleting)
                     {
                         (ICON_STOPPED, theme.dimmed)

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -263,10 +263,45 @@ pub(crate) fn agent_row_icon(inst: &crate::session::Instance) -> &'static str {
         Status::Deleting => ICON_DELETING,
         Status::Creating => spinner_starting(&inst.created_at),
     };
+    // Error and Deleting are live operation states set by this TUI (a failed
+    // or in-flight permanent delete), not stale persisted pane statuses, so
+    // they punch through the sunk-row mask below; swallowing them left a
+    // failed Empty Trash indistinguishable from a healthy trash row.
+    if matches!(inst.status, Status::Error | Status::Deleting) {
+        return icon;
+    }
     if inst.is_archived() || inst.is_snoozed() || inst.is_trashed() {
         ICON_STOPPED
     } else {
         icon
+    }
+}
+
+/// Append the selected row's `last_error` (in red) to a shelf placeholder's
+/// lines when the row sits in `Status::Error`. A failed permanent delete
+/// parks a trashed/archived row exactly here (`apply_deletion_results`);
+/// without this the calm placeholder swallowed the failure entirely.
+fn push_shelf_error_lines(
+    lines: &mut Vec<Line<'static>>,
+    inst: Option<&crate::session::Instance>,
+    theme: &Theme,
+) {
+    let Some(error) = inst
+        .filter(|i| i.status == Status::Error)
+        .and_then(|i| i.last_error.as_deref())
+    else {
+        return;
+    };
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Error:",
+        Style::default().fg(theme.error).bold(),
+    )));
+    for l in error.split('\n') {
+        lines.push(Line::from(Span::styled(
+            l.to_string(),
+            Style::default().fg(theme.error),
+        )));
     }
 }
 
@@ -1361,15 +1396,20 @@ impl HomeView {
                                 icon = ICON_UNREAD;
                                 style = style.add_modifier(ratatui::style::Modifier::BOLD);
                             }
-                            if inst.is_archived() || inst.is_trashed() {
+                            if (inst.is_archived() || inst.is_trashed())
+                                && !matches!(inst.status, Status::Error | Status::Deleting)
+                            {
                                 // Archived and trashed rows render with one
                                 // uniform muted glyph regardless of underlying
-                                // status. The pane is dead, so painting
+                                // pane status. The pane is dead, so painting
                                 // the persisted Running/Waiting status
                                 // would be misleading. The Archived
                                 // section header is the sole textual
                                 // cue, so no italic/dim modifier is
-                                // applied here; just a dim color.
+                                // applied here; just a dim color. Error and
+                                // Deleting are live delete-operation states,
+                                // not pane statuses, so they keep their real
+                                // glyph and color (see `agent_row_icon`).
                                 icon = agent_row_icon(inst);
                                 style = Style::default().fg(theme.dimmed);
                             } else if in_attention && inst.is_snoozed() {
@@ -2193,7 +2233,11 @@ impl HomeView {
                     // "Archived" placeholder. Force the compact title icon to
                     // the stopped glyph so the hoisted title can't show a live
                     // spinner from a stale (pre-poll) status and contradict it.
-                    let (icon, icon_color) = if inst.is_archived() {
+                    // Error/Deleting are live delete-operation states (the
+                    // placeholder surfaces them too), so they keep their icon.
+                    let (icon, icon_color) = if inst.is_archived()
+                        && !matches!(inst.status, Status::Error | Status::Deleting)
+                    {
                         (ICON_STOPPED, theme.dimmed)
                     } else {
                         match inst.status {
@@ -2856,19 +2900,27 @@ impl HomeView {
     /// render an empty body ("No output available"); this explains the state
     /// instead and points at `z` to bring the row back to the active list.
     fn render_archived_preview(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let title = self
+        let inst = self
             .selected_session
             .as_ref()
-            .and_then(|id| self.get_instance(id))
-            .map(|inst| inst.title.clone())
-            .unwrap_or_default();
+            .and_then(|id| self.get_instance(id));
+        let title = inst.map(|i| i.title.clone()).unwrap_or_default();
+
+        // A permanent delete in flight is a live operation on this row; say
+        // so instead of the parked placeholder (whose unarchive hint would
+        // race the purge).
+        if inst.is_some_and(|i| i.status == Status::Deleting) {
+            self.render_shelf_deleting_preview(frame, area, theme, &title);
+            return;
+        }
+
         let key = if self.strict_hotkeys { "Z" } else { "z" };
         let parked = if title.is_empty() {
             "This session is parked. Its agent was stopped.".to_string()
         } else {
             format!("\"{}\" is parked. Its agent was stopped.", title)
         };
-        let lines = vec![
+        let mut lines = vec![
             Line::from(""),
             Line::from(Span::styled(
                 "Archived",
@@ -2876,14 +2928,47 @@ impl HomeView {
             )),
             Line::from(""),
             Line::from(Span::styled(parked, Style::default().fg(theme.dimmed))),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled("Press ", Style::default().fg(theme.dimmed)),
-                Span::styled(key, Style::default().fg(theme.hint).bold()),
-                Span::styled(" to unarchive it.", Style::default().fg(theme.dimmed)),
-            ]),
         ];
-        let para = Paragraph::new(lines).alignment(Alignment::Center);
+        push_shelf_error_lines(&mut lines, inst, theme);
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("Press ", Style::default().fg(theme.dimmed)),
+            Span::styled(key, Style::default().fg(theme.hint).bold()),
+            Span::styled(" to unarchive it.", Style::default().fg(theme.dimmed)),
+        ]));
+        let para = Paragraph::new(lines)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false });
+        frame.render_widget(para, area);
+    }
+
+    /// Shared "Deleting" takeover for the archived/trashed placeholders while
+    /// a permanent delete runs on the deletion worker. No restore/delete
+    /// hints: acting on the row would race the in-flight purge.
+    fn render_shelf_deleting_preview(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        title: &str,
+    ) {
+        let body = if title.is_empty() {
+            "This session is being permanently deleted.".to_string()
+        } else {
+            format!("\"{}\" is being permanently deleted.", title)
+        };
+        let lines = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "Deleting",
+                Style::default().fg(theme.text).bold(),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(body, Style::default().fg(theme.dimmed))),
+        ];
+        let para = Paragraph::new(lines)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false });
         frame.render_widget(para, area);
     }
 
@@ -2891,12 +2976,19 @@ impl HomeView {
     /// agent was stopped on trash but its transcript and workspace are kept;
     /// it can be restored or permanently purged from here.
     fn render_trashed_preview(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let title = self
+        let inst = self
             .selected_session
             .as_ref()
-            .and_then(|id| self.get_instance(id))
-            .map(|inst| inst.title.clone())
-            .unwrap_or_default();
+            .and_then(|id| self.get_instance(id));
+        let title = inst.map(|i| i.title.clone()).unwrap_or_default();
+
+        // See `render_archived_preview`: an in-flight permanent delete takes
+        // over the placeholder.
+        if inst.is_some_and(|i| i.status == Status::Deleting) {
+            self.render_shelf_deleting_preview(frame, area, theme, &title);
+            return;
+        }
+
         let body = if title.is_empty() {
             "This session is in the trash. Its agent was stopped; its transcript and workspace are kept.".to_string()
         } else {
@@ -2927,7 +3019,7 @@ impl HomeView {
                 Span::styled(" to delete permanently.", Style::default().fg(theme.dimmed)),
             ])
         };
-        let lines = vec![
+        let mut lines = vec![
             Line::from(""),
             Line::from(Span::styled(
                 "Trash",
@@ -2935,10 +3027,13 @@ impl HomeView {
             )),
             Line::from(""),
             Line::from(Span::styled(body, Style::default().fg(theme.dimmed))),
-            Line::from(""),
-            hint,
         ];
-        let para = Paragraph::new(lines).alignment(Alignment::Center);
+        push_shelf_error_lines(&mut lines, inst, theme);
+        lines.push(Line::from(""));
+        lines.push(hint);
+        let para = Paragraph::new(lines)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false });
         frame.render_widget(para, area);
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7825,6 +7825,129 @@ fn shelf_renders_trash_with_glyph_and_divider_sort() {
     );
 }
 
+/// Render the full home view into a TestBackend and dump the screen as one
+/// string, for asserting on preview/list text.
+fn render_home_to_string(view: &mut HomeView, width: u16, height: u16) -> String {
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let theme = load_theme("empire");
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            view.render(f, area, &theme, None, None, None);
+        })
+        .unwrap();
+    let buf = terminal.backend().buffer().clone();
+    let mut screen = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            screen.push_str(buf[(x, y)].symbol());
+        }
+        screen.push('\n');
+    }
+    screen
+}
+
+/// A trashed row whose permanent delete failed carries `Status::Error` +
+/// `last_error` (set by `apply_deletion_results`). The preview must surface
+/// that failure instead of the calm "Trash" placeholder, and the shelf row
+/// must show the error glyph instead of the uniform muted one.
+#[test]
+#[serial]
+fn trashed_preview_surfaces_delete_failure() {
+    use crate::session::Status;
+    let mut env = create_test_env_with_sessions(2);
+    env.view.trashed_section_collapsed = false;
+    let id = env.view.instance_at(0).id.clone();
+    env.view.trash_session_by_id(&id);
+    env.view.select_session_by_id(&id);
+
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = Status::Error;
+        inst.last_error = Some("worktree removal failed: directory locked".to_string());
+    });
+
+    let screen = render_home_to_string(&mut env.view, 120, 40);
+    assert!(
+        screen.contains("worktree removal failed"),
+        "a failed delete's error must show in the trashed preview.\n{screen}"
+    );
+    assert!(
+        screen.contains(super::ICON_ERROR),
+        "the shelf row must show the error glyph after a failed delete.\n{screen}"
+    );
+}
+
+/// While a trashed row's permanent delete is running (`Status::Deleting`),
+/// the preview placeholder must say so instead of advertising restore/delete
+/// keys that would race the in-flight purge.
+#[test]
+#[serial]
+fn trashed_preview_shows_deleting_status() {
+    use crate::session::Status;
+    let mut env = create_test_env_with_sessions(2);
+    env.view.trashed_section_collapsed = false;
+    let id = env.view.instance_at(0).id.clone();
+    env.view.trash_session_by_id(&id);
+    env.view.select_session_by_id(&id);
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = Status::Deleting;
+    });
+
+    let screen = render_home_to_string(&mut env.view, 120, 40);
+    assert!(
+        screen.contains("Deleting"),
+        "an in-flight delete must be visible in the trashed preview.\n{screen}"
+    );
+}
+
+/// An archived row can also be deleted; a failed delete must surface in the
+/// archived preview the same way.
+#[test]
+#[serial]
+fn archived_preview_surfaces_delete_failure() {
+    use crate::session::Status;
+    let mut env = create_test_env_with_sessions(2);
+    env.view.archived_section_collapsed = false;
+    let id = env.view.instance_at(0).id.clone();
+    env.view.select_session_by_id(&id);
+    env.view.toggle_archive_at_cursor().unwrap();
+    env.view.select_session_by_id(&id);
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = Status::Error;
+        inst.last_error = Some("container teardown failed".to_string());
+    });
+
+    let screen = render_home_to_string(&mut env.view, 120, 40);
+    assert!(
+        screen.contains("container teardown failed"),
+        "a failed delete's error must show in the archived preview.\n{screen}"
+    );
+}
+
+/// Restart (`e`) on an archived or trashed row is intentionally refused, but
+/// the refusal must be visible: an info dialog, not a silent no-op.
+#[test]
+#[serial]
+fn restart_on_trashed_row_surfaces_refusal() {
+    let mut env = create_test_env_with_sessions(2);
+    env.view.trashed_section_collapsed = false;
+    let id = env.view.instance_at(0).id.clone();
+    env.view.trash_session_by_id(&id);
+    env.view.select_session_by_id(&id);
+
+    env.view
+        .restart_selected_session(None, None, None, None)
+        .unwrap();
+    assert!(
+        env.view.info_dialog.is_some(),
+        "restarting a trashed row must explain why nothing happened"
+    );
+}
+
 /// Regression for #2489: `w` (jump to next needing-attention) must skip
 /// trashed rows even when a stale unread flag survived the trash. A trashed
 /// session is stopped and only lives under the Trash section, so it never

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7948,6 +7948,66 @@ fn restart_on_trashed_row_surfaces_refusal() {
     );
 }
 
+/// While a trashed row's permanent delete is in flight (`Status::Deleting`),
+/// restart must stay a silent drop: the "press z to restore it first" dialog
+/// would race the purge (same rationale as the Deleting preview body, which
+/// drops the restore/delete hints).
+#[test]
+#[serial]
+fn restart_on_deleting_trashed_row_stays_silent() {
+    use crate::session::Status;
+    let mut env = create_test_env_with_sessions(2);
+    env.view.trashed_section_collapsed = false;
+    let id = env.view.instance_at(0).id.clone();
+    env.view.trash_session_by_id(&id);
+    env.view.select_session_by_id(&id);
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = Status::Deleting;
+    });
+
+    env.view
+        .restart_selected_session(None, None, None, None)
+        .unwrap();
+    assert!(
+        env.view.info_dialog.is_none(),
+        "a mid-purge row must not get a restore hint that races the delete"
+    );
+}
+
+/// In compact layouts (< 80 cols) the preview hoists the session's status
+/// icon into the block title. A trashed row must mask a stale persisted
+/// Running status there (no spinner above the "Trash" placeholder body),
+/// matching the archived treatment.
+#[test]
+#[serial]
+fn compact_title_masks_stale_spinner_on_trashed_row() {
+    use crate::session::Status;
+    let mut env = create_test_env_with_sessions(2);
+    env.view.trashed_section_collapsed = false;
+    let id = env.view.instance_at(0).id.clone();
+    env.view.trash_session_by_id(&id);
+    env.view.select_session_by_id(&id);
+    // Stale persisted live status; the pane was killed on trash.
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = Status::Running;
+    });
+
+    let screen = render_home_to_string(&mut env.view, 70, 40);
+    assert!(
+        screen.contains("Trash"),
+        "trashed placeholder should render.\n{screen}"
+    );
+    // The hoisted preview title starts at the block's top-left corner. With
+    // the mask it carries ICON_STOPPED; unmasked, Running would paint a
+    // time-varying `dots()` spinner frame there instead (a frame set that
+    // never includes ICON_STOPPED, so this pin cannot pass by accident).
+    let masked_title = format!("\u{256d} {} session0", super::ICON_STOPPED);
+    assert!(
+        screen.contains(&masked_title),
+        "a trashed row's compact title must show the stopped icon, not a stale spinner.\n{screen}"
+    );
+}
+
 /// Regression for #2489: `w` (jump to next needing-attention) must skip
 /// trashed rows even when a stale unread flag survived the trash. A trashed
 /// session is stopped and only lives under the Trash section, so it never


### PR DESCRIPTION
## Description

When a trashed or archived session was started or deleted, any failure or in-flight status was swallowed: the preview panel kept showing the calm Trash/Archived placeholder and the shelf row kept its uniform muted glyph, no matter what was happening to the row.

Root cause: trashed/archived rows masked ALL status in four independent places, including live operation states the TUI itself sets. The masking rationale ("the pane is dead, so painting persisted Running/Waiting would be misleading") is right for stale pane statuses but wrong for `Status::Deleting` and `Status::Error`, which `apply_deletion_results` sets on a failed permanent delete while the row stays trashed. Restart (`e`) on a shelved row was additionally a silent no-op in `restart_selected_session`.

The fix keeps the mask for stale pane statuses and punches Error/Deleting through it:

- `agent_row_icon` and the dim row-style branch keep the real glyph and color for Error/Deleting, so the shelf row shows `✕` / the deleting glyph instead of the uniform muted one.
- `render_trashed_preview` / `render_archived_preview` append the row's `last_error` in red when it sits in `Status::Error` (retry hints stay: `z` restore, `d` delete), and hand off to a shared "Deleting" body with no restore/delete hints (acting on the row would race the in-flight purge) while the delete runs.
- The compact preview title applies the same punch-through.
- `restart_selected_session` now refuses trashed/archived rows with an info dialog pointing at `z`, matching the existing "Restart in progress" dialog precedent, instead of silently dropping the press.

Empty Trash (#2908) funnels into the same deletion poller, so bulk-delete failures become visible too.

Preview after a failed permanent delete of a trashed session (TestBackend capture):

```
│ ⠒ session1                       │                                       Trash                                       │
│                                  │                                                                                   │
│                                  │  "session0" is in the trash. Its agent was stopped; its transcript and workspace  │
│                                  │                                     are kept.                                     │
│                                  │                                                                                   │
│                                  │                                      Error:                                       │
│                                  │                     worktree removal failed: directory locked                     │
│                                  │                                                                                   │
│                                  │                  Press z to restore, or d to delete permanently.                  │
   ...
│ ────────────────── sort: Newest  │                                                                                   │
│ ▼ ⊘ Trash (1)                    │                                                                                   │
│  ✕ session0                      │                                                                                   │
```

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the four new regression tests in `src/tui/home/tests.rs` render the full home view through a ratatui TestBackend and pin the exact user-visible behavior (error text and glyph in the buffer, Deleting body, refusal dialog); an e2e run adds tmux plumbing but no additional coverage of the render dispatch this PR changes. All four were written first and fail on the pre-fix code.

Tests: `trashed_preview_surfaces_delete_failure`, `trashed_preview_shows_deleting_status`, `archived_preview_surfaces_delete_failure`, `restart_on_trashed_row_surfaces_refusal`. Full suite: 3985 passed; the only failure is `restart_selected_session_surfaces_resume_failed_after_async_restart`, which fails identically on a clean checkout in this sandbox (environmental, tracked separately). `cargo fmt` and `cargo clippy --all-targets` clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:**

Root-cause investigation, fix, and regression tests by Claude, directed and reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Updated the TUI to accurately show delete failures and “deleting in progress” states for trashed and archived sessions (including row icons, preview titles, and preview bodies).
- Added dedicated “Deleting” visual takeover states so users aren’t shown conflicting restore/delete affordances while deletion is still running.
- Ensured deletion error details appear in the archived/trashed previews while still supporting restore and retry guidance.
- Prevented restart attempts on trashed/archived sessions; users are prompted to restore instead, while in-progress deletions are silently skipped.
- Improved bulk-delete visibility by surfacing failures through the shared deletion polling mechanism.
- Added regression tests covering: deletion failures, deleting-state rendering, archived-session behavior, and restart refusal.

### Benefits
Users get clear, consistent feedback about what’s happening with trashed/archived sessions—especially when deletes fail or are still in progress—reducing confusion and making recovery actions more discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->