### PR TITLE
feat(tui): highlight Trash/Archived shelf folders like regular folders

### DIFF
--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1257,24 +1257,16 @@ impl HomeView {
                     Cow::Owned(format!("{} ({})", name, session_count))
                 };
                 let mut style = Style::default().fg(theme.group).bold();
-                if crate::session::is_within_archived_section(path)
-                    || crate::session::is_within_trash_section(path)
-                {
-                    // Synthetic Archived section header (and any
-                    // project sub-folder rendered under it in Project
-                    // mode): muted + italic + dim so it reads as a
-                    // divider rather than a user-created group. The
-                    // contained rows aren't decorated individually;
-                    // the section header is the sole visual signal
-                    // that those sessions are shelved. Matches the
-                    // modifier set used for archived user groups so
-                    // terminals with weak dimmed-fg rendering still
-                    // surface the parked affordance.
-                    style = Style::default()
-                        .fg(theme.dimmed)
-                        .add_modifier(ratatui::style::Modifier::ITALIC)
-                        .add_modifier(ratatui::style::Modifier::DIM);
-                } else if archived_at.is_some() {
+                // Both the top-level Trash / Archived shelf headers and any
+                // project sub-folders nested under them (Project mode) now live
+                // below the sort divider in the pinned bottom shelf, so their
+                // physical placement already reads as "shelved". They no longer
+                // need the muted divider treatment to separate them from active
+                // groups; render them like regular folder headers (theme.group
+                // + bold) so they read as real, clickable folders. The leading
+                // section glyph still marks the top-level shelves as system
+                // shelves.
+                if archived_at.is_some() {
                     // Archived user groups: italic + dim, still visible.
                     style = style
                         .add_modifier(ratatui::style::Modifier::ITALIC)


### PR DESCRIPTION
## Description

The Trash and Archived sections now render in the pinned bottom shelf below the sort divider (#2908), so their physical placement already reads as "shelved". Their headers (and nested project sub-folders in Project mode) were still drawn muted + italic + dim, which made them read as passive dividers rather than real, clickable folders.

This renders both the shelf headers and their nested sub-folders with the regular folder style (`theme.group` + bold). The leading section glyph still marks the top-level shelves as system shelves. Genuine user-archived groups (those with `archived_at` set) keep their italic + dim treatment; only the shelf folders change.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: pure styling tweak. This swaps the `Style` (fg color + text modifiers) applied to the shelf folder header rows; there's no behavioral or layout change and no new branch worth an e2e assertion. Existing render/shelf e2e coverage still passes.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Implemented via Claude Code with back-and-forth review by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Trash and Archived shelf headers and nested folders to use the standard bold folder styling.
- Preserved the leading section glyph to distinguish system shelves.
- Kept genuinely archived user groups italicized and dimmed.
- No behavior or layout changes; improves visual consistency while retaining clear shelf and archive cues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->