### PR TITLE
fix(status): stop typed-but-unsubmitted input from flapping a working Claude session to Idle

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4863,6 +4863,26 @@ impl Instance {
         } else {
             false
         };
+        // A Claude pane with unsubmitted typed text in the input box can show
+        // no running signal at all while a turn streams (typing suppresses the
+        // `esc to interrupt` hint and prose streaming renders no spinner), and
+        // that pane is identical to a parked one minus the completion line. In
+        // the ambiguous state, hold an already-observed Running rather than
+        // flap a working session to Idle; the completion line rendered at turn
+        // end releases the hold on the next poll.
+        let detected = if detected == Status::Idle
+            && !shell_stale
+            && !is_dead
+            && self.status == Status::Running
+            && detection_tool == "claude"
+            && tmux::claude_pane_is_ambiguous_typed_prompt(&pane_content)
+        {
+            tracing::debug!(target: "session.store",
+                "status '{}': holding Running over ambiguous typed-prompt Idle", self.title);
+            Status::Running
+        } else {
+            detected
+        };
         self.status = resolve_detected_status(
             detected,
             is_dead,

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -16,7 +16,8 @@ pub use session::{PaneCursor, Session, SIZE_OWNER_HEARTBEAT, SIZE_OWNER_TTL};
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub use status_detection::detect_status_from_content;
 pub(crate) use status_detection::{
-    reconcile_claude_hook_status, reconcile_codex_hook_status, reconcile_waiting_hook,
+    claude_pane_is_ambiguous_typed_prompt, reconcile_claude_hook_status,
+    reconcile_codex_hook_status, reconcile_waiting_hook,
 };
 pub use terminal_session::{kill_all_terminals_for_id, ContainerTerminalSession, TerminalSession};
 pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -314,10 +314,16 @@ fn claude_line_is_background_wait(line: &str) -> bool {
 /// Match the past-tense turn-completion line Claude renders directly above
 /// the input box when a turn ends: `✻ Cooked for 49s`, `✻ Baked for 10s ·
 /// 1 shell still running`, `✻ Worked for 1m 52s`. Shape: a spinner frame
-/// char, a capitalized verb without the active `…`, then `for <duration>`.
-/// The background-agent wait line (`✻ Waiting for 1 background agent to
-/// finish`) shares the `for <digit>` skeleton but means the session is still
-/// working, so it is explicitly excluded.
+/// char, a capitalized verb without the active `…`, then `for <duration>`
+/// where the duration is a digits+unit token (`49s`, `1m`), not a bare count.
+/// The unit requirement keeps rendered markdown bullets in streamed prose
+/// (`* Thanks for 2 examples`; `*` is a spinner frame char) from reading as
+/// parked evidence. The verb itself is not matched against a list: Claude's
+/// whimsical completion verbs aren't enumerable, and a false negative here
+/// pins a parked hookless session on Running, the costlier direction for
+/// this matcher. The background-agent wait line (`✻ Waiting for 1 background
+/// agent to finish`) shares the `for <digit>` skeleton but means the session
+/// is still working, so it is explicitly excluded.
 fn claude_line_is_completed_turn(line: &str) -> bool {
     if claude_line_is_background_wait(line) {
         return false;
@@ -337,10 +343,16 @@ fn claude_line_is_completed_turn(line: &str) -> bool {
     if !verb.chars().next().is_some_and(|c| c.is_uppercase()) || verb.contains('…') {
         return false;
     }
-    words.next() == Some("for")
-        && words
-            .next()
-            .is_some_and(|w| w.starts_with(|c: char| c.is_ascii_digit()))
+    words.next() == Some("for") && words.next().is_some_and(claude_word_is_duration)
+}
+
+/// A duration token from the completion line's `for <duration>` tail: one or
+/// more digits followed by an `s`/`m`/`h` unit (`49s`, `1m`, `2h`).
+fn claude_word_is_duration(word: &str) -> bool {
+    let digits_end = word
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(word.len());
+    digits_end > 0 && matches!(&word[digits_end..], "s" | "m" | "h")
 }
 
 /// The input box holds unsubmitted typed text and nothing above it positively
@@ -2686,6 +2698,16 @@ enter to select · esc to cancel";
         // No spinner frame char.
         assert!(!claude_line_is_completed_turn("Worked for 1m 52s"));
         assert!(!claude_line_is_completed_turn(""));
+        // Rendered markdown bullets in streamed prose (`*` is a spinner frame
+        // char) must not read as parked evidence: the `for` tail needs a
+        // digits+unit duration, not a bare count or an ordinary word.
+        assert!(!claude_line_is_completed_turn("* Thanks for 2 examples"));
+        assert!(!claude_line_is_completed_turn(
+            "* Tested for 3 edge cases in the parser"
+        ));
+        assert!(!claude_line_is_completed_turn(
+            "● Asked for permission twice"
+        ));
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -311,6 +311,90 @@ fn claude_line_is_background_wait(line: &str) -> bool {
     tail.starts_with("background agent") && tail.ends_with("to finish")
 }
 
+/// Match the past-tense turn-completion line Claude renders directly above
+/// the input box when a turn ends: `✻ Cooked for 49s`, `✻ Baked for 10s ·
+/// 1 shell still running`, `✻ Worked for 1m 52s`. Shape: a spinner frame
+/// char, a capitalized verb without the active `…`, then `for <duration>`.
+/// The background-agent wait line (`✻ Waiting for 1 background agent to
+/// finish`) shares the `for <digit>` skeleton but means the session is still
+/// working, so it is explicitly excluded.
+fn claude_line_is_completed_turn(line: &str) -> bool {
+    if claude_line_is_background_wait(line) {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    let mut chars = trimmed.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !CLAUDE_SPINNER_CHARS.contains(&first) {
+        return false;
+    }
+    let mut words = chars.as_str().split_whitespace();
+    let Some(verb) = words.next() else {
+        return false;
+    };
+    if !verb.chars().next().is_some_and(|c| c.is_uppercase()) || verb.contains('…') {
+        return false;
+    }
+    words.next() == Some("for")
+        && words
+            .next()
+            .is_some_and(|w| w.starts_with(|c: char| c.is_ascii_digit()))
+}
+
+/// The input box holds unsubmitted typed text and nothing above it positively
+/// marks the turn as over. This pane state is statically ambiguous between
+/// running and parked: typed text repurposes Esc to "clear input", so Claude
+/// (verified on 2.1.212) drops the footer's `esc to interrupt` hint, and no
+/// spinner line renders while response prose streams, leaving an actively
+/// working session with zero running signals. The parked variant of the same
+/// pane differs only by the past-tense completion line (or the Esc-interrupt
+/// banner) sitting directly above the input box, so that is the evidence this
+/// check requires before letting the pane read as parked.
+///
+/// Ghost suggestion text also occupies the `❯` line (#2919), but it only
+/// renders after a finished turn, i.e. with the completion line above the box
+/// (see `test_claude_ready_prompt_footer_variants`), so it keeps its parked
+/// verdict; only text over a still-streaming transcript is held back.
+fn claude_typed_prompt_without_parked_evidence(recent: &[&str]) -> bool {
+    let Some(prompt_idx) = recent.iter().rposition(|l| l.trim_start().starts_with('❯')) else {
+        return false;
+    };
+    let prompt_line = recent[prompt_idx].trim_start();
+    let typed = prompt_line.trim_start_matches('❯').trim();
+    if typed.is_empty() || claude_line_is_numbered_choice(prompt_line) {
+        return false;
+    }
+    // Walk up past the input box's top separator and any `⎿ Tip:` rows to the
+    // last transcript line.
+    let above = recent[..prompt_idx].iter().rev().find(|l| {
+        let t = l.trim();
+        let is_separator = !t.is_empty() && t.chars().all(|c| c == '─');
+        let is_tip = t.starts_with('⎿') && t.contains("Tip:");
+        !(is_separator || is_tip)
+    });
+    let Some(above) = above else {
+        // Nothing above the typed prompt carries parked evidence either.
+        return true;
+    };
+    !(claude_line_is_completed_turn(above)
+        || above.to_lowercase().contains(CLAUDE_INTERRUPT_MARKER))
+}
+
+/// A Claude pane whose only verdict would be "parked" but whose input box
+/// holds unsubmitted typed text with no parked evidence above it (see
+/// `claude_typed_prompt_without_parked_evidence`). Used by the hookless
+/// status fallback to hold an already-observed Running instead of flapping a
+/// working session to Idle the moment the user pre-types their next prompt.
+pub(crate) fn claude_pane_is_ambiguous_typed_prompt(raw_content: &str) -> bool {
+    with_claude_recent_pane(raw_content, |recent, recent_joined, recent_lower| {
+        claude_blocking_prompt_rule(recent, recent_lower).is_none()
+            && !claude_pane_has_running_signal(recent, recent_joined, recent_lower)
+            && claude_typed_prompt_without_parked_evidence(recent)
+    })
+}
+
 /// Claude renders a blocking approval prompt when a tool needs the user's
 /// permission (Bash command, file edit, plan exit, ...). Every variant pairs
 /// a yes/no question ("Do you want to proceed?", "Do you want to make this
@@ -435,6 +519,13 @@ const IDLE_RECONCILE_MIN_RUNNING_AGE: std::time::Duration = std::time::Duration:
 /// `⏵`/`⏸` glyph rather than matched as a bare substring, so panes merely
 /// echoing the footer text (a `git diff` of this file, quoted docs, this
 /// repo's own test fixtures in tool output) don't read as parked.
+///
+/// Unsubmitted typed text in the input box vetoes the footer marker: typing
+/// suppresses the `esc to interrupt` hint (Esc now clears the input), and no
+/// spinner renders while prose streams, so a mid-turn pane with typed text
+/// carries the mode-cycle footer and no running signal, identical to the
+/// parked pane except for the completion line above the box. Without the
+/// veto, pre-typing the next prompt flipped a working session to Idle.
 fn claude_pane_shows_ready_prompt(
     recent: &[&str],
     recent_joined: &str,
@@ -449,6 +540,7 @@ fn claude_pane_shows_ready_prompt(
         });
     (has_empty_prompt || has_idle_footer)
         && !claude_pane_has_running_signal(recent, recent_joined, recent_lower)
+        && !claude_typed_prompt_without_parked_evidence(recent)
 }
 
 /// When Claude's status hook reports Running, the pane is consulted to catch two
@@ -2525,6 +2617,123 @@ enter to select · esc to cancel";
             ),
             Status::Idle
         );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_running_with_typed_text_while_streaming() {
+        // Captured from Claude Code 2.1.212 mid-turn with unsubmitted text in
+        // the input box: typing repurposes Esc to "clear input" so the footer
+        // drops `esc to interrupt`, and prose streaming renders no spinner
+        // line, leaving zero running signals while the agent works. The
+        // mode-cycle footer alone must not read as parked here; the stale
+        // `running` write has to survive.
+        let pane = "\
+  signals onto a single channel. Applied to terminals, the idea was seductive: what if a\n\
+  single physical terminal could host several independent logical sessions, each behaving\n\
+  as though it had the machine to itself?\n\
+──────────────────────────────\n\
+❯ this is some unsubmitted text i am typing while the agent works\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert_eq!(
+            reconcile_claude_hook_status(
+                Status::Running,
+                pane,
+                Some(std::time::Duration::from_secs(120))
+            ),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_claude_hook_status_idle_with_typed_text_after_turn_end() {
+        // The parked variant of the typed-text pane (also captured from
+        // 2.1.212): identical footer and prompt line, but the past-tense
+        // completion line above the input box is positive parked evidence, so
+        // the stale `running` write still recovers to Idle.
+        let pane = "\
+✻ Cooked for 49s\n\
+──────────────────────────────\n\
+❯ this is some unsubmitted text i am typing while the agent works\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert_eq!(
+            reconcile_claude_hook_status(
+                Status::Running,
+                pane,
+                Some(std::time::Duration::from_secs(120))
+            ),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_claude_line_is_completed_turn() {
+        assert!(claude_line_is_completed_turn("✻ Cooked for 49s"));
+        assert!(claude_line_is_completed_turn(
+            "✻ Baked for 10s · 1 shell still running"
+        ));
+        assert!(claude_line_is_completed_turn("✻ Worked for 1m 52s"));
+        // Active spinner: ellipsis on the verb.
+        assert!(!claude_line_is_completed_turn(
+            "· Undulating… (14s · ↓ 144 tokens)"
+        ));
+        // Background-agent wait shares the `for <digit>` skeleton but means
+        // the session is still working.
+        assert!(!claude_line_is_completed_turn(
+            "✻ Waiting for 1 background agent to finish"
+        ));
+        // No spinner frame char.
+        assert!(!claude_line_is_completed_turn("Worked for 1m 52s"));
+        assert!(!claude_line_is_completed_turn(""));
+    }
+
+    #[test]
+    fn test_claude_pane_is_ambiguous_typed_prompt() {
+        // Streaming with typed text: ambiguous, hold.
+        let streaming = "\
+  prose still being generated by the model\n\
+──────────────────────────────\n\
+❯ half-typed next prompt\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert!(claude_pane_is_ambiguous_typed_prompt(streaming));
+        // Completion line above the box: parked, not ambiguous.
+        let parked = "\
+✻ Cooked for 49s\n\
+──────────────────────────────\n\
+❯ half-typed next prompt\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert!(!claude_pane_is_ambiguous_typed_prompt(parked));
+        // Esc-interrupt banner above the box: parked.
+        let interrupted = "\
+⎿  Interrupted · What should Claude do instead?\n\
+❯ half-typed next prompt\n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert!(!claude_pane_is_ambiguous_typed_prompt(interrupted));
+        // Bare prompt: the existing parked markers decide, no ambiguity.
+        let bare = "\
+  some prose\n\
+❯ \n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert!(!claude_pane_is_ambiguous_typed_prompt(bare));
+        // Numbered approval menu on the `❯` line is a blocking prompt, not
+        // typed text.
+        let menu = "\
+Do you want to proceed?\n\
+❯ 1. Yes\n\
+  2. No\n\
+  ⏸ plan mode on (shift+tab to cycle)";
+        assert!(!claude_pane_is_ambiguous_typed_prompt(menu));
+        // A live running signal wins over the ambiguity.
+        let running = "\
+✽ Crunching… (19s · ↓ 166 tokens)\n\
+──────────────────────────────\n\
+❯ half-typed next prompt\n\
+──────────────────────────────\n\
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert!(!claude_pane_is_ambiguous_typed_prompt(running));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes a status-detection gap where a working Claude session flaps to Idle the moment the user types text into the input box without submitting it (reported on a sandboxed session after an `e` restart).

Reproduced live against Claude Code 2.1.212: typing text mid-turn repurposes Esc to "clear input", so the footer drops its `esc to interrupt` hint, and no spinner line renders while response prose streams. The pane then carries zero running signals while the agent is actively working:

```
  <streaming prose...>
──────────────────────────────
❯ this is some unsubmitted text i am typing while the agent works
──────────────────────────────
  ⏵⏵ bypass permissions on (shift+tab to cycle)
```

This is byte-identical to the parked pane except for the past-tense completion line (`✻ Cooked for 49s`) above the input box. Both detection layers misread it:

- the hookless pane fallback (`detect_claude_status`) reported Idle outright (the mode-cycle footer reads as an idle marker), and
- the age-gated ready-prompt reconciler (`claude_pane_shows_ready_prompt`) downgraded a stale-but-true Running hook write to Idle.

The fix treats unsubmitted typed text without parked evidence (a completion line or the Esc-interrupt banner directly above the input box) as ambiguous:

- `claude_pane_shows_ready_prompt` gains a veto, so the reconciler keeps the hook's Running;
- the hookless fallback in `update_status_with_metadata_inner` holds an already-observed Running instead of flapping to Idle. The completion line rendered at turn end releases the hold on the next poll.

Ghost suggestion text (#2919) keeps its parked verdict: it only renders after a finished turn, i.e. with the completion line above the box (all existing ghost-text fixtures have it), so those downgrades still fire. The failure direction of the new ambiguity is stuck-Running, which is the documented preferred direction for this detector (see the `IDLE_RECONCILE_MIN_RUNNING_AGE` cost-asymmetry note).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the ambiguity is a pure pane-text-shape property, covered by unit tests built from panes captured from a real Claude Code 2.1.212 session (streaming-with-typed-text, parked-with-typed-text, completion-line shapes, and the ambiguity helper). A regression check confirmed the new reconciler test fails without the fix. Driving a real mid-turn typed-text state through the e2e harness would need a live generating agent, which the fake-agent shims can't express deterministically.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**
Root cause was established by reproducing the pane states against a live Claude Code 2.1.212 session in tmux and diffing the running/parked footer variants; fix and tests reviewed by njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes Claude Code session status “flapping” (switching from **Running** to **Idle**) when a user types text that hasn’t been submitted yet during an active turn.

## Changes

- Added detection for an **ambiguous typed prompt** state: typed-but-unsubmitted input no longer automatically downgrades the pane to idle/ready.
- Updated the status reconciliation logic to **hold onto a Running state** in ambiguous situations:
  - When the hook reports Running, it preserves that state.
  - When no hook evidence exists, it preserves an already-observed Running state.
- Enhanced completion-line detection to avoid false positives by requiring a structured **duration token** (e.g., `49s`, `1m`, `2h`) before treating a line as “turn completed / parked evidence”.
- Kept existing **ghost suggestion text** handling behavior unchanged.
- Added unit tests covering Claude Code 2.1.212 pane shapes, including:
  - streaming with typed (unsubmitted) text
  - parked typed text
  - completion lines releasing the hold
  - ambiguity detection behavior

## Benefits

- More stable and accurate session status reporting for Claude Code.
- Fewer premature Idle transitions while Claude is still actively working.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->