### PR TITLE
fix(trash): stop a raced restore from stranding a sandboxed worktree in the holding area

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -132,35 +132,43 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                     new_project_path: inst.project_path.clone(),
                     pre_trash_project_path: inst.pre_trash_project_path.clone(),
                 };
-                let commit = storage.update(|all_instances, _groups| {
-                    Ok(crate::session::claim::commit_trash_relocation(
+                // The decision travels through this captured slot rather than
+                // the closure's return value, so it survives an update that
+                // decided Superseded and then failed its final write; the
+                // undo keys off the decision alone, since the durable row was
+                // already restored in that case. A Persisted decision whose
+                // write failed needs no repair: the row is still trashed at
+                // its old path and the next reconcile repoints it.
+                let mut decided: Option<crate::session::claim::RelocationCommit> = None;
+                let update_result = storage.update(|all_instances, _groups| {
+                    decided = Some(crate::session::claim::commit_trash_relocation(
                         all_instances,
                         &removed_id,
                         &reloc,
                         chrono::Utc::now(),
-                    ))
+                    ));
+                    Ok(())
                 });
-                match commit {
-                    Ok(crate::session::claim::RelocationCommit::Persisted) => {}
-                    Ok(crate::session::claim::RelocationCommit::Superseded) => {
-                        match crate::session::trash::undo_raced_relocation(&inst, &reloc) {
-                            crate::session::trash::RestoreOutcome::Failed { reason } => {
-                                eprintln!(
-                                    "  Note: a concurrent restore superseded the trash; could not move the worktree back ({reason})."
-                                );
-                            }
-                            _ => {
-                                eprintln!(
-                                    "  Note: a concurrent restore superseded the trash; the worktree was left in place."
-                                );
-                            }
+                if let Err(e) = &update_result {
+                    eprintln!(
+                        "  Note: could not persist the trash relocation ({e}); it will be reconciled on next load."
+                    );
+                }
+                if matches!(
+                    decided,
+                    Some(crate::session::claim::RelocationCommit::Superseded)
+                ) {
+                    match crate::session::trash::undo_raced_relocation(&inst, &reloc) {
+                        crate::session::trash::RestoreOutcome::Failed { reason } => {
+                            eprintln!(
+                                "  Note: a concurrent restore superseded the trash; could not move the worktree back ({reason})."
+                            );
                         }
-                    }
-                    Ok(crate::session::claim::RelocationCommit::AlreadyGone) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "  Note: could not persist the trash relocation ({e}); it will be reconciled on next load."
-                        );
+                        _ => {
+                            eprintln!(
+                                "  Note: a concurrent restore superseded the trash; the worktree was left in place."
+                            );
+                        }
                     }
                 }
             }

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -170,6 +170,13 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                             );
                         }
                     }
