### PR TITLE
feat(tui): mouse scroll, scrollbar grab-drag, and click-to-toggle in Settings

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -975,7 +975,12 @@ impl App {
                                                 let hit_preview = self.home.hit_preview(mouse.column, mouse.row);
                                                 let hit_diff = self.home.is_diff_open()
                                                     && self.home.hit_diff(mouse.column, mouse.row);
-                                                let hit_scroll_target = hit_diff || hit_list || hit_preview;
+                                                // See the non-burst arm: settings takeover
+                                                // makes the whole screen a scroll target.
+                                                let hit_scroll_target = hit_diff
+                                                    || hit_list
+                                                    || hit_preview
+                                                    || self.home.is_settings_open();
                                                 match mouse.kind {
                                                     MouseEventKind::ScrollUp if hit_scroll_target => { self.home.handle_scroll_up(mouse.column, mouse.row); }
                                                     MouseEventKind::ScrollDown if hit_scroll_target => { self.home.handle_scroll_down(mouse.column, mouse.row); }
@@ -1162,7 +1167,14 @@ impl App {
                             let hit_preview = self.home.hit_preview(mouse.column, mouse.row);
                             let hit_diff = self.home.is_diff_open()
                                 && self.home.hit_diff(mouse.column, mouse.row);
-                            let hit_scroll_target = hit_diff || hit_list || hit_preview;
+                            // Settings is a full-screen takeover: the whole
+                            // screen is a scroll target because its fields
+                            // panel is the only scrollable surface and the
+                            // list/preview rects it covers are stale.
+                            let hit_scroll_target = hit_diff
+                                || hit_list
+                                || hit_preview
+                                || self.home.is_settings_open();
                             // Left-click is handled outside the unified
                             // match because it returns an `Option<Action>`
                             // (a double-click activates the session and

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -428,6 +428,14 @@ impl HomeView {
         self.diff_view.is_some()
     }
 
+    /// Whether the full-screen Settings takeover is showing. The wheel
+    /// scroll gate in `app.rs` uses this so the whole screen counts as a
+    /// scroll target (the fields panel is the only scrollable surface,
+    /// but the list/preview hit rects it replaced are now stale).
+    pub fn is_settings_open(&self) -> bool {
+        self.settings_view.is_some()
+    }
+
     pub fn hit_preview(&self, col: u16, row: u16) -> bool {
         self.preview_area.contains(Position::from((col, row)))
     }
@@ -673,6 +681,19 @@ impl HomeView {
     /// path saves on release, the preview-select path emits OSC 52 on
     /// release.
     pub fn handle_drag_move(&mut self, col: u16, row: u16) -> bool {
+        // Settings scrollbar grab: map the live row to a scroll offset.
+        // Handled before the cancel-on-overlay logic below, which keys
+        // off `has_dialog()` (true while settings is open) and would
+        // otherwise tear the drag down on the first move.
+        if matches!(self.drag_state, Some(DragKind::SettingsScrollbar)) {
+            if let Some(view) = &mut self.settings_view {
+                return view.scrollbar_drag_to_row(row);
+            }
+            // Settings closed mid-drag (shouldn't happen while the button
+            // is held); drop the stale drag so the next Up is a no-op.
+            self.drag_state = None;
+            return false;
+        }
         // A dialog opened mid-drag (e.g. a hotkey pressed while the
         // mouse button is still held) shouldn't keep updating the
         // sidebar invisibly under the modal. End the drag here so the
@@ -752,6 +773,8 @@ impl HomeView {
                 sel.extent = new_extent;
                 true
             }
+            // Handled by the early return at the top of this function.
+            Some(DragKind::SettingsScrollbar) => false,
             None => false,
         }
     }
@@ -912,6 +935,9 @@ impl HomeView {
                     }
                 }
             }
+            // The offset was applied live on each move; the release just
+            // ends the gesture. Nothing to persist (scroll is view state).
+            DragKind::SettingsScrollbar => {}
         }
         true
     }
