### PR TITLE
fix(vt): bracket the seed capture with agreeing state probes

### DIFF
--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -376,11 +376,15 @@ struct PaneSeedState {
     /// `#{pane_height}`: resize detector for the same check; a resize mid-seed
     /// invalidates the coordinate space `cursor_y` was reported in.
     pane_height: u16,
+    /// `#{pane_width}`: the other resize axis. A width-only resize rewraps the
+    /// pane content, so a body captured before it pairs with stale geometry
+    /// even when height, history, and cursor all happen to compare equal.
+    pane_width: u16,
 }
 
 /// The `display-message` format both seed probes share. Field order matches
 /// [`parse_seed_state`].
-const SEED_STATE_FMT: &str = "#{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag} #{cursor_x} #{cursor_y} #{cursor_flag} #{keypad_cursor_flag} #{history_size} #{pane_height}";
+const SEED_STATE_FMT: &str = "#{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag} #{cursor_x} #{cursor_y} #{cursor_flag} #{keypad_cursor_flag} #{history_size} #{pane_height} #{pane_width}";
 
 /// Parse one [`SEED_STATE_FMT`] line. Missing or malformed fields fall back to
 /// the same defaults the old single-probe parser used, so a truncated line
@@ -397,6 +401,7 @@ fn parse_seed_state(line: &str) -> PaneSeedState {
     let app_cursor = it.next().map(|f| f != "0").unwrap_or(false);
     let history_size = it.next().and_then(|f| f.parse().ok()).unwrap_or(0);
     let pane_height = it.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+    let pane_width = it.next().and_then(|f| f.parse().ok()).unwrap_or(0);
     PaneSeedState {
         alt,
         mouse,
@@ -408,6 +413,7 @@ fn parse_seed_state(line: &str) -> PaneSeedState {
         app_cursor,
         history_size,
         pane_height,
+        pane_width,
     }
 }
 
@@ -507,7 +513,13 @@ fn capture_seed_snapshot(target: &str) -> Option<(Vec<u8>, PaneSeedState)> {
         if attempt > 0 {
             std::thread::sleep(SEED_RETRY_SETTLE);
         }
-        let pre = pane_seed_state(target)?;
+        // A failure mid-retry (pane vanished, fork error, half-run chain)
+        // breaks to the tail rather than discarding an earlier attempt's
+        // snapshot: every `last` is a self-consistent (body, probe) pair, and
+        // seeding from it beats leaving the grid blank.
+        let Some(pre) = pane_seed_state(target) else {
+            break;
+        };
         // The alternate screen has no scrollback, so only the normal buffer
         // pulls history (`-S`); the pane keeps that history across re-arms.
         let mut args = vec!["capture-pane", "-t", target, "-p", "-e"];
@@ -523,11 +535,20 @@ fn capture_seed_snapshot(target: &str) -> Option<(Vec<u8>, PaneSeedState)> {
             "-F",
             SEED_STATE_FMT,
         ]);
-        let out = crate::tmux::tmux_command().args(&args).output().ok()?;
+        let Ok(out) = crate::tmux::tmux_command().args(&args).output() else {
+            break;
+        };
         if !out.status.success() {
-            return None;
+            break;
         }
         let (body, probe_line) = split_seed_capture(&out.stdout);
+        // A chained invocation can exit 0 with the display-message half
+        // silently dropped (the pane died between the sub-commands), leaving
+        // the capture's last row where the probe belongs; feeding pane content
+        // into the state parser would fabricate modes and a cursor.
+        if !is_probe_line(probe_line) {
+            break;
+        }
         let post = parse_seed_state(probe_line);
         let agreed = pre == post;
         last = Some((body.to_vec(), post));
@@ -535,12 +556,32 @@ fn capture_seed_snapshot(target: &str) -> Option<(Vec<u8>, PaneSeedState)> {
             return last;
         }
     }
