### PR TITLE
fix(tui): scope unread marker and Stop action to the correct view

### DIFF
--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -577,11 +577,11 @@ pub static BINDINGS: &[Binding] = &[
         context: Context::Always,
         help: Some(HelpMeta {
             section: HelpSection::Actions,
-            desc: "Stop session",
+            desc: "Stop session / kill terminal (by view)",
         }),
         palette: Some(PaletteMeta {
-            title: "Stop session",
-            keywords: &["kill", "end", "halt"],
+            title: "Stop session / kill terminal",
+            keywords: &["kill", "end", "halt", "terminal"],
             group: PaletteGroup::Actions,
             serve_only: false,
         }),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1045,6 +1045,14 @@ impl HomeView {
                 None
             }
             "stop_session" => self.pending_stop_session.take().map(Action::StopSession),
+            "stop_terminal" => {
+                if let Some((session_id, mode)) = self.pending_stop_terminal.take() {
+                    if let Err(e) = self.kill_terminal_for(&session_id, mode) {
+                        tracing::error!(target: "tui.input", "Failed to kill terminal: {}", e);
+                    }
+                }
+                None
+            }
             "force_remove_session" => {
                 if let Some(session_id) = self.pending_force_remove_session.take() {
                     if let Err(e) = self.force_remove_session(&session_id) {
@@ -1270,6 +1278,7 @@ impl HomeView {
                     DialogResult::Cancel => {
                         self.confirm_dialog = None;
                         self.pending_stop_session = None;
+                        self.pending_stop_terminal = None;
                         self.pending_force_remove_session = None;
                         self.pending_trash_session = None;
                         self.pending_image_pull = None;
@@ -2071,6 +2080,7 @@ impl HomeView {
                 DialogResult::Cancel => {
                     self.confirm_dialog = None;
                     self.pending_stop_session = None;
+                    self.pending_stop_terminal = None;
                     self.pending_force_remove_session = None;
                     self.pending_trash_session = None;
                     self.pending_image_pull = None;
@@ -3094,7 +3104,15 @@ impl HomeView {
         None
     }
 
-    fn stop_selected(&mut self) {
+    pub(super) fn stop_selected(&mut self) {
+        // In Terminal view, Stop targets the paired terminal, not the agent
+        // session: the user is looking at the terminal pane, so killing the
+        // agent (docker stop + status flip) would be surprising. Kill just the
+        // terminal the row is showing.
+        if self.view_mode == ViewMode::Terminal {
+            self.stop_terminal_selected();
+            return;
+        }
         if let Some(session_id) = &self.selected_session {
             if let Some(inst) = self.get_instance(session_id) {
                 if matches!(
@@ -3109,6 +3127,66 @@ impl HomeView {
                     Some(ConfirmDialog::new("Stop Session", &message, "stop_session"));
             }
         }
+    }
+
+    /// Terminal-view Stop: confirm, then kill the paired terminal (host or
+    /// container, whichever the row is showing) without touching the agent
+    /// session. No-op when the terminal isn't running, so pressing Stop on an
+    /// idle terminal row doesn't pop a pointless dialog.
+    fn stop_terminal_selected(&mut self) {
+        let Some(session_id) = self.selected_session.clone() else {
+            return;
+        };
+        let Some(inst) = self.get_instance(&session_id) else {
+            return;
+        };
+        let mode = if inst.is_sandboxed() {
+            self.get_terminal_mode(&session_id)
+        } else {
+            TerminalMode::Host
+        };
+        let terminal_running = match mode {
+            TerminalMode::Container => inst
+                .container_terminal_tmux_session()
+                .map(|s| s.exists())
+                .unwrap_or(false),
+            TerminalMode::Host => inst
+                .terminal_tmux_session()
+                .map(|s| s.exists())
+                .unwrap_or(false),
+        };
+        if !terminal_running {
+            return;
+        }
+        let message = format!(
+            "Are you sure you want to kill the terminal for '{}'?",
+            inst.title
+        );
+        self.pending_stop_terminal = Some((session_id, mode));
+        self.confirm_dialog = Some(ConfirmDialog::new(
+            "Kill Terminal",
+            &message,
+            "stop_terminal",
+        ));
+    }
+
+    /// Kill the paired terminal for `session_id` (host or container per `mode`),
+    /// then refresh so the Terminal-view row drops back to its idle glyph. The
+    /// agent session is left untouched.
+    pub(super) fn kill_terminal_for(
+        &mut self,
+        session_id: &str,
+        mode: TerminalMode,
+    ) -> anyhow::Result<()> {
+        if let Some(inst) = self.get_instance(session_id) {
+            match mode {
+                TerminalMode::Container => inst.kill_container_terminal()?,
+                TerminalMode::Host => inst.kill_terminal()?,
+            }
+        }
+        crate::tmux::refresh_session_cache();
+        self.reload()?;
+        Ok(())
     }
 
     fn open_diff_for_selected(&mut self) {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1053,6 +1053,14 @@ impl HomeView {
                 }
                 None
             }
+            "stop_tool" => {
+                if let Some((session_id, tool_name)) = self.pending_stop_tool.take() {
+                    if let Err(e) = self.kill_tool_for(&session_id, &tool_name) {
+                        tracing::error!(target: "tui.input", "Failed to kill tool session: {}", e);
+                    }
+                }
+                None
+            }
             "force_remove_session" => {
                 if let Some(session_id) = self.pending_force_remove_session.take() {
                     if let Err(e) = self.force_remove_session(&session_id) {
@@ -1279,6 +1287,7 @@ impl HomeView {
                         self.confirm_dialog = None;
                         self.pending_stop_session = None;
                         self.pending_stop_terminal = None;
+                        self.pending_stop_tool = None;
                         self.pending_force_remove_session = None;
                         self.pending_trash_session = None;
                         self.pending_image_pull = None;
@@ -2081,6 +2090,7 @@ impl HomeView {
                     self.confirm_dialog = None;
                     self.pending_stop_session = None;
                     self.pending_stop_terminal = None;
+                    self.pending_stop_tool = None;
                     self.pending_force_remove_session = None;
                     self.pending_trash_session = None;
                     self.pending_image_pull = None;
@@ -3105,13 +3115,21 @@ impl HomeView {
     }
 
     pub(super) fn stop_selected(&mut self) {
-        // In Terminal view, Stop targets the paired terminal, not the agent
-        // session: the user is looking at the terminal pane, so killing the
-        // agent (docker stop + status flip) would be surprising. Kill just the
-        // terminal the row is showing.
-        if self.view_mode == ViewMode::Terminal {
-            self.stop_terminal_selected();
-            return;
+        // Stop targets what the user is looking at. In Terminal view that is
+        // the paired terminal, and in Tool view the tool session; killing the
+        // agent (docker stop + status flip) from either would be surprising.
+        // Only Agent (structured) view stops the agent session itself.
+        match &self.view_mode {
+            ViewMode::Terminal => {
+                self.stop_terminal_selected();
+                return;
+            }
+            ViewMode::Tool(tool_name) => {
+                let tool_name = tool_name.clone();
+                self.stop_tool_selected(&tool_name);
+                return;
+            }
+            ViewMode::Structured => {}
         }
         if let Some(session_id) = &self.selected_session {
             if let Some(inst) = self.get_instance(session_id) {
@@ -3182,6 +3200,46 @@ impl HomeView {
             match mode {
                 TerminalMode::Container => inst.kill_container_terminal()?,
                 TerminalMode::Host => inst.kill_terminal()?,
+            }
+        }
+        crate::tmux::refresh_session_cache();
+        self.reload()?;
+        Ok(())
+    }
+
+    /// Tool-view Stop: confirm, then kill the tool session (lazygit, yazi,
+    /// ...) without touching the agent session. Mirrors
+    /// `stop_terminal_selected`: no-op when the tool isn't running.
+    fn stop_tool_selected(&mut self, tool_name: &str) {
+        let Some(session_id) = self.selected_session.clone() else {
+            return;
+        };
+        let Some(inst) = self.get_instance(&session_id) else {
+            return;
+        };
+        let tool_session = crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
+        if !tool_session.exists() || tool_session.is_pane_dead() {
+            return;
+        }
+        let message = format!(
+            "Are you sure you want to kill {} for '{}'?",
+            tool_name, inst.title
+        );
+        self.pending_stop_tool = Some((session_id, tool_name.to_string()));
+        self.confirm_dialog = Some(ConfirmDialog::new("Kill Tool", &message, "stop_tool"));
+    }
+
+    /// Kill the tool session for `session_id`, then refresh so the Tool-view
+    /// row drops back to its idle glyph. The agent session is left untouched.
+    pub(super) fn kill_tool_for(
+        &mut self,
+        session_id: &str,
+        tool_name: &str,
+    ) -> anyhow::Result<()> {
+        if let Some(inst) = self.get_instance(session_id) {
+            let tool_session = crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
+            if tool_session.exists() {
+                tool_session.kill()?;
             }
         }
         crate::tmux::refresh_session_cache();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -630,6 +630,11 @@ pub struct HomeView {
     pub(super) pending_attach_after_warning: Option<String>,
     /// Session to stop after the confirmation dialog is accepted
     pub(super) pending_stop_session: Option<String>,
+    /// Paired terminal to kill after the Terminal-view "kill terminal" confirm
+    /// dialog is accepted. Carries the session id and which terminal (host vs
+    /// container) the row was showing, so the accept path kills exactly the
+    /// terminal the user was looking at without touching the agent session.
+    pub(super) pending_stop_terminal: Option<(String, TerminalMode)>,
     /// Sandbox image to pull after the "image update available" confirm dialog
     /// is accepted. Carries the image through the generic `ConfirmDialog`,
     /// which only knows its action string.
@@ -2130,6 +2135,7 @@ impl HomeView {
             pending_paste: None,
             pending_attach_after_warning: None,
             pending_stop_session: None,
+            pending_stop_terminal: None,
             pending_image_pull: None,
             pending_switch_view_session: None,
             pending_force_remove_session: None,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -635,6 +635,10 @@ pub struct HomeView {
     /// container) the row was showing, so the accept path kills exactly the
     /// terminal the user was looking at without touching the agent session.
     pub(super) pending_stop_terminal: Option<(String, TerminalMode)>,
+    /// Tool session to kill after the Tool-view "kill tool" confirm dialog is
+    /// accepted: session id plus the tool name the view was previewing. Same
+    /// contract as `pending_stop_terminal`, the agent session is untouched.
+    pub(super) pending_stop_tool: Option<(String, String)>,
     /// Sandbox image to pull after the "image update available" confirm dialog
     /// is accepted. Carries the image through the generic `ConfirmDialog`,
     /// which only knows its action string.
@@ -2136,6 +2140,7 @@ impl HomeView {
             pending_attach_after_warning: None,
             pending_stop_session: None,
             pending_stop_terminal: None,
+            pending_stop_tool: None,
             pending_image_pull: None,
             pending_switch_view_session: None,
             pending_force_remove_session: None,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1468,23 +1468,17 @@ impl HomeView {
                                     .map(|s| s.exists())
                                     .unwrap_or(false),
                             };
-                            // Sunk rows suppress the unread overlay in every
-                            // sort mode, same rule as the Agent-view path (#2571).
-                            let unread_overlay = crate::session::unread_enabled()
-                                && inst.is_unread()
-                                && !inst.is_archived()
-                                && !inst.is_snoozed();
+                            // Unread is an Agent-view concept: it means the agent
+                            // produced output the user hasn't looked at. The
+                            // paired terminal has no such notion, so Terminal
+                            // view never paints the unread dot; the row just
+                            // tracks whether its terminal pane is live.
                             let (mut icon, color) = if terminal_running {
                                 (spinner_running(&inst.created_at), theme.terminal_active)
-                            } else if unread_overlay {
-                                (ICON_UNREAD, theme.unread)
                             } else {
                                 (ICON_IDLE, theme.dimmed)
                             };
                             let mut style = Style::default().fg(color);
-                            if unread_overlay && !terminal_running {
-                                style = style.add_modifier(ratatui::style::Modifier::BOLD);
-                            }
                             if inst.is_archived() || inst.is_trashed() {
                                 // Archive/trash lifecycle override mirrors the
                                 // Agent-view path: dim color, stopped

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -831,10 +831,10 @@ fn unread_dot_never_paints_in_terminal_view() {
     );
 }
 
-/// Stop in Terminal view kills the paired terminal, not the agent session.
-/// The routing decision lives in `stop_selected`: Agent view arms the
-/// `stop_session` confirm (agent + container stop), Terminal view routes to the
-/// terminal-kill path and never arms an agent stop.
+/// Stop targets what the user is looking at: Agent view arms the
+/// `stop_session` confirm (agent + container stop), while Terminal and Tool
+/// views route to their respective pane-kill paths and never arm an agent
+/// stop. The routing decision lives in `stop_selected`.
 #[test]
 #[serial]
 fn stop_in_terminal_view_does_not_target_agent_session() {
@@ -875,6 +875,20 @@ fn stop_in_terminal_view_does_not_target_agent_session() {
         env.view.confirm_dialog.as_ref().map(|d| d.action()),
         Some("stop_session"),
         "terminal view stop must not open the stop-session confirm"
+    );
+
+    // Tool view: same invariant, Stop routes to the tool-kill path and never
+    // arms an agent stop.
+    env.view.view_mode = ViewMode::Tool("lazygit".to_string());
+    env.view.stop_selected();
+    assert!(
+        env.view.pending_stop_session.is_none(),
+        "tool view stop must not arm an agent-session stop"
+    );
+    assert_ne!(
+        env.view.confirm_dialog.as_ref().map(|d| d.action()),
+        Some("stop_session"),
+        "tool view stop must not open the stop-session confirm"
     );
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -778,6 +778,106 @@ fn unread_dot_suppressed_on_archived_and_snoozed() {
     );
 }
 
+/// Unread is an Agent-view concept: the dot marks agent output the user hasn't
+/// seen. The paired terminal has no such notion, so Terminal view must never
+/// paint the unread dot even when the underlying instance carries the flag.
+#[test]
+#[serial]
+fn unread_dot_never_paints_in_terminal_view() {
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    crate::session::set_unread_enabled(true);
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+    let theme = load_theme("empire");
+
+    let render = |env: &mut TestEnv| -> String {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| env.view.render(f, f.area(), &theme, None, None, None))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+        }
+        out
+    };
+
+    env.view.mutate_instance(&id, |inst| {
+        inst.status = crate::session::Status::Idle;
+        inst.mark_unread();
+    });
+    env.view.flat_items = env.view.build_flat_items();
+
+    // Agent view: the idle unread row paints the dot (baseline sanity).
+    env.view.view_mode = ViewMode::Structured;
+    assert!(
+        render(&mut env).contains('●'),
+        "agent view should paint the unread dot for an idle unread row"
+    );
+
+    // Terminal view: same instance, no dot. The terminal pane isn't running
+    // (no tmux session in the test env), so the row shows its idle glyph.
+    env.view.view_mode = ViewMode::Terminal;
+    assert!(
+        !render(&mut env).contains('●'),
+        "terminal view must not paint the unread dot"
+    );
+}
+
+/// Stop in Terminal view kills the paired terminal, not the agent session.
+/// The routing decision lives in `stop_selected`: Agent view arms the
+/// `stop_session` confirm (agent + container stop), Terminal view routes to the
+/// terminal-kill path and never arms an agent stop.
+#[test]
+#[serial]
+fn stop_in_terminal_view_does_not_target_agent_session() {
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+    env.view
+        .mutate_instance(&id, |inst| inst.status = crate::session::Status::Idle);
+    env.view.selected_session = Some(id.clone());
+
+    // Agent view: Stop arms the agent-session stop and opens its confirm.
+    env.view.view_mode = ViewMode::Structured;
+    env.view.stop_selected();
+    assert_eq!(
+        env.view.pending_stop_session.as_deref(),
+        Some(id.as_str()),
+        "agent view stop must arm the agent-session stop"
+    );
+    assert_eq!(
+        env.view.confirm_dialog.as_ref().map(|d| d.action()),
+        Some("stop_session"),
+        "agent view stop must open the stop-session confirm"
+    );
+
+    env.view.confirm_dialog = None;
+    env.view.pending_stop_session = None;
+
+    // Terminal view: Stop must never touch the agent session. With no live
+    // terminal in the test env the terminal-kill path no-ops, but the critical
+    // invariant is that no agent stop was armed and the stop-session confirm
+    // never opened.
+    env.view.view_mode = ViewMode::Terminal;
+    env.view.stop_selected();
+    assert!(
+        env.view.pending_stop_session.is_none(),
+        "terminal view stop must not arm an agent-session stop"
+    );
+    assert_ne!(
+        env.view.confirm_dialog.as_ref().map(|d| d.action()),
+        Some("stop_session"),
+        "terminal view stop must not open the stop-session confirm"
+    );
+}
+
 /// Render suppression is cosmetic: archive/snooze leave the `unread` flag on
 /// disk so unarchiving or unsnoozing brings the marker back (#2571).
 #[test]


### PR DESCRIPTION
## Description

Two paired-terminal bugs in the TUI Terminal view:

1. **Unread dot painted in Terminal view.** Unread is an Agent-view concept: it marks agent output the user hasn't looked at. The paired terminal has no such notion, but the Terminal-view render branch copied the unread overlay (dot glyph, `theme.unread`, bold) onto terminal rows. The branch now only tracks whether the terminal pane is live: spinner when running, idle glyph otherwise.

2. **Stop (`x`) in Terminal view stopped the agent session.** `stop_selected()` always emitted `Action::StopSession`, which runs `inst.stop()` (docker stop for sandboxed sessions, status flip to Stopped) regardless of which view the user was in. Now it branches on `view_mode`: in Terminal view it opens a "Kill Terminal" confirm and kills just the paired terminal (host or container, whichever the row is showing) via the existing `kill_terminal()` / `kill_container_terminal()` primitives, leaving the agent session untouched. It no-ops when no terminal is running, so pressing Stop on an idle terminal row doesn't pop a pointless dialog. Cancel paths (keyboard and mouse) clear the new `pending_stop_terminal` state.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: covered by two deterministic in-module regression tests instead (`unread_dot_never_paints_in_terminal_view`, `stop_in_terminal_view_does_not_target_agent_session` in `src/tui/home/tests.rs`), which render through `TestBackend` and assert the action routing directly; an e2e run would need a live tmux terminal pane to kill and adds flake without adding coverage of the routing decision.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**
Root-cause investigation, fix, and regression tests done in a Claude Code session; reviewed by njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Terminal rows no longer show “unread” styling; they only reflect whether the paired terminal is running or idle (with dimmed idle styling).
- The Stop (`x`) behavior is now correctly view-aware:
  - **Agent/Structured view**: Stop confirms and stops the agent session.
  - **Terminal view**: Stop confirms and kills **only the paired terminal** (host vs container), and does nothing if the terminal isn’t running.
  - **Tool view**: Stop confirms and kills **only the selected tool session**, without stopping the agent.
- When the Stop confirmation is cancelled (via keyboard or mouse), any pending “terminal stop” state is cleared to prevent stale follow-ups.
- Added regression tests covering:
  - Unread rendering (the unread indicator appears in agent/structured view but never in terminal view).
  - Stop routing (Stop must not arm the agent-session stop from Terminal or Tool views).
- Updated Stop action help/palette text to clarify its view-dependent “stop session / kill terminal” behavior.

## Benefits

- Clearer and more trustworthy terminal status at a glance.
- Reduced risk of accidentally stopping the agent when the user meant to stop a terminal (or a tool).
- More predictable Stop confirmations and safer cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->