### PR TITLE
fix(trash): stop the sandbox container when a session is trashed

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -108,13 +108,16 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
             );
         }
 
-        // The session is durably trashed; now move its worktree out of the
-        // active dir into the holding area and persist the repointed
-        // project_path. A failure here never blocks the trash; the worktree
-        // just stays in place and a later reconcile pass can relocate it.
+        // The session is durably trashed; stop its sandbox container (so it
+        // doesn't keep running for the whole retention window) and move its
+        // worktree out of the active dir into the holding area, then persist the
+        // repointed project_path. Stopping the container also releases the
+        // worktree bind mount, without which the git move hits EBUSY. A failure
+        // here never blocks the trash; the worktree just stays in place and a
+        // later reconcile pass can relocate it.
         let mut inst = inst;
         inst.trash();
-        match crate::session::trash::relocate_worktree_to_trash(&mut inst) {
+        match crate::session::trash::prepare_trashed_worktree(&mut inst) {
             crate::session::trash::RelocateOutcome::Relocated { .. } => {
                 let new_path = inst.project_path.clone();
                 let pre = inst.pre_trash_project_path.clone();

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2445,17 +2445,20 @@ pub async fn trash_session(
         }
     }
 
-    // The session is durably trashed and its agent stopped; relocate its
-    // managed worktree out of the active dir into the holding area, then
-    // persist the repointed project_path. The git move is blocking, so it runs
-    // on a blocking thread. Best-effort: a failure leaves the worktree in
-    // place and the daemon's reconcile pass can move it later. Never blocks the
-    // trash itself, which already landed above.
+    // The session is durably trashed; stop its sandbox container (so it doesn't
+    // keep running for the whole retention window) and relocate its managed
+    // worktree out of the active dir into the holding area, then persist the
+    // repointed project_path. Stopping the container also releases the worktree
+    // bind mount, without which the git move hits EBUSY. Both the container stop
+    // and the git move are blocking, so this runs on a blocking thread.
+    // Best-effort: a failure leaves the worktree in place and the daemon's
+    // reconcile pass can move it later. Never blocks the trash itself, which
+    // already landed above.
     {
         let profile = inst_clone.source_profile.clone();
         match tokio::task::spawn_blocking(move || {
             let mut inst = inst_clone;
-            let outcome = crate::session::trash::relocate_worktree_to_trash(&mut inst);
+            let outcome = crate::session::trash::prepare_trashed_worktree(&mut inst);
             (outcome, inst)
         })
         .await

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4397,42 +4397,15 @@ impl Instance {
     }
 
     /// Stop the session: kill the tmux session and stop the Docker container
-    /// (if sandboxed). The container is stopped but not removed, so it can be
-    /// restarted on re-attach.
-    ///
-    /// On a docker inspect failure ([`crate::containers::Probe::Unknown`])
-    /// the stop is attempted anyway with a `warn!` log, so a possibly-live
-    /// container is not silently abandoned. A second `warn!` is emitted if
-    /// the stop itself also fails (e.g. docker daemon is down); the overall
-    /// `stop()` return still succeeds in that case (best-effort: the session
-    /// record is marked Stopped regardless).
+    /// (if sandboxed) via
+    /// [`stop_sandbox_container`](crate::session::worktree_edit::stop_sandbox_container).
+    /// The container is stopped but not removed, so it can be restarted on
+    /// re-attach. The container-stop semantics (best-effort on a transient
+    /// `docker inspect` failure, propagating a genuine stop failure) live on
+    /// that shared helper, which the trash path reuses.
     pub fn stop(&self) -> Result<()> {
         self.kill()?;
-
-        if self.is_sandboxed() {
-            let container = containers::DockerContainer::from_session_id(&self.id);
-            match container.probe_running() {
-                containers::Probe::Running => container.stop()?,
-                containers::Probe::NotRunning => {}
-                containers::Probe::Unknown(e) => {
-                    tracing::warn!(
-                        target: "containers.runtime",
-                        session = %self.id,
-                        error = %e,
-                        "docker inspect failed while probing sandbox container before session stop; attempting stop anyway to avoid leaving a possibly-live container behind"
-                    );
-                    if let Err(stop_err) = container.stop() {
-                        tracing::warn!(
-                            target: "containers.runtime",
-                            session = %self.id,
-                            error = %stop_err,
-                            "sandbox container stop failed after probe failure; container may already be gone or docker is unreachable"
-                        );
-                    }
-                }
-            }
-        }
-
+        crate::session::worktree_edit::stop_sandbox_container(&self.id, self.is_sandboxed())?;
         crate::hooks::cleanup_hook_status_dir(&self.id);
 
         Ok(())

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -165,6 +165,44 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
     }
 }
 
+/// Bring a freshly-trashed session's sandbox container down, then relocate its
+/// worktree into the holding area.
+///
+/// This is the container + worktree half of trashing (`trash_session_by_id`),
+/// split from [`relocate_worktree_to_trash`] because trashing must first stop
+/// the sandbox container. A sandbox container runs `sleep infinity` for the
+/// life of the session and bind-mounts the worktree dir, so trashing without a
+/// stop leaves it running for the whole retention window and its live mount
+/// makes the relocation's `git worktree move` fail `EBUSY` (the row then stays
+/// in the active dir). Stopping it releases the mount so the relocation's own
+/// [`discard_sandbox_container_after_move`] can then drop it entirely.
+///
+/// `relocate_worktree_to_trash` alone is still the right call for the reconcile
+/// passes (they run on load against already-stopped rows); only the trash
+/// *action*, where the container is still live, needs the stop.
+///
+/// The container stop is injected so the sandbox path is exercisable without a
+/// live docker runtime (mirrors `deletion::perform_deletion_with`).
+pub fn prepare_trashed_worktree(inst: &mut Instance) -> RelocateOutcome {
+    prepare_trashed_worktree_with(inst, |id, is_sandboxed| {
+        if let Err(e) = crate::session::worktree_edit::stop_sandbox_container(id, is_sandboxed) {
+            tracing::warn!(
+                target: "session.trash",
+                session = %id,
+                "stopping sandbox container before trash relocation failed: {e}"
+            );
+        }
+    })
+}
+
+fn prepare_trashed_worktree_with(
+    inst: &mut Instance,
+    stop_container: impl FnOnce(&str, bool),
+) -> RelocateOutcome {
+    stop_container(&inst.id, is_sandboxed(inst));
+    relocate_worktree_to_trash(inst)
+}
+
 /// Move a trashed session's worktree back to its pre-trash location and clear
 /// `pre_trash_project_path`. Strict: if the original path is now occupied, the
 /// session stays trashed and the caller surfaces the failure, rather than
@@ -721,6 +759,110 @@ mod tests {
         assert!(
             !holding.exists(),
             "relocated worktree should be gone after purge"
+        );
+    }
+
+    /// Regression (#the-d-key): trashing must run the sandbox container-stop
+    /// step BEFORE relocating the worktree. Before the fix, `trash_session_by_id`
+    /// only killed tmux and called `relocate_worktree_to_trash` directly, so a
+    /// sandbox container was left running for the whole retention window and its
+    /// live bind mount made this very relocation fail EBUSY. The container stop
+    /// is injected here so the wiring/ordering is verified without a live docker
+    /// runtime; a non-sandbox session exercises the happy path end to end.
+    #[test]
+    fn trash_prep_stops_container_before_relocating() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.trash();
+        let original = PathBuf::from(&inst.project_path);
+
+        use std::cell::Cell;
+        use std::rc::Rc;
+        let stop_calls = Rc::new(Cell::new(0u32));
+        let saw_sandbox_flag = Rc::new(Cell::new(true));
+        let original_present_at_stop = Rc::new(Cell::new(false));
+
+        let outcome = {
+            let stop_calls = Rc::clone(&stop_calls);
+            let saw_sandbox_flag = Rc::clone(&saw_sandbox_flag);
+            let original_present_at_stop = Rc::clone(&original_present_at_stop);
+            let original = original.clone();
+            prepare_trashed_worktree_with(&mut inst, move |_id, is_sandboxed| {
+                stop_calls.set(stop_calls.get() + 1);
+                saw_sandbox_flag.set(is_sandboxed);
+                original_present_at_stop.set(original.exists());
+            })
+        };
+
+        assert_eq!(
+            stop_calls.get(),
+            1,
+            "trash must run the container-stop step exactly once"
+        );
+        assert!(
+            !saw_sandbox_flag.get(),
+            "a non-sandbox session reports is_sandboxed=false to the stop step"
+        );
+        assert!(
+            original_present_at_stop.get(),
+            "the container stop must run BEFORE the worktree is moved"
+        );
+        assert!(
+            matches!(outcome, RelocateOutcome::Relocated { .. }),
+            "relocation still succeeds after the stop step: {outcome:?}"
+        );
+        let holding = trash_holding_path(&original, &inst.id).unwrap();
+        assert_eq!(PathBuf::from(&inst.project_path), holding);
+        assert!(holding.exists(), "worktree moved into the holding area");
+        assert!(!original.exists(), "worktree left its original active path");
+    }
+
+    /// A sandboxed session hands `is_sandboxed = true` to the container-stop
+    /// step. Uses a plain (non-worktree) session so the relocation short-circuits
+    /// to `Skipped` without touching a real docker runtime; the seam still fires
+    /// first, which is what proves the flag is wired through.
+    #[test]
+    fn trash_prep_passes_sandbox_flag_to_container_stop() {
+        let mut inst = Instance::new("sandboxed", "/tmp/sandboxed");
+        inst.sandbox_info = Some(crate::session::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "ubuntu:latest".to_string(),
+            container_name: "aoe-sandbox-test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+            before_start_env: Vec::new(),
+            container_workdir: None,
+        });
+        inst.trash();
+
+        use std::cell::Cell;
+        use std::rc::Rc;
+        let saw_sandbox_flag = Rc::new(Cell::new(false));
+        let outcome = {
+            let saw_sandbox_flag = Rc::clone(&saw_sandbox_flag);
+            prepare_trashed_worktree_with(&mut inst, move |_id, is_sandboxed| {
+                saw_sandbox_flag.set(is_sandboxed);
+            })
+        };
+        assert!(
+            saw_sandbox_flag.get(),
+            "a sandboxed session must report is_sandboxed=true to the stop step"
+        );
+        assert!(
+            matches!(outcome, RelocateOutcome::Skipped),
+            "a plain session has no managed worktree to relocate: {outcome:?}"
+        );
+    }
+
+    /// The container-stop helper is a no-op (and never shells out) when the
+    /// session is not sandboxed, so trashing a plain session stays docker-free.
+    #[test]
+    fn stop_sandbox_container_is_noop_when_not_sandboxed() {
+        assert!(
+            crate::session::worktree_edit::stop_sandbox_container("no-such-session", false).is_ok()
         );
     }
 }

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -118,6 +118,53 @@ pub fn discard_sandbox_container_after_move(session_id: &str, is_sandboxed: bool
     }
 }
 
