### PR TITLE
fix(acp): make structured view sandbox-aware for the ACP version gate

### DIFF
--- a/src/acp/version_probe.rs
+++ b/src/acp/version_probe.rs
@@ -161,7 +161,16 @@ pub fn gates_needed_by_instances(instances: &[Instance]) -> Vec<VersionGate> {
     let registry = AgentRegistry::with_defaults();
     let mut seen = HashSet::new();
     let mut gates = Vec::new();
-    for inst in instances.iter().filter(|inst| inst.is_structured()) {
+    // Only host-run structured sessions gate on the host toolchain. A
+    // sandboxed session's adapter lives inside its container, so probing
+    // `claude-agent-acp --version` on the host would report Missing (the
+    // host never installs it) and emit a bogus "upgrade the ACP package"
+    // warning at every `aoe serve` boot. The in-container adapter is
+    // validated at handshake time by `agent_compat::validate` instead.
+    for inst in instances
+        .iter()
+        .filter(|inst| inst.is_structured() && !inst.is_sandboxed())
+    {
         let explicit_agent = inst.agent_name.as_deref().filter(|name| !name.is_empty());
         let Some(spec) = explicit_agent
             .and_then(|agent| registry.get(agent))
@@ -334,5 +343,38 @@ mod tests {
             .iter()
             .any(|g| g.min_version == CLAUDE_AGENT_ACP_MIN_VERSION));
         assert!(gates.iter().any(|g| g.min_version == OPENCODE_MIN_VERSION));
+    }
+
+    #[test]
+    fn gates_needed_by_instances_skips_sandboxed_sessions() {
+        // A sandboxed structured session runs its adapter inside the
+        // container; the host probe would falsely report it Missing. Only
+        // a host-run structured session on the same tool should contribute
+        // a gate. See the sandbox-only false-warning fix.
+        let mut sandboxed = Instance::new("sandboxed", "/tmp/sandboxed");
+        sandboxed.view = View::Structured;
+        sandboxed.tool = "claude".to_string();
+        sandboxed.sandbox_info = Some(crate::session::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "ghcr.io/agent-of-empires/aoe-sandbox:latest".to_string(),
+            container_name: "aoe-sandbox-sandboxe".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            container_workdir: None,
+            before_start_env: Vec::new(),
+        });
+        assert!(sandboxed.is_sandboxed());
+
+        // Only the sandboxed claude session exists: no host gate is emitted.
+        assert!(gates_needed_by_instances(&[sandboxed.clone()]).is_empty());
+
+        // A host-run claude session alongside it still contributes its gate.
+        let mut host_claude = Instance::new("host", "/tmp/host");
+        host_claude.view = View::Structured;
+        host_claude.tool = "claude".to_string();
+        let gates = gates_needed_by_instances(&[sandboxed, host_claude]);
+        assert_eq!(gates.len(), 1);
+        assert_eq!(gates[0].min_version, CLAUDE_AGENT_ACP_MIN_VERSION);
     }
 }

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -526,16 +526,144 @@ pub struct InstallAgentResponse {
     pub recovered_sessions: usize,
 }
 
