### PR TITLE
feat(tui): full plugin lifecycle in the TUI manager (install, uninstall, re-approve, live daemon reconcile, editable settings)

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -460,10 +460,14 @@ PATCHes against it (`validate_patch_with`), and the TUI/web render it through th
 same generic field path as core settings. The API/validation layer speaks the
 flat `plugin:<id>.<key>` shape; only the merge boundary translates to the on-disk
 storage path `plugins.<id>.settings.<key>` (`settings_schema::plugin`). Plugin
-settings are global-only at Tier 0 (not profile-overridable). In the TUI they
-render as normal editable rows beneath the manager on the settings Plugins tab
-(Tab moves the sub-focus between the manager and the fields), through the same
-generic schema field path every other category uses.
+settings are global-only at Tier 0 (not profile-overridable). In the TUI the
+settings Plugins tab is a master-detail split: the manager list on top (sized
+to its rows), and the selected plugin's settings as normal editable rows
+beneath it, through the same generic schema field path every other category
+uses. Moving the list selection swaps the detail pane, Tab moves the sub-focus
+between the panes, and a settings-search jump to a plugin field selects that
+plugin's row. While the manager captures input (discovery, a consent or
+progress popup) it takes the whole pane.
 
 A manifest may also declare a *default* override for a core setting via
 `[setting_defaults]` (keyed by the core `section.field`).

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -577,8 +577,9 @@ revived by an unrelated plugin's reconcile; disabling it clears the tombstone,
 so a disable then enable is a clean retry. A daemon restart also clears it. The
 CLI `aoe plugin enable|disable` and the TUI manager toggle route through the
 running daemon when one is up (`set_enabled_live`, above), so a disable/enable
-recycle from any surface is a clean retry; only when no daemon is reachable
-does the toggle stay a local config write that a later daemon start picks up.
+recycle from any surface is a clean retry; when no daemon is reachable, or the
+daemon request fails (read-only, auth, server error), the toggle falls back to
+a local config write that a later daemon start picks up.
 
 ### Capability-gated host API
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -125,9 +125,17 @@ path, and reloads the registry. The three surfaces are thin twins over it:
 - CLI: `aoe plugin enable|disable` (`src/cli/plugin.rs`).
 - TUI: the command-palette / settings-tab plugin manager
   (`src/tui/dialogs/plugin_manager.rs`); the settings tab stages the change and
-  persists it on the normal settings save.
+  persists it on the normal settings save (and best-effort nudges a running
+  daemon per changed id afterwards).
 - Web: `POST /api/plugins/{id}/enabled`, gated on read-write mode and (when
   login is enabled) an elevated session (`src/server/api/plugins.rs`).
+
+The CLI and the palette-opened TUI manager route through
+`install::set_enabled_live`: when a local daemon is running (serve builds;
+discovered via the serve state files), the toggle POSTs the daemon endpoint so
+its worker host reconciles live, exactly like the web toggle; with no daemon,
+or when the daemon refuses (read-only, unreachable), the change is written
+locally and the surface says so. A TUI-only build always writes locally.
 
 The one behavior wired to a plugin's state today: `aoe serve` refuses to start
 while `aoe.web` is disabled (`src/cli/serve.rs`).