+/// Stop a sandbox session's container without removing it, so it can be
+/// restarted on re-attach.
+///
+/// No-op for non-sandbox sessions (`is_sandboxed` is taken so they skip the
+/// `docker inspect`/`docker stop` subprocesses entirely). A `Probe::Running`
+/// container is stopped and a stop failure is propagated; a transient
+/// `docker inspect` failure ([`Probe::Unknown`]) still attempts the stop with a
+/// `warn!`, so a possibly-live container is not silently abandoned, and a
+/// second best-effort `warn!` covers a stop that then also fails.
+///
+/// Shared by [`Instance::stop`](crate::session::Instance::stop) and the trash
+/// path (`trash_session_by_id` via
+/// [`prepare_trashed_worktree`](crate::session::trash::prepare_trashed_worktree)):
+/// a trashed session is durably stopped, and its container must come down for
+/// the same reason `stop` brings it down. The container runs `sleep infinity`
+/// for the life of the session and bind-mounts the worktree dir, so leaving it
+/// up both leaks a running container for the whole retention window and makes
+/// [`relocate_worktree_to_trash`](crate::session::trash::relocate_worktree_to_trash)
+/// fail `EBUSY` against the live mount.
+pub fn stop_sandbox_container(session_id: &str, is_sandboxed: bool) -> anyhow::Result<()> {
+    if !is_sandboxed {
+        return Ok(());
+    }
+    let container = DockerContainer::from_session_id(session_id);
+    match container.probe_running() {
+        Probe::Running => container.stop()?,
+        Probe::NotRunning => {}
+        Probe::Unknown(e) => {
+            tracing::warn!(
+                target: "containers.runtime",
+                session = %session_id,
+                error = %e,
+                "docker inspect failed while probing sandbox container before stop; attempting stop anyway to avoid leaving a possibly-live container behind"
+            );
+            if let Err(stop_err) = container.stop() {
+                tracing::warn!(
+                    target: "containers.runtime",
+                    session = %session_id,
+                    error = %stop_err,
+                    "sandbox container stop failed after probe failure; container may already be gone or docker is unreachable"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Inputs for an in-place worktree workdir edit.
 pub struct WorktreeEditRequest<'a> {
     /// The session's current worktree metadata.

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1568,8 +1568,10 @@ impl HomeView {
     }
 
     /// Move a session to the trash: stop its tmux sessions (a structured-view
-    /// worker is reaped by the daemon reconciler once the row reads trashed)
-    /// and set `trashed_at`. Durable artifacts are kept so it can be
+    /// worker is reaped by the daemon reconciler once the row reads trashed),
+    /// stop its sandbox container if any (via `prepare_trashed_worktree`, so it
+    /// doesn't keep running for the whole retention window), and set
+    /// `trashed_at`. Durable artifacts are kept so it can be
     /// restored. The Trash section's collapse state is left untouched: like
     /// single-row archive, the section header's count is the feedback, so a
     /// user who collapsed it stays collapsed (#2489).
@@ -1581,14 +1583,17 @@ impl HomeView {
         if let Some(inst) = self.instances.get(id) {
             inst.kill_all_tmux_sessions();
         }
-        // The session is durably trashed and its agent stopped; relocate its
-        // worktree out of the active dir. The move + repointed project_path
-        // persist through the same diff path. Best-effort: a failure leaves the
-        // worktree in place and a later reconcile pass can move it.
+        // The session is durably trashed; stop its sandbox container (so it
+        // doesn't linger for the whole retention window) and relocate its
+        // worktree out of the active dir. Stopping the container also releases
+        // the worktree bind mount, without which the `git worktree move` below
+        // hits EBUSY. The move + repointed project_path persist through the same
+        // diff path. Best-effort: a failure leaves the worktree in place and a
+        // later reconcile pass can move it.
         let mut relocate_warning: Option<String> = None;
         let _ = self.apply_user_action(id, |inst| {
             if let crate::session::trash::RelocateOutcome::Failed { reason } =
-                crate::session::trash::relocate_worktree_to_trash(inst)
+                crate::session::trash::prepare_trashed_worktree(inst)
             {
                 relocate_warning = Some(reason);
             }


### PR DESCRIPTION
## Description

Trashing a session (the `d` key, with `delete_to_trash` on by default) only killed its tmux sessions via `kill_all_tmux_sessions`; it never stopped the Docker container the way `Instance::stop` does.

A sandbox container runs `sleep infinity` for the life of the session and bind-mounts the worktree directory, so after trashing it kept running for the entire trash retention window. Worse, because the container held the live mount, `relocate_worktree_to_trash` failed with EBUSY and silently skipped, so the trashed worktree never moved into `.aoe-trash/` and stayed cluttering the active worktree directory.

**Fix:** extract the container-stop out of `Instance::stop` into a shared `worktree_edit::stop_sandbox_container(session_id, is_sandboxed)` helper (behavior of `stop` is unchanged, just deduplicated), and route `trash_session_by_id` through a new `trash::prepare_trashed_worktree`, which stops the container before relocating. Stopping releases the bind mount, so relocation succeeds and its own `discard` step then drops the container entirely; if relocation fails for some other reason the container is left cleanly stopped. The reconcile passes keep calling `relocate_worktree_to_trash` directly, since they run on load against already-stopped rows and should not force a docker stop per row.

The container-stop is injected behind a `prepare_trashed_worktree_with` seam (mirroring `deletion::perform_deletion_with`) so the sandbox path is testable without a live docker runtime.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (doc comments on `stop`, `stop_sandbox_container`, `prepare_trashed_worktree`, and `trash_session_by_id`)
- [x] For UI changes: included screenshot or recording (N/A: no visual change; this is session lifecycle behavior)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a full e2e, because: the container-stop is verified by unit regression tests in `src/session/trash.rs` (`trash_prep_stops_container_before_relocating` proves the stop runs once, before the worktree move, and that reversing the order fails the test; plus flag-propagation and non-sandbox no-op coverage). A full binary e2e would need a live Docker runtime, which the existing Docker e2e tests already gate behind `#[ignore]`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8), driven interactively by @njbrake.

**Any Additional AI Details you'd like to share:** Investigation and implementation were done with Claude Code. The root-cause analysis, fix design, and regression tests were reviewed by @njbrake. The reasoning and decisions are his; the prose and code drafting are the model's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed session trashing so sandbox Docker containers are shut down **before** the worktree is moved out of the active directory, preventing relocation failures and “stuck” bind mounts.
- Moved sandbox-container shutdown into a shared helper (`stop_sandbox_container`) and reused it from normal instance stopping to keep behavior consistent.
- Added a shared trash preparation step (`prepare_trashed_worktree`) that performs **stop → relocate** (with an injectable seam to allow testing without Docker) and routed all trash entry points through it:
  - TUI trash action
  - CLI `aoe rm` “trash-first” path
  - Web API trash endpoint (keeping the existing blocking execution wrapper)
- Preserved existing behavior for non-sandbox sessions (no container work) and for reconciliation flows that already use direct relocation when appropriate.
- Added regression tests to verify stop ordering, correct sandbox flag propagation into the stop step, and no-op behavior for non-sandbox sessions.

## Benefits

- Prevents `EBUSY` failures during worktree relocation.
- Reduces the chance of worktrees being left in the active directory and avoids sandbox containers lingering during the trash retention window.
- Makes trashing behavior consistent across TUI, CLI, and web.

## Possible follow-up

- Consider adding more explicit logging/metrics around stop/relocate outcomes (especially when container probing is ambiguous) to improve operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->