### PR TITLE
fix(tui): forward Ctrl+C to the agent in live mode instead of quitting

### DIFF
--- a/docs/guides/live-mode.md
+++ b/docs/guides/live-mode.md
@@ -23,6 +23,13 @@ you work.
 The status bar shows a `● LIVE → <session>` banner while you are
 relayed, including a reminder of the exit chord and the leader menu.
 
+Control chords reach the agent too. `Ctrl+C`, for example, interrupts
+the agent rather than quitting AoE; use it whenever you would send an
+interrupt in a normal terminal. The banner flashes a brief `Ctrl+C sent
+to agent` reminder on each press, next to the exit chord, so it is clear
+the keystroke landed on the agent and how to leave live mode. To quit
+AoE, exit live mode first (`Ctrl+Q`), then quit from the home view.
+
 Live-send also works for the Terminal view and Tool views (lazygit,
 yazi, and other embedded tools), not just the agent pane: whichever
 pane is on screen is what your keystrokes reach.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2535,7 +2535,12 @@ impl App {
     ) -> Result<()> {
         // Global keybindings
         match (key.code, key.modifiers) {
-            (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+            // In live-send mode Ctrl+C belongs to the agent (interrupt), not
+            // aoe: defer to `home.handle_key` below, which forwards it to the
+            // pane. Without this guard the global quit path swallowed it and
+            // exited aoe, the exact surprise #2894 reported. The `q` arm is
+            // already covered because `has_dialog()` includes live-send.
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) if !self.home.is_live_send_capturing() => {
                 if self.home.is_creating_stub_selected() {
                     self.home.cancel_creation();
                     return Ok(());

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5776,11 +5776,20 @@ impl HomeView {
             self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
             return;
         }
+        // Ctrl+C reaching this point is forwarded to the agent rather than
+        // quitting aoe (the app-level global handler defers to live-send via
+        // `is_live_send_capturing`). Flash the footer so the user learns the
+        // keystroke landed on the agent; re-armed on every press (#2894).
+        let is_ctrl_c =
+            matches!(key.code, KeyCode::Char('c')) && key.modifiers.contains(KeyModifiers::CONTROL);
         match live_send::translate(key) {
             live_send::LiveDispatch::Ignore => {}
             live_send::LiveDispatch::Send(tmux_key) => {
                 if let Some(worker) = &self.live_send_worker {
                     worker.send(tmux_key);
+                }
+                if is_ctrl_c {
+                    self.flash_ctrl_c_hint();
                 }
                 self.stamp_last_accessed(&state.session_id);
             }
@@ -5826,6 +5835,9 @@ impl HomeView {
         // clickable here), so exiting live mode deliberately leaves it as
         // the user set it rather than force-revealing the list.
         self.live_send_pending_leader = false;
+        // The Ctrl+C footer flash is live-mode-only; drop any pending window
+        // so it can't linger onto the home-view footer after exit (#2894).
+        self.live_send_ctrl_c_flash_until = None;
         // Live mode just owned the pane's size; the non-live preview must
         // re-assert its geometry on the next render now that the header is
         // visible again (and so the agent reflows back to the previewed size).

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -607,6 +607,13 @@ pub struct HomeView {
     /// shows the which-key menu. Always false outside live mode; cleared on
     /// live-send exit. See `handle_live_send_key`.
     pub(super) live_send_pending_leader: bool,
+    /// Deadline until which the live-send footer flashes a "Ctrl+C sent to
+    /// agent" reminder. Set on every Ctrl+C forwarded through live mode
+    /// (#2894) so the user learns the keystroke reached the agent rather
+    /// than quitting aoe, and cleared on live-send exit. `None` outside the
+    /// flash window; the ~30fps live-mode ticker reverts the footer once it
+    /// lapses.
+    pub(super) live_send_ctrl_c_flash_until: Option<std::time::Instant>,
     /// When true, the session list (sidebar) collapses to a narrow,
     /// click-to-expand strip so the preview pane gets nearly the full
     /// terminal width. Toggled by the collapse button on the list border,
@@ -2131,6 +2138,7 @@ impl HomeView {
             preview_wake: std::sync::Arc::new(tokio::sync::Notify::new()),
             live_send_last_resize: None,
             live_send_pending_leader: false,
+            live_send_ctrl_c_flash_until: None,
             sidebar_collapsed: user_config
                 .as_ref()
                 .and_then(|c| c.app_state.home_sidebar_collapsed)
@@ -4165,6 +4173,30 @@ impl HomeView {
             || serve_open
             || self.settings_view.is_some()
             || self.diff_view.is_some()
+    }
+
+    /// True when live-send owns the keyboard: live mode is active and no
+    /// other overlay has stolen focus on top of it. This is the same
+    /// predicate `handle_key` uses to route keys straight to the agent pane,
+    /// lifted into a helper so the app-level global keybindings (Ctrl+C in
+    /// particular) can defer to live-send instead of quitting aoe (#2894).
+    pub(in crate::tui) fn is_live_send_capturing(&self) -> bool {
+        self.live_send.is_some() && !self.has_non_live_send_overlay()
+    }
+
+    /// Arm the live-send footer's "Ctrl+C sent to agent" flash. Called each
+    /// time a Ctrl+C is forwarded to the agent in live mode so the reminder
+    /// re-shows on every press (#2894).
+    pub(super) fn flash_ctrl_c_hint(&mut self) {
+        self.live_send_ctrl_c_flash_until =
+            Some(std::time::Instant::now() + std::time::Duration::from_secs(3));
+    }
+
+    /// Whether the "Ctrl+C sent to agent" footer flash is currently within
+    /// its display window.
+    pub(super) fn live_send_ctrl_c_flash_active(&self) -> bool {
+        self.live_send_ctrl_c_flash_until
+            .is_some_and(|deadline| std::time::Instant::now() < deadline)
     }
 
     pub fn has_dialog(&self) -> bool {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -3128,6 +3128,13 @@ impl HomeView {
                 .bg(theme.running)
                 .bold();
 
+            // Ctrl+C in live mode is forwarded to the agent (not a quit); the
+            // footer flashes a reminder for a few seconds after each press so
+            // the user sees the keystroke landed on the agent (#2894). While
+            // it shows, the scroll indicator and leader-menu hint step aside
+            // to keep the row from overflowing on narrow terminals.
+            let flash_ctrl_c = self.live_send_ctrl_c_flash_active();
+
             // Which-key menu: the leader is armed, so surface the live-send
             // commands the next key can pick instead of the normal exit
             // hint. This is the discoverability moment the issue asked for;
@@ -3171,10 +3178,14 @@ impl HomeView {
             // the user can discover the palette / sidebar toggle without
             // having entered the menu yet. Empty when the leader is
             // disabled (the user cleared the setting).
-            let leader_hint = state
-                .leader
-                .map(|l| format!(" \u{00b7} {} menu", live_send::display_chord(l)))
-                .unwrap_or_default();
+            let leader_hint = if flash_ctrl_c {
+                String::new()
+            } else {
+                state
+                    .leader
+                    .map(|l| format!(" \u{00b7} {} menu", live_send::display_chord(l)))
+                    .unwrap_or_default()
+            };
             // `preview_visible_rows` is the output-body height the renderer
             // last painted into (pane height minus the inner banner row only
             // when that banner is shown). Reuse it so the live `[offset/max]`
@@ -3184,19 +3195,33 @@ impl HomeView {
             let visible_height = self.preview_visible_rows;
             // Pull `captured_lines` from whichever cache is on screen, not the
             // Agent cache unconditionally: in Terminal/Tool live mode the
-            // wrong cache would show a stale or empty `[offset/max]`.
-            let scroll = format_scroll_indicator(
-                self.active_captured_lines(),
-                visible_height,
-                self.preview_scroll_offset,
-            )
-            .unwrap_or_default();
+            // wrong cache would show a stale or empty `[offset/max]`. Hidden
+            // while the Ctrl+C flash is up so the reminder has room.
+            let scroll = if flash_ctrl_c {
+                String::new()
+            } else {
+                format_scroll_indicator(
+                    self.active_captured_lines(),
+                    visible_height,
+                    self.preview_scroll_offset,
+                )
+                .unwrap_or_default()
+            };
+            // The Ctrl+C reminder, rendered just before the exit chord so it
+            // reads as "Ctrl+C sent to agent · <chord> to exit". Empty unless
+            // the flash window is open.
+            let flash = if flash_ctrl_c {
+                "Ctrl+C sent to agent \u{00b7} "
+            } else {
+                ""
+            };
             // Spaces between chip→title and title→chord. Title gets the
             // budget after the fixed pieces; reserved last so the exit
             // chord never falls off on narrow terminals.
             let fixed_width = unicode_width::UnicodeWidthStr::width(chip)
                 + 1 // single space after the chip
                 + 2 // double space before the chord
+                + unicode_width::UnicodeWidthStr::width(flash)
                 + unicode_width::UnicodeWidthStr::width(chord.as_str())
                 + unicode_width::UnicodeWidthStr::width(suffix)
                 + unicode_width::UnicodeWidthStr::width(leader_hint.as_str())
@@ -3215,6 +3240,12 @@ impl HomeView {
                 ));
             }
             spans.push(Span::raw("  "));
+            if !flash.is_empty() {
+                spans.push(Span::styled(
+                    flash,
+                    Style::default().fg(theme.running).bold(),
+                ));
+            }
             spans.push(Span::styled(
                 chord,
                 Style::default().fg(theme.accent).bold(),

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -615,6 +615,146 @@ fn preview_info_follows_flag_and_never_auto_shows_in_live() {
     );
 }
 
+/// The app-level global keybindings defer Ctrl+C to live-send via this
+/// predicate (#2894). It is true only while live mode owns the keyboard: an
+/// overlay opened on top of live mode takes focus back, and Ctrl+C should
+/// then behave normally.
+#[test]
+#[serial]
+fn is_live_send_capturing_tracks_state_and_overlays() {
+    use super::live_send::{LiveSendState, LiveSendTarget};
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+
+    assert!(
+        !env.view.is_live_send_capturing(),
+        "no live-send means the keyboard is not captured"
+    );
+
+    env.view.live_send = Some(LiveSendState {
+        session_id: id.clone(),
+        title: "session0".to_string(),
+        tmux_name: "aoe_test_live".to_string(),
+        target: LiveSendTarget::Agent,
+        exit_chords: Vec::new(),
+        leader: None,
+    });
+    assert!(
+        env.view.is_live_send_capturing(),
+        "live-send with no overlay captures the keyboard"
+    );
+
+    // An overlay over live mode hands focus back to the overlay, so Ctrl+C
+    // must stop being routed to the agent.
+    env.view.info_dialog = Some(InfoDialog::new("t", "b"));
+    assert!(
+        !env.view.is_live_send_capturing(),
+        "an overlay over live-send releases the capture"
+    );
+}
+
+/// #2894: in live mode Ctrl+C is forwarded to the agent (an interrupt), not
+/// treated as a quit, and each forward arms the footer reminder. Drives the
+/// real `handle_key` routing with the default `C-q` exit chord present so the
+/// test proves Ctrl+C is distinct from exiting.
+#[test]
+#[serial]
+fn ctrl_c_in_live_mode_forwards_to_agent_and_flashes() {
+    use super::live_send::{parse_chord_list, LiveSendState, LiveSendTarget};
+
+    let mut env = create_test_env_with_sessions(1);
+    let inst = env.view.instance_at(0).clone();
+
+    // Match the generated tmux name so the drift guard doesn't tear live mode
+    // down before the key is translated.
+    let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+    env.view.live_send = Some(LiveSendState {
+        session_id: inst.id.clone(),
+        title: inst.title.clone(),
+        tmux_name,
+        target: LiveSendTarget::Agent,
+        exit_chords: parse_chord_list("C-q"),
+        leader: None,
+    });
+
+    assert!(!env.view.live_send_ctrl_c_flash_active());
+
+    let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+    let action = env.view.handle_key(ctrl_c, None);
+
+    assert!(
+        action.is_none(),
+        "Ctrl+C in live mode produces no home-view action"
+    );
+    assert!(
+        env.view.live_send.is_some(),
+        "Ctrl+C reaches the agent; it must not exit live mode"
+    );
+    assert!(
+        env.view.live_send_ctrl_c_flash_active(),
+        "forwarding Ctrl+C arms the footer reminder"
+    );
+}
+
+/// The live-send footer renders the "Ctrl+C sent to agent" reminder only
+/// while the flash window is open (#2894).
+#[test]
+#[serial]
+fn ctrl_c_flash_renders_in_live_footer() {
+    use super::live_send::{parse_chord_list, LiveSendState, LiveSendTarget};
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.select_session_by_id(&id);
+    env.view.view_mode = ViewMode::Structured;
+    let theme = load_theme("empire");
+
+    let render_to_string = |view: &mut HomeView| -> String {
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                view.render(f, area, &theme, None, None, None);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    };
+
+    env.view.live_send = Some(LiveSendState {
+        session_id: id.clone(),
+        title: "session0".to_string(),
+        tmux_name: "aoe_test_live".to_string(),
+        target: LiveSendTarget::Agent,
+        exit_chords: parse_chord_list("C-q"),
+        leader: None,
+    });
+
+    let without = render_to_string(&mut env.view);
+    assert!(
+        !without.contains("Ctrl+C sent to agent"),
+        "the reminder must be absent before any Ctrl+C\n{without}"
+    );
+
+    env.view.flash_ctrl_c_hint();
+    let with = render_to_string(&mut env.view);
+    assert!(
+        with.contains("Ctrl+C sent to agent"),
+        "the reminder must render while the flash window is open\n{with}"
+    );
+}
+
 #[test]
 #[serial]
 fn preview_visible_rows_equal_output_area_with_info_shown() {


### PR DESCRIPTION
## Description

At the home view the global keybinding handler caught `Ctrl+C` and quit `aoe` before delegating to `home.handle_key`, where live-send routing lives. The `q` arm is already guarded by `!has_dialog()` (and `has_dialog()` includes live-send), so a bare `q` reaches the agent in live mode, but the `Ctrl+C` arm had no such guard. The result: pressing `Ctrl+C` to interrupt an agent from live mode exited `aoe`, the surprise reported in #2894.

This guards the global `Ctrl+C` arm with `!is_live_send_capturing()` so that when live-send owns the keyboard the key falls through to `home.handle_key`, which translates it to a `C-c` send-keys against the pane. Outside live mode `Ctrl+C` still quits exactly as before (creation-cancel, quit-during-creation, and plain quit are unchanged).

Because forwarding makes `Ctrl+C` behave differently than a user coming from a plain terminal might expect, the live footer now flashes a `Ctrl+C sent to agent` reminder on every press, so it's clear the keystroke reached the agent and how to actually exit (the exit chord is shown right next to it). The flash auto-clears after a few seconds via the live-mode ticker and is dropped on live-send exit.

```
● LIVE → hermes   Ctrl+C sent to agent · C-q to exit
(after a few seconds, reverts to:)
● LIVE → hermes                     C-q to exit · C-b menu
```

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

<!--
UI note: the change is a single footer line in the TUI live-send status bar.
It is covered by a rendering unit test that asserts the exact reminder text;
capturing an interactive live tmux Ctrl+C recording headless was not practical
in this environment. The ASCII above shows the before/after footer.
-->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test (unit tests in `src/tui/home/tests.rs`)
- [ ] Skipped a test, because:

Three tests were added:
- `is_live_send_capturing_tracks_state_and_overlays`: the predicate the app-level `Ctrl+C` guard branches on (live mode captures the keyboard; an overlay over live mode releases it).
- `ctrl_c_in_live_mode_forwards_to_agent_and_flashes`: drives the real `handle_key` routing with the default `C-q` exit chord present, asserting `Ctrl+C` does not exit live mode and arms the footer reminder.
- `ctrl_c_flash_renders_in_live_footer`: the reminder renders in the live footer only while the flash window is open.

These live as focused unit tests rather than a full `tests/e2e/` case: the behavior is a pure `handle_key` routing decision plus a footer render, both of which the unit tests exercise directly (the render test paints the real status bar and asserts the exact text).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:**

Claude drafted the implementation and this PR text via back-and-forth with @njbrake. The direction (forward `Ctrl+C` to the agent in live mode; flash a footer reminder on every press) and the decisions are his; the code and prose are Claude's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the TUI input routing so `Ctrl+C` is forwarded to the live agent during live mode (instead of triggering AoE’s quit flow).
- Guarded the app-wide `Ctrl+C` handler so it only activates when live-send is *not* actively capturing the keyboard (including when overlays are open).
- Added a transient live-mode footer confirmation (“Ctrl+C sent to agent”) that flashes after forwarding and clears when exiting live-send.
- Updated the live-mode guide to document that `Ctrl+C` interrupts the agent, shows the confirmation, and that quitting AoE requires leaving live mode first.
- Added/expanded tests to cover live-send key capture detection, correct key routing, and footer rendering behavior.

## Benefits

Users can interrupt or stop the live agent reliably with `Ctrl+C` without accidentally exiting the TUI, and they get immediate on-screen confirmation that the key was sent to the agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->