+                    // The trash was superseded: the session is live again, so
+                    // the "moved to trash" summary and restore hint below
+                    // would be contradictory.
+                    println!(
+                        "  Session was restored by another process; it was not moved to the trash."
+                    );
+                    return Ok(());
                 }
             }
             crate::session::trash::RelocateOutcome::Failed { reason } => {

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -117,6 +117,10 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
         // later reconcile pass can relocate it.
         let mut inst = inst;
         inst.trash();
+        // The teardown's still-trashed re-check reads storage via
+        // `source_profile`; stamp it so a `-p <profile>` remove re-checks the
+        // profile it actually trashed the row in, not the default.
+        inst.source_profile = storage.profile().to_string();
         match crate::session::trash::prepare_trashed_worktree(&mut inst) {
             crate::session::trash::RelocateOutcome::Relocated { .. } => {
                 let new_path = inst.project_path.clone();

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -123,15 +123,46 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
         inst.source_profile = storage.profile().to_string();
         match crate::session::trash::prepare_trashed_worktree(&mut inst) {
             crate::session::trash::RelocateOutcome::Relocated { .. } => {
-                let new_path = inst.project_path.clone();
-                let pre = inst.pre_trash_project_path.clone();
-                let _ = storage.update(|all_instances, _groups| {
-                    if let Some(stored) = all_instances.iter_mut().find(|i| i.id == removed_id) {
-                        stored.project_path = new_path.clone();
-                        stored.pre_trash_project_path = pre.clone();
-                    }
-                    Ok(())
+                // Atomic durable check-and-commit: a peer restore or purge can
+                // land between the teardown's pre-move re-check and this
+                // persist, so the decision is re-taken on the durable row
+                // under the flock. Superseded means such a peer won and the
+                // move is undone rather than recorded onto a live row.
+                let reloc = crate::session::trash::TrashRelocation {
+                    new_project_path: inst.project_path.clone(),
+                    pre_trash_project_path: inst.pre_trash_project_path.clone(),
+                };
+                let commit = storage.update(|all_instances, _groups| {
+                    Ok(crate::session::claim::commit_trash_relocation(
+                        all_instances,
+                        &removed_id,
+                        &reloc,
+                        chrono::Utc::now(),
+                    ))
                 });
+                match commit {
+                    Ok(crate::session::claim::RelocationCommit::Persisted) => {}
+                    Ok(crate::session::claim::RelocationCommit::Superseded) => {
+                        match crate::session::trash::undo_raced_relocation(&inst, &reloc) {
+                            crate::session::trash::RestoreOutcome::Failed { reason } => {
+                                eprintln!(
+                                    "  Note: a concurrent restore superseded the trash; could not move the worktree back ({reason})."
+                                );
+                            }
+                            _ => {
+                                eprintln!(
+                                    "  Note: a concurrent restore superseded the trash; the worktree was left in place."
+                                );
+                            }
+                        }
+                    }
+                    Ok(crate::session::claim::RelocationCommit::AlreadyGone) => {}
+                    Err(e) => {
+                        eprintln!(
+                            "  Note: could not persist the trash relocation ({e}); it will be reconciled on next load."
+                        );
+                    }
+                }
             }
             crate::session::trash::RelocateOutcome::Failed { reason } => {
                 eprintln!("  Note: left worktree in place ({reason}).");

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2464,26 +2464,76 @@ pub async fn trash_session(
         .await
         {
             Ok((crate::session::trash::RelocateOutcome::Relocated { .. }, moved)) => {
-                let new_path = moved.project_path.clone();
-                let pre = moved.pre_trash_project_path.clone();
+                // Atomic durable check-and-commit: a peer restore or purge can
+                // land between the teardown's pre-move re-check and this
+                // persist, so the decision is re-taken on the durable row
+                // under the flock (`commit_trash_relocation`). Superseded
+                // means such a peer won: the paths are not recorded and the
+                // disk move is undone off-thread instead.
+                let reloc = crate::session::trash::TrashRelocation {
+                    new_project_path: moved.project_path.clone(),
+                    pre_trash_project_path: moved.pre_trash_project_path.clone(),
+                };
+                let decision: std::sync::Arc<
+                    std::sync::Mutex<Option<crate::session::claim::RelocationCommit>>,
+                > = std::sync::Arc::new(std::sync::Mutex::new(None));
                 let persist_id = id.clone();
-                let (np, pp) = (new_path.clone(), pre.clone());
-                let _ = persist_session_update(
+                let (decision_slot, closure_reloc) = (decision.clone(), reloc.clone());
+                let persisted = persist_session_update(
                     profile,
                     "trash-relocate",
                     state.file_watch.clone(),
                     move |instances| {
-                        if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
-                            inst.project_path = np.clone();
-                            inst.pre_trash_project_path = pp.clone();
-                        }
+                        let commit = crate::session::claim::commit_trash_relocation(
+                            instances,
+                            &persist_id,
+                            &closure_reloc,
+                            chrono::Utc::now(),
+                        );
+                        *decision_slot.lock().unwrap() = Some(commit);
                     },
                 )
                 .await;
-                let mut instances = state.instances.write().await;
-                if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-                    inst.project_path = new_path;
-                    inst.pre_trash_project_path = pre;
+                let commit = decision.lock().unwrap().take();
+                match (persisted, commit) {
+                    (Ok(()), Some(crate::session::claim::RelocationCommit::Persisted)) => {
+                        let mut instances = state.instances.write().await;
+                        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                            inst.project_path = reloc.new_project_path.clone();
+                            inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
+                        }
+                    }
+                    (Ok(()), Some(crate::session::claim::RelocationCommit::Superseded)) => {
+                        let undo_id = id.clone();
+                        let outcome = tokio::task::spawn_blocking(move || {
+                            crate::session::trash::undo_raced_relocation(&moved, &reloc)
+                        })
+                        .await;
+                        match outcome {
+                            Ok(crate::session::trash::RestoreOutcome::Failed { reason }) => {
+                                tracing::warn!(
+                                    target: "http.api.sessions",
+                                    session = %undo_id,
+                                    "superseded trash relocation could not be moved back: {reason}"
+                                );
+                            }
+                            Ok(outcome) => {
+                                tracing::info!(
+                                    target: "http.api.sessions",
+                                    session = %undo_id,
+                                    "trash relocation superseded by a restore/claim; undone ({outcome:?})"
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    target: "http.api.sessions",
+                                    session = %undo_id,
+                                    "superseded trash relocation undo join failed: {e}"
+                                );
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
             Ok((crate::session::trash::RelocateOutcome::Failed { reason }, _)) => {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2495,6 +2495,14 @@ pub async fn trash_session(
                 )
                 .await;
                 let commit = decision.lock().unwrap().take();
+                // The undo keys off the closure's decision alone, not the
+                // write outcome: the closure can decide Superseded (row
+                // already restored on disk) and the final write then fail,
+                // and skipping the undo in that case would leave a live
+                // restored row pointing at a worktree parked in the holding
+                // area. A Persisted decision whose write failed needs no
+                // undo: the durable row is still trashed at its old path,
+                // and the reconcile pass repoints it to the holding area.
                 match (persisted, commit) {
                     (Ok(()), Some(crate::session::claim::RelocationCommit::Persisted)) => {
                         let mut instances = state.instances.write().await;
@@ -2503,7 +2511,7 @@ pub async fn trash_session(
                             inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
                         }
                     }
-                    (Ok(()), Some(crate::session::claim::RelocationCommit::Superseded)) => {
+                    (_, Some(crate::session::claim::RelocationCommit::Superseded)) => {
                         let undo_id = id.clone();
                         let outcome = tokio::task::spawn_blocking(move || {
                             crate::session::trash::undo_raced_relocation(&moved, &reloc)

--- a/src/session/claim.rs
+++ b/src/session/claim.rs
@@ -167,6 +167,59 @@ pub(crate) fn finalize_restore_commit(
     RestoreCommit::Committed
 }
 
+/// Outcome of the final locked commit of a background trash relocation. See
+/// [`commit_trash_relocation`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum RelocationCommit {
+    /// The row still reads trashed and unclaimed; the relocated paths were
+    /// written onto it.
+    Persisted,
+    /// The row was restored, or a fresh purge/restore claim holds it, so the
+    /// relocation must not be recorded. The caller undoes the disk move.
+    Superseded,
+    /// The row is gone from disk (a peer purged it); nothing to record. The
+    /// holding-area entry falls to the purge teardown and the scoped
+    /// `delete_branch` reaping.
+    AlreadyGone,
+}
+
+/// The final locked commit of a background trash teardown's worktree
+/// relocation, run inside a `storage.update` closure at every surface that
+/// persists one (TUI poller drain, server trash handler, CLI remove).
+///
+/// The teardown's pre-move re-check (`durable_row_still_trashed`) narrows the
+/// restore race to the span between that check and this commit; this gate
+/// closes the pointer half of it by re-taking the decision on the durable row
+/// under the flock. A restore that landed in between wins: the caller gets
+/// [`RelocationCommit::Superseded`] and moves the worktree back instead of
+/// repointing a live row into the holding area. A row held by a fresh peer
+/// claim is also superseded: a mid-flight restore loaded the row before this
+/// commit (its `finalize_restore_commit` would clobber these paths), and a
+/// mid-flight purge tears down against its own snapshot; in both cases
+/// undoing the move converges with the peer's commit, and if the peer bails
+/// the un-relocated trashed row is re-relocated by the next reconcile pass.
+/// See #2534, #2541.
+pub(crate) fn commit_trash_relocation(
+    all: &mut [Instance],
+    id: &str,
+    relocation: &crate::session::trash::TrashRelocation,
+    now: DateTime<Utc>,
+) -> RelocationCommit {
+    match all.iter_mut().find(|i| i.id == id) {
+        None => RelocationCommit::AlreadyGone,
+        Some(row) => {
+            let claim_held =
+                matches!(&row.op_claim, Some(c) if (now - c.at) < Instance::OP_CLAIM_TTL);
+            if !row.is_trashed() || claim_held {
+                return RelocationCommit::Superseded;
+            }
+            row.project_path = relocation.new_project_path.clone();
+            row.pre_trash_project_path = relocation.pre_trash_project_path.clone();
+            RelocationCommit::Persisted
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,6 +230,79 @@ mod tests {
         inst.id = id.to_string();
         inst.trash();
         inst
+    }
+
+    fn reloc() -> crate::session::trash::TrashRelocation {
+        crate::session::trash::TrashRelocation {
+            new_project_path: "/wt/.aoe-trash/a".to_string(),
+            pre_trash_project_path: Some("/wt/feature".to_string()),
+        }
+    }
+
+    #[test]
+    fn commit_relocation_persists_on_unclaimed_trashed_row() {
+        let mut all = vec![trashed("a")];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Persisted
+        );
+        assert_eq!(all[0].project_path, "/wt/.aoe-trash/a");
+        assert_eq!(
+            all[0].pre_trash_project_path.as_deref(),
+            Some("/wt/feature")
+        );
+    }
+
+    #[test]
+    fn commit_relocation_superseded_by_restored_row() {
+        let mut row = trashed("a");
+        row.untrash();
+        let mut all = vec![row];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Superseded
+        );
+        assert_eq!(all[0].project_path, "/tmp/x", "restored row is untouched");
+        assert!(all[0].pre_trash_project_path.is_none());
+    }
+
+    #[test]
+    fn commit_relocation_superseded_by_fresh_claim() {
+        for op in [ClaimOp::Restore, ClaimOp::Purge] {
+            let mut row = trashed("a");
+            row.try_claim(op, Instance::OP_CLAIM_TTL, Utc::now())
+                .unwrap();
+            let mut all = vec![row];
+            assert_eq!(
+                commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+                RelocationCommit::Superseded,
+                "a fresh {op:?} claim must supersede the relocation"
+            );
+            assert_eq!(all[0].project_path, "/tmp/x", "claimed row is untouched");
+        }
+    }
+
+    #[test]
+    fn commit_relocation_ignores_expired_claim() {
+        let mut row = trashed("a");
+        let stale = Utc::now() - Instance::OP_CLAIM_TTL - chrono::Duration::minutes(1);
+        row.try_claim(ClaimOp::Restore, Instance::OP_CLAIM_TTL, stale)
+            .unwrap();
+        let mut all = vec![row];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Persisted,
+            "an expired claim is treated as absent, mirroring try_claim"
+        );
+    }
+
+    #[test]
+    fn commit_relocation_already_gone_when_row_missing() {
+        let mut all: Vec<Instance> = Vec::new();
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::AlreadyGone
+        );
     }
 
     #[test]

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -184,28 +184,88 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
 /// The container stop is injected so the sandbox path is exercisable without a
 /// live docker runtime (mirrors `deletion::perform_deletion_with`).
 ///
+/// The container stop blocks for up to the stop grace period (~10s), which is
+/// plenty of time for a restore to land on the durable row (a user who hit `d`
+/// by accident restores immediately; the restore itself is a NoChange because
+/// no relocation has been recorded yet). The durable row is therefore
+/// re-checked between the stop and the move, and the move is skipped when the
+/// row is no longer trashed (or is gone, or storage cannot be read; fail
+/// closed, since a skipped move on a still-trashed row is healed by the next
+/// reconcile pass, while a move on a restored row strands a live session's
+/// worktree in the holding area). The re-check reads storage via
+/// `inst.source_profile`, so callers must pass an instance whose profile is
+/// stamped and must have durably trashed the row before calling.
+///
 /// BLOCKING: the container stop shells out to `docker stop` (~10s grace period)
 /// and the relocation runs `git worktree move`, so never call this on an event
 /// loop / UI thread. The TUI goes through [`perform_trash`] on the
 /// `TrashPoller`, the server wraps it in `spawn_blocking`, and the CLI is a
 /// one-shot process.
 pub fn prepare_trashed_worktree(inst: &mut Instance) -> RelocateOutcome {
-    prepare_trashed_worktree_with(inst, |id, is_sandboxed| {
-        if let Err(e) = crate::session::worktree_edit::stop_sandbox_container(id, is_sandboxed) {
+    prepare_trashed_worktree_with(
+        inst,
+        |id, is_sandboxed| {
+            if let Err(e) = crate::session::worktree_edit::stop_sandbox_container(id, is_sandboxed)
+            {
+                tracing::warn!(
+                    target: "session.trash",
+                    session = %id,
+                    "stopping sandbox container before trash relocation failed: {e}"
+                );
+            }
+        },
+        durable_row_still_trashed,
+    )
+}
+
+/// Whether the durable row for `inst` still reads trashed. Consulted after the
+/// (slow) container stop and immediately before the worktree move; see
+/// [`prepare_trashed_worktree`]. Fail-closed: an unreadable storage, a missing
+/// row (purged by a peer), or an untrashed row (restored by a peer or by the
+/// user mid-teardown) all answer `false` and skip the move.
+fn durable_row_still_trashed(inst: &Instance) -> bool {
+    let loaded = crate::session::Storage::open_unwatched(&inst.source_profile)
+        .and_then(|storage| storage.load());
+    match loaded {
+        Ok(rows) => match rows.iter().find(|r| r.id == inst.id) {
+            Some(row) if row.is_trashed() => true,
+            Some(_) => {
+                tracing::info!(
+                    target: "session.trash",
+                    session = %inst.id,
+                    "row was restored while the trash teardown was in flight; leaving the worktree in place"
+                );
+                false
+            }
+            None => {
+                tracing::info!(
+                    target: "session.trash",
+                    session = %inst.id,
+                    "row disappeared (purged) while the trash teardown was in flight; skipping relocation"
+                );
+                false
+            }
+        },
+        Err(e) => {
             tracing::warn!(
                 target: "session.trash",
-                session = %id,
-                "stopping sandbox container before trash relocation failed: {e}"
+                session = %inst.id,
+                "could not re-check the durable row before trash relocation ({e}); leaving the worktree in place for the next reconcile pass"
             );
+            false
         }
-    })
+    }
 }
 
 fn prepare_trashed_worktree_with(
     inst: &mut Instance,
     stop_container: impl FnOnce(&str, bool),
+    still_trashed: impl FnOnce(&Instance) -> bool,
 ) -> RelocateOutcome {
     stop_container(&inst.id, is_sandboxed(inst));
+    if !still_trashed(inst) {
+        return RelocateOutcome::Skipped;
+    }
     relocate_worktree_to_trash(inst)
 }
 
@@ -282,6 +342,25 @@ pub fn perform_trash(request: &TrashRequest) -> TrashResult {
             relocate_warning: Some(reason),
         },
     }
+}
+
+/// Undo a trash relocation that landed after the row had already been
+/// restored: the worker's still-trashed re-check and the `git worktree move`
+/// are not atomic, so a restore squeezing between them leaves a live,
+/// untrashed row pointing at its original path while the worktree sits in the
+/// holding area. Moves the worktree back so the live row's `project_path` is
+/// real again; the row itself needs no persist (it already points at the
+/// original). `live` supplies the repo metadata and container gate; the
+/// relocation supplies the two paths. Strict like restore: never lands the
+/// worktree anywhere but where it came from.
+pub fn undo_raced_relocation(live: &Instance, relocation: &TrashRelocation) -> RestoreOutcome {
+    let Some(original) = relocation.pre_trash_project_path.clone() else {
+        return RestoreOutcome::NoChange;
+    };
+    let mut tmp = live.clone();
+    tmp.project_path = relocation.new_project_path.clone();
+    tmp.pre_trash_project_path = Some(original);
+    restore_worktree_location(&mut tmp)
 }
 
 /// Move a trashed session's worktree back to its pre-trash location and clear
@@ -932,11 +1011,15 @@ mod tests {
             let saw_sandbox_flag = Rc::clone(&saw_sandbox_flag);
             let original_present_at_stop = Rc::clone(&original_present_at_stop);
             let original = original.clone();
-            prepare_trashed_worktree_with(&mut inst, move |_id, is_sandboxed| {
-                stop_calls.set(stop_calls.get() + 1);
-                saw_sandbox_flag.set(is_sandboxed);
-                original_present_at_stop.set(original.exists());
-            })
+            prepare_trashed_worktree_with(
+                &mut inst,
+                move |_id, is_sandboxed| {
+                    stop_calls.set(stop_calls.get() + 1);
+                    saw_sandbox_flag.set(is_sandboxed);
+                    original_present_at_stop.set(original.exists());
+                },
+                |_| true,
+            )
         };
 
         assert_eq!(
@@ -986,9 +1069,13 @@ mod tests {
         let saw_sandbox_flag = Rc::new(Cell::new(false));
         let outcome = {
             let saw_sandbox_flag = Rc::clone(&saw_sandbox_flag);
-            prepare_trashed_worktree_with(&mut inst, move |_id, is_sandboxed| {
-                saw_sandbox_flag.set(is_sandboxed);
-            })
+            prepare_trashed_worktree_with(
+                &mut inst,
+                move |_id, is_sandboxed| {
+                    saw_sandbox_flag.set(is_sandboxed);
+                },
+                |_| true,
+            )
         };
         assert!(
             saw_sandbox_flag.get(),
@@ -997,6 +1084,97 @@ mod tests {
         assert!(
             matches!(outcome, RelocateOutcome::Skipped),
             "a plain session has no managed worktree to relocate: {outcome:?}"
+        );
+    }
+
+    /// Regression (#2930 follow-up): a restore that lands while the off-thread
+    /// trash teardown is still running must not have the worktree moved out
+    /// from under it. For a sandboxed session the teardown blocks ~10s in
+    /// `docker stop` before the `git worktree move`, so a user who hits `d`
+    /// and immediately restores wins that window: the durable row is untrashed
+    /// (with no `pre_trash_project_path`, so the restore itself is a NoChange)
+    /// while the worker still holds a trashed clone. The teardown must
+    /// re-check the durable row before relocating and skip the move.
+    #[test]
+    #[serial_test::serial]
+    fn teardown_skips_relocation_when_row_was_restored_mid_flight() {
+        if !git_available() {
+            return;
+        }
+        let _app = crate::session::test_support::isolate_app_dir();
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.source_profile = "default".to_string();
+        let original = inst.project_path.clone();
+        inst.trash();
+
+        // The durable row was restored (untrashed) after the trash request was
+        // queued: what the worker's clone says no longer holds.
+        let storage = crate::session::Storage::new_unwatched("default").unwrap();
+        let mut durable = inst.clone();
+        durable.untrash();
+        storage
+            .update(|rows, _groups| {
+                rows.push(durable.clone());
+                Ok(())
+            })
+            .unwrap();
+
+        let result = perform_trash(&TrashRequest {
+            session_id: inst.id.clone(),
+            instance: inst.clone(),
+        });
+
+        assert!(
+            result.relocation.is_none(),
+            "a restored row's worktree must not be relocated: {:?}",
+            result.relocation
+        );
+        assert!(
+            PathBuf::from(&original).exists(),
+            "the worktree must stay at its original path when a restore raced the teardown"
+        );
+    }
+
+    /// A relocation that lands after the row was restored (the not-atomic
+    /// window between the worker's still-trashed re-check and its move) is
+    /// undone: the worktree moves back to the original path the live row
+    /// points at.
+    #[test]
+    fn undo_raced_relocation_moves_worktree_back() {
+        if !git_available() {
+            return;
+        }
+        let (_tmp, mut inst) = real_worktree_instance();
+        let original = inst.project_path.clone();
+        inst.trash();
+        assert!(matches!(
+            relocate_worktree_to_trash(&mut inst),
+            RelocateOutcome::Relocated { .. }
+        ));
+        let reloc = TrashRelocation {
+            new_project_path: inst.project_path.clone(),
+            pre_trash_project_path: inst.pre_trash_project_path.clone(),
+        };
+
+        // The live row a raced restore produced: untrashed, pointing at the
+        // original path, no relocation marker.
+        let mut live = inst.clone();
+        live.untrash();
+        live.project_path = original.clone();
+        live.pre_trash_project_path = None;
+
+        let out = undo_raced_relocation(&live, &reloc);
+        assert!(
+            matches!(out, RestoreOutcome::Restored { .. }),
+            "undo must move the worktree back, got {out:?}"
+        );
+        assert!(
+            PathBuf::from(&original).exists(),
+            "worktree must be back at the path the live row points at"
+        );
+        assert!(
+            !PathBuf::from(&reloc.new_project_path).exists(),
+            "holding area copy must be gone"
         );
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3125,22 +3125,55 @@ impl HomeView {
                     .instances
                     .get(&result.session_id)
                     .is_some_and(|i| i.is_trashed());
-                if let (true, Some(reloc)) = (still_trashed, result.relocation) {
-                    // The worktree moved into the holding area on the worker
-                    // thread; persist the repointed project_path (+ pre-trash
-                    // marker) onto the real row. `merge_user_action_diff`
-                    // carries both fields, mirroring the load-time reconcile.
-                    if let Err(e) = self.apply_user_action(&result.session_id, |inst| {
-                        inst.project_path = reloc.new_project_path.clone();
-                        inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
-                    }) {
-                        tracing::error!(
-                            target: "tui.home",
-                            session = %result.session_id,
-                            "failed to persist trash worktree relocation: {e}",
-                        );
+                match (still_trashed, result.relocation) {
+                    (true, Some(reloc)) => {
+                        // The worktree moved into the holding area on the worker
+                        // thread; persist the repointed project_path (+ pre-trash
+                        // marker) onto the real row. `merge_user_action_diff`
+                        // carries both fields, mirroring the load-time reconcile.
+                        if let Err(e) = self.apply_user_action(&result.session_id, |inst| {
+                            inst.project_path = reloc.new_project_path.clone();
+                            inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
+                        }) {
+                            tracing::error!(
+                                target: "tui.home",
+                                session = %result.session_id,
+                                "failed to persist trash worktree relocation: {e}",
+                            );
+                        }
+                        changed = true;
                     }
-                    changed = true;
+                    (false, Some(reloc)) => {
+                        // A restore squeezed between the worker's still-trashed
+                        // re-check and its move: the row is live and points at
+                        // the original path, but the worktree just landed in
+                        // the holding area. Move it back (a purged row is gone
+                        // from the map and skips; its holding dir falls to the
+                        // purge teardown). Best-effort: a failure is only
+                        // logged, and the git move is a same-filesystem rename,
+                        // so it is cheap enough for the tick loop, the same
+                        // trade `restore_selected_from_trash` makes.
+                        if let Some(live) = self.instances.get(&result.session_id) {
+                            match crate::session::trash::undo_raced_relocation(live, &reloc) {
+                                crate::session::trash::RestoreOutcome::Failed { reason } => {
+                                    tracing::warn!(
+                                        target: "tui.session",
+                                        session = %result.session_id,
+                                        "could not move a raced trash relocation back ({reason}); worktree remains at {}",
+                                        reloc.new_project_path,
+                                    );
+                                }
+                                outcome => {
+                                    tracing::info!(
+                                        target: "tui.session",
+                                        session = %result.session_id,
+                                        "trash relocation raced a restore; undone ({outcome:?})",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    (_, None) => {}
                 }
                 if let Some(reason) = result.relocate_warning {
                     tracing::warn!(

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3121,59 +3121,81 @@ impl HomeView {
                 // skips too. The relocation is best-effort regardless: a later
                 // reconcile pass heals a still-trashed row whose move was
                 // dropped here.
-                let still_trashed = self
-                    .instances
-                    .get(&result.session_id)
-                    .is_some_and(|i| i.is_trashed());
-                match (still_trashed, result.relocation) {
-                    (true, Some(reloc)) => {
-                        // The worktree moved into the holding area on the worker
-                        // thread; persist the repointed project_path (+ pre-trash
-                        // marker) onto the real row. `merge_user_action_diff`
-                        // carries both fields, mirroring the load-time reconcile.
-                        if let Err(e) = self.apply_user_action(&result.session_id, |inst| {
-                            inst.project_path = reloc.new_project_path.clone();
-                            inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
-                        }) {
+                if let Some(reloc) = result.relocation {
+                    // Atomic durable check-and-commit under the storage flock.
+                    // The worker's pre-move re-check leaves a window before
+                    // this drain in which a restore or purge (local or from a
+                    // peer process) can supersede the teardown; deciding
+                    // against the in-memory map would re-open that window
+                    // cross-process, so the decision is re-taken on the
+                    // durable row instead, serialized with the restore/purge
+                    // commits. Superseded means such a peer won: the disk move
+                    // is undone (a same-filesystem rename, the same tick-loop
+                    // trade `restore_selected_from_trash` makes). A row absent
+                    // from the map was purged locally and is skipped; its
+                    // holding dir falls to the purge teardown.
+                    let committed = self
+                        .instances
+                        .get(&result.session_id)
+                        .map(|i| i.source_profile.clone())
+                        .and_then(|profile| self.storages.get(&profile))
+                        .map(|storage| {
+                            storage.update(|insts, _groups| {
+                                let commit = crate::session::claim::commit_trash_relocation(
+                                    insts,
+                                    &result.session_id,
+                                    &reloc,
+                                    chrono::Utc::now(),
+                                );
+                                let row = insts.iter().find(|i| i.id == result.session_id).cloned();
+                                Ok((commit, row))
+                            })
+                        });
+                    use crate::session::claim::RelocationCommit;
+                    match committed {
+                        Some(Ok((RelocationCommit::Persisted, _))) => {
+                            if let Some(inst) = self.instances.get_mut(&result.session_id) {
+                                inst.project_path = reloc.new_project_path.clone();
+                                inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
+                            }
+                            changed = true;
+                        }
+                        Some(Ok((RelocationCommit::Superseded, row))) => {
+                            let undo_with =
+                                row.or_else(|| self.instances.get(&result.session_id).cloned());
+                            if let Some(live) = undo_with {
+                                match crate::session::trash::undo_raced_relocation(&live, &reloc) {
+                                    crate::session::trash::RestoreOutcome::Failed { reason } => {
+                                        tracing::warn!(
+                                            target: "tui.session",
+                                            session = %result.session_id,
+                                            "could not move a superseded trash relocation back ({reason}); worktree remains at {}",
+                                            reloc.new_project_path,
+                                        );
+                                    }
+                                    outcome => {
+                                        tracing::info!(
+                                            target: "tui.session",
+                                            session = %result.session_id,
+                                            "trash relocation superseded by a restore/claim; undone ({outcome:?})",
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Some(Ok((RelocationCommit::AlreadyGone, _))) => {}
+                        Some(Err(e)) => {
+                            // Row stays trashed pointing at the (gone) original
+                            // while the worktree sits in holding; the load-time
+                            // reconcile heals the pointer.
                             tracing::error!(
                                 target: "tui.home",
                                 session = %result.session_id,
                                 "failed to persist trash worktree relocation: {e}",
                             );
                         }
-                        changed = true;
+                        None => {}
                     }
-                    (false, Some(reloc)) => {
-                        // A restore squeezed between the worker's still-trashed
-                        // re-check and its move: the row is live and points at
-                        // the original path, but the worktree just landed in
-                        // the holding area. Move it back (a purged row is gone
-                        // from the map and skips; its holding dir falls to the
-                        // purge teardown). Best-effort: a failure is only
-                        // logged, and the git move is a same-filesystem rename,
-                        // so it is cheap enough for the tick loop, the same
-                        // trade `restore_selected_from_trash` makes.
-                        if let Some(live) = self.instances.get(&result.session_id) {
-                            match crate::session::trash::undo_raced_relocation(live, &reloc) {
-                                crate::session::trash::RestoreOutcome::Failed { reason } => {
-                                    tracing::warn!(
-                                        target: "tui.session",
-                                        session = %result.session_id,
-                                        "could not move a raced trash relocation back ({reason}); worktree remains at {}",
-                                        reloc.new_project_path,
-                                    );
-                                }
-                                outcome => {
-                                    tracing::info!(
-                                        target: "tui.session",
-                                        session = %result.session_id,
-                                        "trash relocation raced a restore; undone ({outcome:?})",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    (_, None) => {}
                 }
                 if let Some(reason) = result.relocate_warning {
                     tracing::warn!(

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3134,7 +3134,18 @@ impl HomeView {
                     // trade `restore_selected_from_trash` makes). A row absent
                     // from the map was purged locally and is skipped; its
                     // holding dir falls to the purge teardown.
-                    let committed = self
+                    // The decision travels through this captured slot rather
+                    // than the closure's return value, so it survives an
+                    // update that decided Superseded and then failed its
+                    // final write; the undo below keys off the decision
+                    // alone, since the durable row was already restored in
+                    // that case and skipping the undo would strand its
+                    // worktree in the holding area.
+                    let mut decided: Option<(
+                        crate::session::claim::RelocationCommit,
+                        Option<crate::session::Instance>,
+                    )> = None;
+                    let update_result = self
                         .instances
                         .get(&result.session_id)
                         .map(|i| i.source_profile.clone())
@@ -3148,19 +3159,33 @@ impl HomeView {
                                     chrono::Utc::now(),
                                 );
                                 let row = insts.iter().find(|i| i.id == result.session_id).cloned();
-                                Ok((commit, row))
+                                decided = Some((commit, row));
+                                Ok(())
                             })
                         });
+                    if let Some(Err(e)) = &update_result {
+                        // A Persisted decision whose write failed needs no
+                        // repair here: the durable row is still trashed at its
+                        // old path and the load-time reconcile repoints it to
+                        // the holding area.
+                        tracing::error!(
+                            target: "tui.home",
+                            session = %result.session_id,
+                            "failed to persist trash worktree relocation: {e}",
+                        );
+                    }
                     use crate::session::claim::RelocationCommit;
-                    match committed {
-                        Some(Ok((RelocationCommit::Persisted, _))) => {
+                    match decided {
+                        Some((RelocationCommit::Persisted, _))
+                            if matches!(update_result, Some(Ok(()))) =>
+                        {
                             if let Some(inst) = self.instances.get_mut(&result.session_id) {
                                 inst.project_path = reloc.new_project_path.clone();
                                 inst.pre_trash_project_path = reloc.pre_trash_project_path.clone();
                             }
                             changed = true;
                         }
-                        Some(Ok((RelocationCommit::Superseded, row))) => {
+                        Some((RelocationCommit::Superseded, row)) => {
                             let undo_with =
                                 row.or_else(|| self.instances.get(&result.session_id).cloned());
                             if let Some(live) = undo_with {
@@ -3183,18 +3208,7 @@ impl HomeView {
                                 }
                             }
                         }
-                        Some(Ok((RelocationCommit::AlreadyGone, _))) => {}
-                        Some(Err(e)) => {
-                            // Row stays trashed pointing at the (gone) original
-                            // while the worktree sits in holding; the load-time
-                            // reconcile heals the pointer.
-                            tracing::error!(
-                                target: "tui.home",
-                                session = %result.session_id,
-                                "failed to persist trash worktree relocation: {e}",
-                            );
-                        }
-                        None => {}
+                        _ => {}
                     }
                 }
                 if let Some(reason) = result.relocate_warning {


### PR DESCRIPTION
## Description

Trashing a containerized session with `d`, then restoring it before the off-thread teardown finishes, left the session unresumable: the worktree quietly moved into `.aoe-trash/<id>` while the restored row kept pointing at the now-empty original path.

The teardown (#2930) runs on the `TrashPoller` against a clone taken at trash time: tmux kill, then `docker stop` (which blocks about 10 seconds because the container's PID-1 `sleep infinity` ignores SIGTERM), then `git worktree move`. A restore landing inside that window is a NoChange on disk (no relocation marker exists yet) and untrashes the durable row, but the worker still moved the worktree and discarded the container. `apply_trash_results` then dropped the relocation result because the row was no longer trashed, and the reconcile pass only heals trashed rows, so nothing ever moved the worktree back. Non-sandbox sessions tear down in well under a second, which is why only containerized sessions hit this in practice.

The fix, in layers:

- `prepare_trashed_worktree` re-checks the durable row between the container stop and the worktree move, and skips the move when the row is no longer trashed. Fail closed: an unreadable storage, a purged row, or a restored row all leave the worktree in place, and a skipped move on a still-trashed row is healed by the next reconcile pass. One change point that covers the TUI, server, and CLI surfaces.
- The relocation is committed atomically against the durable row: `commit_trash_relocation` (in `session/claim.rs`, per CodeRabbit's review) re-takes the decision under the storage flock at every persist site (TUI poller drain, server trash handler, CLI remove), persisting only when the row still reads trashed and unclaimed. A restore or fresh purge/restore claim that won in the meantime supersedes the relocation, and the disk move is undone via the new `trash::undo_raced_relocation` instead of being recorded onto a live row.
- `aoe rm` stamps `source_profile` before the teardown so a profile-scoped remove re-checks the storage it actually trashed the row in.

Follow-up: making the teardown a first-class claimed operation (a `ClaimOp::Trash` alongside Purge and Restore in the #2541 protocol) so peers can observe "teardown in flight" as durable state rather than inferring it. That lands separately.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the race needs a live docker container mid `docker stop` grace period, which an e2e cannot reproduce deterministically. Covered instead by unit-level regression tests in `src/session/trash.rs`: `teardown_skips_relocation_when_row_was_restored_mid_flight` (fails without the fix, with the worktree relocated under `.aoe-trash/`) and `undo_raced_relocation_moves_worktree_back`, both against real git worktrees.

## Testing

`cargo test`: 4114 passed. One failure (`restart_selected_session_surfaces_resume_failed_after_async_restart`) fails identically on a clean `main` checkout in this environment, so it is pre-existing and unrelated. `cargo fmt --check` clean, `cargo clippy --all-targets` adds no new warnings, `cargo check --features serve` compiles.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Fable 5 via Claude Code

**Any Additional AI Details you'd like to share:**
Root-caused via a failing reproduction test before any fix was written; the repro is kept as the regression test.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed a race where a session restore could happen while an async trash teardown was stopping a sandbox/container and moving the worktree, leaving the worktree stranded under `.aoe-trash/<id>` while the restored session record no longer referenced it.
- Added a “last-moment” check right before relocating the worktree so relocation is skipped if the durable record shows the session has already been restored/untrashed.
- Changed trash relocation to be recorded durably first, and only then applied to in-memory state—preventing in-memory/worktree mismatches when races occur.
- Added an “undo” path: if relocation was performed but a restore wins first, the code moves the worktree back to its pre-trash location and cleans up the temporary trash copy.
- Ensured `aoe rm` captures and reuses the correct `source_profile` in trash-first removals, so subsequent `-p <profile>` operations re-check the same storage row.
- Updated TUI and server flows to use the durable relocation decision and trigger the undo logic when relocation is superseded.
- Added regression tests covering both cases: (1) relocation skipped after a mid-flight restore, and (2) raced relocations being properly reversed.

## Benefits

This makes concurrent restore + cleanup much more reliable by preventing stranded trash worktrees and ensuring the session’s recorded location stays consistent with what exists on disk, reducing flakiness under load.

## Potential further enhancement

- The reviewer discussion suggests a follow-up could make teardown itself a first-class state/claim operation (rather than coordinating via the gap around container stop), though that would require a broader protocol change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
