### PR TITLE
fix(web): stop touch drags from panning the page over a full-screen mouse agent

### DIFF
--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -945,10 +945,11 @@ export function MobileLiveTerminal({
         return;
       }
       if (e.touches.length === 1 && forwardModeRef.current && touchForwardYRef.current != null) {
-        // Stop the (overflow-hidden) container / page from scrolling and
-        // translate the drag into wheel notches. Finger moving DOWN reveals
-        // older content = wheel up, so the delta is negated.
-        e.preventDefault();
+        // Translate the drag into wheel notches. Finger moving DOWN reveals
+        // older content = wheel up, so the delta is negated. No preventDefault:
+        // React's delegated touch listeners are passive, so it would be a
+        // console-warning no-op; the page pan is suppressed by touch-action:
+        // none on the scroller instead (see the style below).
         const y = e.touches[0]!.clientY;
         const dy = y - touchForwardYRef.current;
         touchForwardYRef.current = y;
@@ -1380,6 +1381,19 @@ export function MobileLiveTerminal({
           fontVariantLigatures: "none",
           fontFeatureSettings: '"liga" 0, "calt" 0',
           overscrollBehavior: "contain",
+          // Forward mode has no native scrolling (overflow hidden): a drag
+          // becomes forwarded wheel notches in onTouchMove. Suppressing the
+          // browser's own pan must happen HERE, declaratively: React
+          // registers its delegated touchstart/touchmove/wheel listeners as
+          // passive, so a preventDefault inside onTouchMove never reaches
+          // the browser. Without this the pan falls through the
+          // non-scrollable terminal to the page, and whenever the layout
+          // viewport is taller than the visual one (soft keyboard open,
+          // Safari URL bar) iOS pans the whole page while the forwarded
+          // wheel scrolls the app, the double-scroll clunk. touch-action:
+          // none stops the browser from starting any pan or zoom for
+          // touches on the terminal; JS still receives every touch event.
+          touchAction: forwardMode ? "none" : undefined,
           // Do NOT set `-webkit-overflow-scrolling: touch` here. It promotes
           // this opaque scroll region to a composited layer that macOS/iOS
           // Safari rasterizes at 1x, making the DOM terminal text look

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -78,6 +78,20 @@ describe("MobileLiveTerminal wheel forwarding", () => {
     expect(lastUp).toBe(true);
   });
 
+  it("declares touch-action none in forward mode so the page cannot pan", () => {
+    // React's delegated touch listeners are passive, so preventDefault in
+    // onTouchMove cannot stop the browser's native pan; touch-action: none
+    // on the scroller is what keeps a drag from scrolling the whole page
+    // (worst with the soft keyboard open) while the wheel forwards.
+    const { scroller } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
+    expect(scroller.style.touchAction).toBe("none");
+  });
+
+  it("leaves touch-action unset outside forward mode (native capture scroll)", () => {
+    const { scroller } = renderTerm(frame({ altScreen: false, mouse: false }));
+    expect(scroller.style.touchAction).toBe("");
+  });
+
   it("normalizes line-mode wheel deltas (deltaMode 1)", () => {
     const { scroller, forwardWheel } = renderTerm(frame({ altScreen: true, mouse: true, mouseSgr: true }));
     // deltaMode 1 = lines; a few lines should still forward at least one notch.

--- a/web/tests/live-wheel-forward.spec.ts
+++ b/web/tests/live-wheel-forward.spec.ts
@@ -57,6 +57,10 @@ test("swipe over a full-screen SGR-mouse app forwards SGR wheel bytes", async ({
   const handle = await setup(page);
   pushFrame(handle, { altScreen: true, mouse: true, mouseSgr: true });
   await expect.poll(() => scroller(page).getAttribute("class")).toContain("overflow-hidden");
+  // touch-action: none is what keeps the drag from panning the whole page:
+  // React's delegated touch listeners are passive, so the component cannot
+  // preventDefault the native pan (the keyboard-open page-scroll clunk).
+  await expect.poll(() => scroller(page).evaluate((el) => getComputedStyle(el).touchAction)).toBe("none");
   await swipeUp(page);
   await expect.poll(() => texts(handle).some((s) => s.includes("\x1b[<65;"))).toBe(true);
 


### PR DESCRIPTION
## Description

On a phone, opening an agent that runs the new Claude Code TUI renderer (alt-screen with mouse tracking) made touch scrolling clunky: dragging in the terminal panned the whole web page instead of just the agent scrollback, worst with the soft keyboard open.

Root cause: that renderer puts the mobile live view into forward mode, where the scroller is `overflow-hidden` and finger drags are translated into forwarded wheel notches. The code relied on `preventDefault()` inside React's `onTouchMove` to suppress the browser's own pan, but react-dom registers its delegated `touchstart`/`touchmove`/`wheel` listeners as passive (verified in react-dom 19 source), so that call never reaches the browser. With no `touch-action` on the scroller either, the native pan fell through the non-scrollable terminal to the page. With the keyboard open the layout viewport is taller than the visual viewport, so iOS panned the whole page (fighting the `scrollTo(0,0)` snap-back in `useMobileKeyboard`) while the forwarded wheel scrolled the agent at the same time.

Fix: declare `touch-action: none` on the scroller in forward mode. The browser never starts a pan or zoom from touches on the terminal, JS still receives every touch event to forward, and taps, pinch-to-resize, and tap-to-focus keep working. Non-forward mode (native capture scrolling) is unchanged. The now dead `preventDefault()` in the forward branch is removed and the comments explain the passive-listener constraint.

No visual delta, so no screenshot; the observable effect (page panning under an open iOS keyboard) does not reproduce in Chromium emulation. Verified instead via the unit and bundle-level assertions below; a quick drag on a physical phone is the final confirmation.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Updated `web/tests/live-wheel-forward.spec.ts` to assert the computed `touch-action: none` on the real bundle, and added two vitest cases in `MobileLiveTerminal.forward.test.tsx` (the forward-mode assertion fails without the fix). The existing `terminal.mobile-live-wheel-forward` entries in `coverage-matrix.json` already list both files, so no matrix change was needed. Evidence: full vitest suite 3404/3404 green; `live-wheel-forward`, `live-click-forward`, `pinch-zoom`, `scrollback-exit`, `mobile-dom-renderer`, `mobile-fullscreen-agent-layout`, and `keyboard-auto-resize` mocked Playwright specs all pass; oxfmt, ESLint, and tsc clean.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5 via Claude Code

**Any Additional AI Details you'd like to share:** Investigated, fixed, and tested via Claude Code in a back-and-forth with @njbrake; he reported the bug from device testing and reviewed the change.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed mobile touch dragging in forward mode so browser page panning and zooming no longer interfere with scrolling over full-screen mouse-enabled applications.
- Added `touch-action: none` only to the forward-mode scroller, preserving existing behavior for native scrolling.
- Removed the ineffective `preventDefault()` call and clarified the related touch-handling comments.
- Added unit and end-to-end coverage for forward-mode touch behavior.

## Benefits

- More reliable touch scrolling, tapping, focus, and resizing on mobile devices, including when the iOS keyboard is open.
- Prevents regressions while leaving non-forward terminal scrolling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->