### PR TITLE
feat(plugin): plugin-host session API for out-of-process session-driving plugins (#2897)

### DIFF
--- a/aoe-plugin-api/src/acp.rs
+++ b/aoe-plugin-api/src/acp.rs
@@ -1,0 +1,143 @@
+//! ACP capability-discovery DTOs for the `acp.capabilities.get` worker RPC
+//! (API v9, #2897).
+//!
+//! This is the stable wire contract a session-driving plugin (for example
+//! `plugin-cron`) pins its fixtures against. The host assembles it from the
+//! static agent registry plus the last option catalog each agent advertised;
+//! answering never launches an agent, so a never-run agent reports
+//! `CatalogStatus::Undiscovered` with empty model/mode lists. All lists are
+//! sorted by id so serialized fixtures are deterministic. Fields are additive
+//! from here on; an incompatible reshape bumps the crate `API_VERSION`.
+
+use serde::{Deserialize, Serialize};
+
+/// Response of `acp.capabilities.get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpCapabilitiesResponse {
+    pub agents: Vec<AcpAgentCapability>,
+}
+
+/// One agent the host can run in a structured session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpAgentCapability {
+    /// Stable agent id, the value `sessions.create` accepts as `agent_id`.
+    pub id: String,
+    pub display_name: String,
+    pub catalog_status: CatalogStatus,
+    /// RFC3339 timestamp of the advertised catalog snapshot; `Some` only when
+    /// `catalog_status` is `Discovered`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_updated_at: Option<String>,
+    pub models: Vec<AcpModelCapability>,
+    pub modes: Vec<AcpModeCapability>,
+}
+
+/// A model choice the agent advertised.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpModelCapability {
+    pub id: String,
+    pub display_name: String,
+}
+
+/// A permission/approval mode choice, carrying the HOST's security
+/// classification. The plugin must not infer safety from mode names; the
+/// host assigns `approval_class` and enforces it at `sessions.create`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpModeCapability {
+    pub id: String,
+    pub display_name: String,
+    pub approval_class: ApprovalClass,
+}
+
+/// Whether the host has ever observed this agent's advertised option catalog.
+/// Models/modes are populated only after the agent has run at least once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogStatus {
+    Undiscovered,
+    Discovered,
+}
+
+/// Host-assigned security class of an approval mode. `Unattended` requires
+/// the distinct high-severity `session.unattended` grant at
+/// `sessions.create`; the host classifies unknown modes as `Unattended`
+/// (fail closed), never trusting a plugin- or agent-supplied label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalClass {
+    /// Approvals prompt a human through the host UI (adapter default).
+    Interactive,
+    /// A reviewed mode that preserves host approvals or prohibits mutation
+    /// (for example a plan/read-only preset).
+    Guarded,
+    /// The agent can act without a human present (bypass or auto-write
+    /// modes, and every mode the host cannot classify).
+    Unattended,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_fixture_is_stable() {
+        let response = AcpCapabilitiesResponse {
+            agents: vec![AcpAgentCapability {
+                id: "claude".into(),
+                display_name: "Claude Code".into(),
+                catalog_status: CatalogStatus::Discovered,
+                catalog_updated_at: Some("2026-07-16T00:00:00Z".into()),
+                models: vec![AcpModelCapability {
+                    id: "sonnet".into(),
+                    display_name: "Sonnet".into(),
+                }],
+                modes: vec![
+                    AcpModeCapability {
+                        id: "bypassPermissions".into(),
+                        display_name: "Bypass Permissions".into(),
+                        approval_class: ApprovalClass::Unattended,
+                    },
+                    AcpModeCapability {
+                        id: "plan".into(),
+                        display_name: "Plan".into(),
+                        approval_class: ApprovalClass::Guarded,
+                    },
+                ],
+            }],
+        };
+        let json = serde_json::to_value(&response).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "agents": [{
+                    "id": "claude",
+                    "display_name": "Claude Code",
+                    "catalog_status": "discovered",
+                    "catalog_updated_at": "2026-07-16T00:00:00Z",
+                    "models": [{"id": "sonnet", "display_name": "Sonnet"}],
+                    "modes": [
+                        {"id": "bypassPermissions", "display_name": "Bypass Permissions", "approval_class": "unattended"},
+                        {"id": "plan", "display_name": "Plan", "approval_class": "guarded"}
+                    ]
+                }]
+            })
+        );
+        let round: AcpCapabilitiesResponse = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(round, response);
+    }
+
+    #[test]
+    fn undiscovered_omits_updated_at() {
+        let agent = AcpAgentCapability {
+            id: "codex".into(),
+            display_name: "Codex".into(),
+            catalog_status: CatalogStatus::Undiscovered,
+            catalog_updated_at: None,
+            models: vec![],
+            modes: vec![],
+        };
+        let json = serde_json::to_value(&agent).expect("serialize");
+        assert!(json.get("catalog_updated_at").is_none());
+        assert_eq!(json["catalog_status"], "undiscovered");
+    }
+}

--- a/aoe-plugin-api/src/capability.rs
+++ b/aoe-plugin-api/src/capability.rs
@@ -91,6 +91,21 @@ pub const KNOWN_CAPABILITIES: &[&str] = &[
     // plugins only receive a click-scoped snapshot or request a validated edit.
     "composer.read",
     "composer.write",
+    // Reading the ACP capability catalog: which agents exist and their
+    // advertised structured-session models/modes. Read-only discovery; the host
+    // never launches an agent to answer it.
+    "acp.capabilities.read",
+    // Creating a host-owned structured-view session (the host validates agent,
+    // model, mode, and repository trust; the plugin cannot bypass those).
+    "session.create",
+    // Delivering a prompt/turn to a session the plugin created. Scoped to the
+    // creating plugin; it is NOT a license to write to arbitrary user sessions.
+    "session.prompt",
+    // A distinct, high-severity grant required when `session.create` selects a
+    // host-classified unattended (auto-approval) mode, i.e. the plugin may start
+    // an agent and send it a prompt with no user present. Never implied by
+    // `session.create` or `session.prompt`; repository trust still applies.
+    "session.unattended",
 ];
 
 /// How far a plugin is trusted. Host-assigned at load time, never declared in

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -21,9 +21,9 @@ pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};
 pub use manifest::{
     lucide_icon_name_ok, screenshot_path_ok, BuildStep, ClientAction, CommandContribution,
-    KeybindContribution, ManifestError, PluginManifest, RuntimeSpec, Screenshot,
-    SettingContribution, SettingType, StatusContribution, ThemeContribution, UiContribution,
-    UiSlot, MAX_SCREENSHOTS,
+    KeybindContribution, ManifestError, ObjectFieldContribution, ObjectFieldType, OptionSource,
+    PluginManifest, RuntimeSpec, Screenshot, SettingContribution, SettingType, StatusContribution,
+    ThemeContribution, UiContribution, UiSlot, MAX_SCREENSHOTS,
 };
 
 /// Version of the manifest schema and host API this crate describes.

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -11,9 +11,11 @@
 //! plugin (#2096). Panes are not a manifest section: they ship as a `ui` slot
 //! kind (#2432). See `docs/development/internals/plugin-system.md`.
 
+pub mod acp;
 mod capability;
 mod id;
 mod manifest;
+pub mod session;
 
 pub use capability::{CapabilityId, TrustLevel, KNOWN_CAPABILITIES};
 pub use id::{InvalidPluginId, PluginId};

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -35,5 +35,8 @@ pub use manifest::{
 /// presentation metadata was added; 6 when a command could declare a
 /// client-executed `action` (`ClientAction`); 7 when `icon` and `icon_asset`
 /// identity metadata were added; 8 when plugins could contribute composer
-/// actions.
-pub const API_VERSION: u32 = 8;
+/// actions; 9 when the host gained ACP-capability discovery, host-owned
+/// session creation / prompt delivery (with the `session.unattended` grant),
+/// plugin-private storage, and structured settings widgets (`object_list`,
+/// `dynamic_select`).
+pub const API_VERSION: u32 = 9;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -304,6 +304,16 @@ fn validate_object_list_settings(
                 !id_key.trim().is_empty(),
                 format!("settings[{i}].item_id_key must not be empty"),
             );
+            let field_keys: std::collections::HashSet<&str> =
+                s.fields.iter().map(|f| f.key.as_str()).collect();
+            // Sibling fields that resolve the selected agent; acp.models /
+            // acp.modes depend on one of these.
+            let agent_field_keys: std::collections::HashSet<&str> = s
+                .fields
+                .iter()
+                .filter(|f| f.option_source == Some(OptionSource::AcpAgents))
+                .map(|f| f.key.as_str())
+                .collect();
             let mut seen = std::collections::HashSet::new();
             for (j, f) in s.fields.iter().enumerate() {
                 check(
@@ -337,6 +347,41 @@ fn validate_object_list_settings(
                         "settings[{i}].fields[{j}]: depends_on is only valid on a dynamic_select"
                     ),
                 );
+                // Every depends_on entry must name a distinct sibling field
+                // other than itself; a typo would otherwise install cleanly and
+                // leave the select permanently unresolved.
+                let mut dep_seen = std::collections::HashSet::new();
+                for dep in &f.depends_on {
+                    check(
+                        dep != &f.key,
+                        format!("settings[{i}].fields[{j}]: depends_on must not reference itself"),
+                    );
+                    check(
+                        field_keys.contains(dep.as_str()),
+                        format!(
+                            "settings[{i}].fields[{j}]: depends_on {dep:?} is not a sibling field"
+                        ),
+                    );
+                    check(
+                        dep_seen.insert(dep.as_str()),
+                        format!("settings[{i}].fields[{j}]: depends_on {dep:?} is listed twice"),
+                    );
+                }
+                // acp.models / acp.modes are meaningless without the agent they
+                // scope to, so require a dependency on an acp.agents sibling.
+                if matches!(
+                    f.option_source,
+                    Some(OptionSource::AcpModels) | Some(OptionSource::AcpModes)
+                ) {
+                    check(
+                        f.depends_on
+                            .iter()
+                            .any(|d| agent_field_keys.contains(d.as_str())),
+                        format!(
+                            "settings[{i}].fields[{j}]: acp.models/acp.modes require a depends_on referencing an acp.agents field"
+                        ),
+                    );
+                }
             }
         }
         _ => {

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -401,6 +401,86 @@ fn validate_object_list_settings(
     }
 }
 
+/// Validate an `object_list` setting's declared default against its own item
+/// schema (#2897): each element must be a table keyed only by the id key and
+/// declared fields, carry a non-empty id, satisfy required fields, and match
+/// each field's declared type. Without this, an author's malformed default
+/// reaches the UI and cannot be saved unchanged.
+// ponytail: cron *expression* syntax is validated server-side at store time,
+// not re-implemented here to avoid a second copy of the croner dialect.
+fn validate_object_list_default(
+    i: usize,
+    s: &SettingContribution,
+    items: &[toml::Value],
+    check: &mut impl FnMut(bool, String),
+) {
+    let id_key = s.item_id_key.as_deref().unwrap_or("_id");
+    for (k, item) in items.iter().enumerate() {
+        let Some(table) = item.as_table() else {
+            check(false, format!("settings[{i}].default[{k}] must be a table"));
+            continue;
+        };
+        match table.get(id_key).and_then(|v| v.as_str()) {
+            Some(v) if !v.trim().is_empty() => {}
+            _ => check(
+                false,
+                format!("settings[{i}].default[{k}] must carry a non-empty {id_key:?} id"),
+            ),
+        }
+        for key in table.keys() {
+            check(
+                key == id_key || s.fields.iter().any(|f| &f.key == key),
+                format!("settings[{i}].default[{k}] has undeclared key {key:?}"),
+            );
+        }
+        for f in &s.fields {
+            match table.get(&f.key) {
+                None => check(
+                    !f.required,
+                    format!(
+                        "settings[{i}].default[{k}] is missing required field {:?}",
+                        f.key
+                    ),
+                ),
+                Some(v) => {
+                    let type_ok = match f.value_type {
+                        ObjectFieldType::String
+                        | ObjectFieldType::Select
+                        | ObjectFieldType::DynamicSelect
+                        | ObjectFieldType::Cron => v.is_str(),
+                        ObjectFieldType::Bool => v.as_bool().is_some(),
+                        ObjectFieldType::Integer => v.as_integer().is_some(),
+                    };
+                    check(
+                        type_ok,
+                        format!(
+                            "settings[{i}].default[{k}].{} does not match type {:?}",
+                            f.key, f.value_type
+                        ),
+                    );
+                    if f.required && v.as_str().map(|s| s.trim().is_empty()).unwrap_or(false) {
+                        check(
+                            false,
+                            format!("settings[{i}].default[{k}].{} is required but empty", f.key),
+                        );
+                    }
+                    if f.value_type == ObjectFieldType::Select && !f.options.is_empty() {
+                        if let Some(sv) = v.as_str() {
+                            check(
+                                f.options.iter().any(|o| o == sv),
+                                format!(
+                                    "settings[{i}].default[{k}].{} {sv:?} is not one of the options",
+                                    f.key
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// The type of a plugin setting value. One declaration drives both the widget
 /// the surfaces render and the validation the server enforces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -971,6 +1051,11 @@ impl PluginManifest {
                                 format!("settings[{i}].default {v} is above max {hi}"),
                             );
                         }
+                    }
+                }
+                if s.value_type == SettingType::ObjectList {
+                    if let toml::Value::Array(items) = def {
+                        validate_object_list_default(i, s, items, &mut check);
                     }
                 }
             }

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -176,6 +176,180 @@ pub struct SettingContribution {
     /// Group under an "Advanced" fold on the settings surfaces.
     #[serde(default)]
     pub advanced: bool,
+    /// Host option source for a `dynamic_select` (API v9). Ignored for other
+    /// types; the host resolves the choices, so the plugin never ships them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub option_source: Option<OptionSource>,
+    /// Sibling setting keys whose values parameterize a `dynamic_select`'s
+    /// option source (API v9), e.g. an `acp.models` select depends on the
+    /// `acp.agents` select. Empty for an independent source.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    /// Nested per-item fields of an `object_list` (API v9). Non-recursive: an
+    /// item field cannot itself be an object list. Ignored for other types.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<ObjectFieldContribution>,
+    /// The item field that holds each `object_list` row's stable id (API v9).
+    /// Defaults to `_id` (host-generated) when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_id_key: Option<String>,
+    /// Inclusive item-count bounds for an `object_list` (API v9).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_items: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_items: Option<u32>,
+}
+
+/// A host option source a `dynamic_select` draws its choices from (API v9).
+/// The host resolves the choices from its own state; the plugin only names
+/// the source and any dependencies. `acp.models` / `acp.modes` require the
+/// selected agent as their dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OptionSource {
+    #[serde(rename = "acp.agents")]
+    AcpAgents,
+    #[serde(rename = "acp.models")]
+    AcpModels,
+    #[serde(rename = "acp.modes")]
+    AcpModes,
+    #[serde(rename = "projects")]
+    Projects,
+    #[serde(rename = "groups")]
+    Groups,
+}
+
+/// One nested field of an `object_list` item (API v9). A restricted,
+/// non-recursive mirror of [`SettingContribution`]: its type cannot be
+/// `object_list`, so an object list is at most one level deep.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectFieldContribution {
+    pub key: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(rename = "type", default)]
+    pub value_type: ObjectFieldType,
+    /// Whether the item must carry a non-empty value for this field.
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<toml::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub option_source: Option<OptionSource>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+}
+
+/// The type of an `object_list` item field. Deliberately excludes
+/// `object_list`, which keeps object lists one level deep in both the Rust
+/// types and the serialized schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectFieldType {
+    #[default]
+    String,
+    #[serde(alias = "boolean")]
+    Bool,
+    Integer,
+    Select,
+    DynamicSelect,
+    Cron,
+}
+
+/// Validate the API v9 structured-setting shape of one contribution: that a
+/// `dynamic_select` names a source, an `object_list` declares well-formed
+/// non-recursive fields, and no other type carries structured-only
+/// properties. Split out of `validate` to keep that method readable.
+fn validate_object_list_settings(
+    i: usize,
+    s: &SettingContribution,
+    check: &mut impl FnMut(bool, String),
+) {
+    match s.value_type {
+        SettingType::DynamicSelect => {
+            check(
+                s.option_source.is_some(),
+                format!("settings[{i}] is a dynamic_select but declares no option_source"),
+            );
+            check(
+                s.fields.is_empty(),
+                format!("settings[{i}] is a dynamic_select and must not declare object fields"),
+            );
+        }
+        SettingType::ObjectList => {
+            check(
+                !s.fields.is_empty(),
+                format!("settings[{i}] is an object_list but declares no fields"),
+            );
+            check(
+                s.option_source.is_none() && s.depends_on.is_empty(),
+                format!("settings[{i}] is an object_list; option_source/depends_on belong on its fields, not the list"),
+            );
+            check(
+                match (s.min_items, s.max_items) {
+                    (Some(lo), Some(hi)) => lo <= hi,
+                    _ => true,
+                },
+                format!("settings[{i}].min_items must not exceed max_items"),
+            );
+            let id_key = s.item_id_key.as_deref().unwrap_or("_id");
+            let mut seen = std::collections::HashSet::new();
+            for (j, f) in s.fields.iter().enumerate() {
+                check(
+                    !f.key.is_empty(),
+                    format!("settings[{i}].fields[{j}].key must not be empty"),
+                );
+                check(
+                    seen.insert(f.key.as_str()),
+                    format!("settings[{i}].fields[{j}].key {:?} is duplicated", f.key),
+                );
+                check(
+                    f.key != id_key,
+                    format!(
+                        "settings[{i}].fields[{j}].key {:?} collides with the item id key",
+                        f.key
+                    ),
+                );
+                check(
+                    f.value_type != ObjectFieldType::Select || !f.options.is_empty(),
+                    format!("settings[{i}].fields[{j}] is a select but declares no options"),
+                );
+                check(
+                    (f.value_type == ObjectFieldType::DynamicSelect) == f.option_source.is_some(),
+                    format!(
+                        "settings[{i}].fields[{j}]: option_source is required for and exclusive to dynamic_select"
+                    ),
+                );
+                check(
+                    f.value_type == ObjectFieldType::DynamicSelect || f.depends_on.is_empty(),
+                    format!(
+                        "settings[{i}].fields[{j}]: depends_on is only valid on a dynamic_select"
+                    ),
+                );
+            }
+        }
+        _ => {
+            check(
+                s.option_source.is_none(),
+                format!("settings[{i}]: option_source is only valid on a dynamic_select"),
+            );
+            check(
+                s.depends_on.is_empty(),
+                format!("settings[{i}]: depends_on is only valid on a dynamic_select"),
+            );
+            check(
+                s.fields.is_empty(),
+                format!("settings[{i}]: fields are only valid on an object_list"),
+            );
+        }
+    }
 }
 
 /// The type of a plugin setting value. One declaration drives both the widget
@@ -194,6 +368,14 @@ pub enum SettingType {
     Integer,
     /// Closed set of strings, rendered as a select over `options`.
     Select,
+    /// A select whose choices the host resolves from an `option_source`
+    /// (API v9), optionally parameterized by `depends_on` siblings.
+    DynamicSelect,
+    /// A repeatable list of structured items described by `fields` (API v9).
+    /// Rendered with add/remove/reorder; one level deep.
+    ObjectList,
+    /// A cron expression, rendered as a validated text field (API v9).
+    Cron,
 }
 
 /// A color theme the plugin ships. `path` is a theme TOML relative to the
@@ -695,13 +877,18 @@ impl PluginManifest {
                 },
                 format!("settings[{i}].min must not exceed max"),
             );
+            validate_object_list_settings(i, s, &mut check);
             // A declared default must match the value type, so an author learns
             // of a type mismatch at parse time rather than at render/store time.
             if let Some(def) = &s.default {
                 let type_ok = match s.value_type {
-                    SettingType::String | SettingType::Select => def.is_str(),
+                    SettingType::String
+                    | SettingType::Select
+                    | SettingType::DynamicSelect
+                    | SettingType::Cron => def.is_str(),
                     SettingType::Bool => def.as_bool().is_some(),
                     SettingType::Integer => def.as_integer().is_some(),
+                    SettingType::ObjectList => matches!(def, toml::Value::Array(_)),
                 };
                 check(
                     type_ok,
@@ -841,6 +1028,19 @@ impl PluginManifest {
                 "composer-action UI slots require api_version >= 8".into(),
             );
         }
+        // `dynamic_select`, `object_list`, and `cron` settings types are
+        // api_version 9; same reasoning as the gates above.
+        if self.api_version < 9 {
+            check(
+                self.settings.iter().all(|s| {
+                    !matches!(
+                        s.value_type,
+                        SettingType::DynamicSelect | SettingType::ObjectList | SettingType::Cron
+                    )
+                }),
+                "dynamic_select / object_list / cron settings require api_version >= 9".into(),
+            );
+        }
         for key in self.setting_defaults.keys() {
             check(
                 key.contains('.') && !key.starts_with('.') && !key.ends_with('.'),
@@ -866,6 +1066,64 @@ impl PluginManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A v9 manifest declaring an object_list of dynamic_selects plus a cron
+    /// field, the shape the cron plugin (PR2) ships.
+    fn object_list_toml(api_version: u32) -> String {
+        format!(
+            "id = \"acme.cron\"\nname = \"Cron\"\nversion = \"1.0.0\"\napi_version = {api_version}\n\n\
+             [[settings]]\nkey = \"jobs\"\nlabel = \"Jobs\"\ntype = \"object_list\"\nitem_id_key = \"id\"\nmin_items = 0\nmax_items = 50\n\n\
+             [[settings.fields]]\nkey = \"agent_id\"\nlabel = \"Agent\"\ntype = \"dynamic_select\"\noption_source = \"acp.agents\"\nrequired = true\n\n\
+             [[settings.fields]]\nkey = \"model_id\"\nlabel = \"Model\"\ntype = \"dynamic_select\"\noption_source = \"acp.models\"\ndepends_on = [\"agent_id\"]\n\n\
+             [[settings.fields]]\nkey = \"schedule\"\nlabel = \"Schedule\"\ntype = \"cron\"\nrequired = true\n"
+        )
+    }
+
+    #[test]
+    fn v9_object_list_manifest_parses_and_validates() {
+        let m = PluginManifest::from_toml_str(&object_list_toml(9)).expect("v9 manifest parses");
+        let jobs = &m.settings[0];
+        assert_eq!(jobs.value_type, SettingType::ObjectList);
+        assert_eq!(jobs.item_id_key.as_deref(), Some("id"));
+        assert_eq!(jobs.fields.len(), 3);
+        assert_eq!(jobs.fields[0].value_type, ObjectFieldType::DynamicSelect);
+        assert_eq!(jobs.fields[0].option_source, Some(OptionSource::AcpAgents));
+        assert_eq!(jobs.fields[1].depends_on, vec!["agent_id".to_string()]);
+        assert_eq!(jobs.fields[2].value_type, ObjectFieldType::Cron);
+    }
+
+    #[test]
+    fn v9_settings_types_rejected_below_v9() {
+        let err = PluginManifest::from_toml_str(&object_list_toml(8))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("api_version >= 9"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_select_requires_option_source() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"agent\"\ntype = \"dynamic_select\"\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("option_source"), "{err}");
+    }
+
+    #[test]
+    fn object_list_field_key_cannot_collide_with_id_key() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"jobs\"\ntype = \"object_list\"\nitem_id_key = \"id\"\n\n\
+             [[settings.fields]]\nkey = \"id\"\ntype = \"string\"\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("collides with the item id key"), "{err}");
+    }
+
+    #[test]
+    fn option_source_rejected_on_plain_types() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"x\"\ntype = \"string\"\noption_source = \"projects\"\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("only valid on a dynamic_select"), "{err}");
+    }
 
     fn open_ui_link_toml(api_version: u32, caps: &str, ui_slot: &str, action_slot: &str) -> String {
         format!(

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -300,6 +300,10 @@ fn validate_object_list_settings(
                 format!("settings[{i}].min_items must not exceed max_items"),
             );
             let id_key = s.item_id_key.as_deref().unwrap_or("_id");
+            check(
+                !id_key.trim().is_empty(),
+                format!("settings[{i}].item_id_key must not be empty"),
+            );
             let mut seen = std::collections::HashSet::new();
             for (j, f) in s.fields.iter().enumerate() {
                 check(

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -270,6 +270,8 @@ pub enum ObjectFieldType {
 fn validate_object_list_settings(
     i: usize,
     s: &SettingContribution,
+    setting_keys: &std::collections::HashSet<&str>,
+    agent_setting_keys: &std::collections::HashSet<&str>,
     check: &mut impl FnMut(bool, String),
 ) {
     match s.value_type {
@@ -282,6 +284,40 @@ fn validate_object_list_settings(
                 s.fields.is_empty(),
                 format!("settings[{i}] is a dynamic_select and must not declare object fields"),
             );
+            // Every depends_on entry must name a distinct sibling setting other
+            // than itself; a typo would otherwise install cleanly and leave the
+            // select permanently unresolved. Mirrors the object_list item-field
+            // checks below for the top-level dynamic_select path.
+            let mut dep_seen = std::collections::HashSet::new();
+            for dep in &s.depends_on {
+                check(
+                    dep != &s.key,
+                    format!("settings[{i}]: depends_on must not reference itself"),
+                );
+                check(
+                    setting_keys.contains(dep.as_str()),
+                    format!("settings[{i}]: depends_on {dep:?} is not a sibling setting"),
+                );
+                check(
+                    dep_seen.insert(dep.as_str()),
+                    format!("settings[{i}]: depends_on {dep:?} is listed twice"),
+                );
+            }
+            // acp.models / acp.modes are meaningless without the agent they
+            // scope to, so require a dependency on an acp.agents sibling setting.
+            if matches!(
+                s.option_source,
+                Some(OptionSource::AcpModels) | Some(OptionSource::AcpModes)
+            ) {
+                check(
+                    s.depends_on
+                        .iter()
+                        .any(|d| agent_setting_keys.contains(d.as_str())),
+                    format!(
+                        "settings[{i}]: acp.models/acp.modes require a depends_on referencing an acp.agents setting"
+                    ),
+                );
+            }
         }
         SettingType::ObjectList => {
             check(
@@ -463,6 +499,31 @@ fn validate_object_list_default(
                             false,
                             format!("settings[{i}].default[{k}].{} is required but empty", f.key),
                         );
+                    }
+                    // Integer field bounds, mirroring the top-level integer
+                    // default check so an out-of-range object-field default is
+                    // rejected at manifest parse rather than at store time.
+                    if f.value_type == ObjectFieldType::Integer {
+                        if let Some(iv) = v.as_integer() {
+                            if let Some(lo) = f.min {
+                                check(
+                                    iv >= lo,
+                                    format!(
+                                        "settings[{i}].default[{k}].{} {iv} is below min {lo}",
+                                        f.key
+                                    ),
+                                );
+                            }
+                            if let Some(hi) = f.max {
+                                check(
+                                    iv <= hi,
+                                    format!(
+                                        "settings[{i}].default[{k}].{} {iv} is above max {hi}",
+                                        f.key
+                                    ),
+                                );
+                            }
+                        }
                     }
                     if f.value_type == ObjectFieldType::Select && !f.options.is_empty() {
                         if let Some(sv) = v.as_str() {
@@ -990,6 +1051,17 @@ impl PluginManifest {
                 format!("keybinds[{i}].key must not be empty"),
             );
         }
+        // Sibling setting keys for top-level dynamic_select depends_on
+        // validation, and the subset whose source resolves the selected agent
+        // (acp.models / acp.modes depend on one of these).
+        let setting_keys: std::collections::HashSet<&str> =
+            self.settings.iter().map(|s| s.key.as_str()).collect();
+        let agent_setting_keys: std::collections::HashSet<&str> = self
+            .settings
+            .iter()
+            .filter(|s| s.option_source == Some(OptionSource::AcpAgents))
+            .map(|s| s.key.as_str())
+            .collect();
         for (i, s) in self.settings.iter().enumerate() {
             check(
                 !s.key.is_empty(),
@@ -1006,7 +1078,7 @@ impl PluginManifest {
                 },
                 format!("settings[{i}].min must not exceed max"),
             );
-            validate_object_list_settings(i, s, &mut check);
+            validate_object_list_settings(i, s, &setting_keys, &agent_setting_keys, &mut check);
             // A declared default must match the value type, so an author learns
             // of a type mismatch at parse time rather than at render/store time.
             if let Some(def) = &s.default {
@@ -1249,6 +1321,44 @@ mod tests {
              [[settings.fields]]\nkey = \"id\"\ntype = \"string\"\n";
         let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
         assert!(err.contains("collides with the item id key"), "{err}");
+    }
+
+    #[test]
+    fn top_level_dynamic_select_depends_on_must_name_a_sibling() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"agent\"\ntype = \"dynamic_select\"\noption_source = \"acp.agents\"\n\n\
+             [[settings]]\nkey = \"model\"\ntype = \"dynamic_select\"\noption_source = \"acp.models\"\ndepends_on = [\"typo\"]\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("is not a sibling setting"), "{err}");
+    }
+
+    #[test]
+    fn top_level_acp_models_requires_agent_dependency() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"model\"\ntype = \"dynamic_select\"\noption_source = \"acp.models\"\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(
+            err.contains("acp.models/acp.modes require a depends_on"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn top_level_dynamic_select_depends_on_agent_sibling_validates() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"agent\"\ntype = \"dynamic_select\"\noption_source = \"acp.agents\"\n\n\
+             [[settings]]\nkey = \"model\"\ntype = \"dynamic_select\"\noption_source = \"acp.models\"\ndepends_on = [\"agent\"]\n";
+        PluginManifest::from_toml_str(toml).expect("valid dependent selects parse");
+    }
+
+    #[test]
+    fn object_list_default_integer_field_respects_bounds() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
+             [[settings]]\nkey = \"jobs\"\ntype = \"object_list\"\nitem_id_key = \"id\"\n\
+             default = [{ id = \"j1\", retries = 9 }]\n\n\
+             [[settings.fields]]\nkey = \"retries\"\ntype = \"integer\"\nmin = 0\nmax = 5\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("is above max 5"), "{err}");
     }
 
     #[test]

--- a/aoe-plugin-api/src/session.rs
+++ b/aoe-plugin-api/src/session.rs
@@ -1,0 +1,114 @@
+//! Session create / turn-delivery DTOs for the `sessions.create` and
+//! `sessions.turn.send` worker RPCs (API v9, #2897).
+//!
+//! The host validates every field against its own catalogs and policy; a
+//! plugin cannot pick a view other than structured, pre-approve repository
+//! trust, or pass agent launch flags. The caller's plugin identity comes
+//! from the RPC connection, never from these payloads.
+
+use serde::{Deserialize, Serialize};
+
+/// Parameters of `sessions.create`. Requires the `session.create` grant;
+/// additionally `session.prompt` when `initial_turn` is present and
+/// `session.unattended` when the host classifies `mode_id` as unattended.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionsCreateRequest {
+    /// Agent to run, an id from `acp.capabilities.get`.
+    pub agent_id: String,
+    /// Project directory the session runs in. Canonicalized and checked
+    /// against repository trust by the host, fail-closed.
+    pub project_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    /// Approval mode id. Omitted means the adapter default (interactive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    /// First prompt, accepted atomically with the create and delivered once
+    /// the worker is live (at-least-once).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_turn: Option<InitialTurn>,
+    /// Create-deduplication key, scoped to the calling plugin. Retrying with
+    /// the same key and payload returns the existing session
+    /// (`created: false`); a different payload under the same key is a
+    /// conflict. Retained while the session record exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+}
+
+/// The initial prompt of a created session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InitialTurn {
+    pub text: String,
+}
+
+/// Response of `sessions.create`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionsCreateResponse {
+    pub session_id: String,
+    /// `false` when an existing session was returned by idempotency.
+    pub created: bool,
+}
+
+/// Parameters of `sessions.turn.send`. Requires the `session.prompt` grant;
+/// the target must have been created by the calling plugin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TurnSendRequest {
+    pub session_id: String,
+    pub text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_request_wire_fixture_is_stable() {
+        let request = SessionsCreateRequest {
+            agent_id: "claude".into(),
+            project_path: "/home/user/project".into(),
+            model_id: Some("sonnet".into()),
+            mode_id: Some("plan".into()),
+            title: Some("nightly maintenance".into()),
+            group: None,
+            initial_turn: Some(InitialTurn {
+                text: "Run the nightly task".into(),
+            }),
+            idempotency_key: Some("job-1:2026-07-16T03:00:00Z".into()),
+        };
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "agent_id": "claude",
+                "project_path": "/home/user/project",
+                "model_id": "sonnet",
+                "mode_id": "plan",
+                "title": "nightly maintenance",
+                "initial_turn": {"text": "Run the nightly task"},
+                "idempotency_key": "job-1:2026-07-16T03:00:00Z"
+            })
+        );
+        let round: SessionsCreateRequest = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(round, request);
+    }
+
+    #[test]
+    fn create_request_rejects_bypass_flags() {
+        // No unknown field can smuggle a host-side knob (allow_untrusted,
+        // extra args, env) through the create payload.
+        let err = serde_json::from_value::<SessionsCreateRequest>(serde_json::json!({
+            "agent_id": "claude",
+            "project_path": "/p",
+            "allow_untrusted": true
+        }))
+        .expect_err("unknown fields must be rejected");
+        assert!(err.to_string().contains("allow_untrusted"));
+    }
+}

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -879,6 +879,68 @@ A background sweep therefore never grants new capabilities, runs a changed build
 step unattended, or deactivates a working plugin. Applied updates take effect on
 the next launch / daemon restart.
 
+## Unattended plugin sessions (#2897)
+
+With API v9 a worker can create host-owned structured sessions and deliver
+turns to them (`sessions.create`, `sessions.turn.send`), the primitives an
+automation plugin such as a scheduler needs. Because this lets plugin code
+start agents and send prompts with no user present, the host enforces a
+defense-in-depth model; the plugin proposes, the host disposes.
+
+**Capability layering.** `session.create` and `session.prompt` gate creating a
+session and delivering a turn. `session.unattended` is a *separate,
+high-severity* grant, shown as its own install-consent line and never implied
+by the other two: it is required only when the requested approval mode is
+host-classified as unattended.
+
+**Host-owned approval classification.** The plugin supplies a `mode_id`; the
+host, not the plugin, assigns its security class. `classify_mode` (in
+`src/plugin/automation_policy.rs`) resolves: an omitted mode is *interactive*
+(the adapter default that prompts); a mode in the host's trusted table that
+preserves approvals (a read-only or plan preset) is *guarded*; an adapter
+bypass id or auto-write mode (for example claude `bypassPermissions` or
+`acceptEdits`) is *unattended*; and any mode the host does not recognize is
+*unattended* (fail closed). Only an unattended class requires
+`session.unattended`. The plugin can never self-label a mode as safe, and the
+option catalog (what a mode is *available*) is deliberately not treated as a
+statement of what a mode is *allowed* to do.
+
+**Repository trust is independent of install grants.** A session against a
+repository whose hooks need approval is refused at spawn even when
+`session.unattended` was granted, fail closed. Plugin-created sessions force
+`trust_hooks = false`, so a plugin can never pre-approve a repository's hooks;
+that remains a runtime, per-repository user decision. The path is canonicalized
+immediately before the trust check to close symlink/substitution races.
+
+**Ownership.** A turn from `sessions.turn.send` reaches only a session whose
+`created_by_plugin` matches the caller. The check runs in `SessionService`
+before any side effect (no wake, resume, publish, or forward for a denied
+caller), so no transport can bypass it; a plugin cannot adopt or write to a
+user's or another plugin's session. A plugin-delivered turn also re-asserts the
+session's persisted mode before publishing, and withholds the prompt if that
+fails, so a turn never runs under an unconfirmed approval posture.
+
+**Idempotency.** `sessions.create` takes an `idempotency_key` scoped to the
+plugin, persisted on the session record. A retry with the same key and payload
+returns the existing session (`created: false`); a different payload under the
+same key is a conflict. Retention equals the session's lifetime: archive,
+snooze, and trash keep deduplicating; a hard delete releases the key.
+
+**Rate, concurrency, audit, kill switch.** Per plugin the host allows 20
+creates/hour, 5 active (non-trashed) plugin-created sessions, and 120
+turns/hour, backed by a private audit ledger (a dedicated `events` schema in
+`plugin_events.db`, unreachable from worker RPCs) so the rolling windows
+survive daemon restarts. Every admission and denial is audited (plugin id,
+operation, agent, mode, session id, decision) without recording prompt text.
+Disabling the plugin (the existing per-plugin enable toggle) tears down its
+worker and stops all of its automation; there is no plugin-provided bypass flag
+(`allow_untrusted`, raw ACP argv, arbitrary env are not accepted).
+
+**No plugin bypass surface.** `sessions.create` accepts only a structured view,
+an agent/model/mode, a project path, an optional initial turn, and an
+idempotency key. It rejects unknown fields at decode, so a payload cannot
+smuggle a host-side knob.
+
 ## What comes next
 
 Each deferred piece returns as its own PR once the core is proven: the Tier 0

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `8`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `9`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets.
 
 ## Top-level fields
 
@@ -41,7 +41,7 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `8`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `9`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
@@ -80,6 +80,10 @@ themes, ui, status) need no capability.
 | `browser_open` | Opening a URL in the user's browser from a command `action`. |
 | `composer.read` | Reading a click-scoped snapshot of the active ACP composer draft from a `composer-action`. |
 | `composer.write` | Publishing a host-validated draft edit from a `composer-action` UI-state payload. |
+| `acp.capabilities.read` | Discovering available agents and their advertised models/modes via `acp.capabilities.get` (`api_version >= 9`). |
+| `session.create` | Creating a host-owned structured session via `sessions.create` (`api_version >= 9`). |
+| `session.prompt` | Delivering a turn to a session the plugin created via `sessions.turn.send`, and the initial turn on `sessions.create` (`api_version >= 9`). |
+| `session.unattended` | Creating a session in a host-classified *unattended* approval mode. A distinct, high-severity grant, never implied by `session.create` or `session.prompt` (`api_version >= 9`). See [Session-driving RPCs](#session-driving-rpcs). |
 
 A capability this host version does not recognize is rejected, not granted.
 
@@ -155,6 +159,11 @@ advanced = true
 | `min` / `max` | integer | no | Inclusive bounds for `integer`; ignored otherwise. |
 | `default` | any | no | Declared default. Must match `type`. Absent means the type's zero value. |
 | `advanced` | bool | no | Group under the Advanced fold. Defaults to `false`. |
+| `option_source` | string | no | Host source for a `dynamic_select` (`api_version >= 9`). |
+| `depends_on` | array of string | no | Sibling keys whose values parameterize a `dynamic_select` (`api_version >= 9`). |
+| `fields` | array | no | Item fields of an `object_list` (`api_version >= 9`). |
+| `item_id_key` | string | no | Item field holding each `object_list` row's stable id; defaults to `_id` (host-generated) (`api_version >= 9`). |
+| `min_items` / `max_items` | integer | no | Inclusive item-count bounds for an `object_list` (`api_version >= 9`). |
 
 Setting types:
 
@@ -164,6 +173,134 @@ Setting types:
 | `bool` (or `boolean`) | Toggle. |
 | `integer` | Number input, bounded by `min` / `max`. |
 | `select` | Dropdown over a non-empty `options` array. |
+| `dynamic_select` | Dropdown whose choices the host resolves from `option_source` (`api_version >= 9`). |
+| `cron` | Validated 5-field cron expression text field (`api_version >= 9`). |
+| `object_list` | A repeatable list of structured items described by `fields` (`api_version >= 9`). |
+
+### Dynamic selects (`api_version >= 9`)
+
+A `dynamic_select` renders a dropdown whose options the **host** resolves at
+render time, so the plugin never ships a hardcoded list that could drift from
+the host's real agents, models, or projects. Set `option_source` to one of:
+
+| `option_source` | Choices |
+|---|---|
+| `acp.agents` | ACP-capable agents the host knows. |
+| `acp.models` | Models the selected agent advertised. Needs the agent via `depends_on`. |
+| `acp.modes` | Approval modes the selected agent advertised. Needs the agent via `depends_on`. |
+| `projects` | Registered projects (value is the project path). |
+| `groups` | Existing session group paths. |
+
+`depends_on` names sibling keys whose current values parameterize the source;
+`acp.models` and `acp.modes` require the selected agent. Saved ids are
+advisory: the host revalidates them when a session is actually created, so a
+model that later disappears from the catalog surfaces as an error at creation,
+not silently at save.
+
+### Object lists (`api_version >= 9`)
+
+An `object_list` is a repeatable list of structured records (for example, a
+cron plugin's schedule entries), stored on disk as a TOML array of tables under
+`[[plugins."<id>".settings.<key>]]`. It is **one level deep**: each item field
+is declared in `fields` and cannot itself be an `object_list`. Every item
+carries a stable id under `item_id_key` (host-generated on add, never changed on
+edit or reorder) so a worker can track an entry across edits.
+
+```toml
+[[settings]]
+key = "jobs"
+label = "Scheduled jobs"
+type = "object_list"
+item_id_key = "id"
+max_items = 50
+
+[[settings.fields]]
+key = "agent_id"
+label = "Agent"
+type = "dynamic_select"
+option_source = "acp.agents"
+required = true
+
+[[settings.fields]]
+key = "model_id"
+label = "Model"
+type = "dynamic_select"
+option_source = "acp.models"
+depends_on = ["agent_id"]
+
+[[settings.fields]]
+key = "schedule"
+label = "Schedule"
+type = "cron"
+required = true
+```
+
+Each item field takes the same `key` / `label` / `description` / `type` /
+`options` / `min` / `max` / `default` / `option_source` / `depends_on` keys as a
+top-level setting, plus `required` (the item must carry a non-empty value). An
+item field's `type` cannot be `object_list`.
+
+## Session-driving RPCs
+
+With `api_version >= 9` a worker can discover ACP capabilities and create
+host-owned structured sessions, the primitives an automation plugin (for
+example a scheduler) needs. These are worker RPCs, not manifest keys; the host
+enforces a strict security model around them.
+
+| Method | Capability | Purpose |
+|---|---|---|
+| `acp.capabilities.get` | `acp.capabilities.read` | List agents and their advertised models / modes (never launches an agent). |
+| `sessions.create` | `session.create` (+ `session.prompt` for an initial turn, + `session.unattended` for an unattended mode) | Create a structured session, optionally with an initial turn and a plugin-scoped idempotency key. |
+| `sessions.turn.send` | `session.prompt` | Deliver a turn to a session **this plugin created**. |
+| `plugin.storage.get` / `set` / `cas` / `remove` | `runtime.worker` | Plugin-private durable key/value storage (see [Plugin storage](#plugin-storage)). |
+
+**Approval-mode classification.** The plugin proposes a `mode_id`; the **host**
+decides its security class, never the plugin. A mode is *interactive* (omitted /
+adapter default), *guarded* (a reviewed read-only or plan preset), or
+*unattended* (a bypass or auto-write mode, and every mode the host does not
+recognize, which fail closed to unattended). An unattended mode requires the
+distinct `session.unattended` grant on top of `session.create`.
+
+**Repository trust is enforced regardless of grants.** A session against a
+repository whose hooks need approval is refused even with `session.unattended`;
+a plugin cannot pre-approve repository trust. See
+[Unattended sessions](development/internals/plugin-system.md#unattended-plugin-sessions)
+for the full model.
+
+**Ownership.** `sessions.turn.send` only reaches a session the calling plugin
+created; a plugin cannot deliver turns to a user's or another plugin's session.
+
+**Idempotency.** `sessions.create` accepts an `idempotency_key` scoped to the
+plugin: retrying with the same key and payload returns the existing session
+(`created: false`); a different payload under the same key is a conflict.
+
+**Limits.** Per plugin: 20 session creates per hour, 5 active plugin-created
+sessions, 120 turns per hour. Exceeding a limit returns a `rate_limited` /
+`concurrency_limited` error. Disabling the plugin stops all of its automation.
+
+**Settings-change events.** After a settings write the host sends the plugin's
+worker a `plugin.settings.changed` notification carrying `{ revision,
+changed_keys }`; the worker re-reads the affected values via `config.get`
+(whose response includes the current `revision`). Polling `config.get` remains
+a fallback for a worker that was down when the write landed.
+
+## Plugin storage
+
+A worker has a host-backed, private key/value store, namespaced by its plugin
+id, that survives daemon and worker restarts (it is not the install directory,
+which an upgrade can replace). No capability beyond `runtime.worker` is needed:
+a plugin can only reach its own namespace.
+
+| Method | Params | Returns |
+|---|---|---|
+| `plugin.storage.get` | `{ key }` | `{ value }` (null if absent) |
+| `plugin.storage.set` | `{ key, value }` | `{}` |
+| `plugin.storage.cas` | `{ key, expected, value }` | `{ swapped, current }` |
+| `plugin.storage.remove` | `{ key }` | `{ removed }` |
+
+Quotas per plugin: 64 keys, 256-byte keys, 64 KiB values. `cas` (compare-and-swap)
+enables safe concurrent updates: the write applies only when the stored value
+equals `expected`.
 
 ## UI slots
 

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -236,6 +236,16 @@ pub fn resolve(key: &str) -> &'static AgentProfile {
     }
 }
 
+/// Whether `key` names an adapter with a reviewed static profile, rather than
+/// falling back to [`DEFAULT`]. The automation policy uses this to decide
+/// whether an agent's approval-mode conventions can be trusted (#2897).
+pub fn is_reviewed(key: &str) -> bool {
+    matches!(
+        key,
+        "claude" | "claude-code" | "codex" | "opencode" | "gemini" | "vibe" | "pi" | "aoe-agent"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -236,13 +236,19 @@ pub fn resolve(key: &str) -> &'static AgentProfile {
     }
 }
 
-/// Whether `key` names an adapter with a reviewed static profile, rather than
-/// falling back to [`DEFAULT`]. The automation policy uses this to decide
-/// whether an agent's approval-mode conventions can be trusted (#2897).
+/// Whether `key` names an adapter whose approval-mode conventions have been
+/// verified against its adapter source, so the automation policy may grant the
+/// benign (interactive/guarded) classifications for its omitted default and
+/// trusted-table mode ids (#2897). Adapters whose default/mode approval
+/// behavior is not yet verified (`opencode`, `vibe`, `pi`) are deliberately
+/// excluded so they fail closed to unattended, matching the classifier's
+/// fail-closed principle. This is a security-policy set, narrower than "has a
+/// non-[`DEFAULT`] static profile": add an adapter only once its default and
+/// mode approval semantics are confirmed.
 pub fn is_reviewed(key: &str) -> bool {
     matches!(
         key,
-        "claude" | "claude-code" | "codex" | "opencode" | "gemini" | "vibe" | "pi" | "aoe-agent"
+        "claude" | "claude-code" | "codex" | "gemini" | "kimi" | "aoe-agent"
     )
 }
 
@@ -267,6 +273,26 @@ mod tests {
     fn resolve_falls_back_to_default() {
         assert_eq!(resolve("").key, "default");
         assert_eq!(resolve("unknown-agent").key, "default");
+    }
+
+    #[test]
+    fn is_reviewed_covers_only_verified_approval_conventions() {
+        // Verified adapters get the benign automation classifications.
+        for key in [
+            "claude",
+            "claude-code",
+            "codex",
+            "gemini",
+            "kimi",
+            "aoe-agent",
+        ] {
+            assert!(is_reviewed(key), "{key} should be reviewed");
+        }
+        // Adapters whose default/mode approval behavior is unverified fail
+        // closed to unattended, and unknown keys never count as reviewed.
+        for key in ["opencode", "vibe", "pi", "unknown-agent", ""] {
+            assert!(!is_reviewed(key), "{key} should not be reviewed");
+        }
     }
 
     #[test]

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -504,6 +504,11 @@ pub struct SpawnRequest {
     /// Best-effort: adapters that don't advertise bypass mode log a
     /// warning and stay in default. See #1142.
     pub yolo_mode: bool,
+    /// Explicit ACP session mode to apply after the handshake, sourced from
+    /// `Instance.acp_mode_id` (#2897). Takes precedence over `yolo_mode`;
+    /// like it, applied best-effort via `session/set_mode` and re-asserted on
+    /// every worker (re)spawn so the persisted mode survives respawns.
+    pub acp_mode_id: Option<String>,
     /// When `Some`, overlay the instance's resolved launch command on
     /// the registry `AgentSpec` so structured view honors
     /// `session.agent_command_override` like tmux does. Applied only
@@ -1325,6 +1330,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             sandbox_info,
             source_profile,
             yolo_mode,
+            acp_mode_id,
             agent_command_override,
             seed_history_replay,
         } = req;
@@ -1541,7 +1547,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             return Err(SupervisorError::SpawnCancelled(session_id));
         }
         let drain_task = self.start_drain_task(session_id.clone(), inbound);
-        let client_for_yolo = yolo_mode.then(|| Arc::clone(&client));
+        let client_for_mode = (acp_mode_id.is_some() || yolo_mode).then(|| Arc::clone(&client));
         workers.insert(
             session_id.clone(),
             WorkerHandle {
@@ -1579,8 +1585,14 @@ impl<S: BroadcastSink> Supervisor<S> {
         // fire-and-forget through cmd_tx, the connection loop warns on
         // failure, and adapters with no known bypass mode (`yolo_mode_id:
         // None`) stay in default. See #1142.
-        if let Some(client) = client_for_yolo {
-            if let Some(mode_id) = super::agent_profiles::resolve(&agent).yolo_mode_id {
+        if let Some(client) = client_for_mode {
+            // An explicit persisted mode (#2897) wins over the yolo bool;
+            // both re-assert on every (re)spawn so the session's approval
+            // posture survives worker restarts.
+            let mode_id = acp_mode_id
+                .as_deref()
+                .or_else(|| super::agent_profiles::resolve(&agent).yolo_mode_id);
+            if let Some(mode_id) = mode_id {
                 if let Err(e) = client.set_mode(mode_id).await {
                     warn!(
                         target: "acp.supervisor",
@@ -3213,6 +3225,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                acp_mode_id: None,
                 agent_command_override: None,
             })
             .await;
@@ -3255,6 +3268,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                acp_mode_id: None,
                 agent_command_override: None,
             })
             .await;
@@ -4989,6 +5003,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                acp_mode_id: None,
                 agent_command_override: None,
             })
             .await;
@@ -5065,6 +5080,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                acp_mode_id: None,
                 agent_command_override: None,
             })
             .await;
@@ -5279,6 +5295,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                acp_mode_id: None,
                 agent_command_override: None,
             })
             .await;
@@ -5334,6 +5351,7 @@ mod tests {
                 sandbox_info: None,
                 source_profile: None,
                 yolo_mode: false,
+                acp_mode_id: None,
                 agent_command_override: None,
             })
             .await;

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -261,6 +261,25 @@ pub fn insert_event(
     .with_context(|| format!("insert {topic}@{seq}"))
 }
 
+/// Count events for `topic` whose `created_at` is at or after
+/// `min_created_at` (same clock as `insert_event`, unix millis). Used by the
+/// plugin automation policy's rolling-window rate limits (#2897).
+pub fn count_since(
+    conn: &Connection,
+    schema: &Schema,
+    topic: &str,
+    min_created_at: i64,
+) -> Result<u64> {
+    let sql = format!(
+        "SELECT COUNT(*) FROM {} WHERE session_id = ?1 AND created_at >= ?2",
+        schema.events_table()
+    );
+    let count: i64 = conn
+        .query_row(&sql, params![topic, min_created_at], |row| row.get(0))
+        .with_context(|| format!("count events for {topic}"))?;
+    Ok(count.max(0) as u64)
+}
+
 /// Prune the oldest events for `topic` beyond `max_events`, exempting any
 /// event whose payload starts with one of `pinned_prefixes` (matched on the
 /// externally-tagged JSON discriminant). Attachment blobs at or below the

--- a/src/plugin/automation_policy.rs
+++ b/src/plugin/automation_policy.rs
@@ -42,11 +42,11 @@ const ROLLING_WINDOW_MS: i64 = 60 * 60 * 1000;
 /// than the one-hour window the queries need.
 const LEDGER_RETENTION_PER_TOPIC: usize = 2000;
 
-/// Reviewed approval semantics for mode ids the host understands, applied
-/// across adapters (ids are adapter-namespaced in practice; a collision
-/// would still get the more restrictive treatment via the table entry).
-/// Everything else: the adapter profile's bypass id is unattended, and an
-/// unknown id classifies unattended.
+/// Reviewed approval semantics for mode ids the host understands. The
+/// less-restrictive entries (`default`, `plan`) are honored only for a reviewed
+/// adapter (see [`classify_mode`]); an unreviewed agent reusing one of these ids
+/// falls back to unattended. Everything else: the adapter profile's bypass id is
+/// unattended, and an unknown id classifies unattended.
 const TRUSTED_MODE_TABLE: &[(&str, ApprovalClass)] = &[
     // Adapter default approval-prompting presets.
     ("default", ApprovalClass::Interactive),
@@ -77,20 +77,46 @@ pub(crate) enum ModeDecision {
 
 /// Classify `mode_id` for `agent_key`. `catalog` is the agent's last
 /// advertised option snapshot, `None` when never discovered.
+///
+/// The benign classifications (an omitted default, or the `default`/`plan`
+/// table entries) describe the *reviewed* adapters' conventions. An unreviewed
+/// agent (one with no static profile) could advertise a mode literally named
+/// `default` or `plan`, or ship an omitted default that silently auto-applies,
+/// so its less-restrictive treatment is not trusted: those cases fail closed to
+/// unattended and thus require `session.unattended`. The always-unattended
+/// entries and adapter bypass ids apply regardless.
 pub(crate) fn classify_mode(
     agent_key: &str,
     mode_id: Option<&str>,
     catalog: Option<&AgentOptionEntry>,
 ) -> ModeDecision {
+    let profile = crate::acp::agent_profiles::resolve(agent_key);
+    // Only adapters with a reviewed static profile get the benign treatment;
+    // anything falling back to DEFAULT fails closed.
+    let reviewed = crate::acp::agent_profiles::is_reviewed(agent_key);
+
     let Some(mode_id) = mode_id else {
-        // Adapter default: approvals prompt through the host UI.
-        return ModeDecision::Class(ApprovalClass::Interactive);
+        // Omitted mode = the agent's own default. Trusted to prompt only for a
+        // reviewed adapter; an unreviewed default could auto-apply, so fail
+        // closed.
+        return ModeDecision::Class(if reviewed {
+            ApprovalClass::Interactive
+        } else {
+            ApprovalClass::Unattended
+        });
     };
-    if crate::acp::agent_profiles::resolve(agent_key).yolo_mode_id == Some(mode_id) {
+    if profile.yolo_mode_id == Some(mode_id) {
         return ModeDecision::Class(ApprovalClass::Unattended);
     }
     if let Some((_, class)) = TRUSTED_MODE_TABLE.iter().find(|(id, _)| *id == mode_id) {
-        return ModeDecision::Class(*class);
+        // Honor a less-restrictive class only for a reviewed adapter; an
+        // unreviewed agent reusing the id gets the fail-closed treatment.
+        let effective = if *class == ApprovalClass::Unattended || reviewed {
+            *class
+        } else {
+            ApprovalClass::Unattended
+        };
+        return ModeDecision::Class(effective);
     }
     let Some(catalog) = catalog else {
         return ModeDecision::CatalogNotDiscovered;
@@ -350,6 +376,29 @@ mod tests {
         assert_eq!(
             classify_mode("claude", Some("customMode"), None),
             CatalogNotDiscovered
+        );
+    }
+
+    #[test]
+    fn unreviewed_agent_fails_closed() {
+        use ApprovalClass::*;
+        use ModeDecision::*;
+
+        // An unreviewed agent cannot inherit the benign classifications by
+        // reusing a trusted id, nor by omitting the mode.
+        assert_eq!(classify_mode("shady-agent", None, None), Class(Unattended));
+        assert_eq!(
+            classify_mode("shady-agent", Some("default"), None),
+            Class(Unattended)
+        );
+        assert_eq!(
+            classify_mode("shady-agent", Some("plan"), None),
+            Class(Unattended)
+        );
+        // Always-unattended ids stay unattended for anyone.
+        assert_eq!(
+            classify_mode("shady-agent", Some("acceptEdits"), None),
+            Class(Unattended)
         );
     }
 

--- a/src/plugin/automation_policy.rs
+++ b/src/plugin/automation_policy.rs
@@ -1,0 +1,403 @@
+//! Host-owned policy for plugin-driven session automation (#2897):
+//! approval-mode classification, rolling-window rate limits, active-session
+//! concurrency limits, and the durable audit ledger backing them.
+//!
+//! Classification is security policy, so it never derives from agent- or
+//! plugin-supplied metadata: the option catalog only proves a mode is
+//! currently AVAILABLE, while the trusted table below (plus the adapter
+//! profiles' bypass ids) decides what a mode is ALLOWED to do. Unknown modes
+//! classify as unattended, fail closed.
+//!
+//! The ledger is a second, host-private [`crate::events`] schema inside the
+//! existing `plugin_events.db`. It is never addressable from worker RPCs
+//! (workers reach only the public event-bus schema), so a plugin cannot read
+//! or forge policy records. Admissions are recorded before the operation
+//! runs, which makes the rolling-hour limits survive daemon restarts; the
+//! in-memory reservation map only closes same-process races and is
+//! deliberately not persisted (a crashed daemon has no in-flight creates).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use aoe_plugin_api::acp::ApprovalClass;
+
+use crate::acp::option_catalog::AgentOptionEntry;
+use crate::acp::state::ConfigOptionCategory;
+use crate::events;
+use crate::plugin::host_api::DispatchError;
+use crate::plugin::protocol::codes;
+
+/// Hardcoded v1 limits, per plugin. Config exposure is a follow-up; these
+/// are sized for cron-style automation (schedules plus retries) while
+/// stopping rapid provisioning or prompt loops.
+pub(crate) const MAX_PLUGIN_CREATES_PER_HOUR: u64 = 20;
+pub(crate) const MAX_ACTIVE_PLUGIN_SESSIONS: usize = 5;
+pub(crate) const MAX_PLUGIN_TURNS_PER_HOUR: u64 = 120;
+
+const ROLLING_WINDOW_MS: i64 = 60 * 60 * 1000;
+/// Per-topic ledger cap; at the admission limits above this retains far more
+/// than the one-hour window the queries need.
+const LEDGER_RETENTION_PER_TOPIC: usize = 2000;
+
+/// Reviewed approval semantics for mode ids the host understands, applied
+/// across adapters (ids are adapter-namespaced in practice; a collision
+/// would still get the more restrictive treatment via the table entry).
+/// Everything else: the adapter profile's bypass id is unattended, and an
+/// unknown id classifies unattended.
+const TRUSTED_MODE_TABLE: &[(&str, ApprovalClass)] = &[
+    // Adapter default approval-prompting presets.
+    ("default", ApprovalClass::Interactive),
+    // Claude's plan preset: read/analyze, edits still prompt.
+    ("plan", ApprovalClass::Guarded),
+    // Auto-writes files without a human approving each edit: unattended
+    // behavior even though shell commands still prompt.
+    ("acceptEdits", ApprovalClass::Unattended),
+    // Adapter bypass ids (also covered by yolo_mode_id resolution).
+    ("bypassPermissions", ApprovalClass::Unattended),
+    ("agent-full-access", ApprovalClass::Unattended),
+    ("yolo", ApprovalClass::Unattended),
+];
+
+/// Outcome of classifying a requested approval mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModeDecision {
+    /// The mode is usable; enforce the class (unattended needs the grant).
+    Class(ApprovalClass),
+    /// The mode id is neither trusted-table-known nor advertised by the
+    /// agent's discovered catalog.
+    UnknownMode,
+    /// An explicit mode was requested but the agent's catalog has never
+    /// been discovered and the id is not independently known; refusing is
+    /// safer than guessing.
+    CatalogNotDiscovered,
+}
+
+/// Classify `mode_id` for `agent_key`. `catalog` is the agent's last
+/// advertised option snapshot, `None` when never discovered.
+pub(crate) fn classify_mode(
+    agent_key: &str,
+    mode_id: Option<&str>,
+    catalog: Option<&AgentOptionEntry>,
+) -> ModeDecision {
+    let Some(mode_id) = mode_id else {
+        // Adapter default: approvals prompt through the host UI.
+        return ModeDecision::Class(ApprovalClass::Interactive);
+    };
+    if crate::acp::agent_profiles::resolve(agent_key).yolo_mode_id == Some(mode_id) {
+        return ModeDecision::Class(ApprovalClass::Unattended);
+    }
+    if let Some((_, class)) = TRUSTED_MODE_TABLE.iter().find(|(id, _)| *id == mode_id) {
+        return ModeDecision::Class(*class);
+    }
+    let Some(catalog) = catalog else {
+        return ModeDecision::CatalogNotDiscovered;
+    };
+    let advertised = catalog.options.iter().any(|opt| {
+        opt.category == ConfigOptionCategory::Mode
+            && opt.options.iter().any(|choice| choice.value == mode_id)
+    });
+    if advertised {
+        // Available but semantically unknown to the host: fail closed.
+        ModeDecision::Class(ApprovalClass::Unattended)
+    } else {
+        ModeDecision::UnknownMode
+    }
+}
+
+/// Durable admission ledger + process-local reservations. One per daemon,
+/// owned by the plugin host.
+pub struct AutomationPolicy {
+    /// Ledger connection; sync mutex, tiny critical sections, no `await`
+    /// while held (callers run queries via spawn_blocking-free short calls;
+    /// the SQLite file is local and the tables are indexed by topic).
+    ledger: std::sync::Mutex<Ledger>,
+    /// Outstanding create reservations per plugin: creates admitted but not
+    /// yet visible as persisted sessions, so concurrent different-key
+    /// creates cannot overshoot the active-session limit.
+    reservations: std::sync::Mutex<HashMap<String, usize>>,
+}
+
+struct Ledger {
+    conn: Connection,
+    schema: events::Schema,
+}
+
+impl AutomationPolicy {
+    /// Open (creating on first use) the private audit schema inside the
+    /// plugin event-bus database.
+    pub(crate) fn open(plugin_events_db: &Path) -> Result<Self> {
+        let schema = events::Schema::new("plugin_automation_audit")?;
+        let conn = events::open(plugin_events_db, &schema)?;
+        Ok(Self {
+            ledger: std::sync::Mutex::new(Ledger { conn, schema }),
+            reservations: std::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Admit a `sessions.create`: enforce the rolling create rate and the
+    /// active-session cap (persisted sessions + outstanding reservations),
+    /// record the admission durably, and reserve a concurrency slot the
+    /// caller must hold until its create resolves. `active_sessions` is the
+    /// caller-supplied count of live (non-archived/snoozed/trashed) sessions
+    /// this plugin already owns.
+    pub(crate) fn admit_create(
+        self: &std::sync::Arc<Self>,
+        plugin_id: &str,
+        active_sessions: usize,
+    ) -> Result<CreateReservation, DispatchError> {
+        // Reservation check-and-claim under one lock closes the
+        // count-then-create race between concurrent different-key creates.
+        {
+            let mut reservations = self
+                .reservations
+                .lock()
+                .expect("reservations mutex poisoned");
+            let outstanding = reservations.get(plugin_id).copied().unwrap_or(0);
+            if active_sessions + outstanding >= MAX_ACTIVE_PLUGIN_SESSIONS {
+                return Err(DispatchError::with_kind(
+                    codes::RATE_LIMITED,
+                    "concurrency_limited",
+                    format!(
+                        "plugin {plugin_id} already has {} active or pending sessions (limit {MAX_ACTIVE_PLUGIN_SESSIONS})",
+                        active_sessions + outstanding
+                    ),
+                ));
+            }
+            *reservations.entry(plugin_id.to_string()).or_insert(0) += 1;
+        }
+        let reservation = CreateReservation {
+            policy: std::sync::Arc::clone(self),
+            plugin_id: plugin_id.to_string(),
+        };
+        // Rolling-window rate check + durable admission record. Admissions
+        // are counted (not just successes) so failing requests cannot bypass
+        // throttling; on denial the reservation drops with the error return.
+        self.admit_windowed("create", plugin_id, MAX_PLUGIN_CREATES_PER_HOUR)?;
+        Ok(reservation)
+    }
+
+    /// Admit a `sessions.turn.send` under the rolling turn rate.
+    pub(crate) fn admit_turn(&self, plugin_id: &str) -> Result<(), DispatchError> {
+        self.admit_windowed("turn", plugin_id, MAX_PLUGIN_TURNS_PER_HOUR)
+    }
+
+    fn admit_windowed(
+        &self,
+        operation: &str,
+        plugin_id: &str,
+        limit: u64,
+    ) -> Result<(), DispatchError> {
+        let topic = format!("{operation}/{plugin_id}");
+        let now = chrono::Utc::now().timestamp_millis();
+        let ledger = self.ledger.lock().expect("ledger mutex poisoned");
+        let used = events::count_since(
+            &ledger.conn,
+            &ledger.schema,
+            &topic,
+            now - ROLLING_WINDOW_MS,
+        )
+        .map_err(|e| DispatchError::internal(format!("automation ledger read failed: {e:#}")))?;
+        if used >= limit {
+            return Err(DispatchError::with_kind(
+                codes::RATE_LIMITED,
+                "rate_limited",
+                format!(
+                    "plugin {plugin_id} exceeded {limit} admitted {operation} operations in the rolling hour"
+                ),
+            ));
+        }
+        let seq = events::highest_seq(&ledger.conn, &ledger.schema, &topic) + 1;
+        let payload = serde_json::json!({ "op": operation, "plugin": plugin_id }).to_string();
+        events::insert_event(&ledger.conn, &ledger.schema, &topic, seq, &payload, now).map_err(
+            |e| DispatchError::internal(format!("automation ledger write failed: {e:#}")),
+        )?;
+        events::prune_retention(
+            &ledger.conn,
+            &ledger.schema,
+            &topic,
+            LEDGER_RETENTION_PER_TOPIC,
+            &[],
+        );
+        Ok(())
+    }
+
+    /// Record a policy decision or operation outcome in the audit ledger.
+    /// Best-effort: auditing must never fail the operation itself. Never
+    /// records prompt contents.
+    pub(crate) fn audit(&self, plugin_id: &str, record: serde_json::Value) {
+        let topic = format!("decision/{plugin_id}");
+        let now = chrono::Utc::now().timestamp_millis();
+        let ledger = self.ledger.lock().expect("ledger mutex poisoned");
+        let seq = events::highest_seq(&ledger.conn, &ledger.schema, &topic) + 1;
+        if let Err(e) = events::insert_event(
+            &ledger.conn,
+            &ledger.schema,
+            &topic,
+            seq,
+            &record.to_string(),
+            now,
+        ) {
+            tracing::warn!(
+                target: "plugin.automation",
+                plugin = %plugin_id,
+                "audit record write failed: {e:#}"
+            );
+        }
+        events::prune_retention(
+            &ledger.conn,
+            &ledger.schema,
+            &topic,
+            LEDGER_RETENTION_PER_TOPIC,
+            &[],
+        );
+    }
+
+    fn release_reservation(&self, plugin_id: &str) {
+        let mut reservations = self
+            .reservations
+            .lock()
+            .expect("reservations mutex poisoned");
+        if let Some(count) = reservations.get_mut(plugin_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                reservations.remove(plugin_id);
+            }
+        }
+    }
+}
+
+/// Holds one active-session concurrency slot for a create in flight;
+/// released on drop on every exit path (success, error, panic).
+pub(crate) struct CreateReservation {
+    policy: std::sync::Arc<AutomationPolicy>,
+    plugin_id: String,
+}
+
+impl Drop for CreateReservation {
+    fn drop(&mut self) {
+        self.policy.release_reservation(&self.plugin_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::state::{ConfigOptionChoice, ConfigOptionDescriptor};
+
+    fn catalog_with_modes(modes: &[&str]) -> AgentOptionEntry {
+        AgentOptionEntry {
+            updated_at: "2026-07-16T00:00:00Z".to_string(),
+            options: vec![ConfigOptionDescriptor {
+                id: "mode".to_string(),
+                name: "Mode".to_string(),
+                description: None,
+                category: ConfigOptionCategory::Mode,
+                current_value: String::new(),
+                options: modes
+                    .iter()
+                    .map(|m| ConfigOptionChoice {
+                        value: (*m).to_string(),
+                        name: (*m).to_string(),
+                        description: None,
+                    })
+                    .collect(),
+            }],
+        }
+    }
+
+    #[test]
+    fn classification_table() {
+        use ApprovalClass::*;
+        use ModeDecision::*;
+        let catalog = catalog_with_modes(&["default", "plan", "acceptEdits", "customMode"]);
+
+        // Omitted mode: adapter default, interactive.
+        assert_eq!(classify_mode("claude", None, None), Class(Interactive));
+        // Adapter bypass id from the profile: unattended, catalog or not.
+        assert_eq!(
+            classify_mode("claude", Some("bypassPermissions"), None),
+            Class(Unattended)
+        );
+        assert_eq!(
+            classify_mode("codex", Some("agent-full-access"), None),
+            Class(Unattended)
+        );
+        // Trusted table entries work without a discovered catalog.
+        assert_eq!(classify_mode("claude", Some("plan"), None), Class(Guarded));
+        assert_eq!(
+            classify_mode("claude", Some("default"), None),
+            Class(Interactive)
+        );
+        // acceptEdits auto-writes: unattended even though advertised.
+        assert_eq!(
+            classify_mode("claude", Some("acceptEdits"), Some(&catalog)),
+            Class(Unattended)
+        );
+        // Advertised but unknown semantics: fail closed to unattended.
+        assert_eq!(
+            classify_mode("claude", Some("customMode"), Some(&catalog)),
+            Class(Unattended)
+        );
+        // Not advertised, not known: invalid.
+        assert_eq!(
+            classify_mode("claude", Some("nope"), Some(&catalog)),
+            UnknownMode
+        );
+        // Explicit unknown mode with no catalog yet: refuse rather than guess.
+        assert_eq!(
+            classify_mode("claude", Some("customMode"), None),
+            CatalogNotDiscovered
+        );
+    }
+
+    #[test]
+    fn limits_and_reservations() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let policy = std::sync::Arc::new(
+            AutomationPolicy::open(&dir.path().join("plugin_events.db")).expect("open"),
+        );
+
+        // Concurrency: active sessions + reservations are capped together.
+        let mut held = Vec::new();
+        for _ in 0..MAX_ACTIVE_PLUGIN_SESSIONS {
+            held.push(
+                policy
+                    .admit_create("cron", 0)
+                    .map_err(|e| e.message)
+                    .expect("under the cap"),
+            );
+        }
+        let denied = match policy.admit_create("cron", 0) {
+            Err(e) => e,
+            Ok(_) => panic!("cap reached"),
+        };
+        assert_eq!(denied.code, codes::RATE_LIMITED);
+        assert_eq!(denied.data.as_ref().unwrap()["kind"], "concurrency_limited");
+        // Another plugin is unaffected.
+        let _other = policy.admit_create("other", 0).expect("separate scope");
+        // Releasing a slot re-admits.
+        held.pop();
+        let _again = policy.admit_create("cron", 0).expect("slot released");
+
+        // Turn rate: durable rolling window.
+        for _ in 0..MAX_PLUGIN_TURNS_PER_HOUR {
+            policy.admit_turn("cron").expect("under the rate");
+        }
+        let denied = policy.admit_turn("cron").expect_err("rate reached");
+        assert_eq!(denied.code, codes::RATE_LIMITED);
+        assert_eq!(denied.data.as_ref().unwrap()["kind"], "rate_limited");
+        policy.admit_turn("other").expect("separate scope");
+
+        // The ledger survives a reopen (daemon restart): the window still
+        // counts the prior admissions.
+        drop(policy);
+        let reopened = std::sync::Arc::new(
+            AutomationPolicy::open(&dir.path().join("plugin_events.db")).expect("reopen"),
+        );
+        let denied = reopened.admit_turn("cron").expect_err("window persisted");
+        assert_eq!(denied.data.as_ref().unwrap()["kind"], "rate_limited");
+    }
+}

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -699,11 +699,20 @@ async fn serve_connection(
                 Some(deps) => {
                     crate::plugin::session_api::dispatch(deps, ctx, &method, &request.params).await
                 }
-                None => Err(crate::plugin::host_api::DispatchError::with_kind(
-                    codes::SERVICE_UNAVAILABLE,
-                    "service_unavailable",
-                    "session service is not available in this host",
-                )),
+                None => {
+                    // Authorize first so an ungranted caller receives the same
+                    // result as when the service is present; only an authorized
+                    // caller learns the dependency is unavailable.
+                    let unavailable = crate::plugin::host_api::DispatchError::with_kind(
+                        codes::SERVICE_UNAVAILABLE,
+                        "service_unavailable",
+                        "session service is not available in this host",
+                    );
+                    match crate::plugin::session_api::required_capability(&method) {
+                        Some(cap) => ctx.require(cap).and(Err(unavailable)),
+                        None => Err(unavailable),
+                    }
+                }
             };
             match &outcome {
                 Ok(_) => tracing::debug!(

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -95,13 +95,22 @@ pub struct PluginHost {
     sandbox: Arc<dyn SandboxBackend>,
     workers_dir: PathBuf,
     state: Mutex<WorkerTable>,
+    /// Dependencies of the async session RPCs (#2897), injected at
+    /// construction so no worker can race a late binding. `None` only when
+    /// the daemon could not open the automation-policy ledger (or in test
+    /// hosts); the session methods then answer `service_unavailable`.
+    session_rpc: Option<Arc<crate::plugin::session_api::SessionRpcDeps>>,
 }
 
 impl PluginHost {
     /// Build a host bound to `app_dir` (where the worker logs and the plugin
     /// event-bus database live) and `profile` (whose session storage the host
     /// API reads and writes). The only v1 sandbox backend is [`NoSandbox`].
-    pub fn new(app_dir: &std::path::Path, profile: &str) -> Result<Arc<Self>> {
+    pub fn new(
+        app_dir: &std::path::Path,
+        profile: &str,
+        session_rpc: Option<Arc<crate::plugin::session_api::SessionRpcDeps>>,
+    ) -> Result<Arc<Self>> {
         let workers_dir = app_dir.join("plugin-workers");
         worker::ensure_dir(&workers_dir)
             .with_context(|| format!("prepare {}", workers_dir.display()))?;
@@ -119,6 +128,7 @@ impl PluginHost {
                 crashed: HashSet::new(),
                 next_supervisor_id: 1,
             }),
+            session_rpc,
         }))
     }
 
@@ -524,7 +534,14 @@ impl PluginHost {
             ui_contributions,
             ui_generation,
         };
-        serve_connection(&self.api, &ctx, stdout, inbound_tx).await;
+        serve_connection(
+            &self.api,
+            &ctx,
+            stdout,
+            inbound_tx,
+            self.session_rpc.as_ref(),
+        )
+        .await;
         // Serving ended; stop accepting host-initiated pushes and tear down the
         // stdin writer so it does not outlive the worker. Only if still current,
         // so a stale supervisor cannot blank a newer entry's channel.
@@ -599,6 +616,7 @@ async fn serve_connection(
     ctx: &PluginRpcContext,
     stdout: tokio::process::ChildStdout,
     stdin: mpsc::UnboundedSender<String>,
+    session_rpc: Option<&Arc<crate::plugin::session_api::SessionRpcDeps>>,
 ) {
     let mut lines = BufReader::new(stdout).lines();
     // Unbounded line read: per the honest model (D8) the worker is cooperative,
@@ -641,6 +659,50 @@ async fn serve_connection(
                 continue;
             }
         };
+
+        // The session-driving methods (#2897) are async (they call the
+        // shared SessionService), so they route here instead of the
+        // synchronous spawn_blocking dispatch below. Capability gating,
+        // tracing, and response shaping mirror the sync path.
+        if crate::plugin::session_api::handles(&method) {
+            let outcome = match session_rpc {
+                Some(deps) => {
+                    crate::plugin::session_api::dispatch(deps, ctx, &method, &request.params).await
+                }
+                None => Err(crate::plugin::host_api::DispatchError::with_kind(
+                    codes::SERVICE_UNAVAILABLE,
+                    "service_unavailable",
+                    "session service is not available in this host",
+                )),
+            };
+            match &outcome {
+                Ok(_) => tracing::debug!(
+                    target: "plugin.host",
+                    plugin = %ctx.plugin_id,
+                    method = %method,
+                    "worker rpc ok"
+                ),
+                Err(e) => tracing::warn!(
+                    target: "plugin.host",
+                    plugin = %ctx.plugin_id,
+                    method = %method,
+                    code = e.code,
+                    "worker rpc rejected: {}",
+                    e.message
+                ),
+            }
+            let Some(id) = request.id else {
+                continue;
+            };
+            let response = match outcome {
+                Ok(result) => RpcResponse::success(id, result),
+                Err(e) => RpcResponse::error_with_data(id, e.code, e.message, e.data),
+            };
+            if stdin.send(response.to_line()).is_err() {
+                return;
+            }
+            continue;
+        }
 
         // Dispatch does blocking SQLite and session-storage IO; run it off the
         // async runtime. The handler is fully synchronous and self-contained.
@@ -694,7 +756,7 @@ async fn serve_connection(
 
         let response = match outcome {
             Ok(Ok(result)) => RpcResponse::success(id, result),
-            Ok(Err(e)) => RpcResponse::error(id, e.code, e.message),
+            Ok(Err(e)) => RpcResponse::error_with_data(id, e.code, e.message, e.data),
             Err(join_err) => RpcResponse::error(
                 id,
                 codes::INTERNAL_ERROR,
@@ -785,7 +847,7 @@ process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:1,method:"session.meta.set
         let stdin = child.stdin.take().unwrap();
         let stdout = child.stdout.take().unwrap();
 
-        serve_connection(&api, &ctx, stdout, stdin_writer(stdin)).await;
+        serve_connection(&api, &ctx, stdout, stdin_writer(stdin), None).await;
         let _ = child.wait().await;
 
         // Read the event the worker published: it carries the FORBIDDEN code the
@@ -859,7 +921,7 @@ rl.on('line', (line) => {
         )
         .unwrap();
 
-        serve_connection(&api, &ctx, stdout, tx).await;
+        serve_connection(&api, &ctx, stdout, tx, None).await;
         let _ = child.wait().await;
 
         let got = dispatch(

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -179,6 +179,36 @@ impl PluginHost {
         }
     }
 
+    /// Emit `plugin.settings.changed` to each plugin whose settings a write
+    /// just changed (#2897). Bumps the shared settings revision once, then
+    /// sends `{revision, changed_keys}` to each plugin's live worker; a
+    /// plugin with no running worker is skipped (it re-reads via `config.get`
+    /// when it next starts). Revision-only by design: the settings snapshot is
+    /// not inlined (size, secret exposure). Notification failure is logged,
+    /// never rolls back the already-committed write.
+    pub async fn emit_settings_changed(&self, changes: &[(String, Vec<String>)]) {
+        if changes.is_empty() {
+            return;
+        }
+        let revision = self.api.bump_settings_revision();
+        for (plugin_id, changed_keys) in changes {
+            let params = serde_json::json!({
+                "revision": revision,
+                "changed_keys": changed_keys,
+            });
+            let delivered = self
+                .notify_worker(plugin_id, "plugin.settings.changed", params)
+                .await;
+            if !delivered {
+                tracing::debug!(
+                    target: "plugin.host",
+                    plugin = %plugin_id,
+                    "plugin.settings.changed not delivered (no live worker); config.get is the fallback"
+                );
+            }
+        }
+    }
+
     /// Bring the running worker set in line with the registry: launch a worker
     /// for every active plugin that declares a runtime and has none running,
     /// and tear down any running worker whose plugin is no longer active. Logs

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -77,6 +77,12 @@ pub struct HostApiState {
     profile: String,
     /// Host-rendered UI state pushed by workers over `ui.state.*`/`ui.notify`.
     ui: UiStore,
+    /// Monotonic settings revision, bumped on every settings write (#2897).
+    /// `config.get` returns it so a worker can tell whether a fetch already
+    /// reflects a `plugin.settings.changed` event it received. In-memory: a
+    /// worker re-reads config on restart anyway, so cross-restart durability
+    /// buys nothing.
+    settings_revision: std::sync::atomic::AtomicU64,
 }
 
 impl HostApiState {
@@ -109,11 +115,25 @@ impl HostApiState {
             retention,
             profile: profile.to_string(),
             ui: UiStore::new(),
+            settings_revision: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
     fn storage(&self) -> anyhow::Result<Storage> {
         Storage::new_unwatched(&self.profile)
+    }
+
+    /// Bump and return the settings revision. Called by the settings write
+    /// path so the next `config.get` reflects the change.
+    pub fn bump_settings_revision(&self) -> u64 {
+        self.settings_revision
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1
+    }
+
+    fn settings_revision(&self) -> u64 {
+        self.settings_revision
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Register a freshly spawned worker's UI generation. The supervisor threads
@@ -268,7 +288,7 @@ pub fn dispatch(
         }
         "config.get" => {
             ctx.require(CAP_WORKER)?;
-            config_get(ctx, params)
+            config_get(state, ctx, params)
         }
         "ui.state.set" => {
             ctx.require(CAP_WORKER)?;
@@ -573,7 +593,11 @@ fn sessions_list(state: &HostApiState, params: &Value) -> Result<Value, Dispatch
 /// the worker can fall back to its own default. The id is always the caller's
 /// own ([`PluginRpcContext::plugin_id`]), never a request parameter, so one
 /// plugin can never read another's settings.
-fn config_get(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchError> {
+fn config_get(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
     let key = str_param(params, "key")?;
     let config =
         crate::session::Config::load().map_err(|e| DispatchError::internal(e.to_string()))?;
@@ -588,7 +612,10 @@ fn config_get(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchE
         }
         None => Value::Null,
     };
-    Ok(json!({ "value": value }))
+    // Return the current settings revision (#2897) so a worker reacting to a
+    // `plugin.settings.changed` event can tell whether this fetch already
+    // reflects it.
+    Ok(json!({ "value": value, "revision": state.settings_revision() }))
 }
 
 /// Validate a storage key: non-empty and within the byte cap. The key is

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -20,6 +20,10 @@
 //! - `sessions.list` (`session.read`).
 //! - `config.get { key }` (`runtime.worker`): the value at
 //!   `plugins.<plugin-id>.settings.<key>` for the calling plugin's own id.
+//! - `plugin.storage.get { key }` / `set { key, value }` /
+//!   `cas { key, expected, value }` / `remove { key }` (`runtime.worker`):
+//!   a host-backed durable key/value store, namespaced by the calling
+//!   plugin's id (#2897). Survives daemon and worker restarts; quota-bounded.
 //!
 //! Per-plugin namespace: session metadata is always read and written under the
 //! calling plugin's own `Instance.plugin_meta[<plugin-id>]` slot, and
@@ -33,8 +37,9 @@
 use std::collections::HashSet;
 use std::sync::Mutex;
 
+use anyhow::Context as _;
 use aoe_plugin_api::UiSlot;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde_json::{json, Value};
 
 use crate::events::{self, Order, Schema, SeqBound};
@@ -52,6 +57,13 @@ const CAP_SESSION_WRITE: &str = "session.write";
 /// the gate is the manifest `ui` slot declaration (see [`PluginRpcContext`]).
 const CAP_NOTIFICATIONS: &str = "notifications";
 const CAP_COMPOSER_WRITE: &str = "composer.write";
+
+/// Plugin-private storage quotas (#2897), per plugin. A plugin cannot reach
+/// another plugin's namespace, so the store needs no user-facing capability;
+/// these caps bound one plugin's footprint. Config exposure is a follow-up.
+const STORAGE_MAX_KEYS: usize = 64;
+const STORAGE_MAX_KEY_BYTES: usize = 256;
+const STORAGE_MAX_VALUE_BYTES: usize = 64 * 1024;
 
 /// Shared, host-owned state behind the API: the plugin event bus and the
 /// profile whose session storage the API reads and writes. One per running
@@ -77,6 +89,20 @@ impl HostApiState {
     ) -> anyhow::Result<Self> {
         let schema = Schema::new("plugin_host")?;
         let conn = events::open(db_path, &schema)?;
+        // Plugin-private KV store (#2897): host-backed, namespaced by plugin
+        // id, lives alongside the event bus in the app dir (never the install
+        // dir, which an upgrade can replace). Retained on uninstall like
+        // `plugin_meta`, since it is cheap and reinstalling restores state.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS plugin_storage (
+                 plugin_id  TEXT NOT NULL,
+                 key        TEXT NOT NULL,
+                 value_json TEXT NOT NULL,
+                 updated_at INTEGER NOT NULL,
+                 PRIMARY KEY (plugin_id, key)
+             );",
+        )
+        .context("create plugin_storage table")?;
         Ok(Self {
             events: Mutex::new(conn),
             schema,
@@ -255,6 +281,26 @@ pub fn dispatch(
         "ui.notify" => {
             ctx.require(CAP_NOTIFICATIONS)?;
             ui_notify(state, ctx, params)
+        }
+        // Plugin-private storage (#2897). Namespaced by ctx.plugin_id only, so
+        // one plugin cannot reach another's keys; no user-facing capability
+        // beyond runtime.worker (which every worker holds), mirroring
+        // config.get's rationale.
+        "plugin.storage.get" => {
+            ctx.require(CAP_WORKER)?;
+            plugin_storage_get(state, ctx, params)
+        }
+        "plugin.storage.set" => {
+            ctx.require(CAP_WORKER)?;
+            plugin_storage_set(state, ctx, params)
+        }
+        "plugin.storage.cas" => {
+            ctx.require(CAP_WORKER)?;
+            plugin_storage_cas(state, ctx, params)
+        }
+        "plugin.storage.remove" => {
+            ctx.require(CAP_WORKER)?;
+            plugin_storage_remove(state, ctx, params)
         }
         other => Err(DispatchError::method_not_found(other)),
     }
@@ -545,6 +591,191 @@ fn config_get(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchE
     Ok(json!({ "value": value }))
 }
 
+/// Validate a storage key: non-empty and within the byte cap. The key is
+/// caller input, so a bad one is INVALID_PARAMS, not a host failure.
+fn storage_key(params: &Value) -> Result<String, DispatchError> {
+    let key = str_param(params, "key")?;
+    if key.is_empty() {
+        return Err(DispatchError::invalid_params(
+            "storage key must be non-empty",
+        ));
+    }
+    if key.len() > STORAGE_MAX_KEY_BYTES {
+        return Err(DispatchError::with_kind(
+            codes::FORBIDDEN,
+            "storage_quota_exceeded",
+            format!("storage key exceeds {STORAGE_MAX_KEY_BYTES} bytes"),
+        ));
+    }
+    Ok(key.to_string())
+}
+
+/// Serialize a storage value and enforce the size cap.
+fn storage_value(params: &Value) -> Result<String, DispatchError> {
+    let value = params
+        .get("value")
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"value\""))?;
+    let json = serde_json::to_string(value)
+        .map_err(|e| DispatchError::invalid_params(format!("value is not serializable: {e}")))?;
+    if json.len() > STORAGE_MAX_VALUE_BYTES {
+        return Err(DispatchError::with_kind(
+            codes::FORBIDDEN,
+            "storage_quota_exceeded",
+            format!("storage value exceeds {STORAGE_MAX_VALUE_BYTES} bytes"),
+        ));
+    }
+    Ok(json)
+}
+
+fn plugin_storage_get(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let key = storage_key(params)?;
+    let conn = state.events.lock().expect("events mutex poisoned");
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT value_json FROM plugin_storage WHERE plugin_id = ?1 AND key = ?2",
+            rusqlite::params![ctx.plugin_id, key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let value = decode_stored(stored)?;
+    Ok(json!({ "value": value }))
+}
+
+fn plugin_storage_set(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let key = storage_key(params)?;
+    let value_json = storage_value(params)?;
+    let now = chrono::Utc::now().timestamp_millis();
+    let conn = state.events.lock().expect("events mutex poisoned");
+    enforce_key_quota(&conn, &ctx.plugin_id, &key)?;
+    conn.execute(
+        "INSERT INTO plugin_storage (plugin_id, key, value_json, updated_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT (plugin_id, key) DO UPDATE SET value_json = ?3, updated_at = ?4",
+        rusqlite::params![ctx.plugin_id, key, value_json, now],
+    )
+    .map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({}))
+}
+
+fn plugin_storage_cas(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let key = storage_key(params)?;
+    let value_json = storage_value(params)?;
+    let expected = params.get("expected").cloned().unwrap_or(Value::Null);
+    let now = chrono::Utc::now().timestamp_millis();
+    let mut conn = state.events.lock().expect("events mutex poisoned");
+    // One transaction so the read-compare-write cannot interleave with
+    // another worker task's storage call.
+    let tx = conn
+        .transaction()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let stored: Option<String> = tx
+        .query_row(
+            "SELECT value_json FROM plugin_storage WHERE plugin_id = ?1 AND key = ?2",
+            rusqlite::params![ctx.plugin_id, key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let current = decode_stored(stored)?;
+    if current != expected {
+        return Ok(json!({ "swapped": false, "current": current }));
+    }
+    enforce_key_quota_tx(&tx, &ctx.plugin_id, &key)?;
+    tx.execute(
+        "INSERT INTO plugin_storage (plugin_id, key, value_json, updated_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT (plugin_id, key) DO UPDATE SET value_json = ?3, updated_at = ?4",
+        rusqlite::params![ctx.plugin_id, key, value_json, now],
+    )
+    .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let new_value: Value =
+        serde_json::from_str(&value_json).map_err(|e| DispatchError::internal(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "swapped": true, "current": new_value }))
+}
+
+fn plugin_storage_remove(
+    state: &HostApiState,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let key = storage_key(params)?;
+    let conn = state.events.lock().expect("events mutex poisoned");
+    let removed = conn
+        .execute(
+            "DELETE FROM plugin_storage WHERE plugin_id = ?1 AND key = ?2",
+            rusqlite::params![ctx.plugin_id, key],
+        )
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "removed": removed > 0 }))
+}
+
+/// Decode a stored value_json cell into JSON. A corrupt row is a host bug,
+/// not caller input.
+fn decode_stored(stored: Option<String>) -> Result<Value, DispatchError> {
+    match stored {
+        Some(json) => {
+            serde_json::from_str(&json).map_err(|e| DispatchError::internal(e.to_string()))
+        }
+        None => Ok(Value::Null),
+    }
+}
+
+/// Refuse a set/cas that would create a NEW key past the per-plugin key cap.
+/// Overwriting an existing key is always allowed.
+fn enforce_key_quota(conn: &Connection, plugin_id: &str, key: &str) -> Result<(), DispatchError> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM plugin_storage WHERE plugin_id = ?1 AND key = ?2",
+            rusqlite::params![plugin_id, key],
+            |_| Ok(()),
+        )
+        .optional()
+        .map_err(|e| DispatchError::internal(e.to_string()))?
+        .is_some();
+    if exists {
+        return Ok(());
+    }
+    let count: usize = conn
+        .query_row(
+            "SELECT COUNT(*) FROM plugin_storage WHERE plugin_id = ?1",
+            rusqlite::params![plugin_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|e| DispatchError::internal(e.to_string()))? as usize;
+    if count >= STORAGE_MAX_KEYS {
+        return Err(DispatchError::with_kind(
+            codes::FORBIDDEN,
+            "storage_quota_exceeded",
+            format!("plugin storage is limited to {STORAGE_MAX_KEYS} keys"),
+        ));
+    }
+    Ok(())
+}
+
+/// Same key-count quota check inside an open transaction.
+fn enforce_key_quota_tx(
+    tx: &rusqlite::Transaction<'_>,
+    plugin_id: &str,
+    key: &str,
+) -> Result<(), DispatchError> {
+    enforce_key_quota(tx, plugin_id, key)
+}
+
 /// Parse the `slot` param into a typed [`UiSlot`]. An unknown slot is bad
 /// input, not a host failure.
 fn parse_ui_slot(params: &Value) -> Result<UiSlot, DispatchError> {
@@ -717,6 +948,171 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, codes::FORBIDDEN);
+    }
+
+    fn ctx_for(plugin_id: &str, caps: &[&str]) -> PluginRpcContext {
+        PluginRpcContext {
+            plugin_id: plugin_id.to_string(),
+            granted_capabilities: caps.iter().map(|c| c.to_string()).collect(),
+            ui_contributions: HashSet::new(),
+            ui_generation: 0,
+        }
+    }
+
+    #[test]
+    fn plugin_storage_roundtrip_namespace_and_persistence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cron = ctx_for("cron", &[CAP_WORKER]);
+        let other = ctx_for("other", &[CAP_WORKER]);
+        {
+            let state = state(tmp.path());
+            // Absent key reads Null.
+            let got = dispatch(
+                &state,
+                &cron,
+                "plugin.storage.get",
+                &json!({"key": "watermark"}),
+            )
+            .unwrap();
+            assert_eq!(got, json!({ "value": Value::Null }));
+
+            dispatch(
+                &state,
+                &cron,
+                "plugin.storage.set",
+                &json!({"key": "watermark", "value": {"seq": 7}}),
+            )
+            .unwrap();
+            let got = dispatch(
+                &state,
+                &cron,
+                "plugin.storage.get",
+                &json!({"key": "watermark"}),
+            )
+            .unwrap();
+            assert_eq!(got, json!({ "value": {"seq": 7} }));
+
+            // Another plugin sharing the same key sees its own (absent) value:
+            // the namespace is the plugin id, not addressable from the payload.
+            let got = dispatch(
+                &state,
+                &other,
+                "plugin.storage.get",
+                &json!({"key": "watermark"}),
+            )
+            .unwrap();
+            assert_eq!(got, json!({ "value": Value::Null }));
+
+            let removed = dispatch(
+                &state,
+                &cron,
+                "plugin.storage.remove",
+                &json!({"key": "watermark"}),
+            )
+            .unwrap();
+            assert_eq!(removed, json!({ "removed": true }));
+            dispatch(
+                &state,
+                &cron,
+                "plugin.storage.set",
+                &json!({"key": "watermark", "value": "kept"}),
+            )
+            .unwrap();
+        }
+        // Reopen the store (daemon restart): the value survives.
+        let state = state(tmp.path());
+        let got = dispatch(
+            &state,
+            &cron,
+            "plugin.storage.get",
+            &json!({"key": "watermark"}),
+        )
+        .unwrap();
+        assert_eq!(got, json!({ "value": "kept" }));
+    }
+
+    #[test]
+    fn plugin_storage_cas_swaps_only_on_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_WORKER]);
+
+        // CAS from absent (expected null) creates the key.
+        let out = dispatch(
+            &state,
+            &c,
+            "plugin.storage.cas",
+            &json!({"key": "k", "expected": null, "value": 1}),
+        )
+        .unwrap();
+        assert_eq!(out, json!({ "swapped": true, "current": 1 }));
+
+        // Wrong expected: no swap, returns the actual current value.
+        let out = dispatch(
+            &state,
+            &c,
+            "plugin.storage.cas",
+            &json!({"key": "k", "expected": 99, "value": 2}),
+        )
+        .unwrap();
+        assert_eq!(out, json!({ "swapped": false, "current": 1 }));
+
+        // Matching expected swaps.
+        let out = dispatch(
+            &state,
+            &c,
+            "plugin.storage.cas",
+            &json!({"key": "k", "expected": 1, "value": 2}),
+        )
+        .unwrap();
+        assert_eq!(out, json!({ "swapped": true, "current": 2 }));
+    }
+
+    #[test]
+    fn plugin_storage_enforces_quotas() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_WORKER]);
+
+        // Value size cap.
+        let big = "x".repeat(STORAGE_MAX_VALUE_BYTES + 1);
+        let err = dispatch(
+            &state,
+            &c,
+            "plugin.storage.set",
+            &json!({"key": "k", "value": big}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+        assert_eq!(err.data.as_ref().unwrap()["kind"], "storage_quota_exceeded");
+
+        // Key-count cap: fill to the limit, then a NEW key is refused but an
+        // overwrite of an existing key still succeeds.
+        for i in 0..STORAGE_MAX_KEYS {
+            dispatch(
+                &state,
+                &c,
+                "plugin.storage.set",
+                &json!({"key": format!("k{i}"), "value": i}),
+            )
+            .unwrap();
+        }
+        let err = dispatch(
+            &state,
+            &c,
+            "plugin.storage.set",
+            &json!({"key": "overflow", "value": 1}),
+        )
+        .unwrap_err();
+        assert_eq!(err.data.as_ref().unwrap()["kind"], "storage_quota_exceeded");
+        // Overwriting an existing key is always allowed.
+        dispatch(
+            &state,
+            &c,
+            "plugin.storage.set",
+            &json!({"key": "k0", "value": "updated"}),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -126,14 +126,16 @@ impl HostApiState {
     /// Bump and return the settings revision. Called by the settings write
     /// path so the next `config.get` reflects the change.
     pub fn bump_settings_revision(&self) -> u64 {
+        // Release so a reader that observes the new revision with Acquire also
+        // sees the settings write that preceded the bump.
         self.settings_revision
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .fetch_add(1, std::sync::atomic::Ordering::Release)
             + 1
     }
 
     fn settings_revision(&self) -> u64 {
         self.settings_revision
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Register a freshly spawned worker's UI generation. The supervisor threads
@@ -599,23 +601,35 @@ fn config_get(
     params: &Value,
 ) -> Result<Value, DispatchError> {
     let key = str_param(params, "key")?;
-    let config =
-        crate::session::Config::load().map_err(|e| DispatchError::internal(e.to_string()))?;
-    let value = match config
-        .plugins
-        .get(&ctx.plugin_id)
-        .and_then(|plugin| plugin.settings.get(key))
-    {
-        // The stored value is TOML; hand it back to the worker as JSON.
-        Some(toml_value) => {
-            serde_json::to_value(toml_value).map_err(|e| DispatchError::internal(e.to_string()))?
+    // Read the revision before and after loading so a settings write that lands
+    // mid-load cannot pair a stale value with the new revision; retry when a
+    // bump slips in between (#2897). A worker reacting to a
+    // `plugin.settings.changed` event uses the returned revision to tell whether
+    // this fetch already reflects it, so the pair must be consistent.
+    // ponytail: settings writes are rare human actions, so a few retries is
+    // ample; the bound just stops a pathological write storm from spinning.
+    let mut value = Value::Null;
+    let mut revision = state.settings_revision();
+    for _ in 0..8 {
+        let rev_before = revision;
+        let config =
+            crate::session::Config::load().map_err(|e| DispatchError::internal(e.to_string()))?;
+        value = match config
+            .plugins
+            .get(&ctx.plugin_id)
+            .and_then(|plugin| plugin.settings.get(key))
+        {
+            // The stored value is TOML; hand it back to the worker as JSON.
+            Some(toml_value) => serde_json::to_value(toml_value)
+                .map_err(|e| DispatchError::internal(e.to_string()))?,
+            None => Value::Null,
+        };
+        revision = state.settings_revision();
+        if revision == rev_before {
+            break;
         }
-        None => Value::Null,
-    };
-    // Return the current settings revision (#2897) so a worker reacting to a
-    // `plugin.settings.changed` event can tell whether this fetch already
-    // reflects it.
-    Ok(json!({ "value": value, "revision": state.settings_revision() }))
+    }
+    Ok(json!({ "value": value, "revision": revision }))
 }
 
 /// Validate a storage key: non-empty and within the byte cap. The key is

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -700,7 +700,13 @@ fn plugin_storage_cas(
 ) -> Result<Value, DispatchError> {
     let key = storage_key(params)?;
     let value_json = storage_value(params)?;
-    let expected = params.get("expected").cloned().unwrap_or(Value::Null);
+    // `expected` is required: defaulting an omitted field to null would turn a
+    // malformed request into a silent create-if-absent. A caller wanting that
+    // passes `expected: null` explicitly.
+    let expected = params
+        .get("expected")
+        .cloned()
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"expected\""))?;
     let now = chrono::Utc::now().timestamp_millis();
     let mut conn = state.events.lock().expect("events mutex poisoned");
     // One transaction so the read-compare-write cannot interleave with
@@ -1093,6 +1099,16 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out, json!({ "swapped": true, "current": 2 }));
+
+        // Omitting `expected` is a malformed request, not a create-if-absent.
+        let err = dispatch(
+            &state,
+            &c,
+            "plugin.storage.cas",
+            &json!({"key": "k", "value": 3}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::INVALID_PARAMS);
     }
 
     #[test]

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -674,7 +674,7 @@ fn plugin_storage_get(
     params: &Value,
 ) -> Result<Value, DispatchError> {
     let key = storage_key(params)?;
-    let conn = state.events.lock().expect("events mutex poisoned");
+    let conn = state.events.lock().unwrap_or_else(|p| p.into_inner());
     let stored: Option<String> = conn
         .query_row(
             "SELECT value_json FROM plugin_storage WHERE plugin_id = ?1 AND key = ?2",
@@ -695,7 +695,7 @@ fn plugin_storage_set(
     let key = storage_key(params)?;
     let value_json = storage_value(params)?;
     let now = chrono::Utc::now().timestamp_millis();
-    let conn = state.events.lock().expect("events mutex poisoned");
+    let conn = state.events.lock().unwrap_or_else(|p| p.into_inner());
     enforce_key_quota(&conn, &ctx.plugin_id, &key)?;
     conn.execute(
         "INSERT INTO plugin_storage (plugin_id, key, value_json, updated_at)
@@ -722,7 +722,7 @@ fn plugin_storage_cas(
         .cloned()
         .ok_or_else(|| DispatchError::invalid_params("missing param \"expected\""))?;
     let now = chrono::Utc::now().timestamp_millis();
-    let mut conn = state.events.lock().expect("events mutex poisoned");
+    let mut conn = state.events.lock().unwrap_or_else(|p| p.into_inner());
     // One transaction so the read-compare-write cannot interleave with
     // another worker task's storage call.
     let tx = conn
@@ -761,7 +761,7 @@ fn plugin_storage_remove(
     params: &Value,
 ) -> Result<Value, DispatchError> {
     let key = storage_key(params)?;
-    let conn = state.events.lock().expect("events mutex poisoned");
+    let conn = state.events.lock().unwrap_or_else(|p| p.into_inner());
     let removed = conn
         .execute(
             "DELETE FROM plugin_storage WHERE plugin_id = ?1 AND key = ?2",

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -142,8 +142,9 @@ pub struct PluginRpcContext {
 }
 
 impl PluginRpcContext {
-    /// Refuse the call unless the plugin holds `capability`.
-    fn require(&self, capability: &str) -> Result<(), DispatchError> {
+    /// Refuse the call unless the plugin holds `capability`. Shared with the
+    /// async session RPC module, hence pub(crate).
+    pub(crate) fn require(&self, capability: &str) -> Result<(), DispatchError> {
         if self.granted_capabilities.iter().any(|c| c == capability) {
             Ok(())
         } else {
@@ -153,35 +154,54 @@ impl PluginRpcContext {
                     "plugin {} did not declare or was not granted capability {capability:?}",
                     self.plugin_id
                 ),
+                data: Some(serde_json::json!({
+                    "kind": "capability_missing",
+                    "required_capability": capability,
+                })),
             })
         }
     }
 }
 
-/// A failed dispatch, carrying the JSON-RPC error code and message to return.
+/// A failed dispatch, carrying the JSON-RPC error code, diagnostic message,
+/// and optional structured `data` (whose `kind` field is the stable
+/// machine-readable contract) to return.
 #[derive(Debug)]
 pub struct DispatchError {
     pub code: i64,
     pub message: String,
+    pub data: Option<Value>,
 }
 
 impl DispatchError {
-    fn invalid_params(msg: impl Into<String>) -> Self {
+    pub(crate) fn invalid_params(msg: impl Into<String>) -> Self {
         Self {
             code: codes::INVALID_PARAMS,
             message: msg.into(),
+            data: None,
         }
     }
-    fn internal(msg: impl Into<String>) -> Self {
+    pub(crate) fn internal(msg: impl Into<String>) -> Self {
         Self {
             code: codes::INTERNAL_ERROR,
             message: msg.into(),
+            data: None,
         }
     }
     fn method_not_found(method: &str) -> Self {
         Self {
             code: codes::METHOD_NOT_FOUND,
             message: format!("unknown method {method:?}"),
+            data: None,
+        }
+    }
+
+    /// An error whose `data.kind` is part of the stable plugin API (#2897).
+    pub(crate) fn with_kind(code: i64, kind: &str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: Some(serde_json::json!({ "kind": kind })),
         }
     }
 }
@@ -544,10 +564,12 @@ fn ui_dispatch_error(e: UiError) -> DispatchError {
         UiError::QuotaExceeded => DispatchError {
             code: codes::FORBIDDEN,
             message: "plugin UI-state quota exceeded".into(),
+            data: None,
         },
         UiError::StaleWorker => DispatchError {
             code: codes::FORBIDDEN,
             message: "worker generation is no longer active".into(),
+            data: None,
         },
     }
 }
@@ -569,6 +591,7 @@ fn require_declared_slot(
                 "plugin {} did not declare ui slot {slot:?} with id {id:?}",
                 ctx.plugin_id
             ),
+            data: None,
         })
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -24,6 +24,8 @@ pub mod view;
 // store and session storage it serves over the capability-gated API live. A
 // TUI-only build has no host, so these modules are gated with it.
 #[cfg(feature = "serve")]
+pub(crate) mod automation_policy;
+#[cfg(feature = "serve")]
 pub mod host;
 #[cfg(feature = "serve")]
 pub mod host_api;
@@ -31,6 +33,8 @@ pub mod host_api;
 pub mod protocol;
 #[cfg(feature = "serve")]
 pub mod sandbox;
+#[cfg(feature = "serve")]
+pub mod session_api;
 #[cfg(feature = "serve")]
 pub mod ui_state;
 

--- a/src/plugin/protocol.rs
+++ b/src/plugin/protocol.rs
@@ -25,6 +25,19 @@ pub mod codes {
     pub const INTERNAL_ERROR: i64 = -32603;
     /// Capability not declared or not granted for the calling plugin.
     pub const FORBIDDEN: i64 = -32001;
+    /// The request is authorized capability-wise but denied by host policy
+    /// (e.g. an unattended mode without the `session.unattended` grant).
+    pub const POLICY_DENIED: i64 = -32002;
+    /// The request conflicts with existing state (idempotency-key reuse
+    /// with a different payload).
+    pub const CONFLICT: i64 = -32003;
+    /// A rolling-window rate or concurrency limit was exceeded.
+    pub const RATE_LIMITED: i64 = -32004;
+    /// A precondition the plugin cannot fix by retrying as-is (untrusted
+    /// repository, undiscovered catalog, failed mode application).
+    pub const FAILED_PRECONDITION: i64 = -32005;
+    /// The host cannot serve the request right now; retryable.
+    pub const SERVICE_UNAVAILABLE: i64 = -32006;
 }
 
 /// One inbound request from a worker. `id` is absent for a notification.
@@ -78,11 +91,14 @@ pub struct RpcResponse {
     pub error: Option<RpcError>,
 }
 
-/// A JSON-RPC error object.
+/// A JSON-RPC error object. `data.kind` (when present) is the stable
+/// machine-readable contract; `message` is diagnostic prose and not stable.
 #[derive(Debug, Clone, Serialize)]
 pub struct RpcError {
     pub code: i64,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
 }
 
 impl RpcResponse {
@@ -96,6 +112,15 @@ impl RpcResponse {
     }
 
     pub fn error(id: Value, code: i64, message: impl Into<String>) -> Self {
+        Self::error_with_data(id, code, message, None)
+    }
+
+    pub fn error_with_data(
+        id: Value,
+        code: i64,
+        message: impl Into<String>,
+        data: Option<Value>,
+    ) -> Self {
         Self {
             jsonrpc: "2.0",
             id,
@@ -103,6 +128,7 @@ impl RpcResponse {
             error: Some(RpcError {
                 code,
                 message: message.into(),
+                data,
             }),
         }
     }

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -1,0 +1,452 @@
+//! Async worker RPC handlers for the session-driving plugin API (#2897):
+//! `acp.capabilities.get`, `sessions.create`, `sessions.turn.send`.
+//!
+//! These run on the async runtime (unlike the synchronous
+//! [`crate::plugin::host_api::dispatch`]) because they call into the shared
+//! [`SessionService`]. Authorization layers, in order: capability grants
+//! (connection context, never payload), host-side approval classification
+//! (`session.unattended` for unattended modes), automation policy limits,
+//! and the service's own invariants (repo trust fail-closed, plugin
+//! ownership on turn delivery, idempotency).
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use aoe_plugin_api::acp::{
+    AcpAgentCapability, AcpCapabilitiesResponse, AcpModeCapability, AcpModelCapability,
+    ApprovalClass, CatalogStatus,
+};
+use aoe_plugin_api::session::{SessionsCreateRequest, SessionsCreateResponse, TurnSendRequest};
+
+use crate::acp::option_catalog::{AgentOptionEntry, OptionCatalog};
+use crate::acp::state::ConfigOptionCategory;
+use crate::plugin::automation_policy::{classify_mode, AutomationPolicy, ModeDecision};
+use crate::plugin::host_api::{DispatchError, PluginRpcContext};
+use crate::plugin::protocol::codes;
+use crate::server::session_service::{
+    IdempotencyConflict, SendTurnError, SessionCaller, SessionService,
+};
+use crate::server::session_spawn::StructuredSessionSpec;
+
+const CAP_ACP_CAPABILITIES_READ: &str = "acp.capabilities.read";
+const CAP_SESSION_CREATE: &str = "session.create";
+const CAP_SESSION_PROMPT: &str = "session.prompt";
+const CAP_SESSION_UNATTENDED: &str = "session.unattended";
+
+/// Everything the session RPCs need, injected into the plugin host at
+/// construction (before any worker launches).
+pub struct SessionRpcDeps {
+    pub session_service: Arc<SessionService>,
+    pub policy: Arc<AutomationPolicy>,
+    /// The serving profile new sessions are created under.
+    pub profile: String,
+}
+
+/// Whether `method` belongs to this module's async dispatch.
+pub(crate) fn handles(method: &str) -> bool {
+    matches!(
+        method,
+        "acp.capabilities.get" | "sessions.create" | "sessions.turn.send"
+    )
+}
+
+pub(crate) async fn dispatch(
+    deps: &Arc<SessionRpcDeps>,
+    ctx: &PluginRpcContext,
+    method: &str,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    match method {
+        "acp.capabilities.get" => {
+            ctx.require(CAP_ACP_CAPABILITIES_READ)?;
+            capabilities_get().await
+        }
+        "sessions.create" => {
+            ctx.require(CAP_SESSION_CREATE)?;
+            sessions_create(deps, ctx, params).await
+        }
+        "sessions.turn.send" => {
+            ctx.require(CAP_SESSION_PROMPT)?;
+            sessions_turn_send(deps, ctx, params).await
+        }
+        other => Err(DispatchError::internal(format!(
+            "session_api routed unknown method {other:?}"
+        ))),
+    }
+}
+
+/// Merge the static agent registry with the last advertised option catalog
+/// into the stable public DTO. Pure reads; never launches an agent.
+async fn capabilities_get() -> Result<Value, DispatchError> {
+    let catalog = load_catalog().await;
+    let mut ids: Vec<String> = crate::acp::AgentRegistry::with_defaults()
+        .list()
+        .into_iter()
+        .map(|(name, _)| name.clone())
+        .collect();
+    for name in catalog.agents.keys() {
+        if !ids.contains(name) {
+            ids.push(name.clone());
+        }
+    }
+    ids.sort();
+
+    let agents = ids
+        .into_iter()
+        .map(|id| {
+            let entry = catalog.agents.get(&id);
+            let (catalog_status, catalog_updated_at) = match entry {
+                Some(e) => (CatalogStatus::Discovered, Some(e.updated_at.clone())),
+                None => (CatalogStatus::Undiscovered, None),
+            };
+            let mut models: Vec<AcpModelCapability> = entry
+                .map(|e| {
+                    choices(e, ConfigOptionCategory::Model)
+                        .map(|choice| AcpModelCapability {
+                            id: choice.value.clone(),
+                            display_name: choice.name.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            models.sort_by(|a, b| a.id.cmp(&b.id));
+            let mut modes: Vec<AcpModeCapability> = entry
+                .map(|e| {
+                    choices(e, ConfigOptionCategory::Mode)
+                        .map(|choice| AcpModeCapability {
+                            id: choice.value.clone(),
+                            display_name: choice.name.clone(),
+                            approval_class: match classify_mode(&id, Some(&choice.value), entry) {
+                                ModeDecision::Class(class) => class,
+                                // Advertised modes always classify; fail
+                                // closed if that invariant ever breaks.
+                                _ => ApprovalClass::Unattended,
+                            },
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            modes.sort_by(|a, b| a.id.cmp(&b.id));
+            AcpAgentCapability {
+                // The registry has no display metadata; the id doubles as
+                // the display name until it grows one.
+                display_name: id.clone(),
+                id,
+                catalog_status,
+                catalog_updated_at,
+                models,
+                modes,
+            }
+        })
+        .collect();
+
+    serde_json::to_value(AcpCapabilitiesResponse { agents })
+        .map_err(|e| DispatchError::internal(format!("serialize capabilities: {e}")))
+}
+
+fn choices(
+    entry: &AgentOptionEntry,
+    category: ConfigOptionCategory,
+) -> impl Iterator<Item = &crate::acp::state::ConfigOptionChoice> {
+    entry
+        .options
+        .iter()
+        .filter(move |opt| opt.category == category)
+        .flat_map(|opt| opt.options.iter())
+}
+
+async fn load_catalog() -> OptionCatalog {
+    tokio::task::spawn_blocking(crate::acp::option_catalog::load)
+        .await
+        .unwrap_or_default()
+}
+
+async fn sessions_create(
+    deps: &Arc<SessionRpcDeps>,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let req: SessionsCreateRequest = serde_json::from_value(params.clone())
+        .map_err(|e| DispatchError::invalid_params(format!("sessions.create params: {e}")))?;
+    let plugin_id = ctx.plugin_id.clone();
+
+    let outcome = admit_and_create(deps, ctx, &plugin_id, req).await;
+    match &outcome {
+        Ok(resp) => deps.policy.audit(
+            &plugin_id,
+            serde_json::json!({
+                "op": "sessions.create",
+                "decision": "ok",
+                "session": resp.session_id,
+                "created": resp.created,
+            }),
+        ),
+        Err(e) => deps.policy.audit(
+            &plugin_id,
+            serde_json::json!({
+                "op": "sessions.create",
+                "decision": "denied",
+                "code": e.code,
+                "kind": e.data.as_ref().and_then(|d| d.get("kind")).cloned(),
+            }),
+        ),
+    }
+    let resp = outcome?;
+    serde_json::to_value(resp)
+        .map_err(|e| DispatchError::internal(format!("serialize create response: {e}")))
+}
+
+async fn admit_and_create(
+    deps: &Arc<SessionRpcDeps>,
+    ctx: &PluginRpcContext,
+    plugin_id: &str,
+    req: SessionsCreateRequest,
+) -> Result<SessionsCreateResponse, DispatchError> {
+    let catalog = load_catalog().await;
+    let entry = catalog.agents.get(&req.agent_id);
+
+    // Agent must be a registry agent or one the catalog has observed.
+    let known_agent = crate::acp::AgentRegistry::with_defaults()
+        .get(&req.agent_id)
+        .is_some()
+        || entry.is_some();
+    if !known_agent {
+        return Err(DispatchError::with_kind(
+            codes::INVALID_PARAMS,
+            "unknown_agent",
+            format!("unknown agent {:?}", req.agent_id),
+        ));
+    }
+
+    // Host-side approval classification; the plugin cannot self-label.
+    let class = match classify_mode(&req.agent_id, req.mode_id.as_deref(), entry) {
+        ModeDecision::Class(class) => class,
+        ModeDecision::UnknownMode => {
+            return Err(DispatchError::with_kind(
+                codes::INVALID_PARAMS,
+                "unknown_mode",
+                format!(
+                    "mode {:?} is neither known to the host nor advertised by {:?}",
+                    req.mode_id.as_deref().unwrap_or_default(),
+                    req.agent_id
+                ),
+            ));
+        }
+        ModeDecision::CatalogNotDiscovered => {
+            return Err(DispatchError::with_kind(
+                codes::FAILED_PRECONDITION,
+                "catalog_not_discovered",
+                format!(
+                    "agent {:?} has not advertised its options yet; run it once or omit mode_id",
+                    req.agent_id
+                ),
+            ));
+        }
+    };
+    if class == ApprovalClass::Unattended && ctx.require(CAP_SESSION_UNATTENDED).is_err() {
+        return Err(DispatchError {
+            code: codes::POLICY_DENIED,
+            message: format!(
+                "mode {:?} is classified unattended and needs the session.unattended grant",
+                req.mode_id.as_deref().unwrap_or_default()
+            ),
+            data: Some(serde_json::json!({
+                "kind": "unattended_grant_required",
+                "required_capability": CAP_SESSION_UNATTENDED,
+                "agent_id": req.agent_id,
+                "mode_id": req.mode_id,
+                "approval_class": "unattended",
+            })),
+        });
+    }
+
+    // Model must be advertised when the catalog is discovered; with an
+    // undiscovered catalog it passes through and the adapter arbitrates.
+    if let (Some(model), Some(entry)) = (req.model_id.as_deref(), entry) {
+        let advertised = entry.options.iter().any(|opt| {
+            opt.category == ConfigOptionCategory::Model
+                && opt.options.iter().any(|c| c.value == model)
+        });
+        if !advertised {
+            return Err(DispatchError::with_kind(
+                codes::INVALID_PARAMS,
+                "unknown_model",
+                format!("model {model:?} is not advertised by {:?}", req.agent_id),
+            ));
+        }
+    }
+
+    if req.initial_turn.is_some() {
+        ctx.require(CAP_SESSION_PROMPT)?;
+    }
+
+    // Canonicalize immediately before the trust-checked spawn; a dangling
+    // path is the caller's error. Repo trust itself is enforced inside the
+    // service, fail-closed for plugin callers.
+    let project_path = std::fs::canonicalize(&req.project_path)
+        .map_err(|e| {
+            DispatchError::invalid_params(format!("project_path {:?}: {e}", req.project_path))
+        })?
+        .to_string_lossy()
+        .into_owned();
+
+    let active_sessions = {
+        let instances = deps.session_service.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| {
+                i.created_by_plugin.as_deref() == Some(plugin_id)
+                    && !i.is_archived()
+                    && !i.is_snoozed()
+                    && !i.is_trashed()
+            })
+            .count()
+    };
+    // Held until the create resolves so concurrent different-key creates
+    // cannot overshoot the cap.
+    let _reservation = deps.policy.admit_create(plugin_id, active_sessions)?;
+
+    let spec = StructuredSessionSpec {
+        title: req.title,
+        path: project_path,
+        group: req.group.unwrap_or_default(),
+        tool: req.agent_id.clone(),
+        worktree_enabled: false,
+        worktree_branch: None,
+        create_new_branch: false,
+        base_branch: None,
+        sandbox: false,
+        sandbox_image: None,
+        yolo_mode: false,
+        extra_env: Vec::new(),
+        extra_args: String::new(),
+        command_override: String::new(),
+        extra_repo_paths: Vec::new(),
+        scratch: false,
+        // The service forces this to Some(false) for plugin callers; set
+        // explicitly anyway so the intent is local.
+        trust_hooks: Some(false),
+        custom_instruction: None,
+        profile: deps.profile.clone(),
+        created_by_plugin: None,
+        plugin_create_idempotency: None,
+        pending_initial_turn: None,
+        acp_mode_id: req.mode_id.clone(),
+        view: crate::session::View::Structured,
+        agent_name: None,
+        agent_model: req.model_id.clone(),
+        agent_effort: None,
+        import_acp_session_id: None,
+        fork_seed: None,
+    };
+
+    let initial_turn_text = req.initial_turn.as_ref().map(|t| t.text.as_str());
+    let (outcome, created) = deps
+        .session_service
+        .create_structured_session(
+            spec,
+            Some(plugin_id),
+            req.idempotency_key.as_deref(),
+            initial_turn_text,
+        )
+        .await
+        .map_err(map_create_error)?;
+
+    Ok(SessionsCreateResponse {
+        session_id: outcome.instance.id,
+        created,
+    })
+}
+
+fn map_create_error(e: anyhow::Error) -> DispatchError {
+    if let Some(conflict) = e.downcast_ref::<IdempotencyConflict>() {
+        return DispatchError::with_kind(
+            codes::CONFLICT,
+            "idempotency_conflict",
+            conflict.to_string(),
+        );
+    }
+    if e.downcast_ref::<crate::server::api::sessions::HooksNeedTrust>()
+        .is_some()
+    {
+        return DispatchError::with_kind(
+            codes::FAILED_PRECONDITION,
+            "repo_untrusted",
+            "the repository's hooks need user approval; a plugin cannot grant trust",
+        );
+    }
+    DispatchError::internal(format!("session create failed: {e:#}"))
+}
+
+async fn sessions_turn_send(
+    deps: &Arc<SessionRpcDeps>,
+    ctx: &PluginRpcContext,
+    params: &Value,
+) -> Result<Value, DispatchError> {
+    let req: TurnSendRequest = serde_json::from_value(params.clone())
+        .map_err(|e| DispatchError::invalid_params(format!("sessions.turn.send params: {e}")))?;
+    let plugin_id = ctx.plugin_id.clone();
+
+    let result = async {
+        deps.policy.admit_turn(&plugin_id)?;
+        deps.session_service
+            .send_turn(
+                &SessionCaller::Plugin {
+                    plugin_id: plugin_id.clone(),
+                },
+                &req.session_id,
+                &req.text,
+                &[],
+                false,
+            )
+            .await
+            .map_err(map_send_error)
+    }
+    .await;
+
+    deps.policy.audit(
+        &plugin_id,
+        serde_json::json!({
+            "op": "sessions.turn.send",
+            "session": req.session_id,
+            "decision": if result.is_ok() { "ok" } else { "denied" },
+            "kind": result.as_ref().err().and_then(|e| {
+                e.data.as_ref().and_then(|d| d.get("kind")).cloned()
+            }),
+        }),
+    );
+    result?;
+    Ok(serde_json::json!({}))
+}
+
+fn map_send_error(e: SendTurnError) -> DispatchError {
+    match e {
+        SendTurnError::SessionNotFound => DispatchError::with_kind(
+            codes::INVALID_PARAMS,
+            "session_not_found",
+            "session not found",
+        ),
+        SendTurnError::NotOwner => DispatchError::with_kind(
+            codes::FORBIDDEN,
+            "not_owner",
+            "the session was not created by the calling plugin",
+        ),
+        SendTurnError::ModeApplication(e) => DispatchError::with_kind(
+            codes::FAILED_PRECONDITION,
+            "mode_application_failed",
+            format!("mode application failed: {e}"),
+        ),
+        SendTurnError::ResumeFailed(e) => DispatchError::with_kind(
+            codes::SERVICE_UNAVAILABLE,
+            "worker_not_ready",
+            format!("worker resume failed: {e}"),
+        ),
+        SendTurnError::WorkerNotReady => DispatchError::with_kind(
+            codes::SERVICE_UNAVAILABLE,
+            "worker_not_ready",
+            "worker not ready; retry",
+        ),
+        SendTurnError::Send(e) => DispatchError::internal(format!("prompt forward failed: {e}")),
+    }
+}

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -450,3 +450,140 @@ fn map_send_error(e: SendTurnError) -> DispatchError {
         SendTurnError::Send(e) => DispatchError::internal(format!("prompt forward failed: {e}")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::automation_policy::AutomationPolicy;
+    use crate::session::Instance;
+
+    fn ctx_with(caps: &[&str]) -> PluginRpcContext {
+        PluginRpcContext {
+            plugin_id: "cron".to_string(),
+            granted_capabilities: caps.iter().map(|c| c.to_string()).collect(),
+            ui_contributions: std::collections::HashSet::new(),
+            ui_generation: 1,
+        }
+    }
+
+    fn test_deps(prior: Vec<Instance>) -> (Arc<SessionRpcDeps>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_service = crate::server::test_support::build_test_app_state(prior)
+            .session_service
+            .clone();
+        let policy =
+            Arc::new(AutomationPolicy::open(&dir.path().join("plugin_events.db")).expect("policy"));
+        (
+            Arc::new(SessionRpcDeps {
+                session_service,
+                policy,
+                profile: "test".to_string(),
+            }),
+            dir,
+        )
+    }
+
+    fn kind(e: &DispatchError) -> String {
+        e.data
+            .as_ref()
+            .and_then(|d| d.get("kind"))
+            .and_then(|k| k.as_str())
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    /// Every method refuses a caller missing its gating capability, before
+    /// touching any state.
+    #[tokio::test]
+    async fn authz_matrix_capability_gates() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let none = ctx_with(&[]);
+        for method in [
+            "acp.capabilities.get",
+            "sessions.create",
+            "sessions.turn.send",
+        ] {
+            let err = dispatch(&deps, &none, method, &serde_json::json!({}))
+                .await
+                .expect_err("must be refused without the capability");
+            assert_eq!(err.code, codes::FORBIDDEN, "{method}");
+            assert_eq!(kind(&err), "capability_missing", "{method}");
+        }
+        // The wrong capability does not substitute for the right one.
+        let wrong = ctx_with(&["session.prompt"]);
+        let err = dispatch(&deps, &wrong, "sessions.create", &serde_json::json!({}))
+            .await
+            .expect_err("session.prompt must not grant sessions.create");
+        assert_eq!(err.code, codes::FORBIDDEN);
+    }
+
+    /// An unattended-classified mode needs the distinct session.unattended
+    /// grant; session.create alone is refused with the stable policy kind.
+    /// Uses a trusted-table bypass id so the decision is catalog-independent.
+    #[tokio::test]
+    async fn unattended_mode_requires_the_distinct_grant() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let params = serde_json::json!({
+            "agent_id": "claude",
+            "project_path": "/tmp",
+            "mode_id": "bypassPermissions",
+        });
+        let ctx = ctx_with(&["session.create"]);
+        let err = dispatch(&deps, &ctx, "sessions.create", &params)
+            .await
+            .expect_err("unattended without the grant must be refused");
+        assert_eq!(err.code, codes::POLICY_DENIED);
+        assert_eq!(kind(&err), "unattended_grant_required");
+    }
+
+    /// A payload smuggling an unknown field (a would-be bypass flag) is
+    /// rejected at decode, before any capability-gated work.
+    #[tokio::test]
+    async fn create_rejects_unknown_payload_fields() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let ctx = ctx_with(&["session.create"]);
+        let err = dispatch(
+            &deps,
+            &ctx,
+            "sessions.create",
+            &serde_json::json!({
+                "agent_id": "claude",
+                "project_path": "/tmp",
+                "allow_untrusted": true,
+            }),
+        )
+        .await
+        .expect_err("unknown fields must be rejected");
+        assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    /// turn.send maps the service's ownership and existence denials to the
+    /// stable error kinds.
+    #[tokio::test]
+    async fn turn_send_maps_ownership_and_missing_session() {
+        let mut user_session = Instance::new("user-owned", "/tmp/aoe-2897-project");
+        user_session.id = "sess-user".to_string();
+        let mut other_session = Instance::new("other-owned", "/tmp/aoe-2897-project");
+        other_session.id = "sess-other".to_string();
+        other_session.created_by_plugin = Some("other-plugin".to_string());
+        let (deps, _dir) = test_deps(vec![user_session, other_session]);
+        let ctx = ctx_with(&["session.prompt"]);
+
+        for (session, expected_kind, expected_code) in [
+            ("sess-user", "not_owner", codes::FORBIDDEN),
+            ("sess-other", "not_owner", codes::FORBIDDEN),
+            ("sess-gone", "session_not_found", codes::INVALID_PARAMS),
+        ] {
+            let err = dispatch(
+                &deps,
+                &ctx,
+                "sessions.turn.send",
+                &serde_json::json!({ "session_id": session, "text": "hi" }),
+            )
+            .await
+            .expect_err("must be refused");
+            assert_eq!(err.code, expected_code, "{session}");
+            assert_eq!(kind(&err), expected_kind, "{session}");
+        }
+    }
+}

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -25,7 +25,7 @@ use crate::plugin::automation_policy::{classify_mode, AutomationPolicy, ModeDeci
 use crate::plugin::host_api::{DispatchError, PluginRpcContext};
 use crate::plugin::protocol::codes;
 use crate::server::session_service::{
-    IdempotencyConflict, SendTurnError, SessionCaller, SessionService,
+    CreateIdempotencyProbe, IdempotencyConflict, SendTurnError, SessionCaller, SessionService,
 };
 use crate::server::session_spawn::StructuredSessionSpec;
 
@@ -303,22 +303,6 @@ async fn admit_and_create(
         .to_string_lossy()
         .into_owned();
 
-    let active_sessions = {
-        let instances = deps.session_service.instances.read().await;
-        instances
-            .iter()
-            .filter(|i| {
-                i.created_by_plugin.as_deref() == Some(plugin_id)
-                    && !i.is_archived()
-                    && !i.is_snoozed()
-                    && !i.is_trashed()
-            })
-            .count()
-    };
-    // Held until the create resolves so concurrent different-key creates
-    // cannot overshoot the cap.
-    let _reservation = deps.policy.admit_create(plugin_id, active_sessions)?;
-
     let spec = StructuredSessionSpec {
         title: req.title,
         path: project_path,
@@ -343,7 +327,9 @@ async fn admit_and_create(
         profile: deps.profile.clone(),
         created_by_plugin: None,
         plugin_create_idempotency: None,
-        pending_initial_turn: None,
+        // Set here (not just inside the service) so the idempotency probe below
+        // hashes the same payload the create will.
+        pending_initial_turn: req.initial_turn.as_ref().map(|t| t.text.clone()),
         acp_mode_id: req.mode_id.clone(),
         view: crate::session::View::Structured,
         agent_name: None,
@@ -352,6 +338,43 @@ async fn admit_and_create(
         import_acp_session_id: None,
         fork_seed: None,
     };
+
+    // Resolve an idempotent replay/conflict BEFORE charging admission, so a
+    // retry after a lost response returns the prior result without consuming
+    // rate or concurrency capacity (#2897). A brand-new key falls through to
+    // the reservation and create below.
+    if let Some(key) = req.idempotency_key.as_deref() {
+        match deps
+            .session_service
+            .probe_plugin_create_idempotency(&spec, plugin_id, key)
+            .await
+        {
+            Ok(CreateIdempotencyProbe::Replay(instance)) => {
+                return Ok(SessionsCreateResponse {
+                    session_id: instance.id,
+                    created: false,
+                });
+            }
+            Ok(CreateIdempotencyProbe::New) => {}
+            Err(conflict) => return Err(map_create_error(anyhow::Error::new(conflict))),
+        }
+    }
+
+    let active_sessions = {
+        let instances = deps.session_service.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| {
+                i.created_by_plugin.as_deref() == Some(plugin_id)
+                    && !i.is_archived()
+                    && !i.is_snoozed()
+                    && !i.is_trashed()
+            })
+            .count()
+    };
+    // Held until the create resolves so concurrent different-key creates
+    // cannot overshoot the cap.
+    let _reservation = deps.policy.admit_create(plugin_id, active_sessions)?;
 
     let initial_turn_text = req.initial_turn.as_ref().map(|t| t.text.as_str());
     let (outcome, created) = deps
@@ -567,6 +590,38 @@ mod tests {
         .await
         .expect_err("unknown fields must be rejected");
         assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    /// A brand-new create at the active-session limit is denied with the stable
+    /// concurrency kind. The idempotency probe runs before admission (see
+    /// `admit_and_create`), so an idempotent retry replays instead of hitting
+    /// this path; the replay/conflict/new resolution itself is unit-tested in
+    /// `server::session_service::tests::probe_resolves_replay_conflict_and_new`.
+    #[tokio::test]
+    async fn create_at_concurrency_limit_denies_a_new_key() {
+        use crate::plugin::automation_policy::MAX_ACTIVE_PLUGIN_SESSIONS;
+        let prior: Vec<Instance> = (0..MAX_ACTIVE_PLUGIN_SESSIONS)
+            .map(|n| {
+                let mut i = Instance::new("scheduled", "/tmp/aoe-2897-project");
+                i.id = format!("sess-{n}");
+                i.created_by_plugin = Some("cron".to_string());
+                i
+            })
+            .collect();
+        let (deps, _dir) = test_deps(prior);
+        let ctx = ctx_with(&["session.create"]);
+        // "claude" with no mode classifies Interactive (reviewed adapter), so no
+        // unattended grant is needed and the request reaches the limit check.
+        let err = dispatch(
+            &deps,
+            &ctx,
+            "sessions.create",
+            &serde_json::json!({ "agent_id": "claude", "project_path": "/tmp" }),
+        )
+        .await
+        .expect_err("must be denied at the active-session limit");
+        assert_eq!(err.code, codes::RATE_LIMITED);
+        assert_eq!(kind(&err), "concurrency_limited");
     }
 
     /// turn.send maps the service's ownership and existence denials to the

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -3,7 +3,7 @@
 //!
 //! These run on the async runtime (unlike the synchronous
 //! [`crate::plugin::host_api::dispatch`]) because they call into the shared
-//! [`SessionService`]. Authorization layers, in order: capability grants
+//! `SessionService`. Authorization layers, in order: capability grants
 //! (connection context, never payload), host-side approval classification
 //! (`session.unattended` for unattended modes), automation policy limits,
 //! and the service's own invariants (repo trust fail-closed, plugin

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -51,6 +51,18 @@ pub(crate) fn handles(method: &str) -> bool {
     )
 }
 
+/// The base capability a session method requires. Exposed so the host can
+/// authorize before consulting the session dependencies, keeping the authz
+/// result identical whether or not the service happens to be wired up.
+pub(crate) fn required_capability(method: &str) -> Option<&'static str> {
+    match method {
+        "acp.capabilities.get" => Some(CAP_ACP_CAPABILITIES_READ),
+        "sessions.create" => Some(CAP_SESSION_CREATE),
+        "sessions.turn.send" => Some(CAP_SESSION_PROMPT),
+        _ => None,
+    }
+}
+
 pub(crate) async fn dispatch(
     deps: &Arc<SessionRpcDeps>,
     ctx: &PluginRpcContext,

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1301,7 +1301,7 @@ async fn build_spawn_request(
     // structured fork's first connect captured the child id, the handshake
     // must still send session/fork. It is cleared once the forked id lands
     // (Task 11), so a later reattach reads None and resumes normally.
-    let (cwd, seed_history_replay, fork_from) = {
+    let (cwd, seed_history_replay, fork_from, acp_mode_id) = {
         let _guard = inst_lock.lock().await;
         let instances = service.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == target.id) else {
@@ -1311,6 +1311,7 @@ async fn build_spawn_request(
             PathBuf::from(&inst.project_path),
             inst.import_pending == Some(true),
             inst.fork_pending.clone(),
+            inst.acp_mode_id.clone(),
         )
     };
     let agent = supervisor
@@ -1359,6 +1360,7 @@ async fn build_spawn_request(
         sandbox_info,
         source_profile: Some(target.source_profile.clone()),
         yolo_mode: target.yolo_mode,
+        acp_mode_id,
         agent_command_override: command_override_for_spawn(&target.tool, &target.command),
         seed_history_replay,
     })

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -27,6 +27,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 
+use super::session_service::SessionService;
 use super::AppState;
 
 /// Reconciler-side respawn budget. The reconciler is the only respawner
@@ -1179,7 +1180,7 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
         yolo_mode,
         command,
     };
-    let req = match build_spawn_request(&state, &resume_target).await {
+    let req = match build_spawn_request(&state.session_service, &resume_target).await {
         Ok(req) => req,
         Err(()) => return ResumeOutcome::SpawnFinished,
     };
@@ -1233,12 +1234,12 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
 /// reconciler's fresh-spawn fallback and the prompt-wake resume (#1748)
 /// so both paths build identical requests.
 async fn build_spawn_request(
-    state: &Arc<AppState>,
+    service: &Arc<SessionService>,
     target: &ResumeTarget,
 ) -> Result<crate::acp::supervisor::SpawnRequest, ()> {
-    let supervisor = Arc::clone(&state.acp_supervisor);
+    let supervisor = Arc::clone(&service.acp_supervisor);
 
-    let inst_lock = state.instance_lock(&target.id).await;
+    let inst_lock = service.instance_lock(&target.id).await;
     // Re-read project_path under the per-session lock instead of trusting
     // target.project_path, which the reconciler snapshotted up to a tick ago.
     // A tied-worktree rename (rename_session / set_worktree_name) holds this
@@ -1259,7 +1260,7 @@ async fn build_spawn_request(
     // (Task 11), so a later reattach reads None and resumes normally.
     let (cwd, seed_history_replay, fork_from) = {
         let _guard = inst_lock.lock().await;
-        let instances = state.instances.read().await;
+        let instances = service.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == target.id) else {
             return Err(());
         };
@@ -1278,7 +1279,7 @@ async fn build_spawn_request(
         )
         .await;
     let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
-        &state.instances,
+        &service.instances,
         &inst_lock,
         &target.id,
         false,
@@ -1344,8 +1345,11 @@ pub(crate) fn command_override_for_spawn(
 /// structured view session. `in_flight_turn` is always false: this is only used
 /// by the prompt-wake path (#1748), where the worker was idle-auto-stopped
 /// and is by definition not mid-turn.
-async fn resume_target_for_session(state: &Arc<AppState>, id: &str) -> Option<ResumeTarget> {
-    let instances = state.instances.read().await;
+async fn resume_target_for_session(
+    service: &Arc<SessionService>,
+    id: &str,
+) -> Option<ResumeTarget> {
+    let instances = service.instances.read().await;
     // Filter the same triage states the reconciler skips everywhere else.
     // The wake path drops `instance_lock` before calling this, so an archive
     // or snooze can win the race after dormancy was cleared; resolving to
@@ -1394,11 +1398,11 @@ pub(crate) enum ResumeTrigger {
 /// session, so there is no double-spawn. Returns `Err(CapacityFull)` when
 /// the worker cap is reached so the handler can surface 503. See #1748.
 pub(crate) async fn trigger_resume_background(
-    state: &Arc<AppState>,
+    service: &Arc<SessionService>,
     id: &str,
 ) -> Result<ResumeTrigger, crate::acp::supervisor::SupervisorError> {
     use crate::acp::supervisor::{ResumeKind, ResumeReservationOutcome};
-    let reservation = match state
+    let reservation = match service
         .acp_supervisor
         .begin_resume(id, ResumeKind::Spawn)
         .await?
@@ -1406,26 +1410,26 @@ pub(crate) async fn trigger_resume_background(
         ResumeReservationOutcome::Reserved(r) => r,
         ResumeReservationOutcome::AlreadyPresent => return Ok(ResumeTrigger::AlreadyResuming),
     };
-    let Some(target) = resume_target_for_session(state, id).await else {
+    let Some(target) = resume_target_for_session(service, id).await else {
         // Session vanished between the wake and this snapshot; drop the
         // reservation (RAII clears pending + notifies waiters) and report
         // nothing to do.
         drop(reservation);
         return Ok(ResumeTrigger::NotFound);
     };
-    let state = Arc::clone(state);
+    let service = Arc::clone(service);
     crate::task_util::spawn_supervised(
         "acp.prompt_wake_resume",
         crate::task_util::PanicPolicy::Log,
         async move {
-            let req = match build_spawn_request(&state, &target).await {
+            let req = match build_spawn_request(&service, &target).await {
                 // Sandbox failure already published a startup error; the
                 // reservation drops here and wakes any parked send_prompt.
                 Ok(req) => req,
                 Err(()) => return,
             };
             let agent = req.agent.clone();
-            if let Err(e) = state.acp_supervisor.spawn_inner(req, reservation).await {
+            if let Err(e) = service.acp_supervisor.spawn_inner(req, reservation).await {
                 // AlreadyRunning / SpawnCancelled are benign: a worker
                 // already exists or the session was intentionally torn
                 // down mid-handshake. Only surface real startup failures.
@@ -1434,7 +1438,7 @@ pub(crate) async fn trigger_resume_background(
                     crate::acp::supervisor::SupervisorError::AlreadyRunning(_)
                         | crate::acp::supervisor::SupervisorError::SpawnCancelled(_)
                 ) {
-                    let still_present = state
+                    let still_present = service
                         .instances
                         .read()
                         .await
@@ -1449,7 +1453,7 @@ pub(crate) async fn trigger_resume_background(
                             agent = %agent,
                             "prompt-wake spawn failed: {message}"
                         );
-                        state
+                        service
                             .acp_supervisor
                             .publish_startup_error(&target.id, message);
                     }
@@ -1616,7 +1620,7 @@ mod tests {
             command: String::new(),
         };
 
-        let req = build_spawn_request(&state, &target)
+        let req = build_spawn_request(&state.session_service, &target)
             .await
             .expect("spawn request builds for a non-sandboxed structured session");
         assert_eq!(

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -313,6 +313,13 @@ pub async fn reconcile_acp_workers(
     // skips every `attempted` id. See `readopt_orphan_runners`.
     readopt_orphan_runners(state, attempted).await;
 
+    // Retry owner for undelivered initial turns (#2897): a session persisted
+    // with `pending_initial_turn` whose create fast path did not deliver it
+    // (spawn failure, daemon restart, adopted runner) gets its turn drained
+    // here once a worker is live. Normally a no-op: pending turns exist only
+    // between a plugin create and its first successful delivery.
+    drain_pending_initial_turns(state).await;
+
     // Build the work list. Skip ids already in `attempted` (a
     // permanently-failing spawn shouldn't loop every tick) and ids the
     // supervisor already knows about (REST-triggered spawn or
@@ -1225,6 +1232,42 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
         }
     }
     ResumeOutcome::SpawnFinished
+}
+
+/// Spawn a detached drain for every session that still carries a persisted
+/// `pending_initial_turn` and has a live worker to receive it (#2897). The
+/// drain itself claims a per-session slot and runs under the instance lock,
+/// so overlapping ticks and the create fast path cannot double-deliver.
+/// Triaged sessions are skipped like everywhere else in the reconciler; the
+/// turn stays persisted and delivers if the session is ever un-triaged.
+async fn drain_pending_initial_turns(state: &Arc<AppState>) {
+    let candidates: Vec<String> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| {
+                i.pending_initial_turn.is_some()
+                    && i.is_structured()
+                    && !i.is_archived()
+                    && !i.is_snoozed()
+                    && !i.is_trashed()
+            })
+            .map(|i| i.id.clone())
+            .collect()
+    };
+    for id in candidates {
+        if !state.acp_supervisor.is_running(&id).await {
+            continue;
+        }
+        let service = Arc::clone(&state.session_service);
+        crate::task_util::spawn_supervised(
+            "acp.pending_initial_turn_drain",
+            crate::task_util::PanicPolicy::Log,
+            async move {
+                service.drain_pending_initial_turn(&id).await;
+            },
+        );
+    }
 }
 
 /// Build a fresh-spawn `SpawnRequest` for a resume target: pick the

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -23,6 +23,7 @@ use crate::acp::protocol::{
 };
 use crate::acp::state::{Event, PromptAttachmentKind, RateLimitInfo};
 use crate::acp::supervisor::SupervisorError;
+use crate::server::session_service::SendTurnError;
 use crate::server::AppState;
 
 /// Maximum attachments per prompt.
@@ -1175,78 +1176,62 @@ pub async fn acp_prompt(
         Ok(a) => a,
         Err((code, msg)) => return (code, msg).into_response(),
     };
-    // Resume a worker that is not currently live. Two cases:
-    //   - Idle-dormant wake: the worker was auto-stopped for inactivity
-    //     (#1689) and the reconciler will not respawn it until its next
-    //     ~2s tick.
-    //   - Dead worker: the worker exited for another reason (e.g. the
-    //     silent-orphan watchdog escalated a monitor / `/loop` turn) and
-    //     is neither dormant nor mid-respawn, so a send would otherwise
-    //     404 and force a manual `aoe acp restart`.
-    // Either way, reserve the resume slot synchronously and drive a fresh
-    // spawn in a detached task NOW so the `send_prompt` below blocks on
-    // `wait_for_worker` until the worker is live instead of racing ahead
-    // to a 404. The detached task survives this request being cancelled on
-    // client disconnect. `is_running` is true for a live or mid-respawn
-    // worker, so a healthy session never double-spawns. See #1748.
-    let needs_resume = woke_idle_dormant || !state.acp_supervisor.is_running(&id).await;
-    if needs_resume {
-        use crate::server::acp_reconciler::ResumeTrigger;
-        match crate::server::acp_reconciler::trigger_resume_background(&state.session_service, &id)
-            .await
-        {
-            Ok(ResumeTrigger::NotFound) => {
-                // The session was deleted (or triaged) between the wake and
-                // the resume snapshot. Do not publish into a session that no
-                // longer exists; a 404 is the honest answer, not a retryable
-                // worker_not_ready. See #1748.
-                return (StatusCode::NOT_FOUND, "session not found").into_response();
-            }
-            Ok(_) => {}
-            Err(SupervisorError::CapacityFull { current, limit }) => {
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!("worker_capacity_full ({current}/{limit})"),
-                )
-                    .into_response();
-            }
-            Err(e) => {
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!("worker_not_ready: {e}"),
-                )
-                    .into_response();
-            }
-        }
-    }
-    // Publish the user's prompt into the event stream BEFORE forwarding
-    // to the agent so the replay buffer / on-disk store captures it
-    // even if the agent forward fails. The frontend treats UserPromptSent
-    // as authoritative and dedupes against its own optimistic row.
-    state
-        .acp_supervisor
-        .publish_user_prompt_with_attachments(&id, req.text.clone(), &attachments)
+    // Resume + publish + forward all live in the shared service so the
+    // plugin host delivers turns through the same path (#2897).
+    let outcome = state
+        .session_service
+        .send_turn(&id, &req.text, &attachments, woke_idle_dormant)
         .await;
     // Smart-rename fires from `acp_event_listener` on the first clean
-    // `prompt_complete` `Event::Stopped` (turn-end), so the one-shot never
-    // races this handler's live worker for the provider API. See
-    // `session::smart_rename` and #2348.
-    match state
-        .acp_supervisor
-        .send_prompt(&id, &req.text, &attachments)
-        .await
-    {
+    // `prompt_complete` `Event::Stopped` by default (turn-end timing), so the
+    // one-shot never races this handler's live worker for the provider API.
+    // See `session::smart_rename` and #2348. A session on the opt-in
+    // `prompt_start` timing fires here instead, on the first prompt, so the
+    // sidebar retitles immediately; the cheap candidate gate keeps this a no-op
+    // for the turn-end default, and `try_smart_rename` re-checks timing and
+    // eligibility authoritatively (self-cancelling on a timing mismatch).
+    // Only fire once the prompt was actually published (a pre-publish error
+    // means nothing entered the transcript).
+    let published = !matches!(
+        outcome,
+        Err(SendTurnError::SessionNotFound | SendTurnError::ResumeFailed(_))
+    );
+    if published && crate::session::smart_rename::prompt_start_candidate(&state, &id).await {
+        let state_for_rename = state.clone();
+        let session_id = id.clone();
+        let text = req.text.clone();
+        tokio::spawn(async move {
+            crate::session::smart_rename::try_smart_rename(
+                state_for_rename,
+                session_id,
+                crate::session::smart_rename::SmartRenameInput {
+                    first_user_prompt: text.clone(),
+                    context: text,
+                },
+                crate::session::smart_rename::RenameTrigger::PromptStart,
+            )
+            .await;
+        });
+    }
+    match outcome {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
-        // Intentional override of the canonical UnknownSession 404: the
-        // respawn we kicked above did not finish within `send_prompt`'s
-        // wait window (slow sandbox / spawn). The worker is still coming;
-        // signal a retryable typed status so the frontend keeps the prompt
-        // queued and re-fires on the next `AcpSessionAssigned`, rather
-        // than dropping it on a 404. See #1748.
-        Err(SupervisorError::UnknownSession(_)) if needs_resume => {
+        Err(SendTurnError::SessionNotFound) => {
+            (StatusCode::NOT_FOUND, "session not found").into_response()
+        }
+        Err(SendTurnError::ResumeFailed(SupervisorError::CapacityFull { current, limit })) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("worker_capacity_full ({current}/{limit})"),
+        )
+            .into_response(),
+        Err(SendTurnError::ResumeFailed(e)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("worker_not_ready: {e}"),
+        )
+            .into_response(),
+        Err(SendTurnError::WorkerNotReady) => {
             (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
         }
-        Err(e) => supervisor_error_response("prompt failed", &e),
+        Err(SendTurnError::Send(e)) => supervisor_error_response("prompt failed", &e),
     }
 }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1192,39 +1192,9 @@ pub async fn acp_prompt(
         )
         .await;
     // Smart-rename fires from `acp_event_listener` on the first clean
-    // `prompt_complete` `Event::Stopped` by default (turn-end timing), so the
-    // one-shot never races this handler's live worker for the provider API.
-    // See `session::smart_rename` and #2348. A session on the opt-in
-    // `prompt_start` timing fires here instead, on the first prompt, so the
-    // sidebar retitles immediately; the cheap candidate gate keeps this a no-op
-    // for the turn-end default, and `try_smart_rename` re-checks timing and
-    // eligibility authoritatively (self-cancelling on a timing mismatch).
-    // Only fire once the prompt was actually published (a pre-publish error
-    // means nothing entered the transcript).
-    let published = !matches!(
-        outcome,
-        Err(SendTurnError::SessionNotFound
-            | SendTurnError::NotOwner
-            | SendTurnError::ModeApplication(_)
-            | SendTurnError::ResumeFailed(_))
-    );
-    if published && crate::session::smart_rename::prompt_start_candidate(&state, &id).await {
-        let state_for_rename = state.clone();
-        let session_id = id.clone();
-        let text = req.text.clone();
-        tokio::spawn(async move {
-            crate::session::smart_rename::try_smart_rename(
-                state_for_rename,
-                session_id,
-                crate::session::smart_rename::SmartRenameInput {
-                    first_user_prompt: text.clone(),
-                    context: text,
-                },
-                crate::session::smart_rename::RenameTrigger::PromptStart,
-            )
-            .await;
-        });
-    }
+    // `prompt_complete` `Event::Stopped` (turn-end), so the one-shot never
+    // races this handler's live worker for the provider API. See
+    // `session::smart_rename` and #2348.
     match outcome {
         Ok(()) => StatusCode::ACCEPTED.into_response(),
         Err(SendTurnError::SessionNotFound) => {

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -376,6 +376,7 @@ pub async fn spawn_acp(
     let model = req.model.or_else(|| instance.agent_model.clone());
     let stored_acp_session_id = instance.acp_session_id.clone();
     let yolo_mode = instance.yolo_mode;
+    let acp_mode_id = instance.acp_mode_id.clone();
     // #2276: seed the transcript from the session/load replay when importing
     // an existing Claude session (import_pending set, empty store). The
     // supervisor clears any partial replay from a prior attempt after it
@@ -443,6 +444,7 @@ pub async fn spawn_acp(
             sandbox_info,
             source_profile,
             yolo_mode,
+            acp_mode_id,
             agent_command_override: crate::server::acp_reconciler::command_override_for_spawn(
                 &instance.tool,
                 &instance.command,
@@ -968,6 +970,7 @@ pub async fn switch_acp_agent(
             sandbox_info,
             source_profile,
             yolo_mode: instance.yolo_mode,
+            acp_mode_id: instance.acp_mode_id.clone(),
             // Gated in the supervisor: only applies when the selected
             // agent equals the instance tool and its binary matches, so
             // an explicit switch to a different agent is unaffected.
@@ -1763,6 +1766,7 @@ pub async fn acp_enable(
     let model = instance.agent_model.clone();
     let stored_acp_session_id = instance.acp_session_id.clone();
     let yolo_mode = instance.yolo_mode;
+    let acp_mode_id = instance.acp_mode_id.clone();
     // #2276: seed the transcript from the session/load replay when enabling
     // the structured view on an imported session (import_pending, empty store).
     let seed_history_replay = instance.import_pending == Some(true);
@@ -1810,6 +1814,7 @@ pub async fn acp_enable(
                 sandbox_info,
                 source_profile,
                 yolo_mode,
+                acp_mode_id,
                 agent_command_override: command_override,
                 seed_history_replay,
             })

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -23,7 +23,7 @@ use crate::acp::protocol::{
 };
 use crate::acp::state::{Event, PromptAttachmentKind, RateLimitInfo};
 use crate::acp::supervisor::SupervisorError;
-use crate::server::session_service::SendTurnError;
+use crate::server::session_service::{SendTurnError, SessionCaller};
 use crate::server::AppState;
 
 /// Maximum attachments per prompt.
@@ -1183,7 +1183,13 @@ pub async fn acp_prompt(
     // plugin host delivers turns through the same path (#2897).
     let outcome = state
         .session_service
-        .send_turn(&id, &req.text, &attachments, woke_idle_dormant)
+        .send_turn(
+            &SessionCaller::User,
+            &id,
+            &req.text,
+            &attachments,
+            woke_idle_dormant,
+        )
         .await;
     // Smart-rename fires from `acp_event_listener` on the first clean
     // `prompt_complete` `Event::Stopped` by default (turn-end timing), so the
@@ -1197,7 +1203,10 @@ pub async fn acp_prompt(
     // means nothing entered the transcript).
     let published = !matches!(
         outcome,
-        Err(SendTurnError::SessionNotFound | SendTurnError::ResumeFailed(_))
+        Err(SendTurnError::SessionNotFound
+            | SendTurnError::NotOwner
+            | SendTurnError::ModeApplication(_)
+            | SendTurnError::ResumeFailed(_))
     );
     if published && crate::session::smart_rename::prompt_start_candidate(&state, &id).await {
         let state_for_rename = state.clone();
@@ -1233,6 +1242,14 @@ pub async fn acp_prompt(
             .into_response(),
         Err(SendTurnError::WorkerNotReady) => {
             (StatusCode::SERVICE_UNAVAILABLE, "worker_not_ready").into_response()
+        }
+        // Unreachable for a User caller; mapped defensively so the match
+        // stays exhaustive as the service grows plugin-only failure modes.
+        Err(SendTurnError::NotOwner) => {
+            (StatusCode::FORBIDDEN, "session not owned by caller").into_response()
+        }
+        Err(SendTurnError::ModeApplication(e)) => {
+            supervisor_error_response("mode application failed", &e)
         }
         Err(SendTurnError::Send(e)) => supervisor_error_response("prompt failed", &e),
     }

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1192,7 +1192,9 @@ pub async fn acp_prompt(
     let needs_resume = woke_idle_dormant || !state.acp_supervisor.is_running(&id).await;
     if needs_resume {
         use crate::server::acp_reconciler::ResumeTrigger;
-        match crate::server::acp_reconciler::trigger_resume_background(&state, &id).await {
+        match crate::server::acp_reconciler::trigger_resume_background(&state.session_service, &id)
+            .await
+        {
             Ok(ResumeTrigger::NotFound) => {
                 // The session was deleted (or triaged) between the wake and
                 // the resume snapshot. Do not publish into a session that no
@@ -1280,7 +1282,9 @@ pub async fn acp_prompt_diff_comments(
     // acp_prompt. See #1748.
     if woke_idle_dormant {
         use crate::server::acp_reconciler::ResumeTrigger;
-        match crate::server::acp_reconciler::trigger_resume_background(&state, &id).await {
+        match crate::server::acp_reconciler::trigger_resume_background(&state.session_service, &id)
+            .await
+        {
             Ok(ResumeTrigger::NotFound) => {
                 return (StatusCode::NOT_FOUND, "session not found").into_response();
             }

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -19,7 +19,7 @@ mod log_level;
 mod mcp;
 pub mod plugins;
 mod projects;
-mod sessions;
+pub(crate) mod sessions;
 pub(crate) mod system;
 mod telemetry;
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -17,6 +17,7 @@ mod client_log;
 mod git;
 mod log_level;
 mod mcp;
+pub(crate) mod plugin_settings;
 pub mod plugins;
 mod projects;
 pub(crate) mod sessions;
@@ -39,6 +40,7 @@ pub use client_log::post_client_log;
 pub use git::{clone_repo, is_git_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use mcp::{drop_mcp_server, get_mcp_servers, keep_mcp_server, resolve_mcp_conflict};
+pub use plugin_settings::resolve_options;
 pub use plugins::{
     apply_plugin_update, dismiss_plugin_update, invoke_plugin_action, list_plugins,
     plugin_commands, plugin_details, plugin_discover, plugin_job_status, plugin_ui_state,

--- a/src/server/api/plugin_settings.rs
+++ b/src/server/api/plugin_settings.rs
@@ -1,0 +1,189 @@
+//! Host option-source resolver for plugin `dynamic_select` widgets (#2897).
+//!
+//! A `dynamic_select` names an [`OptionSource`]; the host resolves the actual
+//! choices from its own state (agent registry, ACP option catalog, project
+//! registry, session groups). The web and TUI renderers stay ignorant of
+//! where a source's data comes from: they post the source plus any
+//! `depends_on` values and render the returned `{value,label}` list. Saved
+//! ids are authoritatively revalidated at `sessions.create`, so this endpoint
+//! is advisory UI data, not an authorization surface; it still requires an
+//! authenticated dashboard session like every other `/api/*` route.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::session::settings_schema::{OptionSource, SelectOption};
+
+use super::super::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveOptionsRequest {
+    /// The option source, in the same snake_case form the widget schema
+    /// serializes (`acp_agents`, `acp_models`, ...).
+    pub source: OptionSource,
+    /// Values of the `depends_on` sibling fields, in declaration order. For
+    /// `acp.models` / `acp.modes` the first entry is the selected agent id.
+    #[serde(default)]
+    pub depends: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResolveOptionsResponse {
+    pub options: Vec<SelectOption>,
+}
+
+/// `POST /api/plugins/{id}/settings/options/resolve`: resolve one
+/// dynamic-select source for the settings UI. The `{id}` path segment scopes
+/// the request to a plugin for auditing/consistency but does not change the
+/// result: option sources are host-global.
+pub async fn resolve_options(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(_plugin_id): axum::extract::Path<String>,
+    req: Result<Json<ResolveOptionsRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(rej) => return rej.into_response(),
+    };
+    match resolve_option_source(&state, req.source, &req.depends).await {
+        Ok(options) => Json(ResolveOptionsResponse { options }).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("option resolve failed: {e:#}"),
+        )
+            .into_response(),
+    }
+}
+
+/// Resolve a dynamic-select option source to a normalized `{value,label}`
+/// list. Shared by the HTTP endpoint (web) and any in-process caller (TUI).
+pub async fn resolve_option_source(
+    state: &Arc<AppState>,
+    source: OptionSource,
+    depends: &[String],
+) -> anyhow::Result<Vec<SelectOption>> {
+    match source {
+        OptionSource::AcpAgents => Ok(acp_agent_options()),
+        OptionSource::AcpModels => Ok(catalog_options(depends.first(), CatalogCategory::Model)),
+        OptionSource::AcpModes => Ok(catalog_options(depends.first(), CatalogCategory::Mode)),
+        OptionSource::Projects => project_options(&state.profile).await,
+        OptionSource::Groups => Ok(group_options(state).await),
+    }
+}
+
+/// ACP-capable agents from the static registry plus any custom ACP agents the
+/// profile declares. Sorted, deduped by id.
+fn acp_agent_options() -> Vec<SelectOption> {
+    let registry = crate::acp::AgentRegistry::with_defaults();
+    let mut opts: Vec<SelectOption> = registry
+        .list()
+        .into_iter()
+        .map(|(name, _)| SelectOption::new(name, name))
+        .collect();
+    opts.sort_by(|a, b| a.value.cmp(&b.value));
+    opts.dedup_by(|a, b| a.value == b.value);
+    opts
+}
+
+enum CatalogCategory {
+    Model,
+    Mode,
+}
+
+/// Model or mode choices the given agent last advertised. Empty when no agent
+/// is selected yet or the agent's catalog has not been discovered; the UI then
+/// shows an empty/"run the agent first" state, and sessions.create is the
+/// authoritative validator regardless.
+fn catalog_options(agent: Option<&String>, category: CatalogCategory) -> Vec<SelectOption> {
+    let Some(agent) = agent.filter(|a| !a.is_empty()) else {
+        return Vec::new();
+    };
+    let catalog = crate::acp::option_catalog::load();
+    let Some(entry) = catalog.agents.get(agent) else {
+        return Vec::new();
+    };
+    let want = match category {
+        CatalogCategory::Model => crate::acp::state::ConfigOptionCategory::Model,
+        CatalogCategory::Mode => crate::acp::state::ConfigOptionCategory::Mode,
+    };
+    entry
+        .options
+        .iter()
+        .filter(|opt| opt.category == want)
+        .flat_map(|opt| opt.options.iter())
+        .map(|choice| SelectOption::new(&choice.value, &choice.name))
+        .collect()
+}
+
+async fn project_options(profile: &str) -> anyhow::Result<Vec<SelectOption>> {
+    let profile = profile.to_string();
+    let projects =
+        tokio::task::spawn_blocking(move || crate::session::projects::load_merged(&profile))
+            .await??;
+    Ok(projects
+        .into_iter()
+        .map(|p| SelectOption::new(&p.path, &p.name))
+        .collect())
+}
+
+async fn group_options(state: &Arc<AppState>) -> Vec<SelectOption> {
+    let instances = state.instances.read().await;
+    let mut paths: Vec<String> = instances
+        .iter()
+        .filter(|i| !i.group_path.is_empty())
+        .map(|i| i.group_path.clone())
+        .collect();
+    paths.sort();
+    paths.dedup();
+    paths.iter().map(|p| SelectOption::new(p, p)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Instance;
+
+    #[tokio::test]
+    async fn resolves_agents_models_and_groups() {
+        let mut a = Instance::new("one", "/tmp/p");
+        a.group_path = "work/backend".to_string();
+        let mut b = Instance::new("two", "/tmp/q");
+        b.group_path = "work/backend".to_string();
+        let state = crate::server::test_support::build_test_app_state(vec![a, b]);
+
+        // Agents: the static ACP registry always has entries.
+        let agents = resolve_option_source(&state, OptionSource::AcpAgents, &[])
+            .await
+            .expect("agents");
+        assert!(agents.iter().any(|o| o.value == "claude-code"));
+
+        // Models with no selected agent: empty (nothing to resolve yet).
+        let models = resolve_option_source(&state, OptionSource::AcpModels, &[])
+            .await
+            .expect("models");
+        assert!(models.is_empty());
+        // Models for an agent with no discovered catalog: still empty, never errors.
+        let models = resolve_option_source(
+            &state,
+            OptionSource::AcpModels,
+            &["claude-code".to_string()],
+        )
+        .await
+        .expect("models");
+        assert!(models.is_empty());
+
+        // Groups: derived from live instances, deduped.
+        let groups = resolve_option_source(&state, OptionSource::Groups, &[])
+            .await
+            .expect("groups");
+        assert_eq!(
+            groups.iter().map(|o| o.value.as_str()).collect::<Vec<_>>(),
+            vec!["work/backend"]
+        );
+    }
+}

--- a/src/server/api/plugin_settings.rs
+++ b/src/server/api/plugin_settings.rs
@@ -68,7 +68,7 @@ pub async fn resolve_option_source(
     depends: &[String],
 ) -> anyhow::Result<Vec<SelectOption>> {
     match source {
-        OptionSource::AcpAgents => Ok(acp_agent_options()),
+        OptionSource::AcpAgents => Ok(acp_agent_options(&state.profile).await),
         OptionSource::AcpModels => Ok(catalog_options(depends.first(), CatalogCategory::Model)),
         OptionSource::AcpModes => Ok(catalog_options(depends.first(), CatalogCategory::Mode)),
         OptionSource::Projects => project_options(&state.profile).await,
@@ -77,14 +77,37 @@ pub async fn resolve_option_source(
 }
 
 /// ACP-capable agents from the static registry plus any custom ACP agents the
-/// profile declares. Sorted, deduped by id.
-fn acp_agent_options() -> Vec<SelectOption> {
+/// resolved profile config declares via a valid `agent_acp_cmd`. Sorted, deduped
+/// by id (a custom entry shadowing a built-in is dropped by the dedup).
+async fn acp_agent_options(profile: &str) -> Vec<SelectOption> {
     let registry = crate::acp::AgentRegistry::with_defaults();
     let mut opts: Vec<SelectOption> = registry
         .list()
         .into_iter()
         .map(|(name, _)| SelectOption::new(name, name))
         .collect();
+
+    // Custom ACP agents live in the per-profile config; resolve the profile
+    // (global -> profile, no repo) and keep entries whose command parses as a
+    // valid ACP adapter. Config IO runs off the async runtime.
+    let profile = profile.to_string();
+    let custom = tokio::task::spawn_blocking(move || {
+        crate::session::profile_config::resolve_config_or_warn(&profile)
+            .session
+            .agent_acp_cmd
+            .into_iter()
+            .filter(|(name, cmd)| {
+                !name.is_empty() && crate::acp::AgentSpec::from_acp_cmd(name, cmd).is_ok()
+            })
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>()
+    })
+    .await
+    .unwrap_or_default();
+    for name in custom {
+        opts.push(SelectOption::new(&name, &name));
+    }
+
     opts.sort_by(|a, b| a.value.cmp(&b.value));
     opts.dedup_by(|a, b| a.value == b.value);
     opts

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4028,7 +4028,7 @@ fn validate_session_tool_identity(
 /// row, and inserts it first. A blind `push` would then leave two entries
 /// with the same id in `state.instances` until the next poll tick collapses
 /// them, and `GET /api/sessions` would briefly return the session twice.
-fn upsert_instance(
+pub(crate) fn upsert_instance(
     instances: &mut Vec<crate::session::Instance>,
     instance: crate::session::Instance,
 ) {
@@ -4074,7 +4074,7 @@ impl std::error::Error for HooksNeedTrust {}
 /// without leaving an orphan worktree; executed after the build once the
 /// session directory exists.
 #[derive(Debug)]
-struct CreateHookPlan {
+pub(crate) struct CreateHookPlan {
     /// Commands to run, already merged (repo overrides global/profile per type).
     on_create: Vec<String>,
     /// `(hooks_hash, mcp_hash)` to persist into `trusted_repos.toml` when the
@@ -4088,7 +4088,7 @@ struct CreateHookPlan {
 /// caller did not pass `trust_hooks: true`; the surrounding handler maps that to
 /// a structured `hooks_need_trust` response. Mirrors the CLI `--trust-hooks`
 /// path in `src/cli/add.rs`, adapted for the API's non-interactive context.
-fn resolve_create_hook_plan(
+pub(crate) fn resolve_create_hook_plan(
     profile: &str,
     project_path: &std::path::Path,
     scratch: bool,
@@ -4193,7 +4193,7 @@ fn resolve_create_hook_plan(
 /// streamed to a discarded channel so the shared streamed executor's
 /// terminal-detach (credential-prompt suppression) applies; failures surface
 /// through the returned `Result` with a captured output tail.
-fn run_create_hooks(
+pub(crate) fn run_create_hooks(
     instance: &mut Instance,
     plan: &CreateHookPlan,
     project_path: &std::path::Path,
@@ -4508,453 +4508,86 @@ pub async fn create_session(
     };
 
     let profile = body.profile.unwrap_or_else(|| state.profile.clone());
-    let instances = state.instances.read().await;
-    let existing_titles: Vec<String> = instances.iter().map(|i| i.title.clone()).collect();
-    let existing_branches: Vec<String> = instances
-        .iter()
-        .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.clone()))
-        .collect();
-    drop(instances);
 
-    let file_watch_for_create = state.file_watch.clone();
-
-    let result = tokio::task::spawn_blocking(move || {
-        use crate::session::builder::{self, InstanceParams};
-        use crate::session::Config;
-
-        let config = Config::load_or_warn();
-        let sandbox_image = body.sandbox_image.unwrap_or_else(|| {
-            if config.sandbox.default_image.is_empty() {
-                "ubuntu:latest".to_string()
-            } else {
-                config.sandbox.default_image.clone()
-            }
-        });
-
-        let title_refs: Vec<&str> = existing_titles.iter().map(|s| s.as_str()).collect();
-        let branch_refs: Vec<&str> = existing_branches.iter().map(|s| s.as_str()).collect();
-        let extra_repo_paths: Vec<String> = body
-            .extra_repo_paths
-            .into_iter()
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        // Resolve repo hook trust BEFORE building the worktree (#2066): a repo
-        // whose hooks need approval and that was not sent `trust_hooks: true`
-        // is refused here, so the handler never leaves an orphan worktree on
-        // disk. The original `path` is the trust anchor (the same source the
-        // CLI/TUI use); `check_repo_trust` resolves a worktree path to its main
-        // repo, so a worktree created from an already-trusted repo inherits its
-        // trust without a separate prompt.
-        let original_path = body.path.clone();
-        let hook_plan = resolve_create_hook_plan(
-            &profile,
-            std::path::Path::new(&original_path),
-            body.scratch,
-            body.trust_hooks.unwrap_or(false),
-        )?;
-
-        let title = body.title.unwrap_or_default();
-        let worktree_branch = body
-            .worktree_branch
-            .map(|b| b.trim().to_string())
-            .filter(|b| !b.is_empty());
-
-        let params = InstanceParams {
-            title,
-            path: body.path,
-            group: body.group,
-            tool: body.tool,
-            worktree_enabled,
-            worktree_branch,
-            create_new_branch: body.create_new_branch,
-            base_branch: if body.create_new_branch {
-                body.base_branch
-                    .as_ref()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-            } else {
-                None
-            },
-            sandbox: body.sandbox,
-            sandbox_image,
-            yolo_mode: body.yolo_mode,
-            extra_env: body.extra_env,
-            extra_args: body.extra_args,
-            command_override: body.command_override,
-            extra_repo_paths,
-            scratch: body.scratch,
-            #[cfg(feature = "serve")]
-            fork_seed,
-            #[cfg(not(feature = "serve"))]
-            fork_seed: None,
-        };
-
-        let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
-        let mut instance = build_result.instance;
-        instance.source_profile = profile.clone();
-        let build_warnings = build_result.warnings;
-        let created_worktree = build_result.created_worktree;
-        let created_workspace_worktrees = build_result.created_workspace_worktrees;
-
-        // Apply per-session sandbox overrides from the request body.
-        if let Some(ref mut sandbox) = instance.sandbox_info {
-            if body.custom_instruction.is_some() {
-                sandbox.custom_instruction = body.custom_instruction;
-            }
-        }
-
-        // Apply structured-view fields from the request body. structured_view is
-        // re-validated below against real ACP capability; non-ACP tools
-        // fall back to terminal view rather than erroring at spawn time.
+    let spec = crate::server::session_spawn::StructuredSessionSpec {
+        title: body.title,
+        path: body.path,
+        group: body.group,
+        tool: body.tool,
+        worktree_enabled,
+        worktree_branch: body.worktree_branch,
+        create_new_branch: body.create_new_branch,
+        base_branch: body.base_branch,
+        sandbox: body.sandbox,
+        sandbox_image: body.sandbox_image,
+        yolo_mode: body.yolo_mode,
+        extra_env: body.extra_env,
+        extra_args: body.extra_args,
+        command_override: body.command_override,
+        extra_repo_paths: body.extra_repo_paths,
+        scratch: body.scratch,
+        trust_hooks: body.trust_hooks,
+        custom_instruction: body.custom_instruction,
+        profile,
         #[cfg(feature = "serve")]
-        let agent_effort = {
-            instance.view = body.view;
-            // #2276: importing an existing Claude session forces the
-            // structured view and adopts the on-disk session id, so the
-            // structured spawn resumes it via session/load and seeds the
-            // transcript from the agent's history replay. `path` is the
-            // session's original cwd (the wizard prefills it).
-            if let Some(import_id) = body
-                .import_acp_session_id
-                .clone()
-                .filter(|s| !s.trim().is_empty())
-            {
-                instance.view = crate::session::View::Structured;
-                instance.acp_session_id = Some(import_id);
-                instance.import_pending = Some(true);
-            }
-            instance.agent_name = body.agent_name;
-            let agent_key = instance
-                .agent_name
-                .as_deref()
-                .filter(|s| !s.is_empty())
-                .unwrap_or(instance.tool.as_str())
-                .to_string();
-            let resolved_config = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                &instance.source_profile,
-                std::path::Path::new(&instance.project_path),
+        view: body.view,
+        #[cfg(feature = "serve")]
+        agent_name: body.agent_name,
+        #[cfg(feature = "serve")]
+        agent_model: body.agent_model,
+        #[cfg(feature = "serve")]
+        agent_effort: body.agent_effort,
+        #[cfg(feature = "serve")]
+        import_acp_session_id: body.import_acp_session_id,
+        #[cfg(feature = "serve")]
+        fork_seed,
+    };
+
+    match crate::server::session_spawn::spawn_structured_session(&state, spec).await {
+        Ok(outcome) => {
+            let instance = outcome.instance;
+            let mut resp = SessionResponse::from_instance(
+                &instance,
+                crate::claude_settings::read_tui_fullscreen(),
             );
-            let defaults = resolved_config.acp.acp_defaults_for(&agent_key);
-            // Preserve the explicit request model separately (trimmed to match
-            // the resolver's normalization) so a terminal fallback below can
-            // keep it while dropping any ACP-derived default; agent_model is
-            // ACP-only.
-            let explicit_model = body
-                .agent_model
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string);
-            // Explicit request wins, else the per-agent default; effort is keyed
-            // on the resolved model. Same single-source resolver the spawn path
-            // uses; persist the model here so the composer shows it and the
-            // session stays pinned to it. See resolve_spawn_model_effort.
-            let (resolved_model, mut agent_effort) =
-                crate::session::config::resolve_spawn_model_effort(
-                    defaults,
-                    explicit_model.clone(),
-                    body.agent_effort,
-                );
-            instance.agent_model = resolved_model;
-            // Don't trust the client's capability decision. Re-resolve
-            // whether this agent can actually run in structured view; a custom
-            // agent without an `agent_acp_cmd` (or any non-ACP tool)
-            // falls back to tmux here rather than erroring at spawn time.
-            if instance.is_structured() {
-                let acp_registry = crate::acp::AgentRegistry::with_defaults();
-                let resolved = instance
-                    .agent_name
-                    .as_deref()
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or(instance.tool.as_str());
-                let capable = acp_registry.get(resolved).is_some()
-                    || crate::session::repo_config::resolve_config_with_repo_or_warn(
+            resp.warnings = outcome.warnings;
+            // Carry the resolved tie value (#1927); list_sessions' overlay does
+            // not run on this create response, so a managed worktree would
+            // otherwise report untied until the next list refresh.
+            #[cfg(feature = "serve")]
+            {
+                if resp.has_managed_worktree {
+                    resp.tie_workdir_to_name =
+                        crate::session::profile_config::resolve_config_or_warn(
+                            &instance.source_profile,
+                        )
+                        .session
+                        .tie_workdir_to_name;
+                }
+                if !resp.acp_capable {
+                    let acp_cmd = crate::session::repo_config::resolve_config_with_repo_or_warn(
                         &instance.source_profile,
                         std::path::Path::new(&instance.project_path),
                     )
                     .session
-                    .agent_acp_cmd
-                    .get(&instance.tool)
-                    .is_some_and(|cmd| {
-                        crate::acp::AgentSpec::from_acp_cmd(&instance.tool, cmd).is_ok()
-                    });
-                if capable {
-                    instance.view = crate::session::View::Structured;
-                } else {
-                    instance.view = crate::session::View::Terminal;
-                    // A non-ACP tool cannot run the structured session/fork
-                    // handshake. If a malformed request seeded a structured
-                    // fork (fork_pending/import_pending set by the builder),
-                    // drop those markers so a later switch-to-structured does
-                    // not fire an unexpected session/fork against the parent.
-                    instance.fork_pending = None;
-                    instance.import_pending = None;
+                    .agent_acp_cmd;
+                    resp.acp_capable = custom_agent_acp_capable(&acp_cmd, &instance.tool);
                 }
             }
-
-            if !instance.is_structured() {
-                agent_effort = None;
-                // Terminal sessions keep only an explicitly requested model,
-                // never an ACP-derived default (agent_model is ACP-only).
-                instance.agent_model = explicit_model;
-            }
-
-            agent_effort
-        };
-
-        // Run on_create hooks now that the worktree exists, before the session
-        // is persisted or started (#2066). Mirrors the TUI/CLI ordering so the
-        // worktree is bootstrapped (`.env` copies, venv symlinks, DB seeds)
-        // before the agent launches. On failure, tear down the just-built
-        // worktree/container so a broken hook doesn't leave an orphan.
-        if let Err(e) = run_create_hooks(
-            &mut instance,
-            &hook_plan,
-            std::path::Path::new(&original_path),
-        ) {
-            builder::cleanup_instance(
-                &instance,
-                created_worktree.as_ref(),
-                &created_workspace_worktrees,
-            );
-            return Err(anyhow::anyhow!("on_create hook failed: {e:#}"));
+            (StatusCode::CREATED, Json(resp)).into_response()
         }
-
-        // Anything that fails between here and the final `Ok(..)`
-        // would otherwise orphan the scratch directory `build_instance`
-        // already provisioned (Storage::new, storage.update,
-        // instance.start). Wrap the tail in an IIFE-equivalent closure
-        // so we can run cleanup on Err once, regardless of which step
-        // tripped. Matches the CLI cleanup path in
-        // `cleanup_partial_session(... scratch_dir: Some(...))`.
-        let mut persist_and_start = || -> anyhow::Result<()> {
-            let storage = Storage::new(&profile, file_watch_for_create.clone())?;
-            let to_persist = instance.clone();
-            storage.update(|all, _groups| {
-                all.push(to_persist);
-                Ok(())
-            })?;
-
-            // Acp-mode sessions are not backed by tmux; the structured view
-            // supervisor spawns the ACP agent on demand. Skip the tmux
-            // `start()` to avoid creating an empty pane that no one will
-            // attach to.
-            #[cfg(feature = "serve")]
-            let skip_tmux_start = instance.is_structured();
-            #[cfg(not(feature = "serve"))]
-            let skip_tmux_start = false;
-            if !skip_tmux_start {
-                instance.start()?;
-            }
-            Ok(())
-        };
-
-        if let Err(e) = persist_and_start() {
-            // Guarded the same way as the deletion path: only remove a
-            // path that `is_scratch_path` blesses, so a corrupted
-            // `project_path` cannot trick us into wiping unrelated
-            // state.
-            if instance.scratch {
-                let scratch_path = std::path::PathBuf::from(&instance.project_path);
-                if crate::session::scratch::is_scratch_path(&scratch_path) {
-                    if let Err(rm_err) = std::fs::remove_dir_all(&scratch_path) {
-                        tracing::warn!(
-                            target: "http.api.sessions",
-                            "Failed to clean up orphan scratch dir {} after create failure: {}",
-                            scratch_path.display(),
-                            rm_err
-                        );
-                    }
-                }
-            }
-            return Err(e);
-        }
-
-        #[cfg(feature = "serve")]
-        return Ok::<(Instance, Vec<String>, Option<String>), anyhow::Error>((
-            instance,
-            build_warnings,
-            agent_effort,
-        ));
-
-        #[cfg(not(feature = "serve"))]
-        Ok::<(Instance, Vec<String>), anyhow::Error>((instance, build_warnings))
-    })
-    .await;
-
-    match result {
-        #[cfg(feature = "serve")]
-        Ok(Ok((instance, warnings, agent_effort))) => {
-            let mut resp = SessionResponse::from_instance(
-                &instance,
-                crate::claude_settings::read_tui_fullscreen(),
-            );
-            resp.warnings = warnings;
-            // Carry the resolved tie value (#1927); list_sessions' overlay does
-            // not run on this create response, so a managed worktree would
-            // otherwise report untied until the next list refresh.
-            if resp.has_managed_worktree {
-                resp.tie_workdir_to_name = crate::session::profile_config::resolve_config_or_warn(
-                    &instance.source_profile,
-                )
-                .session
-                .tie_workdir_to_name;
-            }
-            if !resp.acp_capable {
-                let acp_cmd = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                    &instance.source_profile,
-                    std::path::Path::new(&instance.project_path),
-                )
-                .session
-                .agent_acp_cmd;
-                resp.acp_capable = custom_agent_acp_capable(&acp_cmd, &instance.tool);
-            }
-            let acp_spawn_target = if instance.is_structured() {
-                Some((
-                    instance.id.clone(),
-                    instance.tool.clone(),
-                    instance.agent_name.clone(),
-                    instance.agent_model.clone(),
-                    agent_effort,
-                    instance.project_path.clone(),
-                    instance.acp_session_id.clone(),
-                    instance.source_profile.clone(),
-                    instance.yolo_mode,
-                    instance.command.clone(),
-                    instance.import_pending == Some(true),
-                    instance.fork_pending.clone(),
-                ))
-            } else {
-                None
-            };
-            let mut instances = state.instances.write().await;
-            upsert_instance(&mut instances, instance);
-            drop(instances);
-
-            // Count the create for the opt-in telemetry trend counter. Bounded
-            // accumulator, read-and-decremented by the snapshot loop; no-op for
-            // opted-out installs (the snapshot is never built / sent).
-            state
-                .telemetry_session_creates
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-            if let Some((
-                id,
-                tool,
-                agent_override,
-                model,
-                effort,
-                project_path,
-                stored_acp_session_id,
-                source_profile,
-                yolo_mode,
-                command,
-                seed_history_replay,
-                fork_from,
-            )) = acp_spawn_target
+        Err(e) => {
+            // A build-task panic keeps its 500; a plain build failure is a 400.
+            if let Some(panicked) =
+                e.downcast_ref::<crate::server::session_spawn::SessionBuildPanicked>()
             {
-                let agent = state
-                    .acp_supervisor
-                    .pick_agent_for_tool(
-                        &tool,
-                        agent_override.as_deref(),
-                        &source_profile,
-                        std::path::Path::new(&project_path),
-                    )
-                    .await;
-                let command_override =
-                    crate::server::acp_reconciler::command_override_for_spawn(&tool, &command);
-                let cwd = std::path::PathBuf::from(project_path);
-                let supervisor = state.acp_supervisor.clone();
-                let state_for_check = state.clone();
-                tokio::spawn(async move {
-                    let inst_lock = state_for_check.instance_lock(&id).await;
-                    let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
-                        &state_for_check.instances,
-                        &inst_lock,
-                        &id,
-                        true,
-                    )
-                    .await
-                    {
-                        Ok(info) => info,
-                        Err(e) => {
-                            let message = format!("sandbox container ensure failed: {e}");
-                            tracing::warn!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create failed: {message}"
-                            );
-                            supervisor.publish_startup_error(&id, message);
-                            return;
-                        }
-                    };
-                    let source_profile_for_spawn = Some(source_profile.clone());
-                    if let Err(e) = supervisor
-                        .spawn(crate::acp::supervisor::SpawnRequest {
-                            session_id: id.clone(),
-                            agent: agent.clone(),
-                            cwd,
-                            additional_dirs: vec![],
-                            provider_env: vec![],
-                            model,
-                            effort,
-                            stored_acp_session_id,
-                            fork_from,
-                            sandbox_info,
-                            source_profile: source_profile_for_spawn,
-                            yolo_mode,
-                            agent_command_override: command_override,
-                            seed_history_replay,
-                        })
-                        .await
-                    {
-                        let still_present = state_for_check
-                            .instances
-                            .read()
-                            .await
-                            .iter()
-                            .any(|i| i.id == id);
-                        // Capacity-aware banner selection (and the benign
-                        // first-tick duplicate) is documented on
-                        // `structured_spawn_error_message`.
-                        let message =
-                            crate::server::api::structured_spawn_error_message(&e, &agent);
-                        if still_present {
-                            tracing::warn!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create failed: {message}"
-                            );
-                            supervisor.publish_startup_error(&id, message);
-                        } else {
-                            tracing::debug!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create error after session removed (ignored): {message}"
-                            );
-                        }
-                    }
-                });
+                tracing::error!(target: "http.api.sessions", "Session creation panicked: {}", panicked.0);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+                )
+                    .into_response();
             }
-
-            (StatusCode::CREATED, Json(resp)).into_response()
-        }
-        #[cfg(not(feature = "serve"))]
-        Ok(Ok((instance, warnings))) => {
-            let mut resp = SessionResponse::from_instance(
-                &instance,
-                crate::claude_settings::read_tui_fullscreen(),
-            );
-            resp.warnings = warnings;
-            let mut instances = state.instances.write().await;
-            instances.push(instance);
-            drop(instances);
-
-            (StatusCode::CREATED, Json(resp)).into_response()
-        }
-        Ok(Err(e)) => {
             // A repo whose hooks need approval gets a distinct, structured
             // response so the caller can surface the commands and resubmit with
             // `trust_hooks: true` (#2066), rather than the opaque create_failed.
@@ -4976,14 +4609,6 @@ pub async fn create_session(
             (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({"error": "create_failed", "message": public_create_session_error(&e)})),
-            )
-                .into_response()
-        }
-        Err(e) => {
-            tracing::error!(target: "http.api.sessions", "Session creation panicked: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
             )
                 .into_response()
         }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4045,7 +4045,7 @@ pub(crate) fn upsert_instance(
 /// structured `hooks_need_trust` response instead of the generic
 /// `create_failed`, so a caller can show the commands and resubmit.
 #[derive(Debug)]
-struct HooksNeedTrust {
+pub(crate) struct HooksNeedTrust {
     /// The `on_create` commands that would run, for display in the prompt.
     on_create: Vec<String>,
     /// The `on_launch` commands the same approval would trust. They don't run

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4534,6 +4534,7 @@ pub async fn create_session(
         created_by_plugin: None,
         plugin_create_idempotency: None,
         pending_initial_turn: None,
+        acp_mode_id: None,
         #[cfg(feature = "serve")]
         view: body.view,
         #[cfg(feature = "serve")]

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4543,7 +4543,8 @@ pub async fn create_session(
         fork_seed,
     };
 
-    match crate::server::session_spawn::spawn_structured_session(&state, spec).await {
+    match crate::server::session_spawn::spawn_structured_session(&state.session_service, spec).await
+    {
         Ok(outcome) => {
             let instance = outcome.instance;
             let mut resp = SessionResponse::from_instance(

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4533,6 +4533,7 @@ pub async fn create_session(
         // stamps these, through create_structured_session. See #2897.
         created_by_plugin: None,
         plugin_create_idempotency: None,
+        pending_initial_turn: None,
         #[cfg(feature = "serve")]
         view: body.view,
         #[cfg(feature = "serve")]
@@ -4549,7 +4550,7 @@ pub async fn create_session(
 
     match state
         .session_service
-        .create_structured_session(spec, None, None)
+        .create_structured_session(spec, None, None, None)
         .await
     {
         Ok((outcome, _created)) => {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -4529,6 +4529,10 @@ pub async fn create_session(
         trust_hooks: body.trust_hooks,
         custom_instruction: body.custom_instruction,
         profile,
+        // Never decoded from the request body: only the plugin host path
+        // stamps these, through create_structured_session. See #2897.
+        created_by_plugin: None,
+        plugin_create_idempotency: None,
         #[cfg(feature = "serve")]
         view: body.view,
         #[cfg(feature = "serve")]
@@ -4543,9 +4547,12 @@ pub async fn create_session(
         fork_seed,
     };
 
-    match crate::server::session_spawn::spawn_structured_session(&state.session_service, spec).await
+    match state
+        .session_service
+        .create_structured_session(spec, None, None)
+        .await
     {
-        Ok(outcome) => {
+        Ok((outcome, _created)) => {
             let instance = outcome.instance;
             let mut resp = SessionResponse::from_instance(
                 &instance,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -240,6 +240,25 @@ pub async fn update_settings(
     if let Err(rej) = validate_patch_with(&runtime_schema(), &body, Scope::Global, true) {
         return reject_response(rej);
     }
+    // Capture which plugins this patch touches (top-level `plugin:<id>`
+    // sections and their changed field keys) BEFORE the rewrite folds them
+    // into `plugins.<id>.settings.*`, so we can emit `plugin.settings.changed`
+    // after a successful write (#2897).
+    let plugin_changes: Vec<(String, Vec<String>)> = body
+        .as_object()
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(section, value)| {
+                    let id = crate::session::settings_schema::section_plugin_id(section)?;
+                    let keys: Vec<String> = value
+                        .as_object()
+                        .map(|m| m.keys().cloned().collect())
+                        .unwrap_or_default();
+                    Some((id.to_string(), keys))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     // Fold validated `plugin:<id>` sections into their on-disk storage path
     // (`plugins.<id>.settings.*`) before the generic merge.
     rewrite_plugin_sections(&mut body);
@@ -267,6 +286,14 @@ pub async fn update_settings(
                     &config.logging.targets,
                     &app_dir,
                 );
+            }
+            // Tell each touched plugin's worker its settings changed (#2897),
+            // after the durable write. Best-effort; config.get is the fallback.
+            #[cfg(feature = "serve")]
+            if !plugin_changes.is_empty() {
+                if let Some(host) = &state.plugin_host {
+                    host.emit_settings_changed(&plugin_changes).await;
+                }
             }
             match serde_json::to_value(&config) {
                 Ok(val) => (StatusCode::OK, Json(val)).into_response(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,7 @@ mod pane;
 pub mod push;
 pub mod push_send;
 pub mod rate_limit;
+pub(crate) mod session_spawn;
 pub mod tunnel;
 
 use std::net::SocketAddr;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1049,14 +1049,21 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let instances = Arc::new(RwLock::new(instances));
     let instance_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
     let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
-    let session_service = Arc::new(session_service::SessionService {
-        instances: Arc::clone(&instances),
-        instance_locks: Arc::clone(&instance_locks),
-        file_watch: Arc::clone(&file_watch),
-        telemetry_session_creates: Arc::clone(&telemetry_session_creates),
-        #[cfg(feature = "serve")]
-        acp_supervisor: acp_supervisor.clone(),
-    });
+    #[cfg(feature = "serve")]
+    let session_service = Arc::new(session_service::SessionService::new(
+        Arc::clone(&instances),
+        Arc::clone(&instance_locks),
+        Arc::clone(&file_watch),
+        Arc::clone(&telemetry_session_creates),
+        acp_supervisor.clone(),
+    ));
+    #[cfg(not(feature = "serve"))]
+    let session_service = Arc::new(session_service::SessionService::new(
+        Arc::clone(&instances),
+        Arc::clone(&instance_locks),
+        Arc::clone(&file_watch),
+        Arc::clone(&telemetry_session_creates),
+    ));
 
     let state = Arc::new(AppState {
         profile: profile.to_string(),
@@ -5298,13 +5305,13 @@ pub mod test_support {
         let instance_locks = Arc::new(RwLock::new(HashMap::new()));
         let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let file_watch = FileWatchService::noop();
-        let session_service = Arc::new(session_service::SessionService {
-            instances: Arc::clone(&instances),
-            instance_locks: Arc::clone(&instance_locks),
-            file_watch: Arc::clone(&file_watch),
-            telemetry_session_creates: Arc::clone(&telemetry_session_creates),
-            acp_supervisor: supervisor.clone(),
-        });
+        let session_service = Arc::new(session_service::SessionService::new(
+            Arc::clone(&instances),
+            Arc::clone(&instance_locks),
+            Arc::clone(&file_watch),
+            Arc::clone(&telemetry_session_creates),
+            supervisor.clone(),
+        ));
         Arc::new(AppState {
             profile: "test".to_string(),
             read_only: false,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,7 @@ mod pane;
 pub mod push;
 pub mod push_send;
 pub mod rate_limit;
+pub(crate) mod session_service;
 pub(crate) mod session_spawn;
 pub mod tunnel;
 
@@ -277,7 +278,13 @@ pub(crate) enum StatusSource {
 pub struct AppState {
     pub profile: String,
     pub read_only: bool,
-    pub instances: RwLock<Vec<Instance>>,
+    pub instances: Arc<RwLock<Vec<Instance>>>,
+    /// Session-domain service handle sharing `instances`, `instance_locks`,
+    /// `file_watch`, the telemetry create counter, and the ACP supervisor
+    /// with the fields on this struct, so a non-HTTP caller (the plugin
+    /// host, #2897) can drive session create/turn without holding
+    /// `AppState`.
+    pub session_service: Arc<session_service::SessionService>,
     pub token_manager: Arc<TokenManager>,
     pub login_manager: Arc<login::LoginManager>,
     pub rate_limiter: Arc<RateLimiter>,
@@ -306,7 +313,7 @@ pub struct AppState {
     /// (e.g. `ensure_session` decide-and-restart). Entries are created on
     /// first use and live for the lifetime of the process — there are only
     /// as many as the user has sessions.
-    pub instance_locks: RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    pub instance_locks: Arc<RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
     /// Session ids with an in-flight smart-rename one-shot, so a burst of rapid
     /// first prompts cannot spawn concurrent title generators for the same
     /// session. Synchronous mutex: critical sections are tiny and never span an
@@ -433,7 +440,7 @@ pub struct AppState {
     /// that start and end between two snapshots are still counted. Decremented (by
     /// the value reported) only after a confirmed send, so a failed send retains
     /// the count for the next snapshot instead of silently dropping it.
-    pub telemetry_session_creates: std::sync::atomic::AtomicU32,
+    pub telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
     /// Aggregate structured-interaction tallies for the next opt-in snapshot
     /// (approvals decision mix, agent/substrate switches, plan-mode, queued
     /// prompts). Same monotonic-counter, decrement-by-reported discipline as
@@ -1039,10 +1046,23 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         "resolved DNS-rebinding allowlist"
     );
 
+    let instances = Arc::new(RwLock::new(instances));
+    let instance_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
+    let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let session_service = Arc::new(session_service::SessionService {
+        instances: Arc::clone(&instances),
+        instance_locks: Arc::clone(&instance_locks),
+        file_watch: Arc::clone(&file_watch),
+        telemetry_session_creates: Arc::clone(&telemetry_session_creates),
+        #[cfg(feature = "serve")]
+        acp_supervisor: acp_supervisor.clone(),
+    });
+
     let state = Arc::new(AppState {
         profile: profile.to_string(),
         read_only,
-        instances: RwLock::new(instances),
+        instances,
+        session_service,
         token_manager: Arc::clone(&token_manager),
         login_manager: Arc::clone(&login_manager),
         rate_limiter: Arc::clone(&rate_limiter),
@@ -1051,7 +1071,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         serve_mode,
         allowed_hosts,
         allowed_origins,
-        instance_locks: RwLock::new(std::collections::HashMap::new()),
+        instance_locks,
         smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
         smart_rename_semaphore: tokio::sync::Semaphore::new(
@@ -1088,7 +1108,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         telemetry_usage_seen: crate::telemetry::usage_signals::UsageSeenCounters::new(),
         telemetry_web_clients: FormFactorCounters::default(),
         telemetry_structured_clients: FormFactorCounters::default(),
-        telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
+        telemetry_session_creates,
         telemetry_structured: StructuredTelemetryCounters::default(),
         telemetry_last_reported: std::sync::Mutex::new(None),
         shutdown: CancellationToken::new(),
@@ -5274,10 +5294,22 @@ pub mod test_support {
         });
         let supervisor =
             std::sync::Arc::new(crate::acp::supervisor::Supervisor::with_capacity(sink, 1));
+        let instances = Arc::new(RwLock::new(prior));
+        let instance_locks = Arc::new(RwLock::new(HashMap::new()));
+        let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let file_watch = FileWatchService::noop();
+        let session_service = Arc::new(session_service::SessionService {
+            instances: Arc::clone(&instances),
+            instance_locks: Arc::clone(&instance_locks),
+            file_watch: Arc::clone(&file_watch),
+            telemetry_session_creates: Arc::clone(&telemetry_session_creates),
+            acp_supervisor: supervisor.clone(),
+        });
         Arc::new(AppState {
             profile: "test".to_string(),
             read_only: false,
-            instances: RwLock::new(prior),
+            instances,
+            session_service,
             token_manager: Arc::new(TokenManager::new(token, Duration::from_secs(3600))),
             login_manager: Arc::new(login::LoginManager::new(None)),
             rate_limiter: Arc::new(RateLimiter::new()),
@@ -5286,7 +5318,7 @@ pub mod test_support {
             serve_mode: "local",
             allowed_hosts,
             allowed_origins,
-            instance_locks: RwLock::new(HashMap::new()),
+            instance_locks,
             smart_rename_inflight: std::sync::Mutex::new(std::collections::HashSet::new()),
             smart_rename_attempted: std::sync::Mutex::new(std::collections::HashSet::new()),
             smart_rename_semaphore: tokio::sync::Semaphore::new(
@@ -5317,11 +5349,11 @@ pub mod test_support {
             telemetry_usage_seen: crate::telemetry::usage_signals::UsageSeenCounters::new(),
             telemetry_web_clients: FormFactorCounters::default(),
             telemetry_structured_clients: FormFactorCounters::default(),
-            telemetry_session_creates: std::sync::atomic::AtomicU32::new(0),
+            telemetry_session_creates,
             telemetry_structured: StructuredTelemetryCounters::default(),
             telemetry_last_reported: std::sync::Mutex::new(None),
             shutdown: CancellationToken::new(),
-            file_watch: FileWatchService::noop(),
+            file_watch,
             disk_changed: Arc::new(tokio::sync::Notify::new()),
             disk_watch_handles: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         })

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1702,6 +1702,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/plugins/{id}/enabled", post(api::set_plugin_enabled))
         .route("/api/plugins/{id}/action", post(api::invoke_plugin_action))
         .route(
+            "/api/plugins/{id}/settings/options/resolve",
+            post(api::resolve_options),
+        )
+        .route(
             "/api/plugins/install/preview",
             post(api::preview_plugin_install),
         )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -803,6 +803,27 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // The Tier 1 plugin worker host. Opening it (the plugin event-bus database,
     // the worker log dir) is cheap and side-effect-free until workers launch,
     // which happens after the daemon is up. A failure here is logged, not fatal:
+    // The session-domain service is built before the plugin host so the
+    // host's session RPCs (#2897) get it by construction, never late-bound.
+    let instances = Arc::new(RwLock::new(instances));
+    let instance_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
+    let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    #[cfg(feature = "serve")]
+    let session_service = Arc::new(session_service::SessionService::new(
+        Arc::clone(&instances),
+        Arc::clone(&instance_locks),
+        Arc::clone(&file_watch),
+        Arc::clone(&telemetry_session_creates),
+        acp_supervisor.clone(),
+    ));
+    #[cfg(not(feature = "serve"))]
+    let session_service = Arc::new(session_service::SessionService::new(
+        Arc::clone(&instances),
+        Arc::clone(&instance_locks),
+        Arc::clone(&file_watch),
+        Arc::clone(&telemetry_session_creates),
+    ));
+
     // the daemon serves fine without plugin workers.
     // The host API includes mutating session.meta.set/cas, so a read-only
     // daemon must not run plugin workers at all: gate the host on !read_only.
@@ -812,13 +833,34 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         None
     } else {
         match crate::session::get_app_dir() {
-            Ok(app_dir) => match crate::plugin::host::PluginHost::new(&app_dir, profile) {
-                Ok(host) => Some(host),
-                Err(e) => {
-                    tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
-                    None
+            Ok(app_dir) => {
+                // Session RPCs need the automation-policy ledger; if it cannot
+                // open, workers still run but session RPCs answer
+                // service_unavailable (fail closed on limits, not open).
+                let session_rpc = match crate::plugin::automation_policy::AutomationPolicy::open(
+                    &app_dir.join("plugin_events.db"),
+                ) {
+                    Ok(policy) => Some(Arc::new(crate::plugin::session_api::SessionRpcDeps {
+                        session_service: Arc::clone(&session_service),
+                        policy: Arc::new(policy),
+                        profile: profile.to_string(),
+                    })),
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "plugin.host",
+                            "plugin session RPCs disabled: automation policy store failed: {e:#}"
+                        );
+                        None
+                    }
+                };
+                match crate::plugin::host::PluginHost::new(&app_dir, profile, session_rpc) {
+                    Ok(host) => Some(host),
+                    Err(e) => {
+                        tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
+                        None
+                    }
                 }
-            },
+            }
             Err(e) => {
                 tracing::warn!(target: "plugin.host", "plugin host disabled: {e:#}");
                 None
@@ -841,7 +883,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     let local_port = listener.local_addr()?.port();
 
-    crate::acp::version_probe::warn_for_structured_sessions(&instances, !is_daemon).await;
+    {
+        let instances = instances.read().await;
+        crate::acp::version_probe::warn_for_structured_sessions(&instances, !is_daemon).await;
+    }
 
     // Start tunnel if remote mode. Preference order:
     //  1. User-specified named Cloudflare tunnel (stable, explicit choice).
@@ -1045,25 +1090,6 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         ?allowed_origins,
         "resolved DNS-rebinding allowlist"
     );
-
-    let instances = Arc::new(RwLock::new(instances));
-    let instance_locks = Arc::new(RwLock::new(std::collections::HashMap::new()));
-    let telemetry_session_creates = Arc::new(std::sync::atomic::AtomicU32::new(0));
-    #[cfg(feature = "serve")]
-    let session_service = Arc::new(session_service::SessionService::new(
-        Arc::clone(&instances),
-        Arc::clone(&instance_locks),
-        Arc::clone(&file_watch),
-        Arc::clone(&telemetry_session_creates),
-        acp_supervisor.clone(),
-    ));
-    #[cfg(not(feature = "serve"))]
-    let session_service = Arc::new(session_service::SessionService::new(
-        Arc::clone(&instances),
-        Arc::clone(&instance_locks),
-        Arc::clone(&file_watch),
-        Arc::clone(&telemetry_session_creates),
-    ));
 
     let state = Arc::new(AppState {
         profile: profile.to_string(),

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -579,6 +579,10 @@ fn spec_payload_hash(spec: &StructuredSessionSpec) -> String {
         "initial_turn",
         spec.pending_initial_turn.as_deref().unwrap_or_default(),
     );
+    field(
+        "acp_mode_id",
+        spec.acp_mode_id.as_deref().unwrap_or_default(),
+    );
     #[cfg(feature = "serve")]
     {
         field("view", &format!("{:?}", spec.view));
@@ -643,6 +647,7 @@ mod tests {
             created_by_plugin: None,
             plugin_create_idempotency: None,
             pending_initial_turn: None,
+            acp_mode_id: None,
             #[cfg(feature = "serve")]
             view: crate::session::View::Structured,
             #[cfg(feature = "serve")]

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -87,6 +87,10 @@ pub struct SessionService {
     // process-local registry closes the duplicate-create race; a cross-process
     // reservation store only becomes necessary if that assumption changes.
     create_in_flight: std::sync::Mutex<HashMap<(String, String), CreateInFlight>>,
+    /// Session ids with a pending-initial-turn drain in flight, so the create
+    /// fast path and the reconciler tick cannot queue duplicate drains.
+    /// Sync mutex: critical sections are tiny and never span an `await`.
+    pending_drains: std::sync::Mutex<std::collections::HashSet<String>>,
 }
 
 /// Typed outcome of [`SessionService::send_turn`], split by whether the
@@ -111,6 +115,18 @@ pub(crate) enum SendTurnError {
     Send(crate::acp::supervisor::SupervisorError),
 }
 
+#[cfg(feature = "serve")]
+impl std::fmt::Display for SendTurnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SessionNotFound => write!(f, "session not found"),
+            Self::ResumeFailed(e) => write!(f, "worker resume failed: {e}"),
+            Self::WorkerNotReady => write!(f, "worker not ready"),
+            Self::Send(e) => write!(f, "prompt forward failed: {e}"),
+        }
+    }
+}
+
 impl SessionService {
     #[cfg(feature = "serve")]
     pub fn new(
@@ -129,6 +145,7 @@ impl SessionService {
             telemetry_session_creates,
             acp_supervisor,
             create_in_flight: std::sync::Mutex::new(HashMap::new()),
+            pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -145,6 +162,7 @@ impl SessionService {
             file_watch,
             telemetry_session_creates,
             create_in_flight: std::sync::Mutex::new(HashMap::new()),
+            pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -175,7 +193,12 @@ impl SessionService {
         mut spec: StructuredSessionSpec,
         plugin_id: Option<&str>,
         idempotency_key: Option<&str>,
+        initial_turn: Option<&str>,
     ) -> anyhow::Result<(SpawnOutcome, bool)> {
+        // Persisted with the instance in the same Storage::update, so the
+        // create and its first turn are accepted atomically; the drain paths
+        // deliver it once the worker is live.
+        spec.pending_initial_turn = initial_turn.map(str::to_string);
         let Some(plugin_id) = plugin_id else {
             let outcome = spawn_structured_session(self, spec).await?;
             return Ok((outcome, true));
@@ -338,6 +361,87 @@ impl SessionService {
         }
     }
 
+    /// Deliver a session's persisted `pending_initial_turn`, then clear it.
+    ///
+    /// Single drain owner: callers (the create fast path and the reconciler
+    /// tick) race through the `pending_drains` claim, and the delivery runs
+    /// under the per-instance lock, so the turn cannot be published twice
+    /// concurrently. A delivery failure leaves the field set; the reconciler
+    /// tick retries once the worker is live. Clearing writes memory first,
+    /// then disk: a crash (or failed persist) between the forward and the
+    /// disk clear re-delivers after restart, which is the documented
+    /// at-least-once contract.
+    #[cfg(feature = "serve")]
+    pub(crate) async fn drain_pending_initial_turn(self: &Arc<Self>, id: &str) {
+        {
+            let mut drains = self
+                .pending_drains
+                .lock()
+                .expect("pending_drains mutex poisoned");
+            if !drains.insert(id.to_string()) {
+                return;
+            }
+        }
+        let _claim = PendingDrainGuard {
+            service: Arc::clone(self),
+            id: id.to_string(),
+        };
+        let inst_lock = self.instance_lock(id).await;
+        let _serialized = inst_lock.lock().await;
+        let Some((text, profile)) = ({
+            let instances = self.instances.read().await;
+            instances.iter().find(|i| i.id == id).and_then(|i| {
+                i.pending_initial_turn
+                    .clone()
+                    .map(|text| (text, i.source_profile.clone()))
+            })
+        }) else {
+            return;
+        };
+        if let Err(e) = self.send_turn(id, &text, &[], false).await {
+            tracing::warn!(
+                target: "acp.supervisor",
+                session = %id,
+                "pending initial turn delivery failed; the reconciler will retry: {e}"
+            );
+            return;
+        }
+        {
+            let mut instances = self.instances.write().await;
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                inst.pending_initial_turn = None;
+            }
+        }
+        match crate::session::Storage::new(&profile, self.file_watch.clone()) {
+            Ok(storage) => {
+                let id_persist = id.to_string();
+                let persisted = tokio::task::spawn_blocking(move || {
+                    storage.update(|instances, _groups| {
+                        if let Some(inst) = instances.iter_mut().find(|i| i.id == id_persist) {
+                            inst.pending_initial_turn = None;
+                        }
+                        Ok(())
+                    })
+                })
+                .await;
+                if !matches!(persisted, Ok(Ok(()))) {
+                    tracing::warn!(
+                        target: "acp.supervisor",
+                        session = %id,
+                        "failed to persist pending initial turn clear; a daemon restart re-delivers it"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "acp.supervisor",
+                    session = %id,
+                    "failed to open storage to clear pending initial turn: {e}"
+                );
+            }
+        }
+    }
+
     /// Same lazy per-instance mutex registry as `AppState::instance_lock`;
     /// both operate on the shared map, so a lock taken through either handle
     /// excludes the other.
@@ -353,6 +457,25 @@ impl SessionService {
             .entry(id.to_string())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
+    }
+}
+
+/// Releases a session's `pending_drains` claim on every exit path of
+/// [`SessionService::drain_pending_initial_turn`], including panics.
+#[cfg(feature = "serve")]
+struct PendingDrainGuard {
+    service: Arc<SessionService>,
+    id: String,
+}
+
+#[cfg(feature = "serve")]
+impl Drop for PendingDrainGuard {
+    fn drop(&mut self) {
+        self.service
+            .pending_drains
+            .lock()
+            .expect("pending_drains mutex poisoned")
+            .remove(&self.id);
     }
 }
 
@@ -452,6 +575,10 @@ fn spec_payload_hash(spec: &StructuredSessionSpec) -> String {
         spec.custom_instruction.as_deref().unwrap_or_default(),
     );
     field("profile", &spec.profile);
+    field(
+        "initial_turn",
+        spec.pending_initial_turn.as_deref().unwrap_or_default(),
+    );
     #[cfg(feature = "serve")]
     {
         field("view", &format!("{:?}", spec.view));
@@ -515,6 +642,7 @@ mod tests {
             profile: "default".to_string(),
             created_by_plugin: None,
             plugin_create_idempotency: None,
+            pending_initial_turn: None,
             #[cfg(feature = "serve")]
             view: crate::session::View::Structured,
             #[cfg(feature = "serve")]
@@ -543,6 +671,14 @@ mod tests {
             a,
             spec_payload_hash(&changed),
             "a semantic field change must change the hash"
+        );
+
+        let mut with_turn = test_spec();
+        with_turn.pending_initial_turn = Some("run the nightly task".to_string());
+        assert_ne!(
+            a,
+            spec_payload_hash(&with_turn),
+            "the initial turn is part of the request identity"
         );
 
         // Adjacent-field concatenation must not collide: moving a suffix of
@@ -636,5 +772,32 @@ mod tests {
         let ClaimOutcome::Claimed = service.try_claim_in_flight(&scope, "hash-a") else {
             panic!("released scope must be claimable again");
         };
+    }
+
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn drain_is_a_noop_without_a_pending_turn_and_releases_its_claim() {
+        let mut inst = Instance::new("no-pending", "/tmp/aoe-2897-project");
+        inst.id = "sess-drain".to_string();
+        inst.view = crate::session::View::Structured;
+        let service = crate::server::test_support::build_test_app_state(vec![inst])
+            .session_service
+            .clone();
+
+        // No pending turn: returns without touching the supervisor. Missing
+        // session: same. Both must release the per-session claim so a later
+        // drain can run (the second call would return early if the first
+        // leaked its claim, which this test cannot distinguish from a no-op,
+        // so assert on the claim set directly).
+        service.drain_pending_initial_turn("sess-drain").await;
+        service.drain_pending_initial_turn("sess-missing").await;
+        assert!(
+            service
+                .pending_drains
+                .lock()
+                .expect("pending_drains mutex poisoned")
+                .is_empty(),
+            "drain must release its claim on the no-op paths"
+        );
     }
 }

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -93,6 +93,19 @@ pub struct SessionService {
     pending_drains: std::sync::Mutex<std::collections::HashSet<String>>,
 }
 
+/// Who is asking the session service to act. Constructed only by the
+/// transport layer (HTTP handler, plugin RPC connection context, or the
+/// drain reconstructing the creator), never decoded from a request payload,
+/// so a caller cannot forge an identity (#2897).
+#[cfg(feature = "serve")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionCaller {
+    /// A human-facing surface (HTTP dashboard, TUI).
+    User,
+    /// A plugin worker, identified by its connection's plugin id.
+    Plugin { plugin_id: String },
+}
+
 /// Typed outcome of [`SessionService::send_turn`], split by whether the
 /// failure happened before or after the prompt was published into the event
 /// stream, so callers can map each stage faithfully (the HTTP handler keeps
@@ -104,6 +117,14 @@ pub(crate) enum SendTurnError {
     /// snapshot. Nothing was published; the honest answer is "not found",
     /// not a retryable worker_not_ready. See #1748.
     SessionNotFound,
+    /// Pre-publish: a plugin caller targeted a session it did not create
+    /// (user-created, another plugin's, or a legacy row). Nothing was
+    /// published; no side effects ran.
+    NotOwner,
+    /// Pre-publish: the session's persisted explicit mode could not be
+    /// re-asserted before a plugin-delivered turn. The prompt is withheld
+    /// rather than run under an unconfirmed approval posture.
+    ModeApplication(crate::acp::supervisor::SupervisorError),
     /// Pre-publish: reserving the resume slot failed (includes
     /// `SupervisorError::CapacityFull`). Nothing was published.
     ResumeFailed(crate::acp::supervisor::SupervisorError),
@@ -120,6 +141,8 @@ impl std::fmt::Display for SendTurnError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SessionNotFound => write!(f, "session not found"),
+            Self::NotOwner => write!(f, "session was not created by the calling plugin"),
+            Self::ModeApplication(e) => write!(f, "mode application failed: {e}"),
             Self::ResumeFailed(e) => write!(f, "worker resume failed: {e}"),
             Self::WorkerNotReady => write!(f, "worker not ready"),
             Self::Send(e) => write!(f, "prompt forward failed: {e}"),
@@ -313,12 +336,30 @@ impl SessionService {
     #[cfg(feature = "serve")]
     pub(crate) async fn send_turn(
         self: &Arc<Self>,
+        caller: &SessionCaller,
         id: &str,
         text: &str,
         attachments: &[crate::acp::event_store::AttachmentBlob],
         woke_idle_dormant: bool,
     ) -> Result<(), SendTurnError> {
         use crate::server::acp_reconciler::ResumeTrigger;
+        // Ownership gate, before ANY side effect (no wake, resume, publish,
+        // or forward for a denied caller): a plugin may deliver turns only
+        // to sessions it created. Ownership is immutable after creation, so
+        // a read snapshot suffices; deliberately no instance_lock here (the
+        // pending-turn drain calls this while holding it).
+        let acp_mode_id = {
+            let instances = self.instances.read().await;
+            let Some(inst) = instances.iter().find(|i| i.id == id) else {
+                return Err(SendTurnError::SessionNotFound);
+            };
+            if let SessionCaller::Plugin { plugin_id } = caller {
+                if inst.created_by_plugin.as_deref() != Some(plugin_id.as_str()) {
+                    return Err(SendTurnError::NotOwner);
+                }
+            }
+            inst.acp_mode_id.clone()
+        };
         // Resume a worker that is not currently live. Two cases:
         //   - Idle-dormant wake: the worker was auto-stopped for inactivity
         //     (#1689) and the reconciler will not respawn it until its next
@@ -340,6 +381,19 @@ impl SessionService {
                 Ok(ResumeTrigger::NotFound) => return Err(SendTurnError::SessionNotFound),
                 Ok(_) => {}
                 Err(e) => return Err(SendTurnError::ResumeFailed(e)),
+            }
+        }
+        // A plugin-delivered turn must run under the session's persisted
+        // explicit mode: re-assert it before publishing, and withhold the
+        // prompt when the assertion fails (#2897). set_mode waits on the
+        // same ready-client path send_prompt uses, so a just-resumed worker
+        // is awaited, not raced. User surfaces skip this; the supervisor
+        // already re-asserts the mode on every (re)spawn.
+        if matches!(caller, SessionCaller::Plugin { .. }) {
+            if let Some(mode_id) = &acp_mode_id {
+                if let Err(e) = self.acp_supervisor.set_mode(id, mode_id).await {
+                    return Err(SendTurnError::ModeApplication(e));
+                }
             }
         }
         // Publish the user's prompt into the event stream BEFORE forwarding
@@ -388,17 +442,26 @@ impl SessionService {
         };
         let inst_lock = self.instance_lock(id).await;
         let _serialized = inst_lock.lock().await;
-        let Some((text, profile)) = ({
+        let Some((text, profile, caller)) = ({
             let instances = self.instances.read().await;
             instances.iter().find(|i| i.id == id).and_then(|i| {
-                i.pending_initial_turn
-                    .clone()
-                    .map(|text| (text, i.source_profile.clone()))
+                i.pending_initial_turn.clone().map(|text| {
+                    // Reconstruct the creator principal so plugin-created
+                    // pending turns keep plugin attribution and the plugin
+                    // mode-assertion path; user-created ones stay User.
+                    let caller = match &i.created_by_plugin {
+                        Some(plugin_id) => SessionCaller::Plugin {
+                            plugin_id: plugin_id.clone(),
+                        },
+                        None => SessionCaller::User,
+                    };
+                    (text, i.source_profile.clone(), caller)
+                })
             })
         }) else {
             return;
         };
-        if let Err(e) = self.send_turn(id, &text, &[], false).await {
+        if let Err(e) = self.send_turn(&caller, id, &text, &[], false).await {
             tracing::warn!(
                 target: "acp.supervisor",
                 session = %id,
@@ -777,6 +840,65 @@ mod tests {
         let ClaimOutcome::Claimed = service.try_claim_in_flight(&scope, "hash-a") else {
             panic!("released scope must be claimable again");
         };
+    }
+
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn send_turn_enforces_plugin_ownership_before_any_side_effect() {
+        let mut user_session = Instance::new("user-owned", "/tmp/aoe-2897-project");
+        user_session.id = "sess-user".to_string();
+        let mut cron_session = Instance::new("cron-owned", "/tmp/aoe-2897-project");
+        cron_session.id = "sess-cron".to_string();
+        cron_session.created_by_plugin = Some("cron".to_string());
+        let service =
+            crate::server::test_support::build_test_app_state(vec![user_session, cron_session])
+                .session_service
+                .clone();
+
+        let cron = SessionCaller::Plugin {
+            plugin_id: "cron".to_string(),
+        };
+        let other = SessionCaller::Plugin {
+            plugin_id: "other-plugin".to_string(),
+        };
+
+        // A plugin cannot deliver to a user-created session, another
+        // plugin's session, or a missing session.
+        assert!(matches!(
+            service
+                .send_turn(&cron, "sess-user", "hi", &[], false)
+                .await,
+            Err(SendTurnError::NotOwner)
+        ));
+        assert!(matches!(
+            service
+                .send_turn(&other, "sess-cron", "hi", &[], false)
+                .await,
+            Err(SendTurnError::NotOwner)
+        ));
+        assert!(matches!(
+            service
+                .send_turn(&cron, "sess-gone", "hi", &[], false)
+                .await,
+            Err(SendTurnError::SessionNotFound)
+        ));
+
+        // The owner passes the gate; these terminal-view test sessions fail
+        // at a LATER stage (resume snapshot or worker capacity, both
+        // environment dependent), proving the denials above came from the
+        // ownership check specifically.
+        assert!(!matches!(
+            service
+                .send_turn(&cron, "sess-cron", "hi", &[], false)
+                .await,
+            Ok(()) | Err(SendTurnError::NotOwner)
+        ));
+        assert!(!matches!(
+            service
+                .send_turn(&SessionCaller::User, "sess-user", "hi", &[], false)
+                .await,
+            Ok(()) | Err(SendTurnError::NotOwner)
+        ));
     }
 
     #[cfg(feature = "serve")]

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -32,7 +32,89 @@ pub struct SessionService {
         Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
 }
 
+/// Typed outcome of [`SessionService::send_turn`], split by whether the
+/// failure happened before or after the prompt was published into the event
+/// stream, so callers can map each stage faithfully (the HTTP handler keeps
+/// its exact pre-extraction status codes, and only fires the post-publish
+/// smart-rename hook when a publish actually happened).
+#[cfg(feature = "serve")]
+pub(crate) enum SendTurnError {
+    /// Pre-publish: the session vanished (or was triaged) before the resume
+    /// snapshot. Nothing was published; the honest answer is "not found",
+    /// not a retryable worker_not_ready. See #1748.
+    SessionNotFound,
+    /// Pre-publish: reserving the resume slot failed (includes
+    /// `SupervisorError::CapacityFull`). Nothing was published.
+    ResumeFailed(crate::acp::supervisor::SupervisorError),
+    /// Post-publish: the respawn kicked by this call did not finish within
+    /// `send_prompt`'s wait window (slow sandbox / spawn). The worker is
+    /// still coming; retryable. See #1748.
+    WorkerNotReady,
+    /// Post-publish: the forward to the agent failed.
+    Send(crate::acp::supervisor::SupervisorError),
+}
+
 impl SessionService {
+    /// Deliver a turn to a structured session: resume a dead/dormant worker
+    /// if needed, publish the prompt into the event stream, then forward it
+    /// to the agent. Extracted from the `acp_prompt` HTTP handler so a
+    /// non-HTTP caller (the plugin host, #2897) delivers turns through the
+    /// same path; the handler keeps HTTP concerns (read-only gate, wake,
+    /// attachment validation, smart-rename, status mapping).
+    ///
+    /// `woke_idle_dormant` forces the resume trigger even when the worker
+    /// looks alive, mirroring the handler's idle-dormant wake (#1689).
+    #[cfg(feature = "serve")]
+    pub(crate) async fn send_turn(
+        self: &Arc<Self>,
+        id: &str,
+        text: &str,
+        attachments: &[crate::acp::event_store::AttachmentBlob],
+        woke_idle_dormant: bool,
+    ) -> Result<(), SendTurnError> {
+        use crate::server::acp_reconciler::ResumeTrigger;
+        // Resume a worker that is not currently live. Two cases:
+        //   - Idle-dormant wake: the worker was auto-stopped for inactivity
+        //     (#1689) and the reconciler will not respawn it until its next
+        //     ~2s tick.
+        //   - Dead worker: the worker exited for another reason (e.g. the
+        //     silent-orphan watchdog escalated a monitor / `/loop` turn) and
+        //     is neither dormant nor mid-respawn, so a send would otherwise
+        //     404 and force a manual `aoe acp restart`.
+        // Either way, reserve the resume slot synchronously and drive a fresh
+        // spawn in a detached task NOW so the `send_prompt` below blocks on
+        // `wait_for_worker` until the worker is live instead of racing ahead
+        // to a 404. The detached task survives the originating request being
+        // cancelled on client disconnect. `is_running` is true for a live or
+        // mid-respawn worker, so a healthy session never double-spawns. See
+        // #1748.
+        let needs_resume = woke_idle_dormant || !self.acp_supervisor.is_running(id).await;
+        if needs_resume {
+            match crate::server::acp_reconciler::trigger_resume_background(self, id).await {
+                Ok(ResumeTrigger::NotFound) => return Err(SendTurnError::SessionNotFound),
+                Ok(_) => {}
+                Err(e) => return Err(SendTurnError::ResumeFailed(e)),
+            }
+        }
+        // Publish the user's prompt into the event stream BEFORE forwarding
+        // to the agent so the replay buffer / on-disk store captures it
+        // even if the agent forward fails. The frontend treats UserPromptSent
+        // as authoritative and dedupes against its own optimistic row.
+        self.acp_supervisor
+            .publish_user_prompt_with_attachments(id, text.to_string(), attachments)
+            .await;
+        match self.acp_supervisor.send_prompt(id, text, attachments).await {
+            Ok(()) => Ok(()),
+            // Intentional override of the canonical UnknownSession 404: the
+            // respawn we kicked above did not finish within `send_prompt`'s
+            // wait window. See the `WorkerNotReady` variant doc.
+            Err(crate::acp::supervisor::SupervisorError::UnknownSession(_)) if needs_resume => {
+                Err(SendTurnError::WorkerNotReady)
+            }
+            Err(e) => Err(SendTurnError::Send(e)),
+        }
+    }
+
     /// Same lazy per-instance mutex registry as `AppState::instance_lock`;
     /// both operate on the shared map, so a lock taken through either handle
     /// excludes the other.

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -56,6 +56,15 @@ impl std::fmt::Display for IdempotencyConflict {
 
 impl std::error::Error for IdempotencyConflict {}
 
+/// Read-only resolution of a plugin create-idempotency key, so a caller can
+/// decide whether to charge admission before building the session (#2897).
+pub(crate) enum CreateIdempotencyProbe {
+    /// A prior create with this plugin/key/payload already exists; replay it.
+    Replay(Box<Instance>),
+    /// No prior create matches; this is a genuinely new create.
+    New,
+}
+
 /// Result of matching a plugin create request against the persisted sessions.
 enum IdempotentMatch {
     /// Same plugin, key, and payload: return this existing session.
@@ -297,6 +306,30 @@ impl SessionService {
         };
         let outcome = spawn_structured_session(self, spec).await?;
         Ok((outcome, true))
+    }
+
+    /// Resolve a persisted plugin create-idempotency decision without any side
+    /// effect, so a caller can charge admission (rate/concurrency) only for
+    /// genuinely new creates (#2897). `spec` must be the exact spec that will
+    /// be passed to [`Self::create_structured_session`] (in particular
+    /// `pending_initial_turn` already set), so the payload hash matches. Only
+    /// the persisted list is consulted: an in-flight same-process retry still
+    /// dedupes inside `create_structured_session`, at the cost of one admission.
+    pub(crate) async fn probe_plugin_create_idempotency(
+        &self,
+        spec: &StructuredSessionSpec,
+        plugin_id: &str,
+        key: &str,
+    ) -> Result<CreateIdempotencyProbe, IdempotencyConflict> {
+        let payload_hash = spec_payload_hash(spec);
+        let instances = self.instances.read().await;
+        match find_idempotent_match(&instances, plugin_id, key, &payload_hash) {
+            IdempotentMatch::Same(instance) => Ok(CreateIdempotencyProbe::Replay(instance)),
+            IdempotentMatch::Conflict => Err(IdempotencyConflict {
+                key: key.to_string(),
+            }),
+            IdempotentMatch::None => Ok(CreateIdempotencyProbe::New),
+        }
     }
 
     /// Claim the in-flight slot for a `(plugin_id, key)` scope, or report an
@@ -840,6 +873,54 @@ mod tests {
         let ClaimOutcome::Claimed = service.try_claim_in_flight(&scope, "hash-a") else {
             panic!("released scope must be claimable again");
         };
+    }
+
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn probe_resolves_replay_conflict_and_new() {
+        // Seed a prior create whose stored hash matches `test_spec()`; the probe
+        // must resolve replay/conflict from the persisted list alone, so a
+        // caller can skip admission (rate/concurrency) for an idempotent retry.
+        let spec = test_spec();
+        let hash = spec_payload_hash(&spec);
+        let mut prior = plugin_instance("cron", "job-1", &hash);
+        prior.id = "sess-prior".to_string();
+        let service = crate::server::test_support::build_test_app_state(vec![prior])
+            .session_service
+            .clone();
+
+        // Same plugin, key, and payload: replay the existing session.
+        match service
+            .probe_plugin_create_idempotency(&spec, "cron", "job-1")
+            .await
+        {
+            Ok(CreateIdempotencyProbe::Replay(inst)) => assert_eq!(inst.id, "sess-prior"),
+            _ => panic!("expected replay"),
+        }
+
+        // Same plugin and key, different payload: conflict.
+        let mut other = test_spec();
+        other.title = Some("different".to_string());
+        assert!(service
+            .probe_plugin_create_idempotency(&other, "cron", "job-1")
+            .await
+            .is_err());
+
+        // Unknown key: a genuinely new create.
+        assert!(matches!(
+            service
+                .probe_plugin_create_idempotency(&spec, "cron", "job-2")
+                .await,
+            Ok(CreateIdempotencyProbe::New)
+        ));
+
+        // Another plugin's session with the same key: new (never cross-plugin).
+        assert!(matches!(
+            service
+                .probe_plugin_create_idempotency(&spec, "other-plugin", "job-1")
+                .await,
+            Ok(CreateIdempotencyProbe::New)
+        ));
     }
 
     #[cfg(feature = "serve")]

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -1,0 +1,52 @@
+//! Shared session-domain service handle.
+//!
+//! Holds the narrow set of daemon state the session create/turn paths need
+//! (live instances, ACP supervisor, storage file-watch, per-instance locks,
+//! telemetry counter), so those paths can be driven by callers that do not
+//! hold the HTTP `AppState`: today the HTTP handlers, next the plugin host
+//! RPCs (#2897). `AppState` constructs one and keeps cloned handles to the
+//! same underlying state, so both views stay consistent; neither owns the
+//! other, which avoids an `AppState`/`PluginHost` reference cycle.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::session::Instance;
+
+pub struct SessionService {
+    /// Live in-memory session list, shared with `AppState.instances`.
+    pub instances: Arc<RwLock<Vec<Instance>>>,
+    /// Per-instance mutation locks, shared with `AppState.instance_locks`.
+    pub instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Storage change-notification service, shared with `AppState.file_watch`.
+    pub file_watch: Arc<crate::file_watch::FileWatchService>,
+    /// Opt-in telemetry create counter, shared with
+    /// `AppState.telemetry_session_creates`.
+    pub telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
+    /// Owns the per-session ACP agent subprocesses, shared with
+    /// `AppState.acp_supervisor`.
+    #[cfg(feature = "serve")]
+    pub acp_supervisor:
+        Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
+}
+
+impl SessionService {
+    /// Same lazy per-instance mutex registry as `AppState::instance_lock`;
+    /// both operate on the shared map, so a lock taken through either handle
+    /// excludes the other.
+    pub async fn instance_lock(&self, id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        {
+            let guard = self.instance_locks.read().await;
+            if let Some(lock) = guard.get(id) {
+                return lock.clone();
+            }
+        }
+        let mut guard = self.instance_locks.write().await;
+        guard
+            .entry(id.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+}

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -13,7 +13,58 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-use crate::session::Instance;
+use crate::server::session_spawn::{spawn_structured_session, SpawnOutcome, StructuredSessionSpec};
+use crate::session::{Instance, PluginCreateIdempotency};
+
+/// A create currently being built for a `(plugin_id, idempotency_key)` scope.
+/// Present only between the idempotency claim and the end of the build, so a
+/// concurrent retry of the same key waits for the winner instead of
+/// provisioning a second worktree.
+struct CreateInFlight {
+    payload_hash: String,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+/// What `try_claim_in_flight` decided for a plugin create request.
+enum ClaimOutcome {
+    /// This caller owns the build; it must drop the returned guard on every
+    /// exit path so waiters wake up.
+    Claimed,
+    /// An identical request is mid-build; wait on the notify, then re-check.
+    Wait(Arc<tokio::sync::Notify>),
+    /// The same key is mid-build with a different payload.
+    Conflict,
+}
+
+/// Marker error for a plugin create that reused an idempotency key with a
+/// different request payload. Callers downcast it the same way the HTTP
+/// handler downcasts `SessionBuildPanicked` / `HooksNeedTrust`.
+#[derive(Debug)]
+pub(crate) struct IdempotencyConflict {
+    pub key: String,
+}
+
+impl std::fmt::Display for IdempotencyConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "idempotency key {:?} was already used with a different request payload",
+            self.key
+        )
+    }
+}
+
+impl std::error::Error for IdempotencyConflict {}
+
+/// Result of matching a plugin create request against the persisted sessions.
+enum IdempotentMatch {
+    /// Same plugin, key, and payload: return this existing session.
+    Same(Box<Instance>),
+    /// Same plugin and key, different payload: refuse.
+    Conflict,
+    /// No session carries this plugin/key pair.
+    None,
+}
 
 pub struct SessionService {
     /// Live in-memory session list, shared with `AppState.instances`.
@@ -30,6 +81,12 @@ pub struct SessionService {
     #[cfg(feature = "serve")]
     pub acp_supervisor:
         Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
+    /// In-flight plugin creates keyed by `(plugin_id, idempotency_key)`.
+    /// Sync mutex: critical sections are tiny and never span an `await`.
+    // ponytail: one daemon process is the only sessions.json writer, so a
+    // process-local registry closes the duplicate-create race; a cross-process
+    // reservation store only becomes necessary if that assumption changes.
+    create_in_flight: std::sync::Mutex<HashMap<(String, String), CreateInFlight>>,
 }
 
 /// Typed outcome of [`SessionService::send_turn`], split by whether the
@@ -55,6 +112,172 @@ pub(crate) enum SendTurnError {
 }
 
 impl SessionService {
+    #[cfg(feature = "serve")]
+    pub fn new(
+        instances: Arc<RwLock<Vec<Instance>>>,
+        instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+        file_watch: Arc<crate::file_watch::FileWatchService>,
+        telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
+        acp_supervisor: Arc<
+            crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>,
+        >,
+    ) -> Self {
+        Self {
+            instances,
+            instance_locks,
+            file_watch,
+            telemetry_session_creates,
+            acp_supervisor,
+            create_in_flight: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(not(feature = "serve"))]
+    pub fn new(
+        instances: Arc<RwLock<Vec<Instance>>>,
+        instance_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+        file_watch: Arc<crate::file_watch::FileWatchService>,
+        telemetry_session_creates: Arc<std::sync::atomic::AtomicU32>,
+    ) -> Self {
+        Self {
+            instances,
+            instance_locks,
+            file_watch,
+            telemetry_session_creates,
+            create_in_flight: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a structured session through the shared spawn pipeline,
+    /// optionally as a plugin with a create-idempotency key (#2897).
+    ///
+    /// For a user caller (`plugin_id: None`) this is exactly the pre-service
+    /// create path. For a plugin caller it additionally:
+    /// - stamps `created_by_plugin` and the idempotency record on the
+    ///   instance before it is persisted, atomically with the row itself;
+    /// - forces repo-hook trust fail-closed (`trust_hooks = false`); a plugin
+    ///   cannot pre-approve a repository's hooks, so an untrusted repo
+    ///   refuses the create regardless of install grants;
+    /// - deduplicates on `(plugin_id, idempotency_key)`: a retry with the
+    ///   same payload returns the existing session (`created: false` in the
+    ///   returned pair), a retry with a different payload fails with
+    ///   [`IdempotencyConflict`], and a concurrent identical retry waits for
+    ///   the in-flight build instead of provisioning a second worktree.
+    ///
+    /// Idempotency retention equals the session record's lifetime: archived,
+    /// snoozed, and trashed sessions still deduplicate; a hard-deleted
+    /// session releases its key, and a later retry creates a fresh session.
+    ///
+    /// Returns the spawn outcome plus `created`: `false` when an existing
+    /// session was returned by idempotency instead of a new one.
+    pub(crate) async fn create_structured_session(
+        self: &Arc<Self>,
+        mut spec: StructuredSessionSpec,
+        plugin_id: Option<&str>,
+        idempotency_key: Option<&str>,
+    ) -> anyhow::Result<(SpawnOutcome, bool)> {
+        let Some(plugin_id) = plugin_id else {
+            let outcome = spawn_structured_session(self, spec).await?;
+            return Ok((outcome, true));
+        };
+
+        spec.created_by_plugin = Some(plugin_id.to_string());
+        // Fail-closed: install-time plugin consent is not repository trust.
+        spec.trust_hooks = Some(false);
+
+        let Some(key) = idempotency_key else {
+            let outcome = spawn_structured_session(self, spec).await?;
+            return Ok((outcome, true));
+        };
+
+        let payload_hash = spec_payload_hash(&spec);
+        spec.plugin_create_idempotency = Some(PluginCreateIdempotency {
+            key: key.to_string(),
+            payload_hash: payload_hash.clone(),
+        });
+        let scope = (plugin_id.to_string(), key.to_string());
+
+        loop {
+            // Persisted-first lookup: a completed create (this daemon life or
+            // an earlier one) wins before any in-flight coordination.
+            {
+                let instances = self.instances.read().await;
+                match find_idempotent_match(&instances, plugin_id, key, &payload_hash) {
+                    IdempotentMatch::Same(instance) => {
+                        return Ok((
+                            SpawnOutcome {
+                                instance: *instance,
+                                warnings: Vec::new(),
+                            },
+                            false,
+                        ));
+                    }
+                    IdempotentMatch::Conflict => {
+                        return Err(anyhow::Error::new(IdempotencyConflict {
+                            key: key.to_string(),
+                        }));
+                    }
+                    IdempotentMatch::None => {}
+                }
+            }
+            match self.try_claim_in_flight(&scope, &payload_hash) {
+                ClaimOutcome::Claimed => break,
+                ClaimOutcome::Wait(notify) => {
+                    // The winner removes its entry and notifies on every exit
+                    // path (guard drop), after which the loop re-checks the
+                    // persisted list: a successful winner is found there, a
+                    // failed winner leaves this retry to build fresh. The
+                    // wait is bounded because `notify_waiters` only wakes
+                    // already-registered waiters; a winner finishing between
+                    // our claim attempt and this await would otherwise strand
+                    // us. A missed notify costs one extra loop iteration.
+                    let _ = tokio::time::timeout(
+                        std::time::Duration::from_millis(250),
+                        notify.notified(),
+                    )
+                    .await;
+                }
+                ClaimOutcome::Conflict => {
+                    return Err(anyhow::Error::new(IdempotencyConflict {
+                        key: key.to_string(),
+                    }));
+                }
+            }
+        }
+
+        let _guard = InFlightGuard {
+            service: Arc::clone(self),
+            scope,
+        };
+        let outcome = spawn_structured_session(self, spec).await?;
+        Ok((outcome, true))
+    }
+
+    /// Claim the in-flight slot for a `(plugin_id, key)` scope, or report an
+    /// identical build to wait on / a payload conflict to refuse.
+    fn try_claim_in_flight(&self, scope: &(String, String), payload_hash: &str) -> ClaimOutcome {
+        let mut in_flight = self
+            .create_in_flight
+            .lock()
+            .expect("create_in_flight mutex poisoned");
+        match in_flight.get(scope) {
+            Some(entry) if entry.payload_hash == payload_hash => {
+                ClaimOutcome::Wait(entry.notify.clone())
+            }
+            Some(_) => ClaimOutcome::Conflict,
+            None => {
+                in_flight.insert(
+                    scope.clone(),
+                    CreateInFlight {
+                        payload_hash: payload_hash.to_string(),
+                        notify: Arc::new(tokio::sync::Notify::new()),
+                    },
+                );
+                ClaimOutcome::Claimed
+            }
+        }
+    }
+
     /// Deliver a turn to a structured session: resume a dead/dormant worker
     /// if needed, publish the prompt into the event stream, then forward it
     /// to the agent. Extracted from the `acp_prompt` HTTP handler so a
@@ -130,5 +353,288 @@ impl SessionService {
             .entry(id.to_string())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
+    }
+}
+
+/// Releases the in-flight slot and wakes waiters on every exit path of the
+/// winning create, including an error return or a panic unwinding through
+/// the caller.
+struct InFlightGuard {
+    service: Arc<SessionService>,
+    scope: (String, String),
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        let mut in_flight = self
+            .service
+            .create_in_flight
+            .lock()
+            .expect("create_in_flight mutex poisoned");
+        if let Some(entry) = in_flight.remove(&self.scope) {
+            entry.notify.notify_waiters();
+        }
+    }
+}
+
+/// Match a plugin create request against the persisted sessions by
+/// `(created_by_plugin, idempotency key)`. Archived, snoozed, and trashed
+/// sessions still match: the record exists, so the create already happened;
+/// returning it does not restore or unarchive anything. Only a hard-deleted
+/// record (absent from the list) frees the key.
+fn find_idempotent_match(
+    instances: &[Instance],
+    plugin_id: &str,
+    key: &str,
+    payload_hash: &str,
+) -> IdempotentMatch {
+    for instance in instances {
+        if instance.created_by_plugin.as_deref() != Some(plugin_id) {
+            continue;
+        }
+        let Some(record) = &instance.plugin_create_idempotency else {
+            continue;
+        };
+        if record.key != key {
+            continue;
+        }
+        if record.payload_hash == payload_hash {
+            return IdempotentMatch::Same(Box::new(instance.clone()));
+        }
+        return IdempotentMatch::Conflict;
+    }
+    IdempotentMatch::None
+}
+
+/// Versioned, restart-stable hash of the semantic create request. Field order
+/// is fixed and every field is length-prefixed by its `Debug`/value rendering
+/// with a separator, so two different requests cannot collide by
+/// concatenation. `trust_hooks` is excluded: it is forced for plugin callers
+/// and never part of the request identity.
+fn spec_payload_hash(spec: &StructuredSessionSpec) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    let mut field = |name: &str, value: &str| {
+        hasher.update(name.as_bytes());
+        hasher.update([0x1f]);
+        hasher.update((value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+        hasher.update([0x1e]);
+    };
+    field("version", "1");
+    field("title", spec.title.as_deref().unwrap_or_default());
+    field("path", &spec.path);
+    field("group", &spec.group);
+    field("tool", &spec.tool);
+    field("worktree_enabled", &spec.worktree_enabled.to_string());
+    field(
+        "worktree_branch",
+        spec.worktree_branch.as_deref().unwrap_or_default(),
+    );
+    field("create_new_branch", &spec.create_new_branch.to_string());
+    field(
+        "base_branch",
+        spec.base_branch.as_deref().unwrap_or_default(),
+    );
+    field("sandbox", &spec.sandbox.to_string());
+    field(
+        "sandbox_image",
+        spec.sandbox_image.as_deref().unwrap_or_default(),
+    );
+    field("yolo_mode", &spec.yolo_mode.to_string());
+    field("extra_env", &spec.extra_env.join("\x1f"));
+    field("extra_args", &spec.extra_args);
+    field("command_override", &spec.command_override);
+    field("extra_repo_paths", &spec.extra_repo_paths.join("\x1f"));
+    field("scratch", &spec.scratch.to_string());
+    field(
+        "custom_instruction",
+        spec.custom_instruction.as_deref().unwrap_or_default(),
+    );
+    field("profile", &spec.profile);
+    #[cfg(feature = "serve")]
+    {
+        field("view", &format!("{:?}", spec.view));
+        field("agent_name", spec.agent_name.as_deref().unwrap_or_default());
+        field(
+            "agent_model",
+            spec.agent_model.as_deref().unwrap_or_default(),
+        );
+        field(
+            "agent_effort",
+            spec.agent_effort.as_deref().unwrap_or_default(),
+        );
+        field(
+            "import_acp_session_id",
+            spec.import_acp_session_id.as_deref().unwrap_or_default(),
+        );
+    }
+    use std::fmt::Write;
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plugin_instance(plugin_id: &str, key: &str, payload_hash: &str) -> Instance {
+        let mut inst = Instance::new("scheduled", "/tmp/aoe-2897-project");
+        inst.created_by_plugin = Some(plugin_id.to_string());
+        inst.plugin_create_idempotency = Some(PluginCreateIdempotency {
+            key: key.to_string(),
+            payload_hash: payload_hash.to_string(),
+        });
+        inst
+    }
+
+    fn test_spec() -> StructuredSessionSpec {
+        StructuredSessionSpec {
+            title: Some("nightly".to_string()),
+            path: "/tmp/aoe-2897-project".to_string(),
+            group: String::new(),
+            tool: "claude".to_string(),
+            worktree_enabled: false,
+            worktree_branch: None,
+            create_new_branch: false,
+            base_branch: None,
+            sandbox: false,
+            sandbox_image: None,
+            yolo_mode: false,
+            extra_env: Vec::new(),
+            extra_args: String::new(),
+            command_override: String::new(),
+            extra_repo_paths: Vec::new(),
+            scratch: false,
+            trust_hooks: None,
+            custom_instruction: None,
+            profile: "default".to_string(),
+            created_by_plugin: None,
+            plugin_create_idempotency: None,
+            #[cfg(feature = "serve")]
+            view: crate::session::View::Structured,
+            #[cfg(feature = "serve")]
+            agent_name: Some("claude".to_string()),
+            #[cfg(feature = "serve")]
+            agent_model: None,
+            #[cfg(feature = "serve")]
+            agent_effort: None,
+            #[cfg(feature = "serve")]
+            import_acp_session_id: None,
+            #[cfg(feature = "serve")]
+            fork_seed: None,
+        }
+    }
+
+    #[test]
+    fn payload_hash_is_deterministic_and_field_sensitive() {
+        let spec = test_spec();
+        let a = spec_payload_hash(&spec);
+        let b = spec_payload_hash(&test_spec());
+        assert_eq!(a, b, "same spec must hash identically across calls");
+
+        let mut changed = test_spec();
+        changed.path = "/tmp/aoe-2897-other".to_string();
+        assert_ne!(
+            a,
+            spec_payload_hash(&changed),
+            "a semantic field change must change the hash"
+        );
+
+        // Adjacent-field concatenation must not collide: moving a suffix of
+        // one field into the prefix of the next is a different request.
+        let mut shifted_a = test_spec();
+        shifted_a.extra_args = "ab".to_string();
+        shifted_a.command_override = "c".to_string();
+        let mut shifted_b = test_spec();
+        shifted_b.extra_args = "a".to_string();
+        shifted_b.command_override = "bc".to_string();
+        assert_ne!(spec_payload_hash(&shifted_a), spec_payload_hash(&shifted_b));
+    }
+
+    #[test]
+    fn idempotent_match_same_conflict_and_scope() {
+        let instances = vec![plugin_instance("cron", "job-1:2026-07-16", "hash-a")];
+
+        assert!(matches!(
+            find_idempotent_match(&instances, "cron", "job-1:2026-07-16", "hash-a"),
+            IdempotentMatch::Same(_)
+        ));
+        assert!(matches!(
+            find_idempotent_match(&instances, "cron", "job-1:2026-07-16", "hash-b"),
+            IdempotentMatch::Conflict
+        ));
+        // Another plugin may reuse the same key: scopes are per plugin id.
+        assert!(matches!(
+            find_idempotent_match(&instances, "other-plugin", "job-1:2026-07-16", "hash-a"),
+            IdempotentMatch::None
+        ));
+        assert!(matches!(
+            find_idempotent_match(&instances, "cron", "job-2:2026-07-16", "hash-a"),
+            IdempotentMatch::None
+        ));
+    }
+
+    #[test]
+    fn idempotent_match_survives_triage_but_not_removal() {
+        let mut archived = plugin_instance("cron", "k", "h");
+        archived.archived_at = Some(chrono::Utc::now());
+        let mut trashed = plugin_instance("cron", "k2", "h");
+        trashed.trashed_at = Some(chrono::Utc::now());
+        let instances = vec![archived, trashed];
+
+        assert!(matches!(
+            find_idempotent_match(&instances, "cron", "k", "h"),
+            IdempotentMatch::Same(_)
+        ));
+        assert!(matches!(
+            find_idempotent_match(&instances, "cron", "k2", "h"),
+            IdempotentMatch::Same(_)
+        ));
+        // Hard delete: the record is gone from the list, the key is free.
+        assert!(matches!(
+            find_idempotent_match(&[], "cron", "k", "h"),
+            IdempotentMatch::None
+        ));
+    }
+
+    #[cfg(feature = "serve")]
+    #[tokio::test]
+    async fn in_flight_claim_waits_same_hash_and_conflicts_on_mismatch() {
+        let service = crate::server::test_support::build_test_app_state(Vec::new())
+            .session_service
+            .clone();
+        let scope = ("cron".to_string(), "job-1".to_string());
+
+        let ClaimOutcome::Claimed = service.try_claim_in_flight(&scope, "hash-a") else {
+            panic!("first claim must win");
+        };
+        let ClaimOutcome::Wait(notify) = service.try_claim_in_flight(&scope, "hash-a") else {
+            panic!("identical concurrent claim must wait");
+        };
+        let ClaimOutcome::Conflict = service.try_claim_in_flight(&scope, "hash-b") else {
+            panic!("same key with a different payload must conflict");
+        };
+
+        let notified = tokio::spawn(async move { notify.notified().await });
+        // Let the waiter task register on the notify before the guard fires
+        // notify_waiters (deterministic on the current-thread test runtime).
+        tokio::task::yield_now().await;
+        drop(InFlightGuard {
+            service: Arc::clone(&service),
+            scope: scope.clone(),
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), notified)
+            .await
+            .expect("guard drop must wake waiters")
+            .expect("waiter task");
+
+        let ClaimOutcome::Claimed = service.try_claim_in_flight(&scope, "hash-a") else {
+            panic!("released scope must be claimable again");
+        };
     }
 }

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -1,0 +1,544 @@
+//! Domain core for creating a session: build the instance, persist it, upsert
+//! it into the live state, and (for a structured session) spawn its ACP worker.
+//!
+//! Extracted from the `create_session` HTTP handler so a non-HTTP caller (for
+//! example a scheduler) can create a structured-view ACP session without
+//! duplicating the build/persist/spawn logic. The handler keeps all request
+//! decoding, validation, and response construction; it decodes a request into a
+//! [`StructuredSessionSpec`], calls [`spawn_structured_session`], and builds its
+//! HTTP response from the returned [`SpawnOutcome`].
+
+use std::sync::Arc;
+
+use crate::session::Instance;
+
+use super::AppState;
+
+/// Already-decoded, already-validated inputs the create core needs. The HTTP
+/// handler fills this in after it has finished request parsing, auth, and
+/// validation; a future non-HTTP caller builds it directly.
+pub(crate) struct StructuredSessionSpec {
+    pub title: Option<String>,
+    pub path: String,
+    pub group: String,
+    pub tool: String,
+    pub worktree_enabled: bool,
+    pub worktree_branch: Option<String>,
+    pub create_new_branch: bool,
+    pub base_branch: Option<String>,
+    pub sandbox: bool,
+    pub sandbox_image: Option<String>,
+    pub yolo_mode: bool,
+    pub extra_env: Vec<String>,
+    pub extra_args: String,
+    pub command_override: String,
+    pub extra_repo_paths: Vec<String>,
+    pub scratch: bool,
+    pub trust_hooks: Option<bool>,
+    pub custom_instruction: Option<String>,
+    /// Resolved source profile (request profile, else the server default).
+    pub profile: String,
+    #[cfg(feature = "serve")]
+    pub view: crate::session::View,
+    #[cfg(feature = "serve")]
+    pub agent_name: Option<String>,
+    #[cfg(feature = "serve")]
+    pub agent_model: Option<String>,
+    #[cfg(feature = "serve")]
+    pub agent_effort: Option<String>,
+    #[cfg(feature = "serve")]
+    pub import_acp_session_id: Option<String>,
+    #[cfg(feature = "serve")]
+    pub fork_seed: Option<crate::session::ForkSeed>,
+}
+
+/// What the create core returns to its caller once the session exists in state.
+/// The HTTP handler builds its `SessionResponse` from `instance` and threads
+/// `warnings` onto it exactly as the inline handler did.
+pub(crate) struct SpawnOutcome {
+    pub instance: Instance,
+    pub warnings: Vec<String>,
+}
+
+/// Marker error the core returns when the blocking build task panicked, so the
+/// HTTP handler can keep answering `500 Internal Server Error` for that case
+/// while a plain build failure stays `400`. Mirrors the existing
+/// `HooksNeedTrust` downcast pattern in the handler.
+#[derive(Debug)]
+pub(crate) struct SessionBuildPanicked(pub String);
+
+impl std::fmt::Display for SessionBuildPanicked {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for SessionBuildPanicked {}
+
+/// Build, persist, and register a session, spawning its ACP worker when the
+/// resolved view is structured. Returns the created instance and any build
+/// warnings; a build-time panic is surfaced as a [`SessionBuildPanicked`] error
+/// and a repo-trust refusal propagates as-is so the caller can map it.
+pub(crate) async fn spawn_structured_session(
+    state: &Arc<AppState>,
+    spec: StructuredSessionSpec,
+) -> anyhow::Result<SpawnOutcome> {
+    let instances = state.instances.read().await;
+    let existing_titles: Vec<String> = instances.iter().map(|i| i.title.clone()).collect();
+    let existing_branches: Vec<String> = instances
+        .iter()
+        .filter_map(|i| i.worktree_info.as_ref().map(|w| w.branch.clone()))
+        .collect();
+    drop(instances);
+
+    let file_watch_for_create = state.file_watch.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        use crate::session::builder::{self, InstanceParams};
+        use crate::session::Config;
+        use crate::session::Storage;
+
+        let StructuredSessionSpec {
+            title,
+            path,
+            group,
+            tool,
+            worktree_enabled,
+            worktree_branch,
+            create_new_branch,
+            base_branch,
+            sandbox,
+            sandbox_image,
+            yolo_mode,
+            extra_env,
+            extra_args,
+            command_override,
+            extra_repo_paths,
+            scratch,
+            trust_hooks,
+            custom_instruction,
+            profile,
+            #[cfg(feature = "serve")]
+            view,
+            #[cfg(feature = "serve")]
+            agent_name,
+            #[cfg(feature = "serve")]
+            agent_model,
+            #[cfg(feature = "serve")]
+            agent_effort,
+            #[cfg(feature = "serve")]
+            import_acp_session_id,
+            #[cfg(feature = "serve")]
+            fork_seed,
+        } = spec;
+
+        let config = Config::load_or_warn();
+        let sandbox_image = sandbox_image.unwrap_or_else(|| {
+            if config.sandbox.default_image.is_empty() {
+                "ubuntu:latest".to_string()
+            } else {
+                config.sandbox.default_image.clone()
+            }
+        });
+
+        let title_refs: Vec<&str> = existing_titles.iter().map(|s| s.as_str()).collect();
+        let branch_refs: Vec<&str> = existing_branches.iter().map(|s| s.as_str()).collect();
+        let extra_repo_paths: Vec<String> = extra_repo_paths
+            .into_iter()
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        // Resolve repo hook trust BEFORE building the worktree (#2066): a repo
+        // whose hooks need approval and that was not sent `trust_hooks: true`
+        // is refused here, so the handler never leaves an orphan worktree on
+        // disk. The original `path` is the trust anchor (the same source the
+        // CLI/TUI use); `check_repo_trust` resolves a worktree path to its main
+        // repo, so a worktree created from an already-trusted repo inherits its
+        // trust without a separate prompt.
+        let original_path = path.clone();
+        let hook_plan = crate::server::api::sessions::resolve_create_hook_plan(
+            &profile,
+            std::path::Path::new(&original_path),
+            scratch,
+            trust_hooks.unwrap_or(false),
+        )?;
+
+        let title = title.unwrap_or_default();
+        let worktree_branch = worktree_branch
+            .map(|b| b.trim().to_string())
+            .filter(|b| !b.is_empty());
+
+        let params = InstanceParams {
+            title,
+            path,
+            group,
+            tool,
+            worktree_enabled,
+            worktree_branch,
+            create_new_branch,
+            base_branch: if create_new_branch {
+                base_branch
+                    .as_ref()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            } else {
+                None
+            },
+            sandbox,
+            sandbox_image,
+            yolo_mode,
+            extra_env,
+            extra_args,
+            command_override,
+            extra_repo_paths,
+            scratch,
+            #[cfg(feature = "serve")]
+            fork_seed,
+            #[cfg(not(feature = "serve"))]
+            fork_seed: None,
+        };
+
+        let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
+        let mut instance = build_result.instance;
+        instance.source_profile = profile.clone();
+        let build_warnings = build_result.warnings;
+        let created_worktree = build_result.created_worktree;
+        let created_workspace_worktrees = build_result.created_workspace_worktrees;
+
+        // Apply per-session sandbox overrides from the request body.
+        if let Some(ref mut sandbox) = instance.sandbox_info {
+            if custom_instruction.is_some() {
+                sandbox.custom_instruction = custom_instruction;
+            }
+        }
+
+        // Apply structured-view fields from the request body. structured_view is
+        // re-validated below against real ACP capability; non-ACP tools
+        // fall back to terminal view rather than erroring at spawn time.
+        #[cfg(feature = "serve")]
+        let agent_effort = {
+            instance.view = view;
+            // #2276: importing an existing Claude session forces the
+            // structured view and adopts the on-disk session id, so the
+            // structured spawn resumes it via session/load and seeds the
+            // transcript from the agent's history replay. `path` is the
+            // session's original cwd (the wizard prefills it).
+            if let Some(import_id) = import_acp_session_id
+                .clone()
+                .filter(|s| !s.trim().is_empty())
+            {
+                instance.view = crate::session::View::Structured;
+                instance.acp_session_id = Some(import_id);
+                instance.import_pending = Some(true);
+            }
+            instance.agent_name = agent_name;
+            let agent_key = instance
+                .agent_name
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(instance.tool.as_str())
+                .to_string();
+            let resolved_config = crate::session::repo_config::resolve_config_with_repo_or_warn(
+                &instance.source_profile,
+                std::path::Path::new(&instance.project_path),
+            );
+            let defaults = resolved_config.acp.acp_defaults_for(&agent_key);
+            // Preserve the explicit request model separately (trimmed to match
+            // the resolver's normalization) so a terminal fallback below can
+            // keep it while dropping any ACP-derived default; agent_model is
+            // ACP-only.
+            let explicit_model = agent_model
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            // Explicit request wins, else the per-agent default; effort is keyed
+            // on the resolved model. Same single-source resolver the spawn path
+            // uses; persist the model here so the composer shows it and the
+            // session stays pinned to it. See resolve_spawn_model_effort.
+            let (resolved_model, mut agent_effort) =
+                crate::session::config::resolve_spawn_model_effort(
+                    defaults,
+                    explicit_model.clone(),
+                    agent_effort,
+                );
+            instance.agent_model = resolved_model;
+            // Don't trust the client's capability decision. Re-resolve
+            // whether this agent can actually run in structured view; a custom
+            // agent without an `agent_acp_cmd` (or any non-ACP tool)
+            // falls back to tmux here rather than erroring at spawn time.
+            if instance.is_structured() {
+                let acp_registry = crate::acp::AgentRegistry::with_defaults();
+                let resolved = instance
+                    .agent_name
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(instance.tool.as_str());
+                let capable = acp_registry.get(resolved).is_some()
+                    || crate::session::repo_config::resolve_config_with_repo_or_warn(
+                        &instance.source_profile,
+                        std::path::Path::new(&instance.project_path),
+                    )
+                    .session
+                    .agent_acp_cmd
+                    .get(&instance.tool)
+                    .is_some_and(|cmd| {
+                        crate::acp::AgentSpec::from_acp_cmd(&instance.tool, cmd).is_ok()
+                    });
+                if capable {
+                    instance.view = crate::session::View::Structured;
+                } else {
+                    instance.view = crate::session::View::Terminal;
+                    // A non-ACP tool cannot run the structured session/fork
+                    // handshake. If a malformed request seeded a structured
+                    // fork (fork_pending/import_pending set by the builder),
+                    // drop those markers so a later switch-to-structured does
+                    // not fire an unexpected session/fork against the parent.
+                    instance.fork_pending = None;
+                    instance.import_pending = None;
+                }
+            }
+
+            if !instance.is_structured() {
+                agent_effort = None;
+                // Terminal sessions keep only an explicitly requested model,
+                // never an ACP-derived default (agent_model is ACP-only).
+                instance.agent_model = explicit_model;
+            }
+
+            agent_effort
+        };
+
+        // Run on_create hooks now that the worktree exists, before the session
+        // is persisted or started (#2066). Mirrors the TUI/CLI ordering so the
+        // worktree is bootstrapped (`.env` copies, venv symlinks, DB seeds)
+        // before the agent launches. On failure, tear down the just-built
+        // worktree/container so a broken hook doesn't leave an orphan.
+        if let Err(e) = crate::server::api::sessions::run_create_hooks(
+            &mut instance,
+            &hook_plan,
+            std::path::Path::new(&original_path),
+        ) {
+            builder::cleanup_instance(
+                &instance,
+                created_worktree.as_ref(),
+                &created_workspace_worktrees,
+            );
+            return Err(anyhow::anyhow!("on_create hook failed: {e:#}"));
+        }
+
+        // Anything that fails between here and the final `Ok(..)`
+        // would otherwise orphan the scratch directory `build_instance`
+        // already provisioned (Storage::new, storage.update,
+        // instance.start). Wrap the tail in an IIFE-equivalent closure
+        // so we can run cleanup on Err once, regardless of which step
+        // tripped. Matches the CLI cleanup path in
+        // `cleanup_partial_session(... scratch_dir: Some(...))`.
+        let mut persist_and_start = || -> anyhow::Result<()> {
+            let storage = Storage::new(&profile, file_watch_for_create.clone())?;
+            let to_persist = instance.clone();
+            storage.update(|all, _groups| {
+                all.push(to_persist);
+                Ok(())
+            })?;
+
+            // Acp-mode sessions are not backed by tmux; the structured view
+            // supervisor spawns the ACP agent on demand. Skip the tmux
+            // `start()` to avoid creating an empty pane that no one will
+            // attach to.
+            #[cfg(feature = "serve")]
+            let skip_tmux_start = instance.is_structured();
+            #[cfg(not(feature = "serve"))]
+            let skip_tmux_start = false;
+            if !skip_tmux_start {
+                instance.start()?;
+            }
+            Ok(())
+        };
+
+        if let Err(e) = persist_and_start() {
+            // Guarded the same way as the deletion path: only remove a
+            // path that `is_scratch_path` blesses, so a corrupted
+            // `project_path` cannot trick us into wiping unrelated
+            // state.
+            if instance.scratch {
+                let scratch_path = std::path::PathBuf::from(&instance.project_path);
+                if crate::session::scratch::is_scratch_path(&scratch_path) {
+                    if let Err(rm_err) = std::fs::remove_dir_all(&scratch_path) {
+                        tracing::warn!(
+                            target: "http.api.sessions",
+                            "Failed to clean up orphan scratch dir {} after create failure: {}",
+                            scratch_path.display(),
+                            rm_err
+                        );
+                    }
+                }
+            }
+            return Err(e);
+        }
+
+        #[cfg(feature = "serve")]
+        return Ok::<(Instance, Vec<String>, Option<String>), anyhow::Error>((
+            instance,
+            build_warnings,
+            agent_effort,
+        ));
+
+        #[cfg(not(feature = "serve"))]
+        Ok::<(Instance, Vec<String>), anyhow::Error>((instance, build_warnings))
+    })
+    .await;
+
+    match result {
+        #[cfg(feature = "serve")]
+        Ok(Ok((instance, warnings, agent_effort))) => {
+            let response_instance = instance.clone();
+            let acp_spawn_target = if instance.is_structured() {
+                Some((
+                    instance.id.clone(),
+                    instance.tool.clone(),
+                    instance.agent_name.clone(),
+                    instance.agent_model.clone(),
+                    agent_effort,
+                    instance.project_path.clone(),
+                    instance.acp_session_id.clone(),
+                    instance.source_profile.clone(),
+                    instance.yolo_mode,
+                    instance.command.clone(),
+                    instance.import_pending == Some(true),
+                    instance.fork_pending.clone(),
+                ))
+            } else {
+                None
+            };
+            let mut instances = state.instances.write().await;
+            crate::server::api::sessions::upsert_instance(&mut instances, instance);
+            drop(instances);
+
+            // Count the create for the opt-in telemetry trend counter. Bounded
+            // accumulator, read-and-decremented by the snapshot loop; no-op for
+            // opted-out installs (the snapshot is never built / sent).
+            state
+                .telemetry_session_creates
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+            if let Some((
+                id,
+                tool,
+                agent_override,
+                model,
+                effort,
+                project_path,
+                stored_acp_session_id,
+                source_profile,
+                yolo_mode,
+                command,
+                seed_history_replay,
+                fork_from,
+            )) = acp_spawn_target
+            {
+                let agent = state
+                    .acp_supervisor
+                    .pick_agent_for_tool(
+                        &tool,
+                        agent_override.as_deref(),
+                        &source_profile,
+                        std::path::Path::new(&project_path),
+                    )
+                    .await;
+                let command_override =
+                    crate::server::acp_reconciler::command_override_for_spawn(&tool, &command);
+                let cwd = std::path::PathBuf::from(project_path);
+                let supervisor = state.acp_supervisor.clone();
+                let state_for_check = state.clone();
+                tokio::spawn(async move {
+                    let inst_lock = state_for_check.instance_lock(&id).await;
+                    let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
+                        &state_for_check.instances,
+                        &inst_lock,
+                        &id,
+                        true,
+                    )
+                    .await
+                    {
+                        Ok(info) => info,
+                        Err(e) => {
+                            let message = format!("sandbox container ensure failed: {e}");
+                            tracing::warn!(
+                                target: "acp.supervisor",
+                                session = %id,
+                                "auto-spawn after create failed: {message}"
+                            );
+                            supervisor.publish_startup_error(&id, message);
+                            return;
+                        }
+                    };
+                    let source_profile_for_spawn = Some(source_profile.clone());
+                    if let Err(e) = supervisor
+                        .spawn(crate::acp::supervisor::SpawnRequest {
+                            session_id: id.clone(),
+                            agent: agent.clone(),
+                            cwd,
+                            additional_dirs: vec![],
+                            provider_env: vec![],
+                            model,
+                            effort,
+                            stored_acp_session_id,
+                            fork_from,
+                            sandbox_info,
+                            source_profile: source_profile_for_spawn,
+                            yolo_mode,
+                            agent_command_override: command_override,
+                            seed_history_replay,
+                        })
+                        .await
+                    {
+                        let still_present = state_for_check
+                            .instances
+                            .read()
+                            .await
+                            .iter()
+                            .any(|i| i.id == id);
+                        // Capacity-aware banner selection (and the benign
+                        // first-tick duplicate) is documented on
+                        // `structured_spawn_error_message`.
+                        let message =
+                            crate::server::api::structured_spawn_error_message(&e, &agent);
+                        if still_present {
+                            tracing::warn!(
+                                target: "acp.supervisor",
+                                session = %id,
+                                "auto-spawn after create failed: {message}"
+                            );
+                            supervisor.publish_startup_error(&id, message);
+                        } else {
+                            tracing::debug!(
+                                target: "acp.supervisor",
+                                session = %id,
+                                "auto-spawn after create error after session removed (ignored): {message}"
+                            );
+                        }
+                    }
+                });
+            }
+
+            Ok(SpawnOutcome {
+                instance: response_instance,
+                warnings,
+            })
+        }
+        #[cfg(not(feature = "serve"))]
+        Ok(Ok((instance, warnings))) => {
+            let response_instance = instance.clone();
+            let mut instances = state.instances.write().await;
+            instances.push(instance);
+            drop(instances);
+            Ok(SpawnOutcome {
+                instance: response_instance,
+                warnings,
+            })
+        }
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(anyhow::Error::new(SessionBuildPanicked(e.to_string()))),
+    }
+}

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -38,6 +38,13 @@ pub(crate) struct StructuredSessionSpec {
     pub custom_instruction: Option<String>,
     /// Resolved source profile (request profile, else the server default).
     pub profile: String,
+    /// Creating plugin id, when the caller is a plugin worker rather than a
+    /// user surface. Stamped by `SessionService::create_structured_session`,
+    /// never decoded from a request body. See #2897.
+    pub created_by_plugin: Option<String>,
+    /// Plugin create-idempotency record to persist with the instance,
+    /// stamped alongside `created_by_plugin`.
+    pub plugin_create_idempotency: Option<crate::session::PluginCreateIdempotency>,
     #[cfg(feature = "serve")]
     pub view: crate::session::View,
     #[cfg(feature = "serve")]
@@ -118,6 +125,8 @@ pub(crate) async fn spawn_structured_session(
             trust_hooks,
             custom_instruction,
             profile,
+            created_by_plugin,
+            plugin_create_idempotency,
             #[cfg(feature = "serve")]
             view,
             #[cfg(feature = "serve")]
@@ -201,6 +210,8 @@ pub(crate) async fn spawn_structured_session(
         let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
         let mut instance = build_result.instance;
         instance.source_profile = profile.clone();
+        instance.created_by_plugin = created_by_plugin;
+        instance.plugin_create_idempotency = plugin_create_idempotency;
         let build_warnings = build_result.warnings;
         let created_worktree = build_result.created_worktree;
         let created_workspace_worktrees = build_result.created_workspace_worktrees;

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -45,6 +45,9 @@ pub(crate) struct StructuredSessionSpec {
     /// Plugin create-idempotency record to persist with the instance,
     /// stamped alongside `created_by_plugin`.
     pub plugin_create_idempotency: Option<crate::session::PluginCreateIdempotency>,
+    /// Initial prompt to persist with the instance and deliver once the ACP
+    /// worker is live, stamped by `SessionService::create_structured_session`.
+    pub pending_initial_turn: Option<String>,
     #[cfg(feature = "serve")]
     pub view: crate::session::View,
     #[cfg(feature = "serve")]
@@ -127,6 +130,7 @@ pub(crate) async fn spawn_structured_session(
             profile,
             created_by_plugin,
             plugin_create_idempotency,
+            pending_initial_turn,
             #[cfg(feature = "serve")]
             view,
             #[cfg(feature = "serve")]
@@ -212,6 +216,7 @@ pub(crate) async fn spawn_structured_session(
         instance.source_profile = profile.clone();
         instance.created_by_plugin = created_by_plugin;
         instance.plugin_create_idempotency = plugin_create_idempotency;
+        instance.pending_initial_turn = pending_initial_turn;
         let build_warnings = build_result.warnings;
         let created_worktree = build_result.created_worktree;
         let created_workspace_worktrees = build_result.created_workspace_worktrees;
@@ -462,6 +467,13 @@ pub(crate) async fn spawn_structured_session(
                 let cwd = std::path::PathBuf::from(project_path);
                 let supervisor = service.acp_supervisor.clone();
                 let service_for_check = service.clone();
+                let has_pending_initial_turn = {
+                    let instances = service.instances.read().await;
+                    instances
+                        .iter()
+                        .find(|i| i.id == id)
+                        .is_some_and(|i| i.pending_initial_turn.is_some())
+                };
                 tokio::spawn(async move {
                     let inst_lock = service_for_check.instance_lock(&id).await;
                     let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
@@ -485,7 +497,7 @@ pub(crate) async fn spawn_structured_session(
                         }
                     };
                     let source_profile_for_spawn = Some(source_profile.clone());
-                    if let Err(e) = supervisor
+                    match supervisor
                         .spawn(crate::acp::supervisor::SpawnRequest {
                             session_id: id.clone(),
                             agent: agent.clone(),
@@ -504,30 +516,42 @@ pub(crate) async fn spawn_structured_session(
                         })
                         .await
                     {
-                        let still_present = service_for_check
-                            .instances
-                            .read()
-                            .await
-                            .iter()
-                            .any(|i| i.id == id);
-                        // Capacity-aware banner selection (and the benign
-                        // first-tick duplicate) is documented on
-                        // `structured_spawn_error_message`.
-                        let message =
-                            crate::server::api::structured_spawn_error_message(&e, &agent);
-                        if still_present {
-                            tracing::warn!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create failed: {message}"
-                            );
-                            supervisor.publish_startup_error(&id, message);
-                        } else {
-                            tracing::debug!(
-                                target: "acp.supervisor",
-                                session = %id,
-                                "auto-spawn after create error after session removed (ignored): {message}"
-                            );
+                        Ok(()) => {
+                            // Fast path for a create that carried an initial
+                            // turn: deliver it now that the worker is live.
+                            // The reconciler tick is the retry owner for
+                            // every other case (spawn failure here, daemon
+                            // restart, adopted runner).
+                            if has_pending_initial_turn {
+                                service_for_check.drain_pending_initial_turn(&id).await;
+                            }
+                        }
+                        Err(e) => {
+                            let still_present = service_for_check
+                                .instances
+                                .read()
+                                .await
+                                .iter()
+                                .any(|i| i.id == id);
+                            // Capacity-aware banner selection (and the benign
+                            // first-tick duplicate) is documented on
+                            // `structured_spawn_error_message`.
+                            let message =
+                                crate::server::api::structured_spawn_error_message(&e, &agent);
+                            if still_present {
+                                tracing::warn!(
+                                    target: "acp.supervisor",
+                                    session = %id,
+                                    "auto-spawn after create failed: {message}"
+                                );
+                                supervisor.publish_startup_error(&id, message);
+                            } else {
+                                tracing::debug!(
+                                    target: "acp.supervisor",
+                                    session = %id,
+                                    "auto-spawn after create error after session removed (ignored): {message}"
+                                );
+                            }
                         }
                     }
                 });

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -48,6 +48,10 @@ pub(crate) struct StructuredSessionSpec {
     /// Initial prompt to persist with the instance and deliver once the ACP
     /// worker is live, stamped by `SessionService::create_structured_session`.
     pub pending_initial_turn: Option<String>,
+    /// Explicit ACP approval-mode id to persist on the instance; the
+    /// supervisor applies it after every worker (re)spawn. Stamped by the
+    /// plugin host create path after host-side classification.
+    pub acp_mode_id: Option<String>,
     #[cfg(feature = "serve")]
     pub view: crate::session::View,
     #[cfg(feature = "serve")]
@@ -131,6 +135,7 @@ pub(crate) async fn spawn_structured_session(
             created_by_plugin,
             plugin_create_idempotency,
             pending_initial_turn,
+            acp_mode_id,
             #[cfg(feature = "serve")]
             view,
             #[cfg(feature = "serve")]
@@ -217,6 +222,7 @@ pub(crate) async fn spawn_structured_session(
         instance.created_by_plugin = created_by_plugin;
         instance.plugin_create_idempotency = plugin_create_idempotency;
         instance.pending_initial_turn = pending_initial_turn;
+        instance.acp_mode_id = acp_mode_id;
         let build_warnings = build_result.warnings;
         let created_worktree = build_result.created_worktree;
         let created_workspace_worktrees = build_result.created_workspace_worktrees;
@@ -420,6 +426,7 @@ pub(crate) async fn spawn_structured_session(
                     instance.acp_session_id.clone(),
                     instance.source_profile.clone(),
                     instance.yolo_mode,
+                    instance.acp_mode_id.clone(),
                     instance.command.clone(),
                     instance.import_pending == Some(true),
                     instance.fork_pending.clone(),
@@ -448,6 +455,7 @@ pub(crate) async fn spawn_structured_session(
                 stored_acp_session_id,
                 source_profile,
                 yolo_mode,
+                acp_mode_id,
                 command,
                 seed_history_replay,
                 fork_from,
@@ -511,6 +519,7 @@ pub(crate) async fn spawn_structured_session(
                             sandbox_info,
                             source_profile: source_profile_for_spawn,
                             yolo_mode,
+                            acp_mode_id,
                             agent_command_override: command_override,
                             seed_history_replay,
                         })

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use crate::session::Instance;
 
-use super::AppState;
+use super::session_service::SessionService;
 
 /// Already-decoded, already-validated inputs the create core needs. The HTTP
 /// handler fills this in after it has finished request parsing, auth, and
@@ -80,10 +80,10 @@ impl std::error::Error for SessionBuildPanicked {}
 /// warnings; a build-time panic is surfaced as a [`SessionBuildPanicked`] error
 /// and a repo-trust refusal propagates as-is so the caller can map it.
 pub(crate) async fn spawn_structured_session(
-    state: &Arc<AppState>,
+    service: &Arc<SessionService>,
     spec: StructuredSessionSpec,
 ) -> anyhow::Result<SpawnOutcome> {
-    let instances = state.instances.read().await;
+    let instances = service.instances.read().await;
     let existing_titles: Vec<String> = instances.iter().map(|i| i.title.clone()).collect();
     let existing_branches: Vec<String> = instances
         .iter()
@@ -91,7 +91,7 @@ pub(crate) async fn spawn_structured_session(
         .collect();
     drop(instances);
 
-    let file_watch_for_create = state.file_watch.clone();
+    let file_watch_for_create = service.file_watch.clone();
 
     let result = tokio::task::spawn_blocking(move || {
         use crate::session::builder::{self, InstanceParams};
@@ -411,14 +411,14 @@ pub(crate) async fn spawn_structured_session(
             } else {
                 None
             };
-            let mut instances = state.instances.write().await;
+            let mut instances = service.instances.write().await;
             crate::server::api::sessions::upsert_instance(&mut instances, instance);
             drop(instances);
 
             // Count the create for the opt-in telemetry trend counter. Bounded
             // accumulator, read-and-decremented by the snapshot loop; no-op for
             // opted-out installs (the snapshot is never built / sent).
-            state
+            service
                 .telemetry_session_creates
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
@@ -437,7 +437,7 @@ pub(crate) async fn spawn_structured_session(
                 fork_from,
             )) = acp_spawn_target
             {
-                let agent = state
+                let agent = service
                     .acp_supervisor
                     .pick_agent_for_tool(
                         &tool,
@@ -449,12 +449,12 @@ pub(crate) async fn spawn_structured_session(
                 let command_override =
                     crate::server::acp_reconciler::command_override_for_spawn(&tool, &command);
                 let cwd = std::path::PathBuf::from(project_path);
-                let supervisor = state.acp_supervisor.clone();
-                let state_for_check = state.clone();
+                let supervisor = service.acp_supervisor.clone();
+                let service_for_check = service.clone();
                 tokio::spawn(async move {
-                    let inst_lock = state_for_check.instance_lock(&id).await;
+                    let inst_lock = service_for_check.instance_lock(&id).await;
                     let sandbox_info = match crate::acp::sandbox::ensure_container_for_session(
-                        &state_for_check.instances,
+                        &service_for_check.instances,
                         &inst_lock,
                         &id,
                         true,
@@ -493,7 +493,7 @@ pub(crate) async fn spawn_structured_session(
                         })
                         .await
                     {
-                        let still_present = state_for_check
+                        let still_present = service_for_check
                             .instances
                             .read()
                             .await
@@ -530,7 +530,7 @@ pub(crate) async fn spawn_structured_session(
         #[cfg(not(feature = "serve"))]
         Ok(Ok((instance, warnings))) => {
             let response_instance = instance.clone();
-            let mut instances = state.instances.write().await;
+            let mut instances = service.instances.write().await;
             instances.push(instance);
             drop(instances);
             Ok(SpawnOutcome {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -477,6 +477,17 @@ pub struct OpClaim {
     pub at: DateTime<Utc>,
 }
 
+/// Create-idempotency record for a plugin-created session (#2897). `key` is
+/// the plugin-supplied idempotency key, unique within the creating plugin's
+/// sessions; `payload_hash` is the host-computed hash of the semantic create
+/// request, so a retried key with a different payload is rejected instead of
+/// silently returning a session that does not match the request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginCreateIdempotency {
+    pub key: String,
+    pub payload_hash: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Instance {
     pub id: String,
@@ -639,6 +650,23 @@ pub struct Instance {
     /// older `sessions.json` rows, so no migration is needed.
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub plugin_meta: std::collections::BTreeMap<String, serde_json::Value>,
+
+    /// Id of the plugin that created this session through the host session
+    /// service (#2897). `None` for user-created sessions, including every row
+    /// that predates the field. Turn delivery from a plugin is restricted to
+    /// sessions whose `created_by_plugin` matches the calling plugin.
+    /// Additive: absent in older `sessions.json` rows, so no migration is
+    /// needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by_plugin: Option<String>,
+
+    /// Create-idempotency record for a plugin-created session, persisted
+    /// atomically with the row itself (same `Storage::update`). Scoped to
+    /// `created_by_plugin`; retention equals the lifetime of this session
+    /// record, so archive/snooze/trash keep deduplicating and a hard delete
+    /// releases the key. Additive: absent in older rows, no migration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_create_idempotency: Option<PluginCreateIdempotency>,
 
     /// Scratch-session marker. When true, `project_path` points at an
     /// auto-provisioned directory under `<app_dir>/scratch/<id>/` that the
@@ -1255,6 +1283,8 @@ impl Instance {
             pre_trash_project_path: None,
             op_claim: None,
             plugin_meta: std::collections::BTreeMap::new(),
+            created_by_plugin: None,
+            plugin_create_idempotency: None,
             scratch: false,
             worktree_info: None,
             workspace_info: None,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -681,6 +681,17 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_initial_turn: Option<String>,
 
+    /// Explicit ACP approval-mode id this session should run under (#2897),
+    /// applied via `session/set_mode` after every worker (re)spawn, taking
+    /// precedence over the legacy `yolo_mode` bool (which stays authoritative
+    /// for sessions without an explicit mode; unification is a follow-up).
+    /// Set by the plugin host session-create path after the host classified
+    /// the mode; also re-asserted before each plugin-delivered turn so a
+    /// mode-application failure blocks unattended prompt delivery. Additive:
+    /// absent in older rows, no migration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acp_mode_id: Option<String>,
+
     /// Scratch-session marker. When true, `project_path` points at an
     /// auto-provisioned directory under `<app_dir>/scratch/<id>/` that the
     /// deletion path removes on `aoe rm` (unless the user opts in to keeping
@@ -1299,6 +1310,7 @@ impl Instance {
             created_by_plugin: None,
             plugin_create_idempotency: None,
             pending_initial_turn: None,
+            acp_mode_id: None,
             scratch: false,
             worktree_info: None,
             workspace_info: None,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -668,6 +668,19 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin_create_idempotency: Option<PluginCreateIdempotency>,
 
+    /// An initial prompt persisted with the session at create time and not
+    /// yet delivered to the agent (#2897). Written in the same
+    /// `Storage::update` that creates the row, so the create request and its
+    /// first turn are accepted atomically; the session service drains it
+    /// once the ACP worker is live (create fast path, and the reconciler
+    /// tick after a crash or restart) and clears it after a successful
+    /// publish + forward. Delivery is at-least-once: a crash between the
+    /// forward and this field's clear re-delivers on the next drain.
+    // ponytail: plain text, no attachments or dedup turn id; move to a typed
+    // record via a vNNN migration if either becomes necessary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_initial_turn: Option<String>,
+
     /// Scratch-session marker. When true, `project_path` points at an
     /// auto-provisioned directory under `<app_dir>/scratch/<id>/` that the
     /// deletion path removes on `aoe rm` (unless the user opts in to keeping
@@ -1285,6 +1298,7 @@ impl Instance {
             plugin_meta: std::collections::BTreeMap::new(),
             created_by_plugin: None,
             plugin_create_idempotency: None,
+            pending_initial_turn: None,
             scratch: false,
             worktree_info: None,
             workspace_info: None,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -67,8 +67,9 @@ pub use groups::{
 pub(crate) use instance::ResumeAttemptPolicy;
 pub use instance::{
     is_valid_session_color, ClaimOp, EnsureReadyError, EnsureReadyOutcome, Instance,
-    LaunchSidOutcome, SandboxInfo, SessionBucket, StartOutcome, Status, TerminalInfo, View,
-    WorkspaceInfo, WorkspaceRepo, WorktreeInfo, SESSION_COLORS, TMUX_SESSION_GONE_ERROR,
+    LaunchSidOutcome, PluginCreateIdempotency, SandboxInfo, SessionBucket, StartOutcome, Status,
+    TerminalInfo, View, WorkspaceInfo, WorkspaceRepo, WorktreeInfo, SESSION_COLORS,
+    TMUX_SESSION_GONE_ERROR,
 };
 pub(crate) use instance::{persist_session_to_storage, PassiveStatusPatch, ResumeIntent, SidWrite};
 

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -70,11 +70,106 @@ pub enum WidgetKind {
     Select { options: Vec<SelectOption> },
     /// List of strings (volumes, env entries, ...).
     List,
+    /// A select whose options the host resolves at render time from an
+    /// [`OptionSource`] (API v9, #2897), optionally parameterized by sibling
+    /// fields named in `depends_on`. The plugin never ships the choices.
+    DynamicSelect {
+        source: OptionSource,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+    },
+    /// A repeatable list of structured items (API v9, #2897). Each item is a
+    /// JSON object keyed by the nested field names, carrying a stable id under
+    /// `id_field`. One level deep: `fields` cannot themselves be object lists.
+    ObjectList {
+        id_field: String,
+        fields: Vec<ObjectFieldDescriptor>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        min_items: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_items: Option<u32>,
+    },
+    /// A cron expression, rendered as a validated text field (API v9, #2897).
+    Cron,
     /// Escape hatch: a bespoke widget keyed by `id`. The web and TUI keep a
     /// registry mapping the id to a hand-written component (e.g. the logging
     /// per-target matrix). The field stays in the schema so it is never
     /// silently web-unwritable.
     Custom { id: String },
+}
+
+/// A host option source a [`WidgetKind::DynamicSelect`] draws its choices
+/// from (#2897). Mirrors `aoe_plugin_api::OptionSource`; the host resolver
+/// maps each variant to the corresponding daemon state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionSource {
+    AcpAgents,
+    AcpModels,
+    AcpModes,
+    Projects,
+    Groups,
+}
+
+impl From<aoe_plugin_api::OptionSource> for OptionSource {
+    fn from(s: aoe_plugin_api::OptionSource) -> Self {
+        use aoe_plugin_api::OptionSource as A;
+        match s {
+            A::AcpAgents => Self::AcpAgents,
+            A::AcpModels => Self::AcpModels,
+            A::AcpModes => Self::AcpModes,
+            A::Projects => Self::Projects,
+            A::Groups => Self::Groups,
+        }
+    }
+}
+
+/// One nested field of a [`WidgetKind::ObjectList`] item (#2897). A restricted
+/// mirror of [`FieldDescriptor`] whose widget cannot be another object list,
+/// so the schema is non-recursive.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ObjectFieldDescriptor {
+    pub field: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// Whether the item must carry a non-empty value for this field.
+    #[serde(default)]
+    pub required: bool,
+    pub widget: ObjectFieldWidget,
+    pub validation: ValidationKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+}
+
+/// The widget for an object-list item field. Deliberately a subset of
+/// [`WidgetKind`] with no object-list variant, enforcing the one-level bound
+/// in both the Rust type and the serialized schema.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ObjectFieldWidget {
+    Toggle,
+    Text {
+        #[serde(default)]
+        multiline: bool,
+        #[serde(default)]
+        mono: bool,
+    },
+    Number {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        min: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max: Option<i64>,
+    },
+    Select {
+        options: Vec<SelectOption>,
+    },
+    DynamicSelect {
+        source: OptionSource,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+    },
+    Cron,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -140,6 +235,20 @@ pub enum ValidationKind {
     /// their options in the widget and need no separate rule).
     OneOf {
         options: Vec<String>,
+    },
+    /// A 5-field cron expression (API v9, #2897). Empty is rejected; the
+    /// grammar matches the plugin scheduler's `croner` dialect.
+    Cron,
+    /// A repeatable list of structured items (API v9, #2897). Validated
+    /// recursively: item count bounds, a unique non-empty id per item under
+    /// `id_field`, only declared fields, required fields present, and each
+    /// field against its own descriptor. Carries the item schema so the
+    /// server validates without re-deriving it from the manifest.
+    ObjectList {
+        id_field: String,
+        fields: Vec<ObjectFieldDescriptor>,
+        min_items: Option<u32>,
+        max_items: Option<u32>,
     },
 }
 

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -217,6 +217,22 @@ pub enum ValidationKind {
     },
     /// Non-empty after trimming.
     NonEmptyString,
+    /// Value must be a JSON string (any content, empty allowed). Used for
+    /// host-resolved optional `dynamic_select` values (revalidated at
+    /// `sessions.create`): enforces the type without constraining content, so a
+    /// number or object cannot be smuggled in (API v9, #2897).
+    #[serde(rename = "str")]
+    StringValue,
+    /// Value must be a JSON boolean (API v9, #2897).
+    #[serde(rename = "bool")]
+    BoolValue,
+    /// Signed inclusive integer range; either bound optional for single-sided
+    /// ranges. Used for `object_list` integer fields whose declared bounds go
+    /// negative, which `RangeU64` cannot express (API v9, #2897).
+    RangeI64 {
+        min: Option<i64>,
+        max: Option<i64>,
+    },
     /// Docker memory-limit grammar (`512m`, `2g`, ...). Empty allowed.
     MemoryLimit,
     /// Each list entry must be `host:container[:options]`.

--- a/src/session/settings_schema/plugin.rs
+++ b/src/session/settings_schema/plugin.rs
@@ -11,7 +11,10 @@
 use aoe_plugin_api::{SettingContribution, SettingType};
 use serde_json::{json, Value};
 
-use super::{FieldDescriptor, SelectOption, ValidationKind, WebWritePolicy, WidgetKind};
+use super::{
+    FieldDescriptor, ObjectFieldDescriptor, ObjectFieldWidget, OptionSource as SchemaOptionSource,
+    SelectOption, ValidationKind, WebWritePolicy, WidgetKind,
+};
 
 /// Prefix marking a virtual plugin settings section.
 pub const PLUGIN_SECTION_PREFIX: &str = "plugin:";
@@ -167,6 +170,115 @@ fn widget_and_validation(s: &SettingContribution) -> (WidgetKind, ValidationKind
                 options: s.options.clone(),
             },
         ),
+        SettingType::DynamicSelect => (
+            WidgetKind::DynamicSelect {
+                // Manifest validation guarantees a source on a dynamic_select;
+                // default to acp.agents defensively rather than panic.
+                source: s
+                    .option_source
+                    .map(SchemaOptionSource::from)
+                    .unwrap_or(SchemaOptionSource::AcpAgents),
+                depends_on: s.depends_on.clone(),
+            },
+            // Options are host-resolved and revalidated at sessions.create;
+            // the only settings-write gate is non-emptiness for a chosen value.
+            ValidationKind::None,
+        ),
+        SettingType::Cron => (WidgetKind::Cron, ValidationKind::Cron),
+        SettingType::ObjectList => {
+            let fields: Vec<ObjectFieldDescriptor> =
+                s.fields.iter().map(object_field_descriptor).collect();
+            let id_field = s.item_id_key.clone().unwrap_or_else(|| "_id".to_string());
+            (
+                WidgetKind::ObjectList {
+                    id_field: id_field.clone(),
+                    fields: fields.clone(),
+                    min_items: s.min_items,
+                    max_items: s.max_items,
+                },
+                ValidationKind::ObjectList {
+                    id_field,
+                    fields,
+                    min_items: s.min_items,
+                    max_items: s.max_items,
+                },
+            )
+        }
+    }
+}
+
+/// Map one manifest object-list item field to its runtime descriptor. The
+/// widget cannot be an object list, so the mapping is total and non-recursive.
+fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> ObjectFieldDescriptor {
+    use aoe_plugin_api::ObjectFieldType as T;
+    let (widget, validation) = match f.value_type {
+        T::Bool => (ObjectFieldWidget::Toggle, ValidationKind::None),
+        T::String => (
+            ObjectFieldWidget::Text {
+                multiline: false,
+                mono: false,
+            },
+            if f.required {
+                ValidationKind::NonEmptyString
+            } else {
+                ValidationKind::None
+            },
+        ),
+        T::Integer => (
+            ObjectFieldWidget::Number {
+                min: f.min,
+                max: f.max,
+            },
+            if f.min.unwrap_or(0) >= 0 && f.max.unwrap_or(0) >= 0 {
+                ValidationKind::RangeU64 {
+                    min: f.min.unwrap_or(0) as u64,
+                    max: f.max.map(|m| m as u64),
+                }
+            } else {
+                ValidationKind::None
+            },
+        ),
+        T::Select => (
+            ObjectFieldWidget::Select {
+                options: f.options.iter().map(|o| SelectOption::new(o, o)).collect(),
+            },
+            ValidationKind::OneOf {
+                options: f.options.clone(),
+            },
+        ),
+        T::DynamicSelect => (
+            ObjectFieldWidget::DynamicSelect {
+                source: f
+                    .option_source
+                    .map(SchemaOptionSource::from)
+                    .unwrap_or(SchemaOptionSource::AcpAgents),
+                depends_on: f.depends_on.clone(),
+            },
+            // Host-resolved + revalidated at sessions.create; non-empty only
+            // when required.
+            if f.required {
+                ValidationKind::NonEmptyString
+            } else {
+                ValidationKind::None
+            },
+        ),
+        T::Cron => (ObjectFieldWidget::Cron, ValidationKind::Cron),
+    };
+    ObjectFieldDescriptor {
+        field: f.key.clone(),
+        label: if f.label.is_empty() {
+            f.key.clone()
+        } else {
+            f.label.clone()
+        },
+        description: f.description.clone(),
+        required: f.required,
+        widget,
+        validation,
+        default: f
+            .default
+            .as_ref()
+            .and_then(|t| serde_json::to_value(t).ok()),
     }
 }
 
@@ -185,6 +297,12 @@ mod tests {
             max: None,
             default: None,
             advanced: false,
+            option_source: None,
+            depends_on: Vec::new(),
+            fields: Vec::new(),
+            item_id_key: None,
+            min_items: None,
+            max_items: None,
         }
     }
 

--- a/src/session/settings_schema/plugin.rs
+++ b/src/session/settings_schema/plugin.rs
@@ -180,9 +180,10 @@ fn widget_and_validation(s: &SettingContribution) -> (WidgetKind, ValidationKind
                     .unwrap_or(SchemaOptionSource::AcpAgents),
                 depends_on: s.depends_on.clone(),
             },
-            // Options are host-resolved and revalidated at sessions.create;
-            // the only settings-write gate is non-emptiness for a chosen value.
-            ValidationKind::None,
+            // Options are host-resolved and revalidated at sessions.create; the
+            // settings-write gate only enforces that a chosen value is a string
+            // (never a number/object smuggled past widget metadata).
+            ValidationKind::StringValue,
         ),
         SettingType::Cron => (WidgetKind::Cron, ValidationKind::Cron),
         SettingType::ObjectList => {
@@ -212,7 +213,7 @@ fn widget_and_validation(s: &SettingContribution) -> (WidgetKind, ValidationKind
 fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> ObjectFieldDescriptor {
     use aoe_plugin_api::ObjectFieldType as T;
     let (widget, validation) = match f.value_type {
-        T::Bool => (ObjectFieldWidget::Toggle, ValidationKind::None),
+        T::Bool => (ObjectFieldWidget::Toggle, ValidationKind::BoolValue),
         T::String => (
             ObjectFieldWidget::Text {
                 multiline: false,
@@ -221,7 +222,7 @@ fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> Objec
             if f.required {
                 ValidationKind::NonEmptyString
             } else {
-                ValidationKind::None
+                ValidationKind::StringValue
             },
         ),
         T::Integer => (
@@ -235,7 +236,11 @@ fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> Objec
                     max: f.max.map(|m| m as u64),
                 }
             } else {
-                ValidationKind::None
+                // Bounds go negative; RangeU64 cannot express them.
+                ValidationKind::RangeI64 {
+                    min: f.min,
+                    max: f.max,
+                }
             },
         ),
         T::Select => (
@@ -254,12 +259,12 @@ fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> Objec
                     .unwrap_or(SchemaOptionSource::AcpAgents),
                 depends_on: f.depends_on.clone(),
             },
-            // Host-resolved + revalidated at sessions.create; non-empty only
-            // when required.
+            // Host-resolved + revalidated at sessions.create; non-empty when
+            // required, otherwise just enforce the string type.
             if f.required {
                 ValidationKind::NonEmptyString
             } else {
-                ValidationKind::None
+                ValidationKind::StringValue
             },
         ),
         T::Cron => (ObjectFieldWidget::Cron, ValidationKind::Cron),

--- a/src/session/settings_schema/validate.rs
+++ b/src/session/settings_schema/validate.rs
@@ -181,7 +181,9 @@ fn validate_object_list(
 /// closely enough to reject garbage at settings-write time; the scheduler is
 /// the authoritative parser at run time.
 fn validate_cron(expr: &str) -> Result<(), String> {
-    const BOUNDS: [(u32, u32); 5] = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)];
+    // day-of-week is 0-7 (both 0 and 7 are Sunday), matching croner and the
+    // web-side cronValidation.ts.
+    const BOUNDS: [(u32, u32); 5] = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 7)];
     let fields: Vec<&str> = expr.split_whitespace().collect();
     if fields.len() != 5 {
         return Err(format!(
@@ -356,7 +358,7 @@ mod tests {
             "* 24 * * *",  // hour out of range
             "* * 0 * *",   // dom below 1
             "* * * 13 *",  // month out of range
-            "* * * * 7",   // dow out of range
+            "* * * * 8",   // dow out of range (0-7 valid, 8 not)
             "5-1 * * * *", // reversed range
             "*/0 * * * *", // zero step
             "abc * * * *", // non-numeric

--- a/src/session/settings_schema/validate.rs
+++ b/src/session/settings_schema/validate.rs
@@ -7,7 +7,7 @@
 
 use serde_json::Value;
 
-use super::ValidationKind;
+use super::{ObjectFieldDescriptor, ValidationKind};
 
 /// A value failed validation for a field. Carries a human-readable reason the
 /// server surfaces to the client (HTTP 400).
@@ -90,7 +90,157 @@ pub fn validate_value(kind: &ValidationKind, value: &Value) -> Result<(), Valida
                 )))
             }
         }
+        ValidationKind::Cron => {
+            let s = value
+                .as_str()
+                .ok_or_else(|| ValidationError::new("expected a string"))?;
+            validate_cron(s).map_err(ValidationError::new)
+        }
+        ValidationKind::ObjectList {
+            id_field,
+            fields,
+            min_items,
+            max_items,
+        } => validate_object_list(value, id_field, fields, *min_items, *max_items),
     }
+}
+
+/// Validate an object-list value: an array of objects, item-count bounds, a
+/// unique non-empty stable id per item, only declared fields plus the id, and
+/// each present field against its own descriptor (a required field must be
+/// present). Dynamic-select membership is NOT checked here: catalogs change,
+/// and a saved id is authoritatively revalidated at `sessions.create`.
+fn validate_object_list(
+    value: &Value,
+    id_field: &str,
+    fields: &[ObjectFieldDescriptor],
+    min_items: Option<u32>,
+    max_items: Option<u32>,
+) -> Result<(), ValidationError> {
+    let arr = value
+        .as_array()
+        .ok_or_else(|| ValidationError::new("expected a list of items"))?;
+    if let Some(min) = min_items {
+        if (arr.len() as u32) < min {
+            return Err(ValidationError::new(format!(
+                "needs at least {min} item(s)"
+            )));
+        }
+    }
+    if let Some(max) = max_items {
+        if (arr.len() as u32) > max {
+            return Err(ValidationError::new(format!(
+                "allows at most {max} item(s)"
+            )));
+        }
+    }
+    let mut seen_ids = std::collections::HashSet::new();
+    for (i, item) in arr.iter().enumerate() {
+        let obj = item
+            .as_object()
+            .ok_or_else(|| ValidationError::new(format!("item {i} must be an object")))?;
+        let id = obj
+            .get(id_field)
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .ok_or_else(|| {
+                ValidationError::new(format!("item {i} is missing a non-empty {id_field:?}"))
+            })?;
+        if !seen_ids.insert(id.to_string()) {
+            return Err(ValidationError::new(format!("duplicate item id {id:?}")));
+        }
+        for key in obj.keys() {
+            if key != id_field && !fields.iter().any(|f| &f.field == key) {
+                return Err(ValidationError::new(format!(
+                    "item {i} has an undeclared field {key:?}"
+                )));
+            }
+        }
+        for field in fields {
+            match obj.get(&field.field) {
+                Some(v) => validate_value(&field.validation, v).map_err(|e| {
+                    ValidationError::new(format!("item {i} field {:?}: {}", field.field, e.reason))
+                })?,
+                None if field.required => {
+                    return Err(ValidationError::new(format!(
+                        "item {i} is missing required field {:?}",
+                        field.field
+                    )));
+                }
+                None => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a 5-field cron expression (minute hour day-of-month month
+/// day-of-week). Each field is `*`, or a comma list of items where an item is
+/// a number, an `a-b` range, or either followed by `/step`, all within the
+/// field's inclusive bounds. Mirrors the plugin scheduler's `croner` dialect
+/// closely enough to reject garbage at settings-write time; the scheduler is
+/// the authoritative parser at run time.
+fn validate_cron(expr: &str) -> Result<(), String> {
+    const BOUNDS: [(u32, u32); 5] = [(0, 59), (0, 23), (1, 31), (1, 12), (0, 6)];
+    let fields: Vec<&str> = expr.split_whitespace().collect();
+    if fields.len() != 5 {
+        return Err(format!(
+            "cron must have 5 fields (got {}); e.g. \"0 9 * * 1-5\"",
+            fields.len()
+        ));
+    }
+    for (field, (lo, hi)) in fields.iter().zip(BOUNDS.iter()) {
+        for item in field.split(',') {
+            validate_cron_item(item, *lo, *hi)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_cron_item(item: &str, lo: u32, hi: u32) -> Result<(), String> {
+    if item.is_empty() {
+        return Err("empty cron field item".to_string());
+    }
+    let (range, step) = match item.split_once('/') {
+        Some((r, s)) => {
+            let step: u32 = s.parse().map_err(|_| format!("invalid cron step {s:?}"))?;
+            if step == 0 {
+                return Err("cron step must be positive".to_string());
+            }
+            (r, Some(step))
+        }
+        None => (item, None),
+    };
+    // `*` (optionally with a step) covers the whole range.
+    if range == "*" {
+        return Ok(());
+    }
+    let in_bounds = |n: u32| n >= lo && n <= hi;
+    match range.split_once('-') {
+        Some((a, b)) => {
+            let a: u32 = a.parse().map_err(|_| format!("invalid cron value {a:?}"))?;
+            let b: u32 = b.parse().map_err(|_| format!("invalid cron value {b:?}"))?;
+            if !in_bounds(a) || !in_bounds(b) {
+                return Err(format!("cron value out of range {lo}-{hi}"));
+            }
+            if a > b {
+                return Err(format!("cron range {a}-{b} is reversed"));
+            }
+        }
+        None => {
+            let n: u32 = range
+                .parse()
+                .map_err(|_| format!("invalid cron value {range:?}"))?;
+            if !in_bounds(n) {
+                return Err(format!("cron value {n} out of range {lo}-{hi}"));
+            }
+            // A bare number with a step (e.g. `5/10`) is meaningless.
+            if step.is_some() {
+                return Err("cron step requires a range or *".to_string());
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Validate that `value` is a JSON array of strings and each passes `check`.
@@ -188,5 +338,118 @@ mod tests {
         assert!(validate_value(&ValidationKind::Network, &json!("egress-proxy")).is_ok());
         assert!(validate_value(&ValidationKind::Network, &json!("host")).is_err());
         assert!(validate_value(&ValidationKind::Network, &json!(42)).is_err());
+    }
+
+    #[test]
+    fn cron_grammar() {
+        let ok = ["0 9 * * 1-5", "*/15 * * * *", "0 0,12 1 */2 *", "* * * * *"];
+        for e in ok {
+            assert!(
+                validate_value(&ValidationKind::Cron, &json!(e)).is_ok(),
+                "{e}"
+            );
+        }
+        let bad = [
+            "0 9 * *",     // too few fields
+            "0 9 * * * *", // too many fields
+            "60 * * * *",  // minute out of range
+            "* 24 * * *",  // hour out of range
+            "* * 0 * *",   // dom below 1
+            "* * * 13 *",  // month out of range
+            "* * * * 7",   // dow out of range
+            "5-1 * * * *", // reversed range
+            "*/0 * * * *", // zero step
+            "abc * * * *", // non-numeric
+        ];
+        for e in bad {
+            assert!(
+                validate_value(&ValidationKind::Cron, &json!(e)).is_err(),
+                "{e}"
+            );
+        }
+        assert!(validate_value(&ValidationKind::Cron, &json!(5)).is_err());
+    }
+
+    fn jobs_validation() -> ValidationKind {
+        ValidationKind::ObjectList {
+            id_field: "id".into(),
+            fields: vec![
+                ObjectFieldDescriptor {
+                    field: "agent".into(),
+                    label: "Agent".into(),
+                    description: String::new(),
+                    required: true,
+                    widget: super::super::ObjectFieldWidget::Text {
+                        multiline: false,
+                        mono: false,
+                    },
+                    validation: ValidationKind::NonEmptyString,
+                    default: None,
+                },
+                ObjectFieldDescriptor {
+                    field: "schedule".into(),
+                    label: "Schedule".into(),
+                    description: String::new(),
+                    required: true,
+                    widget: super::super::ObjectFieldWidget::Cron,
+                    validation: ValidationKind::Cron,
+                    default: None,
+                },
+            ],
+            min_items: Some(0),
+            max_items: Some(2),
+        }
+    }
+
+    #[test]
+    fn object_list_structural_rules() {
+        let kind = jobs_validation();
+        // Happy path.
+        assert!(validate_value(
+            &kind,
+            &json!([{"id": "a", "agent": "claude", "schedule": "0 9 * * 1-5"}])
+        )
+        .is_ok());
+        // Missing stable id.
+        assert!(validate_value(
+            &kind,
+            &json!([{"agent": "claude", "schedule": "* * * * *"}])
+        )
+        .is_err());
+        // Duplicate id.
+        assert!(validate_value(
+            &kind,
+            &json!([
+                {"id": "x", "agent": "a", "schedule": "* * * * *"},
+                {"id": "x", "agent": "b", "schedule": "* * * * *"}
+            ])
+        )
+        .is_err());
+        // Missing required field.
+        assert!(validate_value(&kind, &json!([{"id": "a", "agent": "claude"}])).is_err());
+        // Undeclared field.
+        assert!(validate_value(
+            &kind,
+            &json!([{"id": "a", "agent": "c", "schedule": "* * * * *", "bogus": 1}])
+        )
+        .is_err());
+        // Nested field validation runs (bad cron).
+        assert!(validate_value(
+            &kind,
+            &json!([{"id": "a", "agent": "c", "schedule": "bad"}])
+        )
+        .is_err());
+        // max_items.
+        assert!(validate_value(
+            &kind,
+            &json!([
+                {"id": "1", "agent": "a", "schedule": "* * * * *"},
+                {"id": "2", "agent": "b", "schedule": "* * * * *"},
+                {"id": "3", "agent": "c", "schedule": "* * * * *"}
+            ])
+        )
+        .is_err());
+        // Not an array.
+        assert!(validate_value(&kind, &json!({"id": "a"})).is_err());
     }
 }

--- a/src/session/settings_schema/validate.rs
+++ b/src/session/settings_schema/validate.rs
@@ -58,6 +58,34 @@ pub fn validate_value(kind: &ValidationKind, value: &Value) -> Result<(), Valida
             }
             Ok(())
         }
+        ValidationKind::StringValue => {
+            value
+                .as_str()
+                .ok_or_else(|| ValidationError::new("expected a string"))?;
+            Ok(())
+        }
+        ValidationKind::BoolValue => {
+            value
+                .as_bool()
+                .ok_or_else(|| ValidationError::new("expected a boolean"))?;
+            Ok(())
+        }
+        ValidationKind::RangeI64 { min, max } => {
+            let n = value
+                .as_i64()
+                .ok_or_else(|| ValidationError::new("expected an integer"))?;
+            if let Some(min) = min {
+                if n < *min {
+                    return Err(ValidationError::new(format!("must be at least {min}")));
+                }
+            }
+            if let Some(max) = max {
+                if n > *max {
+                    return Err(ValidationError::new(format!("must be at most {max}")));
+                }
+            }
+            Ok(())
+        }
         ValidationKind::MemoryLimit => {
             let s = value
                 .as_str()
@@ -290,6 +318,32 @@ mod tests {
     fn non_empty_string_trims() {
         assert!(validate_value(&ValidationKind::NonEmptyString, &json!("  ")).is_err());
         assert!(validate_value(&ValidationKind::NonEmptyString, &json!("x")).is_ok());
+    }
+
+    #[test]
+    fn typed_values_reject_mismatched_json() {
+        // str: any string incl. empty, but never a number/object.
+        assert!(validate_value(&ValidationKind::StringValue, &json!("")).is_ok());
+        assert!(validate_value(&ValidationKind::StringValue, &json!("x")).is_ok());
+        assert!(validate_value(&ValidationKind::StringValue, &json!(1)).is_err());
+        assert!(validate_value(&ValidationKind::StringValue, &json!({})).is_err());
+        // bool: only true/false.
+        assert!(validate_value(&ValidationKind::BoolValue, &json!(true)).is_ok());
+        assert!(validate_value(&ValidationKind::BoolValue, &json!("true")).is_err());
+        // signed range, single- and double-sided.
+        let signed = ValidationKind::RangeI64 {
+            min: Some(-5),
+            max: Some(5),
+        };
+        assert!(validate_value(&signed, &json!(-5)).is_ok());
+        assert!(validate_value(&signed, &json!(6)).is_err());
+        assert!(validate_value(&signed, &json!("3")).is_err());
+        let lower_only = ValidationKind::RangeI64 {
+            min: Some(-1),
+            max: None,
+        };
+        assert!(validate_value(&lower_only, &json!(1_000)).is_ok());
+        assert!(validate_value(&lower_only, &json!(-2)).is_err());
     }
 
     #[test]

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -1328,7 +1328,8 @@ impl PluginManagerDialog {
             .title(" Plugins ")
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(border_color));
+            .border_style(Style::default().fg(border_color))
+            .padding(Padding::horizontal(1));
         let inner = block.inner(rect);
         f.render_widget(block, rect);
         self.render_browse(f, inner, theme);
@@ -1889,7 +1890,8 @@ impl PluginManagerDialog {
             .title(title.to_string())
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(theme.accent));
+            .border_style(Style::default().fg(theme.accent))
+            .padding(Padding::horizontal(1));
         let inner = block.inner(rect);
         f.render_widget(block, rect);
         let footer_rows = if footer.is_empty() {

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -359,6 +359,9 @@ fn setting_type_label(t: aoe_plugin_api::SettingType) -> &'static str {
         aoe_plugin_api::SettingType::Bool => "bool",
         aoe_plugin_api::SettingType::Integer => "integer",
         aoe_plugin_api::SettingType::Select => "select",
+        aoe_plugin_api::SettingType::DynamicSelect => "dynamic_select",
+        aoe_plugin_api::SettingType::ObjectList => "object_list",
+        aoe_plugin_api::SettingType::Cron => "cron",
     }
 }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -433,6 +433,21 @@ fn value_from_json(widget: &WidgetKind, current: Option<&Value>) -> FieldValue {
             }
         }
         WidgetKind::List => FieldValue::List(json_to_list(current)),
+        // API v9 (#2897). dynamic_select and cron edit as a plain text value
+        // in the TUI for now (the resolver-backed picker and the object-list
+        // drill-down editor are the structured-editor follow-up); object_list
+        // renders as its raw JSON array so it stays round-trippable.
+        WidgetKind::DynamicSelect { .. } | WidgetKind::Cron => {
+            FieldValue::Text(current.as_str().unwrap_or("").to_string())
+        }
+        WidgetKind::ObjectList { .. } => {
+            let text = if current.is_null() {
+                "[]".to_string()
+            } else {
+                serde_json::to_string_pretty(current).unwrap_or_else(|_| "[]".to_string())
+            };
+            FieldValue::Text(text)
+        }
         WidgetKind::Custom { id } => custom_value_from_json(id, current),
     }
 }
@@ -578,6 +593,14 @@ fn schema_value_to_json(
             } else {
                 json!(items)
             }
+        }
+        // API v9 (#2897): dynamic_select and cron round-trip as text;
+        // object_list parses its raw-JSON text back to an array (server
+        // validation rejects malformed input, so a parse failure stores null
+        // and surfaces as a validation error rather than corrupting the row).
+        (WidgetKind::DynamicSelect { .. } | WidgetKind::Cron, FieldValue::Text(s)) => json!(s),
+        (WidgetKind::ObjectList { .. }, FieldValue::Text(s)) => {
+            serde_json::from_str::<Value>(s).unwrap_or(Value::Null)
         }
         (WidgetKind::Custom { id }, value) => custom_value_to_json(id, value),
         _ => Value::Null,

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -53,8 +53,14 @@ const LINE_RATIO = 1.2;
 const RESIZE_DEBOUNCE_MS = 150;
 /** How long the meaningful-row scroll anchor must stay lower before it
  *  shrinks, so a spinner toggling the lowest non-blank row can't flutter the
- *  viewport. Comfortably longer than an agent's redraw cadence. */
-const SHRINK_DELAY_MS = 600;
+ *  viewport. Must clear the worst-case gap between two spinner-ON captures, not
+ *  just the agent's redraw period: a spinner-on frame resets the timer, but
+ *  under a stalled live stream (busy CI, slow network) consecutive captures can
+ *  all land in the brief spinner-off window, and a delay only slightly above
+ *  the redraw cadence would then trim mid-oscillation and bounce the block back
+ *  on the next grow. 1.5s leaves ample margin while still snapping trailing
+ *  blanks up within ~a second of an agent going quiet. */
+const SHRINK_DELAY_MS = 1500;
 /** Live-edge capture window in screenfuls: the visible screen plus this much
  *  scrollback kept loaded ABOVE it, so a scroll-up lands on real content
  *  instead of the blank history spacer (which otherwise only fills on a

--- a/web/src/components/settings/SchemaSection.tsx
+++ b/web/src/components/settings/SchemaSection.tsx
@@ -11,6 +11,7 @@ import {
   ToggleField,
 } from "./FormFields";
 import { CUSTOM_SETTINGS_WIDGETS } from "./customWidgetRegistry";
+import { CronField, DynamicSelectField, ObjectListField } from "./StructuredWidgets";
 
 interface Props {
   /** Config section name (e.g. "sandbox"). */
@@ -168,6 +169,45 @@ function renderField(
           items={Array.isArray(raw) ? (raw as string[]) : []}
           onChange={save}
           validate={listValidator(d.validation)}
+        />
+      );
+    case "dynamic_select":
+      return (
+        <DynamicSelectField
+          key={d.field}
+          label={d.label}
+          description={description}
+          section={d.section}
+          source={widget.source}
+          dependsOn={widget.depends_on ?? []}
+          sectionValues={values}
+          value={typeof raw === "string" ? raw : ""}
+          onChange={save}
+        />
+      );
+    case "cron":
+      return (
+        <CronField
+          key={d.field}
+          label={d.label}
+          description={description}
+          value={typeof raw === "string" ? raw : ""}
+          onChange={save}
+        />
+      );
+    case "object_list":
+      return (
+        <ObjectListField
+          key={d.field}
+          label={d.label}
+          description={description}
+          section={d.section}
+          idField={widget.id_field}
+          fields={widget.fields}
+          minItems={widget.min_items}
+          maxItems={widget.max_items}
+          items={Array.isArray(raw) ? (raw as Record<string, unknown>[]) : []}
+          onChange={save}
         />
       );
     case "custom": {

--- a/web/src/components/settings/StructuredWidgets.tsx
+++ b/web/src/components/settings/StructuredWidgets.tsx
@@ -1,0 +1,333 @@
+// API v9 structured plugin settings widgets (#2897): dynamic_select (host
+// option source), cron (validated text), and object_list (repeatable
+// structured items). Rendered generically from the schema, so any plugin's
+// object_list of dynamic_selects works without plugin-specific host code.
+
+import { useEffect, useRef, useState } from "react";
+import { resolvePluginOptions } from "../../lib/api";
+import type { SettingsObjectField, SettingsObjectFieldWidget, SettingsOptionSource } from "../../lib/types";
+import { validateCron } from "./cronValidation";
+import { NumberField, SelectField, TextField, ToggleField } from "./FormFields";
+
+/** Plugin id embedded in a `plugin:<id>` section id. */
+function pluginIdOf(section: string): string {
+  return section.startsWith("plugin:") ? section.slice("plugin:".length) : section;
+}
+
+/** A stable item id. Uses crypto.randomUUID in a secure browser context and
+ *  falls back to a random string where it is unavailable (older webviews,
+ *  jsdom); the host only requires a non-empty unique string, not a real UUID. */
+function newItemId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+  return `id-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+/** A select whose options the host resolves for a `dynamic_select`. Reloads
+ *  when its dependency values change; preserves a stored value that is no
+ *  longer offered by showing it as "(unavailable)" rather than dropping it,
+ *  since it may still be valid (sessions.create is the authoritative check). */
+function PluginOptionSelect({
+  label,
+  description,
+  section,
+  source,
+  depends,
+  value,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  section: string;
+  source: SettingsOptionSource;
+  depends: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [options, setOptions] = useState<{ value: string; label: string }[]>([]);
+  const depsKey = depends.join("");
+  // A monotonically-increasing request id so a slow earlier resolve cannot
+  // overwrite a newer one (dependency changed while a fetch was in flight).
+  const reqId = useRef(0);
+
+  useEffect(() => {
+    const id = ++reqId.current;
+    resolvePluginOptions(pluginIdOf(section), source, depends).then((opts) => {
+      if (id === reqId.current) setOptions(opts);
+    });
+    // depsKey captures the dependency values; source/section are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [section, source, depsKey]);
+
+  const known = options.some((o) => o.value === value);
+  const shown = value && !known ? [{ value, label: `${value} (unavailable)` }, ...options] : options;
+  // An empty placeholder so a required-but-unset field does not silently adopt
+  // the first option.
+  const withPlaceholder = value ? shown : [{ value: "", label: "Select..." }, ...shown];
+
+  return (
+    <SelectField label={label} description={description} value={value} onChange={onChange} options={withPlaceholder} />
+  );
+}
+
+/** A cron text field with live client-side validation feedback. The server is
+ *  authoritative; this is a UX nicety mirroring the same 5-field grammar. */
+export function CronField({
+  label,
+  description,
+  value,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const error = value ? validateCron(value) : null;
+  return (
+    <div>
+      <TextField
+        label={label}
+        description={description}
+        value={value}
+        onChange={onChange}
+        mono
+        placeholder="0 9 * * 1-5"
+      />
+      {error && <div className="text-xs text-status-error mt-1">{error}</div>}
+    </div>
+  );
+}
+
+/** Top-level `dynamic_select` field: resolves `depends_on` sibling values from
+ *  the section's current values. */
+export function DynamicSelectField({
+  label,
+  description,
+  section,
+  source,
+  dependsOn,
+  sectionValues,
+  value,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  section: string;
+  source: SettingsOptionSource;
+  dependsOn: string[];
+  sectionValues: Record<string, unknown>;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const depends = dependsOn.map((k) => {
+    const v = sectionValues[k];
+    return typeof v === "string" ? v : "";
+  });
+  return (
+    <PluginOptionSelect
+      label={label}
+      description={description}
+      section={section}
+      source={source}
+      depends={depends}
+      value={value}
+      onChange={onChange}
+    />
+  );
+}
+
+type Item = Record<string, unknown>;
+
+/** Render one nested object-list item field into the matching control. */
+function renderItemField(
+  section: string,
+  field: SettingsObjectField,
+  item: Item,
+  setField: (key: string, value: unknown) => void,
+) {
+  const widget: SettingsObjectFieldWidget = field.widget;
+  const raw = item[field.field];
+  switch (widget.kind) {
+    case "toggle":
+      return (
+        <ToggleField
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          checked={typeof raw === "boolean" ? raw : false}
+          onChange={(v) => setField(field.field, v)}
+        />
+      );
+    case "number":
+      return (
+        <NumberField
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          value={typeof raw === "number" ? raw : 0}
+          onChange={(v) => setField(field.field, v)}
+          min={widget.min}
+          max={widget.max}
+        />
+      );
+    case "select":
+      return (
+        <SelectField
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          value={typeof raw === "string" ? raw : ""}
+          onChange={(v) => setField(field.field, v)}
+          options={widget.options}
+        />
+      );
+    case "cron":
+      return (
+        <CronField
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          value={typeof raw === "string" ? raw : ""}
+          onChange={(v) => setField(field.field, v)}
+        />
+      );
+    case "dynamic_select":
+      return (
+        <PluginOptionSelect
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          section={section}
+          source={widget.source}
+          depends={(widget.depends_on ?? []).map((k) => {
+            const v = item[k];
+            return typeof v === "string" ? v : "";
+          })}
+          value={typeof raw === "string" ? raw : ""}
+          onChange={(v) => setField(field.field, v)}
+        />
+      );
+    case "text":
+      return (
+        <TextField
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          value={typeof raw === "string" ? raw : ""}
+          onChange={(v) => setField(field.field, v)}
+          mono={widget.mono}
+          multiline={widget.multiline}
+        />
+      );
+  }
+}
+
+/** A repeatable list of structured items with add / remove / move controls.
+ *  Each item carries a stable id under `idField`, generated on add and never
+ *  regenerated on edit or reorder, so a dependent worker can track it. */
+export function ObjectListField({
+  label,
+  description,
+  section,
+  idField,
+  fields,
+  minItems,
+  maxItems,
+  items,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  section: string;
+  idField: string;
+  fields: SettingsObjectField[];
+  minItems?: number;
+  maxItems?: number;
+  items: Item[];
+  onChange: (items: Item[]) => void;
+}) {
+  const setItem = (index: number, next: Item) => {
+    onChange(items.map((it, i) => (i === index ? next : it)));
+  };
+  const addItem = () => {
+    const item: Item = { [idField]: newItemId() };
+    for (const f of fields) {
+      if (f.default !== undefined) item[f.field] = f.default;
+    }
+    onChange([...items, item]);
+  };
+  const removeItem = (index: number) => onChange(items.filter((_, i) => i !== index));
+  const move = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= items.length) return;
+    const a = items[index];
+    const b = items[target];
+    if (a === undefined || b === undefined) return;
+    const next = items.slice();
+    next[index] = b;
+    next[target] = a;
+    onChange(next);
+  };
+
+  const atMax = maxItems !== undefined && items.length >= maxItems;
+  const atMin = minItems !== undefined && items.length <= minItems;
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <div className="text-sm text-text-bright">{label}</div>
+        {description && <div className="text-xs text-text-dim">{description}</div>}
+      </div>
+      {items.map((item, index) => {
+        const id = String(item[idField] ?? index);
+        const setField = (key: string, value: unknown) => setItem(index, { ...item, [key]: value });
+        return (
+          <div key={id} className="rounded-lg border border-surface-700 bg-surface-900 p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-dim">Item {index + 1}</span>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  aria-label="Move up"
+                  disabled={index === 0}
+                  onClick={() => move(index, -1)}
+                  className="px-2 py-0.5 text-xs text-text-dim hover:text-text-primary disabled:opacity-40"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  aria-label="Move down"
+                  disabled={index === items.length - 1}
+                  onClick={() => move(index, 1)}
+                  className="px-2 py-0.5 text-xs text-text-dim hover:text-text-primary disabled:opacity-40"
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  aria-label="Remove item"
+                  disabled={atMin}
+                  onClick={() => removeItem(index)}
+                  className="px-2 py-0.5 text-xs text-status-error hover:opacity-80 disabled:opacity-40"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+            {fields.map((f) => renderItemField(section, f, item, setField))}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        disabled={atMax}
+        onClick={addItem}
+        className="px-3 py-1.5 text-sm rounded-md border border-surface-700 text-text-primary hover:border-brand-600 disabled:opacity-40"
+      >
+        Add item
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/settings/StructuredWidgets.tsx
+++ b/web/src/components/settings/StructuredWidgets.tsx
@@ -247,31 +247,59 @@ export function ObjectListField({
   items: Item[];
   onChange: (items: Item[]) => void;
 }) {
+  // Local working copy so a newly added item with unfilled required fields can
+  // be edited in place; we persist only once every item is valid, because the
+  // server rejects an object_list whose required fields are empty (a bare
+  // onChange would fail to save and the row could never enter edit state).
+  // Re-sync when the persisted content changes (keyed by value, not identity, so
+  // the empty-array fallback does not wipe in-progress drafts each render).
+  // Adjusting state during render is React's recommended alternative to a
+  // syncing effect.
+  const [working, setWorking] = useState<Item[]>(items);
+  const itemsKey = JSON.stringify(items);
+  const [syncedKey, setSyncedKey] = useState(itemsKey);
+  if (itemsKey !== syncedKey) {
+    setSyncedKey(itemsKey);
+    setWorking(items);
+  }
+
+  const itemValid = (it: Item) =>
+    fields.every((f) => {
+      if (!f.required) return true;
+      const v = it[f.field];
+      return typeof v === "string" ? v.trim() !== "" : v !== undefined && v !== null;
+    });
+  const commit = (next: Item[]) => {
+    setWorking(next);
+    // Persist only a fully valid list; incomplete new rows stay local until filled.
+    if (next.every(itemValid)) onChange(next);
+  };
+
   const setItem = (index: number, next: Item) => {
-    onChange(items.map((it, i) => (i === index ? next : it)));
+    commit(working.map((it, i) => (i === index ? next : it)));
   };
   const addItem = () => {
     const item: Item = { [idField]: newItemId() };
     for (const f of fields) {
       if (f.default !== undefined) item[f.field] = f.default;
     }
-    onChange([...items, item]);
+    commit([...working, item]);
   };
-  const removeItem = (index: number) => onChange(items.filter((_, i) => i !== index));
+  const removeItem = (index: number) => commit(working.filter((_, i) => i !== index));
   const move = (index: number, delta: number) => {
     const target = index + delta;
-    if (target < 0 || target >= items.length) return;
-    const a = items[index];
-    const b = items[target];
+    if (target < 0 || target >= working.length) return;
+    const a = working[index];
+    const b = working[target];
     if (a === undefined || b === undefined) return;
-    const next = items.slice();
+    const next = working.slice();
     next[index] = b;
     next[target] = a;
-    onChange(next);
+    commit(next);
   };
 
-  const atMax = maxItems !== undefined && items.length >= maxItems;
-  const atMin = minItems !== undefined && items.length <= minItems;
+  const atMax = maxItems !== undefined && working.length >= maxItems;
+  const atMin = minItems !== undefined && working.length <= minItems;
 
   return (
     <div className="space-y-2">
@@ -279,7 +307,7 @@ export function ObjectListField({
         <div className="text-sm text-text-bright">{label}</div>
         {description && <div className="text-xs text-text-dim">{description}</div>}
       </div>
-      {items.map((item, index) => {
+      {working.map((item, index) => {
         const id = String(item[idField] ?? index);
         const setField = (key: string, value: unknown) => setItem(index, { ...item, [key]: value });
         return (
@@ -299,7 +327,7 @@ export function ObjectListField({
                 <button
                   type="button"
                   aria-label="Move down"
-                  disabled={index === items.length - 1}
+                  disabled={index === working.length - 1}
                   onClick={() => move(index, 1)}
                   className="px-2 py-0.5 text-xs text-text-dim hover:text-text-primary disabled:opacity-40"
                 >

--- a/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
@@ -65,15 +65,30 @@ const SCHEMA: SettingsFieldDescriptor[] = [
 ];
 
 describe("structured plugin settings widgets", () => {
-  it("adds an object_list item with a stable id and a host-populated picker", async () => {
+  it("adds a new object_list item as an editable draft, persisting only once required fields are filled", async () => {
     const onSave = vi.fn().mockResolvedValue(true);
     render(<SchemaSection section="plugin:acme.cron" schema={SCHEMA} values={{ jobs: [] }} onSaveField={onSave} />);
 
     fireEvent.click(screen.getByText("Add item"));
 
-    // The whole array (one item with a generated stable id) is persisted.
-    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    const [sec, field, value] = onSave.mock.calls[0]!;
+    // The new item renders and is editable, but its required fields (agent,
+    // schedule) are empty, so nothing is persisted yet.
+    await waitFor(() => expect(screen.getByText("Item 1")).toBeTruthy());
+    expect(onSave).not.toHaveBeenCalled();
+
+    // Filling every required field promotes the draft to a persisted save.
+    // TextField holds a local buffer while focused and commits on blur; the
+    // native select commits on change.
+    const cron = screen.getByPlaceholderText("0 9 * * 1-5");
+    fireEvent.focus(cron);
+    fireEvent.change(cron, { target: { value: "0 9 * * 1-5" } });
+    fireEvent.blur(cron);
+    await waitFor(() => expect(screen.getByText("Claude Code")).toBeTruthy());
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "claude-code" } });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const lastCall = onSave.mock.calls.at(-1)!;
+    const [sec, field, value] = lastCall;
     expect(sec).toBe("plugin:acme.cron");
     expect(field).toBe("jobs");
     expect(Array.isArray(value)).toBe(true);

--- a/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
@@ -132,4 +132,47 @@ describe("structured plugin settings widgets", () => {
     fireEvent.click(screen.getByRole("button", { name: "Remove item" }));
     await waitFor(() => expect(onSave).toHaveBeenCalledWith("plugin:acme.cron", "jobs", []));
   });
+
+  it("reorders two valid items and persists the swap", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={SCHEMA}
+        values={{
+          jobs: [
+            { id: "id-1", agent: "codex", schedule: "0 9 * * 1-5" },
+            { id: "id-2", agent: "claude-code", schedule: "0 17 * * 1-5" },
+          ],
+        }}
+        onSaveField={onSave}
+      />,
+    );
+
+    // Moving the first item down swaps the order; both items stay valid, so the
+    // reordered array persists.
+    fireEvent.click(screen.getAllByRole("button", { name: "Move down" })[0]!);
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [, , value] = onSave.mock.calls[0]!;
+    expect((value as { id: string }[]).map((it) => it.id)).toEqual(["id-2", "id-1"]);
+  });
+
+  it("re-syncs its working copy when the persisted items change externally", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const { rerender } = render(
+      <SchemaSection section="plugin:acme.cron" schema={SCHEMA} values={{ jobs: [] }} onSaveField={onSave} />,
+    );
+    expect(screen.queryByText("Item 1")).toBeNull();
+
+    // An external update to the persisted value flows into the rendered list.
+    rerender(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={SCHEMA}
+        values={{ jobs: [{ id: "id-1", agent: "codex", schedule: "0 9 * * 1-5" }] }}
+        onSaveField={onSave}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("Item 1")).toBeTruthy());
+  });
 });

--- a/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
@@ -157,6 +157,81 @@ describe("structured plugin settings widgets", () => {
     expect((value as { id: string }[]).map((it) => it.id)).toEqual(["id-2", "id-1"]);
   });
 
+  it("renders every item field widget kind and the top-level cron/dynamic_select", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const schema: SettingsFieldDescriptor[] = [
+      {
+        section: "plugin:acme.cron",
+        field: "when",
+        category: "Plugins",
+        label: "When",
+        description: "",
+        web_write: ALLOW,
+        profile_overridable: false,
+        validation: { rule: "cron" },
+        advanced: false,
+        widget: { kind: "cron" },
+      },
+      {
+        section: "plugin:acme.cron",
+        field: "who",
+        category: "Plugins",
+        label: "Who",
+        description: "",
+        web_write: ALLOW,
+        profile_overridable: false,
+        validation: { rule: "str" },
+        advanced: false,
+        widget: { kind: "dynamic_select", source: "acp_agents" },
+      },
+      {
+        section: "plugin:acme.cron",
+        field: "rows",
+        category: "Plugins",
+        label: "Rows",
+        description: "",
+        web_write: ALLOW,
+        profile_overridable: false,
+        validation: NONE,
+        advanced: false,
+        widget: {
+          kind: "object_list",
+          id_field: "id",
+          fields: [
+            { field: "on", label: "On", required: false, widget: { kind: "toggle" }, validation: { rule: "bool" } },
+            { field: "n", label: "N", required: false, widget: { kind: "number" }, validation: { rule: "range_i64" } },
+            {
+              field: "pick",
+              label: "Pick",
+              required: false,
+              widget: { kind: "select", options: ["a", "b"] },
+              validation: { rule: "one_of", options: ["a", "b"] },
+            },
+            { field: "note", label: "Note", required: false, widget: { kind: "text" }, validation: { rule: "str" } },
+          ],
+        },
+      },
+    ];
+
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={schema}
+        values={{ when: "0 9 * * 1-5", who: "codex", rows: [{ id: "r1", on: true, n: 2, pick: "a", note: "hi" }] }}
+        onSaveField={onSave}
+      />,
+    );
+
+    // Top-level cron + dynamic_select render, and the object_list item exposes
+    // every nested widget kind.
+    expect(screen.getByDisplayValue("0 9 * * 1-5")).toBeTruthy();
+    expect(screen.getByText("On")).toBeTruthy();
+    expect(screen.getByText("N")).toBeTruthy();
+    expect(screen.getByText("Pick")).toBeTruthy();
+    expect(screen.getByText("Note")).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Claude Code")).toBeTruthy());
+  });
+
   it("re-syncs its working copy when the persisted items change externally", async () => {
     const onSave = vi.fn().mockResolvedValue(true);
     const { rerender } = render(

--- a/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// Contract test for the API v9 structured plugin settings widgets (#2897):
+// object_list add/remove with a host-populated dynamic_select picker, and
+// dynamic_select dependency-driven option reloads. Pins that the object_list
+// generates a stable id on add, renders nested pickers fed by the resolver
+// endpoint, and emits the full array through onSaveField.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SchemaSection } from "../SchemaSection";
+import type { SettingsFieldDescriptor } from "../../../lib/types";
+
+const ALLOW = { policy: "allow" } as const;
+const NONE = { rule: "none" } as const;
+
+// Stub the resolver endpoint so the picker has host options without a backend.
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      options: [
+        { value: "claude-code", label: "Claude Code" },
+        { value: "codex", label: "Codex" },
+      ],
+    }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+const SCHEMA: SettingsFieldDescriptor[] = [
+  {
+    section: "plugin:acme.cron",
+    field: "jobs",
+    category: "Plugins",
+    label: "Scheduled jobs",
+    description: "",
+    web_write: ALLOW,
+    profile_overridable: false,
+    validation: NONE,
+    advanced: false,
+    widget: {
+      kind: "object_list",
+      id_field: "id",
+      fields: [
+        {
+          field: "agent",
+          label: "Agent",
+          required: true,
+          widget: { kind: "dynamic_select", source: "acp_agents" },
+          validation: { rule: "non_empty_string" },
+        },
+        {
+          field: "schedule",
+          label: "Schedule",
+          required: true,
+          widget: { kind: "cron" },
+          validation: { rule: "cron" },
+        },
+      ],
+    },
+  },
+];
+
+describe("structured plugin settings widgets", () => {
+  it("adds an object_list item with a stable id and a host-populated picker", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(<SchemaSection section="plugin:acme.cron" schema={SCHEMA} values={{ jobs: [] }} onSaveField={onSave} />);
+
+    fireEvent.click(screen.getByText("Add item"));
+
+    // The whole array (one item with a generated stable id) is persisted.
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [sec, field, value] = onSave.mock.calls[0]!;
+    expect(sec).toBe("plugin:acme.cron");
+    expect(field).toBe("jobs");
+    expect(Array.isArray(value)).toBe(true);
+    expect((value as { id: string }[]).length).toBe(1);
+    expect(typeof (value as { id: string }[])[0]!.id).toBe("string");
+  });
+
+  it("renders an item's dynamic_select from host-resolved options", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={SCHEMA}
+        values={{ jobs: [{ id: "id-1", agent: "codex", schedule: "0 9 * * 1-5" }] }}
+        onSaveField={onSave}
+      />,
+    );
+
+    // The nested dynamic_select fetched its options from the resolver endpoint,
+    // scoped to the plugin id, and rendered the host labels.
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/plugins/acme.cron/settings/options/resolve",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    await waitFor(() => expect(screen.getByText("Claude Code")).toBeTruthy());
+  });
+
+  it("removes an object_list item", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={SCHEMA}
+        values={{ jobs: [{ id: "id-1", agent: "codex", schedule: "0 9 * * 1-5" }] }}
+        onSaveField={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove item" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("plugin:acme.cron", "jobs", []));
+  });
+});

--- a/web/src/components/settings/__tests__/cronValidation.test.ts
+++ b/web/src/components/settings/__tests__/cronValidation.test.ts
@@ -1,0 +1,46 @@
+// Unit coverage for the client-side 5-field cron validator (#2897). The server
+// is authoritative; this only mirrors the grammar for early feedback, so the
+// tests pin the field-count, range, list, range, and step branches.
+
+import { describe, expect, it } from "vitest";
+import { validateCron } from "../cronValidation";
+
+describe("validateCron", () => {
+  it("accepts a plain 5-field expression and wildcards", () => {
+    expect(validateCron("0 9 * * 1-5")).toBeNull();
+    expect(validateCron("* * * * *")).toBeNull();
+    expect(validateCron("  0   9   *   *   *  ")).toBeNull();
+  });
+
+  it("accepts lists, ranges, and steps within range", () => {
+    expect(validateCron("0,30 9-17 * * *")).toBeNull();
+    expect(validateCron("*/15 * * * *")).toBeNull();
+    expect(validateCron("0 0 1-15/2 * 0")).toBeNull();
+    // Both 0 and 7 are Sunday for day-of-week.
+    expect(validateCron("0 0 * * 7")).toBeNull();
+  });
+
+  it("rejects the wrong field count", () => {
+    expect(validateCron("0 9 * *")).toMatch(/exactly 5 fields/);
+    expect(validateCron("0 9 * * 1-5 extra")).toMatch(/exactly 5 fields/);
+    expect(validateCron("")).toMatch(/exactly 5 fields/);
+  });
+
+  it("rejects out-of-range values per field", () => {
+    expect(validateCron("60 * * * *")).toMatch(/minute/);
+    expect(validateCron("* 24 * * *")).toMatch(/hour/);
+    expect(validateCron("* * 0 * *")).toMatch(/day-of-month/);
+    expect(validateCron("* * * 13 *")).toMatch(/month/);
+    expect(validateCron("* * * * 8")).toMatch(/day-of-week/);
+  });
+
+  it("rejects malformed items (bad step, non-numeric, over-split range)", () => {
+    expect(validateCron("*/0 * * * *")).toMatch(/minute/);
+    expect(validateCron("*/a * * * *")).toMatch(/minute/);
+    expect(validateCron("1-2-3 * * * *")).toMatch(/minute/);
+    expect(validateCron("1/2/3 * * * *")).toMatch(/minute/);
+    expect(validateCron("abc * * * *")).toMatch(/minute/);
+    // Range with an out-of-range endpoint.
+    expect(validateCron("1-99 * * * *")).toMatch(/minute/);
+  });
+});

--- a/web/src/components/settings/cronValidation.ts
+++ b/web/src/components/settings/cronValidation.ts
@@ -1,0 +1,55 @@
+// Small client-side 5-field cron validator for the scheduled-jobs widget
+// (#2886). The server does not re-validate cron, so an invalid expression would
+// silently never fire; this catches the obvious mistakes (wrong field count,
+// out-of-range values) before save. It is intentionally minimal: numeric fields
+// with `*`, `,`, `-`, `/`, matching the ranges croner enforces server-side and
+// covering everything the picker generates. Named tokens (JAN/MON) are not
+// accepted here; advanced users wanting those edit via the TUI or config.toml.
+
+const FIELD_RANGES: [number, number][] = [
+  [0, 59], // minute
+  [0, 23], // hour
+  [1, 31], // day of month
+  [1, 12], // month
+  [0, 7], // day of week (0 and 7 are both Sunday)
+];
+const FIELD_NAMES = ["minute", "hour", "day-of-month", "month", "day-of-week"];
+
+function inRange(token: string, min: number, max: number): boolean {
+  if (!/^\d+$/.test(token)) return false;
+  const n = Number(token);
+  return n >= min && n <= max;
+}
+
+function validItem(item: string, min: number, max: number): boolean {
+  const slash = item.split("/");
+  if (slash.length > 2) return false;
+  const base = slash[0] ?? "";
+  if (slash.length === 2) {
+    const step = slash[1] ?? "";
+    if (!/^\d+$/.test(step) || Number(step) < 1) return false;
+  }
+  if (base === "*") return true;
+  const dash = base.split("-");
+  if (dash.length === 1) return inRange(dash[0] ?? "", min, max);
+  if (dash.length === 2) return inRange(dash[0] ?? "", min, max) && inRange(dash[1] ?? "", min, max);
+  return false;
+}
+
+/** Return an error string for an invalid 5-field cron, or null when it is
+ *  acceptable. Purely a UX gate; the picker only ever produces valid output. */
+export function validateCron(expr: string): string | null {
+  const parts = expr.trim().split(/\s+/).filter(Boolean);
+  if (parts.length !== 5) {
+    return "Cron must have exactly 5 fields: minute hour day-of-month month day-of-week.";
+  }
+  for (let i = 0; i < 5; i++) {
+    const range = FIELD_RANGES[i];
+    const field = parts[i];
+    if (!range || field === undefined) continue;
+    const [min, max] = range;
+    const ok = field.split(",").every((item) => validItem(item, min, max));
+    if (!ok) return `Invalid ${FIELD_NAMES[i]} field: "${field}".`;
+  }
+  return null;
+}

--- a/web/src/components/settings/cronValidation.ts
+++ b/web/src/components/settings/cronValidation.ts
@@ -1,10 +1,10 @@
 // Small client-side 5-field cron validator for the scheduled-jobs widget
-// (#2886). The server does not re-validate cron, so an invalid expression would
-// silently never fire; this catches the obvious mistakes (wrong field count,
-// out-of-range values) before save. It is intentionally minimal: numeric fields
-// with `*`, `,`, `-`, `/`, matching the ranges croner enforces server-side and
-// covering everything the picker generates. Named tokens (JAN/MON) are not
-// accepted here; advanced users wanting those edit via the TUI or config.toml.
+// (#2897). The API v9 settings validator is authoritative for cron; this only
+// mirrors that rule to give early feedback (wrong field count, out-of-range
+// values) before save. It is intentionally minimal: numeric fields with `*`,
+// `,`, `-`, `/`, matching the ranges croner enforces server-side and covering
+// everything the picker generates. Named tokens (JAN/MON) are not accepted
+// here; advanced users wanting those edit via the TUI or config.toml.
 
 const FIELD_RANGES: [number, number][] = [
   [0, 59], // minute

--- a/web/src/lib/__tests__/pluginsApi.test.ts
+++ b/web/src/lib/__tests__/pluginsApi.test.ts
@@ -10,6 +10,7 @@ import {
   dismissPluginUpdate,
   fetchPlugins,
   previewPluginUpdate,
+  resolvePluginOptions,
   setPluginEnabled,
   updateSettings,
 } from "../api";
@@ -211,5 +212,26 @@ describe("updateSettings", () => {
   it("returns false when the request throws", async () => {
     fetchSpy.mockRejectedValue(new Error("offline"));
     expect(await updateSettings({})).toBe(false);
+  });
+});
+
+describe("resolvePluginOptions", () => {
+  it("POSTs the source/depends and returns the resolved options (#2897)", async () => {
+    const options = [{ value: "claude-code", label: "Claude Code" }];
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ options }), { status: 200 }));
+    expect(await resolvePluginOptions("acme.cron", "acp_agents", ["x"])).toEqual(options);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/plugins/acme.cron/settings/options/resolve");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ source: "acp_agents", depends: ["x"] });
+  });
+
+  it("returns [] on a non-OK response, a missing options field, and a network throw", async () => {
+    fetchSpy.mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await resolvePluginOptions("acme.cron", "acp_agents", [])).toEqual([]);
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    expect(await resolvePluginOptions("acme.cron", "acp_agents", [])).toEqual([]);
+    fetchSpy.mockRejectedValue(new Error("offline"));
+    expect(await resolvePluginOptions("acme.cron", "acp_agents", [])).toEqual([]);
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1520,6 +1520,30 @@ export async function fetchGroups(): Promise<GroupInfo[]> {
   return (await fetchJson<GroupInfo[]>("/api/groups")) ?? [];
 }
 
+/** Resolve a plugin `dynamic_select` widget's options from the host (#2897).
+ *  `depends` carries the current values of the widget's `depends_on` siblings
+ *  in declaration order (for acp_models/acp_modes the first entry is the
+ *  selected agent). Returns [] on any failure so the picker degrades to an
+ *  empty list rather than throwing. */
+export async function resolvePluginOptions(
+  pluginId: string,
+  source: string,
+  depends: string[],
+): Promise<{ value: string; label: string }[]> {
+  try {
+    const res = await fetch(`/api/plugins/${encodeURIComponent(pluginId)}/settings/options/resolve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source, depends }),
+    });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { options?: { value: string; label: string }[] };
+    return body.options ?? [];
+  } catch {
+    return [];
+  }
+}
+
 export async function fetchProjects(scope?: "global" | "profile"): Promise<ProjectInfo[]> {
   const url = scope ? `/api/projects?scope=${scope}` : "/api/projects";
   return (await fetchJson<ProjectInfo[]>(url)) ?? [];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -569,9 +569,46 @@ export type SettingsWidget =
   | { kind: "slider"; min: number; max: number; step: number }
   | { kind: "select"; options: SettingsSelectOption[] }
   | { kind: "list" }
+  /** A select whose options the host resolves at render time (API v9). */
+  | { kind: "dynamic_select"; source: SettingsOptionSource; depends_on?: string[] }
+  /** A repeatable list of structured items (API v9). One level deep. */
+  | {
+      kind: "object_list";
+      id_field: string;
+      fields: SettingsObjectField[];
+      min_items?: number;
+      max_items?: number;
+    }
+  /** A cron expression, rendered as a validated text field (API v9). */
+  | { kind: "cron" }
   /** Escape hatch: a bespoke widget keyed by `id`. The renderer maps the id
    *  to a hand-written component (e.g. the logging per-target matrix). */
   | { kind: "custom"; id: string };
+
+/** Host option source a `dynamic_select` draws from (API v9). Serialized
+ *  snake_case, posted back verbatim to the resolver endpoint. */
+export type SettingsOptionSource = "acp_agents" | "acp_models" | "acp_modes" | "projects" | "groups";
+
+/** The widget of one `object_list` item field (API v9). A subset of
+ *  {@link SettingsWidget} with no object-list variant (non-recursive). */
+export type SettingsObjectFieldWidget =
+  | { kind: "toggle" }
+  | { kind: "text"; multiline?: boolean; mono?: boolean }
+  | { kind: "number"; min?: number; max?: number }
+  | { kind: "select"; options: SettingsSelectOption[] }
+  | { kind: "dynamic_select"; source: SettingsOptionSource; depends_on?: string[] }
+  | { kind: "cron" };
+
+/** One nested field of an `object_list` item (API v9). */
+export interface SettingsObjectField {
+  field: string;
+  label: string;
+  description?: string;
+  required?: boolean;
+  widget: SettingsObjectFieldWidget;
+  validation: SettingsValidation;
+  default?: unknown;
+}
 
 /** Whether the dashboard may write a field (serde `#[serde(tag = "policy")]`).
  *  `local_only` fields are rejected by the server PATCH. */
@@ -593,7 +630,16 @@ export type SettingsValidation =
   | { rule: "memory_limit" }
   | { rule: "volume_list" }
   | { rule: "env_list" }
-  | { rule: "port_mapping_list" };
+  | { rule: "port_mapping_list" }
+  | { rule: "network" }
+  | { rule: "cron" }
+  | {
+      rule: "object_list";
+      id_field: string;
+      fields: SettingsObjectField[];
+      min_items?: number;
+      max_items?: number;
+    };
 
 /** One configurable field. The dotted `${section}.${field}` is its stable id. */
 export interface SettingsFieldDescriptor {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -624,7 +624,7 @@ export type SettingsValidation =
   | { rule: "bool" }
   | { rule: "str" }
   | { rule: "range_u64"; min: number; max?: number }
-  | { rule: "range_i64"; min: number; max?: number }
+  | { rule: "range_i64"; min?: number; max?: number }
   | { rule: "one_of"; options: string[] }
   | { rule: "non_empty_string" }
   | { rule: "memory_limit" }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -292,6 +292,16 @@
       ]
     },
     {
+      "id": "settings.structured-widgets",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/settings/__tests__/StructuredWidgets.test.tsx"],
+      "components": [
+        "web/src/components/settings/StructuredWidgets.tsx",
+        "web/src/components/settings/SchemaSection.tsx"
+      ]
+    },
+    {
       "id": "settings.mobile-header",
       "kind": "mocked-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

PR1 of the plugin-first cron pivot (supersedes the in-core scheduling of #2887). It generalizes the plugin host so an out-of-process worker can discover ACP capabilities, create a host-owned structured session, and deliver prompts to it, under a tight unattended-execution security model, plus plugin-private storage and structured settings widgets. The scheduling logic itself stays out of core: it moves to the `plugin-cron` worker (PR2). This PR ships only the reusable host primitives.

What it adds:

- **SessionService.** Reshapes the extracted `spawn_structured_session` into a shared service (`create_structured_session` + `send_turn`) used by both the HTTP create/prompt handlers and the new plugin RPCs, so there is one create path and one turn-delivery path. It gains creator attribution, plugin-scoped create idempotency (persisted atomically on the session record), and a durable "pending initial turn" that survives a daemon restart and is drained once the ACP worker is live (at-least-once).
- **Session-driving worker RPCs** (`acp.capabilities.get`, `sessions.create`, `sessions.turn.send`), capability-gated and routed through an async dispatcher in front of the existing synchronous host API. Dependencies are injected into the plugin host at construction, so a worker RPC can never race a late binding.
- **Security model.** The host classifies each approval mode (interactive / guarded / unattended); a plugin cannot self-label a mode safe, and unknown modes fail closed to unattended. `session.unattended` is a distinct high-severity grant, never implied. Repository trust is enforced fail-closed at spawn regardless of grants. Turn delivery is restricted to sessions the plugin created. Per-plugin rate/concurrency limits (20 creates/hour, 5 active sessions, 120 turns/hour) are backed by a private audit ledger that survives restarts; every admission and denial is audited without recording prompt text. Errors carry a stable `data.kind` contract.
- **Plugin-private storage** (`plugin.storage.get/set/cas/remove`): host-backed, namespaced by plugin id, quota-bounded, survives daemon and worker restarts.
- **Structured settings widgets (API v9):** first-class `dynamic_select` (host-resolved option sources for agents/models/modes/projects/groups, with dependent selects), `object_list` (repeatable one-level records with stable ids and add/remove/reorder), and `cron` (validated text). Rendered on the web; a `plugin.settings.changed` event with a monotonic revision notifies the worker after a settings write.
- **API_VERSION 8 to 9**, with the manifest schema, capabilities, and DTOs the `plugin-cron` worker (PR2) pins against.

Scope notes: the in-core `[scheduling]` config, `scheduler.rs`, `aoe schedule` CLI, `croner`, and `plan_tick`/`next_due` are deliberately NOT in this branch (they move to the plugin in PR2). The TUI renders the three new widgets in a functional interim form (object_list as raw JSON, dynamic_select/cron as text, all server-validated and round-tripping); the richer TUI drill-down sub-editor with resolver-backed pickers is a tracked follow-up. Web parity (add/remove rows with host-populated pickers) is fully delivered.

Closes #2897

## PR Type

- [x] New Feature
- [x] Refactor
- [x] Documentation

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] `cargo test --features serve` passes (one pre-existing environment-dependent failure, `test_update_status_with_metadata_restamps_on_genuine_transition`, fails on `main` too).
- [ ] `cd web && npx vitest run` passes, including `src/components/settings/__tests__/StructuredWidgets.test.tsx`.
- [ ] Install a plugin declaring an `object_list` of `dynamic_select` fields plus a `cron` field; open the web settings panel and confirm you can add/remove rows and the agent/model/mode/project pickers populate from the host (model/mode update when you change the agent).
- [ ] Save that plugin's settings and confirm the worker receives a `plugin.settings.changed` notification (and that `config.get` returns the bumped `revision`).
- [ ] With a fake-ACP worker holding `session.create` + `session.unattended`, call `sessions.create` with an unattended mode against a TRUSTED repo: a structured session is created and the initial turn is delivered.
- [ ] Repeat against an UNTRUSTED repo: the host refuses fail-closed and audits the denial, even with the grant.
- [ ] Without `session.unattended`, request an unattended mode: denied with `unattended_grant_required`; a guarded/interactive mode is allowed.
- [ ] Call `sessions.create` twice with the same `idempotency_key`: one session created, the second returns it with `created: false`; a different payload under the same key returns a conflict.
- [ ] Call `sessions.turn.send` against a session another plugin or the user created: denied with `not_owner`.
- [ ] Exercise `plugin.storage.set`/`get`/`cas`/`remove`; confirm namespace isolation and quota enforcement, and that a value survives a daemon restart.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec under `web/` and updated `web/tests/coverage-matrix.json` (`settings.structured-widgets`; the object_list/dynamic_select flow is request-payload/rendering logic best covered by Vitest + MSW-style fetch stubbing per the repo's guidance, not Playwright).

**TUI / CLI (e2e test)**
- [x] N/A: the TUI renders the new widgets in an interim text/JSON form with no new navigation surface; the Rust schema, validation, resolver, RPC authz matrix, storage, and idempotency paths are covered by unit/integration tests in `aoe-plugin-api`, `src/session/settings_schema`, `src/plugin`, and `src/server`.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the two-model design debates per chunk, and the implementation were drafted by Claude under my direction. I made the architecture calls (plugin-first split, the security model, the scope cuts), reviewed each commit, and own the decisions.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added API v9 primitives and RPC contracts so plugin workers can **discover ACP capabilities**, **create structured sessions**, and **deliver initial/prompt turns**, all through **capability-gated** worker RPCs.
- Introduced a shared host-side **SessionService** to centralize structured-session creation and turn delivery, including **plugin-scoped idempotency** and durable **“pending initial turn” replay** after restarts.
- Implemented host-enforced unattended automation and reliability controls: **approval posture classification**, **fail-closed** handling for unknown/unsupported modes, **strict ownership checks** for turn delivery, **stable error codes/kinds**, **per-plugin rate/concurrency/session limits**, and an **audit ledger** for automation decisions.
- Added durable **plugin-private storage** with namespaces, **quotas**, and **CAS semantics** to support safe restarts and restart-persistent plugin data.
- Upgraded plugin manifest/settings to **API v9 structured settings** and added new widgets:
  - `dynamic_select` (host-resolved options with dependency handling)
  - `object_list` (validated repeatable structured items)
  - `cron` (validated cron expressions)
- Added host option-resolution plumbing and notifications, plus updated **web/TUI rendering** and added **client/server validation tests and fixtures** for the new structured widgets.
- Extended session/ACP plumbing to carry an explicit **`acp_mode_id`** across structured-view (re)spawns so the correct approval posture is preserved.
- Fixed a configuration consistency risk by making `config_get` ensure the returned **config value and revision** stay consistent even if settings are updated during load.

## Benefits

Plugins can safely drive complex, host-managed session workflows (including unattended automation) without re-implementing security/reliability logic. The host now enforces trust/ownership, limits, auditing, durable idempotency, and consistent structured settings resolution/validation.

## Potential areas for further enhancement

- Ensure end-to-end error mapping and user feedback are consistent across **server responses, web UI, and TUI**, especially for `dynamic_select` availability, `object_list` validation failures, and cron parsing errors.
- Re-check real-world suitability of the introduced **per-plugin limits/quotas** (rate, active sessions, turns/hour, storage sizes) to minimize avoidable denials.
- Keep cron scheduling explicitly out of core (as intended) and ensure the follow-on `plugin-cron` worker reuses the same authorization/storage/session primitives uniformly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->