### PR TITLE
fix(status): stop Claude AskUserQuestion sessions from showing as Running

### DIFF
--- a/docs/development/adding-agents.md
+++ b/docs/development/adding-agents.md
@@ -81,6 +81,7 @@ Each entry in `events: &[HookEvent]` carries:
 | `matcher` | Optional pattern for events that need it (e.g. Claude's `Notification` matcher). |
 | `status` | `Some(HookStatus::Running\|Waiting\|Idle\|Error)` to install a status-writer on this event, or `None` for a purely lifecycle event. |
 | `session_id_capture` | `true` installs a command that extracts `session_id` from the agent's stdin JSON and writes it to `/tmp/aoe-hooks-<euid>/<AOE_INSTANCE_ID>/session_id` (host) or `/tmp/aoe-hooks/<AOE_INSTANCE_ID>/session_id` (sandbox; see issue #1844 for the host/container path split), read by [session-resume](../guides/session-resume.md). Currently only Claude (`SessionStart`, `UserPromptSubmit`). With `status` also set, both commands share the matcher block and the session-id command runs first so it consumes stdin before the status writer. |
+| `waiting_tools` | Tool names whose invocation blocks on the user for the tool's entire execution (Claude's `AskUserQuestion`). When non-empty on a status event, the status writer inspects the payload's `tool_name` on stdin and writes `waiting` for these tools instead of the event's status. Pair it with a tool-scoped event that restores the normal status once the tool completes (Claude adds `PostToolUse` with matcher `AskUserQuestion`), or the status sticks on `waiting` through the rest of the turn. |
 
 ### Codex (custom TOML)
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -104,6 +104,13 @@ pub struct HookEvent {
     /// `session_id` from the agent's stdin JSON payload and writes it to
     /// `/tmp/aoe-hooks-<euid>/<AOE_INSTANCE_ID>/session_id`.
     pub session_id_capture: bool,
+    /// Tool names whose invocation blocks on the user for the tool's entire
+    /// execution (e.g. Claude's `AskUserQuestion` selection UI). When
+    /// non-empty on a status event, the generated hook command inspects the
+    /// payload's `tool_name` and writes `waiting` for these tools instead of
+    /// the event's status, so the session reads as blocked the moment the
+    /// prompt renders rather than sticking on the last `running` write.
+    pub waiting_tools: &'static [&'static str],
 }
 
 /// A hook event after applying profile/global status-map overrides.
@@ -113,6 +120,7 @@ pub struct ResolvedHookEvent {
     pub matcher: Option<String>,
     pub status: Option<HookStatus>,
     pub session_id_capture: bool,
+    pub waiting_tools: Vec<String>,
 }
 
 /// Sidecar hook defaults for agents whose config format is not the generic
@@ -374,54 +382,79 @@ pub struct PermissionResponse {
 /// (background session finished/failed → Idle) rides the `idle_prompt` group.
 /// They only fire while Claude's agent view is open, so they are best-effort
 /// extra coverage for that surface, not a substitute for the pane fallback.
+///
+/// `AskUserQuestion` blocks on the user for the tool's entire execution, but
+/// emits no Waiting-mapped hook: `PreToolUse` fires (running) and nothing else
+/// happens until the user answers, so the status file would stick on `running`
+/// the whole time the question is on screen. `waiting_tools` on `PreToolUse`
+/// makes the status command write `waiting` when the payload's `tool_name` is
+/// `AskUserQuestion`, and the `PostToolUse` matcher restores `running` the
+/// moment the answer lands (the rest of the turn is ordinary generation). The
+/// pane-side `reconcile_claude_hook_status` stays as the backstop for hooks
+/// installed before this pair existed.
 const CLAUDE_HOOK_EVENTS: &[HookEvent] = &[
     HookEvent {
         name: "SessionStart",
         matcher: None,
         status: None,
         session_id_capture: true,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "PreToolUse",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &["AskUserQuestion"],
+    },
+    HookEvent {
+        name: "PostToolUse",
+        matcher: Some("AskUserQuestion"),
+        status: Some(HookStatus::Running),
+        session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: true,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "StopFailure",
         matcher: None,
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog|agent_needs_input"),
         status: Some(HookStatus::Waiting),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Notification",
         matcher: Some("idle_prompt|agent_completed"),
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "ElicitationResult",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
 ];
 
@@ -435,30 +468,35 @@ const CURSOR_HOOK_EVENTS: &[HookEvent] = &[
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some(HookStatus::Waiting),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "ElicitationResult",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
 ];
 
@@ -472,30 +510,35 @@ const QWEN_HOOK_EVENTS: &[HookEvent] = &[
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "PostToolUse",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Notification",
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some(HookStatus::Waiting),
         session_id_capture: false,
+        waiting_tools: &[],
     },
 ];
 
@@ -506,36 +549,42 @@ const CODEX_HOOK_EVENTS: &[HookEvent] = &[
         matcher: None,
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "UserPromptSubmit",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "PreToolUse",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "PermissionRequest",
         matcher: None,
         status: Some(HookStatus::Waiting),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "PostToolUse",
         matcher: None,
         status: Some(HookStatus::Running),
         session_id_capture: false,
+        waiting_tools: &[],
     },
     HookEvent {
         name: "Stop",
         matcher: None,
         status: Some(HookStatus::Idle),
         session_id_capture: false,
+        waiting_tools: &[],
     },
 ];
 
@@ -770,24 +819,28 @@ pub const AGENTS: &[AgentDef] = &[
                     matcher: None,
                     status: Some(HookStatus::Running),
                     session_id_capture: false,
+                    waiting_tools: &[],
                 },
                 HookEvent {
                     name: "BeforeAgent",
                     matcher: None,
                     status: Some(HookStatus::Running),
                     session_id_capture: false,
+                    waiting_tools: &[],
                 },
                 HookEvent {
                     name: "AfterAgent",
                     matcher: None,
                     status: Some(HookStatus::Idle),
                     session_id_capture: false,
+                    waiting_tools: &[],
                 },
                 HookEvent {
                     name: "Notification",
                     matcher: Some("ToolPermission"),
                     status: Some(HookStatus::Waiting),
                     session_id_capture: false,
+                    waiting_tools: &[],
                 },
             ],
             format: HookFormat::JsonSettings,
