### PR TITLE
fix(tests): make update_status_with_metadata tests tmux-independent

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5157,6 +5157,21 @@ mod tests {
     use super::*;
     use crate::session::test_support::EnvGuard;
 
+    /// Force the tmux session cache into a fresh "server reachable, but this
+    /// session is not in its list" snapshot so `Session::existence()` resolves
+    /// to `Absent` regardless of whether a real tmux server happens to be up on
+    /// the per-process test socket. Tests that assert detection latches `Error`
+    /// must call this, otherwise their outcome depends on test scheduling
+    /// (#2936). Returns the RAII guard; keep it bound for the test's duration
+    /// (`let _cache = ...`) so it restores the prior cache on drop, and mark
+    /// the test `#[serial_test::serial]` since the cache is process-global.
+    #[must_use]
+    fn force_session_absent() -> crate::tmux::SessionCacheGuard {
+        let guard = crate::tmux::SessionCacheGuard::capture();
+        guard.force_present(&["aoe_some_other_session"]);
+        guard
+    }
+
     #[test]
     fn set_color_accepts_palette_and_clears_with_none() {
         let mut inst = Instance::new("color-test", "/tmp");
@@ -6692,6 +6707,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_update_status_with_metadata_seeds_baseline_without_restamp() {
         // #2690: a session loaded fresh from disk (e.g. TUI relaunch, or
         // every tick of the daemon's status_poll_loop) has no live
@@ -6710,11 +6726,18 @@ mod tests {
         inst.idle_entered_at = stale_idle_entered_at;
         inst.last_accessed_at = stale_last_accessed_at;
 
+        // Force detection to resolve to `Absent` -> Error deterministically:
+        // a fresh cache snapshot that lists some other session but not this
+        // instance's. Without this the outcome depends on whether an earlier
+        // tmux-spawning test left a server reachable on the per-process
+        // socket, making the test schedule-dependent and flaky (#2936).
+        let _cache = force_session_absent();
+
         inst.update_status_with_metadata(None);
 
-        // No real tmux session exists for this instance, so detection
-        // resolves to Error, differing from the stale disk `Starting`. That
-        // mismatch must NOT be treated as a genuine transition.
+        // Detection confirms the session Absent, resolving to Error, which
+        // differs from the stale disk `Starting`. That mismatch must NOT be
+        // treated as a genuine transition.
         assert_eq!(inst.status, Status::Error);
         assert_eq!(
             inst.idle_entered_at, stale_idle_entered_at,
@@ -6732,6 +6755,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_update_status_with_metadata_restamps_on_genuine_transition() {
         // Once a live baseline is established, a real status change still
         // restamps normally (no regression from the #2690 fix).
@@ -6741,11 +6765,15 @@ mod tests {
         inst.idle_entered_at = Some(Utc::now() - chrono::Duration::hours(2));
         inst.last_accessed_at = Some(Utc::now() - chrono::Duration::hours(2));
 
+        // Force detection to resolve to `Absent` -> Error deterministically
+        // (see #2936; without this the outcome is schedule-dependent).
+        let _cache = force_session_absent();
+
         let before = Utc::now();
         inst.update_status_with_metadata(None);
         let after = Utc::now();
 
-        // No real tmux session exists, so detection resolves to Error: a
+        // Detection confirms the session Absent, resolving to Error: a
         // genuine transition away from the established Idle baseline.
         assert_eq!(inst.status, Status::Error);
         assert_eq!(inst.idle_entered_at, None);
@@ -6755,9 +6783,10 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_update_status_with_metadata_twice_same_status_never_restamps() {
-        // Two consecutive calls that both detect the same status (no real
-        // tmux session, so detection is deterministically Error) must
+        // Two consecutive calls that both detect the same status (session
+        // confirmed Absent, so detection is deterministically Error) must
         // neither restamp: not the first (baseline already matches), and
         // not the second either.
         let mut inst = Instance::new("test", "/tmp/test");
@@ -6767,6 +6796,10 @@ mod tests {
         let sentinel_accessed = Some(Utc::now() - chrono::Duration::hours(3));
         inst.idle_entered_at = sentinel_idle;
         inst.last_accessed_at = sentinel_accessed;
+
+        // Force detection to resolve to `Absent` -> Error deterministically
+        // (see #2936; without this the outcome is schedule-dependent).
+        let _cache = force_session_absent();
 
         inst.update_status_with_metadata(None);
         assert_eq!(inst.status, Status::Error);


### PR DESCRIPTION
## Description

Three `session::instance::tests::test_update_status_with_metadata_*` tests are flaky: their outcome depends on test scheduling rather than the restamp logic they cover.

They assert that probing a nonexistent session resolves to `Status::Error`. That only holds when `Session::existence()` returns `Absent`, which requires a reachable tmux server on the per-process test socket (`build_isolation_socket`). In sharded, filtered, or single-test runs where no earlier tmux-spawning test started a server, `existence()` returns `Unknown` instead; the code deliberately retains the current status (`Starting`) for the grace window, and the assertion sees `Starting` and fails. On a clean checkout, `cargo test --lib -- ...seeds_baseline_without_restamp` fails deterministically (`left: Starting, right: Error`).

Fix (the issue's preferred option: decouple the tests from live detection):

- Add a `force_session_absent()` test helper that seeds a fresh "server reachable, session not listed" snapshot via the existing test-only `SessionCacheGuard`, so `existence()` deterministically returns `Absent` -> `Error`. This is the same mechanism the sibling `Unknown` grace-window tests already use (`test_unreachable_tmux_server_*`).
- Apply it to all three tests and mark them `#[serial_test::serial]`, since the session cache is process-global.

No production code changes; the diff is test-only.

Note on the out-of-scope sibling: `tui::home::tests::restart_selected_session_surfaces_resume_failed_after_async_restart` (flagged in the issue's Scope section as "not root-caused") also fails in this environment, but at a different assertion (the resume-failure dialog message, not status resolution) and it spawns a real tmux server, so it does not share this root cause. Left for a separate follow-up.

Fixes #2936

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This PR only makes three existing unit tests deterministic; it changes no runtime behavior, so no new e2e or Playwright coverage applies. The tests themselves are the regression lock: they now fail (as intended) without a reachable-or-forced `Absent` snapshot and pass with one, independent of scheduling.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root cause was diagnosed in issue #2936 via a controlled A/B experiment; the fix reuses the existing `SessionCacheGuard` test harness.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a test helper that consistently simulates an absent tmux session.
- Updated status and polling tests to use the helper and run serially, avoiding interference from the process-wide session cache.
- Stabilized tests covering baseline and timestamp updates, making them independent of tmux availability and scheduling.

## Benefits

- Removes flaky, environment-dependent test behavior.
- Ensures tests reliably verify status transitions and metadata preservation.
- No production code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->