### PR TITLE
feat(tui): native-feeling structured view in the home preview pane

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -378,6 +378,17 @@ fn default_show_spans() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize, SettingsSection)]
 #[setting_section(name = "acp", category = "Acp")]
 pub struct AcpConfig {
+    /// Show the "Structured view" toggle in the new-session dialog. The
+    /// structured view is still maturing, so it is hidden by default;
+    /// turn this on to opt into creating structured-view sessions from
+    /// the new-session flow. Switching an existing session's view and
+    /// opening already-structured sessions are unaffected.
+    #[serde(default)]
+    #[setting(
+        label = "Offer structured view when creating a session",
+        widget = "toggle"
+    )]
+    pub offer_structured_in_new_session: bool,
     /// Acp agent used when --agent is not specified (e.g. aoe-agent,
     /// claude-code, gemini).
     #[serde(default = "default_agent")]
@@ -524,6 +535,7 @@ fn default_silent_orphan_grace_secs() -> u32 {
 impl Default for AcpConfig {
     fn default() -> Self {
         Self {
+            offer_structured_in_new_session: false,
             default_agent: default_agent(),
             max_concurrent_workers: default_max_workers(),
             replay_events: default_replay_events(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -195,6 +195,18 @@ pub struct App {
     /// the daemon switch POST (awaited; the sync handler can't).
     #[cfg(feature = "serve")]
     pending_view_switch: Option<String>,
+    /// Set by `Action::StartDaemonThenOpenStructured` (the Yes on the
+    /// "start a local daemon?" confirm) so the async loop can spawn the
+    /// daemon, wait for health, and then open the structured view.
+    #[cfg(feature = "serve")]
+    pending_daemon_start_open: Option<String>,
+    /// Debounce for structured preview-on-select: the session the cursor
+    /// settled on and when, so rapid list navigation doesn't connect a
+    /// WebSocket per keystroke. The mounted view itself lives on
+    /// `HomeView::structured_preview` (it is preview content); this App
+    /// side only drives the async mount/unmount.
+    #[cfg(feature = "serve")]
+    preview_mount_pending: Option<(String, std::time::Instant)>,
     /// Version of the install currently being attempted (auto or manual).
     /// Set when the install task is spawned; transferred to
     /// `last_installed_version_in_session` on confirmed success in
@@ -479,6 +491,10 @@ impl App {
             #[cfg(feature = "serve")]
             pending_structured_view_open: None,
             #[cfg(feature = "serve")]
+            pending_daemon_start_open: None,
+            #[cfg(feature = "serve")]
+            preview_mount_pending: None,
+            #[cfg(feature = "serve")]
             pending_view_switch: None,
             pending_install_version: None,
             last_installed_version_in_session: None,
@@ -535,10 +551,25 @@ impl App {
     /// pane caret, not a local IME candidate window, so there's nothing for
     /// the early Hide to protect.
     fn draw(&mut self, terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>) -> Result<()> {
-        let skip_hide = skip_predraw_cursor_hide(
-            self.home.live_send.is_some(),
-            self.home.has_non_live_send_overlay(),
-        );
+        // An ACTIVE embedded structured view sets a composer caret every
+        // frame, just like the live-send preview caret: hiding it
+        // before each ~30fps redraw makes it strobe (the reported "cursor
+        // blinks really fast"). Skip the pre-draw Hide while it's active,
+        // the same treatment live-send gets. A preview shows no caret, so
+        // it needs no skip.
+        #[cfg(feature = "serve")]
+        let embedded_active = self
+            .home
+            .structured_preview
+            .as_ref()
+            .is_some_and(|v| v.is_active());
+        #[cfg(not(feature = "serve"))]
+        let embedded_active = false;
+        let skip_hide = embedded_active
+            || skip_predraw_cursor_hide(
+                self.home.live_send.is_some(),
+                self.home.has_non_live_send_overlay(),
+            );
         crossterm::execute!(
             terminal.backend_mut(),
             crossterm::terminal::BeginSynchronizedUpdate
@@ -861,6 +892,16 @@ impl App {
             let preview_wake = self.home.preview_wake.clone();
             let mut woke_via_preview = false;
 
+            // Whether an embedded structured view is mounted this
+            // iteration, so its WebSocket is pumped. This is true for a
+            // preview too (it streams into the pane), not just an active
+            // view. Computed outside the select! so the arm's `expect` is
+            // guarded by the same check that enables it.
+            #[cfg(feature = "serve")]
+            let embedded_mounted = self.home.structured_preview.is_some();
+            #[cfg(not(feature = "serve"))]
+            let embedded_mounted = false;
+
             // All event sources are polled cooperatively via tokio::select!.
             // This ensures signal futures actually get scheduled (fixing #608
             // defect 1), and that EOF from a dead tty is detected (defect 2).
@@ -946,6 +987,25 @@ impl App {
                                             "paste-burst: routed {} chars via handle_paste (chars={:?})",
                                             paste_text.len(), paste_text
                                         );
+                                        // An embedded structured view owns text
+                                        // input: the burst belongs to its
+                                        // composer, same as a real Paste event.
+                                        #[cfg(feature = "serve")]
+                                        if let Some(view) = self.home.structured_preview.as_mut() {
+                                            if let Err(e) = view
+                                                .handle_event(Event::Paste(paste_text.clone()))
+                                                .await
+                                            {
+                                                self.close_embedded_structured();
+                                                self.update_status =
+                                                    Some(UpdateStatus::transient(format!(
+                                                        "structured view: {e}"
+                                                    )));
+                                            }
+                                        } else {
+                                            self.home.handle_paste(&paste_text);
+                                        }
+                                        #[cfg(not(feature = "serve"))]
                                         self.home.handle_paste(&paste_text);
                                     }
                                     if let Some(enter) = trailing_enter {
@@ -1081,6 +1141,58 @@ impl App {
                             continue;
                         }
                         Some(Ok(Event::Mouse(mouse))) => {
+                            // Structured preview mouse routing is deliberately
+                            // thin: the transcript is ordinary preview content,
+                            // so drags fall through to the home view's own
+                            // drag-select machinery (fed by the transcript
+                            // geometry each render) and a double-click
+                            // activates via `preview_double_click_action`,
+                            // both identical to terminal previews. Only the
+                            // wheel is claimed here (it scrolls the
+                            // transcript, which home cannot do), plus the
+                            // "clicked off the pane while entered" drop back
+                            // to preview so sidebar clicks keep selecting.
+                            #[cfg(feature = "serve")]
+                            {
+                                let in_pane = self.home.structured_preview.is_some()
+                                    && self.home.preview_pane_area.contains(
+                                        ratatui::layout::Position::from((
+                                            mouse.column,
+                                            mouse.row,
+                                        )),
+                                    );
+                                if in_pane
+                                    && matches!(
+                                        mouse.kind,
+                                        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
+                                    )
+                                {
+                                    if let Some(view) = self.home.structured_preview.as_mut() {
+                                        let _ = view.handle_event(Event::Mouse(mouse)).await;
+                                    }
+                                    if !self.needs_redraw {
+                                        self.draw(terminal)?;
+                                    }
+                                    continue;
+                                }
+                                let active = self
+                                    .home
+                                    .structured_preview
+                                    .as_ref()
+                                    .is_some_and(|v| v.is_active());
+                                if active
+                                    && !in_pane
+                                    && matches!(
+                                        mouse.kind,
+                                        MouseEventKind::Down(MouseButton::Left)
+                                            | MouseEventKind::Down(MouseButton::Right)
+                                    )
+                                {
+                                    if let Some(v) = self.home.structured_preview.as_mut() {
+                                        v.deactivate();
+                                    }
+                                }
+                            }
                             // Footer toolbar: a left-click on a button
                             // synthesizes its shortcut and routes it through
                             // the full key handler, so clicking behaves
@@ -1130,7 +1242,7 @@ impl App {
                                 if let Some(session_id) =
                                     self.pending_structured_view_open.take()
                                 {
-                                    self.run_structured_view(&session_id, terminal).await?;
+                                    self.open_structured_view(&session_id).await?;
                                 }
                                 self.sync_mouse_capture(terminal)?;
                                 if self.should_quit {
@@ -1358,7 +1470,7 @@ impl App {
                                 // opens it.
                                 #[cfg(feature = "serve")]
                                 if let Some(session_id) = self.pending_structured_view_open.take() {
-                                    self.run_structured_view(&session_id, terminal).await?;
+                                    self.open_structured_view(&session_id).await?;
                                 }
                             }
                             // Drain any Action stashed by a modal-dialog
@@ -1373,12 +1485,31 @@ impl App {
                                 // click path never reaches the key-path drain.
                                 #[cfg(feature = "serve")]
                                 if let Some(session_id) = self.pending_view_switch.take() {
-                                    self.perform_view_switch(&session_id).await;
+                                    self.perform_view_switch(&session_id, terminal).await;
+                                }
+                                // Same for a [Yes] click on the start-daemon
+                                // confirm from a structured-view open.
+                                #[cfg(feature = "serve")]
+                                if let Some(session_id) = self.pending_daemon_start_open.take() {
+                                    self.start_daemon_then_open(&session_id, terminal).await;
                                 }
                             }
                             continue;
                         }
                         Some(Ok(Event::Paste(text))) => {
+                            // Embedded structured view: pasted text belongs
+                            // to its composer, same as the full-screen view.
+                            #[cfg(feature = "serve")]
+                            if let Some(view) = self.home.structured_preview.as_mut() {
+                                if let Err(e) = view.handle_event(Event::Paste(text)).await {
+                                    self.close_embedded_structured();
+                                    self.update_status = Some(UpdateStatus::transient(format!(
+                                        "structured view: {e}"
+                                    )));
+                                }
+                                self.draw(terminal)?;
+                                continue;
+                            }
                             self.home.handle_paste(&text);
 
                             self.draw(terminal)?;
@@ -1413,6 +1544,37 @@ impl App {
                             self.should_quit = true;
                             break;
                         }
+                    }
+                }
+                // Embedded structured view: pump one daemon-side event
+                // (ws frame, plugin snapshot, path roots). `next_event`
+                // is cancel-safe (channel awaits only); the apply below
+                // runs in the arm body where it can no longer be raced,
+                // so a mid-replay cancellation cannot corrupt the state.
+                ev = async {
+                    #[cfg(feature = "serve")]
+                    {
+                        self.home.structured_preview
+                            .as_mut()
+                            .expect("guarded by embedded_mounted")
+                            .next_event()
+                            .await
+                    }
+                    #[cfg(not(feature = "serve"))]
+                    {
+                        std::future::pending::<()>().await
+                    }
+                }, if embedded_mounted => {
+                    #[cfg(feature = "serve")]
+                    {
+                        if let Some(view) = self.home.structured_preview.as_mut() {
+                            view.apply_event(ev).await;
+                        }
+                        self.draw(terminal)?;
+                    }
+                    #[cfg(not(feature = "serve"))]
+                    {
+                        let _: () = ev;
                     }
                 }
                 _ = refresh_interval.tick() => {}
@@ -1596,7 +1758,7 @@ impl App {
                 // path sits outside the key/click drains).
                 #[cfg(feature = "serve")]
                 if let Some(sid) = self.pending_structured_view_open.take() {
-                    self.run_structured_view(&sid, terminal).await?;
+                    self.open_structured_view(&sid).await?;
                 }
                 refresh_needed = true;
                 needs_full_refresh = true;
@@ -1747,6 +1909,27 @@ impl App {
                 last_spinner_redraw = std::time::Instant::now();
                 refresh_needed = true;
                 needs_full_refresh = true;
+            }
+
+            // Preview-on-select: mount/drop the streaming transcript
+            // preview to track the selected structured session (debounced).
+            #[cfg(feature = "serve")]
+            if self.reconcile_structured_preview().await {
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
+            // Embedded structured view: expire its toast, surface queued
+            // plugin notifications, and repaint on the same 120ms cadence
+            // the full-screen view used so the composer caret blinks.
+            #[cfg(feature = "serve")]
+            if let Some(view) = self.home.structured_preview.as_mut() {
+                let toast_changed = view.tick();
+                if toast_changed || last_spinner_redraw.elapsed() >= SPINNER_REDRAW_INTERVAL {
+                    last_spinner_redraw = std::time::Instant::now();
+                    refresh_needed = true;
+                    needs_full_refresh = true;
+                }
             }
 
             // In live-send, the 33ms ticker is the steady-state
@@ -2533,6 +2716,41 @@ impl App {
         key: KeyEvent,
         terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Result<()> {
+        // An ACTIVE embedded structured view owns the keyboard, just as
+        // the full-screen view owned the whole event stream: letters must
+        // reach the composer, not home-view shortcuts (q, n, d…). A merely
+        // previewed view (mounted but not entered) does NOT capture: list
+        // navigation keeps working, and Enter enters it. Ctrl+Q leaves
+        // interactive mode back to the read-only preview.
+        #[cfg(feature = "serve")]
+        if self
+            .home
+            .structured_preview
+            .as_ref()
+            .is_some_and(|v| v.is_active())
+        {
+            let result = self
+                .home
+                .structured_preview
+                .as_mut()
+                .expect("checked is_some above")
+                .handle_event(crossterm::event::Event::Key(key))
+                .await;
+            match result {
+                Ok(true) => {
+                    if let Some(v) = self.home.structured_preview.as_mut() {
+                        v.deactivate();
+                    }
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    self.close_embedded_structured();
+                    self.update_status =
+                        Some(UpdateStatus::transient(format!("structured view: {e}")));
+                }
+            }
+            return Ok(());
+        }
         // Global keybindings
         match (key.code, key.modifiers) {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
@@ -2620,18 +2838,27 @@ impl App {
             }
             _ => {}
         }
-        #[cfg(feature = "serve")]
-        if let Some(session_id) = self.pending_view_switch.take() {
-            self.perform_view_switch(&session_id).await;
-        }
-
         if let Some(action) = self.home.handle_key(key, self.update_info.as_ref()) {
             self.execute_action(action, terminal)?;
         }
 
+        // Drain AFTER the key was handled: a keyboard-confirmed switch
+        // ('y' / Enter on the switch-view confirm) stashes the id during
+        // `execute_action` above, and draining before `handle_key` would
+        // sit on it until the next keypress (#2925).
+        #[cfg(feature = "serve")]
+        if let Some(session_id) = self.pending_view_switch.take() {
+            self.perform_view_switch(&session_id, terminal).await;
+        }
+
+        #[cfg(feature = "serve")]
+        if let Some(session_id) = self.pending_daemon_start_open.take() {
+            self.start_daemon_then_open(&session_id, terminal).await;
+        }
+
         #[cfg(feature = "serve")]
         if let Some(session_id) = self.pending_structured_view_open.take() {
-            self.run_structured_view(&session_id, terminal).await?;
+            self.open_structured_view(&session_id).await?;
         }
 
         Ok(())
@@ -2643,8 +2870,18 @@ impl App {
     /// tears down the pane; the file watcher refreshes the row, so the
     /// TUI mutates no session state itself. Errors surface as status
     /// text rather than failing the app loop.
+    ///
+    /// When no daemon is running, a localhost one is started first: the
+    /// user just confirmed a dialog that says the agent restarts under
+    /// `aoe serve`, so the spawn is part of the consented action rather
+    /// than a hidden side effect. `terminal` is borrowed to paint the
+    /// "Starting…" status before the (up to several seconds) wait.
     #[cfg(feature = "serve")]
-    async fn perform_view_switch(&mut self, session_id: &str) {
+    async fn perform_view_switch(
+        &mut self,
+        session_id: &str,
+        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    ) {
         use crate::acp::client::{require_daemon, HttpClient, ManagerError};
 
         let Some(inst) = self.home.get_instance(session_id) else {
@@ -2655,13 +2892,23 @@ impl App {
 
         let endpoint = match require_daemon().await {
             Ok(e) => e,
-            Err(e @ ManagerError::NoDaemonRunning(_)) => {
-                let _ = e;
+            Err(ManagerError::NoDaemonRunning(_)) => {
                 self.update_status = Some(UpdateStatus::transient(
-                    "View switch needs a running daemon; start one with `aoe serve --daemon`"
-                        .into(),
+                    "Starting local daemon for the view switch…".into(),
                 ));
-                return;
+                let _ = self.draw(terminal);
+                match crate::tui::dialogs::start_local_daemon_and_wait().await {
+                    Ok(e) => e,
+                    Err(e) => {
+                        // Take the first line only: the log-tail hint is
+                        // multi-line and a transient status is one row.
+                        let first = e.lines().next().unwrap_or("unknown error");
+                        self.update_status = Some(UpdateStatus::transient(format!(
+                            "view switch failed: {first}"
+                        )));
+                        return;
+                    }
+                }
             }
             Err(e) => {
                 self.update_status =
@@ -2689,30 +2936,187 @@ impl App {
         }));
     }
 
+    /// Enter (activate) the structured view for `session_id`: it takes
+    /// the keyboard so the composer works. Usually the view is already
+    /// mounted as a preview (selecting the row mounts it), so this just
+    /// flips it active. If it isn't mounted (e.g. the daemon was down
+    /// when selected), connect now; and with no daemon at all, offer to
+    /// start a localhost one (the Yes path resumes through
+    /// `start_daemon_then_open`).
     #[cfg(feature = "serve")]
-    async fn run_structured_view(
+    async fn open_structured_view(&mut self, session_id: &str) -> Result<()> {
+        use crate::acp::client::{require_daemon, ManagerError};
+
+        if self
+            .home
+            .structured_preview
+            .as_ref()
+            .is_some_and(|v| v.session_id() == session_id)
+        {
+            self.activate_embedded();
+            return Ok(());
+        }
+        match require_daemon().await {
+            Ok(endpoint) => {
+                self.connect_embedded_structured(endpoint, session_id).await;
+                self.activate_embedded();
+            }
+            Err(ManagerError::NoDaemonRunning(_)) => {
+                self.home.prompt_start_daemon_for_structured(session_id);
+            }
+            Err(e) => {
+                self.update_status = Some(UpdateStatus::transient(format!("structured view: {e}")));
+            }
+        }
+        Ok(())
+    }
+
+    /// Flip the mounted embedded view to interactive mode (exiting
+    /// live-send first, since both own the preview pane and keyboard).
+    #[cfg(feature = "serve")]
+    fn activate_embedded(&mut self) {
+        self.home.exit_live_send_if_active();
+        if let Some(v) = self.home.structured_preview.as_mut() {
+            v.activate();
+        }
+    }
+
+    /// Mount the embedded view against a located daemon in preview
+    /// (read-only) state. The caller activates it if the user is
+    /// entering rather than just previewing.
+    #[cfg(feature = "serve")]
+    async fn connect_embedded_structured(
+        &mut self,
+        endpoint: crate::acp::client::DaemonEndpoint,
+        session_id: &str,
+    ) {
+        use crate::tui::structured_view::embedded::EmbeddedView;
+
+        match EmbeddedView::connect(endpoint, session_id).await {
+            Ok(view) => {
+                self.home.structured_preview = Some(view);
+                self.preview_mount_pending = None;
+            }
+            Err(e) => {
+                self.update_status = Some(UpdateStatus::transient(format!("structured view: {e}")));
+            }
+        }
+    }
+
+    /// Drop the embedded structured view and hand the preview pane
+    /// back to the home screen. Dropping the view closes its WebSocket
+    /// and ends the side-channel tasks (their senders error out).
+    ///
+    /// No `needs_redraw`: that forces a full `clear_terminal` on the next
+    /// loop iteration, which blanks the whole screen for a frame (the
+    /// reported Ctrl+Q flash). The home view repaints the same preview
+    /// rect the structured view drew into, so the ordinary diffed draw
+    /// covers it cleanly, the same way exiting live-send does.
+    #[cfg(feature = "serve")]
+    fn close_embedded_structured(&mut self) {
+        self.home.structured_preview = None;
+    }
+
+    /// The Yes path of the "start a local daemon?" confirm: spawn a
+    /// localhost daemon with visible feedback, wait for it to become
+    /// healthy, then mount + enter the embedded structured view.
+    #[cfg(feature = "serve")]
+    async fn start_daemon_then_open(
         &mut self,
         session_id: &str,
         terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
-    ) -> Result<()> {
-        // The acp view borrows the EventStream so it can drive its
-        // own tokio::select! loop. Pull it out for the duration of the
-        // call; restore on return.
-        let mut stream = match self.event_stream.take() {
-            Some(s) => s,
-            None => return Ok(()),
-        };
-        let result =
-            crate::tui::structured_view::run(terminal, &mut stream, &self.theme, session_id).await;
-        self.event_stream = Some(stream);
-        // Force a full redraw so the home screen repaints any cells the acp
-        // view painted over. The main loop's redraw branch runs `clear_terminal`
-        // on the next iteration, so don't clear again here.
-        self.needs_redraw = true;
-        if let Err(e) = result {
-            self.update_status = Some(UpdateStatus::transient(format!("acp closed: {e}")));
+    ) {
+        self.update_status = Some(UpdateStatus::transient("Starting local daemon…".into()));
+        let _ = self.draw(terminal);
+        match crate::tui::dialogs::start_local_daemon_and_wait().await {
+            Ok(endpoint) => {
+                self.update_status = None;
+                self.connect_embedded_structured(endpoint, session_id).await;
+                self.activate_embedded();
+            }
+            Err(e) => {
+                let first = e.lines().next().unwrap_or("unknown error");
+                self.update_status = Some(UpdateStatus::transient(format!(
+                    "daemon start failed: {first}"
+                )));
+            }
         }
-        Ok(())
+    }
+
+    /// Preview-on-select: keep a streaming structured-transcript preview
+    /// mounted for the selected structured session. Debounced so rapid
+    /// list navigation doesn't connect a socket per keystroke, and only
+    /// while a daemon is already reachable (a down daemon leaves the
+    /// "press Enter" placeholder). An active (entered) view is never
+    /// disturbed. Returns true if the mount set changed (needs redraw).
+    #[cfg(feature = "serve")]
+    async fn reconcile_structured_preview(&mut self) -> bool {
+        // An entered view owns the selection and keyboard; leave it be.
+        if self
+            .home
+            .structured_preview
+            .as_ref()
+            .is_some_and(|v| v.is_active())
+        {
+            self.preview_mount_pending = None;
+            self.home.structured_preview_pending = false;
+            return false;
+        }
+        let desired = self.home.selected_structured_session();
+        let mounted = self
+            .home
+            .structured_preview
+            .as_ref()
+            .map(|v| v.session_id().to_string());
+        if desired.as_deref() == mounted.as_deref() {
+            self.preview_mount_pending = None;
+            self.home.structured_preview_pending = false;
+            return false;
+        }
+        // Selection moved off the previewed session: drop the old preview
+        // right away so the pane doesn't show a stale transcript.
+        let Some(sid) = desired else {
+            self.preview_mount_pending = None;
+            self.home.structured_preview_pending = false;
+            if self.home.structured_preview.is_some() {
+                self.home.structured_preview = None;
+                return true;
+            }
+            return false;
+        };
+        // Only preview when a daemon is already up (cheap discovery, no
+        // health round-trip): a down daemon keeps the actionable "press
+        // Enter" placeholder rather than auto-spawning on hover.
+        let Ok(endpoint) = crate::acp::client::discover() else {
+            self.preview_mount_pending = None;
+            self.home.structured_preview_pending = false;
+            return false;
+        };
+        // A mount is coming: the renderer shows a quiet beat instead of
+        // the wordy placeholder while we debounce + connect.
+        self.home.structured_preview_pending = true;
+        // Debounce: wait for the cursor to settle on this row so rapid
+        // list navigation doesn't open a WebSocket per keystroke.
+        const PREVIEW_MOUNT_DEBOUNCE: Duration = Duration::from_millis(120);
+        let now = std::time::Instant::now();
+        match &self.preview_mount_pending {
+            Some((pending, _)) if *pending == sid => {}
+            _ => {
+                self.preview_mount_pending = Some((sid, now));
+                return self.home.structured_preview.take().is_some();
+            }
+        }
+        let settled = self
+            .preview_mount_pending
+            .as_ref()
+            .is_some_and(|(_, at)| now.duration_since(*at) >= PREVIEW_MOUNT_DEBOUNCE);
+        if !settled {
+            return false;
+        }
+        let sid = self.preview_mount_pending.take().unwrap().0;
+        self.connect_embedded_structured(endpoint, &sid).await;
+        self.home.structured_preview_pending = false;
+        true
     }
 
     /// Auto-stop plain tmux sessions idle past `session.auto_stop_idle_secs`
@@ -2915,6 +3319,12 @@ impl App {
                 // must be awaited, which this sync handler can't do.
                 self.pending_view_switch = Some(id);
             }
+            #[cfg(feature = "serve")]
+            Action::StartDaemonThenOpenStructured(id) => {
+                // Same stash pattern: spawning the daemon and waiting for
+                // its health check must be awaited.
+                self.pending_daemon_start_open = Some(id);
+            }
         }
         Ok(())
     }
@@ -2925,15 +3335,27 @@ impl App {
     /// the main loop's `apply_creation_results` handler) so the setting
     /// applies regardless of which one fired.
     ///
-    /// Acp sessions return `None` from the resolver and fall through
-    /// to `attach_session`, which already no-ops for acp. Same for
-    /// missing-instance race conditions: better to do the tmux-attach
-    /// fallback than silently swallow the new session.
+    /// A structured session skips the tmux modes entirely and opens its
+    /// structured view (#2926): the wizard's Structured toggle is an
+    /// explicit "drive this session in the structured view" ask, and
+    /// both callers drain `pending_structured_view_open` right after
+    /// this returns. Missing-instance race conditions fall through to
+    /// `attach_session`: better the tmux-attach fallback than silently
+    /// swallowing the new session.
     fn dispatch_new_session_attach(
         &mut self,
         session_id: &str,
         terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Result<()> {
+        #[cfg(feature = "serve")]
+        if self
+            .home
+            .get_instance(session_id)
+            .is_some_and(|inst| inst.is_structured())
+        {
+            self.pending_structured_view_open = Some(session_id.to_string());
+            return Ok(());
+        }
         let mode = self.home.default_attach_mode(session_id);
         tracing::debug!(target: "tui.input",
             session_id = %session_id,
@@ -2960,12 +3382,13 @@ impl App {
             None => return Ok(()),
         };
 
-        // Acp-mode sessions are not backed by tmux. The Enter
-        // handler in `home::input` already short-circuits with a
-        // transient toast pointing the user at the web dashboard;
-        // this function still gets called from `apply_creation_results`
-        // after `aoe add --launch`, so guard here too. Falling through
-        // would attempt a tmux attach against a non-existent pane.
+        // Acp-mode sessions are not backed by tmux. The Enter handler
+        // in `home::input` routes them to `OpenStructuredView`, and
+        // `dispatch_new_session_attach` opens the structured view for
+        // fresh creates, but this function is still reachable for a
+        // structured row through older call sites, so guard here too.
+        // Falling through would attempt a tmux attach against a
+        // non-existent pane.
         if instance.is_structured() {
             let _ = terminal;
             return Ok(());
@@ -3537,6 +3960,12 @@ pub enum Action {
     /// the file watcher refreshes the row.
     #[cfg(feature = "serve")]
     SwitchSessionView(String),
+    /// The Yes on the "no daemon running, start a local one?" confirm
+    /// shown when opening a structured view. Stashed in
+    /// `pending_daemon_start_open` (spawn + health wait must be
+    /// awaited) and drained alongside the other structured stashes.
+    #[cfg(feature = "serve")]
+    StartDaemonThenOpenStructured(String),
 }
 
 #[cfg(test)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -987,11 +987,18 @@ impl App {
                                             "paste-burst: routed {} chars via handle_paste (chars={:?})",
                                             paste_text.len(), paste_text
                                         );
-                                        // An embedded structured view owns text
+                                        // An ACTIVE structured view owns text
                                         // input: the burst belongs to its
-                                        // composer, same as a real Paste event.
+                                        // composer, same as a real Paste
+                                        // event. A merely-mounted preview
+                                        // must not eat it.
                                         #[cfg(feature = "serve")]
-                                        if let Some(view) = self.home.structured_preview.as_mut() {
+                                        if let Some(view) = self
+                                            .home
+                                            .structured_preview
+                                            .as_mut()
+                                            .filter(|v| v.is_active())
+                                        {
                                             if let Err(e) = view
                                                 .handle_event(Event::Paste(paste_text.clone()))
                                                 .await
@@ -1497,10 +1504,18 @@ impl App {
                             continue;
                         }
                         Some(Ok(Event::Paste(text))) => {
-                            // Embedded structured view: pasted text belongs
-                            // to its composer, same as the full-screen view.
+                            // An ACTIVE structured view owns pasted text (it
+                            // goes to its composer, same as the full-screen
+                            // view). A merely-mounted preview must NOT eat
+                            // it: the user is driving the home screen, and a
+                            // paste belongs to whatever home surface is up.
                             #[cfg(feature = "serve")]
-                            if let Some(view) = self.home.structured_preview.as_mut() {
+                            if let Some(view) = self
+                                .home
+                                .structured_preview
+                                .as_mut()
+                                .filter(|v| v.is_active())
+                            {
                                 if let Err(e) = view.handle_event(Event::Paste(text)).await {
                                     self.close_embedded_structured();
                                     self.update_status = Some(UpdateStatus::transient(format!(
@@ -2947,6 +2962,20 @@ impl App {
     async fn open_structured_view(&mut self, session_id: &str) -> Result<()> {
         use crate::acp::client::{require_daemon, ManagerError};
 
+        // An archived / trashed row renders its own placeholder page, so
+        // an activated view here would capture the keyboard invisibly.
+        // Restoring stays explicit (`z` / the trash menu), matching the
+        // archive contract for terminal sessions.
+        if self
+            .home
+            .get_instance(session_id)
+            .is_some_and(|inst| inst.is_archived() || inst.is_trashed())
+        {
+            self.update_status = Some(UpdateStatus::transient(
+                "This session is archived; restore it first to open the structured view".into(),
+            ));
+            return Ok(());
+        }
         if self
             .home
             .structured_preview
@@ -3051,13 +3080,33 @@ impl App {
     /// disturbed. Returns true if the mount set changed (needs redraw).
     #[cfg(feature = "serve")]
     async fn reconcile_structured_preview(&mut self) -> bool {
-        // An entered view owns the selection and keyboard; leave it be.
+        // An entered view owns the selection and keyboard; leave it be,
+        // but only while its session is still a live structured row AND
+        // still the selected one. A peer (web, another aoe) can delete
+        // the session, flip it to a terminal view, or archive it out
+        // from under us, and a storage reload can move the selection;
+        // an active view that no longer matches what the pane renders
+        // would keep capturing every keystroke invisibly.
         if self
             .home
             .structured_preview
             .as_ref()
             .is_some_and(|v| v.is_active())
         {
+            let mounted_id = self
+                .home
+                .structured_preview
+                .as_ref()
+                .map(|v| v.session_id().to_string());
+            let still_valid = mounted_id
+                .as_deref()
+                .is_some_and(|id| self.home.selected_structured_session().as_deref() == Some(id));
+            if !still_valid {
+                self.close_embedded_structured();
+                self.preview_mount_pending = None;
+                self.home.structured_preview_pending = false;
+                return true;
+            }
             self.preview_mount_pending = None;
             self.home.structured_preview_pending = false;
             return false;
@@ -3086,11 +3135,14 @@ impl App {
         };
         // Only preview when a daemon is already up (cheap discovery, no
         // health round-trip): a down daemon keeps the actionable "press
-        // Enter" placeholder rather than auto-spawning on hover.
+        // Enter" placeholder rather than auto-spawning on hover. Any
+        // stale mount for a different session is dropped here too, so a
+        // daemon that died mid-browse can't leave an orphaned view
+        // pumping a dead socket behind the placeholder.
         let Ok(endpoint) = crate::acp::client::discover() else {
             self.preview_mount_pending = None;
             self.home.structured_preview_pending = false;
-            return false;
+            return self.home.structured_preview.take().is_some();
         };
         // A mount is coming: the renderer shows a quiet beat instead of
         // the wordy placeholder while we debounce + connect.

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -303,7 +303,7 @@ impl Preview {
         );
     }
 
-    fn render_info(
+    pub(crate) fn render_info(
         frame: &mut Frame,
         area: Rect,
         instance: &Instance,

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -143,12 +143,26 @@ impl ConfirmDialog {
     pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         // Spacer rows separate message / checkbox / buttons so the dialog
         // breathes; grow the height (and a touch of width) to fit them when
-        // the checkbox is shown.
-        let (width, height) = if self.dont_ask_again.is_some() {
-            (56, 11)
+        // the checkbox is shown. The height follows the wrapped message so
+        // a multi-sentence body (e.g. the switch-view confirm) is never
+        // clipped by a fixed row budget; short messages keep the historical
+        // minimum so routine confirms don't shrink.
+        let width: u16 = if self.dont_ask_again.is_some() {
+            56
         } else {
-            (50, 8)
+            50
         };
+        // Border (2) + horizontal layout margin (2) eat four columns.
+        let text_width = width.saturating_sub(4).max(1);
+        let message_rows = wrapped_line_count(&self.message, text_width as usize);
+        // Border (2) + vertical margin (2) + buttons (2); the checkbox
+        // variant adds spacer + checkbox + spacer.
+        let chrome: u16 = if self.dont_ask_again.is_some() { 9 } else { 6 };
+        let min_height: u16 = if self.dont_ask_again.is_some() { 11 } else { 8 };
+        let height = (message_rows as u16)
+            .saturating_add(chrome)
+            .max(min_height)
+            .min(area.height);
         let dialog_area = super::centered_rect(area, width, height);
 
         frame.render_widget(Clear, dialog_area);
@@ -216,6 +230,44 @@ impl ConfirmDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, area);
     }
+}
+
+/// Rows a message occupies when word-wrapped at `width` columns.
+/// Greedy fill on whitespace with long words broken mid-word, matching
+/// ratatui's `Wrap { trim: true }` closely enough to size the dialog
+/// (a one-row overestimate just leaves a blank line; an underestimate
+/// would clip, which is what this exists to prevent).
+fn wrapped_line_count(message: &str, width: usize) -> usize {
+    let width = width.max(1);
+    let mut rows = 0usize;
+    for line in message.lines() {
+        let mut used = 0usize;
+        let mut line_rows = 1usize;
+        for word in line.split_whitespace() {
+            let mut len = word.chars().count();
+            if used > 0 && used + 1 + len <= width {
+                used += 1 + len;
+                continue;
+            }
+            if used > 0 && len <= width {
+                line_rows += 1;
+                used = len;
+                continue;
+            }
+            // Either the first word on the row, or a word longer than
+            // the row: consume full rows until the remainder fits.
+            if used > 0 {
+                line_rows += 1;
+            }
+            while len > width {
+                line_rows += 1;
+                len -= width;
+            }
+            used = len;
+        }
+        rows += line_rows;
+    }
+    rows.max(1)
 }
 
 #[cfg(test)]
@@ -413,6 +465,73 @@ mod tests {
             "neutral quit dialog should use the heads-up tone, not destructive red"
         );
         assert_ne!(border_fg, Some(theme.error));
+    }
+
+    /// A multi-sentence body (the switch-view confirm) must be fully
+    /// visible: the old fixed 8-row height clipped it to two lines with
+    /// the buttons painted over the rest (#2923 follow-up).
+    #[test]
+    fn long_message_is_not_clipped() {
+        use crate::tui::styles::load_theme;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let body = "Switch this session to the structured view? The tmux pane \
+                    and its scrollback are destroyed; the agent restarts under \
+                    the aoe serve daemon (a local one is started if none is \
+                    running) with a fresh conversation.";
+        let mut dialog = ConfirmDialog::new("Switch to structured view", body, "switch_view");
+        let theme = load_theme("empire");
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dialog.render(f, f.area(), &theme))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let screen: String = (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+                    + "\n"
+            })
+            .collect();
+
+        // The tail of the message survives wrapping, and the buttons
+        // render below it rather than over it.
+        assert!(
+            screen.contains("fresh"),
+            "message tail should be visible, not clipped:\n{screen}"
+        );
+        assert!(
+            screen.contains("Yes") && screen.contains("No"),
+            "buttons should still render:\n{screen}"
+        );
+        let msg_row = screen
+            .lines()
+            .position(|l| l.contains("fresh"))
+            .expect("message tail row");
+        let yes_row = screen
+            .lines()
+            .position(|l| l.contains("Yes"))
+            .expect("yes button row");
+        assert!(
+            yes_row > msg_row,
+            "buttons must be below the last message line (yes_row={yes_row}, msg_row={msg_row})"
+        );
+    }
+
+    /// Short bodies keep the historical compact height so routine
+    /// confirms don't change shape.
+    #[test]
+    fn wrapped_line_count_basics() {
+        assert_eq!(wrapped_line_count("", 46), 1);
+        assert_eq!(wrapped_line_count("short", 46), 1);
+        assert_eq!(wrapped_line_count("a\nb", 46), 2);
+        // 10-char words at width 10: one per row.
+        assert_eq!(wrapped_line_count("aaaaaaaaaa bbbbbbbbbb", 10), 2);
+        // A single word longer than the row breaks across rows.
+        assert_eq!(wrapped_line_count(&"x".repeat(25), 10), 3);
     }
 
     #[test]

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -59,6 +59,8 @@ pub use repo_trust::{RepoTrustAction, RepoTrustDialog};
 pub use restart::{RestartData, RestartDialog};
 pub use send_message::SendMessageDialog;
 #[cfg(feature = "serve")]
+pub(crate) use serve::start_local_daemon_and_wait;
+#[cfg(feature = "serve")]
 pub use serve::{ServeAction, ServeView};
 pub use snooze_duration::SnoozeDurationDialog;
 pub use sort_picker::SortPickerDialog;

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -385,7 +385,12 @@ fn handle_editable_list_key(
 /// then has no structured view to open, so the wizard must not offer one.
 #[cfg(feature = "serve")]
 fn compute_structured_capable(tool: &str, config: &crate::session::Config) -> bool {
-    crate::session::builder::structured::tool_acp_capable(tool, config)
+    // Gated behind an opt-in setting: the structured view is still
+    // maturing, so the new-session toggle is hidden unless the user
+    // turned it on. Switching an existing session's view is a separate
+    // path and stays available.
+    config.acp.offer_structured_in_new_session
+        && crate::session::builder::structured::tool_acp_capable(tool, config)
 }
 #[cfg(not(feature = "serve"))]
 fn compute_structured_capable(_tool: &str, _config: &crate::session::Config) -> bool {

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -1089,6 +1089,47 @@ impl ServeView {
     }
 }
 
+/// Spawn a localhost daemon (the same Local mode as the serve dialog's
+/// quick-start) and poll until discovery resolves it AND it answers a
+/// health check, so callers can drive the daemon API immediately after
+/// this returns. Used by the structured-view entry points to turn the
+/// old "no structured view daemon is running" dead end into a one-key
+/// recovery; remote modes stay behind the full serve dialog.
+pub(crate) async fn start_local_daemon_and_wait(
+) -> Result<crate::acp::client::DaemonEndpoint, String> {
+    use crate::acp::client::{discovery::discover, HttpClient};
+
+    spawn_daemon(ServeMode::Local, None, None)?;
+    // The daemonized child double-forks, binds, then writes serve.url;
+    // ~1s on a warm start. 20s covers a cold start on a slow disk
+    // without wedging the UI forever if the daemon dies mid-boot.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        let ready = match discover() {
+            Ok(endpoint) => match HttpClient::new(endpoint.clone()) {
+                Ok(client) => client.health_check().await.is_ok().then_some(endpoint),
+                Err(_) => None,
+            },
+            Err(_) => None,
+        };
+        if let Some(endpoint) = ready {
+            return Ok(endpoint);
+        }
+        if std::time::Instant::now() >= deadline {
+            let tail = initial_log_tail();
+            let hint = if tail.is_empty() {
+                String::new()
+            } else {
+                format!(" Last log lines:\n{}", tail.join("\n"))
+            };
+            return Err(format!(
+                "the daemon was started but never became reachable.{hint}"
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+}
+
 /// Spawn the aoe serve daemon in the requested mode. Tunnel requires a
 /// passphrase (it's public-internet exposure) and a transport choice;
 /// Local ignores both.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2966,18 +2966,20 @@ impl HomeView {
         );
     }
 
-    /// The selected session's id when it is a structured-view row and
-    /// not mid create/delete, else `None`. Drives preview-on-select:
-    /// the App mounts a streaming transcript preview for this session.
+    /// The selected session's id when it is a structured-view row that
+    /// can be previewed: not mid create/delete, and not parked in the
+    /// archive or trash (those render their own placeholder pages, so a
+    /// mounted view would be invisible while still streaming). Drives
+    /// preview-on-select and the active-view liveness check.
     #[cfg(feature = "serve")]
     pub(in crate::tui) fn selected_structured_session(&self) -> Option<String> {
         let id = self.selected_session.clone()?;
         let inst = self.get_instance(&id)?;
-        if inst.is_structured() && !matches!(inst.status, Status::Creating | Status::Deleting) {
-            Some(id)
-        } else {
-            None
-        }
+        let previewable = inst.is_structured()
+            && !matches!(inst.status, Status::Creating | Status::Deleting)
+            && !inst.is_archived()
+            && !inst.is_trashed();
+        previewable.then_some(id)
     }
 
     /// Leave live-send mode if it is active, restoring pane sizing.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -943,6 +943,27 @@ impl HomeView {
         if width == 0 || view.total_lines == 0 {
             return None;
         }
+        // The structured preview's transcript is its own line source: the
+        // view re-derives the same pre-wrapped rows the renderer painted
+        // (see `wrapped_transcript`), so (row, column) slicing below maps
+        // one-to-one onto the on-screen cells. Terminal previews keep
+        // reading the tmux capture cache.
+        #[cfg(feature = "serve")]
+        let structured_lines = self
+            .structured_preview
+            .as_ref()
+            .filter(|v| {
+                self.selected_session
+                    .as_deref()
+                    .is_some_and(|id| id == v.session_id())
+            })
+            .map(|v| v.selection_text(width));
+        #[cfg(feature = "serve")]
+        let lines = match structured_lines.as_ref() {
+            Some(text) => text,
+            None => self.active_preview_cache().parsed_text.as_ref()?,
+        };
+        #[cfg(not(feature = "serve"))]
         let lines = self.active_preview_cache().parsed_text.as_ref()?;
         // Resolve `from_bottom` distances to absolute indices against the
         // SAME `total_lines` the renderer used this frame, so the copied
@@ -1083,6 +1104,11 @@ impl HomeView {
                 .pending_switch_view_session
                 .take()
                 .map(Action::SwitchSessionView),
+            #[cfg(feature = "serve")]
+            "start_daemon_structured" => self
+                .pending_daemon_start_session
+                .take()
+                .map(Action::StartDaemonThenOpenStructured),
             "quit_during_creation" => Some(Action::Quit),
             "quit" => Some(Action::Quit),
             _ => None,
@@ -2561,6 +2587,17 @@ impl HomeView {
             // (live-send, tmux attach) `Enter` doesn't. Only fires when
             // `live_send` is None (the live-send capture short-circuits above).
             KeyCode::Tab => {
+                // A structured session has neither a tmux pane to attach
+                // nor one to live-send into; both Tab meanings are
+                // vacuous. Say so instead of silently ignoring the press.
+                if let Some(id) = self.selected_session.as_deref() {
+                    if self.get_instance(id).is_some_and(|i| i.is_structured()) {
+                        return Some(Action::SetTransientStatus(
+                            "Structured sessions have no tmux pane; press Enter to open the structured view."
+                                .to_string(),
+                        ));
+                    }
+                }
                 let swap_to_attach = self
                     .selected_session
                     .as_deref()
@@ -2894,8 +2931,9 @@ impl HomeView {
             (
                 "Switch to structured view",
                 "Switch this session to the structured view? The tmux pane and its \
-                 scrollback are destroyed; the agent restarts under aoe serve with a \
-                 fresh conversation.",
+                 scrollback are destroyed; the agent restarts under the aoe serve \
+                 daemon (a local one is started if none is running) with a fresh \
+                 conversation.",
             )
         } else {
             (
@@ -2906,6 +2944,51 @@ impl HomeView {
         };
         self.pending_switch_view_session = Some(id);
         self.confirm_dialog = Some(ConfirmDialog::new(title, body, "switch_view"));
+    }
+
+    /// Offer to start a localhost daemon when opening a structured view
+    /// found no daemon running. Neutral tone: nothing is destroyed; the
+    /// user is just about to run a background process they may not have
+    /// expected. Remote setups keep their manual commands.
+    #[cfg(feature = "serve")]
+    pub(in crate::tui) fn prompt_start_daemon_for_structured(&mut self, session_id: &str) {
+        self.pending_daemon_start_session = Some(session_id.to_string());
+        self.confirm_dialog = Some(
+            ConfirmDialog::new(
+                "Start structured view daemon",
+                "No `aoe serve` daemon is running, and structured sessions are \
+                 driven by it. Start a local (localhost-only) daemon now? For \
+                 remote access instead, cancel and run `aoe serve --daemon \
+                 --remote` yourself.",
+                "start_daemon_structured",
+            )
+            .neutral(),
+        );
+    }
+
+    /// The selected session's id when it is a structured-view row and
+    /// not mid create/delete, else `None`. Drives preview-on-select:
+    /// the App mounts a streaming transcript preview for this session.
+    #[cfg(feature = "serve")]
+    pub(in crate::tui) fn selected_structured_session(&self) -> Option<String> {
+        let id = self.selected_session.clone()?;
+        let inst = self.get_instance(&id)?;
+        if inst.is_structured() && !matches!(inst.status, Status::Creating | Status::Deleting) {
+            Some(id)
+        } else {
+            None
+        }
+    }
+
+    /// Leave live-send mode if it is active, restoring pane sizing.
+    /// Used by the embedded structured view open path: both modes route
+    /// keystrokes away from the home view and paint the preview pane,
+    /// so they cannot coexist.
+    #[cfg(feature = "serve")]
+    pub(in crate::tui) fn exit_live_send_if_active(&mut self) {
+        if let Some(state) = self.live_send.clone() {
+            self.exit_live_send_and_restore_sizing(&state);
+        }
     }
 
     /// Open the new-session dialog seeded as a fork of the selected session.
@@ -3768,6 +3851,10 @@ impl HomeView {
             if inst.is_structured() {
                 #[cfg(feature = "serve")]
                 {
+                    // The embedded structured view takes over the preview
+                    // pane; leave live-send first so the two don't fight
+                    // over it (mirrors `exit_live_send_before_attach`).
+                    self.exit_live_send_if_active();
                     return Some(Action::OpenStructuredView(id));
                 }
                 #[cfg(not(feature = "serve"))]
@@ -3851,18 +3938,9 @@ impl HomeView {
             if matches!(inst.status, Status::Deleting | Status::Creating) {
                 return None;
             }
-            if inst.is_structured() {
-                #[cfg(feature = "serve")]
-                {
-                    return Some(Action::OpenStructuredView(id));
-                }
-                #[cfg(not(feature = "serve"))]
-                {
-                    return Some(Action::SetTransientStatus(
-                        "Acp session: rebuild with default features to attach".to_string(),
-                    ));
-                }
-            }
+            // Structured rows never reach here: the Tab keybinding
+            // refuses them with a "no tmux pane" toast before calling
+            // this resolver.
         }
         match self.view_mode {
             ViewMode::Structured => Some(Action::AttachSession(id)),

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -646,6 +646,27 @@ pub struct HomeView {
     /// Session whose persisted view flips (structured ↔ terminal) after the
     /// switch-view confirm dialog is accepted.
     pub(super) pending_switch_view_session: Option<String>,
+    /// Session whose structured-view open is waiting on the "start a
+    /// local daemon?" confirm (see `prompt_start_daemon_for_structured`).
+    #[cfg(feature = "serve")]
+    pub(super) pending_daemon_start_session: Option<String>,
+    /// The structured-view session mounted in the preview pane, if any:
+    /// a streaming transcript that `render_preview` paints as the
+    /// preview content for a selected structured row (read-only until
+    /// entered; see `EmbeddedView::is_active`). Owned here so the
+    /// preview renderer, info header, and drag-select all compose with
+    /// it; the `App` loop drives its async sides (connect, WS pump,
+    /// active-mode key routing).
+    #[cfg(feature = "serve")]
+    pub(in crate::tui) structured_preview:
+        Option<crate::tui::structured_view::embedded::EmbeddedView>,
+    /// True while the App's preview-on-select reconcile has picked a
+    /// structured session but its view hasn't finished mounting. The
+    /// preview renderer shows a quiet placeholder instead of the wordy
+    /// "press Enter" page, which otherwise flashes for the connect
+    /// window on every selection.
+    #[cfg(feature = "serve")]
+    pub(in crate::tui) structured_preview_pending: bool,
     /// Session to force-remove after the confirmation dialog is accepted
     pub(super) pending_force_remove_session: Option<String>,
     /// Session to trash after the `session.confirm_delete` dialog is accepted
@@ -2147,6 +2168,12 @@ impl HomeView {
             pending_stop_tool: None,
             pending_image_pull: None,
             pending_switch_view_session: None,
+            #[cfg(feature = "serve")]
+            pending_daemon_start_session: None,
+            #[cfg(feature = "serve")]
+            structured_preview: None,
+            #[cfg(feature = "serve")]
+            structured_preview_pending: false,
             pending_force_remove_session: None,
             pending_trash_session: None,
             pending_dialog_click_action: None,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2405,6 +2405,70 @@ impl HomeView {
         }
 
         if selected_structured {
+            // A mounted structured preview renders as first-class preview
+            // content: info header on top (same `i` toggle and layout as
+            // the terminal previews), the streaming transcript below, and
+            // the drag-select machinery pointed at the painted rows.
+            #[cfg(feature = "serve")]
+            {
+                let selected_id = self.selected_session.clone();
+                let mounted_matches = self
+                    .structured_preview
+                    .as_ref()
+                    .zip(selected_id.as_deref())
+                    .is_some_and(|(v, id)| v.session_id() == id);
+                if mounted_matches {
+                    // Take/put-back so the view's `&mut` render can't
+                    // fight the instance lookup's shared borrow of self.
+                    let mut view = self.structured_preview.take();
+                    let inst = selected_id.as_deref().and_then(|id| self.get_instance(id));
+                    let layout = preview::PreviewLayout::compute(
+                        inner,
+                        compact,
+                        self.show_preview_info,
+                        inst.map(preview::agent_info_height).unwrap_or(0),
+                    );
+                    if let (Some(info_area), Some(inst)) = (layout.info, inst) {
+                        preview::Preview::render_info(
+                            frame,
+                            info_area,
+                            inst,
+                            theme,
+                            self.idle_decay_window,
+                        );
+                    }
+                    // No ` Output ` banner row: the transcript block has
+                    // its own titled border, so the banner slot stays a
+                    // blank separator under the header.
+                    let geometry = view
+                        .as_mut()
+                        .and_then(|v| v.render(frame, layout.output, theme));
+                    self.structured_preview = view;
+                    self.preview_pane_area = layout.output;
+                    if let Some(g) = geometry {
+                        self.preview_visible_rows = g.text_area.height as usize;
+                        self.preview_text_view = crate::tui::home::PreviewTextView {
+                            pane: g.text_area,
+                            first_line: g.first_line,
+                            total_lines: g.total_lines,
+                        };
+                    }
+                    self.paint_preview_selection(frame, theme);
+                    return;
+                }
+                if self.structured_preview_pending {
+                    // A mount is underway (or about to start): render a
+                    // quiet beat instead of the wordy "press Enter" page,
+                    // which otherwise flashes on every selection.
+                    let para = Paragraph::new(Line::from(Span::styled(
+                        "…",
+                        Style::default().fg(theme.dimmed),
+                    )))
+                    .alignment(Alignment::Center);
+                    frame.render_widget(para, inner);
+                    return;
+                }
+            }
             self.render_structured_preview(frame, inner, theme);
             self.paint_preview_selection(frame, theme);
             return;
@@ -3091,7 +3155,7 @@ impl HomeView {
                 Span::styled("Press ", Style::default().fg(theme.dimmed)),
                 Span::styled("Enter", Style::default().fg(theme.hint).bold()),
                 Span::styled(
-                    " to open it (needs a running `aoe serve` daemon).",
+                    " to open it (offers to start a local `aoe serve` daemon if none is running).",
                     Style::default().fg(theme.dimmed),
                 ),
             ]),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -2274,7 +2274,15 @@ impl HomeView {
             // visible height is `inner_height` (no extra row dropped). That
             // equals `PreviewLayout::compute(..).output.height` for the
             // hidden-header case, which is what the renderers paint into.
-            let scroll_indicator = if !self.show_preview_info {
+            // A mounted structured preview owns its own scroll state (the
+            // transcript scrolls inside the embedded view); the generic
+            // indicator below reads the tmux capture cache and home's
+            // wheel offset, both of which are stale or empty for it.
+            #[cfg(feature = "serve")]
+            let structured_mounted = self.structured_preview.is_some();
+            #[cfg(not(feature = "serve"))]
+            let structured_mounted = false;
+            let scroll_indicator = if !self.show_preview_info && !structured_mounted {
                 let inner_height = area.height.saturating_sub(2);
                 let visible_height = inner_height as usize;
                 let captured_lines = self.active_captured_lines();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14181,9 +14181,10 @@ mod live_send_mode {
     #[test]
     #[serial]
     fn tab_does_not_start_live_send_for_acp_session() {
-        // Acp sessions are not tmux-backed, so live-send has no
-        // valid target. Tab must silently no-op rather than enqueue
-        // an Action::EnterLiveSend that would fail downstream.
+        // Acp sessions are not tmux-backed, so live-send has no valid
+        // target. Tab must refuse with a visible "no tmux pane" toast
+        // (a silent no-op reads as a broken key) and must never
+        // enqueue an Action::EnterLiveSend that would fail downstream.
         let mut env = create_test_env_with_sessions(1);
         env.view.cursor = 0;
         env.view.update_selected();
@@ -14203,7 +14204,13 @@ mod live_send_mode {
         let action = env
             .view
             .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE), None);
-        assert!(action.is_none(), "expected no action, got {:?}", action);
+        assert!(
+            matches!(
+                &action,
+                Some(Action::SetTransientStatus(msg)) if msg.contains("no tmux pane")
+            ),
+            "Tab on a structured row must surface the no-tmux-pane toast, got {action:?}"
+        );
         assert!(env.view.live_send.is_none());
     }
 

--- a/src/tui/structured_view/embedded.rs
+++ b/src/tui/structured_view/embedded.rs
@@ -1,0 +1,231 @@
+//! Embedded (preview-pane) variant of the structured view.
+//!
+//! The full-screen loop in the parent module owns the terminal and the
+//! event stream for the duration of the view. The embedded variant
+//! instead lives inside the home screen's `App` loop, rendering into
+//! the preview pane while the session list stays visible, mirroring
+//! how live-send drives a terminal agent without leaving the home view.
+//!
+//! Split of responsibilities with the `App` loop:
+//! - [`EmbeddedView::next_event`] is the cancel-safe await the App's
+//!   `tokio::select!` races against its other arms. It only ever awaits
+//!   channel receives, so dropping the future mid-poll loses nothing.
+//! - [`EmbeddedView::apply_event`] runs in the winning arm's body
+//!   (never cancelled) and may perform HTTP work: replay rehydration,
+//!   queue drains, the bounded-backoff reconnect.
+//! - Terminal input routes through [`EmbeddedView::handle_event`],
+//!   which shares the parent module's intent dispatcher, so keybindings
+//!   cannot drift from the full-screen view.
+
+use anyhow::Result;
+use crossterm::event::Event as CrosstermEvent;
+use ratatui::layout::Rect;
+use ratatui::Frame;
+use tokio::time::Instant;
+
+use super::state::{StructuredViewState, ToastKind};
+use super::{
+    apply_ws_message, drain_plugin_toast, handle_terminal_event, render, set_toast, setup_view,
+    ViewSetup,
+};
+use crate::acp::client::{DaemonEndpoint, WsError, WsMessage};
+use crate::acp::session_paths::SessionPathRoots;
+use crate::plugin::ui_state::UiSnapshot;
+use crate::tui::styles::Theme;
+
+/// One event surfaced by [`EmbeddedView::next_event`], applied by
+/// [`EmbeddedView::apply_event`]. The two-phase shape exists for
+/// cancellation safety; see the module docs.
+pub enum EmbeddedEvent {
+    /// A WebSocket message, or `None` when the ws channel closed.
+    Ws(Option<Result<WsMessage, WsError>>),
+    Plugin(UiSnapshot),
+    PathRoots(Result<SessionPathRoots, String>),
+}
+
+pub struct EmbeddedView {
+    state: StructuredViewState,
+    toast_deadline: Option<Instant>,
+    plugin_rx: tokio::sync::mpsc::Receiver<UiSnapshot>,
+    path_roots_rx: tokio::sync::mpsc::Receiver<Result<SessionPathRoots, String>>,
+    /// Preview vs. interactive. A view is mounted (streaming, rendered
+    /// in the preview pane) as soon as its session is selected, but the
+    /// keyboard only routes to it once activated (Enter), the same
+    /// preview-then-enter model terminal sessions use for live-send.
+    active: bool,
+}
+
+impl EmbeddedView {
+    /// Connect to `session_id` on an already-located daemon: hydrate
+    /// the transcript, open the WebSocket, spawn the side-channel
+    /// tasks. Startup errors (replay/ws) surface as a toast rather
+    /// than a hard failure, matching the full-screen view. Starts in
+    /// preview (inactive) state.
+    pub async fn connect(endpoint: DaemonEndpoint, session_id: &str) -> Result<Self> {
+        let ViewSetup {
+            state,
+            startup_toast,
+            plugin_rx,
+            path_roots_rx,
+        } = setup_view(endpoint, session_id).await?;
+        let mut view = Self {
+            state,
+            toast_deadline: None,
+            plugin_rx,
+            path_roots_rx,
+            active: false,
+        };
+        if let Some(text) = startup_toast {
+            set_toast(
+                &mut view.state,
+                &mut view.toast_deadline,
+                text,
+                ToastKind::Error,
+            );
+        }
+        // A question already pending in the replay presents its menu now.
+        super::auto_present_elicitation(&mut view.state, &mut view.toast_deadline);
+        Ok(view)
+    }
+
+    /// The session this view is streaming.
+    pub fn session_id(&self) -> &str {
+        &self.state.session_id
+    }
+
+    /// Whether the keyboard is routed to this view (interactive) rather
+    /// than the home list (preview).
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Enter interactive mode: the composer takes the keyboard and the
+    /// caret shows. Focus returns to the composer so typing works at
+    /// once (a pending approval re-grabs it on the next reconcile).
+    pub fn activate(&mut self) {
+        self.active = true;
+        if matches!(self.state.focus, super::input::Focus::Transcript) {
+            self.state.focus = super::input::Focus::Composer;
+        }
+    }
+
+    /// Leave interactive mode back to a read-only preview (Ctrl+Q). The
+    /// view stays mounted and streaming.
+    pub fn deactivate(&mut self) {
+        self.active = false;
+    }
+
+    /// Await the next daemon-side event. Cancel-safe: only channel
+    /// receives are awaited, so the App loop may freely race this
+    /// against terminal input and drop the losing future. With no live
+    /// WebSocket the ws arm pends forever and only the side channels
+    /// can wake us, mirroring the full-screen loop's do-not-spin
+    /// behavior after a failed reconnect.
+    pub async fn next_event(&mut self) -> EmbeddedEvent {
+        let ws = self.state.ws.as_mut();
+        tokio::select! {
+            msg = async {
+                match ws {
+                    Some(handle) => handle.recv().await,
+                    None => std::future::pending().await,
+                }
+            } => EmbeddedEvent::Ws(msg),
+            Some(snapshot) = self.plugin_rx.recv() => EmbeddedEvent::Plugin(snapshot),
+            Some(result) = self.path_roots_rx.recv() => EmbeddedEvent::PathRoots(result),
+        }
+    }
+
+    /// Apply one event from [`next_event`]. May perform HTTP work
+    /// (replay, drain, reconnect); the caller must not race this
+    /// against other futures.
+    pub async fn apply_event(&mut self, event: EmbeddedEvent) {
+        match event {
+            EmbeddedEvent::Ws(Some(msg)) => {
+                apply_ws_message(&mut self.state, &mut self.toast_deadline, msg).await;
+            }
+            EmbeddedEvent::Ws(None) => {
+                // Channel closed without an error frame: treat as a
+                // disconnect so `next_event` stops polling the dead
+                // handle and is_busy() queues new prompts.
+                self.state.ws = None;
+                self.state.in_flight = false;
+                set_toast(
+                    &mut self.state,
+                    &mut self.toast_deadline,
+                    "ws closed".into(),
+                    ToastKind::Error,
+                );
+            }
+            EmbeddedEvent::Plugin(snapshot) => {
+                self.state.ingest_plugin_ui(snapshot);
+                drain_plugin_toast(&mut self.state, &mut self.toast_deadline);
+            }
+            EmbeddedEvent::PathRoots(result) => match result {
+                Ok(roots) => self.state.path_roots = Some(roots),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "acp.tui",
+                        "session path roots fetch failed; rendering raw paths: {e}"
+                    );
+                }
+            },
+        }
+    }
+
+    /// Route one terminal event (key / paste / mouse) through the
+    /// shared intent dispatcher. Returns `true` when the user asked to
+    /// exit the view (Esc from the transcript).
+    pub async fn handle_event(&mut self, evt: CrosstermEvent) -> Result<bool> {
+        handle_terminal_event(&mut self.state, evt, &mut self.toast_deadline).await
+    }
+
+    /// Periodic housekeeping driven by the App's refresh ticker:
+    /// expire the toast and surface the next queued plugin
+    /// notification. Returns `true` when something visible changed.
+    pub fn tick(&mut self) -> bool {
+        let mut changed = false;
+        if let Some(deadline) = self.toast_deadline {
+            if Instant::now() >= deadline {
+                self.state.toast = None;
+                self.toast_deadline = None;
+                changed = true;
+            }
+        }
+        let had_toast = self.state.toast.is_some();
+        drain_plugin_toast(&mut self.state, &mut self.toast_deadline);
+        changed || (self.state.toast.is_some() != had_toast)
+    }
+
+    /// Render into `area` (the home view's preview body). Also stashes
+    /// the computed layout, in real frame coordinates, so subsequent
+    /// mouse events hit-test against what is actually on screen.
+    /// Returns the transcript geometry so the home view can point its
+    /// drag-select machinery at the painted rows.
+    pub fn render(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+    ) -> Option<render::TranscriptGeometry> {
+        if area.width == 0 || area.height == 0 {
+            return None;
+        }
+        // The home view may have painted placeholder content under us
+        // this frame; the structured renderer assumes an empty buffer
+        // (it grew up full-screen) and skips cells with no content, so
+        // reset the area first or stale text shows through.
+        frame.render_widget(ratatui::widgets::Clear, area);
+        self.state.layout = Some(render::compute_layout(area, &self.state));
+        Some(render::render(frame, area, theme, &self.state, self.active))
+    }
+
+    /// The transcript as the exact pre-wrapped rows the last render
+    /// painted at `width` columns. The home view's selection extraction
+    /// slices these by (row, column), so they must match the on-screen
+    /// geometry; sharing `wrapped_transcript` with the renderer
+    /// guarantees it. Styles are irrelevant to extraction, so a default
+    /// theme keeps this callable without one.
+    pub fn selection_text(&self, width: u16) -> ratatui::text::Text<'static> {
+        render::wrapped_transcript(&self.state, &crate::tui::styles::Theme::default(), width)
+    }
+}

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -1,14 +1,20 @@
 //! Focus model + key dispatch for the structured view.
 //!
-//! Three focusable regions: composer, transcript, and (when one is
-//! pending) approval card. The composer captures **every** key when
-//! focused, including `a`/`A`/`d`, so typing "always allow" into a
-//! prompt never resolves an approval. `Esc` from any region except
-//! composer exits the view; from composer it returns focus to the
-//! transcript.
+//! The view is meant to feel like a native coding agent. The composer
+//! is the home base: the view lands there so you can type immediately,
+//! and reading history never requires a focus switch (the mouse wheel
+//! and `PageUp`/`PageDown` scroll the transcript from the composer).
+//! `Ctrl-Q` leaves the view, mirroring live-send's exit chord; `Esc` is
+//! an agent-style interrupt (it cancels a generating turn, and is a
+//! no-op when idle), never an exit. The transcript is a secondary focus
+//! reached with `Tab` for its power keys (scroll, mode picker, browser,
+//! elicitation answers); `Esc` there returns to the composer. The
+//! composer captures **every** typed key, including `a`/`A`/`d`, so
+//! typing "always allow" into a prompt never resolves an approval; a
+//! pending approval is resolved by `Tab`-ing to its card (or clicking
+//! it) and then pressing `a`/`A`/`d`.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use ratatui::layout::Position;
 
 use super::state::ViewLayout;
 use crate::acp::protocol::ApprovalDecisionWire;
@@ -115,6 +121,10 @@ pub struct InputContext {
     pub choice_picker_open: bool,
     /// The agent advertised permission modes; gates the transcript `m` key.
     pub has_modes: bool,
+    /// The agent is generating (a turn is active or a prompt is in
+    /// flight). Gates `Esc` in the composer: while busy it interrupts
+    /// the turn like a native agent, and is an inert no-op when idle.
+    pub agent_busy: bool,
 }
 
 /// Translate a key event into an [`Intent`] based on the current
@@ -127,6 +137,13 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
     // is "stop the agent, don't quit the screen."
     if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
         return Intent::CancelInFlight;
+    }
+    // Universal: Ctrl-q leaves the view, mirroring live-send's exit chord
+    // so "get me out" is the same reflex whether you're driving a raw
+    // tmux agent or the structured view. Placed among the universal
+    // chords so it works from any focus (composer, transcript, approval).
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('q') {
+        return Intent::Exit;
     }
     // Universal: Ctrl-o opens the browser. `o` alone is reserved for
     // transcript-focus so typing "no" into the composer doesn't open a
@@ -167,6 +184,10 @@ pub fn dispatch(focus: Focus, key: &KeyEvent, ctx: InputContext) -> Intent {
 /// screen's preview wheel step.
 const WHEEL_SCROLL_LINES: i32 = 3;
 
+/// Transcript lines scrolled per `PageUp`/`PageDown`, from either the
+/// transcript or the composer.
+const PAGE_SCROLL_LINES: i32 = 10;
+
 /// Translate a mouse event into an [`Intent`]. The wheel always scrolls
 /// the transcript (whatever pane the pointer is over; the composer and
 /// status line have no scrollback of their own), and a left click moves
@@ -177,18 +198,14 @@ pub fn dispatch_mouse(mouse: &MouseEvent, layout: Option<&ViewLayout>) -> Intent
     match mouse.kind {
         MouseEventKind::ScrollUp => Intent::Scroll(-WHEEL_SCROLL_LINES),
         MouseEventKind::ScrollDown => Intent::Scroll(WHEEL_SCROLL_LINES),
+        // A click anywhere in the view focuses the composer: it is one
+        // pane, so clicking the chat to read never puts you in a
+        // separate "transcript mode" you'd have to click back out of.
+        // (`layout` is unused now but kept in the signature so a future
+        // click-target, e.g. an approval button, has the geometry.)
         MouseEventKind::Down(MouseButton::Left) => {
-            let Some(layout) = layout else {
-                return Intent::Ignore;
-            };
-            let pos = Position::new(mouse.column, mouse.row);
-            if layout.composer.contains(pos) {
-                Intent::SetFocus(Focus::Composer)
-            } else if layout.transcript.contains(pos) {
-                Intent::SetFocus(Focus::Transcript)
-            } else {
-                Intent::Ignore
-            }
+            let _ = layout;
+            Intent::SetFocus(Focus::Composer)
         }
         _ => Intent::Ignore,
     }
@@ -274,12 +291,36 @@ fn composer_keys(key: &KeyEvent, ctx: InputContext) -> Intent {
         (m, KeyCode::Char('j')) if m == KeyModifiers::CONTROL => {
             Intent::Compose(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
         }
-        // Esc moves focus to the transcript so the user can scroll or
-        // pick an approval card. This also dismisses any accidental
-        // composer focus (e.g. after typing then changing their mind).
-        (m, KeyCode::Esc) if m.is_empty() => Intent::SetFocus(Focus::Transcript),
-        // Tab cycles forward through the focus regions.
-        (m, KeyCode::Tab) if m.is_empty() => Intent::SetFocus(Focus::Transcript),
+        // Page keys scroll the transcript without leaving the composer,
+        // so reading history never needs a focus switch (the mouse wheel
+        // does the same from any focus). PageUp/PageDown aren't textarea
+        // editing keys, so nothing is lost by claiming them here.
+        (m, KeyCode::PageUp) if m.is_empty() => Intent::Scroll(-PAGE_SCROLL_LINES),
+        (m, KeyCode::PageDown) if m.is_empty() => Intent::Scroll(PAGE_SCROLL_LINES),
+        // Esc is native-agent behavior, not an exit (Ctrl-Q leaves the
+        // view). While the agent is generating it interrupts the turn,
+        // the same reflex as hitting Esc in a raw agent session; when
+        // idle it is an inert no-op so a stray Esc never drops you out.
+        // Pickers and queue-browse intercept Esc above.
+        (m, KeyCode::Esc) if m.is_empty() => {
+            if ctx.agent_busy {
+                Intent::CancelInFlight
+            } else {
+                Intent::Ignore
+            }
+        }
+        // Shift+Tab opens the permission-mode picker, mirroring Claude
+        // Code's mode-cycle chord. It's the one "power" control that
+        // used to live behind the transcript focus; everything else
+        // (scroll, browser, exit) is reachable from the composer now, so
+        // there is no Tab-to-the-chat toggle at all. crossterm reports
+        // Shift+Tab as BackTab. A no-op when the agent advertised no
+        // modes. Plain Tab is inert (pickers claim it above to accept).
+        (_, KeyCode::BackTab) if ctx.has_modes => Intent::OpenModePicker,
+        // BackTab is never text; swallow it even with no modes so it
+        // can't leak into the composer as a stray character.
+        (_, KeyCode::BackTab) => Intent::Ignore,
+        (m, KeyCode::Tab) if m.is_empty() => Intent::Ignore,
         // Everything else is forwarded to the textarea, including
         // `a`/`A`/`d`. This is the focus-isolation guarantee.
         _ => Intent::Compose(*key),
@@ -303,8 +344,10 @@ fn transcript_keys(key: &KeyEvent, ctx: InputContext) -> Intent {
         }
         // Permission-mode picker, when the agent advertised modes.
         (m, KeyCode::Char('m')) if m.is_empty() && ctx.has_modes => Intent::OpenModePicker,
-        // Exit / dismiss.
-        (m, KeyCode::Esc) if m.is_empty() => Intent::Exit,
+        // Esc returns to the composer (the home base), not straight out:
+        // the transcript is a secondary focus you Tab into for its power
+        // keys, so Esc backs out one level rather than leaving the view.
+        (m, KeyCode::Esc) if m.is_empty() => Intent::SetFocus(Focus::Composer),
         // Switch to composer.
         (m, KeyCode::Char('i')) if m.is_empty() => Intent::SetFocus(Focus::Composer),
         (m, KeyCode::Tab) if m.is_empty() => {
@@ -319,8 +362,8 @@ fn transcript_keys(key: &KeyEvent, ctx: InputContext) -> Intent {
         (m, KeyCode::Char('k')) if m.is_empty() => Intent::Scroll(-1),
         (m, KeyCode::Down) if m.is_empty() => Intent::Scroll(1),
         (m, KeyCode::Up) if m.is_empty() => Intent::Scroll(-1),
-        (m, KeyCode::PageDown) if m.is_empty() => Intent::Scroll(10),
-        (m, KeyCode::PageUp) if m.is_empty() => Intent::Scroll(-10),
+        (m, KeyCode::PageDown) if m.is_empty() => Intent::Scroll(PAGE_SCROLL_LINES),
+        (m, KeyCode::PageUp) if m.is_empty() => Intent::Scroll(-PAGE_SCROLL_LINES),
         (m, KeyCode::Char('g')) if m.is_empty() => Intent::Scroll(i32::MIN),
         (m, KeyCode::Char('G')) if m.contains(KeyModifiers::SHIFT) => Intent::Scroll(i32::MAX),
         // Plain 'o' opens browser only when transcript is focused.
@@ -340,8 +383,11 @@ fn approval_keys(key: &KeyEvent) -> Intent {
         (m, KeyCode::Char('d')) if m.is_empty() => {
             Intent::ResolveApproval(ApprovalDecisionWire::Deny)
         }
-        (m, KeyCode::Esc) if m.is_empty() => Intent::SetFocus(Focus::Transcript),
-        (m, KeyCode::Tab) if m.is_empty() => Intent::SetFocus(Focus::Composer),
+        // A pending approval is modal (it grabs focus like a native
+        // permission prompt), so Esc interrupts the turn rather than
+        // trying to "leave" the prompt: cancelling clears the request
+        // and drops you back to the composer.
+        (m, KeyCode::Esc) if m.is_empty() => Intent::CancelInFlight,
         _ => Intent::Ignore,
     }
 }
@@ -570,15 +616,94 @@ mod tests {
     }
 
     #[test]
-    fn esc_from_composer_returns_focus_to_transcript() {
-        let intent = dispatch(Focus::Composer, &key(KeyCode::Esc), ctx());
-        assert_eq!(intent, Intent::SetFocus(Focus::Transcript));
+    fn esc_in_composer_is_native_interrupt_not_exit() {
+        // Idle: Esc is an inert no-op (never drops out of the view).
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Esc), ctx()),
+            Intent::Ignore
+        );
+        // Generating: Esc interrupts the turn, like a native agent.
+        let busy = InputContext {
+            agent_busy: true,
+            ..InputContext::default()
+        };
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Esc), busy),
+            Intent::CancelInFlight
+        );
     }
 
     #[test]
-    fn esc_from_transcript_exits() {
+    fn ctrl_q_exits_from_any_focus() {
+        // Ctrl-Q is the single way out, mirroring live-send's exit chord.
+        for focus in [Focus::Composer, Focus::Transcript, Focus::Approval] {
+            assert_eq!(
+                dispatch(
+                    focus,
+                    &key_mod(KeyCode::Char('q'), KeyModifiers::CONTROL),
+                    ctx_pending()
+                ),
+                Intent::Exit
+            );
+        }
+        // Plain 'q' in the composer is still a typed character.
+        assert!(matches!(
+            dispatch(Focus::Composer, &key(KeyCode::Char('q')), ctx()),
+            Intent::Compose(_)
+        ));
+    }
+
+    #[test]
+    fn esc_from_transcript_returns_to_composer() {
+        // The transcript is a secondary focus; Esc backs out to the
+        // composer rather than leaving the view.
         let intent = dispatch(Focus::Transcript, &key(KeyCode::Esc), ctx());
-        assert_eq!(intent, Intent::Exit);
+        assert_eq!(intent, Intent::SetFocus(Focus::Composer));
+    }
+
+    #[test]
+    fn page_keys_scroll_transcript_from_composer() {
+        // Reading history never requires leaving the composer.
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::PageUp), ctx()),
+            Intent::Scroll(-PAGE_SCROLL_LINES)
+        );
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::PageDown), ctx()),
+            Intent::Scroll(PAGE_SCROLL_LINES)
+        );
+    }
+
+    #[test]
+    fn tab_is_inert_and_shift_tab_opens_mode_picker() {
+        // There is no Tab-to-the-chat toggle anymore: plain Tab is inert.
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::Tab), ctx()),
+            Intent::Ignore
+        );
+        // Shift+Tab (crossterm BackTab) opens the mode picker when the
+        // agent advertised modes, mirroring Claude Code's mode chord.
+        let with_modes = InputContext {
+            has_modes: true,
+            ..InputContext::default()
+        };
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::BackTab), with_modes),
+            Intent::OpenModePicker
+        );
+        // Without modes it's inert (nothing to pick).
+        assert_eq!(
+            dispatch(Focus::Composer, &key(KeyCode::BackTab), ctx()),
+            Intent::Ignore
+        );
+    }
+
+    #[test]
+    fn esc_from_approval_interrupts() {
+        // The approval is modal (it grabbed focus), so Esc interrupts the
+        // turn, which cancels the request and hands focus back.
+        let intent = dispatch(Focus::Approval, &key(KeyCode::Esc), ctx_pending());
+        assert_eq!(intent, Intent::CancelInFlight);
     }
 
     #[test]
@@ -782,9 +907,10 @@ mod tests {
             dispatch(Focus::Composer, &key(KeyCode::Esc), ctx_mention()),
             Intent::MentionClose
         );
+        // With the picker closed and idle, Esc is an inert no-op.
         assert_eq!(
             dispatch(Focus::Composer, &key(KeyCode::Esc), ctx()),
-            Intent::SetFocus(Focus::Transcript)
+            Intent::Ignore
         );
     }
 
@@ -891,10 +1017,10 @@ mod tests {
             ),
             Intent::RecallCancel
         );
-        // Not browsing: Esc still returns focus to the transcript.
+        // Not browsing and idle: Esc is an inert no-op (Ctrl-Q exits).
         assert_eq!(
             dispatch(Focus::Composer, &key(KeyCode::Esc), ctx()),
-            Intent::SetFocus(Focus::Transcript)
+            Intent::Ignore
         );
     }
 
@@ -953,40 +1079,33 @@ mod tests {
     }
 
     #[test]
-    fn left_click_focuses_pane_under_pointer() {
+    fn left_click_always_focuses_composer() {
+        // One pane: a click anywhere (transcript, composer, status row)
+        // focuses the composer, so reading the chat never drops you into
+        // a separate mode you'd have to click back out of.
         let l = layout();
-        assert_eq!(
-            dispatch_mouse(
-                &mouse(MouseEventKind::Down(MouseButton::Left), 10, 22),
-                Some(&l)
-            ),
-            Intent::SetFocus(Focus::Composer)
-        );
-        assert_eq!(
-            dispatch_mouse(
-                &mouse(MouseEventKind::Down(MouseButton::Left), 10, 3),
-                Some(&l)
-            ),
-            Intent::SetFocus(Focus::Transcript)
-        );
-        // The status row belongs to no focusable pane.
-        assert_eq!(
-            dispatch_mouse(
-                &mouse(MouseEventKind::Down(MouseButton::Left), 10, 20),
-                Some(&l)
-            ),
-            Intent::Ignore
-        );
+        for row in [3u16, 20, 22] {
+            assert_eq!(
+                dispatch_mouse(
+                    &mouse(MouseEventKind::Down(MouseButton::Left), 10, row),
+                    Some(&l)
+                ),
+                Intent::SetFocus(Focus::Composer),
+                "click at row {row}"
+            );
+        }
     }
 
     #[test]
-    fn click_before_first_draw_is_ignored() {
+    fn click_before_first_draw_focuses_composer() {
+        // No layout yet: a click still just focuses the composer (there
+        // is only one focus target), no hit-test needed.
         assert_eq!(
             dispatch_mouse(
                 &mouse(MouseEventKind::Down(MouseButton::Left), 10, 10),
                 None
             ),
-            Intent::Ignore
+            Intent::SetFocus(Focus::Composer)
         );
     }
 

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -8,6 +8,7 @@
 //! with `src/acp/` per the recipe in
 //! <https://github.com/agent-of-empires/agent-of-empires/issues/1018#issuecomment-4444040929>.
 
+pub mod embedded;
 pub mod input;
 pub mod mention;
 pub mod queue;
@@ -115,12 +116,11 @@ pub async fn run_standalone(session_id: &str) -> anyhow::Result<()> {
     result
 }
 
-/// Open the structured view for `session_id` and run its event loop until
-/// the user exits with `Esc`, or until the structured view daemon becomes
-/// unreachable in a way the view can't recover from.
-///
-/// Borrows the host terminal + event stream so the parent App can
-/// resume rendering when the view returns.
+/// Open the full-screen structured view for `session_id` and run its
+/// event loop until the user exits with `Esc`, or until the structured
+/// view daemon becomes unreachable in a way the view can't recover
+/// from. Used by the standalone `aoe acp attach` path; the home screen
+/// embeds the view in its preview pane instead (see [`embedded`]).
 pub async fn run(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     event_stream: &mut EventStream,
@@ -147,21 +147,75 @@ pub async fn run(
             wait_for_dismiss(event_stream).await?;
             return Ok(());
         }
-        Err(e @ ManagerError::NoDaemonRunning(_)) => {
-            // Carries the multi-line "start one with..." hint from the
-            // error variant. Render as-is so the user sees the choice
-            // between localhost/Tailscale/Cloudflare without having to
-            // dig through docs.
-            render_error_screen(
-                terminal,
-                theme,
-                &format!("{e}\n\nPress any key to return to the session list."),
-            )?;
-            wait_for_dismiss(event_stream).await?;
-            return Ok(());
+        Err(ManagerError::NoDaemonRunning(_)) => {
+            // Not a dead end: a structured session cannot function
+            // without the daemon, so offer to start a localhost one
+            // right here (Enter). Remote modes keep their manual
+            // commands on the same screen; auto-picking a tunnel on
+            // the user's behalf would hide that choice.
+            match offer_daemon_start(terminal, event_stream, theme).await? {
+                Some(endpoint) => endpoint,
+                None => return Ok(()),
+            }
         }
     };
     run_for_endpoint(terminal, event_stream, theme, endpoint, session_id).await
+}
+
+/// Render the "no daemon running" screen with a one-key recovery:
+/// Enter spawns a localhost daemon (via the serve dialog's shared
+/// spawn path) and waits for it to become healthy, then returns its
+/// endpoint so the caller can proceed straight into the view. Any
+/// other key returns `None` (back to the session list). Spawn or
+/// health-check failures render an error screen and also return
+/// `None` after a dismiss keypress.
+async fn offer_daemon_start(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    event_stream: &mut EventStream,
+    theme: &Theme,
+) -> Result<Option<DaemonEndpoint>> {
+    render_error_screen(
+        terminal,
+        theme,
+        "No structured view daemon is running.\n\n\
+         The structured view is driven by the `aoe serve` daemon.\n\n  \
+         Enter  start a local daemon now\n  \
+         Esc    back to the session list\n\n\
+         For remote access, start one by hand instead:\n  \
+         aoe serve --daemon --remote        (Tailscale Funnel or Cloudflare quick tunnel)\n  \
+         aoe serve --daemon --tunnel-name … (named Cloudflare Tunnel)\n\n\
+         Or attach to an existing remote daemon with:\n  \
+         AOE_DAEMON_URL=<url> AOE_DAEMON_TOKEN=<token> aoe …",
+    )?;
+    loop {
+        let Some(evt) = event_stream.next().await else {
+            return Ok(None);
+        };
+        match evt.context("read terminal event")? {
+            CrosstermEvent::Key(key) if key.kind != KeyEventKind::Release => {
+                if key.code == crossterm::event::KeyCode::Enter {
+                    break;
+                }
+                return Ok(None);
+            }
+            _ => {}
+        }
+    }
+    render_error_screen(terminal, theme, "Starting local daemon…")?;
+    match crate::tui::dialogs::start_local_daemon_and_wait().await {
+        Ok(endpoint) => Ok(Some(endpoint)),
+        Err(e) => {
+            render_error_screen(
+                terminal,
+                theme,
+                &format!(
+                    "Failed to start the daemon: {e}\n\nPress any key to return to the session list."
+                ),
+            )?;
+            wait_for_dismiss(event_stream).await?;
+            Ok(None)
+        }
+    }
 }
 
 /// Same as [`run`] but the caller has already located the daemon
@@ -169,13 +223,24 @@ pub async fn run(
 /// step against a fixed `AOE_DAEMON_URL`). Skips `require_daemon` so
 /// the view doesn't re-run discovery / health-check when the caller
 /// has already done it.
-pub async fn run_for_endpoint(
-    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-    event_stream: &mut EventStream,
-    theme: &Theme,
-    endpoint: DaemonEndpoint,
-    session_id: &str,
-) -> Result<()> {
+/// Everything a structured-view surface needs after connecting: the
+/// hydrated state, the folded startup error (if any), and the two
+/// side-channel receivers (plugin UI snapshots, session path roots).
+/// Shared by the full-screen loop and the embedded (preview-pane)
+/// variant so the two cannot drift.
+struct ViewSetup {
+    state: StructuredViewState,
+    startup_toast: Option<String>,
+    plugin_rx: tokio::sync::mpsc::Receiver<UiSnapshot>,
+    path_roots_rx:
+        tokio::sync::mpsc::Receiver<Result<crate::acp::session_paths::SessionPathRoots, String>>,
+}
+
+/// Hydrate the transcript via /replay, open the WebSocket, and spawn
+/// the side-channel tasks (path roots fetch, plugin UI-state poll).
+/// Both spawned tasks exit once their receiver is dropped, so the
+/// setup owns no cleanup obligations beyond dropping the `ViewSetup`.
+async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSetup> {
     let http = HttpClient::new(endpoint.clone()).context("build structured view HTTP client")?;
 
     // Hydrate the transcript via /replay before opening the WebSocket
@@ -190,10 +255,12 @@ pub async fn run_for_endpoint(
     };
 
     let mut state = StructuredViewState::new(session_id.to_string(), endpoint, http, ws);
-    state.focus = Focus::Transcript;
+    // Land in the composer so the user can type immediately, live-view
+    // style. Reading history is scroll (wheel / PageUp/PageDown), not a
+    // focus switch, so there is no "which pane am I in" juggling.
+    state.focus = Focus::Composer;
 
-    let mut toast_deadline: Option<Instant> = None;
-    let (path_roots_tx, mut path_roots_rx) = tokio::sync::mpsc::channel(1);
+    let (path_roots_tx, path_roots_rx) = tokio::sync::mpsc::channel(1);
     {
         let http = state.http.clone();
         let session_id = state.session_id.clone();
@@ -217,6 +284,9 @@ pub async fn run_for_endpoint(
             for frame in &replay.frames {
                 state.transcript.apply(frame);
             }
+            // `reconcile_selection` also focus-grabs a pending approval
+            // (modal). A pending elicitation is auto-presented by the
+            // caller, which owns the toast deadline its menu needs.
             state.reconcile_selection();
             state.reconcile_slash_selection();
             None
@@ -239,19 +309,10 @@ pub async fn run_for_endpoint(
         (None, None) => None,
     };
 
-    if let Some(text) = startup_toast {
-        set_toast(&mut state, &mut toast_deadline, text, ToastKind::Error);
-    }
-
-    redraw(terminal, theme, &mut state)?;
-
-    let mut redraw_ticker = tokio::time::interval(REDRAW_INTERVAL);
-    redraw_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
     // Poll the daemon's plugin UI-state on its own task and stream snapshots
     // back over a channel, so a slow daemon stalls neither input nor render.
     // The task exits once the view returns and drops the receiver.
-    let (plugin_tx, mut plugin_rx) = tokio::sync::mpsc::channel::<UiSnapshot>(8);
+    let (plugin_tx, plugin_rx) = tokio::sync::mpsc::channel::<UiSnapshot>(8);
     {
         let http = state.http.clone();
         tokio::spawn(async move {
@@ -276,6 +337,41 @@ pub async fn run_for_endpoint(
         });
     }
 
+    Ok(ViewSetup {
+        state,
+        startup_toast,
+        plugin_rx,
+        path_roots_rx,
+    })
+}
+
+pub async fn run_for_endpoint(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    event_stream: &mut EventStream,
+    theme: &Theme,
+    endpoint: DaemonEndpoint,
+    session_id: &str,
+) -> Result<()> {
+    let ViewSetup {
+        mut state,
+        startup_toast,
+        mut plugin_rx,
+        mut path_roots_rx,
+    } = setup_view(endpoint, session_id).await?;
+
+    let mut toast_deadline: Option<Instant> = None;
+    if let Some(text) = startup_toast {
+        set_toast(&mut state, &mut toast_deadline, text, ToastKind::Error);
+    }
+    // A question already pending in the replay presents its menu now, so
+    // opening onto a waiting elicitation shows the prompt immediately.
+    auto_present_elicitation(&mut state, &mut toast_deadline);
+
+    redraw(terminal, theme, &mut state)?;
+
+    let mut redraw_ticker = tokio::time::interval(REDRAW_INTERVAL);
+    redraw_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
     loop {
         tokio::select! {
             biased;
@@ -294,85 +390,8 @@ pub async fn run_for_endpoint(
             }
             ws_msg = recv_ws(&mut state) => {
                 match ws_msg {
-                    Some(Ok(WsMessage::Frame(frame))) => {
-                        let was_active = state.transcript.turn_active;
-                        state.transcript.apply(&frame);
-                        state.reconcile_selection();
-                        state.reconcile_slash_selection();
-                        let now_active = state.transcript.turn_active;
-                        if !was_active && now_active {
-                            // Turn started (our own prompt echoed back, or
-                            // another client's). The optimistic lock has
-                            // served its purpose; release it.
-                            state.in_flight = false;
-                        } else if was_active && !now_active {
-                            // Turn ended: release the lock and drain the
-                            // next queued batch, if any.
-                            state.in_flight = false;
-                            maybe_drain(&mut state, &mut toast_deadline).await;
-                        }
-                        redraw(terminal, theme, &mut state)?;
-                    }
-                    Some(Ok(WsMessage::Lagged)) => {
-                        // Daemon evicted events we hadn't seen yet. Drop
-                        // local reducer state and rehydrate from /replay.
-                        state.transcript.reset();
-                        match state
-                            .http
-                            .replay_paged(&state.session_id, 0, REPLAY_PAGE_SIZE)
-                            .await
-                        {
-                            Ok(replay) => {
-                                if replay.lost {
-                                    state.transcript.set_lagged();
-                                }
-                                for frame in &replay.frames {
-                                    state.transcript.apply(frame);
-                                }
-                                state.reconcile_selection();
-                                state.reconcile_slash_selection();
-                                // Re-derived turn state from the rebuilt
-                                // transcript; the lock no longer reflects
-                                // anything observable. Drain if idle.
-                                state.in_flight = false;
-                                maybe_drain(&mut state, &mut toast_deadline).await;
-                            }
-                            Err(e) => {
-                                set_toast(&mut state, &mut toast_deadline, format!("replay failed: {e}"), ToastKind::Error);
-                            }
-                        }
-                        redraw(terminal, theme, &mut state)?;
-                    }
-                    Some(Err(e)) => {
-                        // WS dropped; show a banner and try to reconnect
-                        // from the last seq we processed. Bounded backoff
-                        // so a flaky daemon restart (e.g. a 2-second
-                        // process bounce) survives without paging the
-                        // user, but a permanently-down daemon doesn't
-                        // pin a worker tight-looping retries.
-                        tracing::warn!(target: "acp.tui.ws", "ws disconnect: {e}");
-                        set_toast(&mut state, &mut toast_deadline, format!("ws disconnected: {e}; reconnecting…"), ToastKind::Error);
-                        state.ws = None;
-                        // Can't observe turn boundaries while the socket
-                        // is down; drop the lock so a stuck send doesn't
-                        // wedge the composer, and queue any new prompts
-                        // (is_busy() is true while ws is None).
-                        state.in_flight = false;
-                        let since = state.transcript.last_seq;
-                        match reconnect_with_backoff(&state.endpoint, &state.session_id, since).await {
-                            Ok(handle) => {
-                                state.ws = Some(handle);
-                                set_toast(&mut state, &mut toast_deadline, "ws reconnected".into(), ToastKind::Info);
-                                // Resumed frames will re-derive turn state
-                                // and drain on the next edge, but if the
-                                // turn already ended before reconnect there
-                                // is no edge to wait for: drain now.
-                                maybe_drain(&mut state, &mut toast_deadline).await;
-                            }
-                            Err(e) => {
-                                set_toast(&mut state, &mut toast_deadline, format!("ws reconnect failed: {e}"), ToastKind::Error);
-                            }
-                        }
+                    Some(msg) => {
+                        apply_ws_message(&mut state, &mut toast_deadline, msg).await;
                         redraw(terminal, theme, &mut state)?;
                     }
                     None => {
@@ -407,6 +426,120 @@ pub async fn run_for_endpoint(
                 // A freed slot lets the next buffered plugin notification show.
                 drain_plugin_toast(&mut state, &mut toast_deadline);
                 redraw(terminal, theme, &mut state)?;
+            }
+        }
+    }
+}
+
+/// Apply one WebSocket message to the view state: reduce a frame (with
+/// turn-edge queue draining), rehydrate from /replay on Lagged, or run
+/// the bounded-backoff reconnect on a dropped socket. Shared by the
+/// full-screen loop and the embedded (preview-pane) variant; callers
+/// redraw afterwards.
+async fn apply_ws_message(
+    state: &mut StructuredViewState,
+    toast_deadline: &mut Option<Instant>,
+    msg: Result<WsMessage, WsError>,
+) {
+    match msg {
+        Ok(WsMessage::Frame(frame)) => {
+            let was_active = state.transcript.turn_active;
+            state.transcript.apply(&frame);
+            state.reconcile_selection();
+            auto_present_elicitation(state, toast_deadline);
+            state.reconcile_slash_selection();
+            let now_active = state.transcript.turn_active;
+            if !was_active && now_active {
+                // Turn started (our own prompt echoed back, or
+                // another client's). The optimistic lock has
+                // served its purpose; release it.
+                state.in_flight = false;
+            } else if was_active && !now_active {
+                // Turn ended: release the lock and drain the
+                // next queued batch, if any.
+                state.in_flight = false;
+                maybe_drain(state, toast_deadline).await;
+            }
+        }
+        Ok(WsMessage::Lagged) => {
+            // Daemon evicted events we hadn't seen yet. Drop
+            // local reducer state and rehydrate from /replay.
+            state.transcript.reset();
+            match state
+                .http
+                .replay_paged(&state.session_id, 0, REPLAY_PAGE_SIZE)
+                .await
+            {
+                Ok(replay) => {
+                    if replay.lost {
+                        state.transcript.set_lagged();
+                    }
+                    for frame in &replay.frames {
+                        state.transcript.apply(frame);
+                    }
+                    state.reconcile_selection();
+                    auto_present_elicitation(state, toast_deadline);
+                    state.reconcile_slash_selection();
+                    // Re-derived turn state from the rebuilt
+                    // transcript; the lock no longer reflects
+                    // anything observable. Drain if idle.
+                    state.in_flight = false;
+                    maybe_drain(state, toast_deadline).await;
+                }
+                Err(e) => {
+                    set_toast(
+                        state,
+                        toast_deadline,
+                        format!("replay failed: {e}"),
+                        ToastKind::Error,
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            // WS dropped; show a banner and try to reconnect
+            // from the last seq we processed. Bounded backoff
+            // so a flaky daemon restart (e.g. a 2-second
+            // process bounce) survives without paging the
+            // user, but a permanently-down daemon doesn't
+            // pin a worker tight-looping retries.
+            tracing::warn!(target: "acp.tui.ws", "ws disconnect: {e}");
+            set_toast(
+                state,
+                toast_deadline,
+                format!("ws disconnected: {e}; reconnecting…"),
+                ToastKind::Error,
+            );
+            state.ws = None;
+            // Can't observe turn boundaries while the socket
+            // is down; drop the lock so a stuck send doesn't
+            // wedge the composer, and queue any new prompts
+            // (is_busy() is true while ws is None).
+            state.in_flight = false;
+            let since = state.transcript.last_seq;
+            match reconnect_with_backoff(&state.endpoint, &state.session_id, since).await {
+                Ok(handle) => {
+                    state.ws = Some(handle);
+                    set_toast(
+                        state,
+                        toast_deadline,
+                        "ws reconnected".into(),
+                        ToastKind::Info,
+                    );
+                    // Resumed frames will re-derive turn state
+                    // and drain on the next edge, but if the
+                    // turn already ended before reconnect there
+                    // is no edge to wait for: drain now.
+                    maybe_drain(state, toast_deadline).await;
+                }
+                Err(e) => {
+                    set_toast(
+                        state,
+                        toast_deadline,
+                        format!("ws reconnect failed: {e}"),
+                        ToastKind::Error,
+                    );
+                }
             }
         }
     }
@@ -457,6 +590,7 @@ async fn handle_terminal_event(
                 queue_len: state.queue.len(),
                 choice_picker_open: state.choice.is_some(),
                 has_modes: !state.transcript.available_modes.is_empty(),
+                agent_busy: state.transcript.turn_active || state.in_flight,
             };
             input::dispatch(state.focus, &key, ctx)
         }
@@ -849,6 +983,31 @@ fn open_mode_picker(state: &mut StructuredViewState) {
 /// free-text "custom answer" fields are simply omitted). Richer forms
 /// (required free text, multi-select, numbers) punt to the web with a
 /// toast instead of half-answering.
+/// Present a pending single-select question as its answer menu, once
+/// per question, so an elicitation surfaces itself the way a native
+/// agent would (the menu just appears) without any focus juggling.
+/// Approvals take priority (they are already modal via
+/// `reconcile_selection`); a menu the user has open is left alone.
+fn auto_present_elicitation(state: &mut StructuredViewState, toast_deadline: &mut Option<Instant>) {
+    if state.choice.is_some() || !state.transcript.pending_approvals.is_empty() {
+        return;
+    }
+    let Some(nonce) = state
+        .transcript
+        .pending_elicitations
+        .first()
+        .map(|e| e.nonce.clone())
+    else {
+        state.auto_presented_elicitation = None;
+        return;
+    };
+    if state.auto_presented_elicitation.as_deref() == Some(nonce.as_str()) {
+        return;
+    }
+    state.auto_presented_elicitation = Some(nonce);
+    start_elicitation_answer(state, toast_deadline);
+}
+
 fn start_elicitation_answer(state: &mut StructuredViewState, toast_deadline: &mut Option<Instant>) {
     use crate::acp::elicitations::ElicitationFieldKind;
 
@@ -1137,12 +1296,26 @@ fn accept_mention(state: &mut StructuredViewState) {
 fn apply_scroll(state: &mut StructuredViewState, delta: i32) {
     if delta == i32::MIN {
         state.scroll_offset = 0;
-    } else if delta == i32::MAX {
+        return;
+    }
+    if delta == i32::MAX {
         state.scroll_offset = u16::MAX;
-    } else if delta < 0 {
-        state.scroll_offset = state.scroll_offset.saturating_sub((-delta) as u16);
+        return;
+    }
+    // Resolve the current position first: `scroll_offset == u16::MAX`
+    // means "stuck to bottom", which is really the last-rendered max.
+    // Without this, a wheel-up from the bottom computes `MAX - 3`, which
+    // still clamps to the bottom, so scrollback never moves (the
+    // reported "wheel scroll does nothing").
+    let max = state.last_scroll_max.get();
+    let current = state.scroll_offset.min(max);
+    if delta < 0 {
+        state.scroll_offset = current.saturating_sub((-delta) as u16);
     } else {
-        state.scroll_offset = state.scroll_offset.saturating_add(delta as u16);
+        let next = current.saturating_add(delta as u16);
+        // Scrolling back down to the bottom re-arms auto-follow so new
+        // streaming content keeps the view pinned to the latest row.
+        state.scroll_offset = if next >= max { u16::MAX } else { next };
     }
 }
 
@@ -1215,9 +1388,11 @@ fn redraw(
 ) -> Result<()> {
     terminal.draw(|f| {
         // Stash the pane geometry this frame draws with so mouse events
-        // hit-test against what is actually on screen.
+        // hit-test against what is actually on screen. The full-screen
+        // attach view always has the keyboard, so `active` is true.
         state.layout = Some(render::compute_layout(f.area(), state));
-        render::render(f, f.area(), theme, state)
+        // The geometry return only matters to the embedded caller.
+        let _ = render::render(f, f.area(), theme, state, true);
     })?;
     Ok(())
 }

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -11,8 +11,8 @@
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph};
 use ratatui::Frame;
 use similar::{ChangeTag, TextDiff};
 
@@ -29,15 +29,28 @@ use crate::acp::state::SessionUsage;
 use crate::tui::plugin_ui;
 use crate::tui::styles::Theme;
 
-pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
+/// Render the structured view into `area`. `active` is true when the
+/// view has the keyboard (full-screen attach, or an embedded view the
+/// user entered); false for an embedded preview that is merely showing
+/// the transcript of the selected session. When inactive the composer
+/// caret is not shown and its chrome reads as a prompt to enter.
+/// Returns the transcript geometry so the embedded caller can feed the
+/// home view's drag-select machinery.
+pub fn render(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    state: &StructuredViewState,
+    active: bool,
+) -> TranscriptGeometry {
     let layout = compute_layout(area, state);
 
-    render_transcript(frame, layout.transcript, theme, state);
-    render_status(frame, layout.status, theme, state);
+    let geometry = render_transcript(frame, layout.transcript, theme, state, active);
+    render_status(frame, layout.status, theme, state, active);
     if layout.queue.height > 0 {
         render_queue(frame, layout.queue, theme, state);
     }
-    render_composer(frame, layout.composer, theme, state);
+    render_composer(frame, layout.composer, theme, state, active);
     // Pickers float above the composer (the composer sits at the screen
     // bottom, so a dropdown below it would render off-screen). Drawn
     // last so they overlay the transcript's lower rows. The choice
@@ -52,6 +65,7 @@ pub fn render(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredVi
     } else if state.mention.is_some() {
         render_mention_picker(frame, layout.composer, theme, state);
     }
+    geometry
 }
 
 /// Floating single-choice picker (permission mode, elicitation answer),
@@ -400,7 +414,13 @@ fn composer_height(state: &StructuredViewState) -> u16 {
     lines.clamp(1, COMPOSER_MAX_CONTENT_ROWS) + COMPOSER_BORDER_ROWS
 }
 
-fn render_transcript(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
+fn render_transcript(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    state: &StructuredViewState,
+    active: bool,
+) -> TranscriptGeometry {
     let title = format!(
         " Acp · {}{} ",
         state.session_id,
@@ -409,13 +429,61 @@ fn render_transcript(frame: &mut Frame, area: Rect, theme: &Theme, state: &Struc
             None => String::new(),
         }
     );
+    // The outer box is the "you are interacting here" cue, mirroring how
+    // live view highlights the preview pane border when entered: bright
+    // while active, calm while merely previewing.
+    let outer_border = if active {
+        Style::default().fg(theme.title)
+    } else {
+        Style::default().fg(theme.border)
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .title(title)
-        .border_style(border_style(theme, state, Focus::Transcript));
+        .border_style(outer_border);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    let text = wrapped_transcript(state, theme, inner.width);
+    // The lines are pre-wrapped at the render width, so visual rows ARE
+    // logical rows: the scroll clamp is exact (no wrap estimation), and
+    // the same geometry serves the home view's drag-select machinery.
+    let total = text.lines.len().min(u16::MAX as usize) as u16;
+    let max = total.saturating_sub(inner.height);
+    // Record the concrete max so a wheel/PageUp step can resolve the
+    // stick-to-bottom sentinel before moving (see `apply_scroll`).
+    state.last_scroll_max.set(max);
+    let first = state.scroll_offset.min(max);
+    let para = Paragraph::new(text).scroll((first, 0));
+    frame.render_widget(para, inner);
+    TranscriptGeometry {
+        text_area: inner,
+        first_line: first as usize,
+        total_lines: total as usize,
+    }
+}
+
+/// Where the transcript text landed in the last render: the inner text
+/// rect (borders stripped), the absolute index of the top visible row,
+/// and the total wrapped row count. The home view feeds this into its
+/// preview drag-select machinery so selection coordinates line up with
+/// the painted cells.
+#[derive(Debug, Clone, Copy)]
+pub struct TranscriptGeometry {
+    pub text_area: Rect,
+    pub first_line: usize,
+    pub total_lines: usize,
+}
+
+/// Build the transcript as pre-wrapped lines at `width` columns. This is
+/// the single source of transcript geometry: the renderer paints precisely
+/// these rows (no Paragraph wrap), the scroll clamp counts them, and the
+/// home view's selection extraction slices them.
+pub(crate) fn wrapped_transcript(
+    state: &StructuredViewState,
+    theme: &Theme,
+    width: u16,
+) -> Text<'static> {
     let lines = transcript_lines(
         &state.transcript,
         state.selected_approval,
@@ -423,41 +491,90 @@ fn render_transcript(frame: &mut Frame, area: Rect, theme: &Theme, state: &Struc
         theme,
         state.path_roots.as_ref(),
     );
-    // Clamp scroll against the *wrapped* visual row count, not
-    // `lines.len()`. Streaming `AgentMessage` rows grew text inside
-    // a single logical line: Paragraph's wrap inflated the
-    // rendered row count while `lines.len()` stayed constant, so
-    // `state.scroll_offset = u16::MAX` (stick to bottom) clipped
-    // short of the newest chunk. Tool calls didn't show the bug
-    // because each call adds whole new Line entries.
-    let total = visual_line_count(&lines, inner.width);
-    let max = total.saturating_sub(inner.height);
-    let scroll = (state.scroll_offset.min(max), 0);
-    let para = Paragraph::new(lines)
-        .wrap(Wrap { trim: false })
-        .scroll(scroll);
-    frame.render_widget(para, inner);
-}
-
-/// Estimate the number of terminal rows `lines` will occupy when
-/// rendered into a paragraph of width `width`. Each `Line`'s display
-/// width divided by the available columns, rounded up, summed. Used
-/// to keep `scroll_offset = u16::MAX` pinned to the bottom as
-/// streaming chunks grow inside a single logical line.
-fn visual_line_count(lines: &[Line], width: u16) -> u16 {
-    if width == 0 {
-        return lines.len() as u16;
-    }
-    let w = width as usize;
-    let mut total: usize = 0;
+    let mut wrapped: Vec<Line<'static>> = Vec::with_capacity(lines.len());
     for line in lines {
-        let lw = line.width().max(1);
-        total = total.saturating_add(lw.div_ceil(w));
+        wrap_line_into(own_line(line), width, &mut wrapped);
     }
-    total.min(u16::MAX as usize) as u16
+    Text::from(wrapped)
 }
 
-fn render_status(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
+/// Detach a line from whatever transcript strings it borrows so the
+/// wrapped text can outlive the state borrow.
+fn own_line(line: Line<'_>) -> Line<'static> {
+    let spans: Vec<Span<'static>> = line
+        .spans
+        .into_iter()
+        .map(|s| Span::styled(s.content.into_owned(), s.style))
+        .collect();
+    Line::from(spans).style(line.style)
+}
+
+/// Word-wrap one styled line into rows of at most `width` columns,
+/// preserving span styles. Char-level flatten + regroup: simple, style
+/// exact, and O(len). Breaks at the last space when one exists in the
+/// current row, hard-breaks otherwise (long paths, hashes). Wide chars
+/// count via their display width.
+fn wrap_line_into(line: Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
+    use unicode_width::UnicodeWidthChar;
+
+    let width = width.max(1) as usize;
+    if line.width() <= width {
+        out.push(line);
+        return;
+    }
+    // Flatten to (char, style); wrap; regroup runs of equal style.
+    let chars: Vec<(char, Style)> = line
+        .spans
+        .iter()
+        .flat_map(|s| s.content.chars().map(move |c| (c, s.style)))
+        .collect();
+    let mut row: Vec<(char, Style)> = Vec::new();
+    let mut row_width = 0usize;
+    let mut last_space: Option<usize> = None;
+    let flush = |row: &mut Vec<(char, Style)>, out: &mut Vec<Line<'static>>| {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        for (c, style) in row.drain(..) {
+            match spans.last_mut() {
+                Some(last) if last.style == style => last.content.to_mut().push(c),
+                _ => spans.push(Span::styled(c.to_string(), style)),
+            }
+        }
+        out.push(Line::from(spans));
+    };
+    for (c, style) in chars {
+        let cw = c.width().unwrap_or(0);
+        if row_width + cw > width && !row.is_empty() {
+            if let Some(cut) = last_space {
+                // Break at the space: it ends the current row (and is
+                // dropped, like a terminal word wrap); the tail carries
+                // into the next row.
+                let tail: Vec<(char, Style)> = row.split_off(cut + 1);
+                row.truncate(cut);
+                flush(&mut row, out);
+                row = tail;
+                row_width = row.iter().map(|(c, _)| c.width().unwrap_or(0)).sum();
+            } else {
+                flush(&mut row, out);
+                row_width = 0;
+            }
+            last_space = None;
+        }
+        if c == ' ' {
+            last_space = Some(row.len());
+        }
+        row.push((c, style));
+        row_width += cw;
+    }
+    flush(&mut row, out);
+}
+
+fn render_status(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    state: &StructuredViewState,
+    active: bool,
+) {
     let mut spans: Vec<Span> = Vec::new();
     if let Some(toast) = &state.toast {
         let color = match toast.kind {
@@ -489,9 +606,11 @@ fn render_status(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structure
     }
     if !state.transcript.pending_approvals.is_empty() {
         let n = state.transcript.pending_approvals.len();
+        // The prompt is modal (it already has the keyboard), so the hint
+        // names the decision keys, not a focus switch.
         spans.push(Span::styled(
             format!(
-                " {n} pending approval{}; Tab to focus ",
+                " {n} pending approval{}: a allow · A always · d deny ",
                 if n == 1 { "" } else { "s" }
             ),
             Style::default().fg(theme.error),
@@ -511,11 +630,14 @@ fn render_status(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structure
         }
     }
     if spans.is_empty() {
-        // Footer help when nothing else is going on.
-        spans.push(Span::styled(
-            help_hint(state.focus),
-            Style::default().fg(theme.hint),
-        ));
+        // Footer help when nothing else is going on. A preview points at
+        // how to start interacting; an active view shows the live hint.
+        let hint = if active {
+            help_hint(state.focus)
+        } else {
+            " Enter to reply · scroll to read "
+        };
+        spans.push(Span::styled(hint, Style::default().fg(theme.hint)));
     }
     // Context-window token meter, mirroring the web composer's usage
     // chip (`formatTokens` / `formatCost` in Composer.tsx). Rendered
@@ -553,12 +675,15 @@ fn render_status(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structure
 const USAGE_WARN_PERCENT: u64 = 90;
 
 /// Rounded context-fill percentage; 0 when the agent reported no window
-/// size (avoids a divide-by-zero on a malformed snapshot).
+/// size (avoids a divide-by-zero on a malformed snapshot). Capped at
+/// 100: some agents report `used > size` transiently (e.g. before a
+/// compaction lands), and "105%" reads as a rendering bug (#2927). The
+/// web composer caps identically.
 fn usage_percent(usage: &SessionUsage) -> u64 {
     if usage.size == 0 {
         return 0;
     }
-    ((usage.used as f64 / usage.size as f64) * 100.0).round() as u64
+    (((usage.used as f64 / usage.size as f64) * 100.0).round() as u64).min(100)
 }
 
 /// `12.3k/200k (6%) · $0.42`-style usage summary, matching the web
@@ -595,29 +720,37 @@ fn format_tokens(n: u64) -> String {
     }
 }
 
-fn render_composer(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
-    // While browsing the queue, the title signals that an existing queued
-    // prompt is being edited (and where it sits), so the composer does not
-    // look like it merely copied text in. Position counts from the newest
-    // entry (1 = newest), matching the ArrowUp-from-newest browse order.
+fn render_composer(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    state: &StructuredViewState,
+    active: bool,
+) {
+    // No "Composer" label: the box sits at the bottom and (when active)
+    // holds the caret, so it is self-evidently the input. The one title
+    // worth showing is the queue-edit banner, which changes what Enter
+    // does. When inactive (a preview of the selected session), the box
+    // reads as a prompt to enter.
     let title: String = if let Some(recall) = &state.recall {
         let total = state.queue.len();
         let pos = total.saturating_sub(recall.index);
         format!(
             " Editing queued message {pos} of {total} (Enter=save, Esc=restore draft, ↑/↓=browse) "
         )
+    } else if active {
+        String::new()
     } else {
-        match state.focus {
-            Focus::Composer => " Composer (Enter=send, Shift+Enter=newline, Esc=back) ".to_string(),
-            _ => " Composer (Tab/i to focus) ".to_string(),
-        }
+        " Press Enter to reply ".to_string()
     };
-    // Highlight the border while editing a queued prompt so the mode is
-    // obvious at a glance.
-    let composer_border = if state.recall.is_some() {
+    // Both boxes (transcript + composer) carry the golden active border
+    // together, so the whole embedded view reads as one entered pane,
+    // the same "you are here" cue live view puts on the preview border.
+    // A preview keeps the calm border; queue-edit keeps its own accent.
+    let composer_border = if state.recall.is_some() || active {
         Style::default().fg(theme.title)
     } else {
-        border_style(theme, state, Focus::Composer)
+        Style::default().fg(theme.border)
     };
     let block = Block::default()
         .borders(Borders::ALL)
@@ -629,7 +762,9 @@ fn render_composer(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structu
     let inner = block.inner(area);
     frame.render_widget(block, area);
     frame.render_widget(&state.composer, inner);
-    if matches!(state.focus, Focus::Composer) && inner.width > 0 && inner.height > 0 {
+    // Only show the caret when the view is active: a preview must not
+    // plant a blinking cursor in a box the keyboard isn't routed to.
+    if active && matches!(state.focus, Focus::Composer) && inner.width > 0 && inner.height > 0 {
         let cursor = state.composer.screen_cursor();
         let max_x = inner.x.saturating_add(inner.width.saturating_sub(1));
         let max_y = inner.y.saturating_add(inner.height.saturating_sub(1));
@@ -639,10 +774,20 @@ fn render_composer(frame: &mut Frame, area: Rect, theme: &Theme, state: &Structu
     }
 }
 
-/// Gutter marking the first line of an agent message. Continuation
-/// lines align under the text with `AGENT_GUTTER_CONT`.
-const AGENT_GUTTER: &str = "aoe  ";
-const AGENT_GUTTER_CONT: &str = "     ";
+/// Render one of the user's turns the way Claude Code shows the
+/// human's messages: no "you" speaker label, just the text on a
+/// highlighted background so it stands apart from the agent's plain
+/// replies. Embedded newlines (Shift+Enter multi-line input) are split
+/// into one highlighted line each, with a space of padding on both
+/// sides so the highlight reads as a block rather than tight-wrapping
+/// the glyphs. A blank input line keeps a highlighted gap so the break
+/// is visible.
+fn user_message_lines<'a>(text: &str, theme: &Theme) -> Vec<Line<'a>> {
+    let style = Style::default().bg(theme.selection).fg(theme.text);
+    text.split('\n')
+        .map(|line| Line::from(Span::styled(format!(" {line} "), style)))
+        .collect()
+}
 
 /// Render an agent message as markdown-styled transcript lines.
 ///
@@ -650,30 +795,19 @@ const AGENT_GUTTER_CONT: &str = "     ";
 /// ratatui `Line`s ourselves (see [`MarkdownBuilder`]). This strips the
 /// raw `#`/`**`/backtick/fence markers and styles content with modifiers
 /// only (BOLD/ITALIC/DIM), so the output tracks the app theme rather than
-/// carrying hardcoded colors. Each line is prefixed with the `aoe` gutter
-/// on the first row and an aligned indent on continuation rows. Empty or
-/// marker-only input falls back to the bare `aoe  …` placeholder the
-/// streaming UI showed before.
+/// carrying hardcoded colors. The agent's reply is rendered as plain
+/// body text with no speaker label, the way a native agent prints its
+/// response; the user's turns are what stand out (highlighted), not the
+/// agent's. Empty or marker-only input falls back to a bare `…`.
 fn render_agent_message_lines(text: &str) -> Vec<Line<'static>> {
     if text.trim().is_empty() {
-        return vec![Line::from(format!("{AGENT_GUTTER}…"))];
+        return vec![Line::from("…".to_string())];
     }
     let body = MarkdownBuilder::render(text);
     if body.is_empty() {
-        return vec![Line::from(format!("{AGENT_GUTTER}…"))];
+        return vec![Line::from("…".to_string())];
     }
-    body.into_iter()
-        .enumerate()
-        .map(|(i, mut line)| {
-            let prefix = if i == 0 {
-                AGENT_GUTTER
-            } else {
-                AGENT_GUTTER_CONT
-            };
-            line.spans.insert(0, Span::raw(prefix));
-            line
-        })
-        .collect()
+    body
 }
 
 /// Accumulates `pulldown-cmark` events into themed ratatui lines.
@@ -857,7 +991,12 @@ impl MarkdownBuilder {
                     self.push_span(&text, Modifier::DIM);
                 }
             }
-            Event::SoftBreak if !self.in_code_block => self.current.push(Span::raw(" ")),
+            // A soft break (single newline in the source) renders as a
+            // real line break, matching how Claude Code prints agent
+            // output: a reply formatted "one item per line" must not
+            // collapse into one wrapped paragraph, which is what the
+            // markdown-standard space treatment did.
+            Event::SoftBreak if !self.in_code_block => self.flush(),
             Event::HardBreak => self.flush(),
             Event::Rule => {
                 self.block_break();
@@ -918,10 +1057,7 @@ fn transcript_lines<'a>(
     for row in &transcript.rows {
         match row {
             ActivityRow::UserPrompt(text) => {
-                out.push(Line::from(Span::styled(
-                    format!("you  ▸ {text}"),
-                    Style::default().add_modifier(Modifier::BOLD),
-                )));
+                out.extend(user_message_lines(text, theme));
                 out.push(Line::default());
             }
             ActivityRow::AgentMessage(text) => {
@@ -960,7 +1096,11 @@ fn transcript_lines<'a>(
                     Some(ApprovalDecision::AllowAlways) => "  → allow-always",
                     Some(ApprovalDecision::Deny) => "  → denied",
                     Some(ApprovalDecision::Cancelled) => "  → cancelled",
-                    None => "  press a / A / d to resolve, Esc to leave",
+                    // The prompt is modal and already holds the keyboard
+                    // (no Tab): the active one shows the decision keys,
+                    // any others queued behind it read as pending.
+                    None if highlighted => "  press a / A / d to resolve · Esc to stop",
+                    None => "  pending…",
                 };
                 out.push(Line::from(body));
                 out.push(Line::default());
@@ -982,11 +1122,13 @@ fn transcript_lines<'a>(
                 out.push(Line::default());
             }
             ActivityRow::ElicitationAnswer(answers) => {
+                // The user's answer is one of their turns, so it reads
+                // the same as a user prompt: highlighted, no label.
                 for answer in answers {
-                    out.push(Line::from(Span::styled(
-                        format!("you  ▸ {}: {}", answer.question, answer.answer),
-                        Style::default().add_modifier(Modifier::BOLD),
-                    )));
+                    out.extend(user_message_lines(
+                        &format!("{}: {}", answer.question, answer.answer),
+                        theme,
+                    ));
                 }
                 out.push(Line::default());
             }
@@ -1319,23 +1461,15 @@ fn render_generic_body(tool: &ToolCallRow) -> Vec<Line<'static>> {
     lines
 }
 
-fn border_style(theme: &Theme, state: &StructuredViewState, this_focus: Focus) -> Style {
-    if state.focus == this_focus {
-        Style::default().fg(theme.title)
-    } else {
-        Style::default().fg(theme.border)
-    }
-}
-
 fn help_hint(focus: Focus) -> &'static str {
     match focus {
-        Focus::Composer => {
-            " Enter=send · Shift+Enter=newline · /=commands · Esc=back · Ctrl-C=cancel "
-        }
-        Focus::Transcript => {
-            " j/k=scroll · i=compose · Tab=approvals · m=mode · o=browser · Esc=exit "
-        }
-        Focus::Approval => " a=allow · A=always · d=deny · Esc=back ",
+        // The composer is the resting state, so keep its hint to the two
+        // things that aren't obvious from the placeholder: how to send
+        // and how to leave. Scrolling is just the wheel / PageUp-Down;
+        // Ctrl+Q leaves the view (Esc interrupts the agent, like native).
+        Focus::Composer => " Enter to send · Ctrl+Q to exit ",
+        Focus::Transcript => " scroll to read · Ctrl+Q to exit ",
+        Focus::Approval => " a allow · A always · d deny · Esc stop ",
     }
 }
 
@@ -1379,37 +1513,64 @@ mod tests {
         );
     }
 
-    #[test]
-    fn visual_line_count_counts_wrapped_rows() {
-        // 40 chars at width 10 wraps to 4 visual rows.
-        let lines = vec![Line::from("a".repeat(40))];
-        assert_eq!(visual_line_count(&lines, 10), 4);
+    /// Wrap one line and return the resulting row count.
+    fn wrap_rows(line: Line<'static>, width: u16) -> usize {
+        let mut out = Vec::new();
+        wrap_line_into(line, width, &mut out);
+        out.len()
     }
 
     #[test]
-    fn visual_line_count_floors_empty_line_to_one() {
-        // A logical empty line still occupies one row.
-        let lines = vec![Line::default()];
-        assert_eq!(visual_line_count(&lines, 10), 1);
+    fn wrap_hard_breaks_unbreakable_text() {
+        // 40 chars, no spaces, at width 10: four hard-broken rows.
+        assert_eq!(wrap_rows(Line::from("a".repeat(40)), 10), 4);
     }
 
     #[test]
-    fn visual_line_count_handles_zero_width() {
-        // Degenerate area (e.g. during teardown); fall back to logical
-        // line count so we don't divide by zero.
-        let lines = vec![Line::from("x"), Line::from("y")];
-        assert_eq!(visual_line_count(&lines, 0), 2);
+    fn wrap_keeps_empty_line_as_one_row() {
+        assert_eq!(wrap_rows(Line::default(), 10), 1);
     }
 
     #[test]
-    fn visual_line_count_streaming_growth_advances_max_scroll() {
-        // Regression for the agent-message auto-scroll bug: as a
-        // single logical line grows, the visual row count must
-        // grow so `scroll_offset = u16::MAX` keeps tracking the
-        // bottom.
-        let short = vec![Line::from("a".repeat(20))];
-        let long = vec![Line::from("a".repeat(200))];
-        assert!(visual_line_count(&long, 40) > visual_line_count(&short, 40));
+    fn wrap_survives_zero_width() {
+        // Degenerate area (e.g. during teardown): the width floors to 1
+        // instead of dividing by zero.
+        assert_eq!(wrap_rows(Line::from("x"), 0), 1);
+    }
+
+    #[test]
+    fn wrap_streaming_growth_adds_rows() {
+        // Regression for the agent-message auto-scroll bug: as a single
+        // logical line grows, the wrapped row count must grow so
+        // `scroll_offset = u16::MAX` keeps tracking the bottom.
+        assert!(
+            wrap_rows(Line::from("a".repeat(200)), 40) > wrap_rows(Line::from("a".repeat(20)), 40)
+        );
+    }
+
+    #[test]
+    fn wrap_breaks_at_word_boundary_and_keeps_styles() {
+        let styled = Style::default().add_modifier(Modifier::BOLD);
+        let line = Line::from(vec![
+            Span::raw("hello brave "),
+            Span::styled("new world", styled),
+        ]);
+        let mut out = Vec::new();
+        wrap_line_into(line, 12, &mut out);
+        let texts: Vec<String> = out
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        // Breaks at the space before "new", dropping the break space.
+        assert_eq!(
+            texts,
+            vec!["hello brave".to_string(), "new world".to_string()]
+        );
+        // The bold style survives on the wrapped-away words.
+        assert!(out[1]
+            .spans
+            .iter()
+            .any(|s| s.style == styled && s.content.contains("new")));
     }
 
     #[test]
@@ -1496,27 +1657,45 @@ mod tests {
     }
 
     #[test]
-    fn agent_message_gutter_marks_first_line_then_indents() {
-        let lines = render_agent_message_lines("line one\n\nline two");
-        // First rendered line gets the `aoe  ` gutter.
+    fn agent_message_honors_single_newlines() {
+        // A reply formatted one-item-per-line must keep its line breaks
+        // (markdown soft breaks), matching how a native agent prints it,
+        // instead of collapsing into one wrapped paragraph.
+        let lines = render_agent_message_lines("1\n2\n3");
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
         assert!(
-            line_text(&lines[0]).starts_with(AGENT_GUTTER),
-            "first line missing gutter: {:?}",
-            line_text(&lines[0])
+            texts.iter().any(|t| t.trim() == "1") && texts.iter().any(|t| t.trim() == "3"),
+            "each source line should render as its own row: {texts:?}"
         );
-        // Every continuation line aligns under the text with spaces, no
-        // repeated `aoe` literal.
-        for line in &lines[1..] {
+    }
+
+    #[test]
+    fn agent_message_has_no_speaker_label() {
+        // The agent's reply is plain body text: no "aoe" gutter, no
+        // speaker label. The user's turns are what stand out, not this.
+        let lines = render_agent_message_lines("line one\n\nline two");
+        for line in &lines {
             let text = line_text(line);
             assert!(
-                text.is_empty() || text.starts_with(AGENT_GUTTER_CONT),
-                "continuation line not indented: {text:?}"
-            );
-            assert!(
                 !text.trim_start().starts_with("aoe"),
-                "gutter literal repeated on continuation: {text:?}"
+                "agent message must carry no speaker label: {text:?}"
             );
         }
+        assert!(line_text(&lines[0]).contains("line one"));
+    }
+
+    #[test]
+    fn user_message_is_highlighted_and_splits_newlines() {
+        use crate::tui::styles::load_theme;
+        let theme = load_theme("empire");
+        let lines = user_message_lines("first\nsecond", &theme);
+        // One line per input line, no "you" label, text preserved.
+        assert_eq!(lines.len(), 2);
+        assert!(line_text(&lines[0]).contains("first"));
+        assert!(line_text(&lines[1]).contains("second"));
+        assert!(!line_text(&lines[0]).contains("you"));
+        // The highlight is a background style on the text span.
+        assert_eq!(lines[0].spans[0].style.bg, Some(theme.selection));
     }
 
     use crate::acp::state::AvailableCommand;
@@ -1554,7 +1733,7 @@ mod tests {
         for input in ["", "   ", "\n\n"] {
             let lines = render_agent_message_lines(input);
             assert_eq!(lines.len(), 1, "input {input:?}");
-            assert_eq!(line_text(&lines[0]), format!("{AGENT_GUTTER}…"));
+            assert_eq!(line_text(&lines[0]), "…");
         }
     }
 
@@ -1591,7 +1770,9 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
-            .draw(|f| render(f, f.area(), &theme, &state))
+            .draw(|f| {
+                render(f, f.area(), &theme, &state, true);
+            })
             .expect("draw");
 
         let buf = terminal.backend().buffer().clone();
@@ -1629,7 +1810,9 @@ mod tests {
         let backend = TestBackend::new(40, 9);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
-            .draw(|f| render(f, f.area(), &theme, &state))
+            .draw(|f| {
+                render(f, f.area(), &theme, &state, true);
+            })
             .expect("draw");
 
         let buf = terminal.backend().buffer().clone();
@@ -1751,8 +1934,10 @@ mod tests {
             &Theme::default(),
             None,
         ));
-        assert!(out.contains("you  ▸ Proceed?: Yes"), "{out:?}");
-        assert!(out.contains("you  ▸ Mode: Fast"), "{out:?}");
+        // Rendered as user turns: highlighted text, no "you" label.
+        assert!(out.contains("Proceed?: Yes"), "{out:?}");
+        assert!(out.contains("Mode: Fast"), "{out:?}");
+        assert!(!out.contains("you  ▸"), "{out:?}");
     }
 
     #[test]
@@ -1963,6 +2148,18 @@ mod tests {
     }
 
     #[test]
+    fn usage_percent_caps_at_100_when_used_exceeds_size() {
+        // Some agents transiently report used > size (e.g. right before a
+        // compaction lands); "105%" reads as a rendering bug (#2927).
+        let usage = SessionUsage {
+            used: 210_000,
+            size: 200_000,
+            cost: None,
+        };
+        assert_eq!(usage_percent(&usage), 100);
+    }
+
+    #[test]
     fn status_line_renders_usage_meter() {
         let mut state = test_state();
         state.transcript.usage = Some(SessionUsage {
@@ -2049,7 +2246,9 @@ mod tests {
         let backend = TestBackend::new(w, h);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
-            .draw(|f| render(f, f.area(), &theme, state))
+            .draw(|f| {
+                render(f, f.area(), &theme, state, true);
+            })
             .expect("draw");
         let buf = terminal.backend().buffer().clone();
         buf.content().iter().map(|c| c.symbol()).collect()

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -89,10 +89,21 @@ pub struct StructuredViewState {
     /// hit-tested against what is actually on screen. `None` until the
     /// first frame renders.
     pub layout: Option<ViewLayout>,
-    /// Floating single-choice picker, opened by `m` (permission mode) or
-    /// `a` (answer a pending single-select question). `None` when closed.
-    /// While open it owns Up/Down/Enter/Esc, whatever the focus.
+    /// Floating single-choice picker: the permission-mode picker
+    /// (Shift+Tab), or the auto-opened answer menu for a pending
+    /// single-select question. `None` when closed. While open it owns
+    /// Up/Down/Enter/Esc, whatever the focus.
     pub choice: Option<ChoicePicker>,
+    /// Nonce of the elicitation whose answer menu was last auto-opened,
+    /// so a pending question presents itself once, not repeatedly, instead of
+    /// re-opening (or re-toasting) on every frame.
+    pub auto_presented_elicitation: Option<String>,
+    /// The maximum scroll offset (wrapped rows minus visible rows) from
+    /// the last render, stashed so a wheel/PageUp step can resolve the
+    /// `u16::MAX` "stick to bottom" sentinel to a concrete position
+    /// before moving. Interior-mutable so the render (which borrows the
+    /// state immutably) can record it. See `apply_scroll`.
+    pub last_scroll_max: std::cell::Cell<u16>,
 }
 
 /// One open choice-picker: a titled option list plus what accepting the
@@ -227,7 +238,7 @@ impl StructuredViewState {
             endpoint,
             http,
             composer: new_composer_textarea(),
-            focus: Focus::Transcript,
+            focus: Focus::Composer,
             scroll_offset: u16::MAX, // stick to bottom by default; render clamps to last row
             selected_approval: None,
             ws,
@@ -249,6 +260,8 @@ impl StructuredViewState {
             plugin_notify: PluginNotifyState::default(),
             layout: None,
             choice: None,
+            auto_presented_elicitation: None,
+            last_scroll_max: std::cell::Cell::new(0),
         }
     }
 
@@ -509,8 +522,9 @@ impl StructuredViewState {
         let len = self.transcript.pending_approvals.len();
         if len == 0 {
             self.selected_approval = None;
+            // The prompt is gone; hand the keyboard back to the composer.
             if matches!(self.focus, Focus::Approval) {
-                self.focus = Focus::Transcript;
+                self.focus = Focus::Composer;
             }
             return;
         }
@@ -518,6 +532,13 @@ impl StructuredViewState {
             Some(i) if i >= len => self.selected_approval = Some(len - 1),
             None => self.selected_approval = Some(0),
             _ => {}
+        }
+        // A pending approval is modal, like a native agent's permission
+        // prompt: it grabs focus so the decision keys work with no Tab
+        // into the chat. A menu the user opened themselves (mode) keeps
+        // the keyboard until dismissed.
+        if matches!(self.focus, Focus::Composer) && self.choice.is_none() {
+            self.focus = Focus::Approval;
         }
     }
 }

--- a/tests/e2e/acp_focus_isolation_e2e.rs
+++ b/tests/e2e/acp_focus_isolation_e2e.rs
@@ -1,11 +1,12 @@
-//! Full-stack e2e: TUI structured view focus isolation against a live daemon.
+//! Full-stack e2e: TUI structured view modal approval against a live daemon.
 //!
-//! The structured view focus model (composer swallows approval letters; approval
-//! letters only resolve under approval focus) is unit-tested in isolation
-//! at `src/tui/structured_view/input.rs`. This test proves the same guarantee
-//! end-to-end: a real `aoe serve --daemon`, a real structured view worker driving
-//! a real ACP `session/request_permission`, the native TUI attached over
-//! tmux, and the keystrokes routed through the production input loop.
+//! The structured view presents a pending approval like a native agent's
+//! permission prompt: it grabs focus on its own (no Tab into the chat), only
+//! the decision keys act, and `a`/`A`/`d` resolve it in place. That model is
+//! unit-tested at `src/tui/structured_view/input.rs`; this test proves it
+//! end-to-end: a real `aoe serve --daemon`, a real structured view worker
+//! driving a real ACP `session/request_permission`, the native TUI attached
+//! over tmux, and the keystrokes routed through the production input loop.
 //!
 //! Determinism comes from the shared Node fake-ACP agent
 //! (`web/tests/helpers/fakeAcpAgent.mjs`): its `permission_request` turn
@@ -85,13 +86,14 @@ fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration
 }
 
 /// Stand up a live daemon, attach the native TUI structured view to a session
-/// with a real pending approval, and prove focus isolation:
-///   1. With the composer focused, typing `a`/`A`/`d` does NOT resolve the
-///      approval (the letters land in the composer textarea instead).
-///   2. Moving focus to the approval card and pressing `a` DOES resolve it.
+/// with a real pending approval, and prove the modal-approval model:
+///   1. A pending approval grabs focus on its own (no Tab): the card shows
+///      the decision hint immediately.
+///   2. A non-decision key does NOT resolve it (only a/A/d act).
+///   3. Pressing `a` resolves it, with no focus switch anywhere.
 #[test]
 #[serial]
-fn tui_acp_focus_isolation_with_live_daemon() {
+fn tui_acp_modal_approval_with_live_daemon() {
     require_tmux!();
     require_node!();
 
@@ -175,25 +177,20 @@ fn tui_acp_focus_isolation_with_live_daemon() {
     h.spawn(&["acp", "attach", &session_id]);
 
     // The approval must surface through the full stack (replay + WS).
+    // It is modal: it grabs focus on its own, so the decision hint shows
+    // with no Tab or other gesture.
     h.wait_for(" pending approval");
-    h.assert_screen_contains("press a / A / d to resolve");
+    h.wait_for("press a / A / d to resolve");
 
-    // --- Negative path: composer swallows approval letters ---
-    // Default focus on attach is Transcript; `i` focuses the composer.
-    h.send_keys("i");
-    h.type_text("aAd");
-    // If the letters render in the composer textarea, the input dispatcher
-    // routed them to Intent::Compose, which mathematically proves none of
-    // them resolved the approval (a resolve would have consumed the key as
-    // ResolveApproval, so it would never reach the textarea). This is the
-    // race-free oracle for "composer swallowed the approval letters".
-    h.wait_for("aAd");
+    // --- Negative path: a non-decision key does not resolve ---
+    // Only a/A/d act while the prompt is up; a stray letter is ignored
+    // (the modal approval owns the keyboard, so it can't leak into a
+    // composer draft either).
+    h.send_keys("z");
     h.assert_screen_not_contains("→ allowed");
     h.assert_screen_contains(" pending approval");
 
-    // --- Positive path: resolve only under approval focus ---
-    h.send_keys("Escape"); // composer -> transcript
-    h.send_keys("Tab"); // transcript -> approval card (pending)
+    // --- Positive path: `a` resolves it directly, no focus switch ---
     h.send_keys("a"); // resolve: allow
     h.wait_for("→ allowed");
 }

--- a/tests/e2e/acp_focus_isolation_e2e.rs
+++ b/tests/e2e/acp_focus_isolation_e2e.rs
@@ -193,4 +193,8 @@ fn tui_acp_modal_approval_with_live_daemon() {
     // --- Positive path: `a` resolves it directly, no focus switch ---
     h.send_keys("a"); // resolve: allow
     h.wait_for("→ allowed");
+    // Neither the ignored `z` nor the resolving `a` may leak into the
+    // composer: the empty-composer placeholder proves the modal owned
+    // both keys end to end.
+    h.assert_screen_contains("Message the agent");
 }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -52,6 +52,7 @@ mod resume_fallback;
 mod sandbox;
 mod serve;
 mod settings;
+mod structured_tui_flows_e2e;
 mod tool_sessions;
 mod tui_launch;
 mod unified_view;

--- a/tests/e2e/structured_tui_flows_e2e.rs
+++ b/tests/e2e/structured_tui_flows_e2e.rs
@@ -135,9 +135,17 @@ fn wizard_created_structured_session_opens_structured_view() {
     h.type_text(project.to_str().unwrap());
     h.send_keys("Tab"); // -> Title
     h.type_text("wizstruct");
-    h.send_keys("Tab"); // -> Tool (claude via the shim)
-    h.send_keys("Tab"); // -> Structured toggle
-    h.send_keys("Space");
+    // The Tool row is only in the Tab order when more than one tool is
+    // available (`available_tools.len() > 1`); a lone stubbed `claude`
+    // renders it read-only and Tab skips it. Detect which layout this
+    // environment produced from the cycler chrome (`[1/N]` only renders
+    // in the multi-tool form) instead of hard-coding the Tab count,
+    // which is exactly what broke on CI's single-tool runner.
+    h.send_keys("Tab");
+    if h.capture_screen().contains("[1/") {
+        h.send_keys("Tab"); // multi-tool: hop over the Tool row
+    }
+    h.send_keys("Space"); // -> Structured toggle
     h.assert_screen_contains("[x] Structured view");
     h.send_keys("Enter");
 

--- a/tests/e2e/structured_tui_flows_e2e.rs
+++ b/tests/e2e/structured_tui_flows_e2e.rs
@@ -1,0 +1,221 @@
+//! Full-stack e2e for the TUI structured-view entry flows (#1965):
+//!
+//! 1. Creating a session with the wizard's Structured toggle drops the
+//!    user straight into the native structured view (#2926) instead of
+//!    stranding them on the home list.
+//! 2. Keyboard-confirming the context menu's "Switch to structured"
+//!    (`y` on the confirm dialog) performs the switch immediately
+//!    (#2925); before the fix the stashed switch only fired on the
+//!    NEXT keypress, which read as "switching does nothing".
+//!
+//! Both stand up a real `aoe serve --daemon` and the shared Node
+//! fake-ACP agent so the daemon can actually spawn a worker for the
+//! structured session. Compiled only with the `serve` feature. Run:
+//!
+//! ```sh
+//! cargo test --features e2e-tests --test e2e -- structured_tui_flows
+//! ```
+#![cfg(feature = "serve")]
+
+use std::time::Duration;
+
+use serial_test::serial;
+
+use crate::harness::{pick_free_port, require_node, require_tmux, wait_for_port, TuiTestHarness};
+
+/// Minimal fake-ACP script: one message turn, so a prompt (if any test
+/// ever sends one) completes cleanly. Session creation itself only needs
+/// the handshake, which the fake always answers.
+const MESSAGE_SCRIPT: &str = r#"{
+  "turns": [
+    {
+      "updates": [
+        {
+          "sessionUpdate": "agent_message_chunk",
+          "content": { "type": "text", "text": "hello from the fake agent" }
+        }
+      ],
+      "stopReason": "end_turn"
+    }
+  ]
+}"#;
+
+/// Seed the app config so no first-run dialog (welcome, telemetry
+/// consent, agent-hooks install) overlays the wizard mid-test.
+fn write_seeded_config(h: &TuiTestHarness) {
+    let config_dir = crate::harness::app_dir_in(h.home_path());
+    let config_content = format!(
+        r#"[updates]
+update_check_mode = "off"
+
+[acp]
+offer_structured_in_new_session = true
+
+[app_state]
+has_seen_welcome = true
+has_responded_to_telemetry = true
+last_seen_version = "{version}"
+has_acknowledged_agent_hooks = true
+"#,
+        version = env!("CARGO_PKG_VERSION"),
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content)
+        .expect("write seeded config.toml");
+}
+
+/// Init the harness project dir as a git repo (structured sessions use
+/// it as their workspace root).
+fn init_git_repo(path: &std::path::Path) {
+    for args in [
+        vec!["init", "-q"],
+        vec!["commit", "--allow-empty", "-q", "-m", "init"],
+    ] {
+        let out = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(path)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+/// Start a daemon on a free port and wait for it to bind.
+fn start_daemon(h: &TuiTestHarness) {
+    let port = pick_free_port();
+    let port_s = port.to_string();
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {port}"
+    );
+}
+
+/// Wizard-created structured session must open the native structured
+/// view without any further input (#2926). The load-bearing tell is the
+/// structured view chrome (composer hint) replacing the home screen.
+#[test]
+#[serial]
+fn wizard_created_structured_session_opens_structured_view() {
+    require_tmux!();
+    require_node!();
+
+    let mut h = TuiTestHarness::new_in_tmp("structured_wizard");
+    write_seeded_config(&h);
+    let script_path = h.home_path().join("fake-acp-script.json");
+    std::fs::write(&script_path, MESSAGE_SCRIPT).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+    h.stop_daemon_on_drop();
+
+    let project = h.project_path();
+    init_git_repo(&project);
+    start_daemon(&h);
+
+    h.spawn_tui();
+    h.wait_for(" aoe ");
+
+    h.send_keys("n");
+    h.wait_for(" New Session ");
+    // Path is the default focused field; replace its prefill.
+    h.send_keys("C-u");
+    h.type_text(project.to_str().unwrap());
+    h.send_keys("Tab"); // -> Title
+    h.type_text("wizstruct");
+    h.send_keys("Tab"); // -> Tool (claude via the shim)
+    h.send_keys("Tab"); // -> Structured toggle
+    h.send_keys("Space");
+    h.assert_screen_contains("[x] Structured view");
+    h.send_keys("Enter");
+
+    // The structured view must open embedded in the preview pane:
+    // composer chrome on screen, wizard gone, and the sidebar still
+    // visible around it (live-mode style, not a full-screen takeover).
+    // Generous timeout; creation runs hooks + storage and the view
+    // only opens after the create result lands.
+    h.wait_for_timeout("Message the agent", Duration::from_secs(15));
+    h.assert_screen_not_contains(" New Session ");
+    h.assert_screen_contains("wizstruct");
+    h.assert_screen_contains(" aoe ");
+}
+
+/// Keyboard-confirmed view switch ('y' on the confirm) must fire
+/// without waiting for another keypress (#2925). The test sends `y`
+/// and then ONLY waits: the "switched to the structured view" toast
+/// can only appear if the drain runs as part of handling that same
+/// key event.
+#[test]
+#[serial]
+fn keyboard_confirmed_view_switch_fires_immediately() {
+    require_tmux!();
+    require_node!();
+
+    let mut h = TuiTestHarness::new_in_tmp("structured_switch");
+    write_seeded_config(&h);
+    let script_path = h.home_path().join("fake-acp-script.json");
+    std::fs::write(&script_path, MESSAGE_SCRIPT).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+    h.stop_daemon_on_drop();
+
+    let project = h.project_path();
+    init_git_repo(&project);
+    start_daemon(&h);
+
+    // A plain terminal claude session; the switch flips it to structured.
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "switchme",
+        "-c",
+        "claude",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr),
+    );
+
+    h.spawn_tui();
+    h.wait_for("switchme");
+
+    // Right-click the session row to open the context menu. The row's
+    // 1-indexed terminal position is derived from the captured screen so
+    // grouping/header layout changes don't silently break the click.
+    // The preview panel title also carries the session name, so anchor
+    // on sidebar rows only (they start with the box-drawing `│`).
+    let screen = h.capture_screen();
+    let row_idx = screen
+        .lines()
+        .position(|l| l.starts_with('│') && l.contains("switchme"))
+        .expect("session row on screen") as u16
+        + 1;
+    h.send_mouse_click(2, 5, row_idx);
+    h.wait_for("Switch to structured");
+
+    // Highlight the last menu item ("Switch to structured") and submit.
+    h.send_keys("Up");
+    h.send_keys("Enter");
+    h.wait_for("Switch to structured view");
+
+    // Confirm with 'y' and then ONLY wait. Before the #2925 fix the
+    // stashed switch sat until the next keypress, so this wait_for
+    // timed out.
+    h.send_keys("y");
+    h.wait_for_timeout("switched to the structured view", Duration::from_secs(15));
+    h.wait_for("[structured]");
+}


### PR DESCRIPTION
## Description

Makes the TUI structured view feel like a native coding agent instead of a separate bolt-on surface, and fixes the entry-point bugs that made it hard to reach at all.

**Interaction model (Claude Code-style):**
- Selecting a structured session streams its transcript straight into the preview pane, with the info header (and its `i` toggle) intact. No more static "press Enter to open" placeholder, and no flash while the preview connects.
- Enter (or double-click) enters the session; you land in the composer and type immediately. Ctrl+Q drops back to the read-only preview, mirroring live-send's exit chord. The golden border on both boxes is the "entered" cue.
- One pane, no Tab toggle between chat and input. Scrollback is the wheel or PageUp/PageDown from the composer; drag-to-select copies transcript text through the same machinery terminal previews use.
- Esc interrupts a generating turn (and is a no-op when idle); Shift+Tab opens the permission-mode picker.
- Approvals are modal: a pending permission grabs the keyboard and resolves with `a` / `A` / `d` in place. Elicitation questions auto-open their answer menu. The composer still swallows approval letters while typing (focus-isolation guarantee preserved).
- Transcript renders like Claude Code: no `you`/`aoe` speaker labels, user turns on a highlighted background, soft breaks keep their line breaks.

**Structural refactor:**
The view is owned by `HomeView` as first-class preview content rather than an App-level overlay, so the preview placeholder, info header, layout caching, and drag-select compose with it by construction. Transcript lines are pre-wrapped at render width (span-preserving), making scroll math exact and feeding the home selection extractor. `App` keeps only the async sides: the cancel-safe WebSocket pump in the main `select!`, the debounced preview-on-select mount, and key routing while entered.

**Entry-point fixes:**
- Keyboard-confirmed view switch fires immediately instead of one keystroke late (closes #2925).
- Wizard-created structured sessions open their view (closes #2926).
- Usage meter caps at 100% (closes #2927).
- The "no structured view daemon" dead end now offers to start a localhost daemon (confirm dialog from the home flow; offer screen in `aoe acp attach`); the view switch auto-starts one after its consented confirm.
- Confirm dialogs size their height to the wrapped body text instead of clipping.
- Tab on a structured row explains there is no tmux pane instead of silently doing nothing.

**Rollout gate:** the wizard's Structured toggle is now behind `acp.offer_structured_in_new_session` (single-source schema setting), default off, so users don't see the surface until it is ready. Switching an existing session's view and opening structured sessions are unaffected. The web wizard's structured toggle is not yet gated by this setting; that needs its own coverage-matrix entry and is left as follow-up.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: no web code changes; the new `acp.offer_structured_in_new_session` setting renders through the existing schema-driven settings surface, and gating the web wizard on it is called out as follow-up work.

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

New `tests/e2e/structured_tui_flows_e2e.rs` covers the wizard-create flow (structured session opens embedded with the sidebar visible) and the immediate keyboard-confirmed view switch, both against a live daemon plus the shared fake ACP agent. `acp_focus_isolation_e2e.rs` was rewritten for the modal-approval model (auto-focus, only decision keys act, `a` resolves). Unit tests cover the input model (Ctrl+Q, native Esc, inert Tab, Shift+Tab), wrap geometry, newline honoring, user-turn highlighting, confirm-dialog sizing, the usage-meter cap, and the Tab refusal toast.

Verified live end-to-end with a real `claude-agent-acp` worker: preview-on-select, enter/exit, prompt round-trips with streaming, a real Write-tool approval resolved in place, drag-select producing an OSC52 clipboard write, wheel scrollback, and the daemon auto-start flows.

`cargo fmt`, `cargo clippy --features serve`, and TUI-only builds are clean. Lib suite passes except three pre-existing chmod-based fixtures that cannot fail while running as root in the dev sandbox (they fail on clean main there too).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Fable 5)

**Any Additional AI Details you'd like to share:**
Implemented via an interactive Claude Code session driven by @njbrake, with repeated live verification in a sandboxed TUI against a real claude ACP worker.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Made the TUI “Structured view” a first-class preview-pane experience: selecting a structured session streams its transcript directly in the preview (keeping the info header), and you can then enter the full composer from that preview.
- Clarified and tightened entry/exit controls: **Enter** (or double-click) opens the composer, and **Ctrl+Q** reliably returns to the read-only preview immediately.
- Improved the preview experience substantially: native-style scrolling, better transcript rendering, and drag-selection support—plus improved keyboard/mouse behavior for switching and focusing.
- Refactored responsibilities: structured preview ownership and selection behavior moved into **`HomeView`**, while **`App`** focuses on async WebSocket handling and routing events/input when the embedded composer is active.
- Fixed several timing and workflow edge cases:
  - view-switch confirmation now applies within the same keypress (not the next one),
  - wizard-created structured sessions open structured view automatically,
  - structured-session daemon startup is handled more smoothly (including “start then open”),
  - structured switching/cleanup timing and related focus behavior were corrected.
- Added/expanded modal and permission workflows in the structured view, with a clearer “approval modal” key/focus behavior and updated focus isolation so decision keys don’t leak into the composer.
- Added UX and robustness polish:
  - confirm dialog height now adjusts dynamically so long prompts aren’t clipped,
  - structured-row **Tab** behavior now gives clear feedback when it can’t attach (structured rows have no tmux pane),
  - structured view usage-meter is now capped at 100% when reported usage exceeds the context window.
- Introduced an opt-in config flag: **`acp.offer_structured_in_new_session`** gates showing the “Structured view” option in the new-session dialog (default off).

## Benefits

This update makes it much easier to browse structured sessions without leaving the main screen, then confidently switch into composing when needed—while reducing confusing focus jumps, delayed/next-keypress switching, and awkward daemon/permission flows. It also improves reliability for keyboard-driven workflows and avoids common UI clipping/feedback issues.

## Technical details (optional)

- Added an embedded structured-view component with “mounted preview” vs “active composer” modes, including event streaming and transcript geometry for scrolling and drag selection.
- Updated structured input routing and focus semantics (including **Ctrl+Q**, **Esc** interrupt/no-op behavior, modal approval focus isolation, and page scrolling).
- Expanded E2E and unit coverage for structured entry flows, immediate keyboard-confirm switching, and modal keyboard isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->