### PR TITLE
fix(tui): stop trashing from freezing the TUI on the container stop

### DIFF
--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -183,6 +183,12 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
 ///
 /// The container stop is injected so the sandbox path is exercisable without a
 /// live docker runtime (mirrors `deletion::perform_deletion_with`).
+///
+/// BLOCKING: the container stop shells out to `docker stop` (~10s grace period)
+/// and the relocation runs `git worktree move`, so never call this on an event
+/// loop / UI thread. The TUI goes through [`perform_trash`] on the
+/// `TrashPoller`, the server wraps it in `spawn_blocking`, and the CLI is a
+/// one-shot process.
 pub fn prepare_trashed_worktree(inst: &mut Instance) -> RelocateOutcome {
     prepare_trashed_worktree_with(inst, |id, is_sandboxed| {
         if let Err(e) = crate::session::worktree_edit::stop_sandbox_container(id, is_sandboxed) {
@@ -201,6 +207,81 @@ fn prepare_trashed_worktree_with(
 ) -> RelocateOutcome {
     stop_container(&inst.id, is_sandboxed(inst));
     relocate_worktree_to_trash(inst)
+}
+
+/// A request to run a freshly-trashed session's off-thread teardown: tmux
+/// kill, sandbox container stop, and worktree relocation into the holding
+/// area. Mirrors [`StopRequest`](crate::session::stop::StopRequest).
+///
+/// The container stop shells out to `docker stop`, which blocks for the
+/// container's grace period (~10s; its PID-1 `sleep infinity` ignores
+/// SIGTERM), so the TUI runs this on the `TrashPoller` worker thread instead of
+/// the input thread. See [`perform_trash`].
+pub struct TrashRequest {
+    pub session_id: String,
+    pub instance: Instance,
+}
+
+/// The worktree relocation a background trash-prepare produced, for the main
+/// loop to persist. Only present when the move actually happened.
+#[derive(Debug, Clone)]
+pub struct TrashRelocation {
+    /// The repointed worktree directory (now under the holding area).
+    pub new_project_path: String,
+    /// The original location, to persist as `pre_trash_project_path` so a
+    /// later restore can move it back.
+    pub pre_trash_project_path: Option<String>,
+}
+
+/// The outcome of a background trash-prepare, delivered back over the
+/// `TrashPoller` channel. Mirrors [`StopResult`](crate::session::stop::StopResult).
+#[derive(Debug)]
+pub struct TrashResult {
+    pub session_id: String,
+    /// The relocation to persist, or `None` when nothing moved (`Skipped`) or
+    /// the move could not run (`Failed`).
+    pub relocation: Option<TrashRelocation>,
+    /// Set when relocation could not run safely; surfaced as a `warn!` by the
+    /// drain. The row stays durably trashed in place regardless; a later
+    /// reconcile pass can move it.
+    pub relocate_warning: Option<String>,
+}
+
+/// Run a trashed session's teardown off the caller's thread: kill its tmux
+/// panes, stop its sandbox container, and relocate its worktree into the
+/// holding area. Pure side effects on a cloned `Instance`; the caller persists
+/// the returned [`TrashRelocation`] onto the real row.
+///
+/// This is the TUI's off-thread entry point (run on the `TrashPoller` worker),
+/// the counterpart to [`perform_stop`](crate::session::stop::perform_stop) for
+/// the stop path. The server runs the same `prepare_trashed_worktree` inside
+/// `spawn_blocking` and the CLI runs it inline in a one-shot process; only the
+/// TUI needs this wrapper, because only it has a UI thread to keep responsive.
+pub fn perform_trash(request: &TrashRequest) -> TrashResult {
+    let mut inst = request.instance.clone();
+    // tmux teardown runs off-thread here for the same reason force_remove and
+    // archive-group do it: N shellouts should not sit on the input thread.
+    inst.kill_all_tmux_sessions();
+    match prepare_trashed_worktree(&mut inst) {
+        RelocateOutcome::Relocated { .. } => TrashResult {
+            session_id: request.session_id.clone(),
+            relocation: Some(TrashRelocation {
+                new_project_path: inst.project_path.clone(),
+                pre_trash_project_path: inst.pre_trash_project_path.clone(),
+            }),
+            relocate_warning: None,
+        },
+        RelocateOutcome::Skipped => TrashResult {
+            session_id: request.session_id.clone(),
+            relocation: None,
+            relocate_warning: None,
+        },
+        RelocateOutcome::Failed { reason } => TrashResult {
+            session_id: request.session_id.clone(),
+            relocation: None,
+            relocate_warning: Some(reason),
+        },
+    }
 }
 
 /// Move a trashed session's worktree back to its pre-trash location and clear

--- a/src/session/worktree_edit.rs
+++ b/src/session/worktree_edit.rs
@@ -137,6 +137,15 @@ pub fn discard_sandbox_container_after_move(session_id: &str, is_sandboxed: bool
 /// up both leaks a running container for the whole retention window and makes
 /// [`relocate_worktree_to_trash`](crate::session::trash::relocate_worktree_to_trash)
 /// fail `EBUSY` against the live mount.
+///
+/// BLOCKING: `docker stop` waits out the container's stop grace period (~10s,
+/// because the PID-1 `sleep infinity` ignores SIGTERM until the SIGKILL), so
+/// this must never run on the TUI input thread. Every UI-facing caller runs it
+/// off-thread: the stop path via [`perform_stop`](crate::session::stop::perform_stop)
+/// on the `StopPoller`, the trash path via
+/// [`perform_trash`](crate::session::trash::perform_trash) on the `TrashPoller`,
+/// and the server via `spawn_blocking`. The CLI runs it inline only because it
+/// is a one-shot process with no event loop to starve.
 pub fn stop_sandbox_container(session_id: &str, is_sandboxed: bool) -> anyhow::Result<()> {
     if !is_sandboxed {
         return Ok(());

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1566,6 +1566,11 @@ impl App {
                 needs_full_refresh = true;
             }
 
+            if self.home.apply_trash_results() {
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
             if last_session_idle_reap.elapsed() >= SESSION_IDLE_REAP_INTERVAL {
                 last_session_idle_reap = std::time::Instant::now();
                 if self.reap_idle_sessions() {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -667,6 +667,10 @@ pub struct HomeView {
     // Performance: background stop (docker stop can block up to ~10s)
     pub(super) stop_poller: StopPoller,
 
+    // Performance: background trash prep (stops the sandbox container, so the
+    // same ~10s docker stop block as `stop_poller`, plus the worktree move)
+    pub(super) trash_poller: crate::tui::trash_poller::TrashPoller,
+
     // Performance: background restart (the start cascade shells out to docker
     // and runs the before_start host hook, which can block for seconds)
     pub(super) restart_poller: RestartPoller,
@@ -2144,6 +2148,7 @@ impl HomeView {
             pending_status_refresh: false,
             deletion_poller: DeletionPoller::new(),
             stop_poller: StopPoller::new(),
+            trash_poller: crate::tui::trash_poller::TrashPoller::new(),
             restart_poller: RestartPoller::new(),
             restart_in_flight: std::collections::HashSet::new(),
             purge_claimed: std::collections::HashSet::new(),
@@ -3072,6 +3077,62 @@ impl HomeView {
                     tracing::error!(target: "tui.home", "Failed to save after stop: {}", e);
                 }
                 true
+            }
+        }
+    }
+
+    /// Apply the result of a background trash prepare: persist the relocated
+    /// worktree path onto the (already-trashed) row. Returns true if an
+    /// instance was updated so the caller can trigger a redraw.
+    pub fn apply_trash_results(&mut self) -> bool {
+        use std::sync::mpsc::TryRecvError;
+
+        match self.trash_poller.try_recv_result() {
+            Ok(result) => {
+                let mut changed = false;
+                if let Some(reloc) = result.relocation {
+                    // The worktree moved into the holding area on the worker
+                    // thread; persist the repointed project_path (+ pre-trash
+                    // marker) onto the real row. `merge_user_action_diff`
+                    // carries both fields, mirroring the load-time reconcile.
+                    if let Err(e) = self.apply_user_action(&result.session_id, |inst| {
+                        inst.project_path = reloc.new_project_path.clone();
+                        inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
+                    }) {
+                        tracing::error!(
+                            target: "tui.home",
+                            session = %result.session_id,
+                            "failed to persist trash worktree relocation: {e}",
+                        );
+                    }
+                    changed = true;
+                }
+                if let Some(reason) = result.relocate_warning {
+                    tracing::warn!(
+                        target: "tui.session",
+                        session = %result.session_id,
+                        "trash worktree relocation skipped: {reason}",
+                    );
+                }
+                changed
+            }
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                // The worker thread is gone (a panic in perform_trash dropped
+                // result_tx). The rows are already durably trashed, so no
+                // status surgery is needed; their worktrees just did not
+                // relocate. A later reconcile pass (`reconcile_trashed_location`
+                // at load) moves them, so this only logs which are deferred.
+                let stuck = self.trash_poller.take_pending();
+                if stuck.is_empty() {
+                    return false;
+                }
+                tracing::error!(
+                    target: "tui.home",
+                    rows = stuck.len(),
+                    "trash poller worker gone; worktree relocation deferred to next reconcile",
+                );
+                false
             }
         }
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3090,7 +3090,19 @@ impl HomeView {
         match self.trash_poller.try_recv_result() {
             Ok(result) => {
                 let mut changed = false;
-                if let Some(reloc) = result.relocation {
+                // Only persist the relocation if the row is still trashed. The
+                // teardown ran off-thread, so a fast restore or purge could have
+                // landed in between; applying the holding-area path to a row the
+                // user just restored would repoint a live session's worktree
+                // into `.aoe-trash/`. A purged row is gone from the map and this
+                // skips too. The relocation is best-effort regardless: a later
+                // reconcile pass heals a still-trashed row whose move was
+                // dropped here.
+                let still_trashed = self
+                    .instances
+                    .get(&result.session_id)
+                    .is_some_and(|i| i.is_trashed());
+                if let (true, Some(reloc)) = (still_trashed, result.relocation) {
                     // The worktree moved into the holding area on the worker
                     // thread; persist the repointed project_path (+ pre-trash
                     // marker) onto the real row. `merge_user_action_diff`

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1567,39 +1567,39 @@ impl HomeView {
         Ok(())
     }
 
-    /// Move a session to the trash: stop its tmux sessions (a structured-view
-    /// worker is reaped by the daemon reconciler once the row reads trashed),
-    /// stop its sandbox container if any (via `prepare_trashed_worktree`, so it
-    /// doesn't keep running for the whole retention window), and set
-    /// `trashed_at`. Durable artifacts are kept so it can be
-    /// restored. The Trash section's collapse state is left untouched: like
-    /// single-row archive, the section header's count is the feedback, so a
-    /// user who collapsed it stays collapsed (#2489).
+    /// Move a session to the trash and set `trashed_at`. Durable artifacts are
+    /// kept so it can be restored. The Trash section's collapse state is left
+    /// untouched: like single-row archive, the section header's count is the
+    /// feedback, so a user who collapsed it stays collapsed (#2489).
+    ///
+    /// The durable trash marker is written inline (a fast local write) so the
+    /// row flips to Trashed immediately. Everything that can block, tmux
+    /// teardown, the sandbox container stop, and the worktree relocation out of
+    /// the active dir, runs off-thread on the `TrashPoller` and is reconciled
+    /// by [`apply_trash_results`](crate::tui::home::HomeView::apply_trash_results).
+    /// Stopping the container matters because it otherwise lingers for the whole
+    /// retention window and its live bind mount makes the worktree
+    /// `git worktree move` fail EBUSY; but `docker stop` blocks for the
+    /// container's grace period (~10s, its PID-1 `sleep infinity` ignores
+    /// SIGTERM), so running it inline froze the input thread (the same reason
+    /// `Instance::stop` runs on the `StopPoller`, #1496). A structured-view
+    /// worker is reaped by the daemon reconciler once the row reads trashed.
     pub(super) fn trash_session_by_id(&mut self, id: &str) {
         if let Err(e) = self.apply_user_action(id, |inst| inst.trash()) {
             tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
             return;
         }
+        // The row is durably trashed; hand the blocking teardown (tmux kill,
+        // container stop, worktree relocation) to the worker. The relocated
+        // path persists later via apply_trash_results. Best-effort: if the
+        // relocation cannot run, the worktree stays in place and a later
+        // reconcile pass moves it.
         if let Some(inst) = self.instances.get(id) {
-            inst.kill_all_tmux_sessions();
-        }
-        // The session is durably trashed; stop its sandbox container (so it
-        // doesn't linger for the whole retention window) and relocate its
-        // worktree out of the active dir. Stopping the container also releases
-        // the worktree bind mount, without which the `git worktree move` below
-        // hits EBUSY. The move + repointed project_path persist through the same
-        // diff path. Best-effort: a failure leaves the worktree in place and a
-        // later reconcile pass can move it.
-        let mut relocate_warning: Option<String> = None;
-        let _ = self.apply_user_action(id, |inst| {
-            if let crate::session::trash::RelocateOutcome::Failed { reason } =
-                crate::session::trash::prepare_trashed_worktree(inst)
-            {
-                relocate_warning = Some(reason);
-            }
-        });
-        if let Some(reason) = relocate_warning {
-            tracing::warn!(target: "tui.session", session = %id, "trash worktree relocation skipped: {reason}");
+            self.trash_poller
+                .request_trash(crate::session::trash::TrashRequest {
+                    session_id: id.to_string(),
+                    instance: inst.clone(),
+                });
         }
         self.rebuild_flat_items();
         self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7592,6 +7592,36 @@ fn trashing_leaves_collapsed_trash_section_collapsed() {
     );
 }
 
+/// Regression: trashing must offload the blocking teardown (tmux kill, the
+/// ~10s `docker stop`, and the worktree relocation) to the `TrashPoller`
+/// instead of running it on the input thread, which froze the TUI while the
+/// sandbox container stopped. The durable trash marker is still written inline
+/// so the row flips to Trashed instantly; the teardown is merely queued.
+#[test]
+#[serial]
+fn trash_offloads_blocking_teardown_to_poller() {
+    let mut env = create_test_env_with_sessions(2);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    env.view.trash_session_by_id(&id);
+
+    // Inline: the row is durably trashed the instant the key is handled.
+    assert!(
+        env.view.get_instance(&id).unwrap().is_trashed(),
+        "trash marker must be written inline for instant feedback"
+    );
+    // Off-thread: the blocking teardown is in flight on the worker, tracked in
+    // its pending set until a result is drained. If trashing had run the
+    // teardown inline (the frozen-TUI bug), nothing would be queued here.
+    let pending = env.view.trash_poller.take_pending();
+    assert_eq!(
+        pending,
+        vec![id],
+        "trash teardown must be queued on the TrashPoller, not run on the input thread"
+    );
+}
+
 /// Right-clicking the synthetic Trash section header opens the bulk menu
 /// (Empty Trash / Restore All / Collapse), not the meaningless "Rename Group /
 /// Delete Group" a real group would show.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -21,6 +21,7 @@ mod stop_poller;
 #[cfg(feature = "serve")]
 pub(crate) mod structured_view;
 pub(crate) mod styles;
+mod trash_poller;
 mod worker;
 
 pub use app::*;

--- a/src/tui/trash_poller.rs
+++ b/src/tui/trash_poller.rs
@@ -1,0 +1,124 @@
+//! Background trash handler for TUI responsiveness.
+//!
+//! Trashing a sandboxed session stops its Docker container (`docker stop`,
+//! which blocks for the container's grace period, ~10s) and then relocates its
+//! worktree into the holding area. Running that on the UI event loop froze the
+//! TUI (issue #2924 added the container stop inline; this moves it off-thread,
+//! the same fix `StopPoller` applied for the stop path in #1496). Requests go
+//! to a worker thread, results come back over a channel the main loop polls
+//! each frame.
+
+use std::collections::HashSet;
+use std::sync::mpsc::TryRecvError;
+
+use crate::session::trash::perform_trash;
+pub use crate::session::trash::{TrashRequest, TrashResult};
+use crate::tui::worker::Worker;
+
+pub struct TrashPoller {
+    worker: Worker<TrashRequest, TrashResult>,
+    /// Session ids with a trash prepare in flight. The row is already durably
+    /// trashed at request time, so its status alone cannot identify which
+    /// relocations were still pending if the worker dies (Disconnected); this
+    /// set can, so the drain can log them as deferred.
+    pending: HashSet<String>,
+}
+
+impl TrashPoller {
+    pub fn new() -> Self {
+        Self {
+            worker: Worker::spawn("aoe-trash-poller", |request| perform_trash(&request)),
+            pending: HashSet::new(),
+        }
+    }
+
+    pub fn request_trash(&mut self, request: TrashRequest) {
+        self.pending.insert(request.session_id.clone());
+        self.worker.request(request);
+    }
+
+    /// Non-blocking poll for a completed trash prepare. Surfaces `Disconnected`
+    /// (see `Worker::try_recv`) so the caller can note the relocations still in
+    /// [`Self::take_pending`] as deferred rather than silently lost.
+    pub fn try_recv_result(&mut self) -> Result<TrashResult, TryRecvError> {
+        let result = self.worker.try_recv();
+        if let Ok(ref trash) = result {
+            self.pending.remove(&trash.session_id);
+        }
+        result
+    }
+
+    /// Drain the in-flight set. Called once the worker is known dead so the
+    /// consumer can log which relocations never landed (the rows stay trashed;
+    /// a later reconcile pass moves their worktrees).
+    pub fn take_pending(&mut self) -> Vec<String> {
+        self.pending.drain().collect()
+    }
+}
+
+impl Default for TrashPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Instance;
+    use std::time::Duration;
+
+    fn create_test_instance() -> Instance {
+        Instance::new("Test Session", "/tmp/test-project")
+    }
+
+    #[test]
+    fn test_trash_poller_channel_communication() {
+        let mut poller = TrashPoller::new();
+        let instance = create_test_instance();
+        let session_id = instance.id.clone();
+
+        poller.request_trash(TrashRequest {
+            session_id: session_id.clone(),
+            instance,
+        });
+
+        let mut result = None;
+        for _ in 0..50 {
+            if let Ok(r) = poller.try_recv_result() {
+                result = Some(r);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let result = result.expect("Timed out waiting for trash result");
+
+        assert_eq!(result.session_id, session_id);
+        // A plain (non-worktree, non-sandbox) session has nothing to relocate.
+        assert!(result.relocation.is_none());
+        assert!(result.relocate_warning.is_none());
+        // The delivered result must clear the in-flight marker.
+        assert!(poller.take_pending().is_empty());
+    }
+
+    #[test]
+    fn test_trash_poller_try_recv_returns_empty_when_idle() {
+        let mut poller = TrashPoller::new();
+        assert!(matches!(poller.try_recv_result(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn test_trash_poller_tracks_pending_requests() {
+        let mut poller = TrashPoller::new();
+        let instance = create_test_instance();
+        let session_id = instance.id.clone();
+
+        poller.request_trash(TrashRequest {
+            session_id: session_id.clone(),
+            instance,
+        });
+
+        assert_eq!(poller.take_pending(), vec![session_id]);
+        assert!(poller.take_pending().is_empty(), "take_pending drains");
+    }
+}


### PR DESCRIPTION
## Description

Trashing a containerized session with `d` froze the whole TUI for the container's stop grace period (~10s).

#2924 added a `prepare_trashed_worktree` call directly inside `trash_session_by_id`, which runs on the TUI input thread. That function shells out to a blocking `docker stop`. The sandbox container's PID 1 is `sleep infinity`, which gets no default signal handling and ignores SIGTERM, so Docker waits out its full grace period before SIGKILL. The event loop was parked on that subprocess the whole time.

The codebase already solved this exact freeze for the sibling stop path in #1496 (`StopPoller` + `perform_stop`, running `Instance::stop` off-thread), and #2924's own server handler correctly wrapped `prepare_trashed_worktree` in `spawn_blocking`. Only the TUI trash path ran it inline. This change consolidates trash onto the same off-thread worker pattern as stop / delete / restart / creation.

### What changed

- **New `TrashPoller`** (`src/tui/trash_poller.rs`), mirroring `StopPoller`: requests go to a worker thread, results come back over a channel the main loop drains each frame.
- **`perform_trash` / `TrashRequest` / `TrashResult`** in `session::trash`: tmux kill + sandbox container stop + worktree relocation on a cloned `Instance`, off-thread.
- **`trash_session_by_id`** writes the durable trash marker inline (so the row flips to Trashed instantly), then hands the blocking teardown to the poller.
- **`apply_trash_results`** drains the worker and persists the relocated worktree path (`project_path` + `pre_trash_project_path`), wired into the `App::run` tick loop next to `apply_stop_results`.
- **Doc fixes**: `stop_sandbox_container` and `prepare_trashed_worktree` previously framed their UI-thread and worker-thread callers as equivalent, which is what let the inline call slip in. Both now carry a BLOCKING warning naming every offload site (StopPoller, TrashPoller, server `spawn_blocking`, CLI one-shot).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The user-facing change is the absence of a freeze; there is no new visual state to screenshot. The Trashed row and section behavior are unchanged.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the server trash handler was already off-thread and is untouched)

**TUI / CLI (e2e test)**
- [x] Added or updated a test: `trash_offloads_blocking_teardown_to_poller` (unit-level, `src/tui/home/tests.rs`) asserts the row is trashed inline while the teardown is queued on the `TrashPoller` (fails if the teardown runs inline), plus three `TrashPoller` channel/pending tests. A full-binary e2e that measures wall-clock non-blocking would need a live Docker sandbox; the behavioral invariant (offloaded vs inline) is covered deterministically here without one.

### How tested

- `cargo test --lib trash`: 49 passed, 0 failed (new regression test + 3 poller tests included).
- `cargo build`, `cargo check --features serve`, `cargo clippy --all-targets`: clean (the 2 pre-existing clippy warnings are present on the base commit; verified via `git stash`).
- The one full-suite failure (`restart_..._async_restart`) fails identically on the base commit, so it is pre-existing environment flake, not introduced here.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-caused and implemented via Claude Code, reviewed by @njbrake. The investigation traced the freeze to the inline `docker stop` in the #2924 trash path and identified the existing `StopPoller` (#1496) and server `spawn_blocking` as the pattern to consolidate onto.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **What changed**
  - Fixes a TUI freeze during “trash” by moving the slow teardown work off the UI/input thread.
  - Adds a background **TrashPoller** that runs the blocking teardown (tmux termination, container stop, and worktree relocation) in a worker thread.
  - When a session is trashed, the UI now marks it as trashed immediately, and then later reconciles the relocated worktree paths once the worker finishes.
  - Updates the TUI loop to periodically apply completed trash results.

- **What was added**
  - New trash worker request/response types: **TrashRequest**, **TrashResult**, and **TrashRelocation**.
  - A new **perform_trash** function that does the actual teardown work and returns relocation info/warnings.
  - **TrashPoller** with non-blocking result polling and tracking of in-flight sessions.
  - Regression tests ensuring trashing offloads blocking teardown and that the poller/channel behavior works as expected.

- **What was removed or moved**
  - The previous inline teardown path in `trash_session_by_id` (including the synchronous `docker stop` + worktree move) was removed from the TUI input thread and replaced with queued async teardown.

- **Bug fix / benefit**
  - Prevents UI hangs caused by waiting out container stop grace periods.
  - Improves user experience by keeping the interface responsive and still updating session/worktree state once cleanup completes.
  - Adds safer handling for races (e.g., if a session is restored/purged before async teardown finishes, relocation results won’t be applied).

## Technical details (optional)

- Introduced off-thread trash teardown (`perform_trash`) and asynchronous result application via `HomeView::apply_trash_results`.
- Updated `apply_trash_results` to persist relocation changes only when the session is still in the trashed state; logs/defers work when the worker disconnects or when relocation fails.
- Expanded docs/comments to explicitly call out that the container stop step (`docker stop`) is blocking and must not run on the TUI input thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->