@@ -1232,6 +1285,7 @@ fn append_configured_status_events(
                 matcher: None,
                 status: Some(*status),
                 session_id_capture: false,
+                waiting_tools: Vec::new(),
             });
         }
     }
@@ -1255,6 +1309,7 @@ pub fn resolved_hook_events(
                 .and_then(|map| map.get(event.name).copied())
                 .or(event.status),
             session_id_capture: event.session_id_capture,
+            waiting_tools: event.waiting_tools.iter().map(|t| t.to_string()).collect(),
         })
         .collect();
     append_configured_status_events(&mut events, overrides);
@@ -1281,6 +1336,7 @@ pub fn resolved_sidecar_hook_events(
                     .unwrap_or(event.status),
             ),
             session_id_capture: false,
+            waiting_tools: Vec::new(),
         })
         .collect();
     append_configured_status_events(&mut events, overrides);

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -287,11 +287,15 @@ fn resolve_config_dir_override(var: &str, host_env: &[String]) -> Option<String>
 /// (no field could expand today, but a future change to the path format
 /// could re-expose it).
 fn hook_command(status: &str, target: HookInstallTarget) -> String {
-    let base = match target {
+    hook_command_with_base(status, &hook_base_for_target(target), target)
+}
+
+/// The status-file base directory the generated command bakes in, per target.
+fn hook_base_for_target(target: HookInstallTarget) -> String {
+    match target {
         HookInstallTarget::Host => dir_guard::hook_base_path().display().to_string(),
         HookInstallTarget::Sandbox => HOOK_STATUS_BASE_IN_CONTAINER.to_string(),
-    };
-    hook_command_with_base(status, &base, target)
+    }
 }
 
 #[cfg(test)]
@@ -299,7 +303,88 @@ pub(crate) fn canonical_status_command(status: &str, target: HookInstallTarget) 
     hook_command(status, target)
 }
 