-    tracing::debug!(
-        %target,
-        attempts = SEED_PROBE_ATTEMPTS,
-        "vt seed: pane kept changing across probe attempts; seeding from last snapshot"
-    );
+    if last.is_some() {
+        tracing::debug!(
+            %target,
+            attempts = SEED_PROBE_ATTEMPTS,
+            "vt seed: bracketing probes never agreed; seeding from last snapshot"
+        );
+    }
     last
+}
+
+/// Whether a chained-output line is plausibly the [`SEED_STATE_FMT`] probe
+/// rather than a swallowed capture row: the probe's exact field count, every
+/// token numeric. Guards the one hole in the chained transport, verified
+/// against tmux 3.6: the invocation exits 0 even when its `display-message`
+/// half silently fails (the pane died between the sub-commands), so status
+/// alone cannot prove the probe line is present.
+fn is_probe_line(line: &str) -> bool {
+    let expected = SEED_STATE_FMT.split_whitespace().count();
+    let mut tokens = 0usize;
+    for tok in line.split_whitespace() {
+        if tok.bytes().any(|b| !b.is_ascii_digit()) {
+            return false;
+        }
+        tokens += 1;
+    }
+    tokens == expected
 }
 
 /// Split a chained `capture-pane ; display-message` output into the capture
@@ -1637,18 +1678,25 @@ mod tests {
     #[test]
     fn parse_seed_state_reads_extended_probe_fields() {
         // The probe line carries the drift-detector fields (history_size,
-        // pane_height) after the mode/cursor fields; all must parse.
-        let s = parse_seed_state("1 0 1 0 7 12 0 1 345 48");
+        // pane_height, pane_width) after the mode/cursor fields; all must
+        // parse.
+        let s = parse_seed_state("1 0 1 0 7 12 0 1 345 48 120");
         assert!(s.alt && !s.mouse && s.mouse_sgr && !s.mouse_all);
         assert_eq!((s.cursor_x, s.cursor_y), (7, 12));
         assert!(!s.cursor_visible && s.app_cursor);
-        assert_eq!((s.history_size, s.pane_height), (345, 48));
+        assert_eq!(
+            (s.history_size, s.pane_height, s.pane_width),
+            (345, 48, 120)
+        );
         // A truncated line falls back to the old defaults instead of erroring,
         // so a probe against an odd tmux build still seeds something usable.
         let short = parse_seed_state("0 0 0 0 3 4");
         assert_eq!((short.cursor_x, short.cursor_y), (3, 4));
         assert!(short.cursor_visible);
-        assert_eq!((short.history_size, short.pane_height), (0, 0));
+        assert_eq!(
+            (short.history_size, short.pane_height, short.pane_width),
+            (0, 0, 0)
+        );
     }
 
     #[test]
@@ -1674,23 +1722,47 @@ mod tests {
     }
 
     #[test]
+    fn is_probe_line_rejects_swallowed_capture_rows() {
+        // A chained `capture-pane ; display-message` exits 0 even when the
+        // display-message half silently fails (pane died mid-chain, verified
+        // on tmux 3.6), so the split can hand back a capture row where the
+        // probe belongs. The gate must reject anything that isn't the probe's
+        // exact all-numeric field shape.
+        let fields = SEED_STATE_FMT.split_whitespace().count();
+        let probe = vec!["7"; fields].join(" ");
+        assert!(is_probe_line(&probe));
+        // Shell-ish pane content.
+        assert!(!is_probe_line("$ cargo build --release"));
+        assert!(!is_probe_line("zsh: command not found: python"));
+        // Numeric but truncated (an old tmux missing a format variable, or a
+        // half-written line).
+        assert!(!is_probe_line(&vec!["1"; fields - 1].join(" ")));
+        // One extra field is just as wrong as one missing.
+        assert!(!is_probe_line(&vec!["1"; fields + 1].join(" ")));
+        assert!(!is_probe_line(""));
+    }
+
+    #[test]
     fn seed_probe_agreement_detects_drift() {
         // `capture_seed_snapshot` accepts a snapshot only when the probes
         // bracketing the capture compare equal; every drift a mid-seed pane can
         // exhibit must break equality so the seed retries instead of pairing a
         // stale cursor with newer cells.
-        let base = parse_seed_state("0 0 0 0 10 20 1 0 100 40");
-        assert_eq!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 40"));
+        let base = parse_seed_state("0 0 0 0 10 20 1 0 100 40 80");
+        assert_eq!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 40 80"));
         // Cursor moved (an echo, a CUP).
-        assert_ne!(base, parse_seed_state("0 0 0 0 11 20 1 0 100 40"));
+        assert_ne!(base, parse_seed_state("0 0 0 0 11 20 1 0 100 40 80"));
         // Scrolled with the cursor pinned to the same row: only history grew.
-        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 101 40"));
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 101 40 80"));
         // Alt-screen flip (a full-screen app starting or quitting).
-        assert_ne!(base, parse_seed_state("1 0 0 0 10 20 1 0 100 40"));
+        assert_ne!(base, parse_seed_state("1 0 0 0 10 20 1 0 100 40 80"));
         // Resize mid-seed changes the cursor's coordinate space.
-        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 41"));
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 41 80"));
+        // Width-only resize rewraps the body while height, history, and cursor
+        // can all compare equal.
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 40 79"));
         // DECTCEM toggle (app showed/hid the caret between the probes).
-        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 0 0 100 40"));
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 0 0 100 40 80"));
     }
 
     /// A hand-built channel (no tmux, no forwarder) for registry / sample

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -342,7 +342,14 @@ fn pane_size(target: &str) -> Option<(u16, u16)> {
 /// position and DECTCEM (show/hide) flag. `capture-pane` returns cell text and
 /// SGR only, so without these the seeded parser has default modes and its cursor
 /// stranded wherever the last replayed glyph ended (issue #2902).
-#[derive(Clone, Copy, Default)]
+///
+/// `PartialEq` is the seed's race guard: `capture_seed_snapshot` probes this
+/// state before and after the `capture-pane` fork and retries while the two
+/// disagree, so a pane that scrolled, moved its cursor, or flipped screens
+/// mid-seed can't stamp a stale position into the fresh grid. `history_size`
+/// and `pane_height` exist for that comparison alone, mirroring the drift
+/// fields `merge_cursor_probes` trusts on the legacy capture path.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 struct PaneSeedState {
     alt: bool,
     mouse: bool,
@@ -362,27 +369,24 @@ struct PaneSeedState {
     /// `ESC [ A` instead of `ESC O A` until the app happens to re-emit the
     /// mode, and arrow keys misbehave in the meantime.
     app_cursor: bool,
+    /// `#{history_size}`: scroll detector for the pre/post agreement check. A
+    /// pane that scrolled between the probes grew its history, even when the
+    /// cursor stayed pinned to the same bottom row.
+    history_size: u32,
+    /// `#{pane_height}`: resize detector for the same check; a resize mid-seed
+    /// invalidates the coordinate space `cursor_y` was reported in.
+    pane_height: u16,
 }
 
-/// Query the pane's seed state in one `display-message` round-trip (the live
-/// path is fork-sensitive, #2822, so modes and cursor share a single call).
-fn pane_seed_state(target: &str) -> Option<PaneSeedState> {
-    let out = crate::tmux::tmux_command()
-        .args([
-            "display-message",
-            "-p",
-            "-t",
-            target,
-            "-F",
-            "#{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag} #{cursor_x} #{cursor_y} #{cursor_flag} #{keypad_cursor_flag}",
-        ])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let s = String::from_utf8_lossy(&out.stdout);
-    let mut it = s.split_whitespace();
+/// The `display-message` format both seed probes share. Field order matches
+/// [`parse_seed_state`].
+const SEED_STATE_FMT: &str = "#{alternate_on} #{mouse_any_flag} #{mouse_sgr_flag} #{mouse_all_flag} #{cursor_x} #{cursor_y} #{cursor_flag} #{keypad_cursor_flag} #{history_size} #{pane_height}";
+
+/// Parse one [`SEED_STATE_FMT`] line. Missing or malformed fields fall back to
+/// the same defaults the old single-probe parser used, so a truncated line
+/// still yields a usable (if conservative) state.
+fn parse_seed_state(line: &str) -> PaneSeedState {
+    let mut it = line.split_whitespace();
     let alt = it.next().map(|f| f != "0").unwrap_or(false);
     let mouse = it.next().map(|f| f != "0").unwrap_or(false);
     let mouse_sgr = it.next().map(|f| f != "0").unwrap_or(false);
@@ -391,7 +395,9 @@ fn pane_seed_state(target: &str) -> Option<PaneSeedState> {
     let cursor_y = it.next().and_then(|f| f.parse().ok()).unwrap_or(0);
     let cursor_visible = it.next().map(|f| f != "0").unwrap_or(true);
     let app_cursor = it.next().map(|f| f != "0").unwrap_or(false);
-    Some(PaneSeedState {
+    let history_size = it.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+    let pane_height = it.next().and_then(|f| f.parse().ok()).unwrap_or(0);
+    PaneSeedState {
         alt,
         mouse,
         mouse_sgr,
@@ -400,7 +406,22 @@ fn pane_seed_state(target: &str) -> Option<PaneSeedState> {
         cursor_y,
         cursor_visible,
         app_cursor,
-    })
+        history_size,
+        pane_height,
+    }
+}
+
+/// Query the pane's seed state in one `display-message` round-trip (the live
+/// path is fork-sensitive, #2822, so modes and cursor share a single call).
+fn pane_seed_state(target: &str) -> Option<PaneSeedState> {
+    let out = crate::tmux::tmux_command()
+        .args(["display-message", "-p", "-t", target, "-F", SEED_STATE_FMT])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(parse_seed_state(&String::from_utf8_lossy(&out.stdout)))
 }
 
 /// Translate bare LF to CRLF so `capture-pane` seed rows (LF-separated) each
@@ -431,7 +452,7 @@ fn lf_to_crlf(raw: &[u8]) -> Vec<u8> {
 ///
 /// The seed is rendered content (`capture-pane -e`), so it carries no DEC
 /// private-mode SETs, no cursor position, and no DECTCEM state. The pane's
-/// modes, cursor, and hide flag are queried once ([`pane_seed_state`]) and
+/// modes, cursor, and hide flag come from [`capture_seed_snapshot`] and are
 /// woven into the byte stream by [`assemble_seed_stream`].
 fn seed_parser(
     target: &str,
@@ -440,22 +461,102 @@ fn seed_parser(
     cols: u16,
     rows: u16,
 ) {
-    let state = pane_seed_state(target).unwrap_or_default();
-    // The alternate screen has no scrollback, so only the normal buffer pulls
-    // history (`-S`); the pane keeps that history across re-arms.
-    let seed_start = format!("-{SCROLLBACK_LINES}");
-    let mut seed_args = vec!["capture-pane", "-t", target, "-p", "-e"];
-    if !state.alt {
-        seed_args.extend_from_slice(&["-S", &seed_start]);
-    }
-    let Ok(out) = crate::tmux::tmux_command().args(&seed_args).output() else {
+    let Some((body, state)) = capture_seed_snapshot(target) else {
         return;
     };
-    let stream = assemble_seed_stream(&out.stdout, &state, rows);
+    let stream = assemble_seed_stream(&body, &state, rows);
     if let Ok(mut p) = parser.lock() {
         *p = vt100::Parser::new(rows, cols, SCROLLBACK_LINES);
         p.process(&stream);
         app_cursor.store(p.screen().application_cursor(), Ordering::Relaxed);
+    }
+}
+
+/// How many times [`capture_seed_snapshot`] re-runs the probe/capture/probe
+/// round before settling for its last (possibly raced) snapshot. Each retry
+/// costs two forks plus a short settle sleep, and only fires while the pane is
+/// actively changing under the seed, so the bound is about capping seed latency
+/// on a pane that streams continuously, not about a steady state.
+const SEED_PROBE_ATTEMPTS: usize = 3;
+
+/// Pause between disagreeing seed attempts, letting a mid-flight burst (a
+/// clear-then-reprint, an alt-screen flip) finish before the re-probe.
+const SEED_RETRY_SETTLE: Duration = Duration::from_millis(5);
+
+/// One `capture-pane -e` body plus a [`PaneSeedState`] that is KNOWN to
+/// describe the same instant, or `None` when the pane is gone.
+///
+/// The state probe and the capture are separate tmux commands, and tmux
+/// processes pane output between them: a seed taken while the pane streams,
+/// clears, or flips the alternate screen would otherwise pair a stale cursor
+/// (or screen-mode prefix) with newer cells, and `cursor_from_screen` stamps
+/// the seeded position `position_reliable`, so the misplaced caret sticks
+/// until the next output chunk moves it (the legacy capture path documents
+/// this same race at ~100% of frames against a fast-scrolling pane, which is
+/// why `capture_pane_with_cursor` double-probes). Guard the seed the same way:
+/// probe, then run the capture and a second probe in ONE tmux invocation, and
+/// accept the snapshot only when the two probes agree. On disagreement retry
+/// after a short settle; a pane still changing after the last attempt seeds
+/// from the final snapshot (its post-probe rode the same fork as the capture,
+/// so it is the tightest pairing available, and the next live chunk heals any
+/// residue).
+fn capture_seed_snapshot(target: &str) -> Option<(Vec<u8>, PaneSeedState)> {
+    let seed_start = format!("-{SCROLLBACK_LINES}");
+    let mut last: Option<(Vec<u8>, PaneSeedState)> = None;
+    for attempt in 0..SEED_PROBE_ATTEMPTS {
+        if attempt > 0 {
+            std::thread::sleep(SEED_RETRY_SETTLE);
+        }
+        let pre = pane_seed_state(target)?;
+        // The alternate screen has no scrollback, so only the normal buffer
+        // pulls history (`-S`); the pane keeps that history across re-arms.
+        let mut args = vec!["capture-pane", "-t", target, "-p", "-e"];
+        if !pre.alt {
+            args.extend_from_slice(&["-S", &seed_start]);
+        }
+        args.extend_from_slice(&[
+            ";",
+            "display-message",
+            "-p",
+            "-t",
+            target,
+            "-F",
+            SEED_STATE_FMT,
+        ]);
+        let out = crate::tmux::tmux_command().args(&args).output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let (body, probe_line) = split_seed_capture(&out.stdout);
+        let post = parse_seed_state(probe_line);
+        let agreed = pre == post;
+        last = Some((body.to_vec(), post));
+        if agreed {
+            return last;
+        }
+    }
+    tracing::debug!(
+        %target,
+        attempts = SEED_PROBE_ATTEMPTS,
+        "vt seed: pane kept changing across probe attempts; seeding from last snapshot"
+    );
+    last
+}
+
+/// Split a chained `capture-pane ; display-message` output into the capture
+/// body and the trailing probe line. The probe is the LAST line; everything
+/// before it (including its own trailing newline, which
+/// [`strip_trailing_row_terminator`] later drops) is the verbatim capture
+/// body, so blank padded rows survive the split byte-for-byte.
+fn split_seed_capture(raw: &[u8]) -> (&[u8], &str) {
+    let trimmed = raw.strip_suffix(b"\n").unwrap_or(raw);
+    match trimmed.iter().rposition(|&b| b == b'\n') {
+        Some(idx) => (
+            &trimmed[..=idx],
+            std::str::from_utf8(&trimmed[idx + 1..]).unwrap_or(""),
+        ),
+        // Single line: no body, just the probe.
+        None => (b"", std::str::from_utf8(trimmed).unwrap_or("")),
     }
 }
 
@@ -1531,6 +1632,65 @@ mod tests {
             "newest row must be on the visible screen:\n{}",
             p.screen().contents()
         );
+    }
+
+    #[test]
+    fn parse_seed_state_reads_extended_probe_fields() {
+        // The probe line carries the drift-detector fields (history_size,
+        // pane_height) after the mode/cursor fields; all must parse.
+        let s = parse_seed_state("1 0 1 0 7 12 0 1 345 48");
+        assert!(s.alt && !s.mouse && s.mouse_sgr && !s.mouse_all);
+        assert_eq!((s.cursor_x, s.cursor_y), (7, 12));
+        assert!(!s.cursor_visible && s.app_cursor);
+        assert_eq!((s.history_size, s.pane_height), (345, 48));
+        // A truncated line falls back to the old defaults instead of erroring,
+        // so a probe against an odd tmux build still seeds something usable.
+        let short = parse_seed_state("0 0 0 0 3 4");
+        assert_eq!((short.cursor_x, short.cursor_y), (3, 4));
+        assert!(short.cursor_visible);
+        assert_eq!((short.history_size, short.pane_height), (0, 0));
+    }
+
+    #[test]
+    fn split_seed_capture_separates_body_and_probe() {
+        // The probe rides the same tmux invocation as the capture and lands as
+        // the LAST output line. The body must survive byte-for-byte, blank
+        // padded rows included, with its own trailing newline intact (that is
+        // what `strip_trailing_row_terminator` expects to drop).
+        let raw = b"row-a\n\n\nrow-d\n0 0 0 0 5 3 1 0 12 24\n";
+        let (body, probe) = split_seed_capture(raw);
+        assert_eq!(body, b"row-a\n\n\nrow-d\n");
+        let post = parse_seed_state(probe);
+        assert_eq!((post.cursor_x, post.cursor_y), (5, 3));
+        assert_eq!((post.history_size, post.pane_height), (12, 24));
+
+        // No capture rows at all (a zero-height oddity): the single line is
+        // the probe, the body is empty.
+        let (body, probe) = split_seed_capture(b"0 0 0 0 1 2 1 0 0 5\n");
+        assert!(body.is_empty());
+        assert_eq!(parse_seed_state(probe).cursor_y, 2);
+
+        assert_eq!(split_seed_capture(b""), (&b""[..], ""));
+    }
+
+    #[test]
+    fn seed_probe_agreement_detects_drift() {
+        // `capture_seed_snapshot` accepts a snapshot only when the probes
+        // bracketing the capture compare equal; every drift a mid-seed pane can
+        // exhibit must break equality so the seed retries instead of pairing a
+        // stale cursor with newer cells.
+        let base = parse_seed_state("0 0 0 0 10 20 1 0 100 40");
+        assert_eq!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 40"));
+        // Cursor moved (an echo, a CUP).
+        assert_ne!(base, parse_seed_state("0 0 0 0 11 20 1 0 100 40"));
+        // Scrolled with the cursor pinned to the same row: only history grew.
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 101 40"));
+        // Alt-screen flip (a full-screen app starting or quitting).
+        assert_ne!(base, parse_seed_state("1 0 0 0 10 20 1 0 100 40"));
+        // Resize mid-seed changes the cursor's coordinate space.
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 1 0 100 41"));
+        // DECTCEM toggle (app showed/hid the caret between the probes).
+        assert_ne!(base, parse_seed_state("0 0 0 0 10 20 0 0 100 40"));
     }
 
     /// A hand-built channel (no tmux, no forwarder) for registry / sample

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1175,10 +1175,13 @@ impl LiveCaptureWorker {
         self.latest.lock().ok().and_then(|mut guard| guard.take())
     }
 
-    /// The newest live-send cursor, or `None` when the displayed pane isn't
-    /// the live-send target (or its cursor is hidden). Cloned, not taken, so
-    /// the cursor persists across frames until the next live cycle refreshes
-    /// it. The render loop maps this onto the preview output rect.
+    /// The newest cursor for the worker's CURRENT target pane, or `None`
+    /// right after a retarget (`set_target` clears it so the old pane's
+    /// cursor can't paint over the new view) or when the last capture
+    /// couldn't probe one. Always the displayed pane's cursor; the render
+    /// loop additionally gates painting on live-send being active. Cloned,
+    /// not taken, so the cursor persists across frames until the next live
+    /// cycle refreshes it.
     pub(in crate::tui) fn current_cursor(&self) -> Option<crate::tmux::PaneCursor> {
         self.cursor.lock().ok().and_then(|guard| *guard)
     }


### PR DESCRIPTION
## Description

Investigating the "live-mode caret parked way up top while typing echoes at the bottom prompt" sighting (paired terminal, live mode, heavy compile output + nested full-screen apps) surfaced an unguarded race in the VT seed that #2907 introduced alongside its fix for #2902.

`seed_parser` ran its state probe (`pane_seed_state`: cursor, alt-screen, mouse modes, DECCKM) and the `capture-pane` body as two separate tmux forks. tmux processes pane output between them, so a pane that scrolled, cleared, or flipped the alternate screen in the gap got seeded with a stale cursor (or wrong screen-mode prefix) paired with newer cells. `cursor_from_screen` stamps the seeded position `position_reliable`, so the misplaced caret sticks until the next output chunk moves it. Seeds fire on every channel arm and every resize reconcile, so entering live-send against a streaming pane walks straight into the window. The legacy capture path documents this same race at ~100% of frames against a fast-scrolling pane, which is why `capture_pane_with_cursor` double-probes; the seed had no equivalent guard.

The fix mirrors the legacy design: probe, then run the capture and a second probe in ONE tmux invocation, and accept the snapshot only when the two probes agree. Disagreement retries after a 5ms settle, bounded at 3 attempts; a pane still changing after the last attempt seeds from the final snapshot, whose post-probe rode the same fork as the capture, the tightest pairing available. The probe format gains `#{history_size}` and `#{pane_height}` as drift detectors, so a scroll with the cursor pinned to the bottom row and a mid-seed resize both break agreement, mirroring the fields `merge_cursor_probes` trusts.

Also rewrites `current_cursor()`'s doc comment, which claimed a displayed-pane-vs-live-target guard the implementation does not have.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the race needs pane output to land inside a millisecond fork gap, which an e2e harness cannot schedule deterministically. The decision logic is covered by new unit tests instead: `parse_seed_state_reads_extended_probe_fields`, `split_seed_capture_separates_body_and_probe`, and `seed_probe_agreement_detects_drift` in `src/tmux/vt.rs`. Behavior parity on the happy path was verified live against a real tmux (isolated `$HOME` + `AOE_TMUX_SOCKET`, TUI in an outer tmux, live-send onto a paired terminal): pre- and post-change binaries paint the caret on the identical prompt cell, including when the channel arms against a continuously streaming pane.

How tested:
- `cargo fmt`, `cargo clippy` clean; `cargo test` passes (4043 passed; the one failure, `restart_selected_session_surfaces_resume_failed_after_async_restart`, fails identically on unmodified `main` in this environment and is unrelated).
- Live tmux verification as above: quiet pane, cleared-screen-with-history, alt-screen round trip, live exit/re-enter, resizes, and mid-stream arming all keep the painted caret on the prompt cell.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Fable 5 (Claude Code)

**Any Additional AI Details you'd like to share:**
Root-cause investigation, fix, and tests by Claude via /investigate with @njbrake directing; the seed race was identified by code inspection after live reproduction attempts of the original sighting all passed on current main.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reworked VT “seed snapshot” capture so the cursor/state probe and the pane content capture happen together and are only accepted when both probes match.
- Added short, bounded retries when tmux pane state changes mid-capture, improving reliability during scrolling, cursor moves, and screen-mode switches.
- Extended the probe data used to detect drift by including additional pane geometry fields (including width), so resizes that reflow content are detected.
- Hardened parsing of tmux’s chained output by validating the probe-line shape and safely falling back to the last known consistent snapshot when probes never agree.
- Updated and expanded unit tests to cover the extended probe fields, capture/probe splitting correctness, malformed-probe rejection, and drift detection behavior.
- Updated `current_cursor()` documentation to match the real behavior of the cursor reporting logic.

## Benefits

- Prevents stale cursor/screen-mode information from being paired with newer pane content during initialization.
- Makes VT seeding more robust when the target pane is actively changing (scrolling, resizing, alt-screen transitions), leading to fewer “wrong first frame” style inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->