### PR TITLE
feat(agents): add Kimi Code (Moonshot AI) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A session manager for AI coding agents on Linux and macOS, driven from the termi
 
 ## Features
 
-- **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code
+- **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code
 - **TUI dashboard**: visual interface to create, monitor, and manage sessions
 - **Web dashboard**: create, monitor, and control your agents from any browser, installable as a PWA
 - **Structured view** (web dashboard default): mobile-first native rendering of agent state via the Agent Client Protocol, with plan panels, tool-call cards, and swipe-to-approve. Flip a session to the terminal view for raw tmux rendering
@@ -136,7 +136,7 @@ Nothing. Sessions are tmux sessions running in the background. Open and close `a
 
 ### Which AI tools are supported?
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code. AoE auto-detects which are installed on your system.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code. AoE auto-detects which are installed on your system.
 
 ### Can I use AoE over SSH?
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,14 @@ RUN curl -fsSL https://cli.kiro.dev/install | bash
 # Install Qwen Code (Alibaba / QwenLM)
 RUN npm install -g @qwen-code/qwen-code
 
+# Install Kimi Code (Moonshot AI). Ships its own native ACP server
+# (`kimi acp`), so no separate adapter is needed below. Install to
+# /usr/local (binary at /usr/local/bin/kimi) rather than the default
+# ~/.kimi-code/bin: the aoe sandbox bind-mounts the host's ~/.kimi-code
+# config over /root/.kimi-code, which would otherwise shadow the binary.
+RUN curl -fsSL https://code.kimi.com/kimi-code/install.sh \
+    | KIMI_INSTALL_DIR=/usr/local KIMI_NO_MODIFY_PATH=1 bash
+
 # Install ACP adapters used by `aoe`'s structured view mode when the session is
 # sandboxed. The structured view runner `docker exec`s these by their bare binary
 # name (see `src/acp/agent_registry.rs`); if they aren't present in
@@ -98,6 +106,7 @@ RUN mkdir -p /root/.claude \
     /root/.factory \
     /root/.kiro \
     /root/.qwen \
+    /root/.kimi-code \
     /root/.ssh
 
 # Allow Claude Code to use --dangerously-skip-permissions as root

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 # aoe-dev-sandbox: Extended sandbox with development tools
 # Includes: Rust, uv (Python), nvm + Node.js, pnpm, bun, gh (GitHub CLI)
 # Note: Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI,
-# Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code are inherited from the base image
+# Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, and Kimi Code are inherited from the base image
 
 ARG BASE_IMAGE=ghcr.io/agent-of-empires/aoe-sandbox:latest
 FROM ${BASE_IMAGE}

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code) inside isolated Docker containers while maintaining access to your project files and credentials.
+Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, Kimi Code) inside isolated Docker containers while maintaining access to your project files and credentials.
 
 > **Linux users:** AoE also supports [Podman](podman.md) as a daemonless, rootless-friendly alternative to Docker.
 >
@@ -150,7 +150,7 @@ AOE provides two official sandbox images:
 
 | Image | Description |
 |-------|-------------|
-| `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, git, ripgrep, fzf |
+| `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, Kimi Code, git, ripgrep, fzf |
 | `ghcr.io/agent-of-empires/aoe-dev-sandbox:latest` | Extended image with additional dev tools |
 
 ### Dev Sandbox Tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Running several AI coding agents in parallel across tasks or branches means jugg
 
 ## Supported Agents
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Factory Droid, Hermes, Kiro CLI, and Qwen Code. AoE auto-detects which are installed.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code. AoE auto-detects which are installed.
 
 <div class="cta-box">
 <p><strong>Ready to get started?</strong></p>

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -26,6 +26,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 | `gemini` | `gemini --acp` (native) | `npm install -g @google/gemini-cli` | `GEMINI_API_KEY`, OAuth, or Vertex |
 | `vibe` | `vibe-acp` (native) | see [mistral-vibe](https://github.com/mistralai/mistral-vibe) | Mistral API key |
 | `pi` | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) | `pi-acp --terminal-login`, or provider env |
+| `kimi` | `kimi acp` (native) | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | `kimi login`, or provider env |
 | `aoe-agent` | bundled (Vercel AI SDK 6) | ships with `aoe` | provider env vars |
 
 Tools not yet wired into the registry (aider, cursor, copilot, droid, hermes, kiro) always run in the terminal view. A **custom agent** can opt in by setting an ACP launch command via `agent_acp_cmd` (see [Configuration](guides/configuration.md#running-a-custom-agent-in-the-structured-view)).

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -182,6 +182,21 @@ pub const PI: AgentProfile = AgentProfile {
     yolo_mode_id: None,
 };
 
+/// Kimi Code (Moonshot AI) via native `kimi acp`. Verified against the
+/// binary's `acp-adapter/src/modes.ts`: it advertises the canonical
+/// four-mode taxonomy (`default`, `plan`, `auto`, `yolo`), so `yolo` is
+/// the bypass-all-permissions mode. Its parent/child subagent linkage
+/// convention over ACP is unobserved, so indentation stays off. `/new`
+/// starts a fresh conversation.
+pub const KIMI: AgentProfile = AgentProfile {
+    key: "kimi",
+    parent_meta_namespaces: &[],
+    clear_aliases: &["/new"],
+    supports_exit_plan_mode: false,
+    supports_wakeup_tools: false,
+    yolo_mode_id: Some("yolo"),
+};
+
 /// aoe's bundled multi-provider agent. Treated as Claude-equivalent
 /// for now (Vercel AI SDK 6 with Claude as one of the providers); the
 /// claude_capabilities subset is the safest reference until aoe-agent
@@ -215,6 +230,7 @@ pub fn resolve(key: &str) -> &'static AgentProfile {
         "gemini" => &GEMINI,
         "vibe" => &VIBE,
         "pi" => &PI,
+        "kimi" => &KIMI,
         "aoe-agent" => &AOE_AGENT,
         _ => &DEFAULT,
     }
@@ -233,6 +249,7 @@ mod tests {
         assert_eq!(resolve("gemini").key, "gemini");
         assert_eq!(resolve("vibe").key, "vibe");
         assert_eq!(resolve("pi").key, "pi");
+        assert_eq!(resolve("kimi").key, "kimi");
         assert_eq!(resolve("aoe-agent").key, "aoe-agent");
     }
 
@@ -260,6 +277,9 @@ mod tests {
         // prompting for approvals despite yolo_mode_default.
         assert_eq!(resolve("codex").yolo_mode_id, Some("agent-full-access"));
         assert_eq!(resolve("gemini").yolo_mode_id, Some("yolo"));
+        // Kimi's acp-adapter advertises the canonical default/plan/auto/yolo
+        // taxonomy; `yolo` is its bypass-all-permissions mode.
+        assert_eq!(resolve("kimi").yolo_mode_id, Some("yolo"));
         // Adapters with no verified bypass mode keep YOLO a no-op.
         assert_eq!(resolve("opencode").yolo_mode_id, None);
         assert_eq!(resolve("vibe").yolo_mode_id, None);
@@ -350,7 +370,7 @@ mod tests {
             assert!(profile.supports_exit_plan_mode);
             assert!(profile.supports_wakeup_tools);
         }
-        for profile in [&CODEX, &OPENCODE, &GEMINI, &VIBE, &PI, &DEFAULT] {
+        for profile in [&CODEX, &OPENCODE, &GEMINI, &VIBE, &PI, &KIMI, &DEFAULT] {
             assert!(!profile.supports_exit_plan_mode, "{}", profile.key);
             assert!(!profile.supports_wakeup_tools, "{}", profile.key);
         }

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -151,6 +151,15 @@ impl AgentRegistry {
             },
         );
         reg.agents.insert(
+            "kimi".into(),
+            AgentSpec {
+                command: "kimi".into(),
+                args: vec!["acp".into()],
+                description: "Kimi Code (Moonshot AI) — native ACP via `kimi acp`".into(),
+                env_allowlist: None,
+            },
+        );
+        reg.agents.insert(
             "aoe-agent".into(),
             AgentSpec {
                 command: "${aoe_data_dir}/acp-worker/dist/aoe-agent".into(),

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -18,6 +18,7 @@ pub fn install_hint_for(binary: &str) -> Option<&'static str> {
         "vibe-acp" => {
             "follow https://github.com/mistralai/mistral-vibe (ships the `vibe-acp` binary)"
         }
+        "kimi" => "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash  (then `kimi acp`)",
         _ => return None,
     })
 }
@@ -68,6 +69,7 @@ mod tests {
             "gemini",
             "vibe-acp",
             "pi-acp",
+            "kimi",
         ] {
             assert!(
                 install_hint_for(binary).is_some(),

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -239,6 +239,12 @@ pub enum SidecarFormat {
     /// Kiro per-agent JSON with a flat `hooks.{event}: [{command, ...}]`
     /// shape under `.kiro/...` agent files.
     KiroJson,
+    /// Kimi Code `[[hooks]]` array of tables in `.kimi-code/config.toml`,
+    /// each `{ event, command }` (matcher/timeout optional). Shares the
+    /// flat-array shape with settl but lives in Kimi's runtime config file,
+    /// which also holds provider/oauth settings, so its installer preserves
+    /// the surrounding document.
+    KimiToml,
 }
 
 /// Everything we know about a single agent CLI.
@@ -586,6 +592,38 @@ pub(crate) const KIRO_SIDECAR_EVENTS: &[SidecarHookEvent] = &[
     },
     SidecarHookEvent {
         name: "stop",
+        status: HookStatus::Idle,
+    },
+];
+
+/// Kimi Code hook events. AoE writes these into `~/.kimi-code/config.toml`
+/// as `[[hooks]]` entries. Kimi exposes dedicated permission events
+/// (`PermissionRequest` / `PermissionResult`), so the waiting/running
+/// transition needs no `Notification` matcher the way Claude's does.
+/// `StopFailure` backstops `Stop` for the API-error turn-end path.
+pub(crate) const KIMI_SIDECAR_EVENTS: &[SidecarHookEvent] = &[
+    SidecarHookEvent {
+        name: "UserPromptSubmit",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "PreToolUse",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "PermissionRequest",
+        status: HookStatus::Waiting,
+    },
+    SidecarHookEvent {
+        name: "PermissionResult",
+        status: HookStatus::Running,
+    },
+    SidecarHookEvent {
+        name: "Stop",
+        status: HookStatus::Idle,
+    },
+    SidecarHookEvent {
+        name: "StopFailure",
         status: HookStatus::Idle,
     },
 ];
@@ -1027,6 +1065,41 @@ pub const AGENTS: &[AgentDef] = &[
         install_hint: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
         permission_response: None,
     },
+    AgentDef {
+        name: "kimi",
+        oneshot_flag: Some("-p"),
+        binary: "kimi",
+        launch_subcommand: None,
+        aliases: &["kimi-code"],
+        detection: DetectionMethod::Which("kimi"),
+        yolo: Some(YoloMode::CliFlag("--yolo")),
+        instruction_flag: None,
+        set_default_command: false,
+        detect_status: status_detection::detect_kimi_status,
+        container_env: &[("KIMI_CODE_HOME", "/root/.kimi-code")],
+        // Kimi Code stores hooks as `[[hooks]]` entries in its runtime
+        // `config.toml` (which also holds provider/oauth settings), so it
+        // installs via a sidecar hook rather than the JSON settings.json
+        // path. Status comes from the hook sidecar file; the pane stub is
+        // unused.
+        hook_config: None,
+        sidecar_hooks: Some(SidecarHooks {
+            host_config_subpath: ".kimi-code/config.toml",
+            sandbox_config_subpath: ".kimi-code/sandbox/config.toml",
+            install: crate::hooks::install_kimi_hooks_with_events,
+            uninstall: crate::hooks::uninstall_kimi_hooks,
+            post_install_host: None,
+            selected_agent_hooks: None,
+            format: SidecarFormat::KimiToml,
+            events: KIMI_SIDECAR_EVENTS,
+        }),
+        resume_strategy: ResumeStrategy::Flag("--session"),
+        fork_strategy: ForkStrategy::Unsupported,
+        host_only: false,
+        send_keys_enter_delay_ms: 0,
+        install_hint: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        permission_response: None,
+    },
 ];
 
 /// Look up an agent by canonical name.
@@ -1408,6 +1481,7 @@ mod tests {
         assert_eq!(get_agent("kiro").unwrap().binary, "kiro-cli");
         assert_eq!(get_agent("qwen").unwrap().binary, "qwen");
         assert_eq!(get_agent("antigravity").unwrap().binary, "agy");
+        assert_eq!(get_agent("kimi").unwrap().binary, "kimi");
     }
 
     #[test]
@@ -1553,7 +1627,8 @@ mod tests {
                 "hermes",
                 "kiro",
                 "qwen",
-                "antigravity"
+                "antigravity",
+                "kimi"
             ]
         );
     }
@@ -1580,6 +1655,8 @@ mod tests {
         assert_eq!(resolve_tool_name("qwen"), Some("qwen"));
         assert_eq!(resolve_tool_name("antigravity"), Some("antigravity"));
         assert_eq!(resolve_tool_name("agy"), Some("antigravity"));
+        assert_eq!(resolve_tool_name("kimi"), Some("kimi"));
+        assert_eq!(resolve_tool_name("kimi-code"), Some("kimi"));
         assert_eq!(resolve_tool_name(""), Some("claude"));
         assert_eq!(resolve_tool_name("agent"), Some("cursor"));
         assert_eq!(resolve_tool_name("unknown-tool"), None);
@@ -1599,6 +1676,7 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("kiro")), 12);
         assert_eq!(settings_index_from_name(Some("qwen")), 13);
         assert_eq!(settings_index_from_name(Some("antigravity")), 14);
+        assert_eq!(settings_index_from_name(Some("kimi")), 15);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -1612,6 +1690,7 @@ mod tests {
         assert_eq!(name_from_settings_index(12), Some("kiro"));
         assert_eq!(name_from_settings_index(13), Some("qwen"));
         assert_eq!(name_from_settings_index(14), Some("antigravity"));
+        assert_eq!(name_from_settings_index(15), Some("kimi"));
         assert_eq!(name_from_settings_index(99), None);
     }
 
@@ -1834,6 +1913,10 @@ mod tests {
             install_hint("antigravity"),
             Some("curl -fsSL https://antigravity.google/cli/install.sh | bash")
         );
+        assert_eq!(
+            install_hint("kimi"),
+            Some("curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash")
+        );
         assert!(install_hint("unknown").is_none());
     }
 
@@ -1879,6 +1962,7 @@ mod tests {
             ("settl", SidecarFormat::SettlToml),
             ("hermes", SidecarFormat::HermesYaml),
             ("kiro", SidecarFormat::KiroJson),
+            ("kimi", SidecarFormat::KimiToml),
         ];
         for (name, fmt) in expected {
             let agent = get_agent(name).unwrap_or_else(|| panic!("missing agent {name}"));

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1093,6 +1093,10 @@ pub const AGENTS: &[AgentDef] = &[
             format: SidecarFormat::KimiToml,
             events: KIMI_SIDECAR_EVENTS,
         }),
+        // `kimi --session <id>` resumes a prior conversation. On the host the id
+        // is captured from `~/.kimi-code/session_index.jsonl` (see
+        // `capture_kimi_session_id`); sandboxed sessions have no capture yet and
+        // start fresh on restart, mirroring Copilot.
         resume_strategy: ResumeStrategy::Flag("--session"),
         fork_strategy: ForkStrategy::Unsupported,
         host_only: false,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1321,6 +1321,164 @@ pub fn uninstall_settl_hooks(config_path: &Path) -> Result<bool> {
     })
 }
 
+/// Install AoE status hooks into Kimi Code's runtime `config.toml`
+/// (typically `~/.kimi-code/config.toml`).
+///
+/// Kimi stores hooks as a flat `[[hooks]]` array of tables, each
+/// `{ event, command }` (matcher/timeout optional). It shares that shape
+/// with settl, but the same file also holds Kimi's provider, model, and
+/// OAuth settings (login populates it), so this installer edits the
+/// document with `toml_edit` to preserve the surrounding tables, comments,
+/// and formatting rather than reserialising the whole file the way the
+/// settl installer does. That preservation is why `SidecarFormat::KimiToml`
+/// is distinct from `SidecarFormat::SettlToml`.
+///
+/// Idempotent on disk: when the file already encodes the same AoE-managed
+/// hooks, it is not rewritten (same bytes).
+pub fn install_kimi_hooks(config_path: &Path, target: HookInstallTarget) -> Result<()> {
+    let events = default_sidecar_events("kimi");
+    install_kimi_hooks_with_events(config_path, target, &events)
+}
+
+pub fn install_kimi_hooks_with_events(
+    config_path: &Path,
+    target: HookInstallTarget,
+    events: &[crate::agents::ResolvedHookEvent],
+) -> Result<()> {
+    with_config_lock(config_path, "toml.lock", || {
+        let mut config = if config_path.exists() {
+            let content = std::fs::read_to_string(config_path)?;
+            content
+                .parse::<toml_edit::DocumentMut>()
+                .with_context(|| format!("Failed to parse {}", config_path.display()))?
+        } else {
+            toml_edit::DocumentMut::new()
+        };
+
+        let before = config.to_string();
+
+        let hooks = ensure_kimi_hooks_array(&mut config)?;
+        // Drop any prior AoE-managed entries (marker in the command), then
+        // re-add the current set. Non-AoE entries the user added are kept.
+        hooks.retain(|entry| {
+            !entry
+                .get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(is_aoe_hook_command)
+        });
+
+        for event in events {
+            let Some(status) = event.status else {
+                continue;
+            };
+            let mut entry = toml_edit::Table::new();
+            entry.insert("event", toml_edit::value(event.name.as_str()));
+            entry.insert(
+                "command",
+                toml_edit::value(hook_command(status.as_str(), target)),
+            );
+            hooks.push(entry);
+        }
+
+        if config.to_string() == before {
+            tracing::debug!(target: "hooks.install",
+                "AoE hooks in {} already up to date; skipping write",
+                config_path.display());
+            return Ok(());
+        }
+
+        if let Some(parent) = config_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        crate::session::atomic_write_following_symlinks(
+            config_path,
+            config.to_string().as_bytes(),
+        )?;
+
+        tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
+        Ok(())
+    })
+}
+
+/// Ensure the document's top-level `hooks` key is an array of tables and
+/// return it. Tolerates an absent key (creates it) and an empty inline
+/// array (`hooks = []`, coerced to `[[hooks]]`). Refuses to clobber any
+/// other existing shape so a malformed or unexpected config is left intact
+/// rather than overwritten.
+fn ensure_kimi_hooks_array(
+    config: &mut toml_edit::DocumentMut,
+) -> Result<&mut toml_edit::ArrayOfTables> {
+    let root = config.as_table_mut();
+    if !root.contains_key("hooks") {
+        root.insert(
+            "hooks",
+            toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new()),
+        );
+    }
+
+    let item = root
+        .get_mut("hooks")
+        .ok_or_else(|| anyhow::anyhow!("hooks key was not created"))?;
+    if !item.is_array_of_tables() {
+        if item.as_array().is_some_and(|arr| arr.is_empty()) {
+            *item = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+        } else {
+            return Err(anyhow::anyhow!("Kimi hooks key is not an array of tables"));
+        }
+    }
+
+    item.as_array_of_tables_mut()
+        .ok_or_else(|| anyhow::anyhow!("Kimi hooks key is not an array of tables"))
+}
+
+/// Remove AoE hooks from Kimi Code's `config.toml`, preserving the rest of
+/// the document. Returns whether anything changed.
+pub fn uninstall_kimi_hooks(config_path: &Path) -> Result<bool> {
+    if !config_path.exists() {
+        return Ok(false);
+    }
+
+    with_config_lock(config_path, "toml.lock", || {
+        let content = std::fs::read_to_string(config_path)?;
+        let mut config = content.parse::<toml_edit::DocumentMut>().unwrap_or_else(|e| {
+            tracing::warn!(target: "hooks.uninstall", "Failed to parse {}: {}", config_path.display(), e);
+            toml_edit::DocumentMut::new()
+        });
+
+        let Some(hooks) = config
+            .as_table_mut()
+            .get_mut("hooks")
+            .and_then(|item| item.as_array_of_tables_mut())
+        else {
+            return Ok(false);
+        };
+
+        let before = hooks.len();
+        hooks.retain(|entry| {
+            !entry
+                .get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(is_aoe_hook_command)
+        });
+
+        if hooks.len() == before {
+            return Ok(false);
+        }
+
+        // Drop an emptied `hooks` array so uninstall leaves no residue.
+        if hooks.is_empty() {
+            config.as_table_mut().remove("hooks");
+        }
+
+        crate::session::atomic_write_following_symlinks(
+            config_path,
+            config.to_string().as_bytes(),
+        )?;
+        tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", config_path.display());
+        Ok(true)
+    })
+}
+
 /// Install AoE status hooks into Hermes's `config.yaml`.
 ///
 /// Reads the existing YAML, removes any prior AoE-managed hook entries
@@ -5014,6 +5172,95 @@ hooks_auto_accept: false
             bytes_before,
             "second install must leave bytes byte-identical"
         );
+    }
+
+    #[test]
+    fn test_install_kimi_hooks_preserves_oauth_block_and_comments() {
+        // Kimi's config.toml also holds provider/model/oauth settings, so the
+        // installer must preserve the surrounding document (comments, nested
+        // tables, key order) rather than reserialise it.
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        let original = "\
+# ~/.kimi-code/config.toml
+default_model = \"kimi-k2\"
+
+[providers.kimi]
+type = \"kimi\"
+oauth = { storage = \"keyring\", key = \"user@example.com\" }
+
+[models.\"kimi-k2\"]
+provider = \"kimi\"
+model = \"kimi-k2\"
+max_context_size = 200000
+";
+        std::fs::write(&config_path, original).unwrap();
+
+        install_kimi_hooks(&config_path, HookInstallTarget::Host).unwrap();
+
+        let written = std::fs::read_to_string(&config_path).unwrap();
+        // The comment and the oauth/provider/model tables survive verbatim.
+        assert!(written.contains("# ~/.kimi-code/config.toml"));
+        assert!(written.contains("[providers.kimi]"));
+        assert!(written.contains("key = \"user@example.com\""));
+        assert!(written.contains("max_context_size = 200000"));
+
+        // Hooks were appended and the file still parses as valid TOML.
+        let parsed: toml::Value = toml::from_str(&written).unwrap();
+        let hooks = parsed["hooks"].as_array().expect("hooks array installed");
+        assert_eq!(
+            hooks.len(),
+            crate::agents::KIMI_SIDECAR_EVENTS.len(),
+            "one hook entry per default kimi status event"
+        );
+        assert!(hooks.iter().all(|h| {
+            h.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(is_aoe_hook_command)
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_install_kimi_hooks_no_rewrite_when_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        install_kimi_hooks(&config_path, HookInstallTarget::Host).unwrap();
+        let ino_before = std::fs::metadata(&config_path).unwrap().ino();
+        let bytes_before = std::fs::read(&config_path).unwrap();
+
+        install_kimi_hooks(&config_path, HookInstallTarget::Host).unwrap();
+        assert_eq!(
+            std::fs::metadata(&config_path).unwrap().ino(),
+            ino_before,
+            "second install must not replace the inode"
+        );
+        assert_eq!(
+            std::fs::read(&config_path).unwrap(),
+            bytes_before,
+            "second install must leave bytes byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_uninstall_kimi_hooks_removes_only_aoe_and_preserves_rest() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "default_model = \"kimi-k2\"\n").unwrap();
+
+        install_kimi_hooks(&config_path, HookInstallTarget::Host).unwrap();
+        assert!(uninstall_kimi_hooks(&config_path).unwrap(), "removed hooks");
+
+        let parsed: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(parsed["default_model"].as_str(), Some("kimi-k2"));
+        // The emptied hooks array is dropped, leaving no residue.
+        assert!(parsed.get("hooks").is_none(), "empty hooks key removed");
+
+        // A second uninstall is a no-op.
+        assert!(!uninstall_kimi_hooks(&config_path).unwrap());
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1425,17 +1425,21 @@ fn ensure_kimi_hooks_array(
         if let Some(array) = item.as_array() {
             // Migrate an inline `hooks = [{...}]` array into `[[hooks]]`,
             // carrying every inline-table entry over as a standard table so
-            // user-authored hooks survive. A non-inline-table element cannot be
-            // a valid Kimi hook, so it is dropped.
+            // user-authored hooks survive. If any element is not an inline
+            // table it is not a shape we understand, so fail before touching
+            // the document rather than silently dropping the user's entry.
             let mut migrated = toml_edit::ArrayOfTables::new();
             for value in array.iter() {
-                if let Some(inline) = value.as_inline_table() {
-                    let mut table = toml_edit::Table::new();
-                    for (key, val) in inline.iter() {
-                        table.insert(key, toml_edit::value(val.clone()));
-                    }
-                    migrated.push(table);
+                let inline = value.as_inline_table().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Kimi hooks inline array has a non-table entry; leaving config untouched"
+                    )
+                })?;
+                let mut table = toml_edit::Table::new();
+                for (key, val) in inline.iter() {
+                    table.insert(key, toml_edit::value(val.clone()));
                 }
+                migrated.push(table);
             }
             *item = toml_edit::Item::ArrayOfTables(migrated);
         } else {
@@ -5316,6 +5320,25 @@ max_context_size = 200000
         assert_eq!(
             after_hooks[0].get("command").and_then(|c| c.as_str()),
             Some("echo hi")
+        );
+    }
+
+    #[test]
+    fn test_install_kimi_hooks_rejects_mixed_inline_array_leaving_file_untouched() {
+        // A hooks array with a non-table element is a shape we don't
+        // understand; install must fail without rewriting the file rather than
+        // silently dropping the unexpected entry.
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        let original =
+            "hooks = [{ event = \"SessionStart\", command = \"echo hi\" }, \"custom\"]\n";
+        std::fs::write(&config_path, original).unwrap();
+
+        assert!(install_kimi_hooks(&config_path, HookInstallTarget::Host).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&config_path).unwrap(),
+            original,
+            "a rejected install must leave the config byte-for-byte unchanged"
         );
     }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1401,10 +1401,12 @@ pub fn install_kimi_hooks_with_events(
 }
 
 /// Ensure the document's top-level `hooks` key is an array of tables and
-/// return it. Tolerates an absent key (creates it) and an empty inline
-/// array (`hooks = []`, coerced to `[[hooks]]`). Refuses to clobber any
-/// other existing shape so a malformed or unexpected config is left intact
-/// rather than overwritten.
+/// return it. Tolerates an absent key (creates it) and an inline array
+/// (`hooks = [{...}]`, which Kimi accepts as equivalent to `[[hooks]]`):
+/// each inline entry is migrated into a standard table so existing user
+/// hooks are preserved. Refuses to clobber any other existing shape (e.g. a
+/// `hooks` scalar or table) so a malformed or unexpected config is left
+/// intact rather than overwritten.
 fn ensure_kimi_hooks_array(
     config: &mut toml_edit::DocumentMut,
 ) -> Result<&mut toml_edit::ArrayOfTables> {
@@ -1420,8 +1422,22 @@ fn ensure_kimi_hooks_array(
         .get_mut("hooks")
         .ok_or_else(|| anyhow::anyhow!("hooks key was not created"))?;
     if !item.is_array_of_tables() {
-        if item.as_array().is_some_and(|arr| arr.is_empty()) {
-            *item = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+        if let Some(array) = item.as_array() {
+            // Migrate an inline `hooks = [{...}]` array into `[[hooks]]`,
+            // carrying every inline-table entry over as a standard table so
+            // user-authored hooks survive. A non-inline-table element cannot be
+            // a valid Kimi hook, so it is dropped.
+            let mut migrated = toml_edit::ArrayOfTables::new();
+            for value in array.iter() {
+                if let Some(inline) = value.as_inline_table() {
+                    let mut table = toml_edit::Table::new();
+                    for (key, val) in inline.iter() {
+                        table.insert(key, toml_edit::value(val.clone()));
+                    }
+                    migrated.push(table);
+                }
+            }
+            *item = toml_edit::Item::ArrayOfTables(migrated);
         } else {
             return Err(anyhow::anyhow!("Kimi hooks key is not an array of tables"));
         }
@@ -5261,6 +5277,46 @@ max_context_size = 200000
 
         // A second uninstall is a no-op.
         assert!(!uninstall_kimi_hooks(&config_path).unwrap());
+    }
+
+    #[test]
+    fn test_install_kimi_hooks_migrates_inline_hooks_array_preserving_user_entries() {
+        // A user (or Kimi) may write hooks as an inline `hooks = [{...}]`
+        // array. Install must migrate it to `[[hooks]]` and keep the
+        // user-authored entry rather than refusing or dropping it.
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "hooks = [{ event = \"SessionStart\", command = \"echo hi\" }]\n",
+        )
+        .unwrap();
+
+        install_kimi_hooks(&config_path, HookInstallTarget::Host).unwrap();
+
+        let parsed: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        let hooks = parsed["hooks"].as_array().unwrap();
+        // The user's non-AoE hook survives alongside the installed AoE hooks.
+        assert!(hooks.iter().any(|h| {
+            h.get("command").and_then(|c| c.as_str()) == Some("echo hi")
+                && h.get("event").and_then(|e| e.as_str()) == Some("SessionStart")
+        }));
+        assert_eq!(
+            hooks.len(),
+            crate::agents::KIMI_SIDECAR_EVENTS.len() + 1,
+            "AoE events plus the preserved user hook"
+        );
+        // Uninstall removes only the AoE hooks, leaving the user's entry.
+        assert!(uninstall_kimi_hooks(&config_path).unwrap());
+        let after: toml::Value =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        let after_hooks = after["hooks"].as_array().unwrap();
+        assert_eq!(after_hooks.len(), 1);
+        assert_eq!(
+            after_hooks[0].get("command").and_then(|c| c.as_str()),
+            Some("echo hi")
+        );
     }
 
     #[test]

--- a/src/hooks/targets.rs
+++ b/src/hooks/targets.rs
@@ -174,6 +174,10 @@ pub(crate) fn has_aoe_marker(target: &HookTarget) -> bool {
             crate::agents::SidecarFormat::SettlToml => settl_config_has_aoe_marker(&target.path),
             crate::agents::SidecarFormat::HermesYaml => hermes_config_has_aoe_marker(&target.path),
             crate::agents::SidecarFormat::KiroJson => kiro_config_has_aoe_marker(&target.path),
+            // Kimi's config.toml uses the same flat `[[hooks]]` array of
+            // `{ event, command }` entries as settl, so the settl marker
+            // walker identifies AoE-managed hooks in it unchanged.
+            crate::agents::SidecarFormat::KimiToml => settl_config_has_aoe_marker(&target.path),
         },
     }
 }

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2127,6 +2127,136 @@ pub(crate) fn copilot_poll_fn(
     }
 }
 
+// ─── Kimi Code session capture ────────────────────────────────────────────────
+
+/// One live entry from Kimi's session index.
+struct KimiSession {
+    id: String,
+    session_dir: String,
+    work_dir: String,
+}
+
+/// Parse Kimi's append-only session index (`session_index.jsonl`) into the set
+/// of live sessions. Each line is a JSON object: either a session record
+/// (`{sessionId, sessionDir, workDir}`) or a deletion tombstone
+/// (`{sessionId, deleted: true}`). Later lines win, and a tombstone removes an
+/// earlier record, mirroring Kimi's own `readSessionIndex`. Malformed lines are
+/// skipped rather than failing the whole read.
+fn read_kimi_session_index(index_path: &Path) -> Result<Vec<KimiSession>> {
+    if !index_path.exists() {
+        anyhow::bail!("Kimi session index not found at {}", index_path.display());
+    }
+    let content = std::fs::read_to_string(index_path)
+        .with_context(|| format!("Failed to read {}", index_path.display()))?;
+
+    let mut live: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(session_id) = value.get("sessionId").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if value.get("deleted").and_then(|v| v.as_bool()) == Some(true) {
+            live.remove(session_id);
+            continue;
+        }
+        let (Some(session_dir), Some(work_dir)) = (
+            value.get("sessionDir").and_then(|v| v.as_str()),
+            value.get("workDir").and_then(|v| v.as_str()),
+        ) else {
+            continue;
+        };
+        live.insert(
+            session_id.to_string(),
+            (session_dir.to_string(), work_dir.to_string()),
+        );
+    }
+
+    Ok(live
+        .into_iter()
+        .map(|(id, (session_dir, work_dir))| KimiSession {
+            id,
+            session_dir,
+            work_dir,
+        })
+        .collect())
+}
+
+/// Unix mtime (seconds) of a session directory, `0` when it cannot be read.
+/// Kimi creates a fresh `sessionDir` per session, so the newest directory is
+/// the session AoE most recently launched for this project.
+fn kimi_session_dir_mtime(session_dir: &str) -> u64 {
+    std::fs::metadata(session_dir)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Pick the newest unexcluded Kimi session whose `workDir` matches
+/// `project_path`. Paths are canonicalized so a symlinked or `/tmp` ->
+/// `/private/tmp` cwd still matches.
+fn select_kimi_session(
+    sessions: &[KimiSession],
+    project_path: &str,
+    exclusion: &HashSet<String>,
+) -> Result<String> {
+    let canonical_match = canonicalize_or_raw(project_path);
+    let mut candidates: Vec<(String, u64)> = sessions
+        .iter()
+        .filter(|s| !exclusion.contains(&s.id))
+        .filter(|s| canonicalize_or_raw(&s.work_dir) == canonical_match)
+        .map(|s| (s.id.clone(), kimi_session_dir_mtime(&s.session_dir)))
+        .collect();
+
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.1));
+    candidates
+        .into_iter()
+        .next()
+        .map(|(id, _)| id)
+        .ok_or_else(|| anyhow::anyhow!("No Kimi session found matching project path"))
+}
+
+/// Capture a Kimi Code session ID for `project_path`.
+///
+/// Reads `~/.kimi-code/session_index.jsonl` (or
+/// `$KIMI_CODE_HOME/session_index.jsonl`) and returns the id of the most
+/// recently created session whose recorded `workDir` matches `project_path`,
+/// skipping any ids in `exclusion`. Kimi resumes it with
+/// `kimi --session <id>`.
+pub(crate) fn capture_kimi_session_id(
+    project_path: &str,
+    exclusion: &HashSet<String>,
+) -> Result<String> {
+    let home = resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code")?;
+    let sessions = read_kimi_session_index(&home.join("session_index.jsonl"))?;
+    select_kimi_session(&sessions, project_path, exclusion)
+}
+
+/// Polling closure for Kimi Code session tracking.
+pub(crate) fn kimi_poll_fn(
+    project_path: String,
+    instance_id: String,
+    extra_excludes: HashSet<String>,
+) -> impl Fn() -> Option<String> + Send + 'static {
+    move || {
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
+        capture_kimi_session_id(&project_path, &exclusion)
+            .map_err(
+                |e| tracing::debug!(target: "session.capture", "Kimi poll capture failed: {}", e),
+            )
+            .ok()
+            .and_then(validated_session_id)
+    }
+}
+
 // ─── Hermes session capture ───────────────────────────────────────────────────
 
 const HERMES_COMMAND_TIMEOUT_SECS: u64 = 5;
@@ -4101,6 +4231,94 @@ mod tests {
         let entries = vec![("a".to_string(), "/work/elsewhere".to_string())];
         let result = select_copilot_session(&entries, "/work/proj", &HashSet::new());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_kimi_session_index_applies_deletions_and_last_wins() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let index = tmp.path().join("session_index.jsonl");
+        // A record, an update to it, a second record, a deletion of the second,
+        // a malformed line, and a record missing workDir (skipped).
+        std::fs::write(
+            &index,
+            concat!(
+                r#"{"sessionId":"session_a","sessionDir":"/s/a-old","workDir":"/p/one"}"#,
+                "\n",
+                r#"{"sessionId":"session_a","sessionDir":"/s/a","workDir":"/p/one"}"#,
+                "\n",
+                r#"{"sessionId":"session_b","sessionDir":"/s/b","workDir":"/p/two"}"#,
+                "\n",
+                r#"{"sessionId":"session_b","deleted":true}"#,
+                "\n",
+                "not json at all\n",
+                r#"{"sessionId":"session_c","workDir":"/p/three"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let sessions = read_kimi_session_index(&index).unwrap();
+        let by_id: std::collections::HashMap<&str, &str> = sessions
+            .iter()
+            .map(|s| (s.id.as_str(), s.session_dir.as_str()))
+            .collect();
+        // session_a survives with its updated dir; session_b was tombstoned;
+        // session_c had no sessionDir; the malformed line was skipped.
+        assert_eq!(by_id.len(), 1);
+        assert_eq!(by_id.get("session_a"), Some(&"/s/a"));
+    }
+
+    #[test]
+    fn test_read_kimi_session_index_missing_file_errs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(read_kimi_session_index(&tmp.path().join("nope.jsonl")).is_err());
+    }
+
+    #[test]
+    fn test_select_kimi_session_matches_workdir() {
+        let proj = tempfile::TempDir::new().unwrap();
+        let proj_path = proj.path().to_str().unwrap().to_string();
+        let sessions = vec![
+            KimiSession {
+                id: "session_match".to_string(),
+                session_dir: proj.path().join("sdir").to_string_lossy().into_owned(),
+                work_dir: proj_path.clone(),
+            },
+            KimiSession {
+                id: "session_other".to_string(),
+                session_dir: "/s/other".to_string(),
+                work_dir: "/some/other/project".to_string(),
+            },
+        ];
+        let got = select_kimi_session(&sessions, &proj_path, &HashSet::new()).unwrap();
+        assert_eq!(got, "session_match");
+    }
+
+    #[test]
+    fn test_select_kimi_session_skips_excluded_and_errs_on_no_match() {
+        let proj = tempfile::TempDir::new().unwrap();
+        let proj_path = proj.path().to_str().unwrap().to_string();
+        let sessions = vec![
+            KimiSession {
+                id: "session_excluded".to_string(),
+                session_dir: "/s/x".to_string(),
+                work_dir: proj_path.clone(),
+            },
+            KimiSession {
+                id: "session_keep".to_string(),
+                session_dir: "/s/k".to_string(),
+                work_dir: proj_path.clone(),
+            },
+        ];
+        // Excluding the one leaves exactly one candidate, so the result is
+        // deterministic regardless of directory mtimes.
+        let exclusion: HashSet<String> = ["session_excluded".to_string()].into_iter().collect();
+        assert_eq!(
+            select_kimi_session(&sessions, &proj_path, &exclusion).unwrap(),
+            "session_keep"
+        );
+        // No session matches an unrelated project path.
+        assert!(select_kimi_session(&sessions, "/no/such/project", &HashSet::new()).is_err());
     }
 
     #[test]

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -2188,33 +2188,53 @@ fn read_kimi_session_index(index_path: &Path) -> Result<Vec<KimiSession>> {
         .collect())
 }
 
-/// Unix mtime (seconds) of a session directory, `0` when it cannot be read.
-/// Kimi creates a fresh `sessionDir` per session, so the newest directory is
-/// the session AoE most recently launched for this project.
-fn kimi_session_dir_mtime(session_dir: &str) -> u64 {
+/// Slack (ms) applied to the launch-time floor to absorb filesystem mtimes
+/// that are only second-granular: a session directory created in the same
+/// second AoE launched can carry an mtime a few hundred ms below the
+/// millisecond launch timestamp, and must still count as "created after
+/// launch". Far smaller than the gap to any genuinely historical session.
+const KIMI_MTIME_FLOOR_SLACK_MS: f64 = 2000.0;
+
+/// Unix mtime (milliseconds) of a session directory, `0` when it cannot be
+/// read. Kimi creates a fresh `sessionDir` per session (appends inside it do
+/// not touch the directory mtime), so a directory newer than the launch floor
+/// is the session created for the current run.
+fn kimi_session_dir_mtime_ms(session_dir: &str) -> u64 {
     std::fs::metadata(session_dir)
         .and_then(|m| m.modified())
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
 
 /// Pick the newest unexcluded Kimi session whose `workDir` matches
 /// `project_path`. Paths are canonicalized so a symlinked or `/tmp` ->
 /// `/private/tmp` cwd still matches.
+///
+/// When `launch_time_ms` is `Some`, only sessions whose directory was created
+/// at/after that floor are eligible, so a fresh live poll cannot latch onto a
+/// pre-existing conversation for the same `workDir` before Kimi writes the new
+/// record. Retroactive recovery passes `None` to allow resuming an older
+/// session.
 fn select_kimi_session(
     sessions: &[KimiSession],
     project_path: &str,
     exclusion: &HashSet<String>,
+    launch_time_ms: Option<f64>,
 ) -> Result<String> {
     let canonical_match = canonicalize_or_raw(project_path);
     let mut candidates: Vec<(String, u64)> = sessions
         .iter()
         .filter(|s| !exclusion.contains(&s.id))
         .filter(|s| canonicalize_or_raw(&s.work_dir) == canonical_match)
-        .map(|s| (s.id.clone(), kimi_session_dir_mtime(&s.session_dir)))
+        .map(|s| (s.id.clone(), kimi_session_dir_mtime_ms(&s.session_dir)))
         .collect();
+
+    if let Some(threshold) = launch_time_ms {
+        candidates
+            .retain(|(_, mtime_ms)| (*mtime_ms as f64) + KIMI_MTIME_FLOOR_SLACK_MS >= threshold);
+    }
 
     candidates.sort_by_key(|c| std::cmp::Reverse(c.1));
     candidates
@@ -2229,26 +2249,30 @@ fn select_kimi_session(
 /// Reads `~/.kimi-code/session_index.jsonl` (or
 /// `$KIMI_CODE_HOME/session_index.jsonl`) and returns the id of the most
 /// recently created session whose recorded `workDir` matches `project_path`,
-/// skipping any ids in `exclusion`. Kimi resumes it with
-/// `kimi --session <id>`.
+/// skipping any ids in `exclusion`. `launch_time_ms` gates live polling to
+/// sessions created after this run started (`None` for retroactive recovery).
+/// Kimi resumes the returned id with `kimi --session <id>`.
 pub(crate) fn capture_kimi_session_id(
     project_path: &str,
     exclusion: &HashSet<String>,
+    launch_time_ms: Option<f64>,
 ) -> Result<String> {
     let home = resolve_agent_home(Some("KIMI_CODE_HOME"), ".kimi-code")?;
     let sessions = read_kimi_session_index(&home.join("session_index.jsonl"))?;
-    select_kimi_session(&sessions, project_path, exclusion)
+    select_kimi_session(&sessions, project_path, exclusion, launch_time_ms)
 }
 
-/// Polling closure for Kimi Code session tracking.
+/// Polling closure for Kimi Code session tracking. `launch_time_ms` floors the
+/// live poll so it never claims a conversation that predates this launch.
 pub(crate) fn kimi_poll_fn(
     project_path: String,
     instance_id: String,
+    launch_time_ms: f64,
     extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
         let exclusion = compose_exclusion(&instance_id, &extra_excludes);
-        capture_kimi_session_id(&project_path, &exclusion)
+        capture_kimi_session_id(&project_path, &exclusion, Some(launch_time_ms))
             .map_err(
                 |e| tracing::debug!(target: "session.capture", "Kimi poll capture failed: {}", e),
             )
@@ -4290,8 +4314,55 @@ mod tests {
                 work_dir: "/some/other/project".to_string(),
             },
         ];
-        let got = select_kimi_session(&sessions, &proj_path, &HashSet::new()).unwrap();
+        let got = select_kimi_session(&sessions, &proj_path, &HashSet::new(), None).unwrap();
         assert_eq!(got, "session_match");
+    }
+
+    #[test]
+    fn test_select_kimi_session_launch_floor_excludes_pre_launch_sessions() {
+        // A real directory carries an mtime of ~now; a nonexistent one reads as
+        // mtime 0. With a launch floor well in the past, only the real (fresh)
+        // session is eligible; with a future floor, neither is.
+        let proj = tempfile::TempDir::new().unwrap();
+        let proj_path = proj.path().to_str().unwrap().to_string();
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as f64;
+        let sessions = vec![
+            KimiSession {
+                id: "session_fresh".to_string(),
+                session_dir: proj.path().join("live").to_string_lossy().into_owned(),
+                work_dir: proj_path.clone(),
+            },
+            KimiSession {
+                id: "session_stale".to_string(),
+                session_dir: "/does/not/exist".to_string(),
+                work_dir: proj_path.clone(),
+            },
+        ];
+        std::fs::create_dir(proj.path().join("live")).unwrap();
+
+        // Floor 10s in the past: the fresh dir passes, the mtime-0 stale one is
+        // filtered out.
+        assert_eq!(
+            select_kimi_session(
+                &sessions,
+                &proj_path,
+                &HashSet::new(),
+                Some(now_ms - 10_000.0)
+            )
+            .unwrap(),
+            "session_fresh"
+        );
+        // Floor far in the future: nothing qualifies.
+        assert!(select_kimi_session(
+            &sessions,
+            &proj_path,
+            &HashSet::new(),
+            Some(now_ms + 1_000_000.0)
+        )
+        .is_err());
     }
 
     #[test]
@@ -4314,11 +4385,11 @@ mod tests {
         // deterministic regardless of directory mtimes.
         let exclusion: HashSet<String> = ["session_excluded".to_string()].into_iter().collect();
         assert_eq!(
-            select_kimi_session(&sessions, &proj_path, &exclusion).unwrap(),
+            select_kimi_session(&sessions, &proj_path, &exclusion, None).unwrap(),
             "session_keep"
         );
         // No session matches an unrelated project path.
-        assert!(select_kimi_session(&sessions, "/no/such/project", &HashSet::new()).is_err());
+        assert!(select_kimi_session(&sessions, "/no/such/project", &HashSet::new(), None).is_err());
     }
 
     #[test]

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -274,6 +274,20 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         preserve_files: &["antigravity-oauth-token"],
         clean_files: &[],
     },
+    AgentConfigMount {
+        tool_name: "kimi",
+        host_rel: ".kimi-code",
+        container_suffix: ".kimi-code",
+        // Skip the sandbox staging dir (recursion), plus Kimi's session,
+        // log, and cache state, which the container regenerates.
+        skip_entries: &["sandbox", "sessions", "logs", "cache", "agents"],
+        seed_files: &[],
+        copy_dirs: &["skills"],
+        keychain_credential: None,
+        home_seed_files: &[],
+        preserve_files: &[],
+        clean_files: &[],
+    },
 ];
 
 /// Sync host agent config into the shared sandbox directory. Copies top-level files

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2263,7 +2263,9 @@ impl Instance {
                     None
                 } else {
                     let exclusion = self.retroactive_capture_exclusion_set();
-                    capture_kimi_session_id(&self.project_path, &exclusion).ok()
+                    // Retroactive recovery is unrestricted (no launch floor):
+                    // resuming an older session on restart is the goal here.
+                    capture_kimi_session_id(&self.project_path, &exclusion, None).ok()
                 }
             }
             _ => None,
@@ -2334,11 +2336,13 @@ impl Instance {
             return false;
         }
         let (mut session_id, is_existing) = self.acquire_session_id();
-        // Sandboxed Copilot starts fresh: the session db lives inside the
-        // container, so a host-captured or manually pinned sid would launch
-        // `--session-id <id>` against a UUID that does not resolve there.
-        // Capture is already host-only above; drop the sid to gate emission too.
-        if self.tool == "copilot" && self.is_sandboxed() {
+        // Sandboxed Copilot and Kimi start fresh: their session stores live
+        // inside the container (Copilot's SQLite db, Kimi's
+        // `~/.kimi-code/session_index.jsonl`), so a host-captured or manually
+        // pinned sid would launch `--session[-id] <id>` against an id that does
+        // not resolve there. Capture is already host-only above; drop the sid
+        // to gate emission too.
+        if matches!(self.tool.as_str(), "copilot" | "kimi") && self.is_sandboxed() {
             session_id = None;
         }
         let emitted =
@@ -3857,9 +3861,14 @@ impl Instance {
                 if self.is_sandboxed() {
                     return;
                 }
+                let launch_time_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as f64)
+                    .unwrap_or(0.0);
                 Box::new(kimi_poll_fn(
                     self.project_path.clone(),
                     self.id.clone(),
+                    launch_time_ms,
                     extra_excludes,
                 ))
             }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -20,15 +20,16 @@ use super::poller::SessionPoller;
 use crate::session::capture::{
     capture_claude_session_id, capture_claude_session_id_in_container, capture_codex_session_id,
     capture_copilot_session_id, capture_gemini_session_id, capture_hermes_session_id,
-    capture_pi_session_id, capture_vibe_session_id, claude_poll_fn, claude_poll_fn_sandboxed,
-    codex_poll_fn, codex_poll_fn_sandboxed, copilot_poll_fn, gemini_poll_fn,
-    gemini_poll_fn_sandboxed, generate_claude_session_id, hermes_poll_fn, hermes_poll_fn_sandboxed,
-    is_valid_session_id, opencode_poll_fn, opencode_poll_fn_sandboxed, pi_poll_fn,
-    pi_poll_fn_sandboxed, try_capture_codex_session_id_in_container,
-    try_capture_gemini_session_id_in_container, try_capture_hermes_session_id_in_container,
-    try_capture_opencode_session_id, try_capture_opencode_session_id_in_container,
-    try_capture_pi_session_id_in_container, try_capture_vibe_session_id_in_container,
-    validated_session_id, vibe_poll_fn, vibe_poll_fn_sandboxed,
+    capture_kimi_session_id, capture_pi_session_id, capture_vibe_session_id, claude_poll_fn,
+    claude_poll_fn_sandboxed, codex_poll_fn, codex_poll_fn_sandboxed, copilot_poll_fn,
+    gemini_poll_fn, gemini_poll_fn_sandboxed, generate_claude_session_id, hermes_poll_fn,
+    hermes_poll_fn_sandboxed, is_valid_session_id, kimi_poll_fn, opencode_poll_fn,
+    opencode_poll_fn_sandboxed, pi_poll_fn, pi_poll_fn_sandboxed,
+    try_capture_codex_session_id_in_container, try_capture_gemini_session_id_in_container,
+    try_capture_hermes_session_id_in_container, try_capture_opencode_session_id,
+    try_capture_opencode_session_id_in_container, try_capture_pi_session_id_in_container,
+    try_capture_vibe_session_id_in_container, validated_session_id, vibe_poll_fn,
+    vibe_poll_fn_sandboxed,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2252,6 +2253,19 @@ impl Instance {
                     capture_copilot_session_id(&self.project_path, &exclusion).ok()
                 }
             }
+            "kimi" => {
+                // Kimi records sessions in `~/.kimi-code/session_index.jsonl`
+                // keyed by workDir. Host capture reads it directly; sandbox
+                // resume is a follow-up (the container's index is not read over
+                // `docker exec`), so a sandboxed Kimi session starts fresh on
+                // restart, mirroring Copilot.
+                if self.is_sandboxed() {
+                    None
+                } else {
+                    let exclusion = self.retroactive_capture_exclusion_set();
+                    capture_kimi_session_id(&self.project_path, &exclusion).ok()
+                }
+            }
             _ => None,
         };
         result.and_then(validated_session_id)
@@ -3830,6 +3844,20 @@ impl Instance {
                     return;
                 }
                 Box::new(copilot_poll_fn(
+                    self.project_path.clone(),
+                    self.id.clone(),
+                    extra_excludes,
+                ))
+            }
+            "kimi" => {
+                // Host-only, mirroring Copilot: the Kimi session index is read
+                // from the host `~/.kimi-code`. Sandboxed sessions have no
+                // poller and start fresh on restart (sandbox resume is a
+                // follow-up).
+                if self.is_sandboxed() {
+                    return;
+                }
+                Box::new(kimi_poll_fn(
                     self.project_path.clone(),
                     self.id.clone(),
                     extra_excludes,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -7895,6 +7895,10 @@ mod tests {
             status_hook_env_prefix("work", "abc123", crate::agents::get_agent("kiro")),
             "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
         );
+        assert_eq!(
+            status_hook_env_prefix("work", "abc123", crate::agents::get_agent("kimi")),
+            "AOE_PROFILE='work' AOE_INSTANCE_ID='abc123' "
+        );
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1454,6 +1454,13 @@ pub fn detect_settl_status(_content: &str) -> Status {
     Status::Idle
 }
 
+/// Kimi Code status is detected via hooks (`[[hooks]]` in config.toml), not
+/// tmux pane parsing. This stub exists so the agent registry has a valid
+/// function pointer.
+pub fn detect_kimi_status(_content: &str) -> Status {
+    Status::Idle
+}
+
 pub fn detect_gemini_status(raw_content: &str) -> Status {
     let content = raw_content.to_lowercase();
     let lines: Vec<&str> = content.lines().collect();
@@ -3562,6 +3569,13 @@ run this command? (y/n)
     fn test_detect_settl_status_is_stub() {
         // settl uses hook-based detection; the stub always returns Idle
         assert_eq!(detect_settl_status("anything"), Status::Idle);
+    }
+
+    #[test]
+    fn test_detect_kimi_status_is_stub() {
+        // Kimi uses hook-based detection; the stub always returns Idle
+        assert_eq!(detect_kimi_status("anything"), Status::Idle);
+        assert_eq!(detect_kimi_status(""), Status::Idle);
     }
 
     #[test]

--- a/web/src/lib/agentProfiles.test.ts
+++ b/web/src/lib/agentProfiles.test.ts
@@ -10,6 +10,7 @@ describe("resolveAgentProfile", () => {
     expect(resolveAgentProfile("gemini").key).toBe("gemini");
     expect(resolveAgentProfile("vibe").key).toBe("vibe");
     expect(resolveAgentProfile("pi").key).toBe("pi");
+    expect(resolveAgentProfile("kimi").key).toBe("kimi");
     expect(resolveAgentProfile("aoe-agent").key).toBe("aoe-agent");
   });
 
@@ -75,6 +76,7 @@ describe("resolveAgentProfile", () => {
     expect(resolveAgentProfile("codex").clearAliases).toEqual(["/new"]);
     expect(resolveAgentProfile("opencode").clearAliases).toEqual(["/new"]);
     expect(resolveAgentProfile("gemini").clearAliases).toEqual([]);
+    expect(resolveAgentProfile("kimi").clearAliases).toEqual(["/new"]);
   });
 });
 

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -198,6 +198,27 @@ const PI: AgentProfile = {
   specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
+// Kimi Code (Moonshot AI) via native `kimi acp`. Kimi is Claude-influenced
+// (skills, plan mode, `mcp__` MCP naming), but its ACP tool-title surface
+// hasn't been verified hands-on, so specialised cards stay off and tools
+// render through the generic kind path. `/new` starts a fresh conversation,
+// mirroring the Rust KIMI profile.
+const KIMI: AgentProfile = {
+  key: "kimi",
+  capabilities: {
+    todos: false,
+    skills: false,
+    wakeup: false,
+    subagents: false,
+    legacyModeFallback: false,
+  },
+  parentMetaNamespaces: [],
+  mcpPrefixes: ["mcp__"],
+  clearAliases: ["/new"],
+  aliases: {},
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
+};
+
 const AOE_AGENT: AgentProfile = {
   ...CLAUDE,
   key: "aoe-agent",
@@ -230,6 +251,7 @@ const PROFILES: Record<string, AgentProfile> = {
   gemini: GEMINI,
   vibe: VIBE,
   pi: PI,
+  kimi: KIMI,
   "aoe-agent": AOE_AGENT,
 };
 


### PR DESCRIPTION
## Description

Adds [Kimi Code](https://code.kimi.com) (Moonshot AI's `kimi` CLI) as a first-class agent across the TUI, Docker sandbox, and native structured view. Every detail was verified against the real `kimi` v0.26.0 binary rather than guessed.

**What Kimi ships (verified):** binary `kimi`; `-y/--yolo`; `-p/--prompt` one-shot; `-S/--session` resume; a native `kimi acp` ACP server; and a Claude-style hook engine whose hooks live as a flat `[[hooks]]` array in `~/.kimi-code/config.toml`.

**Changes:**

- **Registry** (`src/agents.rs`): `kimi` `AgentDef` (yolo `--yolo`, one-shot `-p`, resume `--session`), a new `SidecarFormat::KimiToml`, and `KIMI_SIDECAR_EVENTS`.
- **Status hooks** (`src/hooks/`): a `toml_edit`-based installer that maps UserPromptSubmit / PreToolUse to running, PermissionRequest to waiting, PermissionResult to running, and Stop / StopFailure to idle. It edits the document in place so Kimi's provider, model, and OAuth blocks (which share `config.toml`) are preserved byte for byte. It also migrates a pre-existing inline `hooks = [{...}]` array into `[[hooks]]`, keeping user hooks.
- **Session resume** (`src/session/capture.rs`): host resume reads Kimi's `~/.kimi-code/session_index.jsonl` (keyed by workDir, with deletion tombstones), picks the most recent matching session, and feeds both the live poller and the retroactive-capture path. Sandbox resume is deferred, mirroring Copilot.
- **Sandbox** (`src/session/container_config.rs`, `docker/Dockerfile`): a `.kimi-code` config mount plus a Dockerfile install into `/usr/local`, so the binary is not shadowed by the mounted config dir.
- **Structured view** (`src/acp/*`, `web/src/lib/agentProfiles.ts`): native `kimi acp` registry entry, install hint, and Rust plus web agent profiles (`yolo` bypass mode, `/new` clear command).
- **Docs**: README, `docs/index.md`, sandbox guide, and the structured-view feature matrix.

**Validation beyond the test suite:** the emitted hook TOML is accepted by Kimi's own `kimi doctor config` (all six events), and the `kimi acp` handshake was verified with a real initialize / session round trip (native, advertises `default`/`plan`/`auto`/`yolo` modes). The session-index parser, session selection, and inline-array migration have unit tests using the exact on-disk formats extracted from the binary.

**Known limitations (follow-ups):** sandboxed Kimi sessions do not yet capture a session id over `docker exec`, so they start fresh on restart (same as Copilot). Host status-hook installation always writes `~/.kimi-code/config.toml`; a user who sets `$KIMI_CODE_HOME` on the host would need those hooks relocated (a limitation shared by every sidecar-hook agent, tracked separately). Session-id capture already honors `$KIMI_CODE_HOME`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo fmt`, `clippy --features serve`, `cargo test`, and web `oxfmt`/ESLint/`tsc`/vitest all clean)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A: no new visual surface; the structured-view change is a data-only agent classifier entry)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: this adds a data-only entry to the structured-view agent classifier (`agentProfiles.ts`), already covered by `web/src/lib/agentProfiles.test.ts` (vitest), which I extended with kimi assertions. No dashboard flow behavior changed, so no new Playwright spec or coverage-matrix entry is warranted.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: kimi follows the same data-driven sidecar-agent path as settl/kiro/hermes, exercised by the existing `container_config` sandbox-hooks test (auto-includes kimi) plus new `src/hooks` and `src/session/capture` unit tests (OAuth preservation, idempotence, uninstall, inline-array migration, session-index parsing/selection). A live end-to-end run needs the `kimi` binary plus a Kimi account login (device-code auth), which is not available in CI; the hook shape was instead validated against `kimi doctor config`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:** Claude drafted the implementation and this description through back-and-forth with @njbrake; the reasoning and decisions are his. Facts about Kimi's CLI, hook schema, session-index format, and ACP handshake were gathered by installing and inspecting the actual `kimi` v0.26.0 binary.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added first-class **Kimi Code** support across the app: agent registration/detection, **native structured view integration** via `kimi acp`, and matching **web/server agent profiles** (including the `/new` clear-alias behavior).
- Implemented **Kimi-aware status hook management** for `config.toml`: installs/uninstalls cleanly, **preserves existing Kimi configuration**, supports **idempotent** installs, and **migrates** from inline `hooks = [...]` to `[[hooks]]` while safely **rejecting unsupported/mixed hook shapes** instead of rewriting user config.
- Improved **session resume** using Kimi’s `session_index.jsonl`: selects the newest valid session for the project with robust handling for updates/deletions, applies a **launch-time safety floor** to avoid resuming pre-launch sessions, and hardens behavior for **sandboxed launches** (so unusable host session IDs aren’t carried into containers).
- Enhanced **Docker sandbox** setup: installs Kimi Code in the image and mounts host Kimi configuration into the container (`/root/.kimi-code`) to keep settings consistent.

## Testing & Reliability

- Added/extended unit tests covering hook install/uninstall behavior, config preservation and migration (including failure cases), session capture/resume selection logic (including tombstones and launch-time gating), and profile resolution consistency.

## Documentation

- Updated README and docs to include **Kimi Code** in supported tools/agents, sandbox guidance, and structured-view supported agents.

## Benefits

Users can run Kimi Code in a consistent way (native structured view + Docker sandbox) with more reliable status integration and safer reconnect/resume behavior—without clobbering existing Kimi `config.toml` settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->