+/// Select the status-writer command for a resolved event: the tool-gated
+/// variant when `waiting_tools` can change the outcome, the plain writer
+/// otherwise. A Waiting-status event skips the gate even with tools declared,
+/// because the gate only ever rewrites the status to `waiting`; emitting a
+/// command that inspects stdin for a no-op would be pure overhead.
+fn status_command_for_event(
+    status: crate::agents::HookStatus,
+    waiting_tools: &[String],
+    target: HookInstallTarget,
+) -> String {
+    if waiting_tools.is_empty() || status == crate::agents::HookStatus::Waiting {
+        hook_command(status.as_str(), target)
+    } else {
+        hook_command_waiting_tools(status.as_str(), waiting_tools, target)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn canonical_status_command_for_event(
+    status: crate::agents::HookStatus,
+    waiting_tools: &[String],
+    target: HookInstallTarget,
+) -> String {
+    status_command_for_event(status, waiting_tools, target)
+}
+
+/// Build the status-writer command for an event with `waiting_tools`: the
+/// payload's `tool_name` decides between the event's default status and
+/// `waiting`. Used for Claude's `PreToolUse`, where an `AskUserQuestion` call
+/// blocks on the user for the tool's entire execution and would otherwise
+/// leave the status file stuck on `running` (no Waiting-mapped hook fires
+/// while the question is on screen).
+///
+/// The match is a substring check for the compact-JSON key
+/// (`"tool_name":"AskUserQuestion"`) on the hook's stdin. Occurrences of that
+/// text inside `tool_input` strings (e.g. an Edit call on this repo's own
+/// source) cannot false-positive: inside a JSON string value the quotes are
+/// backslash-escaped, so the exact byte sequence differs. If the agent ever
+/// stops delivering stdin or reformats the payload, the `case` falls through
+/// to the event's default status, which is today's behavior, with the pane
+/// reconciler as backstop.
+fn hook_command_waiting_tools(
+    default_status: &str,
+    waiting_tools: &[String],
+    target: HookInstallTarget,
+) -> String {
+    hook_command_waiting_tools_with_base(
+        default_status,
+        waiting_tools,
+        &hook_base_for_target(target),
+        target,
+    )
+}
+
+fn hook_command_waiting_tools_with_base(
+    default_status: &str,
+    waiting_tools: &[String],
+    base: &str,
+    target: HookInstallTarget,
+) -> String {
+    let patterns: Vec<String> = waiting_tools
+        .iter()
+        .map(|tool| format!("*\\\"tool_name\\\":\\\"{tool}\\\"*"))
+        .collect();
+    let write = format!(
+        "IN=$(cat 2>/dev/null); S={default_status}; \
+         case \"$IN\" in {patterns}) S=waiting ;; esac; \
+         printf %s \"$S\" > \"$D/status\" 2>/dev/null; ",
+        patterns = patterns.join("|")
+    );
+    hook_command_with_write(&write, base, target)
+}
+
 fn hook_command_with_base(status: &str, base: &str, target: HookInstallTarget) -> String {
+    hook_command_with_write(
+        &format!("printf {status} > \"$D/status\" 2>/dev/null; "),
+        base,
+        target,
+    )
+}
+
+fn hook_command_with_write(write: &str, base: &str, target: HookInstallTarget) -> String {
     let parent_check = match target {
         HookInstallTarget::Host => {
             // mkdir -p $B is the wipe-recovery primitive for the
@@ -339,7 +424,7 @@ fn hook_command_with_base(status: &str, base: &str, target: HookInstallTarget) -
          set -- $LS; M=\"$1\"; \
          case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; \
          {owner_recheck}\
-         printf {status} > \"$D/status\" 2>/dev/null; \
+         {write}\
          exit 0 # {AOE_HOOK_MARKER}'"
     )
 }
@@ -467,7 +552,11 @@ fn build_aoe_hooks(
             commands.push(hook_command_session_id(target));
         }
         if let Some(status) = event.status {
-            commands.push(hook_command(status.as_str(), target));
+            commands.push(status_command_for_event(
+                status,
+                &event.waiting_tools,
+                target,
+            ));
         }
         if commands.is_empty() {
             continue;
@@ -3152,6 +3241,97 @@ command = "echo user-hook"
         assert!(output.status.success(), "happy-path hook should exit 0");
         let status_path = base.join("happy_path").join("status");
         assert_eq!(std::fs::read_to_string(&status_path).unwrap(), "waiting");
+    }
+
+    /// Run a waiting-tools PreToolUse command against a temp hook base with
+    /// the given stdin payload; return what it wrote to the status file.
+    fn run_waiting_tools_hook(stdin_payload: &str) -> String {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::{Command, Stdio};
+
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join("aoe-hooks");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let cmd = hook_command_waiting_tools_with_base(
+            "running",
+            &["AskUserQuestion".to_string()],
+            base.to_str().unwrap(),
+            HookInstallTarget::Host,
+        );
+
+        let mut child = Command::new("sh")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", "waiting_tools")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn sh");
+        child
+            .stdin
+            .take()
+            .expect("piped stdin")
+            .write_all(stdin_payload.as_bytes())
+            .expect("write hook stdin");
+        let output = child.wait_with_output().expect("wait for sh");
+        assert!(output.status.success(), "hook must exit 0: {output:?}");
+        std::fs::read_to_string(base.join("waiting_tools").join("status")).unwrap()
+    }
+
+    #[test]
+    fn test_waiting_tools_hook_writes_waiting_for_ask_user_question() {
+        // The real PreToolUse payload shape for an AskUserQuestion call:
+        // compact JSON with a top-level tool_name key.
+        let payload = r#"{"session_id":"6cbahc1c-83e0-4a1c-b22e-df2a70518746","hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Which approach?"}]}}"#;
+        assert_eq!(run_waiting_tools_hook(payload), "waiting");
+    }
+
+    #[test]
+    fn test_waiting_tools_hook_writes_default_for_other_tools() {
+        let payload =
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls"}}"#;
+        assert_eq!(run_waiting_tools_hook(payload), "running");
+    }
+
+    #[test]
+    fn test_waiting_tools_hook_ignores_escaped_mention_in_tool_input() {
+        // An Edit writing this repo's own source can carry the literal text
+        // `"tool_name":"AskUserQuestion"` inside a tool_input string, where
+        // JSON escapes its quotes (`\"tool_name\":\"AskUserQuestion\"`), so
+        // the exact byte sequence differs and must not flip the status.
+        let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"new_string":"match on \"tool_name\":\"AskUserQuestion\" here"}}"#;
+        assert_eq!(run_waiting_tools_hook(payload), "running");
+    }
+
+    #[test]
+    fn test_waiting_tools_hook_writes_default_without_stdin() {
+        // If the agent ever stops delivering stdin, the command must fall
+        // back to the event's default status, not hang or error.
+        assert_eq!(run_waiting_tools_hook(""), "running");
+    }
+
+    #[test]
+    fn test_claude_hooks_gate_pre_tool_use_on_ask_user_question() {
+        let hooks = build_aoe_hooks(claude_events(), HookInstallTarget::Host);
+
+        // PreToolUse carries the tool-gated writer: running by default,
+        // waiting when the payload names AskUserQuestion.
+        let pre = hooks["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 1);
+        let pre_cmd = pre[0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(pre_cmd.contains(r#"*\"tool_name\":\"AskUserQuestion\"*"#));
+        assert!(pre_cmd.contains("S=running"));
+
+        // PostToolUse restores running the moment the answer lands; it is
+        // scoped to AskUserQuestion so no catch-all PostToolUse group exists.
+        let post = hooks["PostToolUse"].as_array().unwrap();
+        assert_eq!(post.len(), 1);
+        assert_eq!(post[0]["matcher"].as_str().unwrap(), "AskUserQuestion");
+        let post_cmd = post[0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(post_cmd.contains("printf running"));
     }
 
     #[test]

--- a/src/migrations/v015_rewrite_hook_strings.rs
+++ b/src/migrations/v015_rewrite_hook_strings.rs
@@ -264,7 +264,7 @@ mod tests {
     /// criterion #4 (byte-for-byte, not "contains the guard substring").
     fn assert_claude_canonical(claude: &Path) {
         use crate::hooks::{
-            canonical_session_id_command, canonical_status_command, HookInstallTarget,
+            canonical_session_id_command, canonical_status_command_for_event, HookInstallTarget,
         };
         let parsed: Value = serde_json::from_str(&fs::read_to_string(claude).unwrap()).unwrap();
         let hooks = parsed["hooks"].as_object().expect("hooks present");
@@ -311,8 +311,14 @@ mod tests {
                                 .push(canonical_session_id_command(HookInstallTarget::Host));
                         }
                         if let Some(status) = event_def.status {
-                            canonical_set.push(canonical_status_command(
-                                status.as_str(),
+                            let waiting_tools: Vec<String> = event_def
+                                .waiting_tools
+                                .iter()
+                                .map(|t| t.to_string())
+                                .collect();
+                            canonical_set.push(canonical_status_command_for_event(
+                                status,
+                                &waiting_tools,
                                 HookInstallTarget::Host,
                             ));
                         }
@@ -484,9 +490,15 @@ mod tests {
         // legacy entry is preserved AND v015 still installs the current
         // canonical bytes adjacent to it (so live status detection works
         // for the next session).
-        use crate::hooks::canonical_status_command;
-        let canonical_running =
-            canonical_status_command("running", crate::hooks::HookInstallTarget::Host);
+        use crate::hooks::canonical_status_command_for_event;
+        // Claude's PreToolUse is the tool-gated writer (running by default,
+        // waiting for AskUserQuestion), so canonicalize through the same
+        // selector the installer uses.
+        let canonical_running = canonical_status_command_for_event(
+            crate::agents::HookStatus::Running,
+            &["AskUserQuestion".to_string()],
+            crate::hooks::HookInstallTarget::Host,
+        );
         let found_hardened = pre_tool.iter().skip(1).any(|m| {
             m["hooks"].as_array().is_some_and(|arr| {
                 arr.iter()

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -171,7 +171,7 @@ fn claude_blocking_prompt_rule(recent: &[&str], recent_lower: &str) -> Option<&'
     if claude_has_approval_prompt(recent, recent_lower) {
         return Some("approval_prompt");
     }
-    if claude_has_ask_user_question(recent, recent_lower) {
+    if claude_has_ask_user_question(recent) {
         return Some("ask_user_question");
     }
     None
@@ -342,9 +342,20 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
 /// prompt (whose footer is `Esc to cancel · Tab to amend`). Pairing it with a
 /// numbered choice mirrors `claude_has_approval_prompt`'s two-signal guard so a
 /// rendered markdown list in prose can't match on the footer text alone.
-fn claude_has_ask_user_question(recent: &[&str], recent_lower: &str) -> bool {
-    let has_select_footer =
-        recent_lower.contains("enter to select") && recent_lower.contains("to navigate");
+///
+/// The footer match is anchored to the start of a single trimmed line, for the
+/// same reason `claude_pane_shows_ready_prompt` anchors the mode-cycle footer
+/// glyph: panes merely echoing the footer text (a diff of this file, this
+/// repo's own test fixtures in Read/grep output, quoted docs) carry a prefix
+/// on the echoed line (line numbers, `+`, `⎿`, `>`), so they don't read as a
+/// live prompt. The trade-off is a pane too narrow to hold the footer on one
+/// line falls back to the running signal, i.e. pre-detector behavior, with
+/// the hook-side `waiting_tools` write as the primary layer there.
+fn claude_has_ask_user_question(recent: &[&str]) -> bool {
+    let has_select_footer = recent.iter().any(|line| {
+        let trimmed = line.trim_start().to_lowercase();
+        trimmed.starts_with("enter to select") && trimmed.contains("to navigate")
+    });
     has_select_footer
         && recent
             .iter()
@@ -2020,6 +2031,27 @@ enter to select · esc to cancel";
             reconcile_claude_hook_status(Status::Running, pane, None),
             Status::Waiting
         );
+    }
+
+    #[test]
+    fn test_detect_claude_status_running_when_pane_echoes_fixture_footer() {
+        // A Read/grep of this repo's own test fixtures (or a diff of this
+        // file) echoes the AskUserQuestion footer into the pane while a turn
+        // is live, alongside prose that quotes a numbered choice. Echoed
+        // footer lines carry a prefix (line numbers, `+`, `⎿`), so the footer
+        // match is anchored to the start of the trimmed line and must not
+        // fire; the live spinner wins. Same hardening rationale as the
+        // mode-cycle footer anchoring in claude_pane_shows_ready_prompt.
+        let content = "\
+● The fixture renders these options:
+  ❯ 1. Static plugin (comparator stays core)
+    2. True-worker extraction
+  and then the footer line:
+  ⎿ 2052   Enter to select · ↑/↓ to navigate · Esc to cancel
+
+✶ Herding… (12s · ↓ 1234 tokens)
+  esc to interrupt";
+        assert_eq!(detect_claude_status(content), Status::Running);
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -123,33 +123,45 @@ const CLAUDE_INTERRUPT_MARKER: &str = "what should claude do instead";
 /// don't need a separate past-tense verb list. Shape (4) is the one active
 /// state rendered without an ellipsis; it gets its own structural match.
 pub fn detect_claude_status(content: &str) -> Status {
-    // Claude often leaves the bottom of the pane blank (cursor parked below
-    // the spinner line, or a small response in a tall pane), so we filter
-    // empty lines first and look at the last 30 non-empty lines. Matches
-    // the pattern used by detect_opencode_status and friends.
-    let non_empty: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    with_claude_recent_pane(content, |recent, recent_joined, recent_lower| {
+        // A blocking prompt has to outrank the spinner. Claude keeps its live
+        // "Working…" line rendered *below* a permission prompt or
+        // AskUserQuestion menu while it waits for the user, so a session on
+        // this pane fallback (hooks disabled, or the sandbox hook-dir
+        // bind-mount failed) would otherwise match the spinner and report
+        // Running the whole time it is blocked. See #1913.
+        if let Some(rule) = claude_blocking_prompt_rule(recent, recent_lower) {
+            tracing::trace!(target: "tmux.status", "claude pane detector: Waiting ({rule})");
+            return Status::Waiting;
+        }
+
+        if claude_pane_has_running_signal(recent, recent_joined, recent_lower) {
+            tracing::trace!(target: "tmux.status", "claude pane detector: Running (running_signal)");
+            return Status::Running;
+        }
+
+        tracing::trace!(target: "tmux.status", "claude pane detector: Idle (no_signal)");
+        Status::Idle
+    })
+}
+
+/// Build the recent-window view every Claude pane detector shares (strip
+/// ANSI, keep the last 30 non-empty lines, precompute the joined and
+/// lowercased forms) and hand it to `f` as `(recent, joined, lower)`.
+///
+/// Claude often leaves the bottom of the pane blank (cursor parked below the
+/// spinner line, or a small response in a tall pane), so empty lines are
+/// filtered before taking the window; matches the pattern used by
+/// `detect_opencode_status` and friends. Building the window in one place
+/// keeps the detectors in lockstep and lets `reconcile_claude_hook_status`
+/// scan a capture once instead of re-deriving it per check.
+fn with_claude_recent_pane<T>(raw_content: &str, f: impl FnOnce(&[&str], &str, &str) -> T) -> T {
+    let clean = strip_ansi(raw_content);
+    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
     let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
     let recent_joined = recent.join("\n");
     let recent_lower = recent_joined.to_lowercase();
-
-    // A blocking prompt has to outrank the spinner. Claude keeps its live
-    // "Working…" line rendered *below* a permission prompt or AskUserQuestion
-    // menu while it waits for the user, so a session on this pane fallback
-    // (hooks disabled, or the sandbox hook-dir bind-mount failed) would
-    // otherwise match the spinner and report Running the whole time it is
-    // blocked. See #1913.
-    if let Some(rule) = claude_blocking_prompt_rule(&recent, &recent_lower) {
-        tracing::trace!(target: "tmux.status", "claude pane detector: Waiting ({rule})");
-        return Status::Waiting;
-    }
-
-    if claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower) {
-        tracing::trace!(target: "tmux.status", "claude pane detector: Running (running_signal)");
-        return Status::Running;
-    }
-
-    tracing::trace!(target: "tmux.status", "claude pane detector: Idle (no_signal)");
-    Status::Idle
+    f(&recent, &recent_joined, &recent_lower)
 }
 
 /// Which blocking-prompt rule matches the recent pane lines, if any. The rule
@@ -352,20 +364,6 @@ fn claude_line_is_numbered_choice(line: &str) -> bool {
     matches!(chars.next(), Some('1'..='9')) && matches!(chars.next(), Some('.'))
 }
 
-/// Strip ANSI and scan the recent pane lines for any state where Claude is
-/// blocked on the user: a tool-permission approval prompt or an `AskUserQuestion`
-/// selection UI. Returns the matching rule name for status-decision tracing.
-/// Shares the same recent-window shape as `detect_claude_status`; this entry
-/// point exists for callers that hold raw (un-stripped) `capture-pane -e`
-/// output.
-fn claude_pane_blocking_prompt_rule(raw_content: &str) -> Option<&'static str> {
-    let clean = strip_ansi(raw_content);
-    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
-    let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
-    let recent_lower = recent.join("\n").to_lowercase();
-    claude_blocking_prompt_rule(&recent, &recent_lower)
-}
-
 /// Claude has parked at the prompt after the user cancelled a turn with Esc.
 /// That path fires neither `Stop` nor an `idle_prompt` notification (verified
 /// against Claude Code 2.1.193: the `idle_prompt` timer is armed by turn
@@ -374,14 +372,13 @@ fn claude_pane_blocking_prompt_rule(raw_content: &str) -> Option<&'static str> {
 /// *and* the absence of any active-turn signal so that a fresh turn started
 /// right after the interrupt (banner still in scrollback, spinner now showing)
 /// still reads as Running.
-fn claude_pane_shows_interrupted_turn(raw_content: &str) -> bool {
-    let clean = strip_ansi(raw_content);
-    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
-    let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
-    let recent_joined = recent.join("\n");
-    let recent_lower = recent_joined.to_lowercase();
+fn claude_pane_shows_interrupted_turn(
+    recent: &[&str],
+    recent_joined: &str,
+    recent_lower: &str,
+) -> bool {
     recent_lower.contains(CLAUDE_INTERRUPT_MARKER)
-        && !claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower)
+        && !claude_pane_has_running_signal(recent, recent_joined, recent_lower)
 }
 
 /// How long a `running` hook write must have been standing before a pane that
@@ -427,13 +424,11 @@ const IDLE_RECONCILE_MIN_RUNNING_AGE: std::time::Duration = std::time::Duration:
 /// `⏵`/`⏸` glyph rather than matched as a bare substring, so panes merely
 /// echoing the footer text (a `git diff` of this file, quoted docs, this
 /// repo's own test fixtures in tool output) don't read as parked.
-fn claude_pane_shows_ready_prompt(raw_content: &str) -> bool {
-    let clean = strip_ansi(raw_content);
-    let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
-    let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
-    let recent_joined = recent.join("\n");
-    let recent_lower = recent_joined.to_lowercase();
-
+fn claude_pane_shows_ready_prompt(
+    recent: &[&str],
+    recent_joined: &str,
+    recent_lower: &str,
+) -> bool {
     let has_empty_prompt = recent.iter().any(|line| line.trim() == "❯");
     let has_idle_footer = recent_lower.contains("? for shortcuts")
         || recent.iter().any(|line| {
@@ -442,7 +437,7 @@ fn claude_pane_shows_ready_prompt(raw_content: &str) -> bool {
                 && trimmed.to_lowercase().contains("shift+tab to cycle")
         });
     (has_empty_prompt || has_idle_footer)
-        && !claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower)
+        && !claude_pane_has_running_signal(recent, recent_joined, recent_lower)
 }
 
 /// When Claude's status hook reports Running, the pane is consulted to catch two
@@ -479,26 +474,28 @@ pub(crate) fn reconcile_claude_hook_status(
     if hook_status != Status::Running {
         return hook_status;
     }
-    if let Some(rule) = claude_pane_blocking_prompt_rule(raw_content) {
-        tracing::debug!(target: "tmux.status",
-            "claude reconciler: hook Running downgraded to Waiting ({rule})");
-        return Status::Waiting;
-    }
-    if claude_pane_shows_interrupted_turn(raw_content) {
-        tracing::debug!(target: "tmux.status",
-            "claude reconciler: hook Running downgraded to Idle (esc_interrupt)");
-        return Status::Idle;
-    }
-    if running_age.is_some_and(|age| age >= IDLE_RECONCILE_MIN_RUNNING_AGE)
-        && claude_pane_shows_ready_prompt(raw_content)
-    {
-        tracing::debug!(target: "tmux.status",
-            "claude reconciler: hook Running downgraded to Idle \
-             (stale_running_ready_prompt, age {:?})",
-            running_age);
-        return Status::Idle;
-    }
-    hook_status
+    with_claude_recent_pane(raw_content, |recent, recent_joined, recent_lower| {
+        if let Some(rule) = claude_blocking_prompt_rule(recent, recent_lower) {
+            tracing::debug!(target: "tmux.status",
+                "claude reconciler: hook Running downgraded to Waiting ({rule})");
+            return Status::Waiting;
+        }
+        if claude_pane_shows_interrupted_turn(recent, recent_joined, recent_lower) {
+            tracing::debug!(target: "tmux.status",
+                "claude reconciler: hook Running downgraded to Idle (esc_interrupt)");
+            return Status::Idle;
+        }
+        if running_age.is_some_and(|age| age >= IDLE_RECONCILE_MIN_RUNNING_AGE)
+            && claude_pane_shows_ready_prompt(recent, recent_joined, recent_lower)
+        {
+            tracing::debug!(target: "tmux.status",
+                "claude reconciler: hook Running downgraded to Idle \
+                 (stale_running_ready_prompt, age {:?})",
+                running_age);
+            return Status::Idle;
+        }
+        hook_status
+    })
 }
 
 pub fn detect_opencode_status(raw_content: &str) -> Status {
@@ -2410,18 +2407,24 @@ Do you want to proceed?\n\
         ] {
             let pane = format!("✻ Churned for 10s\n❯ ghost suggestion text\n{footer}");
             assert!(
-                claude_pane_shows_ready_prompt(&pane),
+                with_claude_recent_pane(&pane, claude_pane_shows_ready_prompt),
                 "expected parked for footer: {footer}"
             );
         }
         let echoed = "\
 +  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n\
 ❯ ghost suggestion text";
-        assert!(!claude_pane_shows_ready_prompt(echoed));
+        assert!(!with_claude_recent_pane(
+            echoed,
+            claude_pane_shows_ready_prompt
+        ));
         let running = "\
 ❯ ghost suggestion text\n\
   ⏵⏵ auto mode on (shift+tab to cycle) · esc to interrupt · ← for agents";
-        assert!(!claude_pane_shows_ready_prompt(running));
+        assert!(!with_claude_recent_pane(
+            running,
+            claude_pane_shows_ready_prompt
+        ));
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -132,21 +132,37 @@ pub fn detect_claude_status(content: &str) -> Status {
     let recent_joined = recent.join("\n");
     let recent_lower = recent_joined.to_lowercase();
 
-    // A blocking approval prompt has to outrank the spinner. Claude keeps its
-    // live "Working…" line rendered *below* the permission prompt while it
-    // waits for the user, so a sandboxed session (whose in-container hook
-    // status the host can't read, see `claude_poll_fn_sandboxed`) would
+    // A blocking prompt has to outrank the spinner. Claude keeps its live
+    // "Working…" line rendered *below* a permission prompt or AskUserQuestion
+    // menu while it waits for the user, so a session on this pane fallback
+    // (hooks disabled, or the sandbox hook-dir bind-mount failed) would
     // otherwise match the spinner and report Running the whole time it is
     // blocked. See #1913.
-    if claude_has_approval_prompt(&recent, &recent_lower) {
+    if let Some(rule) = claude_blocking_prompt_rule(&recent, &recent_lower) {
+        tracing::trace!(target: "tmux.status", "claude pane detector: Waiting ({rule})");
         return Status::Waiting;
     }
 
     if claude_pane_has_running_signal(&recent, &recent_joined, &recent_lower) {
+        tracing::trace!(target: "tmux.status", "claude pane detector: Running (running_signal)");
         return Status::Running;
     }
 
+    tracing::trace!(target: "tmux.status", "claude pane detector: Idle (no_signal)");
     Status::Idle
+}
+
+/// Which blocking-prompt rule matches the recent pane lines, if any. The rule
+/// name feeds status-decision tracing so a wrong-state report can be resolved
+/// by grepping debug.log for which detector fired.
+fn claude_blocking_prompt_rule(recent: &[&str], recent_lower: &str) -> Option<&'static str> {
+    if claude_has_approval_prompt(recent, recent_lower) {
+        return Some("approval_prompt");
+    }
+    if claude_has_ask_user_question(recent, recent_lower) {
+        return Some("ask_user_question");
+    }
+    None
 }
 
 /// True when the recent pane lines show that a turn is actively generating or
@@ -298,6 +314,31 @@ fn claude_has_approval_prompt(recent: &[&str], recent_lower: &str) -> bool {
             .any(|line| claude_line_is_numbered_choice(line))
 }
 
+/// Claude's `AskUserQuestion` tool renders an interactive selection UI: an
+/// author-written question, a numbered `❯ N.` menu, and a footer that always
+/// leads with `Enter to select · ↑/↓ to navigate` (both the single-question
+/// `... · Esc to cancel` and the multi-question `... · Tab to switch questions
+/// · Esc to cancel` variants). Unlike a tool-permission prompt it carries no
+/// fixed "Do you want to" / "Would you like to proceed" phrasing, the question
+/// is arbitrary turn text, so `claude_has_approval_prompt` misses it and the
+/// `PreToolUse` `running` write sticks, pinning a session that is blocked on the
+/// user at Running. This is the Claude analogue of the codex `request_user_input`
+/// radio prompt handled by `reconcile_codex_hook_status`.
+///
+/// The footer is the positive marker: `enter to select` paired with the `↑/↓`
+/// navigate hint is unique to this selection UI and absent from a permission
+/// prompt (whose footer is `Esc to cancel · Tab to amend`). Pairing it with a
+/// numbered choice mirrors `claude_has_approval_prompt`'s two-signal guard so a
+/// rendered markdown list in prose can't match on the footer text alone.
+fn claude_has_ask_user_question(recent: &[&str], recent_lower: &str) -> bool {
+    let has_select_footer =
+        recent_lower.contains("enter to select") && recent_lower.contains("to navigate");
+    has_select_footer
+        && recent
+            .iter()
+            .any(|line| claude_line_is_numbered_choice(line))
+}
+
 /// A numbered menu option, optionally preceded by the `❯`/`>` selection
 /// cursor: `❯ 1. Yes`, `2. No`, `3. No, and tell Claude ...`.
 fn claude_line_is_numbered_choice(line: &str) -> bool {
@@ -311,15 +352,18 @@ fn claude_line_is_numbered_choice(line: &str) -> bool {
     matches!(chars.next(), Some('1'..='9')) && matches!(chars.next(), Some('.'))
 }
 
-/// Strip ANSI and scan the recent pane lines for an approval prompt. Shares
-/// the same recent-window shape as `detect_claude_status`; this entry point
-/// exists for callers that hold raw (un-stripped) `capture-pane -e` output.
-fn claude_pane_has_approval_prompt(raw_content: &str) -> bool {
+/// Strip ANSI and scan the recent pane lines for any state where Claude is
+/// blocked on the user: a tool-permission approval prompt or an `AskUserQuestion`
+/// selection UI. Returns the matching rule name for status-decision tracing.
+/// Shares the same recent-window shape as `detect_claude_status`; this entry
+/// point exists for callers that hold raw (un-stripped) `capture-pane -e`
+/// output.
+fn claude_pane_blocking_prompt_rule(raw_content: &str) -> Option<&'static str> {
     let clean = strip_ansi(raw_content);
     let non_empty: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
     let recent: Vec<&str> = non_empty.iter().rev().take(30).rev().copied().collect();
     let recent_lower = recent.join("\n").to_lowercase();
-    claude_has_approval_prompt(&recent, &recent_lower)
+    claude_blocking_prompt_rule(&recent, &recent_lower)
 }
 
 /// Claude has parked at the prompt after the user cancelled a turn with Esc.
@@ -404,11 +448,12 @@ fn claude_pane_shows_ready_prompt(raw_content: &str) -> bool {
 /// When Claude's status hook reports Running, the pane is consulted to catch two
 /// cases the hook stream can't express on its own:
 ///
-/// 1. A blocking approval prompt: Claude keeps its live spinner rendered below
-///    the prompt and re-emits running-mapped hook events (`PreToolUse`,
-///    `UserPromptSubmit`) while it waits, so the last hook write stays
-///    `running` even though the agent is blocked on the user. Downgrade to
-///    Waiting. See #1913.
+/// 1. A blocking prompt the user must answer: a tool-permission approval prompt
+///    or an `AskUserQuestion` selection UI. Claude keeps its live spinner
+///    rendered below the prompt and re-emits running-mapped hook events
+///    (`PreToolUse`, `UserPromptSubmit`) while it waits, so the last hook write
+///    stays `running` even though the agent is blocked on the user. Downgrade to
+///    Waiting. See #1913 (permission prompt) and `claude_has_ask_user_question`.
 /// 2. An Esc-interrupted turn: cancelling a turn fires no `Stop` and no
 ///    `idle_prompt`, so the status file sticks on `running` indefinitely.
 ///    Downgrade to Idle when the pane shows the interrupt banner and no
@@ -434,15 +479,23 @@ pub(crate) fn reconcile_claude_hook_status(
     if hook_status != Status::Running {
         return hook_status;
     }
-    if claude_pane_has_approval_prompt(raw_content) {
+    if let Some(rule) = claude_pane_blocking_prompt_rule(raw_content) {
+        tracing::debug!(target: "tmux.status",
+            "claude reconciler: hook Running downgraded to Waiting ({rule})");
         return Status::Waiting;
     }
     if claude_pane_shows_interrupted_turn(raw_content) {
+        tracing::debug!(target: "tmux.status",
+            "claude reconciler: hook Running downgraded to Idle (esc_interrupt)");
         return Status::Idle;
     }
     if running_age.is_some_and(|age| age >= IDLE_RECONCILE_MIN_RUNNING_AGE)
         && claude_pane_shows_ready_prompt(raw_content)
     {
+        tracing::debug!(target: "tmux.status",
+            "claude reconciler: hook Running downgraded to Idle \
+             (stale_running_ready_prompt, age {:?})",
+            running_age);
         return Status::Idle;
     }
     hook_status
@@ -1922,6 +1975,68 @@ enter to select · esc to cancel";
     2. Yes, and manually approve edits
     3. No, keep planning";
         assert_eq!(detect_claude_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_claude_status_waiting_on_ask_user_question() {
+        // Regression: Claude's AskUserQuestion tool renders a selection UI while
+        // blocked on the user, but the question is author-written (no "Do you
+        // want to" phrasing), so the permission-prompt detector misses it and
+        // the session reports Running the whole time it is waiting. The
+        // "Enter to select · ↑/↓ to navigate" footer is the marker.
+        let content = "\
+  PREMISE GATE (your call, not auto-decided).
+  So which shape do you actually want?
+
+  ❯ 1. Static plugin (comparator stays core)
+    2. True-worker extraction (as first scoped)
+    3. Don't extract; ship the valuable byproducts
+
+  Enter to select · ↑/↓ to navigate · Esc to cancel";
+        assert_eq!(detect_claude_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_claude_status_waiting_on_multi_question_ask_user_question() {
+        // The multi-question footer variant carries the extra "Tab to switch
+        // questions" / "n to add notes" hints; it must still read as Waiting.
+        let content = "\
+  How should the encryption key be managed?
+
+  ❯ 1. Require OTARI_SECRET_KEY
+    2. Auto-generate KEK to a file
+    3. Auto-generate KEK in DB
+
+  Enter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel";
+        assert_eq!(detect_claude_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_waiting_on_ask_user_question() {
+        // The hook reports Running (PreToolUse for AskUserQuestion fired) but the
+        // pane is parked on the selection UI. The reconciler must downgrade to
+        // Waiting. ANSI is preserved to exercise the strip path.
+        let pane = "\x1b[1m  Which approach do you prefer?\x1b[0m\n\
+\x1b[1m❯ 1. First\x1b[0m\n    2. Second\n\n\
+  Enter to select · ↑/↓ to navigate · Esc to cancel";
+        assert_eq!(
+            reconcile_claude_hook_status(Status::Running, pane, None),
+            Status::Waiting
+        );
+    }
+
+    #[test]
+    fn test_detect_claude_status_running_not_confused_by_select_footer_prose() {
+        // The select footer must not be mistaken for a live prompt when it only
+        // appears as quoted text (e.g. this file's own fixtures shown in tool
+        // output) with an active spinner running below it: the footer needs a
+        // real numbered choice AND the spinner still wins if there is none.
+        let content = "\
+  The footer reads \"Enter to select · ↑/↓ to navigate\" while parked.
+
+✶ Working… (4s · ↓ 88 tokens)
+  esc to interrupt";
+        assert_eq!(detect_claude_status(content), Status::Running);
     }
 
     #[test]


### PR DESCRIPTION
## Description

A Claude Code session parked on an `AskUserQuestion` prompt (numbered menu plus the `Enter to select · ↑/↓ to navigate` footer) reported **Running** in aoe the entire time it was blocked on the user.

Two layers both missed this state:

1. **Hooks said Running, truthfully but incompletely.** `AskUserQuestion` is a tool call, so `PreToolUse` writes `running`, and no Waiting-mapped hook fires while the question is on screen. The status file sat on `running` until the user answered.
2. **The pane-side safety net had a hole.** `claude_has_approval_prompt` was written for tool-permission prompts and requires the fixed phrasing "do you want to" / "would you like to proceed". An AskUserQuestion's text is author-written, so no Waiting rule matched and the stale `running` stood. This is the Claude analogue of the codex `request_user_input` radio prompt, which already had its fix.

Three commits:

- **fix(tmux)**: new pane detector keyed on the AskUserQuestion footer (`enter to select` plus the navigate hint) paired with a numbered choice, mirroring the two-signal guard the approval detector uses against prose false positives. Checked in both `detect_claude_status` (pane fallback) and `reconcile_claude_hook_status` (stuck running hook write). Also adds status-decision tracing: the pane detector trace-logs which rule decided each status and the reconciler debug-logs every downgrade with its rule name and hook age, so the next wrong-state report is a grep of debug.log instead of an archaeology session. Corrects a stale comment claiming the host cannot read a sandboxed session's hook status (the hook dir is bind-mounted; sandboxed sessions reconcile like host sessions).
- **feat(hooks)**: make the hook stream say Waiting directly. `HookEvent` grows `waiting_tools`; Claude's `PreToolUse` declares `["AskUserQuestion"]`, and the generated status command inspects the payload's `tool_name` on stdin, writing `waiting` for those tools and the event's status otherwise. A `PostToolUse` hook scoped to `AskUserQuestion` restores `running` the moment the answer lands. A single branching command avoids the parallel-hook write race two `PreToolUse` matcher groups would have. Escaped mentions of the key inside `tool_input` strings cannot false-positive (their quotes are backslash-escaped, so the bytes differ), and a missing or reshaped payload falls through to the default status, which is today's behavior with the pane reconciler as backstop. `install_hooks` reconciles settings at session launch, so this rolls out without a migration.
- **refactor(tmux)**: the four Claude pane detectors each rebuilt the same recent-window view (strip ANSI, last 30 non-empty lines, join, lowercase) and the reconciler re-derived it three times per poll tick; `with_claude_recent_pane` now builds it once. No behavior change.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the change is entirely in the status-detection layer, which is locked by unit tests at the layer boundary: 4 new pane-fixture regression tests (from the real panes that reproduced the bug), and 5 hook tests of which 4 execute the generated command under `sh` with real payload shapes and assert the status-file bytes (AskUserQuestion writes waiting, other tools write running, escaped mention in tool_input writes running, empty stdin writes running). A full e2e would need a real Claude Code binary deterministically emitting an AskUserQuestion mid-turn, which the fake-agent harness cannot do today.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Opus 4.8 via Claude Code

**Any Additional AI Details you'd like to share:**
Investigation, fix, and tests were done in a Claude Code session driven by @njbrake, starting from a live repro (an aoe preview showing an AskUserQuestion session as Running). The full lib suite passes locally (4049 tests; one pre-existing sandbox-environment failure in `restart_selected_session_surfaces_resume_failed_after_async_restart` that also fails on a clean checkout of main in the same container).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed Claude interactive `AskUserQuestion` sessions incorrectly showing as **Running** while the system is actually waiting for the user to select an option.
- Improved Claude pane status detection by recognizing the `AskUserQuestion` “Enter to select …” UI footer more reliably (matching anchored at the start of a trimmed line to avoid false positives from echoed/quoted text).
- Added tool-aware hook status behavior: the system can write **Waiting** for `AskUserQuestion` during `PreToolUse`, then automatically restore **Running** when `PostToolUse` arrives.
- Centralized/reused Claude “recent pane” parsing so status reconciliation is consistent and doesn’t repeatedly reprocess pane content.
- Added clearer tracing/logging for status decisions (including downgrade reasons) and corrected a sandbox hook-status comment.
- Expanded documentation and regression coverage (unit tests, migration assertions, and generated-hook tests) to cover the new `waiting` behavior and the hardened footer detection.

## Benefits

Users get accurate session status during Claude’s interactive question flow, with fewer incorrect “Running” indicators and stronger safeguards against mis-detecting prompts that appear as plain text in the pane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->