+/// How long a single `npm install -g` (host or in-container) may run before
+/// it is killed and the held install lock released.
+const INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// Run `npm install -g <package>` on the daemon host. Returns the process
+/// output on completion, or a ready-to-send error response for the failure
+/// modes (`npm` absent, spawn failure, timeout).
+async fn install_on_host(package: &str) -> Result<std::process::Output, axum::response::Response> {
+    let Ok(npm) = which::which("npm") else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "npm_missing",
+                "message": "`npm` is not on the daemon's PATH. Start `aoe serve` from a shell where `which npm` resolves.",
+            })),
+        )
+            .into_response());
+    };
+
+    // Bound the install so a network stall or a wedged lifecycle script
+    // cannot hang the request (and the held lock) forever. kill_on_drop
+    // reaps the child if the timeout fires.
+    match tokio::time::timeout(
+        INSTALL_TIMEOUT,
+        tokio::process::Command::new(&npm)
+            .arg("install")
+            .arg("-g")
+            .arg(package)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => Ok(o),
+        Ok(Err(e)) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "npm_start_failed",
+                "message": format!("npm install failed to start: {e}"),
+            })),
+        )
+            .into_response()),
+        Err(_) => Err((
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({
+                "error": "install_timeout",
+                "message": "`npm install -g` did not finish within 180s.",
+            })),
+        )
+            .into_response()),
+    }
+}
+
+/// Run `npm install -g <package>` inside the session's sandbox container via
+/// `<runtime> exec`. The container must be running for `exec` to land, so a
+/// stopped/absent container returns a targeted error rather than a cryptic
+/// runtime one. Mirrors [`install_on_host`]'s fixed-argv, no-shell, bounded
+/// execution.
+async fn install_in_container(
+    session_id: &str,
+    package: &str,
+) -> Result<std::process::Output, axum::response::Response> {
+    use crate::containers::DockerContainer;
+
+    let sid = session_id.to_string();
+    let running = tokio::task::spawn_blocking(move || {
+        DockerContainer::from_session_id(&sid)
+            .is_running()
+            .unwrap_or(false)
+    })
+    .await
+    .unwrap_or(false);
+    if !running {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "container_not_running",
+                "message": "The session's sandbox container is not running. Open the session (which starts its container) and try again.",
+            })),
+        )
+            .into_response());
+    }
+
+    let container_name = DockerContainer::generate_name(session_id);
+    let runtime_bin = crate::containers::runtime_binary();
+    match tokio::time::timeout(
+        INSTALL_TIMEOUT,
+        tokio::process::Command::new(runtime_bin)
+            .arg("exec")
+            .arg(&container_name)
+            .arg("npm")
+            .arg("install")
+            .arg("-g")
+            .arg(package)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    {
+        Ok(Ok(o)) => Ok(o),
+        Ok(Err(e)) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "exec_start_failed",
+                "message": format!("`{runtime_bin} exec` failed to start: {e}"),
+            })),
+        )
+            .into_response()),
+        Err(_) => Err((
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({
+                "error": "install_timeout",
+                "message": "`npm install -g` in the sandbox did not finish within 180s.",
+            })),
+        )
+            .into_response()),
+    }
+}
+
 /// `POST /api/sessions/{id}/acp/install-agent`: run `npm install -g <pkg>`
-/// for the session's agent on the host, then let the client respawn.
+/// for the session's agent where the adapter actually lives, then let the
+/// client respawn.
+///
+/// A host-run session installs on the host; a sandboxed session installs
+/// *inside its container* (`<runtime> exec … npm install -g`), because a
+/// host `npm install -g` never reaches the containerized adapter. This is
+/// the recovery path when a cached `aoe-sandbox` image ships a
+/// `claude-agent-acp` below the current floor: the in-container install
+/// lifts the running container's adapter without recreating it. The image
+/// itself stays stale for *future* containers until refreshed; the
+/// structured-view error screen points sandboxed users at that follow-up.
 ///
 /// Hardened, opt-in (Tier 2 of #2109): blocked in read-only mode; gated on
 /// the `acp.allow_agent_install` setting (default off, `local_only`); the
 /// package is resolved server-side from the session's agent via a static
 /// npm-only table, never from client input; npm runs with fixed argv and no
 /// shell; the per-session instance lock serializes installs so a
-/// double-click cannot race the global npm prefix. Sandbox sessions are
-/// refused because a host install never reaches the containerized agent.
+/// double-click cannot race the global npm prefix (host) or the container.
 pub async fn install_agent(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -562,17 +690,6 @@ pub async fn install_agent(
         return (StatusCode::NOT_FOUND, "session not found").into_response();
     };
     drop(instances);
-
-    if instance.is_sandboxed() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "sandboxed",
-                "message": "This session runs in a sandbox container; a host install would not reach the agent. Install it inside the container or rebuild its image.",
-            })),
-        )
-            .into_response();
-    }
 
     // Resolve the binary the session would spawn, then its npm package.
     let agent = state