@@ -1319,6 +1345,17 @@ impl HomeView {
             return true;
         }
         if let Some(view) = &mut self.settings_view {
+            // A press on the fields-panel scrollbar begins a grab-drag:
+            // seed the drag state and jump to the pressed row so the
+            // subsequent Drag(Left) events map to the bar. Must precede
+            // handle_click so the bar column isn't treated as a field
+            // miss. The drag_state assignment ends the `view` borrow, so
+            // this is split into a hit test and a follow-up.
+            if view.hit_scrollbar(col, row) {
+                view.scrollbar_drag_to_row(row);
+                self.drag_state = Some(DragKind::SettingsScrollbar);
+                return true;
+            }
             // Settings is a full-screen takeover: every click inside
             // the area is for it, even when the click landed on the
             // background between widgets. `handle_click` mutates
@@ -4229,6 +4266,14 @@ impl HomeView {
 
     pub fn handle_scroll_up(&mut self, col: u16, row: u16) -> bool {
         const STEP: u16 = 3;
+        // Settings is a full-screen takeover with its own scrollable
+        // fields panel; the wheel drives it regardless of where the
+        // (now-hidden) list/preview rects were. Checked before the
+        // diff/live/dialog routing below, which would otherwise swallow
+        // the wheel via `has_dialog()`.
+        if let Some(view) = &mut self.settings_view {
+            return view.handle_wheel_scroll(true);
+        }
         // A preview selection is anchored to absolute scrollback lines,
         // not screen cells, so scrolling no longer invalidates it: the
         // highlight tracks its text as the pane moves and the copy spans
@@ -5443,6 +5488,10 @@ impl HomeView {
     /// Route a mouse-wheel-down at (col, row); see handle_scroll_up.
     pub fn handle_scroll_down(&mut self, col: u16, row: u16) -> bool {
         const STEP: u16 = 3;
+        // Settings takeover owns the wheel; see handle_scroll_up.
+        if let Some(view) = &mut self.settings_view {
+            return view.handle_wheel_scroll(false);
+        }
         // Mirror handle_scroll_up: the selection is anchored to scrollback
         // lines, so it survives the scroll and is left in place.
         if let Some(ref mut diff) = self.diff_view {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -79,6 +79,10 @@ pub(super) enum DragKind {
     /// so `handle_drag_move` / `handle_drag_end` can dispatch by
     /// variant without re-checking `live_send`.
     PreviewSelect,
+    /// Grab-dragging the Settings fields-panel scrollbar. The live row is
+    /// mapped to a scroll offset on each move (`scrollbar_drag_to_row`);
+    /// there's no payload because the settings view owns the offset.
+    SettingsScrollbar,
 }
 
 /// The output pane's text layout, captured at render time so the input

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -17025,3 +17025,108 @@ mod permission_response_dialog {
         );
     }
 }
+
+/// The Settings takeover owns the wheel and the scrollbar grab-drag. The
+/// bug these guard: with settings open, `has_dialog()` is true, so the
+/// generic scroll and drag paths used to swallow (scroll) or cancel
+/// (drag) the gesture, leaving the fields panel dead to the mouse.
+mod settings_scroll_wiring {
+    use super::*;
+    use crate::tui::home::DragKind;
+    use crate::tui::settings::SettingsView;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Render the home view (with its settings takeover) at a deliberately
+    /// short height so the fields panel overflows and paints a scrollbar.
+    fn render_short(env: &mut TestEnv) {
+        let theme = crate::tui::styles::load_theme("empire");
+        let mut terminal = Terminal::new(TestBackend::new(100, 14)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                env.view.render(f, area, &theme, None, None, None);
+            })
+            .unwrap();
+    }
+
+    fn open_overflowing_settings(env: &mut TestEnv) {
+        env.view.settings_view = Some(SettingsView::new("test", None).unwrap());
+        render_short(env);
+    }
+
+    /// Locate a cell the settings scrollbar hit test accepts, so the drag
+    /// test doesn't hard-code render geometry.
+    fn scrollbar_hit(env: &TestEnv) -> Option<(u16, u16)> {
+        let sv = env.view.settings_view.as_ref()?;
+        for row in 0..14u16 {
+            for col in 0..100u16 {
+                if sv.hit_scrollbar(col, row) {
+                    return Some((col, row));
+                }
+            }
+        }
+        None
+    }
+
+    /// Wheel-down while Settings is open must be consumed by the fields
+    /// panel (returns true), not swallowed by the `has_dialog()` guard.
+    #[test]
+    #[serial]
+    fn wheel_routes_into_open_settings() {
+        let mut env = create_test_env_empty();
+        open_overflowing_settings(&mut env);
+        assert!(
+            scrollbar_hit(&env).is_some(),
+            "fields must overflow at this size so there is something to scroll"
+        );
+        assert!(
+            env.view.handle_scroll_down(10, 10),
+            "a wheel-down must scroll the settings fields panel"
+        );
+    }
+
+    /// Pressing the scrollbar starts a `SettingsScrollbar` drag, and a
+    /// subsequent move keeps it alive (the drag path no longer cancels on
+    /// `has_dialog()`), until release clears it.
+    #[test]
+    #[serial]
+    fn scrollbar_press_starts_a_drag_that_survives_moves() {
+        let mut env = create_test_env_empty();
+        open_overflowing_settings(&mut env);
+        let (col, row) = scrollbar_hit(&env).expect("scrollbar should render");
+
+        assert!(
+            env.view.handle_dialog_click(col, row),
+            "a scrollbar press is consumed by the settings takeover"
+        );
+        assert!(
+            matches!(env.view.drag_state, Some(DragKind::SettingsScrollbar)),
+            "the press seeds a scrollbar drag"
+        );
+
+        env.view.handle_drag_move(col, row.saturating_add(2));
+        assert!(
+            matches!(env.view.drag_state, Some(DragKind::SettingsScrollbar)),
+            "the drag must survive a move even though has_dialog() is true"
+        );
+
+        env.view.handle_drag_end();
+        assert!(env.view.drag_state.is_none(), "release ends the drag");
+    }
+
+    /// A plain click that misses the scrollbar must NOT start a scrollbar
+    /// drag; it falls through to the normal settings click routing.
+    #[test]
+    #[serial]
+    fn click_off_the_scrollbar_does_not_start_a_drag() {
+        let mut env = create_test_env_empty();
+        open_overflowing_settings(&mut env);
+        // Column 2 is deep in the categories panel, nowhere near the bar.
+        assert!(env.view.handle_dialog_click(2, 6));
+        assert!(
+            env.view.drag_state.is_none(),
+            "a click off the bar must not begin a scrollbar drag"
+        );
+    }
+}

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -872,6 +872,15 @@ impl SettingsView {
             if self.current_category() == SettingsCategory::Plugins {
                 self.plugins_fields_focus = true;
             }
+            // A click on a checkbox row toggles it in one action, like a
+            // real checkbox, instead of only selecting it and waiting for
+            // Space. Other field types keep select-only: their editors /
+            // cyclers open on Enter, so a stray click shouldn't mutate
+            // them.
+            if let FieldValue::Bool(ref mut value) = self.fields[idx].value {
+                *value = !*value;
+                self.apply_field_to_config(idx);
+            }
             return Some(SettingsAction::Continue);
         }
 
@@ -1439,6 +1448,70 @@ mod tests {
             view.handle_click(25, 9);
             assert_eq!(view.focus, crate::tui::settings::SettingsFocus::Fields);
             assert_eq!(view.selected_field, 1);
+        }
+
+        /// A click on a checkbox row toggles it in one action, like a
+        /// real checkbox, not just selecting it.
+        #[test]
+        #[serial]
+        fn click_on_bool_field_toggles_it() {
+            let (_t, _guard, mut view) = fresh_view();
+            // Walk to whichever category first exposes a toggle so the
+            // test doesn't depend on the default tab's field mix.
+            let (idx, before) = 'outer: loop {
+                for cat in 0..view.categories.len() {
+                    if !matches!(
+                        view.categories[cat],
+                        crate::tui::settings::CategoryRow::Tab(_)
+                    ) {
+                        continue;
+                    }
+                    view.selected_category = cat;
+                    view.rebuild_fields();
+                    if let Some((i, b)) = view.fields.iter().enumerate().find_map(|(i, f)| match f
+                        .value
+                    {
+                        FieldValue::Bool(b) => Some((i, b)),
+                        _ => None,
+                    }) {
+                        break 'outer (i, b);
+                    }
+                }
+                panic!("no category exposes a toggle field");
+            };
+            view.field_rects.push((idx, Rect::new(20, 5, 50, 2)));
+            view.handle_click(25, 6);
+            assert_eq!(view.selected_field, idx, "the click selects the row");
+            match view.fields[idx].value {
+                FieldValue::Bool(after) => {
+                    assert_eq!(after, !before, "the checkbox flips on click");
+                }
+                _ => unreachable!("index came from a Bool match above"),
+            }
+        }
+
+        /// A click on a non-boolean field selects it but must NOT mutate
+        /// it: its editor/cycler opens on Enter, so a stray click can't
+        /// change the value out from under the user.
+        #[test]
+        #[serial]
+        fn click_on_non_bool_field_only_selects() {
+            let (_t, _guard, mut view) = fresh_view();
+            let idx = view
+                .fields
+                .iter()
+                .position(|f| !matches!(f.value, FieldValue::Bool(_) | FieldValue::SectionHeader))
+                .expect("the default category should have a non-toggle field");
+            // FieldValue is Debug but not PartialEq; compare its rendering.
+            let before = format!("{:?}", view.fields[idx].value);
+            view.field_rects.push((idx, Rect::new(20, 5, 50, 2)));
+            view.handle_click(25, 6);
+            assert_eq!(view.selected_field, idx, "the click selects the row");
+            assert_eq!(
+                format!("{:?}", view.fields[idx].value),
+                before,
+                "a non-boolean field must not change on a plain click"
+            );
         }
 
         /// Clicking a hit row in the search popup jumps to that hit,

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1456,29 +1456,8 @@ mod tests {
         #[serial]
         fn click_on_bool_field_toggles_it() {
             let (_t, _guard, mut view) = fresh_view();
-            // Walk to whichever category first exposes a toggle so the
-            // test doesn't depend on the default tab's field mix.
-            let (idx, before) = 'outer: loop {
-                for cat in 0..view.categories.len() {
-                    if !matches!(
-                        view.categories[cat],
-                        crate::tui::settings::CategoryRow::Tab(_)
-                    ) {
-                        continue;
-                    }
-                    view.selected_category = cat;
-                    view.rebuild_fields();
-                    if let Some((i, b)) = view.fields.iter().enumerate().find_map(|(i, f)| match f
-                        .value
-                    {
-                        FieldValue::Bool(b) => Some((i, b)),
-                        _ => None,
-                    }) {
-                        break 'outer (i, b);
-                    }
-                }
-                panic!("no category exposes a toggle field");
-            };
+            let (idx, before) =
+                first_bool_field(&mut view).expect("some category should expose a toggle field");
             view.field_rects.push((idx, Rect::new(20, 5, 50, 2)));
             view.handle_click(25, 6);
             assert_eq!(view.selected_field, idx, "the click selects the row");
@@ -1488,6 +1467,37 @@ mod tests {
                 }
                 _ => unreachable!("index came from a Bool match above"),
             }
+        }
+
+        /// Select the first category (by tab order) that has a toggle
+        /// field and return its `(field index, current value)`, so mouse
+        /// tests don't depend on which fields the default tab happens to
+        /// carry. Leaves `view` parked on that category.
+        fn first_bool_field(
+            view: &mut crate::tui::settings::SettingsView,
+        ) -> Option<(usize, bool)> {
+            for cat in 0..view.categories.len() {
+                if !matches!(
+                    view.categories[cat],
+                    crate::tui::settings::CategoryRow::Tab(_)
+                ) {
+                    continue;
+                }
+                view.selected_category = cat;
+                view.rebuild_fields();
+                let found = view
+                    .fields
+                    .iter()
+                    .enumerate()
+                    .find_map(|(i, f)| match f.value {
+                        FieldValue::Bool(b) => Some((i, b)),
+                        _ => None,
+                    });
+                if found.is_some() {
+                    return found;
+                }
+            }
+            None
         }
 
         /// A click on a non-boolean field selects it but must NOT mutate

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -722,6 +722,11 @@ impl SettingsView {
     /// When the search popup is open the wheel drives its ranked-hit
     /// cursor instead, matching the Up/Down keys. Returns true when
     /// something changed so the caller can redraw.
+    ///
+    /// The wheel scrolls the fields panel wherever the cursor sits in the
+    /// takeover, including over the categories panel: that panel is a
+    /// short List with no scroll offset of its own, so there is nothing
+    /// else a wheel there could reasonably move.
     pub fn handle_wheel_scroll(&mut self, up: bool) -> bool {
         // One content line per wheel notch: field rows have varying
         // heights (label + wrapped description + spacing), so a bigger

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -282,6 +282,11 @@ pub struct SettingsView {
     /// Skipped while a field is being edited or a list is being
     /// edited so a stray click during composition doesn't reset focus.
     pub(super) field_rects: Vec<(usize, ratatui::layout::Rect)>,
+    /// Rect of the fields-panel scrollbar, captured each frame so the
+    /// wheel and a grab-drag on the bar can move the fields viewport.
+    /// A zero-area rect (the default when content fits) makes the
+    /// hit test miss, so there's nothing to grab when nothing scrolls.
+    pub(super) scrollbar_area: ratatui::layout::Rect,
     /// Last `(col, row)` reported by a `MouseEventKind::Moved` event
     /// while a non-editing settings surface is in view. Drives the
     /// hover highlight on scope chips, categories, and fields, kept
@@ -375,6 +380,7 @@ impl SettingsView {
             scope_tab_rects: Vec::new(),
             category_rects: Vec::new(),
             field_rects: Vec::new(),
+            scrollbar_area: ratatui::layout::Rect::default(),
             mouse_pos: None,
             plugin_manager: crate::tui::dialogs::PluginManagerDialog::embedded(),
             plugins_fields_focus: false,
@@ -688,6 +694,99 @@ impl SettingsView {
         if field_bottom > self.fields_scroll_offset + viewport_height {
             self.fields_scroll_offset = field_bottom.saturating_sub(viewport_height);
         }
+    }
+
+    /// Total height of all field rows plus inter-row spacing, in the same
+    /// content-space units the render pass and `ensure_field_visible` use.
+    /// Depends on `fields_content_width` (set at render) for description
+    /// wrapping, so it matches what the next frame paints.
+    fn fields_content_height(&self) -> u16 {
+        let mut total = 0u16;
+        for (i, field) in self.fields.iter().enumerate() {
+            if i > 0 {
+                total += 1; // spacing between fields
+            }
+            total += self.field_height(field, i);
+        }
+        total
+    }
+
+    /// Largest valid `fields_scroll_offset`: everything past this would
+    /// scroll blank space below the last field into view.
+    fn max_fields_scroll(&self) -> u16 {
+        self.fields_content_height()
+            .saturating_sub(self.fields_viewport_height)
+    }
+
+    /// Move the fields viewport by the wheel. `up` scrolls toward the top.
+    /// When the search popup is open the wheel drives its ranked-hit
+    /// cursor instead, matching the Up/Down keys. Returns true when
+    /// something changed so the caller can redraw.
+    pub fn handle_wheel_scroll(&mut self, up: bool) -> bool {
+        // One content line per wheel notch: field rows have varying
+        // heights (label + wrapped description + spacing), so a bigger
+        // step lands mid-row and reads as jumpy. Line granularity keeps
+        // the panel gliding.
+        const STEP: u16 = 1;
+        if self.search_input.is_some() {
+            if up {
+                if self.search_selected > 0 {
+                    self.search_selected -= 1;
+                    return true;
+                }
+            } else if self.search_selected + 1 < self.search_hits.len() {
+                self.search_selected += 1;
+                return true;
+            }
+            return false;
+        }
+        let next = if up {
+            self.fields_scroll_offset.saturating_sub(STEP)
+        } else {
+            self.fields_scroll_offset
+                .saturating_add(STEP)
+                .min(self.max_fields_scroll())
+        };
+        if next == self.fields_scroll_offset {
+            return false;
+        }
+        self.fields_scroll_offset = next;
+        true
+    }
+
+    /// Whether `(col, row)` lands on the fields-panel scrollbar. False
+    /// when nothing overflows (the bar isn't drawn, so its rect is empty).
+    /// The grab zone is widened one column left of the 1-cell bar; that
+    /// column is block padding (empty), so it's a free hit that makes the
+    /// bar easier to grab without stealing clicks from the field controls
+    /// further left.
+    pub fn hit_scrollbar(&self, col: u16, row: u16) -> bool {
+        let bar = self.scrollbar_area;
+        if bar.width == 0 {
+            return false;
+        }
+        let left = bar.x.saturating_sub(1);
+        col >= left && col <= bar.x && row >= bar.y && row < bar.y.saturating_add(bar.height)
+    }
+
+    /// Map a screen `row` on the scrollbar track to a scroll offset and
+    /// apply it, so a grab-drag on the bar moves the viewport. The top of
+    /// the track is offset 0; the bottom is `max_fields_scroll`. Returns
+    /// true when the offset changed.
+    pub fn scrollbar_drag_to_row(&mut self, row: u16) -> bool {
+        let bar = self.scrollbar_area;
+        let max = self.max_fields_scroll();
+        if bar.height == 0 || max == 0 {
+            return false;
+        }
+        let rel = row.saturating_sub(bar.y).min(bar.height.saturating_sub(1));
+        let denom = bar.height.saturating_sub(1).max(1) as u32;
+        let offset = ((rel as u32 * max as u32) / denom).min(max as u32) as u16;
+        if offset == self.fields_scroll_offset {
+            return false;
+        }
+        self.fields_scroll_offset = offset;
+        true
     }
 
     /// Apply the current field values back to the configs
@@ -1418,6 +1517,138 @@ mod search_tests {
         assert!(
             title_hit > desc_hit,
             "title match ({title_hit}) must outrank description match ({desc_hit})"
+        );
+    }
+}
+
+#[cfg(test)]
+mod scroll_tests {
+    use super::test_util::fresh_view;
+    use ratatui::layout::Rect;
+    use serial_test::serial;
+
+    /// Force the fields panel to overflow its viewport so the scroll math
+    /// has room to move. Uses the real fields the default category loads.
+    fn make_overflowing(view: &mut super::SettingsView) {
+        assert!(
+            view.fields.len() > 1,
+            "the default category should load several fields"
+        );
+        view.fields_content_width = 60;
+        view.fields_viewport_height = 3;
+        view.fields_scroll_offset = 0;
+        assert!(
+            view.max_fields_scroll() > 0,
+            "test setup must produce an overflowing panel"
+        );
+    }
+
+    /// Regression for the dead scroll wheel in Settings: a wheel-down must
+    /// advance the fields offset, and wheel-up must bring it back, both
+    /// clamped to the panel bounds.
+    #[test]
+    #[serial]
+    fn wheel_scrolls_fields_panel_with_clamping() {
+        let (_t, _guard, mut view) = fresh_view();
+        make_overflowing(&mut view);
+        let max = view.max_fields_scroll();
+
+        assert!(view.handle_wheel_scroll(false), "wheel-down must move");
+        assert_eq!(
+            view.fields_scroll_offset,
+            1.min(max),
+            "one wheel notch scrolls one line"
+        );
+
+        // Scroll to the floor and confirm it clamps (no scrolling blank
+        // space past the last field into view).
+        for _ in 0..50 {
+            view.handle_wheel_scroll(false);
+        }
+        assert_eq!(view.fields_scroll_offset, max, "must clamp at the bottom");
+        assert!(
+            !view.handle_wheel_scroll(false),
+            "a wheel at the bottom is a no-op"
+        );
+
+        // And back up to the top.
+        for _ in 0..50 {
+            view.handle_wheel_scroll(true);
+        }
+        assert_eq!(view.fields_scroll_offset, 0, "must clamp at the top");
+        assert!(
+            !view.handle_wheel_scroll(true),
+            "a wheel at the top is a no-op"
+        );
+    }
+
+    /// The scrollbar hit test covers the 1-cell bar plus the padding
+    /// column to its left, and misses everything outside that band.
+    #[test]
+    #[serial]
+    fn hit_scrollbar_covers_the_bar_and_its_padding_column() {
+        let (_t, _guard, mut view) = fresh_view();
+        view.scrollbar_area = Rect::new(70, 3, 1, 10);
+
+        assert!(view.hit_scrollbar(70, 5), "on the bar");
+        assert!(view.hit_scrollbar(69, 5), "padding column left of the bar");
+        assert!(!view.hit_scrollbar(68, 5), "two columns left is a miss");
+        assert!(!view.hit_scrollbar(71, 5), "right of the bar is a miss");
+        assert!(!view.hit_scrollbar(70, 2), "above the track is a miss");
+        assert!(!view.hit_scrollbar(70, 13), "below the track is a miss");
+
+        // With no bar drawn (nothing overflows) nothing is grabbable.
+        view.scrollbar_area = Rect::default();
+        assert!(!view.hit_scrollbar(70, 5), "no bar => no hit");
+    }
+
+    /// Regression for grab-drag on the right bar: dragging the thumb to
+    /// the track bottom pins the offset to the max, and to the top pins
+    /// it to zero.
+    #[test]
+    #[serial]
+    fn scrollbar_drag_maps_row_to_offset() {
+        let (_t, _guard, mut view) = fresh_view();
+        make_overflowing(&mut view);
+        let max = view.max_fields_scroll();
+        view.scrollbar_area = Rect::new(70, 3, 1, 10); // rows 3..=12
+
+        assert!(view.scrollbar_drag_to_row(12), "drag to the bottom moves");
+        assert_eq!(view.fields_scroll_offset, max, "bottom of track => max");
+
+        assert!(view.scrollbar_drag_to_row(3), "drag to the top moves");
+        assert_eq!(view.fields_scroll_offset, 0, "top of track => 0");
+
+        // A row past the track bottom is clamped, not extrapolated.
+        view.scrollbar_drag_to_row(99);
+        assert_eq!(view.fields_scroll_offset, max, "past-bottom clamps to max");
+    }
+
+    /// While the search popup is open the wheel drives the ranked-hit
+    /// cursor instead of the background fields, matching Up/Down.
+    #[test]
+    #[serial]
+    fn wheel_moves_search_selection_when_popup_open() {
+        let (_t, _guard, mut view) = fresh_view();
+        view.open_search(); // empty query lists every interactive field
+        assert!(
+            view.search_hits.len() > 1,
+            "an empty query should list many hits"
+        );
+        let baseline_offset = view.fields_scroll_offset;
+
+        assert!(view.handle_wheel_scroll(false), "wheel-down moves a hit");
+        assert_eq!(view.search_selected, 1);
+        assert_eq!(
+            view.fields_scroll_offset, baseline_offset,
+            "the background fields must not scroll while the popup owns the wheel"
+        );
+
+        assert!(view.handle_wheel_scroll(true), "wheel-up moves a hit");
+        assert_eq!(view.search_selected, 0);
+        assert!(
+            !view.handle_wheel_scroll(true),
+            "at the first hit a wheel-up is a no-op"
         );
     }
 }

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -87,6 +87,9 @@ impl SettingsView {
         self.field_rects.clear();
         self.search_hit_rows.clear();
         self.search_popup_area = Rect::default();
+        // Repopulated below only when the fields panel overflows; a zero
+        // rect means "no bar to grab" for the mouse hit test.
+        self.scrollbar_area = Rect::default();
 
         // Clear the area
         frame.render_widget(Clear, area);
@@ -695,6 +698,9 @@ impl SettingsView {
                 width: 1,
                 height: area.height.saturating_sub(2),
             };
+            // Captured for the mouse hit test so a grab-drag on the bar
+            // can move the viewport (input handlers run between frames).
+            self.scrollbar_area = scrollbar_area;
 
             let mut scrollbar_state = ScrollbarState::new(
                 total_content_height.saturating_sub(fields_viewport_height) as usize,


### PR DESCRIPTION
## Description

The TUI Settings screen is a full-screen takeover, but the mouse was mostly dead there. Three fixes:

1. **Wheel scroll did nothing.** `handle_scroll_up/down` early-return on `has_dialog()` (true whenever Settings is open), and `app.rs` only counts the list/preview/diff hit rects as scroll targets, which are stale under the takeover. Now the wheel scrolls the fields panel. It moves **1 content line per notch** so variable-height rows (label + wrapped description + spacing) glide instead of jumping (the earlier 3-line step read as herky-jerky). While the search-jump popup is open the wheel drives its ranked-hit list instead.
2. **The right scrollbar couldn't be grabbed.** It was decorative. Its rect is now captured each frame, and a press begins a `DragKind::SettingsScrollbar` grab that maps the pointer row to a scroll offset (grab zone widened one column into the empty padding so it's easier to catch). The drag is handled ahead of the `has_dialog()`-based cancel logic so it survives moves.
3. **Clicking a checkbox didn't toggle it.** A click on a field row only selected it; you then had to press Space. A click on a `Bool` row now toggles it in one action, like a real checkbox. Other field types stay select-only (their editors/cyclers open on Enter, so a stray click can't silently mutate a text/number/select value).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no user-facing docs cover TUI mouse handling)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (TUI only)

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the e2e harness (`tests/e2e/harness.rs`) drives the TUI via key sequences over tmux and has no mouse-wheel / drag / click primitives, so scroll and grab-drag can't be exercised there. Instead these land as unit tests on the settings scroll math and scrollbar geometry (`src/tui/settings/mod.rs` `scroll_tests`, `src/tui/settings/input.rs` `mouse_routing`) plus integration tests that drive the real `HomeView` mouse handlers with Settings open (`src/tui/home/tests.rs` `settings_scroll_wiring`). Each new-behavior test was verified to fail without its fix.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-caused and implemented via Claude Code, driven by @njbrake. Tests were written to fail-without-fix / pass-with-fix and that was verified by temporarily reverting each fix.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added mouse-wheel scrolling support to the Settings screen, including correct routing when the cursor is over the categories panel and when the search-jump popup is open.
- Implemented a right-side draggable scrollbar for the Settings fields panel, with a wider grab zone and accurate mapping between drag position and scroll offset (with clamping at bounds).
- Updated click behavior for Settings fields: Boolean fields now toggle directly on click, while other field types remain select-only.
- Refined full-screen Settings event routing and drag lifecycle so scrollbar dragging behaves consistently even when the UI is otherwise considered “dialog-like.”
- Added/expanded tests covering wheel routing, scrollbar hit-testing and drag geometry, and Boolean toggle correctness.

## Benefits

These changes make the Settings UI much faster and more comfortable to navigate with a mouse—especially for long lists—by enabling intuitive wheel scrolling, direct scrollbar dragging, and one-click toggling for boolean options.

## Potential follow-up

Consider extending the same direct-click/toggle behavior patterns to other frequently toggled control types (if any) and validating mouse interaction consistency across all Settings overlays/popups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->