@@ -141,7 +149,7 @@ write them, so the later API PRs (#2094, #2095) stay focused on behavior:
   an opaque `toml::Table` persisted as `[plugins."<id>".settings]` in
   `config.toml`. It is kept schema-free on purpose: values survive on disk even
   while the plugin is disabled, and the typed schema that validates and renders
-  them arrives with the Tier 0 settings registry (#2094). `enabled` is declared
+  them arrived with the Tier 0 settings registry (#2094). `enabled` is declared
   before `settings` so the scalar reads above the nested table; the toml
   serializer emits scalars before subtables regardless, so the order is for
   readability. An empty table is omitted.
@@ -341,9 +349,10 @@ Builtins are first-party, auto-granted, and never store a grant.
 ## External install, trust, and the lockfile (#2093)
 
 `aoe plugin install <source>` installs an external plugin under
-`<app_dir>/plugins/<id>/`; `aoe plugin` stays reserved for management (D4), so
-there is no web install path. A source is a `gh:owner/repo[@ref]` slug or a
-local directory (`src/plugin/source.rs`).
+`<app_dir>/plugins/<id>/`. A source is a `gh:owner/repo[@ref]` slug or a
+local directory (`src/plugin/source.rs`). The web dashboard and the TUI
+manager install `gh:` sources through the preview/apply consent flow (see Web
+lifecycle jobs below); local-directory installs stay CLI-only.
 
 `src/plugin/fetch.rs` stages a plugin before install. A GitHub source is
 `git clone`d (shallow when possible, a full clone plus checkout for a commit
@@ -452,8 +461,9 @@ same generic field path as core settings. The API/validation layer speaks the
 flat `plugin:<id>.<key>` shape; only the merge boundary translates to the on-disk
 storage path `plugins.<id>.settings.<key>` (`settings_schema::plugin`). Plugin
 settings are global-only at Tier 0 (not profile-overridable). In the TUI they
-render read-only under the Plugins tab; edit them from the web dashboard or
-`aoe settings`.
+render as normal editable rows beneath the manager on the settings Plugins tab
+(Tab moves the sub-focus between the manager and the fields), through the same
+generic schema field path every other category uses.
 
 A manifest may also declare a *default* override for a core setting via
 `[setting_defaults]` (keyed by the core `section.field`).
@@ -565,9 +575,10 @@ When a worker exhausts its respawn budget the host records an in-memory crash
 tombstone and surfaces a dashboard notification. A tombstoned plugin is not
 revived by an unrelated plugin's reconcile; disabling it clears the tombstone,
 so a disable then enable is a clean retry. A daemon restart also clears it. The
-CLI `aoe plugin enable|disable` mutates only on-disk config and does not reach a
-running daemon (it is a separate process), so recovering a live daemon needs the
-web toggle or a restart.
+CLI `aoe plugin enable|disable` and the TUI manager toggle route through the
+running daemon when one is up (`set_enabled_live`, above), so a disable/enable
+recycle from any surface is a clean retry; only when no daemon is reachable
+does the toggle stay a local config write that a later daemon start picks up.
 
 ### Capability-gated host API
 
@@ -810,11 +821,14 @@ no extra request. This is a source-identity affordance, not the plugin's own
 deliberately never does); the dashboard renders it as a separate, distinctly
 styled avatar rather than through the plugin identity icon component.
 
-Surfaces: `aoe plugin discover [query]`, the TUI plugin manager `d` key, and the
-dashboard "Search GitHub" button (`GET /api/plugins/discover?q=`). The dashboard
-has no install path (capability approval needs a terminal), so each result shows
-a copyable `aoe plugin install gh:owner/repo` command instead of an install
-button.
+Surfaces: `aoe plugin discover [query]`, the TUI plugin manager `d` key (`/`
+edits the free-text search term), and the dashboard "Search GitHub" button
+(`GET /api/plugins/discover?q=`). Both in-app surfaces install a result through
+the preview/apply consent flow: the dashboard marketplace's Install button and
+the TUI discover list's Enter open the same structured disclosure
+(`preview_install`) before anything runs, and each result still shows the
+copyable `aoe plugin install gh:owner/repo` command for users who prefer the
+terminal.
 
 Unauthenticated GitHub search is rate limited (about 10 requests/minute/IP); the
 client maps a 403/429 to a `RateLimited` error so each surface reports it plainly

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -223,6 +223,28 @@ impl HttpClient {
         Ok(res.json::<UiSnapshot>().await?)
     }
 
+    /// `POST /api/plugins/{id}/enabled`. Toggling through the daemon (rather
+    /// than writing config locally) lets its plugin host reconcile workers
+    /// live: enabling launches the worker, disabling tears it down. Global,
+    /// like `plugin_ui_state`.
+    pub async fn set_plugin_enabled(
+        &self,
+        plugin_id: &str,
+        enabled: bool,
+    ) -> Result<(), HttpError> {
+        let url = format!(
+            "{}/api/plugins/{}/enabled",
+            self.endpoint.base_url, plugin_id
+        );
+        let res = self
+            .auth(self.http.post(&url))
+            .json(&serde_json::json!({ "enabled": enabled }))
+            .send()
+            .await?;
+        check_global_status(res).await?;
+        Ok(())
+    }
+
     /// `POST /api/sessions/{id}/acp/cancel`.
     pub async fn cancel(&self, session_id: &str) -> Result<(), HttpError> {
         let url = format!(

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -65,8 +65,8 @@ pub async fn run(command: PluginCommands) -> Result<()> {
     match command {
         PluginCommands::List => run_list(),
         PluginCommands::Info { id } => run_info(&id),
-        PluginCommands::Enable { id } => run_set_enabled(&id, true),
-        PluginCommands::Disable { id } => run_set_enabled(&id, false),
+        PluginCommands::Enable { id } => run_set_enabled(&id, true).await,
+        PluginCommands::Disable { id } => run_set_enabled(&id, false).await,
         PluginCommands::Install { source, yes } => run_install(&source, yes).await,
         PluginCommands::Update { id } => run_update(&id).await,
         PluginCommands::Uninstall { id } => run_uninstall(&id),
@@ -168,9 +168,17 @@ fn run_info(id: &str) -> Result<()> {
     Ok(())
 }
 
-fn run_set_enabled(id: &str, enabled: bool) -> Result<()> {
-    crate::plugin::install::set_enabled(id, enabled)?;
+async fn run_set_enabled(id: &str, enabled: bool) -> Result<()> {
+    use crate::plugin::install::LiveToggle;
+    let outcome = crate::plugin::install::set_enabled_live(id, enabled).await?;
     println!("{} {id}.", if enabled { "Enabled" } else { "Disabled" });
+    match outcome {
+        LiveToggle::Daemon => println!("  the running daemon reconciled its workers."),
+        LiveToggle::Local => {}
+        LiveToggle::LocalDaemonStale { reason } => println!(
+            "  warning: a daemon is running but was not updated ({reason}); restart it or toggle from the dashboard."
+        ),
+    }
     Ok(())
 }
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -1034,6 +1034,13 @@ pub fn reapprove_consent(id: &str) -> Result<ReapproveConsent> {
 /// disclosure the user saw ([`reapprove_consent`]); if the on-disk manifest
 /// changed since, this refuses rather than granting something unseen.
 pub fn approve_installed(id: &str, expected_manifest_hash: &str) -> Result<()> {
+    // Re-read the installed tree before honoring the pin: the disclosure may
+    // have been open for a while, and the process-global registry the
+    // disclosure was built from could be stale against disk. Without this, a
+    // manifest changed on disk after the popup opened would pass a
+    // stale-vs-stale hash comparison and write a grant the next load rejects
+    // (safe, but reported as success).
+    super::reload_registry();
     let consent = reapprove_consent(id)?;
     if consent.manifest_hash != expected_manifest_hash {
         bail!("{id} changed on disk since its disclosure was shown; review it again");
@@ -1063,7 +1070,13 @@ pub fn approve_installed(id: &str, expected_manifest_hash: &str) -> Result<()> {
 /// missing daemon is fine (nothing to reconcile); a failure only warns, since
 /// the on-disk state is already correct and applies on the daemon's next
 /// start.
-pub async fn nudge_daemon_enabled(changes: Vec<(String, bool)>) {
+///
+/// Batches are ordered: the daemon endpoint rewrites config per request, so a
+/// stale batch landing after a newer save's batch would persist the older
+/// value. A generation counter (bumped synchronously here, so it follows call
+/// order) supersedes older batches, and a global lock serializes the actual
+/// requests, so the newest save's values always land last.
+pub fn nudge_daemon_enabled(changes: Vec<(String, bool)>) {
     // No daemon client in a TUI-only build (see `set_enabled_live`).
     #[cfg(not(feature = "serve"))]
     {
@@ -1071,27 +1084,43 @@ pub async fn nudge_daemon_enabled(changes: Vec<(String, bool)>) {
     }
     #[cfg(feature = "serve")]
     {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static GENERATION: AtomicU64 = AtomicU64::new(0);
+        static IN_FLIGHT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
         if changes.is_empty() {
             return;
         }
-        let Ok(endpoint) = crate::acp::client::discovery::discover_local() else {
-            return;
-        };
-        let client = match crate::acp::client::HttpClient::new(endpoint) {
-            Ok(client) => client,
-            Err(e) => {
-                tracing::warn!("plugin toggle: daemon client build failed: {e}");
+        let generation = GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+        tokio::spawn(async move {
+            let _serialize = IN_FLIGHT.lock().await;
+            // A newer save superseded this batch while it waited its turn;
+            // its values are already stale against disk, so drop it.
+            if GENERATION.load(Ordering::SeqCst) != generation {
                 return;
             }
-        };
-        for (id, enabled) in changes {
-            if let Err(e) = client.set_plugin_enabled(&id, enabled).await {
-                tracing::warn!(
-                    "plugin toggle: daemon did not reconcile {id} (enabled={enabled}): {e}; \
-                     restart the daemon or toggle from the dashboard"
-                );
+            let Ok(endpoint) = crate::acp::client::discovery::discover_local() else {
+                return;
+            };
+            let client = match crate::acp::client::HttpClient::new(endpoint) {
+                Ok(client) => client,
+                Err(e) => {
+                    tracing::warn!("plugin toggle: daemon client build failed: {e}");
+                    return;
+                }
+            };
+            for (id, enabled) in changes {
+                if GENERATION.load(Ordering::SeqCst) != generation {
+                    return;
+                }
+                if let Err(e) = client.set_plugin_enabled(&id, enabled).await {
+                    tracing::warn!(
+                        "plugin toggle: daemon did not reconcile {id} (enabled={enabled}): {e}; \
+                         restart the daemon or toggle from the dashboard"
+                    );
+                }
             }
-        }
+        });
     }
 }
 

--- a/src/plugin/install.rs
+++ b/src/plugin/install.rs
@@ -85,6 +85,71 @@ pub fn set_enabled(plugin_id: &str, enabled: bool) -> Result<()> {
     Ok(())
 }
 
+/// Where a live enable/disable landed, so the caller can tell the user
+/// whether a running daemon's workers actually reconciled.
+#[derive(Debug)]
+pub enum LiveToggle {
+    /// A running daemon applied the change: config written and its plugin
+    /// host reconciled, so a worker launched or stopped immediately.
+    Daemon,
+    /// No daemon is running; the change was written to config locally.
+    Local,
+    /// A daemon appears to be running but the toggle could not go through it
+    /// (unreachable, read-only, auth). The change was written locally, so the
+    /// daemon's workers keep their old state until it restarts or the plugin
+    /// is toggled from the dashboard.
+    LocalDaemonStale { reason: String },
+}
+
+/// [`set_enabled`], but routed through a running local daemon when there is
+/// one. `set_enabled` alone only rewrites config and this process's registry;
+/// a live daemon would keep a disabled plugin's worker running (and never
+/// launch an enabled one) until restart. The daemon's own handler does the
+/// same config write plus a worker reconcile, so prefer it whenever it is up.
+pub async fn set_enabled_live(plugin_id: &str, enabled: bool) -> Result<LiveToggle> {
+    // Validate against the local registry first so an unknown id fails the
+    // same way with or without a daemon.
+    if super::registry().get(plugin_id).is_none() {
+        bail!("unknown plugin {plugin_id:?}; see `aoe plugin list`");
+    }
+    // The daemon client lives in the serve-gated `acp` module; a TUI-only
+    // build ships no daemon, so it always writes locally.
+    #[cfg(feature = "serve")]
+    {
+        let endpoint = match crate::acp::client::discovery::discover_local() {
+            Ok(endpoint) => endpoint,
+            Err(_) => {
+                set_enabled(plugin_id, enabled)?;
+                return Ok(LiveToggle::Local);
+            }
+        };
+        let daemon_result = async {
+            let client = crate::acp::client::HttpClient::new(endpoint)?;
+            client.set_plugin_enabled(plugin_id, enabled).await
+        }
+        .await;
+        match daemon_result {
+            Ok(()) => {
+                // The daemon wrote config to disk; refresh this process's
+                // registry from it rather than writing again.
+                super::reload_registry();
+                Ok(LiveToggle::Daemon)
+            }
+            Err(e) => {
+                set_enabled(plugin_id, enabled)?;
+                Ok(LiveToggle::LocalDaemonStale {
+                    reason: format!("{e}"),
+                })
+            }
+        }
+    }
+    #[cfg(not(feature = "serve"))]
+    {
+        set_enabled(plugin_id, enabled)?;
+        Ok(LiveToggle::Local)
+    }
+}
+
 fn enable_in_config(plugin_id: &str, enabled: bool) -> Result<()> {
     update_config(|config| {
         config
@@ -481,6 +546,10 @@ pub async fn update_clean(id: &str) -> Result<UpdateOutcome> {
 struct Prepared {
     id: String,
     source_str: String,
+    /// One line stating what was fetched (resolved release, ref). Printed by
+    /// the interactive CLI path only; the in-app preview/apply flows render
+    /// their own surfaces and must not write to a raw-mode terminal.
+    notice: String,
     fetched: FetchedPlugin,
     featured_verified: bool,
     prior_grant: Option<CapabilityGrant>,
@@ -542,7 +611,6 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
     // so an update never silently switches a release-tracking install onto the
     // moving default branch; an explicit `@ref` install keeps following its ref.
     let resolved = resolve_source(source, false).await?;
-    eprintln!("{}", resolved.notice);
     let fetched = fetch::fetch(&resolved.source).await?;
     if fetched.manifest.id.as_str() != id {
         bail!(
@@ -653,6 +721,7 @@ async fn prepare_update(id: &str) -> Result<Prepared> {
     Ok(Prepared {
         id: id.to_string(),
         source_str,
+        notice: resolved.notice,
         fetched,
         featured_verified,
         prior_grant,
@@ -725,6 +794,9 @@ fn apply_prepared(
 
 async fn update_with_consent(id: &str, mode: ConsentMode) -> Result<UpdateOutcome> {
     let prepared = prepare_update(id).await?;
+    if mode == ConsentMode::Interactive {
+        eprintln!("{}", prepared.notice);
+    }
 
     // Decide the grant BEFORE touching the installed tree, so a declined or
     // non-interactive prompt bails while the old install, config, and lockfile
@@ -890,6 +962,137 @@ pub async fn apply_update(
         granted_at: chrono::Utc::now(),
     });
     apply_prepared(&prepared, grant, log)
+}
+
+/// The disclosure for re-approving an installed plugin whose grant no longer
+/// covers its manifest (`needs_reapproval`), built entirely from the on-disk
+/// install; no network. Unlike an update this replaces nothing and runs no
+/// build steps: approving grants the already-installed manifest's declared
+/// capabilities, pinned to its hash.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReapproveConsent {
+    pub id: String,
+    pub version: String,
+    /// Resolved trust class (featured / community / local).
+    pub validation: String,
+    /// Capabilities the installed manifest declares (the grant this approves).
+    pub capabilities: Vec<String>,
+    /// Dashboard UI slots the installed manifest contributes to.
+    pub ui: Vec<UiView>,
+    /// Pin: the installed manifest's hash. `approve_installed` refuses if the
+    /// manifest on disk changed after this disclosure was shown.
+    pub manifest_hash: String,
+}
+
+/// Build the [`ReapproveConsent`] disclosure for an installed external plugin.
+pub fn reapprove_consent(id: &str) -> Result<ReapproveConsent> {
+    let registry = super::registry();
+    let plugin = registry
+        .get(id)
+        .ok_or_else(|| anyhow!("unknown plugin {id:?}; see `aoe plugin list`"))?;
+    if plugin.builtin() {
+        bail!("{id} is a builtin plugin; it is always granted");
+    }
+    let unknown: Vec<&str> = plugin
+        .manifest
+        .capabilities
+        .iter()
+        .filter(|c| !c.is_known())
+        .map(|c| c.as_str())
+        .collect();
+    if !unknown.is_empty() {
+        bail!(
+            "plugin requests capabilities this host does not support: {}; upgrade aoe",
+            unknown.join(", ")
+        );
+    }
+    Ok(ReapproveConsent {
+        id: id.to_string(),
+        version: plugin.manifest.version.clone(),
+        validation: plugin.validation.as_str().to_string(),
+        capabilities: plugin
+            .manifest
+            .capabilities
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect(),
+        ui: plugin
+            .manifest
+            .ui
+            .iter()
+            .map(|u| UiView {
+                slot: u.slot.as_str().to_string(),
+                id: u.id.clone(),
+            })
+            .collect(),
+        manifest_hash: plugin.manifest_hash.clone(),
+    })
+}
+
+/// Grant the installed manifest's declared capabilities, pinned to its hash:
+/// the approve half of the re-approval flow. `expected_manifest_hash` pins the
+/// disclosure the user saw ([`reapprove_consent`]); if the on-disk manifest
+/// changed since, this refuses rather than granting something unseen.
+pub fn approve_installed(id: &str, expected_manifest_hash: &str) -> Result<()> {
+    let consent = reapprove_consent(id)?;
+    if consent.manifest_hash != expected_manifest_hash {
+        bail!("{id} changed on disk since its disclosure was shown; review it again");
+    }
+    update_config(|config| {
+        let Some(entry) = config.plugins.get_mut(id) else {
+            bail!("{id} is not an installed external plugin");
+        };
+        if entry.source.is_none() {
+            bail!("{id} is not an installed external plugin");
+        }
+        entry.grant = Some(CapabilityGrant {
+            manifest_hash: consent.manifest_hash.clone(),
+            capabilities: consent.capabilities.clone(),
+            granted_at: chrono::Utc::now(),
+        });
+        Ok(())
+    })??;
+    super::reload_registry();
+    Ok(())
+}
+
+/// Best-effort: push already-persisted enable/disable states to a running
+/// daemon so its workers reconcile without a restart. The settings save path
+/// writes `config.plugins` wholesale rather than toggling one id at a time,
+/// so it calls this afterwards with every id whose enabled flag changed. A
+/// missing daemon is fine (nothing to reconcile); a failure only warns, since
+/// the on-disk state is already correct and applies on the daemon's next
+/// start.
+pub async fn nudge_daemon_enabled(changes: Vec<(String, bool)>) {
+    // No daemon client in a TUI-only build (see `set_enabled_live`).
+    #[cfg(not(feature = "serve"))]
+    {
+        let _ = changes;
+    }
+    #[cfg(feature = "serve")]
+    {
+        if changes.is_empty() {
+            return;
+        }
+        let Ok(endpoint) = crate::acp::client::discovery::discover_local() else {
+            return;
+        };
+        let client = match crate::acp::client::HttpClient::new(endpoint) {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::warn!("plugin toggle: daemon client build failed: {e}");
+                return;
+            }
+        };
+        for (id, enabled) in changes {
+            if let Err(e) = client.set_plugin_enabled(&id, enabled).await {
+                tracing::warn!(
+                    "plugin toggle: daemon did not reconcile {id} (enabled={enabled}): {e}; \
+                     restart the daemon or toggle from the dashboard"
+                );
+            }
+        }
+    }
 }
 
 /// Record that the user declined an available update by its fingerprint, so the

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -29,6 +29,7 @@ pub use merge::{apply_changed_leaves, clear_path, merge_json};
 pub use plugin::{
     plugin_field_descriptors, plugin_section_id, rewrite_plugin_sections, section_plugin_id,
     storage_leaf as plugin_storage_leaf, storage_value as plugin_storage_value, PLUGIN_CATEGORY,
+    PLUGIN_SECTION_PREFIX,
 };
 pub use policy::{strip_local_only, validate_patch, validate_patch_with, PatchRejection, Scope};
 pub use registry::{descriptor, runtime_schema, schema};

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -419,6 +419,38 @@ impl PluginManagerDialog {
         self.has_settings_pane = has;
     }
 
+    /// Height the inline (settings-embedded) manager wants: its rows plus
+    /// chrome. The settings host sizes the master-detail split from this so
+    /// the list stops taking half the pane to show two rows.
+    pub fn preferred_inline_height(&self) -> u16 {
+        let errors: u16 = if self.load_errors.is_empty() { 0 } else { 2 };
+        (self.rows.len().max(1) as u16)
+            .saturating_add(2) // borders
+            .saturating_add(2) // footer
+            .saturating_add(errors)
+    }
+
+    /// Select the row owning a `plugin:<id>.<field>` settings ident, so a
+    /// settings-search jump into the Plugins tab lands on the right plugin's
+    /// detail pane. Returns whether a row matched.
+    pub fn select_plugin_owning_ident(&mut self, ident: &str) -> bool {
+        let Some(rest) = ident.strip_prefix(crate::session::settings_schema::PLUGIN_SECTION_PREFIX)
+        else {
+            return false;
+        };
+        // Plugin ids are dotted themselves, so match "<id>." as a prefix of
+        // the remainder rather than splitting on the first dot.
+        if let Some(idx) = self.rows.iter().position(|r| {
+            rest.strip_prefix(r.id.as_str())
+                .is_some_and(|tail| tail.starts_with('.'))
+        }) {
+            self.selected = idx;
+            true
+        } else {
+            false
+        }
+    }
+
     fn reload(&mut self) {
         // reload() runs only after a config-mutating action (and once at
         // construction), so it is the single place to flag a mutation.

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -1,11 +1,15 @@
 //! Plugin manager: list plugins (builtin and external) with their trust and
-//! enabled/approval state, enable/disable them, and update an external plugin
-//! through an in-TUI review popup that shows the changelog (and the access
-//! disclosure when the new version expands what the plugin can do). The TUI
-//! twin of `aoe plugin list` and the web Plugins tab. Installing a new plugin is
-//! still CLI-driven (`aoe plugin install`); the TUI shows the resulting state.
+//! enabled/approval state, toggle them (reconciling a running daemon's workers
+//! live), inspect a plugin's full disclosure (capabilities, keybinds, runtime),
+//! and run the whole external-plugin lifecycle in-TUI: install from GitHub
+//! discovery, update, re-approve a stale grant, and uninstall, each behind the
+//! same consent popup the CLI prompt and the web modals render. The TUI twin of
+//! `aoe plugin` and the web Plugins tab.
 
+use std::cell::Cell;
 use std::collections::HashMap;
+use std::io::{Read as _, Seek as _, SeekFrom};
+use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
@@ -14,8 +18,10 @@ use tokio::sync::oneshot;
 
 use super::{centered_rect, DialogResult};
 use crate::plugin::changelog::{ChangelogEntry, UpdateChangelog};
-use crate::plugin::discover::DiscoveryResult;
-use crate::plugin::install::{UpdateConsent, UpdatePreview};
+use crate::plugin::discover::{DiscoveryBadge, DiscoveryResult};
+use crate::plugin::install::{
+    InstallConsent, LiveToggle, ReapproveConsent, UpdateConsent, UpdatePreview,
+};
 use crate::plugin::update_check::UpdateStatus;
 use crate::tui::styles::Theme;
 
@@ -30,6 +36,43 @@ struct Review {
     fingerprint: String,
     changelog: UpdateChangelog,
     consent: Option<UpdateConsent>,
+}
+
+/// Installed-plugin details, captured from the registry when opened so the
+/// popup never re-reads a registry that may reload underneath it.
+struct Details {
+    view: crate::plugin::PluginView,
+    commands: Vec<String>,
+    keybinds: Vec<String>,
+    runtime: Option<String>,
+    settings: Vec<String>,
+    dir: Option<String>,
+}
+
+/// A running or finished lifecycle operation (install / update) whose log file
+/// the popup tails, the TUI twin of the dashboard's job progress modal.
+struct Progress {
+    title: String,
+    log_path: PathBuf,
+    /// `None` while running; the final outcome line once done.
+    done: Option<Result<String, String>>,
+}
+
+/// The floating popup owning the keyboard; at most one at a time.
+enum Popup {
+    /// Update review: changelog plus, when access expands, the consent
+    /// disclosure.
+    Review(Box<Review>),
+    /// Install consent for a discovery result.
+    Install(Box<InstallConsent>),
+    /// Re-approval consent for an installed plugin whose grant went stale.
+    Reapprove(ReapproveConsent),
+    /// Uninstall confirmation.
+    ConfirmUninstall { id: String },
+    /// Installed-plugin details (Enter on a row).
+    Details(Box<Details>),
+    /// A lifecycle operation streaming its log tail.
+    Progress(Progress),
 }
 
 /// Which view the manager is showing: the installed list or GitHub discovery
@@ -48,8 +91,16 @@ enum Pending {
     Discover(oneshot::Receiver<Result<Vec<DiscoveryResult>, String>>),
     /// Classifying one plugin's available update (the `u` key).
     Preview(oneshot::Receiver<Result<UpdatePreview, String>>),
-    /// Applying an approved update.
-    Apply(oneshot::Receiver<Result<(), String>>),
+    /// Applying an approved update; the Ok string is the final report line.
+    Apply(oneshot::Receiver<Result<String, String>>),
+    /// An enable/disable running through [`set_enabled_live`] (a running
+    /// daemon reconciles its workers); the Ok string reports where it landed.
+    Toggle(oneshot::Receiver<Result<String, String>>),
+    /// Fetching the install consent disclosure for a discovery result.
+    InstallPreview(oneshot::Receiver<Result<InstallConsent, String>>),
+    /// Applying an approved install.
+    InstallApply(oneshot::Receiver<Result<String, String>>),
+    Uninstall(oneshot::Receiver<Result<String, String>>),
 }
 
 pub struct PluginManagerDialog {
@@ -61,15 +112,19 @@ pub struct PluginManagerDialog {
     selected: usize,
     error: Option<String>,
     info: Option<String>,
-    /// Set whenever the on-disk plugin config changed (enable/disable). An
-    /// embedding surface drains it via [`take_mutated`] to re-sync its own
-    /// config view; the standalone modal ignores it.
+    /// Set whenever the on-disk plugin config changed (enable/disable,
+    /// install, update, uninstall, re-approve). An embedding surface drains it
+    /// via [`take_mutated`] to re-sync its own config view; the standalone
+    /// modal ignores it.
     mutated: bool,
     /// True when hosted inside the settings screen (vs the command-palette
     /// modal). Only changes the footer hint: Esc returns to the category list.
     embedded: bool,
+    /// Set by the settings host when an editable plugin-settings pane renders
+    /// beneath the manager, so the footer advertises the Tab sub-focus.
+    has_settings_pane: bool,
     mode: Mode,
-    /// An in-flight discovery / update-check task; `None` when idle.
+    /// An in-flight discovery / update-check / lifecycle task; `None` when idle.
     pending: Option<Pending>,
     /// A transient status line shown while a task runs ("Checking for updates…").
     loading: Option<&'static str>,
@@ -79,12 +134,18 @@ pub struct PluginManagerDialog {
     /// Discovery results from the last `d` search, plus the cursor into them.
     discover_rows: Vec<DiscoveryResult>,
     discover_selected: usize,
+    /// The free-text GitHub search term, edited with `/` in discover mode.
+    discover_query: String,
+    /// The `/` input line is active: printable keys edit the query.
+    query_editing: bool,
     /// The plugin id a preview/apply is running for, so `tick` knows which row
     /// the result belongs to.
     pending_plugin: Option<String>,
-    /// An open update review popup: the changelog plus, when access expands, the
-    /// consent disclosure to render and approve / decline.
-    review: Option<Review>,
+    /// The floating popup owning the keyboard, if any.
+    popup: Option<Popup>,
+    /// Scroll offset into the open popup's body. A `Cell` so render (`&self`)
+    /// can clamp it to the real content height, which only render knows.
+    popup_scroll: Cell<u16>,
 }
 
 impl Default for PluginManagerDialog {
@@ -93,16 +154,23 @@ impl Default for PluginManagerDialog {
     }
 }
 
-/// Most changelog lines the non-scrollable popup renders before linking out to
-/// GitHub for the rest, so a long release body can never push the consent
-/// disclosure and the approve/decline hint off screen.
-const MAX_CHANGELOG_LINES: usize = 12;
+/// Most changelog lines the review popup renders before linking out to GitHub
+/// for the rest. The popup scrolls, so this only bounds the popup body (the
+/// entry counts are already capped by the backend; this bounds multi-line
+/// release bodies too).
+const MAX_CHANGELOG_LINES: usize = 60;
+
+/// How many trailing log lines the progress popup tails.
+const PROGRESS_TAIL_LINES: usize = 30;
+
+/// How far back in the log file the tail reads. Build output can grow to
+/// megabytes; only the end is ever shown.
+const PROGRESS_TAIL_BYTES: u64 = 16 * 1024;
 
 /// Append the changelog to a review popup's lines: release notes or commit
-/// subjects, or a single "unavailable" / "none" line. The popup `Paragraph` is
-/// not scrollable, so the rendered body is hard-capped at [`MAX_CHANGELOG_LINES`]
-/// and the full history is linked via `more_url`; the entry counts are already
-/// capped by the backend, this bounds multi-line release bodies too.
+/// subjects, or a single "unavailable" / "none" line. The rendered body is
+/// capped at [`MAX_CHANGELOG_LINES`] and the full history is linked via
+/// `more_url`.
 fn push_changelog_lines(lines: &mut Vec<Line>, changelog: &UpdateChangelog, theme: &Theme) {
     if let Some(reason) = &changelog.unavailable_reason {
         lines.push(Line::from(Span::styled(
@@ -178,6 +246,58 @@ fn push_changelog_lines(lines: &mut Vec<Line>, changelog: &UpdateChangelog, them
     }
 }
 
+/// The log file a TUI-run lifecycle operation writes build output to, beside
+/// the dashboard's job logs (`<plugins_dir>/jobs/`).
+fn tui_job_log(op: &str, id: &str) -> anyhow::Result<PathBuf> {
+    Ok(crate::plugin::plugins_dir()?
+        .join("jobs")
+        .join(format!("tui-{op}-{id}.log")))
+}
+
+/// Last `max_lines` lines of a log file, reading at most
+/// [`PROGRESS_TAIL_BYTES`] from its end. Returns an empty vec while the file
+/// does not exist yet.
+fn read_log_tail(path: &Path, max_lines: usize) -> Vec<String> {
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let seeked = len > PROGRESS_TAIL_BYTES;
+    if seeked
+        && file
+            .seek(SeekFrom::End(-(PROGRESS_TAIL_BYTES as i64)))
+            .is_err()
+    {
+        return Vec::new();
+    }
+    let mut buf = Vec::new();
+    if file.read_to_end(&mut buf).is_err() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines: Vec<&str> = text.lines().collect();
+    // A mid-file seek almost certainly landed inside a line; drop the partial.
+    if seeked && !lines.is_empty() {
+        lines.remove(0);
+    }
+    lines
+        .into_iter()
+        .rev()
+        .take(max_lines)
+        .rev()
+        .map(str::to_string)
+        .collect()
+}
+
+fn setting_type_label(t: aoe_plugin_api::SettingType) -> &'static str {
+    match t {
+        aoe_plugin_api::SettingType::String => "string",
+        aoe_plugin_api::SettingType::Bool => "bool",
+        aoe_plugin_api::SettingType::Integer => "integer",
+        aoe_plugin_api::SettingType::Select => "select",
+    }
+}
+
 impl PluginManagerDialog {
     pub fn new() -> Self {
         let mut dialog = Self {
@@ -188,14 +308,18 @@ impl PluginManagerDialog {
             info: None,
             mutated: false,
             embedded: false,
+            has_settings_pane: false,
             mode: Mode::Browse,
             pending: None,
             loading: None,
             updates: HashMap::new(),
             discover_rows: Vec::new(),
             discover_selected: 0,
+            discover_query: String::new(),
+            query_editing: false,
             pending_plugin: None,
-            review: None,
+            popup: None,
+            popup_scroll: Cell::new(0),
         };
         dialog.reload();
         dialog.mutated = false; // Initial load is not a user mutation.
@@ -210,10 +334,24 @@ impl PluginManagerDialog {
         dialog
     }
 
-    /// Take and clear the "config mutated" flag (enable/disable wrote to disk
-    /// and reloaded the registry).
+    /// Take and clear the "config mutated" flag (a lifecycle action wrote to
+    /// disk and reloaded the registry).
     pub fn take_mutated(&mut self) -> bool {
         std::mem::take(&mut self.mutated)
+    }
+
+    /// Whether the dialog currently owns every key (an open popup, or discover
+    /// mode). The settings host checks this before intercepting Space to stage
+    /// an enable/disable, so a popup or the discovery search never loses keys
+    /// to the staging shortcut.
+    pub fn captures_input(&self) -> bool {
+        self.popup.is_some() || self.mode == Mode::Discover
+    }
+
+    /// Told by the settings host whether an editable plugin-settings pane
+    /// renders beneath the manager, so the footer can advertise Tab.
+    pub fn set_has_settings_pane(&mut self, has: bool) {
+        self.has_settings_pane = has;
     }
 
     fn reload(&mut self) {
@@ -228,11 +366,16 @@ impl PluginManagerDialog {
         }
     }
 
+    fn open_popup(&mut self, popup: Popup) {
+        self.popup = Some(popup);
+        self.popup_scroll.set(0);
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         self.info = None;
-        // An open review popup owns the keyboard until the user decides.
-        if self.review.is_some() {
-            return self.handle_review_key(key);
+        // An open popup owns the keyboard until the user decides.
+        if self.popup.is_some() {
+            return self.handle_popup_key(key);
         }
         if self.mode == Mode::Discover {
             return self.handle_discover_key(key);
@@ -249,21 +392,17 @@ impl PluginManagerDialog {
                 self.selected = self.selected.saturating_sub(1);
                 DialogResult::Continue
             }
-            KeyCode::Char(' ') | KeyCode::Enter => {
-                if let Some(row) = self.rows.get(self.selected) {
-                    let (id, enabled) = (row.id.clone(), row.enabled);
-                    match crate::plugin::install::set_enabled(&id, !enabled) {
-                        Ok(()) => {
-                            self.info = Some(format!(
-                                "{} {id}",
-                                if enabled { "Disabled" } else { "Enabled" }
-                            ));
-                            self.error = None;
-                            self.reload();
-                        }
-                        Err(e) => self.error = Some(format!("{e:#}")),
-                    }
-                }
+            KeyCode::Char(' ') => {
+                self.start_toggle();
+                DialogResult::Continue
+            }
+            KeyCode::Enter => {
+                self.open_details();
+                DialogResult::Continue
+            }
+            // Re-approve a plugin whose grant no longer covers its manifest.
+            KeyCode::Char('a') => {
+                self.open_reapprove();
                 DialogResult::Continue
             }
             // Explicit, on-demand network actions. They run off the event loop
@@ -286,53 +425,170 @@ impl PluginManagerDialog {
                 }
                 DialogResult::Continue
             }
+            KeyCode::Char('x') => {
+                if let Some(row) = self.rows.get(self.selected) {
+                    if row.builtin {
+                        self.info = Some(format!("{} is builtin; disable it instead.", row.id));
+                    } else {
+                        self.open_popup(Popup::ConfirmUninstall { id: row.id.clone() });
+                    }
+                }
+                DialogResult::Continue
+            }
+            // Re-read the registry from disk (an external `aoe plugin` command
+            // may have changed it while the manager was open).
+            KeyCode::Char('r') => {
+                self.reload();
+                self.info = Some("Refreshed.".to_string());
+                DialogResult::Continue
+            }
             _ => DialogResult::Continue,
         }
     }
 
+    fn handle_popup_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        // Every popup body scrolls with the same keys.
+        match key.code {
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.popup_scroll
+                    .set(self.popup_scroll.get().saturating_add(1));
+                return DialogResult::Continue;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.popup_scroll
+                    .set(self.popup_scroll.get().saturating_sub(1));
+                return DialogResult::Continue;
+            }
+            _ => {}
+        }
+        let Some(popup) = self.popup.take() else {
+            return DialogResult::Continue;
+        };
+        match popup {
+            Popup::Review(review) => self.handle_review_key(key, *review),
+            Popup::Install(consent) => match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    self.start_install_apply(*consent);
+                    DialogResult::Continue
+                }
+                KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => {
+                    self.info = Some("Install cancelled.".to_string());
+                    DialogResult::Continue
+                }
+                _ => {
+                    self.popup = Some(Popup::Install(consent));
+                    DialogResult::Continue
+                }
+            },
+            Popup::Reapprove(consent) => match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    match crate::plugin::install::approve_installed(
+                        &consent.id,
+                        &consent.manifest_hash,
+                    ) {
+                        Ok(()) => {
+                            self.info = Some(format!("Approved {}.", consent.id));
+                            self.error = None;
+                            self.reload();
+                        }
+                        Err(e) => self.error = Some(format!("{e:#}")),
+                    }
+                    DialogResult::Continue
+                }
+                KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => DialogResult::Continue,
+                _ => {
+                    self.popup = Some(Popup::Reapprove(consent));
+                    DialogResult::Continue
+                }
+            },
+            Popup::ConfirmUninstall { id } => match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    self.start_uninstall(id);
+                    DialogResult::Continue
+                }
+                KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => DialogResult::Continue,
+                _ => {
+                    self.popup = Some(Popup::ConfirmUninstall { id });
+                    DialogResult::Continue
+                }
+            },
+            Popup::Details(details) => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => DialogResult::Continue,
+                _ => {
+                    self.popup = Some(Popup::Details(details));
+                    DialogResult::Continue
+                }
+            },
+            Popup::Progress(progress) => {
+                // Once done, any decision key dismisses the popup. While the
+                // operation still runs, Esc hides the popup without cancelling
+                // it (a hung network fetch must never trap the keyboard); the
+                // result then lands in the footer.
+                let dismiss = if progress.done.is_some() {
+                    matches!(key.code, KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter)
+                } else {
+                    key.code == KeyCode::Esc
+                };
+                if !dismiss {
+                    self.popup = Some(Popup::Progress(progress));
+                }
+                DialogResult::Continue
+            }
+        }
+    }
+
     /// Keys while the update review popup is open: approve/update, decline (only
-    /// when access expands), or close.
-    fn handle_review_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+    /// when access expands), or close. The popup was taken out of `self.popup`
+    /// by the caller; put it back unless the key decided it.
+    fn handle_review_key(&mut self, key: KeyEvent, review: Review) -> DialogResult<()> {
         match key.code {
             KeyCode::Char('y') | KeyCode::Enter => {
-                if let Some(review) = self.review.take() {
-                    self.start_apply(review.id, Some(review.fingerprint));
-                }
+                self.start_apply(review.id, Some(review.fingerprint));
                 DialogResult::Continue
             }
             // Decline only applies to a consent-expanding update: record the
             // dismissal so it stops nagging, keep the active version. A safe
             // update has nothing to dismiss, so `n` just closes it.
             KeyCode::Char('n') => {
-                if let Some(review) = self.review.take() {
-                    if review.consent.is_some() {
-                        match crate::plugin::install::dismiss_update(
-                            &review.id,
-                            &review.fingerprint,
-                        ) {
-                            Ok(()) => {
-                                // dismiss_update wrote plugin config; flag it so
-                                // an embedding settings surface resyncs and a
-                                // later save does not clobber the dismissal.
-                                self.mutated = true;
-                                self.info = Some(format!("Declined update for {}.", review.id));
-                            }
-                            Err(e) => self.error = Some(format!("{e:#}")),
+                if review.consent.is_some() {
+                    match crate::plugin::install::dismiss_update(&review.id, &review.fingerprint) {
+                        Ok(()) => {
+                            // dismiss_update wrote plugin config; flag it so
+                            // an embedding settings surface resyncs and a
+                            // later save does not clobber the dismissal.
+                            self.mutated = true;
+                            self.info = Some(format!("Declined update for {}.", review.id));
                         }
+                        Err(e) => self.error = Some(format!("{e:#}")),
                     }
                 }
                 DialogResult::Continue
             }
             // Close without deciding.
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.review = None;
+            KeyCode::Esc | KeyCode::Char('q') => DialogResult::Continue,
+            _ => {
+                self.popup = Some(Popup::Review(Box::new(review)));
                 DialogResult::Continue
             }
-            _ => DialogResult::Continue,
         }
     }
 
     fn handle_discover_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        if self.query_editing {
+            match key.code {
+                KeyCode::Esc => self.query_editing = false,
+                KeyCode::Enter => {
+                    self.query_editing = false;
+                    self.start_discover();
+                }
+                KeyCode::Backspace => {
+                    self.discover_query.pop();
+                }
+                KeyCode::Char(c) => self.discover_query.push(c),
+                _ => {}
+            }
+            return DialogResult::Continue;
+        }
         match key.code {
             // Esc/q leave discovery for the installed list, not the whole dialog.
             KeyCode::Esc | KeyCode::Char('q') => {
@@ -350,12 +606,14 @@ impl PluginManagerDialog {
                 self.discover_selected = self.discover_selected.saturating_sub(1);
                 DialogResult::Continue
             }
-            // The dashboard/TUI have no install path (capability approval needs a
-            // terminal prompt); show the command to run instead.
+            // Install the selected result: fetch its consent disclosure, then
+            // approve in the same popup the CLI prompt and web modal render.
             KeyCode::Enter => {
-                if let Some(r) = self.discover_rows.get(self.discover_selected) {
-                    self.info = Some(format!("Install with: {}", r.install_command));
-                }
+                self.start_install_preview();
+                DialogResult::Continue
+            }
+            KeyCode::Char('/') => {
+                self.query_editing = true;
                 DialogResult::Continue
             }
             KeyCode::Char('d') => {
@@ -363,6 +621,140 @@ impl PluginManagerDialog {
                 DialogResult::Continue
             }
             _ => DialogResult::Continue,
+        }
+    }
+
+    /// Toggle the selected plugin through [`set_enabled_live`], which routes
+    /// the write through a running daemon (so its workers reconcile) and falls
+    /// back to a local config write. Async because the daemon round-trip is.
+    fn start_toggle(&mut self) {
+        if self.pending.is_some() {
+            return;
+        }
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        let id = row.id.clone();
+        let target = !row.enabled;
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let verb = if target { "Enabled" } else { "Disabled" };
+            let message = match crate::plugin::install::set_enabled_live(&id, target).await {
+                Ok(LiveToggle::Daemon) => {
+                    Ok(format!("{verb} {id}; the daemon reconciled its workers."))
+                }
+                Ok(LiveToggle::Local) => Ok(format!("{verb} {id}.")),
+                Ok(LiveToggle::LocalDaemonStale { reason }) => Ok(format!(
+                    "{verb} {id}. Daemon not updated ({reason}); restart it or toggle from the dashboard."
+                )),
+                Err(e) => Err(format!("{e:#}")),
+            };
+            let _ = tx.send(message);
+        });
+        self.pending = Some(Pending::Toggle(rx));
+        self.loading = Some("Applying…");
+        self.error = None;
+    }
+
+    /// Open the details popup for the selected row: the full disclosure
+    /// (`aoe plugin info`'s TUI twin).
+    fn open_details(&mut self) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        let registry = crate::plugin::registry();
+        let Some(plugin) = registry.get(&row.id) else {
+            return;
+        };
+        let m = &plugin.manifest;
+        let commands = m
+            .commands
+            .iter()
+            .map(|c| {
+                let title = if c.title.is_empty() {
+                    c.id.clone()
+                } else {
+                    format!("{} ({})", c.title, c.id)
+                };
+                if c.description.is_empty() {
+                    title
+                } else {
+                    format!("{title}: {}", c.description)
+                }
+            })
+            .collect();
+        let keybinds = m
+            .keybinds
+            .iter()
+            .map(|kb| {
+                let note = match crate::tui::home::bindings::parse_chord(&kb.key) {
+                    Some(c) if crate::tui::home::bindings::core_shadows(&c) => {
+                        " (shadowed by core)"
+                    }
+                    Some(_) => "",
+                    None => " (invalid key, ignored)",
+                };
+                format!("{} -> {}{note}", kb.key, kb.command)
+            })
+            .collect();
+        let runtime = m.runtime.as_ref().map(|r| match r {
+            aoe_plugin_api::RuntimeSpec::Command {
+                command,
+                system,
+                build,
+            } => {
+                let mut s = format!("command: {}", command.join(" "));
+                if *system {
+                    s.push_str(" (resolved on the daemon's PATH)");
+                }
+                if !build.is_empty() {
+                    s.push_str(&format!(
+                        "; {} build step(s) at install/update",
+                        build.len()
+                    ));
+                }
+                s
+            }
+            aoe_plugin_api::RuntimeSpec::ReleaseBinary { asset, .. } => {
+                format!("release binary: {asset}")
+            }
+        });
+        let settings = m
+            .settings
+            .iter()
+            .map(|s| {
+                let label = if s.label.is_empty() {
+                    s.key.clone()
+                } else {
+                    format!("{} ({})", s.label, s.key)
+                };
+                format!("{label}: {}", setting_type_label(s.value_type))
+            })
+            .collect();
+        let details = Details {
+            view: row.clone(),
+            commands,
+            keybinds,
+            runtime,
+            settings,
+            dir: plugin.dir.as_ref().map(|d| d.display().to_string()),
+        };
+        self.open_popup(Popup::Details(Box::new(details)));
+    }
+
+    /// Open the re-approval consent popup for a plugin whose grant no longer
+    /// covers its installed manifest.
+    fn open_reapprove(&mut self) {
+        let Some(row) = self.rows.get(self.selected) else {
+            return;
+        };
+        if !row.needs_reapproval {
+            self.info = Some(format!("{} does not need approval.", row.id));
+            return;
+        }
+        match crate::plugin::install::reapprove_consent(&row.id) {
+            Ok(consent) => self.open_popup(Popup::Reapprove(consent)),
+            Err(e) => self.error = Some(format!("{e:#}")),
         }
     }
 
@@ -402,22 +794,36 @@ impl PluginManagerDialog {
         if self.pending.is_some() {
             return;
         }
+        let log_path = match tui_job_log("update", &id) {
+            Ok(path) => path,
+            Err(e) => {
+                self.error = Some(format!("{e:#}"));
+                return;
+            }
+        };
+        let _ = std::fs::remove_file(&log_path);
         let (tx, rx) = oneshot::channel();
         let apply_id = id.clone();
+        let task_log = log_path.clone();
         tokio::spawn(async move {
-            let _ = tx.send(
-                crate::plugin::install::apply_update(
-                    &apply_id,
-                    fingerprint,
-                    &crate::plugin::install::OperationLog::Inherit,
-                )
-                .await
-                .map(|_| ())
-                .map_err(|e| format!("{e:#}")),
-            );
+            let result = async {
+                let log = crate::plugin::install::OperationLog::file(&task_log)
+                    .map_err(|e| format!("{e:#}"))?;
+                crate::plugin::install::apply_update(&apply_id, fingerprint, &log)
+                    .await
+                    .map(|report| format!("Updated {} to {}.", report.id, report.version))
+                    .map_err(|e| format!("{e:#}"))
+            }
+            .await;
+            let _ = tx.send(result);
         });
-        self.pending_plugin = Some(id);
+        self.pending_plugin = Some(id.clone());
         self.pending = Some(Pending::Apply(rx));
+        self.open_popup(Popup::Progress(Progress {
+            title: format!(" Updating {id} "),
+            log_path,
+            done: None,
+        }));
         self.loading = Some("Updating…");
         self.error = None;
     }
@@ -426,9 +832,13 @@ impl PluginManagerDialog {
         if self.pending.is_some() {
             return;
         }
+        let query = {
+            let trimmed = self.discover_query.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        };
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
-            let result = crate::plugin::discover::discover(None)
+            let result = crate::plugin::discover::discover(query.as_deref())
                 .await
                 .map_err(|e| format!("{e:#}"));
             let _ = tx.send(result);
@@ -438,8 +848,115 @@ impl PluginManagerDialog {
         self.error = None;
     }
 
-    /// Poll an in-flight discovery / update-check task. Returns true when the
-    /// result landed (the host should redraw). Called from the event-loop tick.
+    /// Fetch the consent disclosure for the selected discovery result (the
+    /// `preview_install` probe: network-only, installs nothing).
+    fn start_install_preview(&mut self) {
+        if self.pending.is_some() {
+            return;
+        }
+        let Some(result) = self.discover_rows.get(self.discover_selected) else {
+            return;
+        };
+        if result.badge == DiscoveryBadge::Installed {
+            self.info = Some(format!("{} is already installed.", result.slug));
+            return;
+        }
+        let source = result.slug.clone();
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = tx.send(
+                crate::plugin::install::preview_install(&source)
+                    .await
+                    .map_err(|e| format!("{e:#}")),
+            );
+        });
+        self.pending = Some(Pending::InstallPreview(rx));
+        self.loading = Some("Fetching plugin…");
+        self.error = None;
+    }
+
+    /// Apply an approved install, pinned to the fingerprint the consent popup
+    /// showed. Build output streams to a job log the progress popup tails.
+    fn start_install_apply(&mut self, consent: InstallConsent) {
+        if self.pending.is_some() {
+            return;
+        }
+        let log_path = match tui_job_log("install", &consent.id) {
+            Ok(path) => path,
+            Err(e) => {
+                self.error = Some(format!("{e:#}"));
+                return;
+            }
+        };
+        let _ = std::fs::remove_file(&log_path);
+        let (tx, rx) = oneshot::channel();
+        let source = consent.source.clone();
+        let fingerprint = consent.fingerprint.clone();
+        let task_log = log_path.clone();
+        tokio::spawn(async move {
+            let result = async {
+                let log = crate::plugin::install::OperationLog::file(&task_log)
+                    .map_err(|e| format!("{e:#}"))?;
+                crate::plugin::install::apply_install(&source, &fingerprint, &log)
+                    .await
+                    .map(|report| format!("Installed {} {}.", report.id, report.version))
+                    .map_err(|e| format!("{e:#}"))
+            }
+            .await;
+            let _ = tx.send(result);
+        });
+        self.pending_plugin = Some(consent.id.clone());
+        self.pending = Some(Pending::InstallApply(rx));
+        self.open_popup(Popup::Progress(Progress {
+            title: format!(" Installing {} ", consent.id),
+            log_path,
+            done: None,
+        }));
+        self.loading = Some("Installing…");
+        self.error = None;
+    }
+
+    fn start_uninstall(&mut self, id: String) {
+        if self.pending.is_some() {
+            return;
+        }
+        let (tx, rx) = oneshot::channel();
+        let task_id = id.clone();
+        tokio::spawn(async move {
+            let blocking_id = task_id.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                crate::plugin::install::uninstall(&blocking_id).map_err(|e| format!("{e:#}"))
+            })
+            .await
+            .unwrap_or_else(|e| Err(e.to_string()))
+            .map(|()| format!("Uninstalled {task_id}."));
+            let _ = tx.send(result);
+        });
+        self.pending_plugin = Some(id);
+        self.pending = Some(Pending::Uninstall(rx));
+        self.loading = Some("Uninstalling…");
+        self.error = None;
+    }
+
+    /// Resolve a finished lifecycle task into the open progress popup (so the
+    /// user reads the outcome over the log tail) or, if the popup is gone, the
+    /// footer.
+    fn finish_operation(&mut self, result: Result<String, String>) {
+        let ok = result.is_ok();
+        if ok {
+            self.reload();
+        }
+        match &mut self.popup {
+            Some(Popup::Progress(progress)) => progress.done = Some(result),
+            _ => match result {
+                Ok(message) => self.info = Some(message),
+                Err(message) => self.error = Some(message),
+            },
+        }
+    }
+
+    /// Poll an in-flight task. Returns true when the result landed (the host
+    /// should redraw). Called from the event-loop tick.
     pub fn tick(&mut self) -> bool {
         use oneshot::error::TryRecvError;
         let Some(pending) = &mut self.pending else {
@@ -522,14 +1039,14 @@ impl PluginManagerDialog {
                                     .find(|r| r.id == id)
                                     .map(|r| r.version.clone())
                                     .unwrap_or_default();
-                                self.review = Some(Review {
+                                self.open_popup(Popup::Review(Box::new(Review {
                                     id,
                                     from_version,
                                     to_version,
                                     fingerprint,
                                     changelog,
                                     consent: None,
-                                });
+                                })));
                             }
                         }
                         // An already-dismissed version must not re-prompt; it
@@ -541,14 +1058,14 @@ impl PluginManagerDialog {
                                     consent.id
                                 ));
                             } else {
-                                self.review = Some(Review {
+                                self.open_popup(Popup::Review(Box::new(Review {
                                     id: consent.id.clone(),
                                     from_version: consent.from_version.clone(),
                                     to_version: consent.to_version.clone(),
                                     fingerprint: consent.fingerprint.clone(),
                                     changelog: consent.changelog.clone(),
                                     consent: Some(*consent),
-                                });
+                                })));
                             }
                         }
                         Err(message) => self.error = Some(message),
@@ -567,12 +1084,30 @@ impl PluginManagerDialog {
                 Ok(result) => {
                     self.pending = None;
                     self.loading = None;
+                    if result.is_ok() {
+                        if let Some(id) = self.pending_plugin.take() {
+                            self.updates.remove(&id);
+                        }
+                    }
+                    self.finish_operation(result);
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.pending = None;
+                    self.loading = None;
+                    self.finish_operation(Err("Update failed.".to_string()));
+                    true
+                }
+            },
+            Pending::Toggle(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    self.pending = None;
+                    self.loading = None;
                     match result {
-                        Ok(()) => {
-                            if let Some(id) = self.pending_plugin.take() {
-                                self.updates.remove(&id);
-                                self.info = Some(format!("Updated {id}."));
-                            }
+                        Ok(message) => {
+                            self.info = Some(message);
+                            self.error = None;
                             self.reload();
                         }
                         Err(message) => self.error = Some(message),
@@ -581,7 +1116,64 @@ impl PluginManagerDialog {
                 }
                 Err(TryRecvError::Empty) => false,
                 Err(TryRecvError::Closed) => {
-                    self.error = Some("Update failed.".to_string());
+                    self.error = Some("Toggle failed.".to_string());
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+            },
+            Pending::InstallPreview(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    self.pending = None;
+                    self.loading = None;
+                    match result {
+                        Ok(consent) => self.open_popup(Popup::Install(Box::new(consent))),
+                        Err(message) => self.error = Some(message),
+                    }
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.error = Some("Install preview failed.".to_string());
+                    self.pending = None;
+                    self.loading = None;
+                    true
+                }
+            },
+            Pending::InstallApply(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    self.pending = None;
+                    self.loading = None;
+                    self.pending_plugin = None;
+                    self.finish_operation(result);
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.pending = None;
+                    self.loading = None;
+                    self.finish_operation(Err("Install failed.".to_string()));
+                    true
+                }
+            },
+            Pending::Uninstall(rx) => match rx.try_recv() {
+                Ok(result) => {
+                    self.pending = None;
+                    self.loading = None;
+                    self.pending_plugin = None;
+                    match result {
+                        Ok(message) => {
+                            self.info = Some(message);
+                            self.error = None;
+                            self.reload();
+                        }
+                        Err(message) => self.error = Some(message),
+                    }
+                    true
+                }
+                Err(TryRecvError::Empty) => false,
+                Err(TryRecvError::Closed) => {
+                    self.error = Some("Uninstall failed.".to_string());
                     self.pending = None;
                     self.loading = None;
                     true
@@ -637,9 +1229,17 @@ impl PluginManagerDialog {
         let inner = block.inner(rect);
         f.render_widget(block, rect);
         self.render_browse(f, inner, theme);
-        // The review popup floats over the list, centered on the dialog rect.
-        if let Some(review) = &self.review {
-            self.render_review(f, rect, theme, review);
+        // The popup floats over the list, centered on the dialog rect.
+        match &self.popup {
+            Some(Popup::Review(review)) => self.render_review(f, rect, theme, review),
+            Some(Popup::Install(consent)) => self.render_install_consent(f, rect, theme, consent),
+            Some(Popup::Reapprove(consent)) => self.render_reapprove(f, rect, theme, consent),
+            Some(Popup::ConfirmUninstall { id }) => {
+                self.render_confirm_uninstall(f, rect, theme, id)
+            }
+            Some(Popup::Details(details)) => self.render_details(f, rect, theme, details),
+            Some(Popup::Progress(progress)) => self.render_progress(f, rect, theme, progress),
+            None => {}
         }
     }
 
@@ -666,10 +1266,10 @@ impl PluginManagerDialog {
         let Some(consent) = &review.consent else {
             // Safe update: changelog only, with an update/cancel hint.
             lines.push(Line::from(Span::styled(
-                "enter update · esc cancel",
+                "enter update · esc cancel · j/k scroll",
                 Style::default().fg(theme.dimmed),
             )));
-            self.draw_review_popup(f, area, theme, lines, " Update plugin ");
+            self.draw_popup(f, area, theme, lines, " Update plugin ");
             return;
         };
 
@@ -731,21 +1331,351 @@ impl PluginManagerDialog {
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
-            "y approve · n decline · esc close",
+            "y approve · n decline · esc close · j/k scroll",
             Style::default().fg(theme.dimmed),
         )));
-        self.draw_review_popup(f, area, theme, lines, " Approve update ");
+        self.draw_popup(f, area, theme, lines, " Approve update ");
     }
 
-    /// Draw the review popup body into a clamped, centered sub-rect.
-    fn draw_review_popup(
+    fn render_install_consent(
         &self,
         f: &mut Frame,
         area: Rect,
         theme: &Theme,
-        lines: Vec<Line>,
-        title: &str,
+        consent: &InstallConsent,
     ) {
+        let mut lines: Vec<Line> = vec![Line::from(Span::styled(
+            format!("Install {} v{}?", consent.id, consent.version),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        ))];
+        lines.push(Line::from(Span::styled(
+            consent.notice.clone(),
+            Style::default().fg(theme.dimmed),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("Source: {} ({})", consent.source, consent.validation),
+            Style::default().fg(theme.dimmed),
+        )));
+        if consent.unverified {
+            lines.push(Line::from(Span::styled(
+                "Unverified source: not an audited release (explicit ref or default branch).",
+                Style::default().fg(theme.waiting),
+            )));
+        }
+        lines.push(Line::from(""));
+        if consent.capabilities.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No capabilities requested.",
+                Style::default().fg(theme.dimmed),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "Capabilities:",
+                Style::default().fg(theme.waiting),
+            )));
+            for cap in &consent.capabilities {
+                lines.push(Line::from(Span::styled(
+                    format!("  {cap}"),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        if !consent.build_steps.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "Build commands (run as you, unsandboxed):",
+                Style::default().fg(theme.waiting),
+            )));
+            for step in &consent.build_steps {
+                lines.push(Line::from(Span::styled(
+                    format!("  $ {step}"),
+                    Style::default().fg(theme.dimmed),
+                )));
+            }
+        }
+        if !consent.ui.is_empty() {
+            let mut slots: Vec<&str> = Vec::new();
+            for u in &consent.ui {
+                if !slots.contains(&u.slot.as_str()) {
+                    slots.push(u.slot.as_str());
+                }
+            }
+            lines.push(Line::from(Span::styled(
+                format!("UI slots: {}", slots.join(", ")),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Approving trusts this plugin; a worker and build steps run without OS sandboxing.",
+            Style::default().fg(theme.dimmed),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "y install · n cancel · j/k scroll",
+            Style::default().fg(theme.dimmed),
+        )));
+        self.draw_popup(f, area, theme, lines, " Approve install ");
+    }
+
+    fn render_reapprove(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        consent: &ReapproveConsent,
+    ) {
+        let mut lines: Vec<Line> = vec![Line::from(Span::styled(
+            format!("Re-approve {} v{}?", consent.id, consent.version),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        ))];
+        lines.push(Line::from(Span::styled(
+            "Its manifest changed since the last approval; it stays inactive until re-approved.",
+            Style::default().fg(theme.dimmed),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("Validation: {}", consent.validation),
+            Style::default().fg(theme.dimmed),
+        )));
+        lines.push(Line::from(""));
+        if consent.capabilities.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No capabilities requested.",
+                Style::default().fg(theme.dimmed),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "Capabilities:",
+                Style::default().fg(theme.waiting),
+            )));
+            for cap in &consent.capabilities {
+                lines.push(Line::from(Span::styled(
+                    format!("  {cap}"),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        if !consent.ui.is_empty() {
+            let mut slots: Vec<&str> = Vec::new();
+            for u in &consent.ui {
+                if !slots.contains(&u.slot.as_str()) {
+                    slots.push(u.slot.as_str());
+                }
+            }
+            lines.push(Line::from(Span::styled(
+                format!("UI slots: {}", slots.join(", ")),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "No build steps run; this only re-grants the already-installed version.",
+            Style::default().fg(theme.dimmed),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "y approve · esc cancel · j/k scroll",
+            Style::default().fg(theme.dimmed),
+        )));
+        self.draw_popup(f, area, theme, lines, " Approve plugin ");
+    }
+
+    fn render_confirm_uninstall(&self, f: &mut Frame, area: Rect, theme: &Theme, id: &str) {
+        let lines: Vec<Line> = vec![
+            Line::from(Span::styled(
+                format!("Uninstall {id}?"),
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                "Removes its files, configuration, and lockfile entry. Per-session plugin data is kept.",
+                Style::default().fg(theme.dimmed),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "y uninstall · esc cancel",
+                Style::default().fg(theme.dimmed),
+            )),
+        ];
+        self.draw_popup(f, area, theme, lines, " Uninstall plugin ");
+    }
+
+    fn render_details(&self, f: &mut Frame, area: Rect, theme: &Theme, details: &Details) {
+        let view = &details.view;
+        let state = if !view.enabled {
+            "disabled"
+        } else if view.needs_reapproval {
+            "needs approval"
+        } else {
+            "enabled"
+        };
+        let mut lines: Vec<Line> = vec![Line::from(Span::styled(
+            format!("{} v{} ({})", view.name, view.version, view.id),
+            Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+        ))];
+        if !view.description.is_empty() {
+            lines.push(Line::from(Span::styled(
+                view.description.clone(),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        lines.push(Line::from(Span::styled(
+            format!("Validation: {} · State: {state}", view.validation),
+            Style::default().fg(theme.dimmed),
+        )));
+        match &view.source {
+            Some(source) => lines.push(Line::from(Span::styled(
+                format!("Source: {source}"),
+                Style::default().fg(theme.dimmed),
+            ))),
+            None => lines.push(Line::from(Span::styled(
+                "Builtin plugin (compiled into aoe).",
+                Style::default().fg(theme.dimmed),
+            ))),
+        }
+        if let Some(dir) = &details.dir {
+            lines.push(Line::from(Span::styled(
+                format!("Install dir: {dir}"),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        lines.push(Line::from(""));
+        if view.capabilities.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No capabilities requested.",
+                Style::default().fg(theme.dimmed),
+            )));
+        } else {
+            let granted = if view.granted {
+                "Capabilities (granted):"
+            } else {
+                "Capabilities (NOT granted):"
+            };
+            lines.push(Line::from(Span::styled(
+                granted,
+                Style::default().fg(if view.granted {
+                    theme.running
+                } else {
+                    theme.waiting
+                }),
+            )));
+            for cap in &view.capabilities {
+                lines.push(Line::from(Span::styled(
+                    format!("  {cap}"),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        if !view.ui_contributions.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "UI slots:",
+                Style::default().fg(theme.dimmed),
+            )));
+            for u in &view.ui_contributions {
+                lines.push(Line::from(Span::styled(
+                    format!("  {} ({})", u.slot, u.id),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        if !details.commands.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "Commands:",
+                Style::default().fg(theme.dimmed),
+            )));
+            for command in &details.commands {
+                lines.push(Line::from(Span::styled(
+                    format!("  {command}"),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        if !details.keybinds.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "Keybinds:",
+                Style::default().fg(theme.dimmed),
+            )));
+            for keybind in &details.keybinds {
+                lines.push(Line::from(Span::styled(
+                    format!("  {keybind}"),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        match &details.runtime {
+            Some(runtime) => lines.push(Line::from(Span::styled(
+                format!("Runtime: {runtime}"),
+                Style::default().fg(theme.dimmed),
+            ))),
+            None => lines.push(Line::from(Span::styled(
+                "Runtime: none (no worker).",
+                Style::default().fg(theme.dimmed),
+            ))),
+        }
+        if !details.settings.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "Settings:",
+                Style::default().fg(theme.dimmed),
+            )));
+            for setting in &details.settings {
+                lines.push(Line::from(Span::styled(
+                    format!("  {setting}"),
+                    Style::default().fg(theme.text),
+                )));
+            }
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "j/k scroll · esc close",
+            Style::default().fg(theme.dimmed),
+        )));
+        self.draw_popup(f, area, theme, lines, " Plugin details ");
+    }
+
+    fn render_progress(&self, f: &mut Frame, area: Rect, theme: &Theme, progress: &Progress) {
+        let mut lines: Vec<Line> = Vec::new();
+        for line in read_log_tail(&progress.log_path, PROGRESS_TAIL_LINES) {
+            lines.push(Line::from(Span::styled(
+                line,
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+        lines.push(Line::from(""));
+        match &progress.done {
+            None => lines.push(Line::from(Span::styled(
+                format!("Working… (log: {})", progress.log_path.display()),
+                Style::default().fg(theme.waiting),
+            ))),
+            Some(Ok(message)) => {
+                lines.push(Line::from(Span::styled(
+                    message.clone(),
+                    Style::default().fg(theme.running),
+                )));
+                lines.push(Line::from(Span::styled(
+                    "esc close",
+                    Style::default().fg(theme.dimmed),
+                )));
+            }
+            Some(Err(message)) => {
+                lines.push(Line::from(Span::styled(
+                    message.clone(),
+                    Style::default().fg(theme.error),
+                )));
+                lines.push(Line::from(Span::styled(
+                    format!("Full log: {}", progress.log_path.display()),
+                    Style::default().fg(theme.dimmed),
+                )));
+                lines.push(Line::from(Span::styled(
+                    "esc close",
+                    Style::default().fg(theme.dimmed),
+                )));
+            }
+        }
+        self.draw_popup(f, area, theme, lines, &progress.title);
+    }
+
+    /// Draw a popup body into a clamped, centered sub-rect, scrolled by
+    /// `popup_scroll` (clamped here to the real content height, which only
+    /// render knows).
+    fn draw_popup(&self, f: &mut Frame, area: Rect, theme: &Theme, lines: Vec<Line>, title: &str) {
         // A tiny terminal can be narrower/shorter than our preferred size;
         // never pass clamp/centered_rect a max below the min (it panics).
         if area.width == 0 || area.height == 0 {
@@ -762,7 +1692,15 @@ impl PluginManagerDialog {
             .border_style(Style::default().fg(theme.accent));
         let inner = block.inner(rect);
         f.render_widget(block, rect);
-        let body = Paragraph::new(lines).wrap(Wrap { trim: true });
+        // Clamp the scroll so the last line can always be brought into view
+        // but never scrolled past; `Cell` because render is `&self`.
+        let max_scroll = (lines.len() as u16).saturating_sub(inner.height.max(1));
+        if self.popup_scroll.get() > max_scroll {
+            self.popup_scroll.set(max_scroll);
+        }
+        let body = Paragraph::new(lines)
+            .wrap(Wrap { trim: true })
+            .scroll((self.popup_scroll.get(), 0));
         f.render_widget(body, inner);
     }
 
@@ -812,7 +1750,7 @@ impl PluginManagerDialog {
                 }
                 // Disclose the dashboard UI slots the plugin renders into, so the
                 // manager shows that a plugin modifies the UI (#2366). Distinct
-                // slot names only; ids are in `aoe plugin info`.
+                // slot names only; ids are in the details popup (Enter).
                 if !row.ui_contributions.is_empty() {
                     let mut slots: Vec<&str> = Vec::new();
                     for u in &row.ui_contributions {
@@ -854,10 +1792,32 @@ impl PluginManagerDialog {
     }
 
     fn render_discover_list(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+        // The search line renders whenever a query exists or is being edited,
+        // so the list always shows what filtered it.
+        let show_query = self.query_editing || !self.discover_query.is_empty();
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(if show_query { 1 } else { 0 }),
+                Constraint::Min(1),
+            ])
+            .split(area);
+        if show_query {
+            let (text, color) = if self.query_editing {
+                (format!("Search: {}▌", self.discover_query), theme.accent)
+            } else {
+                (format!("Search: {}", self.discover_query), theme.dimmed)
+            };
+            f.render_widget(
+                Paragraph::new(text).style(Style::default().fg(color)),
+                chunks[0],
+            );
+        }
+        let list_area = chunks[1];
         if self.discover_rows.is_empty() {
             let empty = Paragraph::new("No plugins found on the aoe-plugin topic.")
                 .style(Style::default().fg(theme.dimmed));
-            f.render_widget(empty, area);
+            f.render_widget(empty, list_area);
             return;
         }
         let items: Vec<ListItem> = self
@@ -891,7 +1851,7 @@ impl PluginManagerDialog {
             .highlight_symbol("> ");
         let mut state = ListState::default();
         state.select(Some(self.discover_selected));
-        f.render_stateful_widget(list, area, &mut state);
+        f.render_stateful_widget(list, list_area, &mut state);
     }
 
     fn render_footer(&self, f: &mut Frame, area: Rect, theme: &Theme) {
@@ -904,20 +1864,48 @@ impl PluginManagerDialog {
         } else if let Some(i) = self.info.as_deref() {
             (i.to_string(), theme.running)
         } else if self.mode == Mode::Discover {
-            (
-                "enter: install command · d: re-search · esc: back".to_string(),
-                theme.dimmed,
-            )
+            if self.query_editing {
+                (
+                    "type query · enter search · esc cancel".to_string(),
+                    theme.dimmed,
+                )
+            } else {
+                (
+                    "enter install · / search · d re-search · esc back".to_string(),
+                    theme.dimmed,
+                )
+            }
         } else {
             let back = if self.embedded {
                 "esc back"
             } else {
                 "esc close"
             };
-            (
-                format!("space toggle · c check updates · u update · d discover · {back}"),
-                theme.dimmed,
-            )
+            // Contextual hints for the selected row keep the footer short:
+            // update / approve / uninstall only apply to some rows.
+            let mut hints = vec![
+                "space toggle",
+                "enter details",
+                "d discover",
+                "c updates",
+                "r refresh",
+            ];
+            if let Some(row) = self.rows.get(self.selected) {
+                if self.updates.get(&row.id).is_some_and(|u| u.needs_update) {
+                    hints.push("u update");
+                }
+                if row.needs_reapproval {
+                    hints.push("a approve");
+                }
+                if !row.builtin {
+                    hints.push("x uninstall");
+                }
+            }
+            if self.embedded && self.has_settings_pane {
+                hints.push("tab settings");
+            }
+            hints.push(back);
+            (hints.join(" · "), theme.dimmed)
         };
         let footer = Paragraph::new(text)
             .style(Style::default().fg(color))

--- a/src/tui/dialogs/plugin_manager.rs
+++ b/src/tui/dialogs/plugin_manager.rs
@@ -58,6 +58,16 @@ struct Progress {
     done: Option<Result<String, String>>,
 }
 
+/// Content for [`PluginManagerDialog::draw_popup`]: a scrollable body over a
+/// pinned footer (the decision keys / status), and whether the body should
+/// follow its tail as it grows (the running progress log).
+struct PopupContent<'a> {
+    body: Vec<Line<'a>>,
+    footer: Vec<Line<'a>>,
+    follow_tail: bool,
+    title: &'a str,
+}
+
 /// The floating popup owning the keyboard; at most one at a time.
 enum Popup {
     /// Update review: changelog plus, when access expands, the consent
@@ -146,6 +156,9 @@ pub struct PluginManagerDialog {
     /// Scroll offset into the open popup's body. A `Cell` so render (`&self`)
     /// can clamp it to the real content height, which only render knows.
     popup_scroll: Cell<u16>,
+    /// The user scrolled the open popup themselves; a following popup (the
+    /// running progress log) stops auto-scrolling to the tail once set.
+    popup_user_scrolled: bool,
 }
 
 impl Default for PluginManagerDialog {
@@ -289,6 +302,57 @@ fn read_log_tail(path: &Path, max_lines: usize) -> Vec<String> {
         .collect()
 }
 
+/// Rows `line` occupies when rendered with `Wrap { trim: true }` into `width`
+/// columns: greedy word wrap, leading indentation counted toward the first
+/// row, over-wide words split across rows. Popup sizing and scroll bounds use
+/// this so a wrapped line can never push content (like the decision-key
+/// footer) off the bottom edge.
+fn wrapped_rows(line: &Line, width: u16) -> u16 {
+    use unicode_width::UnicodeWidthStr;
+    if width == 0 {
+        return 1;
+    }
+    let max = width as usize;
+    let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    let trimmed = text.trim_end();
+    if trimmed.trim_start().is_empty() {
+        return 1;
+    }
+    let indent = trimmed.len() - trimmed.trim_start().len();
+    let mut rows: u16 = 1;
+    let mut used = trimmed[..indent].width().min(max);
+    let mut first_in_row = used == 0;
+    for word in trimmed.split_whitespace() {
+        let word_width = word.width().max(1);
+        let sep = if first_in_row { 0 } else { 1 };
+        if used + sep + word_width <= max {
+            used += sep + word_width;
+            first_in_row = false;
+        } else if word_width <= max {
+            rows = rows.saturating_add(1);
+            used = word_width;
+            first_in_row = false;
+        } else {
+            // A word wider than the popup hard-splits across rows.
+            let full = word_width.div_ceil(max);
+            if used > 0 {
+                rows = rows.saturating_add(1);
+            }
+            rows = rows.saturating_add((full - 1) as u16);
+            used = word_width - (full - 1) * max;
+            first_in_row = false;
+        }
+    }
+    rows
+}
+
+fn wrapped_rows_total(lines: &[Line], width: u16) -> u16 {
+    lines
+        .iter()
+        .map(|l| wrapped_rows(l, width))
+        .fold(0u16, u16::saturating_add)
+}
+
 fn setting_type_label(t: aoe_plugin_api::SettingType) -> &'static str {
     match t {
         aoe_plugin_api::SettingType::String => "string",
@@ -320,6 +384,7 @@ impl PluginManagerDialog {
             pending_plugin: None,
             popup: None,
             popup_scroll: Cell::new(0),
+            popup_user_scrolled: false,
         };
         dialog.reload();
         dialog.mutated = false; // Initial load is not a user mutation.
@@ -369,6 +434,7 @@ impl PluginManagerDialog {
     fn open_popup(&mut self, popup: Popup) {
         self.popup = Some(popup);
         self.popup_scroll.set(0);
+        self.popup_user_scrolled = false;
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
@@ -452,11 +518,13 @@ impl PluginManagerDialog {
             KeyCode::Down | KeyCode::Char('j') => {
                 self.popup_scroll
                     .set(self.popup_scroll.get().saturating_add(1));
+                self.popup_user_scrolled = true;
                 return DialogResult::Continue;
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 self.popup_scroll
                     .set(self.popup_scroll.get().saturating_sub(1));
+                self.popup_user_scrolled = true;
                 return DialogResult::Continue;
             }
             _ => {}
@@ -1265,11 +1333,21 @@ impl PluginManagerDialog {
 
         let Some(consent) = &review.consent else {
             // Safe update: changelog only, with an update/cancel hint.
-            lines.push(Line::from(Span::styled(
+            let footer = vec![Line::from(Span::styled(
                 "enter update · esc cancel · j/k scroll",
                 Style::default().fg(theme.dimmed),
-            )));
-            self.draw_popup(f, area, theme, lines, " Update plugin ");
+            ))];
+            self.draw_popup(
+                f,
+                area,
+                theme,
+                PopupContent {
+                    body: lines,
+                    footer,
+                    follow_tail: false,
+                    title: " Update plugin ",
+                },
+            );
             return;
         };
 
@@ -1329,12 +1407,21 @@ impl PluginManagerDialog {
             "Approving trusts this plugin; a worker and build steps run without OS sandboxing.",
             Style::default().fg(theme.dimmed),
         )));
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
+        let footer = vec![Line::from(Span::styled(
             "y approve · n decline · esc close · j/k scroll",
             Style::default().fg(theme.dimmed),
-        )));
-        self.draw_popup(f, area, theme, lines, " Approve update ");
+        ))];
+        self.draw_popup(
+            f,
+            area,
+            theme,
+            PopupContent {
+                body: lines,
+                footer,
+                follow_tail: false,
+                title: " Approve update ",
+            },
+        );
     }
 
     fn render_install_consent(
@@ -1409,12 +1496,21 @@ impl PluginManagerDialog {
             "Approving trusts this plugin; a worker and build steps run without OS sandboxing.",
             Style::default().fg(theme.dimmed),
         )));
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
+        let footer = vec![Line::from(Span::styled(
             "y install · n cancel · j/k scroll",
             Style::default().fg(theme.dimmed),
-        )));
-        self.draw_popup(f, area, theme, lines, " Approve install ");
+        ))];
+        self.draw_popup(
+            f,
+            area,
+            theme,
+            PopupContent {
+                body: lines,
+                footer,
+                follow_tail: false,
+                title: " Approve install ",
+            },
+        );
     }
 
     fn render_reapprove(
@@ -1471,12 +1567,21 @@ impl PluginManagerDialog {
             "No build steps run; this only re-grants the already-installed version.",
             Style::default().fg(theme.dimmed),
         )));
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
+        let footer = vec![Line::from(Span::styled(
             "y approve · esc cancel · j/k scroll",
             Style::default().fg(theme.dimmed),
-        )));
-        self.draw_popup(f, area, theme, lines, " Approve plugin ");
+        ))];
+        self.draw_popup(
+            f,
+            area,
+            theme,
+            PopupContent {
+                body: lines,
+                footer,
+                follow_tail: false,
+                title: " Approve plugin ",
+            },
+        );
     }
 
     fn render_confirm_uninstall(&self, f: &mut Frame, area: Rect, theme: &Theme, id: &str) {
@@ -1489,13 +1594,22 @@ impl PluginManagerDialog {
                 "Removes its files, configuration, and lockfile entry. Per-session plugin data is kept.",
                 Style::default().fg(theme.dimmed),
             )),
-            Line::from(""),
-            Line::from(Span::styled(
-                "y uninstall · esc cancel",
-                Style::default().fg(theme.dimmed),
-            )),
         ];
-        self.draw_popup(f, area, theme, lines, " Uninstall plugin ");
+        let footer = vec![Line::from(Span::styled(
+            "y uninstall · esc cancel",
+            Style::default().fg(theme.dimmed),
+        ))];
+        self.draw_popup(
+            f,
+            area,
+            theme,
+            PopupContent {
+                body: lines,
+                footer,
+                follow_tail: false,
+                title: " Uninstall plugin ",
+            },
+        );
     }
 
     fn render_details(&self, f: &mut Frame, area: Rect, theme: &Theme, details: &Details) {
@@ -1622,12 +1736,21 @@ impl PluginManagerDialog {
                 )));
             }
         }
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
+        let footer = vec![Line::from(Span::styled(
             "j/k scroll · esc close",
             Style::default().fg(theme.dimmed),
-        )));
-        self.draw_popup(f, area, theme, lines, " Plugin details ");
+        ))];
+        self.draw_popup(
+            f,
+            area,
+            theme,
+            PopupContent {
+                body: lines,
+                footer,
+                follow_tail: false,
+                title: " Plugin details ",
+            },
+        );
     }
 
     fn render_progress(&self, f: &mut Frame, area: Rect, theme: &Theme, progress: &Progress) {
@@ -1638,51 +1761,93 @@ impl PluginManagerDialog {
                 Style::default().fg(theme.dimmed),
             )));
         }
-        lines.push(Line::from(""));
+        // Status and keys live in the pinned footer so a long log tail (or a
+        // long error) can never push them off screen.
+        let mut footer: Vec<Line> = Vec::new();
         match &progress.done {
-            None => lines.push(Line::from(Span::styled(
-                format!("Working… (log: {})", progress.log_path.display()),
-                Style::default().fg(theme.waiting),
-            ))),
+            None => {
+                footer.push(Line::from(Span::styled(
+                    "Working…",
+                    Style::default().fg(theme.waiting),
+                )));
+                footer.push(Line::from(Span::styled(
+                    format!(
+                        "esc hide (keeps running) · log: {}",
+                        progress.log_path.display()
+                    ),
+                    Style::default().fg(theme.dimmed),
+                )));
+            }
             Some(Ok(message)) => {
-                lines.push(Line::from(Span::styled(
+                footer.push(Line::from(Span::styled(
                     message.clone(),
                     Style::default().fg(theme.running),
                 )));
-                lines.push(Line::from(Span::styled(
+                footer.push(Line::from(Span::styled(
                     "esc close",
                     Style::default().fg(theme.dimmed),
                 )));
             }
             Some(Err(message)) => {
-                lines.push(Line::from(Span::styled(
+                footer.push(Line::from(Span::styled(
                     message.clone(),
                     Style::default().fg(theme.error),
                 )));
-                lines.push(Line::from(Span::styled(
+                footer.push(Line::from(Span::styled(
                     format!("Full log: {}", progress.log_path.display()),
                     Style::default().fg(theme.dimmed),
                 )));
-                lines.push(Line::from(Span::styled(
+                footer.push(Line::from(Span::styled(
                     "esc close",
                     Style::default().fg(theme.dimmed),
                 )));
             }
         }
-        self.draw_popup(f, area, theme, lines, &progress.title);
+        // While the operation runs, follow the newest log rows (unless the
+        // user scrolled away themselves); once done, the last position keeps
+        // the outcome context in view.
+        let follow = progress.done.is_none() && !self.popup_user_scrolled;
+        self.draw_popup(
+            f,
+            area,
+            theme,
+            PopupContent {
+                body: lines,
+                footer,
+                follow_tail: follow,
+                title: &progress.title,
+            },
+        );
     }
 
-    /// Draw a popup body into a clamped, centered sub-rect, scrolled by
-    /// `popup_scroll` (clamped here to the real content height, which only
-    /// render knows).
-    fn draw_popup(&self, f: &mut Frame, area: Rect, theme: &Theme, lines: Vec<Line>, title: &str) {
+    /// Draw a popup as a scrollable body above a pinned footer (the decision
+    /// keys / status), both word-wrapped, in a clamped centered sub-rect.
+    /// Sizing and the scroll bound are computed from wrapped (visual) rows,
+    /// not logical line counts, so a wrapping body can never push the footer
+    /// off screen and the last body row is always reachable by scrolling.
+    fn draw_popup(&self, f: &mut Frame, area: Rect, theme: &Theme, content: PopupContent) {
+        let PopupContent {
+            body,
+            footer,
+            follow_tail,
+            title,
+        } = content;
         // A tiny terminal can be narrower/shorter than our preferred size;
         // never pass clamp/centered_rect a max below the min (it panics).
         if area.width == 0 || area.height == 0 {
             return;
         }
         let width = area.width.clamp(1, 72);
-        let height = (lines.len() as u16).saturating_add(2).clamp(1, area.height);
+        let inner_width = width.saturating_sub(2).max(1);
+        let body_rows = wrapped_rows_total(&body, inner_width);
+        // The footer is pinned in full, but a pathological one (a long error
+        // chain) may never starve the body of its half of the popup.
+        let footer_rows = wrapped_rows_total(&footer, inner_width)
+            .min((area.height.saturating_sub(2) / 2).max(1));
+        let height = body_rows
+            .saturating_add(footer_rows)
+            .saturating_add(2)
+            .clamp(1, area.height);
         let rect = centered_rect(area, width, height);
         f.render_widget(Clear, rect);
         let block = Block::default()
@@ -1692,16 +1857,51 @@ impl PluginManagerDialog {
             .border_style(Style::default().fg(theme.accent));
         let inner = block.inner(rect);
         f.render_widget(block, rect);
-        // Clamp the scroll so the last line can always be brought into view
-        // but never scrolled past; `Cell` because render is `&self`.
-        let max_scroll = (lines.len() as u16).saturating_sub(inner.height.max(1));
+        let footer_rows = if footer.is_empty() {
+            0
+        } else {
+            footer_rows.min(inner.height)
+        };
+        let body_height = inner.height.saturating_sub(footer_rows);
+        // Clamp the scroll so the last body row can always be brought into
+        // view but never scrolled far past; `Cell` because render is `&self`.
+        // One slack row absorbs any wrap-estimation drift, erring toward
+        // reachable rather than clipped.
+        let max_scroll = if body_rows > body_height {
+            (body_rows - body_height).saturating_add(1)
+        } else {
+            0
+        };
+        // A following popup (the running progress log) pins the view to the
+        // newest rows; writing it back to the Cell means a later manual `k`
+        // scrolls up from the bottom, not from wherever the offset last was.
+        if follow_tail {
+            self.popup_scroll.set(max_scroll);
+        }
         if self.popup_scroll.get() > max_scroll {
             self.popup_scroll.set(max_scroll);
         }
-        let body = Paragraph::new(lines)
-            .wrap(Wrap { trim: true })
-            .scroll((self.popup_scroll.get(), 0));
-        f.render_widget(body, inner);
+        if body_height > 0 {
+            let body_area = Rect {
+                height: body_height,
+                ..inner
+            };
+            let body = Paragraph::new(body)
+                .wrap(Wrap { trim: true })
+                .scroll((self.popup_scroll.get(), 0));
+            f.render_widget(body, body_area);
+        }
+        if footer_rows > 0 {
+            let footer_area = Rect {
+                y: inner.y + body_height,
+                height: footer_rows,
+                ..inner
+            };
+            f.render_widget(
+                Paragraph::new(footer).wrap(Wrap { trim: true }),
+                footer_area,
+            );
+        }
     }
 
     fn render_browse(&self, f: &mut Frame, area: Rect, theme: &Theme) {
@@ -1911,5 +2111,51 @@ impl PluginManagerDialog {
             .style(Style::default().fg(color))
             .wrap(Wrap { trim: true });
         f.render_widget(footer, area);
+    }
+}
+
+#[cfg(test)]
+mod wrapped_rows_tests {
+    use super::{wrapped_rows, wrapped_rows_total};
+    use ratatui::prelude::*;
+
+    fn line(s: &str) -> Line<'static> {
+        Line::from(s.to_string())
+    }
+
+    #[test]
+    fn short_and_empty_lines_take_one_row() {
+        assert_eq!(wrapped_rows(&line(""), 20), 1);
+        assert_eq!(wrapped_rows(&line("hello"), 20), 1);
+        assert_eq!(wrapped_rows(&line("fits the row width"), 18), 1);
+    }
+
+    #[test]
+    fn word_wrap_counts_continuation_rows() {
+        // "alpha bravo" (11) into width 7: "alpha" / "bravo".
+        assert_eq!(wrapped_rows(&line("alpha bravo"), 7), 2);
+        assert_eq!(wrapped_rows(&line("alpha bravo charlie"), 7), 3);
+    }
+
+    #[test]
+    fn indentation_counts_toward_the_first_row() {
+        // Two leading spaces + "abcdef" into width 6 needs a wrap that the
+        // unindented text would not.
+        assert_eq!(wrapped_rows(&line("abcdef"), 6), 1);
+        assert_eq!(wrapped_rows(&line("  abcdef"), 6), 2);
+    }
+
+    #[test]
+    fn over_wide_word_splits_across_rows() {
+        // A 20-wide token into width 8 needs three rows on its own.
+        assert_eq!(wrapped_rows(&line("aaaaaaaaaaaaaaaaaaaa"), 8), 3);
+        // After a word already on the row, the split starts on a fresh row.
+        assert_eq!(wrapped_rows(&line("hi aaaaaaaaaaaaaaaaaaaa"), 8), 4);
+    }
+
+    #[test]
+    fn totals_sum_per_line() {
+        let lines = [line("alpha bravo"), line(""), line("x")];
+        assert_eq!(wrapped_rows_total(&lines, 7), 4);
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -104,15 +104,24 @@ impl SettingsView {
         if self.current_category() == SettingsCategory::Plugins
             && self.focus == SettingsFocus::Fields
         {
-            if key.code == KeyCode::Tab
-                && !self.fields.is_empty()
-                && !self.plugin_manager.captures_input()
-            {
-                self.plugins_fields_focus = !self.plugins_fields_focus;
-                return SettingsAction::Continue;
-            }
-            if !self.plugins_fields_focus {
-                return self.handle_plugins_manager_key(key);
+            // Scope keys behave like on every other tab rather than being
+            // swallowed by the manager: the Plugins tab is Global-only (like
+            // Telemetry), so a scope switch falls back to the new scope's
+            // first tab. Not while the manager captures input, where `[`/`{`
+            // are literal text for the discovery search query.
+            let scope_key = matches!(key.code, KeyCode::Char('[' | ']' | '{' | '}'))
+                && !self.plugin_manager.captures_input();
+            if !scope_key {
+                if key.code == KeyCode::Tab
+                    && !self.fields.is_empty()
+                    && !self.plugin_manager.captures_input()
+                {
+                    self.plugins_fields_focus = !self.plugins_fields_focus;
+                    return SettingsAction::Continue;
+                }
+                if !self.plugins_fields_focus {
+                    return self.handle_plugins_manager_key(key);
+                }
             }
         }
 

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -799,6 +799,13 @@ impl SettingsView {
         {
             self.focus = SettingsFocus::Fields;
             self.selected_field = idx;
+            // On the Plugins tab the field list shares the right pane with
+            // the plugin manager; a click on a field row must also move the
+            // sub-focus there, or the keyboard would keep driving the manager
+            // while the clicked field renders selected.
+            if self.current_category() == SettingsCategory::Plugins {
+                self.plugins_fields_focus = true;
+            }
             return Some(SettingsAction::Continue);
         }
 

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -94,14 +94,26 @@ impl SettingsView {
             return SettingsAction::Continue;
         }
 
-        // The Plugins category hosts the plugin manager inline. While the right
-        // pane is focused the manager owns the keys: Space stages an
-        // enable/disable into this view's config, Esc steps back to the
-        // category panel.
+        // The Plugins category hosts the plugin manager inline, with the
+        // active plugins' editable settings fields beneath it. Tab toggles
+        // the sub-focus between the two panes; the manager owns every key
+        // while it has the sub-focus (Space stages an enable/disable, Esc
+        // steps back to the category panel). With the fields sub-focused,
+        // keys fall through to the normal field handling below, so plugin
+        // settings edit and save exactly like core settings.
         if self.current_category() == SettingsCategory::Plugins
             && self.focus == SettingsFocus::Fields
         {
-            return self.handle_plugins_manager_key(key);
+            if key.code == KeyCode::Tab
+                && !self.fields.is_empty()
+                && !self.plugin_manager.captures_input()
+            {
+                self.plugins_fields_focus = !self.plugins_fields_focus;
+                return SettingsAction::Continue;
+            }
+            if !self.plugins_fields_focus {
+                return self.handle_plugins_manager_key(key);
+            }
         }
 
         // Normal mode
@@ -395,14 +407,17 @@ impl SettingsView {
     }
 
     /// Route a key to the embedded plugin manager (Plugins category). Space
-    /// (and Enter) stage an enable/disable into this view's config; Esc/`q`
+    /// stages an enable/disable into this view's config; Esc/`q`
     /// (manager Cancel) returns to the category panel.
     fn handle_plugins_manager_key(&mut self, key: KeyEvent) -> SettingsAction {
-        // Space/Enter STAGE enable/disable in this view's config, like every
+        // Space STAGES enable/disable in this view's config, like every
         // other settings row, instead of writing to disk immediately. That
         // keeps it in the Ctrl-s save flow (no surprise immediate write, no
-        // file-watch flash); the row shows the pending state at once.
-        if matches!(key.code, KeyCode::Char(' ') | KeyCode::Enter) {
+        // file-watch flash); the row shows the pending state at once. Only
+        // when the manager is not capturing input itself (a consent popup,
+        // the discovery search): those own every key, Space included. Enter
+        // falls through to the manager (details popup).
+        if key.code == KeyCode::Char(' ') && !self.plugin_manager.captures_input() {
             if let Some(p) = self.plugin_manager.selected() {
                 let id = p.id.clone();
                 let enabled = !p.enabled;

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -431,7 +431,8 @@ impl SettingsView {
             }
             return SettingsAction::Continue;
         }
-        match self.plugin_manager.handle_key(key) {
+        let selected_before = self.plugin_manager.selected().map(|p| p.id.clone());
+        let result = match self.plugin_manager.handle_key(key) {
             DialogResult::Continue | DialogResult::Submit(()) => {
                 if self.plugin_manager.take_mutated() {
                     self.resync_after_plugin_mutation();
@@ -442,7 +443,14 @@ impl SettingsView {
                 self.focus = SettingsFocus::Categories;
                 SettingsAction::Continue
             }
+        };
+        // Master-detail: moving the manager selection swaps which plugin's
+        // settings the fields pane shows, so a selection change rebuilds the
+        // (filtered) field list.
+        if self.plugin_manager.selected().map(|p| p.id.clone()) != selected_before {
+            self.rebuild_fields();
         }
+        result
     }
 
     /// Drive the settings-wide search overlay. Esc closes without

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -525,11 +525,47 @@ impl SettingsView {
         let Ok(disk) = Config::load() else {
             return;
         };
+        // The user may hold unsaved staged edits (a staged toggle, an edited
+        // plugin setting) while a lifecycle operation rewrites plugin config
+        // on disk. Re-apply the staged diff (staged vs old baseline) on top
+        // of the fresh disk state so those edits survive the resync. The
+        // merge is per field: only the user-editable fields (`enabled`,
+        // `settings`) carry staged diffs; the lifecycle-owned fields
+        // (`source`, `grant`, `dismissed_update`) always take the disk value,
+        // so a staged toggle can never wipe a grant the operation just wrote.
+        let old_baseline: std::collections::BTreeMap<String, crate::session::PluginConfig> = self
+            .baseline_global
+            .get("plugins")
+            .cloned()
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default();
+        let staged = std::mem::take(&mut self.global_config.plugins);
+        let baseline_val = serde_json::to_value(&disk.plugins);
         self.global_config.plugins = disk.plugins;
-        if let (Some(obj), Ok(plugins_val)) = (
-            self.baseline_global.as_object_mut(),
-            serde_json::to_value(&self.global_config.plugins),
-        ) {
+        for (id, staged_config) in staged {
+            let was_in_baseline = old_baseline.contains_key(&id);
+            match self.global_config.plugins.get_mut(&id) {
+                Some(disk_entry) => {
+                    let base = old_baseline.get(&id).cloned().unwrap_or_default();
+                    if staged_config.enabled != base.enabled {
+                        disk_entry.enabled = staged_config.enabled;
+                    }
+                    if staged_config.settings != base.settings {
+                        disk_entry.settings = staged_config.settings;
+                    }
+                }
+                None => {
+                    // Not on disk: keep a purely user-staged entry (a first
+                    // toggle for a plugin with no config row yet); drop edits
+                    // for an id the operation removed (it was in the
+                    // baseline, so the removal is the newer intent).
+                    if !was_in_baseline {
+                        self.global_config.plugins.insert(id, staged_config);
+                    }
+                }
+            }
+        }
+        if let (Some(obj), Ok(plugins_val)) = (self.baseline_global.as_object_mut(), baseline_val) {
             obj.insert("plugins".to_string(), plugins_val);
         }
         self.recompute_dirty();
@@ -754,7 +790,7 @@ impl SettingsView {
                 let changes =
                     plugin_enabled_changes(self.baseline_global.get("plugins"), &now_plugins);
                 if !changes.is_empty() {
-                    tokio::spawn(crate::plugin::install::nudge_daemon_enabled(changes));
+                    crate::plugin::install::nudge_daemon_enabled(changes);
                 }
             }
         }
@@ -1127,6 +1163,85 @@ mod dirty_tracking_tests {
         assert!(
             Config::load().unwrap().session.confirm_delete,
             "an edit-free save must not revert a peer's write"
+        );
+    }
+
+    /// A lifecycle operation resync must keep unsaved staged edits: the
+    /// staged diff is re-applied per user-editable field on top of the disk
+    /// state, while a lifecycle-owned field (the grant) always takes the disk
+    /// value, even on a plugin the user also staged an edit for.
+    #[test]
+    #[serial]
+    fn resync_after_plugin_mutation_preserves_staged_edits() {
+        let (_home, _temp, mut view) = fresh_view();
+        view.scope = SettingsScope::Global;
+
+        // The user stages (unsaved): disable plugin "a".
+        view.global_config
+            .plugins
+            .entry("a".to_string())
+            .or_default()
+            .enabled = false;
+        view.recompute_dirty();
+        assert!(view.has_changes);
+
+        // A lifecycle operation rewrites plugin config on disk: grants "a"
+        // and installs "b".
+        crate::session::config::update_config(|c| {
+            let a = c.plugins.entry("a".to_string()).or_default();
+            a.grant = Some(crate::session::CapabilityGrant {
+                manifest_hash: "sha256:abc".to_string(),
+                capabilities: vec!["net".to_string()],
+                granted_at: chrono::Utc::now(),
+            });
+            c.plugins.entry("b".to_string()).or_default().enabled = true;
+        })
+        .unwrap();
+
+        view.resync_after_plugin_mutation();
+
+        let a = view.global_config.plugins.get("a").expect("a survives");
+        assert!(!a.enabled, "the staged toggle must survive the resync");
+        assert!(
+            a.grant.is_some(),
+            "the lifecycle-written grant must win over the staged copy"
+        );
+        assert!(
+            view.global_config.plugins.contains_key("b"),
+            "the disk-side install must appear in the staged view"
+        );
+        assert!(view.has_changes, "the staged toggle keeps the view dirty");
+    }
+
+    /// A staged entry for a plugin with no config row on disk (a first toggle
+    /// for a builtin) survives a resync; it was never in the baseline, so no
+    /// lifecycle operation can have removed it.
+    #[test]
+    #[serial]
+    fn resync_keeps_staged_entry_for_plugin_absent_from_disk() {
+        let (_home, _temp, mut view) = fresh_view();
+        view.scope = SettingsScope::Global;
+        view.global_config
+            .plugins
+            .entry("aoe.web".to_string())
+            .or_default()
+            .enabled = false;
+
+        crate::session::config::update_config(|c| {
+            c.plugins.entry("other".to_string()).or_default().enabled = false;
+        })
+        .unwrap();
+
+        view.resync_after_plugin_mutation();
+
+        assert!(
+            !view
+                .global_config
+                .plugins
+                .get("aoe.web")
+                .expect("staged entry kept")
+                .enabled,
+            "a purely user-staged entry must survive the resync"
         );
     }
 }

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -259,6 +259,11 @@ pub struct SettingsView {
     /// hosted inline so the builtin plugin list lives on the settings screen.
     /// One implementation, reused; it reloads its own list on mutation.
     pub(super) plugin_manager: crate::tui::dialogs::PluginManagerDialog,
+
+    /// Sub-focus within the Plugins category's right pane: `false` targets
+    /// the plugin manager (top), `true` the editable plugin settings fields
+    /// beneath it. Tab toggles; reset when the field list rebuilds.
+    pub(super) plugins_fields_focus: bool,
 }
 
 impl SettingsView {
@@ -333,6 +338,7 @@ impl SettingsView {
             field_rects: Vec::new(),
             mouse_pos: None,
             plugin_manager: crate::tui::dialogs::PluginManagerDialog::embedded(),
+            plugins_fields_focus: false,
         };
 
         // The constructor parks `selected_category` at 0, which is the
@@ -497,6 +503,12 @@ impl SettingsView {
             self.selected_field = 0;
         }
         self.fields_scroll_offset = 0;
+        // With no fields there is no pane to sub-focus; otherwise keep the
+        // Plugins sub-focus where the user left it (a save or plugin mutation
+        // rebuilds this list and must not yank focus back to the manager).
+        if self.fields.is_empty() {
+            self.plugins_fields_focus = false;
+        }
         // If the (clamped) selected_field landed on a non-interactive
         // section divider, advance to the next real field so the user
         // never sees the cursor parked on a heading.
@@ -521,6 +533,10 @@ impl SettingsView {
             obj.insert("plugins".to_string(), plugins_val);
         }
         self.recompute_dirty();
+        // An install/uninstall/re-approve changes the active plugin set, and
+        // with it the virtual `plugin:<id>` settings sections; rebuild so the
+        // fields pane under the manager tracks it.
+        self.rebuild_fields();
     }
 
     /// Advance `selected_field` to the first interactive field
@@ -725,11 +741,21 @@ impl SettingsView {
         // changed, reload the registry so the save takes effect live (a
         // disabled plugin drops from the active set). Compared against the
         // still-old baseline before snapshotting. Mirrors what the immediate
-        // `aoe plugin enable/disable` CLI path does.
+        // `aoe plugin enable/disable` CLI path does. A running daemon's
+        // workers are nudged too (best-effort, fire-and-forget): the save
+        // wrote config wholesale, which a daemon never watches.
         if self.scope == SettingsScope::Global {
             let now_plugins = serde_json::to_value(&self.global_config.plugins).ok();
             if now_plugins.as_ref() != self.baseline_global.get("plugins") {
                 crate::plugin::reload_registry();
+                // The active set changed, so the virtual `plugin:<id>`
+                // settings sections may have too.
+                self.rebuild_fields();
+                let changes =
+                    plugin_enabled_changes(self.baseline_global.get("plugins"), &now_plugins);
+                if !changes.is_empty() {
+                    tokio::spawn(crate::plugin::install::nudge_daemon_enabled(changes));
+                }
             }
         }
 
@@ -746,9 +772,15 @@ impl SettingsView {
     /// toast was cleared so the caller can request a redraw. Errors are sticky
     /// (no expiry) and clear only on the next keypress.
     pub fn tick_status(&mut self) -> bool {
-        // Poll the embedded plugin manager's in-flight discovery / update-check
-        // task so its results land without waiting for the next keypress.
+        // Poll the embedded plugin manager's in-flight discovery / update /
+        // install / uninstall task so its results land without waiting for the
+        // next keypress. A completed lifecycle operation rewrote plugin config
+        // on disk; resync right away so this view's staged copy (and the dirty
+        // marker) never lags a keypress behind.
         let plugin_changed = self.plugin_manager.tick();
+        if plugin_changed && self.plugin_manager.take_mutated() {
+            self.resync_after_plugin_mutation();
+        }
         let toast_changed = match self.success_message_expires_at {
             Some(expires_at) if std::time::Instant::now() >= expires_at => {
                 self.success_message = None;
@@ -882,7 +914,92 @@ impl SettingsView {
             self.ensure_field_visible(self.fields_viewport_height);
         }
         self.focus = SettingsFocus::Fields;
+        // A hit inside the Plugins category targets a plugin settings field,
+        // not the manager pane above it: give the field list the sub-focus so
+        // the jump lands on an editable row.
+        self.plugins_fields_focus = self.current_category() == SettingsCategory::Plugins;
         self.close_search();
+    }
+}
+
+/// Ids whose `enabled` flag differs between two serialized `config.plugins`
+/// subtrees, with the flag's new value. An absent entry (or an id missing
+/// entirely) counts as enabled, the config default. Drives the best-effort
+/// daemon worker nudge after a settings save, which writes `config.plugins`
+/// wholesale rather than toggling one id at a time.
+fn plugin_enabled_changes(
+    before: Option<&serde_json::Value>,
+    after: &Option<serde_json::Value>,
+) -> Vec<(String, bool)> {
+    fn enabled_map(value: Option<&serde_json::Value>) -> std::collections::BTreeMap<String, bool> {
+        value
+            .and_then(|v| v.as_object())
+            .map(|map| {
+                map.iter()
+                    .map(|(id, cfg)| {
+                        let enabled = cfg.get("enabled").and_then(|e| e.as_bool()).unwrap_or(true);
+                        (id.clone(), enabled)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    let old = enabled_map(before);
+    let new = enabled_map(after.as_ref());
+    let mut changes = Vec::new();
+    for (id, enabled) in &new {
+        if old.get(id).copied().unwrap_or(true) != *enabled {
+            changes.push((id.clone(), *enabled));
+        }
+    }
+    // An id dropped from the map reverts to the default (enabled).
+    for (id, was_enabled) in &old {
+        if !new.contains_key(id) && !*was_enabled {
+            changes.push((id.clone(), true));
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod plugin_enabled_changes_tests {
+    use super::plugin_enabled_changes;
+    use serde_json::json;
+
+    #[test]
+    fn detects_toggles_and_ignores_unchanged() {
+        let before = json!({
+            "a": { "enabled": true },
+            "b": { "enabled": false },
+            "c": { "enabled": true, "settings": { "k": 1 } },
+        });
+        let after = Some(json!({
+            "a": { "enabled": false },
+            "b": { "enabled": false },
+            "c": { "enabled": true, "settings": { "k": 2 } },
+        }));
+        let changes = plugin_enabled_changes(Some(&before), &after);
+        assert_eq!(changes, vec![("a".to_string(), false)]);
+    }
+
+    #[test]
+    fn absent_entry_counts_as_enabled() {
+        // A new id appearing as disabled is a change; one appearing enabled
+        // is not (enabled is the default for unknown ids).
+        let after = Some(json!({
+            "fresh-off": { "enabled": false },
+            "fresh-on": { "enabled": true },
+        }));
+        let changes = plugin_enabled_changes(None, &after);
+        assert_eq!(changes, vec![("fresh-off".to_string(), false)]);
+    }
+
+    #[test]
+    fn dropped_disabled_entry_reverts_to_enabled() {
+        let before = json!({ "gone": { "enabled": false } });
+        let after = Some(json!({}));
+        let changes = plugin_enabled_changes(Some(&before), &after);
+        assert_eq!(changes, vec![("gone".to_string(), true)]);
     }
 }
 

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -1234,6 +1234,43 @@ mod dirty_tracking_tests {
         assert!(view.has_changes, "the staged toggle keeps the view dirty");
     }
 
+    /// The Plugins tab is Global-only, so `]` from either of its sub-panes
+    /// switches scope like on every other Global-only tab (Telemetry),
+    /// falling back to the new scope's first tab, instead of the manager
+    /// pane swallowing the key.
+    #[test]
+    #[serial]
+    fn scope_keys_from_plugins_tab_switch_scope_in_both_sub_panes() {
+        use crossterm::event::{KeyCode, KeyEvent};
+
+        for fields_subfocus in [false, true] {
+            let (_home, _temp, mut view) = fresh_view();
+            view.scope = SettingsScope::Global;
+            let plugins_idx = view
+                .categories
+                .iter()
+                .position(|r| *r == CategoryRow::Tab(SettingsCategory::Plugins))
+                .expect("Plugins tab exists in Global scope");
+            view.selected_category = plugins_idx;
+            view.rebuild_fields();
+            view.focus = SettingsFocus::Fields;
+            view.plugins_fields_focus = fields_subfocus;
+
+            view.handle_key(KeyEvent::from(KeyCode::Char(']')));
+
+            assert_eq!(
+                view.scope,
+                SettingsScope::Profile,
+                "']' must switch scope with fields_subfocus={fields_subfocus}"
+            );
+            assert_ne!(
+                view.current_category(),
+                SettingsCategory::Plugins,
+                "the Global-only Plugins tab falls back to another tab in Profile scope"
+            );
+        }
+    }
+
     /// A staged entry for a plugin with no config row on disk (a first toggle
     /// for a builtin) survives a resync; it was never in the baseline, so no
     /// lifecycle operation can have removed it.

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -499,6 +499,17 @@ impl SettingsView {
         };
         self.fields =
             fields::build_fields_for_category(category, scope_for_fields, global_ref, profile_ref);
+        // Master-detail on the Plugins tab: the fields pane tracks the
+        // manager's selected plugin, so only that plugin's settings render
+        // beneath the list (moving the list selection swaps the pane).
+        if category == SettingsCategory::Plugins {
+            let selected = self.plugin_manager.selected().map(|p| p.id.clone());
+            self.fields.retain(|f| {
+                f.schema_section()
+                    .and_then(crate::session::settings_schema::section_plugin_id)
+                    == selected.as_deref()
+            });
+        }
         if self.selected_field >= self.fields.len() {
             self.selected_field = 0;
         }
@@ -941,6 +952,16 @@ impl SettingsView {
             self.selected_category = idx;
         }
         self.rebuild_fields();
+        // A hit inside the Plugins category belongs to one plugin's virtual
+        // section: select that plugin's manager row first, then rebuild so
+        // the master-detail filter keeps the target field.
+        if self.current_category() == SettingsCategory::Plugins
+            && self
+                .plugin_manager
+                .select_plugin_owning_ident(&hit.field_ident)
+        {
+            self.rebuild_fields();
+        }
         if let Some(idx) = self
             .fields
             .iter()

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -255,10 +255,12 @@ impl SettingsView {
         // pane; every other category renders the normal field list.
         if self.current_category() == SettingsCategory::Plugins {
             let focused = self.focus == SettingsFocus::Fields;
-            // When the active plugin set declares settings, split the right pane:
-            // the enable/disable manager on top, a read-only summary of plugin
-            // settings below. Editing plugin settings is done from the web
-            // dashboard or `aoe settings` at Tier 0; the manager keeps focus.
+            // When the active plugin set declares settings, split the right
+            // pane: the enable/disable manager on top, the plugins' editable
+            // settings fields below (the same generic field list every other
+            // category renders). Tab moves the sub-focus between the panes.
+            self.plugin_manager
+                .set_has_settings_pane(!self.fields.is_empty());
             if self.fields.is_empty() {
                 self.plugin_manager
                     .render_inline(frame, layout[1], theme, focused);
@@ -267,12 +269,16 @@ impl SettingsView {
                     .direction(Direction::Vertical)
                     .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
                     .split(layout[1]);
-                self.plugin_manager
-                    .render_inline(frame, split[0], theme, focused);
-                self.render_plugin_settings_summary(frame, split[1], theme);
+                self.plugin_manager.render_inline(
+                    frame,
+                    split[0],
+                    theme,
+                    focused && !self.plugins_fields_focus,
+                );
+                self.render_fields(frame, split[1], theme, focused && self.plugins_fields_focus);
             }
         } else {
-            self.render_fields(frame, layout[1], theme);
+            self.render_fields(frame, layout[1], theme, self.focus == SettingsFocus::Fields);
         }
     }
 
@@ -364,53 +370,7 @@ impl SettingsView {
         }
     }
 
-    /// Read-only summary of the active plugins' settings, grouped by plugin,
-    /// shown beneath the plugin manager. Editing is via the web dashboard or
-    /// `aoe settings` at Tier 0.
-    fn render_plugin_settings_summary(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(theme.border))
-            .title(" Plugin Settings (edit via web or `aoe settings`) ")
-            .padding(Padding::horizontal(1));
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
-        let mut lines: Vec<Line> = Vec::new();
-        let mut current_section: Option<String> = None;
-        for field in &self.fields {
-            let Some(section) = field.schema_section() else {
-                continue;
-            };
-            let Some(plugin_id) = crate::session::settings_schema::section_plugin_id(section)
-            else {
-                continue;
-            };
-            if current_section.as_deref() != Some(section) {
-                if current_section.is_some() {
-                    lines.push(Line::from(""));
-                }
-                lines.push(Line::from(Span::styled(
-                    plugin_id.to_string(),
-                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
-                )));
-                current_section = Some(section.to_string());
-            }
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {}: ", field.label),
-                    Style::default().fg(theme.dimmed),
-                ),
-                Span::styled(field.display_value(), Style::default().fg(theme.text)),
-            ]));
-        }
-        frame.render_widget(Paragraph::new(lines), inner);
-    }
-
-    fn render_fields(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let is_focused = self.focus == SettingsFocus::Fields;
-
+    fn render_fields(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, is_focused: bool) {
         let border_style = if is_focused {
             Style::default().fg(theme.accent)
         } else {
@@ -1670,7 +1630,7 @@ mod status_message_tests {
         let area = Rect::new(0, 0, 30, 8);
         let mut terminal = Terminal::new(TestBackend::new(30, 12)).unwrap();
         terminal
-            .draw(|f| view.render_fields(f, area, &theme))
+            .draw(|f| view.render_fields(f, area, &theme, true))
             .unwrap();
         let buf = terminal.backend().buffer().clone();
 

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -255,19 +255,28 @@ impl SettingsView {
         // pane; every other category renders the normal field list.
         if self.current_category() == SettingsCategory::Plugins {
             let focused = self.focus == SettingsFocus::Fields;
-            // When the active plugin set declares settings, split the right
-            // pane: the enable/disable manager on top, the plugins' editable
-            // settings fields below (the same generic field list every other
-            // category renders). Tab moves the sub-focus between the panes.
+            // Master-detail: the manager list on top, sized to its rows, and
+            // the SELECTED plugin's editable settings beneath it (the same
+            // generic field list every other category renders;
+            // `rebuild_fields` filters it to the selection). Tab moves the
+            // sub-focus between the panes. While the manager captures input
+            // (discover mode, an open consent/progress popup) it owns the
+            // whole pane: those surfaces need the space, and popups center
+            // within its rect.
             self.plugin_manager
                 .set_has_settings_pane(!self.fields.is_empty());
-            if self.fields.is_empty() {
+            if self.fields.is_empty() || self.plugin_manager.captures_input() {
                 self.plugin_manager
                     .render_inline(frame, layout[1], theme, focused);
             } else {
+                let manager_height = self
+                    .plugin_manager
+                    .preferred_inline_height()
+                    .min(layout[1].height / 2)
+                    .max(5);
                 let split = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                    .constraints([Constraint::Length(manager_height), Constraint::Min(3)])
                     .split(layout[1]);
                 self.plugin_manager.render_inline(
                     frame,
@@ -275,10 +284,26 @@ impl SettingsView {
                     theme,
                     focused && !self.plugins_fields_focus,
                 );
-                self.render_fields(frame, split[1], theme, focused && self.plugins_fields_focus);
+                let title = self
+                    .plugin_manager
+                    .selected()
+                    .map(|p| format!(" {} settings ", p.name));
+                self.render_fields(
+                    frame,
+                    split[1],
+                    theme,
+                    focused && self.plugins_fields_focus,
+                    title.as_deref(),
+                );
             }
         } else {
-            self.render_fields(frame, layout[1], theme, self.focus == SettingsFocus::Fields);
+            self.render_fields(
+                frame,
+                layout[1],
+                theme,
+                self.focus == SettingsFocus::Fields,
+                None,
+            );
         }
     }
 
@@ -370,18 +395,29 @@ impl SettingsView {
         }
     }
 
-    fn render_fields(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, is_focused: bool) {
+    fn render_fields(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        is_focused: bool,
+        title: Option<&str>,
+    ) {
         let border_style = if is_focused {
             Style::default().fg(theme.accent)
         } else {
             Style::default().fg(theme.border)
         };
 
-        let block = Block::default()
+        let mut block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(border_style)
             .padding(Padding::new(1, 1, 0, 0));
+        // The Plugins master-detail pane names the plugin it shows.
+        if let Some(title) = title {
+            block = block.title(title.to_string());
+        }
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -1630,7 +1666,7 @@ mod status_message_tests {
         let area = Rect::new(0, 0, 30, 8);
         let mut terminal = Terminal::new(TestBackend::new(30, 12)).unwrap();
         terminal
-            .draw(|f| view.render_fields(f, area, &theme, true))
+            .draw(|f| view.render_fields(f, area, &theme, true, None))
             .unwrap();
         let buf = terminal.backend().buffer().clone();
 

--- a/tests/e2e/plugins.rs
+++ b/tests/e2e/plugins.rs
@@ -204,3 +204,120 @@ fn test_palette_opens_plugin_manager_listing_builtins() {
     h.assert_screen_contains("Web Dashboard v1.0.0");
     h.assert_screen_contains("enabled");
 }
+
+/// Open the plugin manager through the palette. Shared by the interactive
+/// manager tests below.
+fn open_manager(h: &TuiTestHarness) {
+    h.wait_for(" aoe ");
+    h.send_keys("C-k");
+    h.wait_for("Commands");
+    h.type_text("plugins");
+    h.wait_for("Manage plugins");
+    h.send_keys("Enter");
+    h.wait_for(" Plugins ");
+}
+
+/// Space in the manager toggles the selected plugin and reports where the
+/// write landed (no daemon here, so the plain local message).
+#[test]
+#[serial]
+fn test_tui_manager_toggle_round_trip() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("plugin_manager_toggle");
+    h.spawn_tui();
+    open_manager(&h);
+    h.assert_screen_contains("enabled");
+
+    h.send_keys("Space");
+    h.wait_for("Disabled aoe.web");
+    h.assert_screen_contains("disabled");
+
+    h.send_keys("Space");
+    h.wait_for("Enabled aoe.web");
+}
+
+/// Enter opens the details popup: the full manifest disclosure for the
+/// selected plugin (`aoe plugin info`'s TUI twin), Esc closes it.
+#[test]
+#[serial]
+fn test_tui_manager_details_popup() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("plugin_manager_details");
+    h.spawn_tui();
+    open_manager(&h);
+
+    h.send_keys("Enter");
+    h.wait_for(" Plugin details ");
+    h.assert_screen_contains("Web Dashboard v1.0.0 (aoe.web)");
+    h.assert_screen_contains("Builtin plugin (compiled into aoe)");
+    h.assert_screen_contains("No capabilities requested.");
+
+    h.send_keys("Escape");
+    h.wait_for_absent(" Plugin details ", std::time::Duration::from_secs(5));
+}
+
+/// The full external-plugin loop the manager now owns: a locally installed
+/// plugin whose manifest changed shows "needs approval"; `a` opens the
+/// re-approval consent popup disclosing its capabilities, `y` re-grants; `x`
+/// then uninstalls it behind a confirmation.
+#[test]
+#[serial]
+fn test_tui_manager_reapprove_and_uninstall_local_plugin() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("plugin_manager_lifecycle");
+
+    // Install a local plugin, then grow its on-disk capability set so the
+    // recorded grant no longer covers the manifest (needs re-approval).
+    let src = h.home_path().join("src-plugin");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("aoe-plugin.toml"),
+        r#"
+id = "acme.tui"
+name = "Tui Test"
+version = "0.1.0"
+api_version = 2
+capabilities = ["net"]
+"#,
+    )
+    .unwrap();
+    let installed = h.run_cli(&["plugin", "install", src.to_str().unwrap(), "--yes"]);
+    assert!(
+        installed.status.success(),
+        "local install failed: {}",
+        String::from_utf8_lossy(&installed.stderr)
+    );
+    let manifest = crate::harness::app_dir_in(h.home_path())
+        .join("plugins")
+        .join("acme.tui")
+        .join("aoe-plugin.toml");
+    let text = std::fs::read_to_string(&manifest).unwrap().replace(
+        "capabilities = [\"net\"]",
+        "capabilities = [\"net\", \"notifications\"]",
+    );
+    std::fs::write(&manifest, text).unwrap();
+
+    h.spawn_tui();
+    open_manager(&h);
+    h.wait_for("Tui Test v0.1.0");
+    h.assert_screen_contains("needs approval");
+
+    // Row order is builtins first, then externals: step down to acme.tui.
+    h.send_keys("j");
+    h.send_keys("a");
+    h.wait_for(" Approve plugin ");
+    h.assert_screen_contains("notifications");
+    h.send_keys("y");
+    h.wait_for("Approved acme.tui");
+    h.wait_for_absent("needs approval", std::time::Duration::from_secs(5));
+
+    // Uninstall the same row behind the confirmation popup.
+    h.send_keys("x");
+    h.wait_for(" Uninstall plugin ");
+    h.send_keys("y");
+    h.wait_for("Uninstalled acme.tui");
+    h.wait_for_absent("Tui Test", std::time::Duration::from_secs(5));
+}

--- a/tests/e2e/plugins.rs
+++ b/tests/e2e/plugins.rs
@@ -310,6 +310,9 @@ capabilities = ["net"]
     h.send_keys("a");
     h.wait_for(" Approve plugin ");
     h.assert_screen_contains("notifications");
+    // The decision keys are a pinned footer: they must be visible no matter
+    // how tall the disclosure body is.
+    h.assert_screen_contains("y approve");
     h.send_keys("y");
     h.wait_for("Approved acme.tui");
     h.wait_for_absent("needs approval", std::time::Duration::from_secs(5));
@@ -317,6 +320,7 @@ capabilities = ["net"]
     // Uninstall the same row behind the confirmation popup.
     h.send_keys("x");
     h.wait_for(" Uninstall plugin ");
+    h.assert_screen_contains("y uninstall");
     h.send_keys("y");
     h.wait_for("Uninstalled acme.tui");
     h.wait_for_absent("Tui Test", std::time::Duration::from_secs(5));

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -325,6 +325,59 @@ capabilities = ["net"]
     }
 }
 
+/// `approve_installed` re-reads the installed tree before honoring the pin: a
+/// manifest changed on disk after the disclosure was built, while the
+/// process-global registry is still stale, must refuse rather than write a
+/// grant for content the user never saw.
+#[tokio::test]
+#[serial]
+async fn approve_refuses_when_manifest_changes_after_disclosure() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.stale"
+name = "Stale"
+version = "0.1.0"
+api_version = 2
+capabilities = ["net"]
+"#,
+    );
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    // Stale the grant so there is a disclosure to approve.
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.stale")
+        .join("aoe-plugin.toml");
+    let text = std::fs::read_to_string(&installed).unwrap().replace(
+        "capabilities = [\"net\"]",
+        "capabilities = [\"net\", \"notifications\"]",
+    );
+    std::fs::write(&installed, text).unwrap();
+    agent_of_empires::plugin::reload_registry();
+    let consent = install::reapprove_consent("acme.stale").unwrap();
+
+    // The manifest changes again after the disclosure, with no registry
+    // reload in between (the popup sat open).
+    let mut text = std::fs::read_to_string(&installed).unwrap();
+    text.push_str("\n# tampered after disclosure\n");
+    std::fs::write(&installed, text).unwrap();
+
+    let err = install::approve_installed("acme.stale", &consent.manifest_hash)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("changed on disk"), "got: {err}");
+    assert!(
+        load_registry()
+            .get("acme.stale")
+            .unwrap()
+            .needs_reapproval(),
+        "the refused approval must leave the plugin inactive"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn github_source_clones_and_records_commit() {

--- a/tests/plugin_install.rs
+++ b/tests/plugin_install.rs
@@ -261,6 +261,70 @@ capabilities = ["net"]
     assert!(plugin.needs_reapproval());
 }
 
+/// Re-approval closes the stale-grant loop without a network fetch: the
+/// disclosure is built from the installed manifest, and approving re-grants
+/// pinned to its hash. A stale disclosure pin refuses rather than granting
+/// something the user never saw.
+#[tokio::test]
+#[serial]
+async fn reapprove_regrants_the_installed_manifest() {
+    let _home = isolate();
+    let src = tempfile::tempdir().unwrap();
+    let dir = write_plugin_dir(
+        src.path(),
+        r#"
+id = "acme.regrant"
+name = "Regrant"
+version = "0.1.0"
+api_version = 2
+capabilities = ["net"]
+"#,
+    );
+    install::install(dir.to_str().unwrap(), true).await.unwrap();
+
+    // Grow the capability set on disk so the grant no longer covers the
+    // manifest; reload the process-global registry the install API consults.
+    let installed = agent_of_empires::plugin::plugins_dir()
+        .unwrap()
+        .join("acme.regrant")
+        .join("aoe-plugin.toml");
+    let text = std::fs::read_to_string(&installed).unwrap().replace(
+        "capabilities = [\"net\"]",
+        "capabilities = [\"net\", \"notifications\"]",
+    );
+    std::fs::write(&installed, text).unwrap();
+    agent_of_empires::plugin::reload_registry();
+    assert!(load_registry()
+        .get("acme.regrant")
+        .unwrap()
+        .needs_reapproval());
+
+    let consent = install::reapprove_consent("acme.regrant").unwrap();
+    assert_eq!(consent.capabilities, vec!["net", "notifications"]);
+
+    // A pin that no longer matches the on-disk manifest refuses.
+    let err = install::approve_installed("acme.regrant", "sha256:stale")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("changed on disk"), "got: {err}");
+
+    install::approve_installed("acme.regrant", &consent.manifest_hash).unwrap();
+    let reg = load_registry();
+    let plugin = reg.get("acme.regrant").unwrap();
+    assert!(plugin.active(), "re-approval must reactivate the plugin");
+    assert!(!plugin.needs_reapproval());
+
+    // A builtin is always granted; re-approval is meaningless for it. Only
+    // checkable when a builtin is compiled in (`aoe.web` is serve-gated).
+    #[cfg(feature = "serve")]
+    {
+        let err = install::reapprove_consent("aoe.web")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("builtin"), "got: {err}");
+    }
+}
+
 #[tokio::test]
 #[serial]
 async fn github_source_clones_and_records_commit() {


### PR DESCRIPTION
> _Note: this PR was implemented and drafted by Claude via back-and-forth with @njbrake. The direction and decisions are his; the code and prose are Claude's._

## Description

The plugin system's web surface got the full lifecycle (install, update, uninstall, consent modals, editable settings) while the TUI manager stalled at list, toggle, and update. An investigation of the gap turned up several missing flows plus one behavioral trap; this PR closes all of them, so the TUI manager is now a full peer of the web Plugins tab.

**Correctness**

- Enable/disable from the TUI manager and `aoe plugin enable|disable` now routes through a running daemon (new `install::set_enabled_live` calling `POST /api/plugins/{id}/enabled`), so workers reconcile live instead of silently keeping their old state until a restart. Falls back to a local config write with a visible warning when no daemon is reachable; TUI-only builds always write locally. The settings-tab save path nudges the daemon per changed plugin id.
- The update preview path no longer writes `eprintln!` progress into the raw-mode terminal (the fetch notice moved to the interactive CLI path).

**New TUI manager flows**

- Install from discovery: Enter on a result opens the `preview_install` consent popup (capabilities, build commands, UI slots, unverified-source warning), approval runs `apply_install` pinned to the previewed fingerprint, and build output streams into a progress popup tailing a job log under `<plugins_dir>/jobs/`. The stale "the TUI has no install path" comment is gone.
- Uninstall (`x`) behind a confirmation popup.
- Re-approval (`a`) for plugins whose grant no longer covers the installed manifest, backed by new `install::reapprove_consent` / `approve_installed` (disclosure built from the on-disk manifest, grant pinned to its hash, stale pin refused). Previously a needs-approval plugin with no newer release could only be recovered from a shell.
- Details popup (Enter): capabilities with grant status, trust, source, install dir, commands, keybinds with core-shadow flags, runtime, declared settings; the TUI twin of `aoe plugin info`.
- Editable plugin settings on the settings Plugins tab through the generic schema field path, replacing the read-only "edit via web" summary; Tab moves sub-focus between the manager and the fields, and settings-search jumps land on the field.
- Discovery search input (`/`), scrollable popups, changelog cap raised from 12 to 60 lines, manual refresh (`r`), contextual footer hints, and Esc can always escape a running progress popup.

Out of scope, tracked on their own issues: pane-slot rendering in the structured view (#2467), TUI plugin command execution (#2528), plugin slots in the standalone home view (#2402 follow-up).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The UI changes are terminal dialogs asserted by the new e2e screen captures; happy to add the `needs-recording` label if a recording is wanted.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

New tests: three TUI e2e tests in `tests/e2e/plugins.rs` (toggle round-trip through the manager, details popup, and a full install, tamper, re-approve, uninstall lifecycle against a local plugin fixture), a backend re-approval round-trip in `tests/plugin_install.rs` (stale pin refused, grant reactivates the plugin), and unit tests for the settings-save toggle diff that drives the daemon nudge.

Verified locally: `cargo fmt`, `cargo clippy`, `cargo test --features serve` and `cargo test --test plugin_install` (with and without `serve`), plus `cargo test --features serve,e2e-tests --test e2e`. Six unrelated failures reproduce identically on a clean checkout of `main` in the dev sandbox (daemon `--stop` and process-group semantics under linuxkit) and are untouched by this diff.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:**
Claude investigated the TUI/web plugin parity gap, implemented the changes, and wrote the tests under njbrake's direction and review.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Delivered end-to-end external plugin lifecycle support in the TUI plugin manager to match the web Plugins experience: discovery, installation (including consent), live build/progress monitoring, uninstall (with confirmation), plugin details, and capability re-approval when grants must be refreshed.
- Made plugin enable/disable “live” when a daemon is available: changes reconcile through the running daemon; if the daemon can’t be reached or refuses the request, the app falls back to updating local configuration and shows clear warnings.
- Upgraded the TUI UX substantially: better discovery search and manual refresh, scrollable/rich popups (including progress), expanded changelog rendering, contextual footer hints, and improved keyboard/escape handling during popups/progress.
- Reworked the Settings tab Plugins experience into a master-detail layout: selecting a plugin updates a dedicated editable fields pane for that plugin, with keyboard focus/staging fixed so edits don’t interfere with list navigation/toggling.
- Hardened consent/re-approval correctness: re-approval is pinned to the installed manifest state, and approvals are refused if the installed manifest changes after the consent was prepared.
- Removed raw terminal progress output from the update preview path so plugin/update flows stay fully TUI-driven.
- Expanded backend and test coverage with new/updated unit and TUI end-to-end tests covering lifecycle flows, toggling, details, installation, manifest tampering, stale consent/refusal behavior, and uninstall.

## Benefits

- Users get a guided, consistent, and safer plugin workflow in the TUI—especially around consent and re-approval—while still handling daemon availability gracefully.
- The new master-detail settings layout makes plugin-specific configuration editing clearer and less error-prone.

## Further Enhancement

Pane-slot rendering, in-TUI plugin command execution, and standalone home-view plugin slots remain out of scope.

## Technical notes (optional)

- Added daemon-backed enable/disable via a new HTTP endpoint and async “live toggle” path with local-config fallback.
- Introduced manifest-hash–pinned re-approval with “refuse if disk changed after consent” validation.
- Added TUI popup unification with log-tailed progress rendering and improved wrapped/changelog scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->