@@ -620,61 +737,29 @@ pub async fn install_agent(
     let inst_lock = state.instance_lock(&id).await;
     let _guard = inst_lock.lock().await;
 
-    let Ok(npm) = which::which("npm") else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "npm_missing",
-                "message": "`npm` is not on the daemon's PATH. Start `aoe serve` from a shell where `which npm` resolves.",
-            })),
-        )
-            .into_response();
-    };
-
-    // Bound the install so a network stall or a wedged lifecycle script
-    // cannot hang the request (and the held lock) forever. kill_on_drop
-    // reaps the child if the timeout fires.
-    let output = match tokio::time::timeout(
-        std::time::Duration::from_secs(180),
-        tokio::process::Command::new(&npm)
-            .arg("install")
-            .arg("-g")
-            .arg(package)
-            .kill_on_drop(true)
-            .output(),
-    )
-    .await
-    {
-        Ok(Ok(o)) => o,
-        Ok(Err(e)) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "error": "npm_start_failed",
-                    "message": format!("npm install failed to start: {e}"),
-                })),
-            )
-                .into_response();
+    // Run the install where the adapter actually lives: on the host for a
+    // host-run session, inside the container for a sandboxed one.
+    let output = if instance.is_sandboxed() {
+        match install_in_container(&id, package).await {
+            Ok(output) => output,
+            Err(resp) => return resp,
         }
-        Err(_) => {
-            return (
-                StatusCode::GATEWAY_TIMEOUT,
-                Json(serde_json::json!({
-                    "error": "install_timeout",
-                    "message": "`npm install -g` did not finish within 180s.",
-                })),
-            )
-                .into_response();
+    } else {
+        match install_on_host(package).await {
+            Ok(output) => output,
+            Err(resp) => return resp,
         }
     };
 
-    // On success the global npm prefix now carries the required version, so
-    // every other session parked on the same binary's compatibility check
-    // can recover too. Queue them for the reconciler to fresh-spawn; the
-    // current session is excluded because the client respawns it directly
-    // (and a double-spawn would race). See #2109.
+    // On success a *host* install updates the global npm prefix shared by
+    // every host-run session, so others parked on the same binary's
+    // compatibility check can recover too; queue them for the reconciler to
+    // fresh-spawn (the current session is excluded because the client
+    // respawns it directly and a double-spawn would race). A *container*
+    // install only touched this session's container, so no cross-session
+    // recovery applies. See #2109.
     let mut recovered_sessions = 0;
-    if output.status.success() {
+    if output.status.success() && !instance.is_sandboxed() {
         for other in state
             .acp_supervisor
             .incompatible_sessions_for_binary(&binary)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1619,6 +1619,7 @@ function AppContent({
                         onOpenFileRef={handleOpenFileRef}
                         fileRefSession={activeSession}
                         onOpenAgentsPane={openAgentsPane}
+                        isSandboxed={activeSession.is_sandboxed}
                       />
                     </Suspense>
                   ) : (

--- a/web/src/components/MobileMainPane.tsx
+++ b/web/src/components/MobileMainPane.tsx
@@ -121,6 +121,7 @@ export function MobileMainPane({
                 trashedAt={activeSession.trashed_at ?? null}
                 onOpenFileRef={onOpenFileRef}
                 fileRefSession={activeSession}
+                isSandboxed={activeSession.is_sandboxed}
               />
             </Suspense>
           ) : (

--- a/web/src/components/acp/StartupErrorScreen.tsx
+++ b/web/src/components/acp/StartupErrorScreen.tsx
@@ -4,13 +4,6 @@ import type { IncompatibleAgentDetail } from "../../lib/acpTypes";
 import { fetchSettings, installAcpAgent } from "../../lib/api";
 import { useRespawnSession } from "../../hooks/useRespawnSession";
 
-/** Default sandbox image, mirrored from `RuntimeBase::default_sandbox_image`.
- *  Shown in the durable-fix hint so a sandboxed user has an exact `docker
- *  pull` to refresh a stale image. A custom `sandbox.default_image` is not
- *  surfaced here; the pull command is illustrative, and the in-place button
- *  is the actionable recovery. */
-const DEFAULT_SANDBOX_IMAGE = "ghcr.io/agent-of-empires/aoe-sandbox:latest";
-
 interface Props {
   detail: IncompatibleAgentDetail;
   sessionId: string;
@@ -132,15 +125,10 @@ export function StartupErrorScreen({ detail, sessionId, isSandboxed = false }: P
               session.
             </p>
             <p className="mt-2 text-xs text-text-dim">
-              This updates the running container only. To keep new sessions from hitting this, refresh the sandbox image
-              (the aoe TUI shows a "sandbox image update available" banner), or pull it manually:
+              This updates the running container only. To keep new sessions from hitting this, refresh the sandbox
+              image: the aoe TUI shows a "sandbox image update available" banner that pulls the right image with your
+              configured container runtime.
             </p>
-            <pre
-              data-testid="startup-error-image-pull-command"
-              className="mt-1 overflow-x-auto rounded-md border border-surface-700 bg-surface-950 p-2 font-mono text-[12px] text-text-primary"
-            >
-              {`docker pull ${DEFAULT_SANDBOX_IMAGE}`}
-            </pre>
           </div>
         )}
 

--- a/web/src/components/acp/StartupErrorScreen.tsx
+++ b/web/src/components/acp/StartupErrorScreen.tsx
@@ -4,9 +4,21 @@ import type { IncompatibleAgentDetail } from "../../lib/acpTypes";
 import { fetchSettings, installAcpAgent } from "../../lib/api";
 import { useRespawnSession } from "../../hooks/useRespawnSession";
 
+/** Default sandbox image, mirrored from `RuntimeBase::default_sandbox_image`.
+ *  Shown in the durable-fix hint so a sandboxed user has an exact `docker
+ *  pull` to refresh a stale image. A custom `sandbox.default_image` is not
+ *  surfaced here; the pull command is illustrative, and the in-place button
+ *  is the actionable recovery. */
+const DEFAULT_SANDBOX_IMAGE = "ghcr.io/agent-of-empires/aoe-sandbox:latest";
+
 interface Props {
   detail: IncompatibleAgentDetail;
   sessionId: string;
+  /** True when the session runs in a sandbox container. The adapter then
+   *  lives inside the container, so the host `install_command` in `detail`
+   *  is misleading: "Update & restart" installs into the container instead,
+   *  and the copy points at refreshing the image for a durable fix. */
+  isSandboxed?: boolean;
 }
 
 /** Dedicated full-region replacement for the structured view chat layout when
@@ -25,11 +37,15 @@ interface Props {
  *  one click. When the setting is off the button is shown disabled with a
  *  hint to enable it in the TUI (it is `local_only`, so the web cannot flip
  *  it). See #2109. */
-export function StartupErrorScreen({ detail, sessionId }: Props) {
+export function StartupErrorScreen({ detail, sessionId, isSandboxed = false }: Props) {
   const heading = headingFor(detail);
   const summary = summaryFor(detail);
   const installCommand = installCommandFor(detail);
   const autoInstallable = "auto_install" in detail && detail.auto_install;
+  // A host `install_command` never reaches a containerized adapter, so hide
+  // the host copy-paste block for sandboxed sessions and lead with the
+  // container-aware guidance below instead.
+  const showHostCommand = installCommand && !isSandboxed;
 
   const { state: respawnState, error: respawnError, respawn } = useRespawnSession(sessionId);
   const [allowInstall, setAllowInstall] = useState(false);
@@ -89,7 +105,7 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
         <h2 className="mt-2 text-lg font-semibold text-text-primary">{heading}</h2>
         <p className="mt-3 text-sm text-text-secondary">{summary}</p>
 
-        {installCommand && (
+        {showHostCommand && (
           <div className="mt-4">
             <div className="text-[11px] font-medium uppercase tracking-wide text-text-dim">
               Run this, then restart the agent
@@ -99,6 +115,31 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
               className="mt-1 overflow-x-auto rounded-md border border-surface-700 bg-surface-950 p-2 font-mono text-[12px] text-text-primary"
             >
               {installCommand}
+            </pre>
+          </div>
+        )}
+
+        {isSandboxed && installCommand && (
+          <div className="mt-4" data-testid="startup-error-sandbox-note">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-text-dim">
+              This session runs in a sandbox
+            </div>
+            <p className="mt-1 text-sm text-text-secondary">
+              The adapter lives inside the container, so a host{" "}
+              <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">npm install</code> would not reach it.
+              Use <span className="font-medium text-text-secondary">Update &amp; restart</span> below to install the
+              adapter <span className="font-medium text-text-secondary">inside the container</span> and reload the
+              session.
+            </p>
+            <p className="mt-2 text-xs text-text-dim">
+              This updates the running container only. To keep new sessions from hitting this, refresh the sandbox image
+              (the aoe TUI shows a "sandbox image update available" banner), or pull it manually:
+            </p>
+            <pre
+              data-testid="startup-error-image-pull-command"
+              className="mt-1 overflow-x-auto rounded-md border border-surface-700 bg-surface-950 p-2 font-mono text-[12px] text-text-primary"
+            >
+              {`docker pull ${DEFAULT_SANDBOX_IMAGE}`}
             </pre>
           </div>
         )}
@@ -123,7 +164,11 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
               disabled={busy}
               className="rounded-md border border-status-error/60 bg-status-error/20 px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-status-error/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {installState === "installing" ? "Updating…" : "Update & restart"}
+              {installState === "installing"
+                ? "Updating…"
+                : isSandboxed
+                  ? "Update in sandbox & restart"
+                  : "Update & restart"}
             </button>
           )}
           {autoInstallable && !allowInstall && (
@@ -145,7 +190,8 @@ export function StartupErrorScreen({ detail, sessionId }: Props) {
             <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">acp.allow_agent_install</code> in the{" "}
             <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">aoe</code> TUI settings (Advanced) to
             run the update from here. It is blocked from the web on purpose: it runs{" "}
-            <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">npm install</code> on the host.
+            <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">npm install</code>{" "}
+            {isSandboxed ? "inside the sandbox container" : "on the host"}.
           </div>
         )}
 

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -116,6 +116,10 @@ interface Props {
   /** Repo roots for this session, forwarded to the tool cards so file
    *  paths render repo-relative instead of absolute. See #2143. */
   fileRefSession?: FileRefSession | null;
+  /** True when the session runs in a sandbox container. Forwarded to the
+   *  adapter-compatibility `StartupErrorScreen` so its remediation targets
+   *  the in-container adapter (host `npm install` never reaches it). */
+  isSandboxed?: boolean;
   /** Open (or focus) the Sub agents dock pane. Lets an inline async
    *  sub-agent card jump to its panel entry. */
   onOpenAgentsPane?: () => void;
@@ -140,6 +144,7 @@ export function StructuredView(props: Props) {
     onOpenFileRef,
     fileRefSession,
     onOpenAgentsPane,
+    isSandboxed,
   } = props;
   // Folds rows above the most recent `/clear` divider out of the
   // thread by default; the disclosure banner toggles this. Lives on
@@ -176,6 +181,7 @@ export function StructuredView(props: Props) {
                   snoozedUntil={snoozedUntil}
                   trashedAt={trashedAt}
                   onRestore={onRestore}
+                  isSandboxed={isSandboxed}
                   {...ctx}
                 />
               </BackgroundAgentsContext.Provider>
@@ -262,6 +268,7 @@ function AcpChrome({
   canLoadEarlierHistory,
   loadEarlierHistory,
   loadingEarlierHistory,
+  isSandboxed,
 }: AcpContext & {
   sessionId: string;
   acpWorkerState: "absent" | "resuming" | "running";
@@ -274,6 +281,7 @@ function AcpChrome({
   snoozedUntil: string | null;
   trashedAt: string | null;
   onRestore?: () => Promise<boolean> | void;
+  isSandboxed?: boolean;
 }) {
   // Count how many activity rows precede the latest `session_cleared`
   // divider so the banner can say "12 earlier turns hidden". The
@@ -465,7 +473,7 @@ function AcpChrome({
   if (state.incompatibleAgent) {
     return (
       <div className="flex h-full flex-col bg-surface-900 text-text-primary">
-        <StartupErrorScreen detail={state.incompatibleAgent} sessionId={sessionId} />
+        <StartupErrorScreen detail={state.incompatibleAgent} sessionId={sessionId} isSandboxed={isSandboxed} />
       </div>
     );
   }

--- a/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
@@ -215,17 +215,19 @@ describe("StartupErrorScreen", () => {
   });
 
   describe("sandboxed session", () => {
-    it("hides the host install command and shows the container note + image pull", () => {
+    it("hides the host install command and shows the runtime-aware container note", () => {
       const { queryByTestId, getByTestId } = render(
         <StartupErrorScreen detail={incompatible()} sessionId="s1" isSandboxed />,
       );
       // The host copy-paste block is misleading in a sandbox, so it is gone.
       expect(queryByTestId("startup-error-install-command")).toBeNull();
-      // The container-aware note replaces it, with an image-refresh command.
-      expect(getByTestId("startup-error-sandbox-note").textContent).toContain("inside the container");
-      expect(getByTestId("startup-error-image-pull-command").textContent).toContain(
-        "docker pull ghcr.io/agent-of-empires/aoe-sandbox:latest",
-      );
+      // The container-aware note replaces it and points at the durable fix.
+      const note = getByTestId("startup-error-sandbox-note").textContent ?? "";
+      expect(note).toContain("inside the container");
+      expect(note).toContain("sandbox image update available");
+      // No hardcoded, runtime-specific pull command: a literal `docker pull`
+      // would be wrong for Podman / Apple Container or a custom image.
+      expect(note).not.toContain("docker pull");
     });
 
     it("relabels the recovery button to install inside the sandbox", async () => {

--- a/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/acp/__tests__/StartupErrorScreen.test.tsx
@@ -213,4 +213,52 @@ describe("StartupErrorScreen", () => {
     fireEvent.click(getByTestId("startup-error-restart"));
     await waitFor(() => expect(container.textContent).toContain("Restart failed"));
   });
+
+  describe("sandboxed session", () => {
+    it("hides the host install command and shows the container note + image pull", () => {
+      const { queryByTestId, getByTestId } = render(
+        <StartupErrorScreen detail={incompatible()} sessionId="s1" isSandboxed />,
+      );
+      // The host copy-paste block is misleading in a sandbox, so it is gone.
+      expect(queryByTestId("startup-error-install-command")).toBeNull();
+      // The container-aware note replaces it, with an image-refresh command.
+      expect(getByTestId("startup-error-sandbox-note").textContent).toContain("inside the container");
+      expect(getByTestId("startup-error-image-pull-command").textContent).toContain(
+        "docker pull ghcr.io/agent-of-empires/aoe-sandbox:latest",
+      );
+    });
+
+    it("relabels the recovery button to install inside the sandbox", async () => {
+      fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+      const { findByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" isSandboxed />);
+      const btn = await findByTestId("startup-error-update-restart");
+      expect(btn.textContent).toContain("Update in sandbox & restart");
+    });
+
+    it("Update in sandbox & restart calls the same install endpoint then respawns", async () => {
+      fetchSettings.mockResolvedValue({ acp: { allow_agent_install: true } });
+      installAcpAgent.mockResolvedValue({
+        session_id: "s1",
+        package: "@agentclientprotocol/claude-agent-acp@latest",
+        success: true,
+        exit_code: 0,
+        stdout: "added 1 package",
+        stderr: "",
+        recovered_sessions: 0,
+      });
+      const { findByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" isSandboxed />);
+      fireEvent.click(await findByTestId("startup-error-update-restart"));
+      expect(installAcpAgent).toHaveBeenCalledWith("s1");
+      await waitFor(() =>
+        expect(fetch).toHaveBeenCalledWith("/api/sessions/s1/acp/spawn", expect.objectContaining({ method: "POST" })),
+      );
+    });
+
+    it("enable hint says the install runs inside the sandbox container", async () => {
+      fetchSettings.mockResolvedValue({ acp: { allow_agent_install: false } });
+      const { findByTestId } = render(<StartupErrorScreen detail={incompatible(true)} sessionId="s1" isSandboxed />);
+      const hint = await findByTestId("startup-error-enable-hint");
+      expect(hint.textContent).toContain("inside the sandbox container");
+    });
+  });
 });


### PR DESCRIPTION
## Description

Structured view gates `claude-agent-acp` on a minimum version at two checkpoints, both written as if the adapter lives on the host. For a **sandboxed** session the adapter runs inside the container, so users hit the red "Adapter compatibility check failed" screen and could not recover:

- When a cached `aoe-sandbox` image ships a `claude-agent-acp` below the current floor, the runtime gate (`agent_compat::validate`) rejects the handshake, and `StartupErrorScreen` offered a host `npm install -g ...@latest` that never reaches the container. Following the instructions did nothing; the session stayed stuck.
- The `aoe serve` boot preflight (`version_probe`) probed the **host** toolchain even for sandbox-only sessions, printing a spurious "upgrade the ACP package" warning at every launch (the host never installs the adapter when you only run sandboxed).

### Fixes

- **Preflight is sandbox-aware** (`src/acp/version_probe.rs`): `gates_needed_by_instances` skips sandboxed sessions; their in-container adapter is validated at handshake time instead. New unit test.
- **Recovery reaches the container** (`src/server/api/acp.rs`): the `install-agent` endpoint no longer hard-refuses sandboxed sessions. It runs `npm install -g <pkg>` **inside the session's container** via `<runtime> exec` (fixed argv, no shell, 180s timeout, kill-on-drop), pre-checking the container is running. This lifts the running container's adapter without recreating it. Cross-session recovery stays host-only (a container install only touched its own container). Refactored into `install_on_host` / `install_in_container` helpers.
- **The error screen tells the truth for sandboxes** (`StartupErrorScreen.tsx`, with `is_sandboxed` threaded from `App.tsx` / `MobileMainPane.tsx` -> `StructuredView` -> `AcpChrome`): hides the misleading host command, explains the adapter lives in the container, relabels the recovery button to "Update in sandbox & restart", and points at the durable fix (refresh the image / `docker pull ...:latest`, or the existing TUI image-update banner). New vitest cases.

### Scope note

For the durable "image refresh" the in-container install is the one-click fix (fast, non-disruptive, fixes the live session immediately); image refresh is surfaced as guidance rather than auto-pulling a large image on a restart click or recreating the container (which would re-run `on_launch` hooks and drop container state). A dedicated "pull fresh image & recreate container" button is a clean follow-up.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

<!-- The UI change is copy/behavior on an error screen that only renders when a sandboxed adapter fails the version gate; reproducing it needs a stale sandbox image. Covered by vitest instead. -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec (`web/src/components/acp/__tests__/StartupErrorScreen.test.tsx`); the existing `acp.startup-error-screen` matrix entry already lists it. Coverage-matrix validator passes.

<!-- This is copy + a conditional-render toggle on an existing screen, not a new backend/persistence flow, so Vitest + RTL is the right tier per AGENTS.md; no new Playwright surface. -->

**TUI / CLI (e2e test)**
- [x] N/A: no TUI rendering, CLI subcommand, or session lifecycle change. Backend change is a server endpoint (`install-agent`) whose sandbox branch needs Docker + a stale image; covered by Rust unit tests for the preflight and by compile/typecheck for the exec path.

### Verification

`cargo fmt`, `cargo clippy --features serve` (0 warnings), `cargo test` (`version_probe`, `server::api::acp`), and web `format:check` / `lint` / `tsc` / vitest (17/17) / coverage-matrix validator all pass.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Investigation and implementation done via Claude Code with @njbrake; reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated structured-session ACP version gating to ignore sandboxed sessions so they don’t trigger incorrect host-side warnings.
- Changed the ACP `install-agent` flow to install the ACP package inside an active sandbox container (with a fixed install command, timeout, and process cleanup) while keeping host-only recovery behavior for non-sandboxed sessions.
- Improved the sandbox startup error screen to show container-aware remediation (including relabeled recovery action and guidance for refreshing the sandbox image) instead of host copy/paste instructions.
- Plumbed sandbox state (`isSandboxed`) through the Structured View and related UI components so the correct messaging is shown.
- Added Rust and UI test coverage for the preflight/version gating behavior, the recovery/install behavior, and the sandbox-specific UI states.

## Benefits

Sandboxed sessions now validate and repair their ACP adapter in the correct environment, reducing misleading warnings and making onboarding/recovery more reliable for container-based setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->