### PR TITLE
feat(trash): track the teardown as a first-class claimed operation

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -96,6 +96,11 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
         let landed = storage.update(|all_instances, _groups| {
             if let Some(stored) = all_instances.iter_mut().find(|i| i.id == removed_id) {
                 stored.trash();
+                // Mark the teardown in flight (ClaimOp::Trash) so peers
+                // observe it as durable state. Best-effort: a refused claim
+                // still tears down, gated by the pre-move re-check and the
+                // locked relocation commit.
+                let _ = stored.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now());
                 Ok(true)
             } else {
                 Ok(false)
@@ -166,8 +171,11 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
             }
             crate::session::trash::RelocateOutcome::Failed { reason } => {
                 eprintln!("  Note: left worktree in place ({reason}).");
+                release_trash_claim_best_effort(&storage, &removed_id);
             }
-            crate::session::trash::RelocateOutcome::Skipped => {}
+            crate::session::trash::RelocateOutcome::Skipped => {
+                release_trash_claim_best_effort(&storage, &removed_id);
+            }
         }
 
         println!(
@@ -347,6 +355,16 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Release the teardown's in-flight Trash claim on a no-relocation terminal
+/// path (the relocation paths release inside `commit_trash_relocation`).
+/// Ownership-guarded; best-effort, a stranded claim self-heals via the TTL.
+fn release_trash_claim_best_effort(storage: &Storage, removed_id: &str) {
+    let _ = storage.update(|all_instances, _groups| {
+        crate::session::claim::release_trash_claim(all_instances, removed_id);
+        Ok(())
+    });
 }
 
 /// Release a purge claim on a kept row (teardown or transcript failed),

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2382,6 +2382,15 @@ pub async fn trash_session(
         move |instances| {
             if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
                 inst.trash();
+                // Mark the teardown in flight (ClaimOp::Trash) so peers
+                // observe it as durable state. Best-effort: a refused claim
+                // still tears down, gated by the pre-move re-check and the
+                // locked relocation commit.
+                let _ = inst.try_claim(
+                    crate::session::ClaimOp::Trash,
+                    Instance::OP_CLAIM_TTL,
+                    chrono::Utc::now(),
+                );
             }
         },
     )
@@ -2542,8 +2551,32 @@ pub async fn trash_session(
                     session = %id,
                     "trash worktree relocation skipped: {reason}"
                 );
+                let release_id = id.clone();
+                let _ = persist_session_update(
+                    profile,
+                    "trash-claim-release",
+                    state.file_watch.clone(),
+                    move |instances| {
+                        crate::session::claim::release_trash_claim(instances, &release_id);
+                    },
+                )
+                .await;
             }
-            Ok((crate::session::trash::RelocateOutcome::Skipped, _)) => {}
+            Ok((crate::session::trash::RelocateOutcome::Skipped, _)) => {
+                // No-relocation terminal path: release the teardown's
+                // in-flight Trash claim (ownership-guarded; a claim a peer
+                // seized is untouched).
+                let release_id = id.clone();
+                let _ = persist_session_update(
+                    profile,
+                    "trash-claim-release",
+                    state.file_watch.clone(),
+                    move |instances| {
+                        crate::session::claim::release_trash_claim(instances, &release_id);
+                    },
+                )
+                .await;
+            }
             Err(e) => tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,

--- a/src/session/claim.rs
+++ b/src/session/claim.rs
@@ -58,8 +58,10 @@ pub(crate) fn decide_purge_claim(
         Some(stored) => match stored.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, now) {
             Ok(()) => PurgeClaimDecision::Claimed,
             Err(ClaimOp::Restore) => PurgeClaimDecision::RestoreInProgress,
-            // `try_claim(Purge)` only ever refuses with the OTHER op.
+            // `try_claim(Purge)` only ever refuses with the OTHER op, and a
+            // fresh Trash claim is seized rather than refused.
             Err(ClaimOp::Purge) => unreachable!("try_claim(Purge) cannot be refused by Purge"),
+            Err(ClaimOp::Trash) => unreachable!("try_claim seizes a fresh Trash claim"),
         },
     }
 }
@@ -127,6 +129,7 @@ pub(crate) fn decide_restore_claim(
             Err(ClaimOp::Restore) => {
                 unreachable!("try_claim(Restore) cannot be refused by Restore")
             }
+            Err(ClaimOp::Trash) => unreachable!("try_claim seizes a fresh Trash claim"),
         },
     }
 }
@@ -167,6 +170,55 @@ pub(crate) fn finalize_restore_commit(
     RestoreCommit::Committed
 }
 
+/// Outcome of the trash claim acquisition, run under the flock right after
+/// the trash marker is durably written at every trash site (TUI, server,
+/// CLI). See [`decide_trash_claim`].
+#[derive(Debug, PartialEq)]
+pub(crate) enum TrashClaimDecision {
+    /// The Trash claim is set; the teardown is observable as in flight.
+    Claimed,
+    /// A fresh purge or restore claim holds the row, so the teardown runs
+    /// unclaimed and relies on its pre-move re-check and the locked
+    /// relocation commit alone.
+    PeerHeld(ClaimOp),
+    /// The row is gone from disk (a peer removed it).
+    AlreadyGone,
+}
+
+/// Mark a freshly-trashed row's teardown as in flight by taking the Trash
+/// claim, run inside a `storage.update` closure. The claim is durable state
+/// peers can observe (and that purge/restore seize, see
+/// [`Instance::try_claim`]); it is released by
+/// [`commit_trash_relocation`] on the relocation paths and
+/// [`release_trash_claim`] on the no-relocation ones, and the
+/// [`Instance::OP_CLAIM_TTL`] self-heal covers a crash in between.
+/// Best-effort by design: a `PeerHeld` row still tears down, gated by the
+/// re-check and the locked commit.
+pub(crate) fn decide_trash_claim(
+    all: &mut [Instance],
+    id: &str,
+    now: DateTime<Utc>,
+) -> TrashClaimDecision {
+    match all.iter_mut().find(|i| i.id == id) {
+        None => TrashClaimDecision::AlreadyGone,
+        Some(row) => match row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now) {
+            Ok(()) => TrashClaimDecision::Claimed,
+            Err(op) => TrashClaimDecision::PeerHeld(op),
+        },
+    }
+}
+
+/// Release the Trash claim on a teardown's no-relocation terminal paths
+/// (`Skipped` / `Failed`), run inside a `storage.update` closure.
+/// Ownership-guarded, so a claim a purge or restore seized in the meantime is
+/// never cleared. The relocation paths release through
+/// [`commit_trash_relocation`] instead.
+pub(crate) fn release_trash_claim(all: &mut [Instance], id: &str) {
+    if let Some(row) = all.iter_mut().find(|i| i.id == id) {
+        row.clear_op_claim_if_owned(ClaimOp::Trash);
+    }
+}
+
 /// Outcome of the final locked commit of a background trash relocation. See
 /// [`commit_trash_relocation`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -187,7 +239,7 @@ pub(crate) enum RelocationCommit {
 /// relocation, run inside a `storage.update` closure at every surface that
 /// persists one (TUI poller drain, server trash handler, CLI remove).
 ///
-/// The teardown's pre-move re-check (`durable_row_still_trashed`) narrows the
+/// The teardown's pre-move re-check (`teardown_may_relocate`) narrows the
 /// restore race to the span between that check and this commit; this gate
 /// closes the pointer half of it by re-taking the decision on the durable row
 /// under the flock. A restore that landed in between wins: the caller gets
@@ -208,13 +260,21 @@ pub(crate) fn commit_trash_relocation(
     match all.iter_mut().find(|i| i.id == id) {
         None => RelocationCommit::AlreadyGone,
         Some(row) => {
-            let claim_held =
-                matches!(&row.op_claim, Some(c) if (now - c.at) < Instance::OP_CLAIM_TTL);
-            if !row.is_trashed() || claim_held {
+            // The teardown's own Trash claim does not block its commit; a
+            // fresh Purge or Restore claim (which seized it) does. Either
+            // way this commit is a terminal teardown path, so any Trash
+            // claim still owned is released (ownership-guarded).
+            let seized = matches!(
+                &row.op_claim,
+                Some(c) if c.op != ClaimOp::Trash && (now - c.at) < Instance::OP_CLAIM_TTL
+            );
+            if !row.is_trashed() || seized {
+                row.clear_op_claim_if_owned(ClaimOp::Trash);
                 return RelocationCommit::Superseded;
             }
             row.project_path = relocation.new_project_path.clone();
             row.pre_trash_project_path = relocation.pre_trash_project_path.clone();
+            row.clear_op_claim_if_owned(ClaimOp::Trash);
             RelocationCommit::Persisted
         }
     }
@@ -302,6 +362,89 @@ mod tests {
         assert_eq!(
             commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
             RelocationCommit::AlreadyGone
+        );
+    }
+
+    #[test]
+    fn commit_relocation_persists_over_own_trash_claim_and_releases_it() {
+        let mut row = trashed("a");
+        row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Persisted,
+            "the teardown's own Trash claim must not block its commit"
+        );
+        assert_eq!(all[0].project_path, "/wt/.aoe-trash/a");
+        assert_eq!(all[0].op_claim, None, "commit is terminal: claim released");
+    }
+
+    #[test]
+    fn commit_relocation_superseded_releases_leftover_trash_claim() {
+        // A restored row that somehow still carries the teardown's Trash claim
+        // (restore raced between seize and commit) is cleaned up here; a claim
+        // a peer owns is never touched (ownership-guarded clear).
+        let mut row = trashed("a");
+        row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        row.untrash();
+        let mut all = vec![row];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Superseded
+        );
+        assert_eq!(all[0].op_claim, None, "leftover own Trash claim released");
+    }
+
+    #[test]
+    fn decide_trash_claim_claims_and_reports_peers() {
+        let mut all = vec![trashed("a")];
+        assert_eq!(
+            decide_trash_claim(&mut all, "a", Utc::now()),
+            TrashClaimDecision::Claimed
+        );
+        assert_eq!(all[0].op_claim.as_ref().map(|c| c.op), Some(ClaimOp::Trash));
+
+        let mut row = trashed("b");
+        row.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        assert_eq!(
+            decide_trash_claim(&mut all, "b", Utc::now()),
+            TrashClaimDecision::PeerHeld(ClaimOp::Purge)
+        );
+        assert_eq!(
+            all[0].op_claim.as_ref().map(|c| c.op),
+            Some(ClaimOp::Purge),
+            "a peer-held claim is never overwritten by trash"
+        );
+
+        let mut all: Vec<Instance> = Vec::new();
+        assert_eq!(
+            decide_trash_claim(&mut all, "a", Utc::now()),
+            TrashClaimDecision::AlreadyGone
+        );
+    }
+
+    #[test]
+    fn release_trash_claim_is_ownership_guarded() {
+        let mut row = trashed("a");
+        row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        release_trash_claim(&mut all, "a");
+        assert_eq!(all[0].op_claim, None);
+
+        let mut row = trashed("b");
+        row.try_claim(ClaimOp::Restore, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        release_trash_claim(&mut all, "b");
+        assert_eq!(
+            all[0].op_claim.as_ref().map(|c| c.op),
+            Some(ClaimOp::Restore),
+            "a seized (Restore-owned) claim must survive the release"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -454,15 +454,28 @@ pub enum SessionBucket {
 }
 
 /// Which irreversible operation currently owns a session's `op_claim`. The
-/// purge (permanent teardown) and restore (worktree move-back) paths run their
-/// slow work on an unlocked snapshot; the claim is the durable, cross-process
-/// primitive that serializes the two so neither tears down (or moves) state the
-/// other is authoritative over. See #2541.
+/// purge (permanent teardown), restore (worktree move-back), and trash
+/// (container stop + worktree relocation into the holding area) paths run
+/// their slow work on an unlocked snapshot; the claim is the durable,
+/// cross-process primitive that serializes them so none tears down (or moves)
+/// state another is authoritative over. See #2541.
+///
+/// `Trash` is deliberately the weakest claim: it marks "teardown in flight"
+/// so peers can observe it, but it never blocks user intent. A purge or
+/// restore seizes a fresh `Trash` claim (see [`Instance::try_claim`]) and the
+/// teardown yields via its pre-move re-check and the locked relocation
+/// commit, so a `d` followed by an immediate restore stays instant.
+///
+/// Compat: `trash` claims in `sessions.json` are not parseable by aoe
+/// binaries that predate the variant. A claim lives at most
+/// [`Instance::OP_CLAIM_TTL`] (10 minutes), so the exposure is a mixed
+/// version fleet reading storage inside that window.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ClaimOp {
     Purge,
     Restore,
+    Trash,
 }
 
 /// A durable ownership marker for an in-flight purge or restore. `at` serves
@@ -1748,14 +1761,23 @@ impl Instance {
     pub const OP_CLAIM_TTL: chrono::Duration = chrono::Duration::minutes(10);
 
     /// Atomically acquire or keep the op claim for `want`. Returns `Ok` when
-    /// the claim is free, already ours, or expired (self-heal), and
-    /// `Err(holder)` when the other operation holds a still-fresh claim.
+    /// the claim is free, already ours, expired (self-heal), or held by a
+    /// fresh `Trash` claim being seized by a purge or restore; returns
+    /// `Err(holder)` when another operation holds a still-fresh claim that
+    /// `want` may not seize.
+    ///
+    /// Seizure order: `Trash` is the weakest claim. A teardown marks state,
+    /// it does not gate user intent, so `Purge` and `Restore` take over a
+    /// fresh `Trash` claim and the teardown yields via its pre-move re-check
+    /// and the locked relocation commit. `Trash` itself never seizes a fresh
+    /// `Purge` or `Restore` claim, and `Purge`/`Restore` still exclude each
+    /// other as before.
     ///
     /// Must be called inside a `Storage::update` closure so the check-and-set
     /// runs under the storage flock, the only cross-process serialization
     /// point. The whole destructive/irreversible phase (purge teardown, restore
-    /// worktree move) must win this before running unlocked, and clear the
-    /// claim when it finishes. See #2541.
+    /// worktree move, trash relocation) must win this before running unlocked,
+    /// and clear the claim when it finishes. See #2541.
     pub fn try_claim(
         &mut self,
         want: ClaimOp,
@@ -1763,7 +1785,7 @@ impl Instance {
         now: DateTime<Utc>,
     ) -> Result<(), ClaimOp> {
         match &self.op_claim {
-            Some(c) if c.op != want && (now - c.at) < ttl => Err(c.op),
+            Some(c) if c.op != want && c.op != ClaimOp::Trash && (now - c.at) < ttl => Err(c.op),
             _ => {
                 self.op_claim = Some(OpClaim { op: want, at: now });
                 Ok(())
@@ -6275,6 +6297,55 @@ mod tests {
         assert_eq!(
             inst.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, now),
             Err(ClaimOp::Restore),
+        );
+    }
+
+    // Trash is the weakest claim: a fresh Trash claim is seized by both
+    // Purge and Restore (teardown state never blocks user intent), while
+    // Trash itself is refused by a fresh Purge or Restore claim.
+    #[test]
+    fn trash_claim_seizure_matrix() {
+        let now = Utc::now();
+        for seizer in [ClaimOp::Purge, ClaimOp::Restore] {
+            let mut inst = Instance::new("s", "/tmp/x");
+            inst.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now)
+                .expect("trash wins the free row");
+            inst.try_claim(seizer, Instance::OP_CLAIM_TTL, now)
+                .unwrap_or_else(|holder| {
+                    panic!("{seizer:?} must seize a fresh Trash claim, refused by {holder:?}")
+                });
+            assert_eq!(inst.op_claim.as_ref().map(|c| c.op), Some(seizer));
+        }
+        for holder in [ClaimOp::Purge, ClaimOp::Restore] {
+            let mut inst = Instance::new("s", "/tmp/x");
+            inst.try_claim(holder, Instance::OP_CLAIM_TTL, now)
+                .expect("holder wins the free row");
+            assert_eq!(
+                inst.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now),
+                Err(holder),
+                "a fresh {holder:?} claim must refuse a Trash claim"
+            );
+        }
+    }
+
+    // The Trash variant round-trips on the wire as "trash" (compat note on
+    // ClaimOp: binaries predating the variant cannot parse it; TTL bounds
+    // the exposure window).
+    #[test]
+    fn trash_claim_serde_roundtrip() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        let now = Utc::now();
+        inst.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now)
+            .expect("free row grants the claim");
+        let json = serde_json::to_string(&inst).expect("serialize");
+        assert!(json.contains("\"trash\""), "lowercase wire form");
+        let back: Instance = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(
+            back.op_claim,
+            Some(OpClaim {
+                op: ClaimOp::Trash,
+                at: now
+            })
         );
     }
 

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -189,12 +189,13 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
 /// by accident restores immediately; the restore itself is a NoChange because
 /// no relocation has been recorded yet). The durable row is therefore
 /// re-checked between the stop and the move, and the move is skipped when the
-/// row is no longer trashed (or is gone, or storage cannot be read; fail
-/// closed, since a skipped move on a still-trashed row is healed by the next
-/// reconcile pass, while a move on a restored row strands a live session's
-/// worktree in the holding area). The re-check reads storage via
-/// `inst.source_profile`, so callers must pass an instance whose profile is
-/// stamped and must have durably trashed the row before calling.
+/// row is no longer trashed, was seized by a fresh purge/restore claim, is
+/// gone, or storage cannot be read (fail closed, since a skipped move on a
+/// still-trashed row is healed by the next reconcile pass, while a move on a
+/// restored row strands a live session's worktree in the holding area). The
+/// re-check reads storage via `inst.source_profile`, so callers must pass an
+/// instance whose profile is stamped and must have durably trashed the row
+/// before calling.
 ///
 /// BLOCKING: the container stop shells out to `docker stop` (~10s grace period)
 /// and the relocation runs `git worktree move`, so never call this on an event
@@ -214,22 +215,23 @@ pub fn prepare_trashed_worktree(inst: &mut Instance) -> RelocateOutcome {
                 );
             }
         },
-        durable_row_still_trashed,
+        teardown_may_relocate,
     )
 }
 
-/// Whether the durable row for `inst` still reads trashed. Consulted after the
-/// (slow) container stop and immediately before the worktree move; see
-/// [`prepare_trashed_worktree`]. Fail-closed: an unreadable storage, a missing
-/// row (purged by a peer), or an untrashed row (restored by a peer or by the
-/// user mid-teardown) all answer `false` and skip the move.
-fn durable_row_still_trashed(inst: &Instance) -> bool {
+/// Whether the teardown still owns the durable row for `inst`. Consulted after
+/// the (slow) container stop and immediately before the worktree move; see
+/// [`prepare_trashed_worktree`]. The row must still read trashed AND not be
+/// held by a fresh purge/restore claim that seized the teardown's Trash claim
+/// (the teardown's own Trash claim, or no claim at all, passes). Fail-closed:
+/// an unreadable storage, a missing row (purged by a peer), a restored row, or
+/// a seized row all answer `false` and skip the move.
+fn teardown_may_relocate(inst: &Instance) -> bool {
     let loaded = crate::session::Storage::open_unwatched(&inst.source_profile)
         .and_then(|storage| storage.load());
     match loaded {
         Ok(rows) => match rows.iter().find(|r| r.id == inst.id) {
-            Some(row) if row.is_trashed() => true,
-            Some(_) => {
+            Some(row) if !row.is_trashed() => {
                 tracing::info!(
                     target: "session.trash",
                     session = %inst.id,
@@ -237,6 +239,22 @@ fn durable_row_still_trashed(inst: &Instance) -> bool {
                 );
                 false
             }
+            Some(row)
+                if matches!(
+                    &row.op_claim,
+                    Some(c) if c.op != crate::session::ClaimOp::Trash
+                        && (chrono::Utc::now() - c.at) < Instance::OP_CLAIM_TTL
+                ) =>
+            {
+                tracing::info!(
+                    target: "session.trash",
+                    session = %inst.id,
+                    claim = ?row.op_claim,
+                    "a purge/restore claim seized the row mid-teardown; leaving the worktree in place"
+                );
+                false
+            }
+            Some(_) => true,
             None => {
                 tracing::info!(
                     target: "session.trash",
@@ -260,10 +278,10 @@ fn durable_row_still_trashed(inst: &Instance) -> bool {
 fn prepare_trashed_worktree_with(
     inst: &mut Instance,
     stop_container: impl FnOnce(&str, bool),
-    still_trashed: impl FnOnce(&Instance) -> bool,
+    may_relocate: impl FnOnce(&Instance) -> bool,
 ) -> RelocateOutcome {
     stop_container(&inst.id, is_sandboxed(inst));
-    if !still_trashed(inst) {
+    if !may_relocate(inst) {
         return RelocateOutcome::Skipped;
     }
     relocate_worktree_to_trash(inst)
@@ -1132,6 +1150,56 @@ mod tests {
         assert!(
             PathBuf::from(&original).exists(),
             "the worktree must stay at its original path when a restore raced the teardown"
+        );
+    }
+
+    /// A purge (or restore) that seized the teardown's Trash claim mid-flight
+    /// owns the row: the teardown's pre-move re-check must observe the seized
+    /// claim on the still-trashed durable row and leave the worktree in
+    /// place for the claim owner to handle.
+    #[test]
+    #[serial_test::serial]
+    fn teardown_skips_relocation_when_claim_was_seized_mid_flight() {
+        if !git_available() {
+            return;
+        }
+        let _app = crate::session::test_support::isolate_app_dir();
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.source_profile = "default".to_string();
+        let original = inst.project_path.clone();
+        inst.trash();
+
+        // Durable row: still trashed, but a purge seized the Trash claim
+        // while the teardown was stopping the container.
+        let storage = crate::session::Storage::new_unwatched("default").unwrap();
+        let mut durable = inst.clone();
+        durable
+            .try_claim(
+                crate::session::ClaimOp::Purge,
+                Instance::OP_CLAIM_TTL,
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        storage
+            .update(|rows, _groups| {
+                rows.push(durable.clone());
+                Ok(())
+            })
+            .unwrap();
+
+        let result = perform_trash(&TrashRequest {
+            session_id: inst.id.clone(),
+            instance: inst.clone(),
+        });
+
+        assert!(
+            result.relocation.is_none(),
+            "a seized row's worktree must not be relocated: {:?}",
+            result.relocation
+        );
+        assert!(
+            PathBuf::from(&original).exists(),
+            "the worktree must stay in place for the claim owner"
         );
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3121,6 +3121,30 @@ impl HomeView {
                 // skips too. The relocation is best-effort regardless: a later
                 // reconcile pass heals a still-trashed row whose move was
                 // dropped here.
+                if result.relocation.is_none() {
+                    // Skipped/Failed teardown: nothing moved, but the drain is
+                    // this teardown's terminal path, so release its in-flight
+                    // Trash claim (ownership-guarded; a claim a purge/restore
+                    // seized is untouched). The row stays trashed in place and
+                    // the next reconcile pass relocates it.
+                    if let Some(storage) = self
+                        .instances
+                        .get(&result.session_id)
+                        .map(|i| i.source_profile.clone())
+                        .and_then(|profile| self.storages.get(&profile))
+                    {
+                        if let Err(e) = storage.update(|insts, _groups| {
+                            crate::session::claim::release_trash_claim(insts, &result.session_id);
+                            Ok(())
+                        }) {
+                            tracing::warn!(
+                                target: "tui.session",
+                                session = %result.session_id,
+                                "could not release the Trash claim: {e}"
+                            );
+                        }
+                    }
+                }
                 if let Some(reloc) = result.relocation {
                     // Atomic durable check-and-commit under the storage flock.
                     // The worker's pre-move re-check leaves a window before

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1589,6 +1589,42 @@ impl HomeView {
             tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
             return;
         }
+        // Mark the teardown as in flight with the durable Trash claim, so
+        // peers observe it as state rather than inferring it. Driven directly
+        // against storage because `merge_user_action_diff` deliberately drops
+        // `op_claim` (#2541). Best-effort: an unclaimed teardown still runs,
+        // gated by its re-check and the locked relocation commit.
+        if let Some(storage) = self
+            .instances
+            .get(id)
+            .map(|i| i.source_profile.clone())
+            .and_then(|profile| self.storages.get(&profile))
+        {
+            let claim = storage.update(|insts, _groups| {
+                Ok(crate::session::claim::decide_trash_claim(
+                    insts,
+                    id,
+                    chrono::Utc::now(),
+                ))
+            });
+            match claim {
+                Ok(crate::session::claim::TrashClaimDecision::PeerHeld(op)) => {
+                    tracing::info!(
+                        target: "tui.session",
+                        session = %id,
+                        "trash teardown runs unclaimed; a fresh {op:?} claim holds the row"
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "tui.session",
+                        session = %id,
+                        "could not set the Trash claim: {e}"
+                    );
+                }
+            }
+        }
         // The row is durably trashed; hand the blocking teardown (tmux kill,
         // container stop, worktree relocation) to the worker. The relocated
         // path persists later via apply_trash_results. Best-effort: if the

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7871,6 +7871,29 @@ fn trash_offloads_blocking_teardown_to_poller() {
     );
 }
 
+/// Trashing marks the teardown as in flight on the durable row: `d` sets the
+/// Trash claim under the storage flock so peer processes observe the teardown
+/// as state instead of inferring it. Driven directly against storage because
+/// `merge_user_action_diff` deliberately drops `op_claim` (#2541).
+#[test]
+#[serial]
+fn trash_sets_durable_teardown_claim() {
+    let mut env = create_test_env_with_sessions(2);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    env.view.trash_session_by_id(&id);
+
+    let rows = env.view.storages.get("test").unwrap().load().unwrap();
+    let row = rows.iter().find(|i| i.id == id).unwrap();
+    assert!(row.is_trashed());
+    assert_eq!(
+        row.op_claim.as_ref().map(|c| c.op),
+        Some(crate::session::ClaimOp::Trash),
+        "the durable row must carry the in-flight Trash claim"
+    );
+}
+
 /// Right-clicking the synthetic Trash section header opens the bulk menu
 /// (Empty Trash / Restore All / Collapse), not the meaningless "Rename Group /
 /// Delete Group" a real group would show.


### PR DESCRIPTION
## Description

Follow-up to #2945, closing the gap @jerome-benoit identified there: the trash teardown ran as fire-and-forget compensation, observable only through its side effects. It now participates in the #2541 claim protocol as durable state.

Stacked on #2945 (based on `wt_delete`); it retargets to `main` automatically once that merges.

- `ClaimOp::Trash` is written under the storage flock right after the trash marker at all three trash sites (TUI, server handler, CLI remove), so "teardown in flight" is durable state peers can observe.
- It is deliberately the weakest claim. `try_claim` lets Purge and Restore seize a fresh Trash claim, so hitting `d` and immediately restoring stays instant; Trash never seizes a fresh Purge or Restore.
- The teardown yields to a seizure at both of its decision points: the pre-move gate skips the move when a fresh non-Trash claim holds the still-trashed row, and `commit_trash_relocation` treats a seized row as superseded (undoing the move) while releasing the teardown's own claim on every relocation outcome. No-relocation terminal paths release through `release_trash_claim`; a crash mid-teardown falls back to the existing 10 minute `OP_CLAIM_TTL` self-heal.

Compat note: `sessions.json` rows carrying `op:"trash"` are not parseable by aoe binaries predating the variant. Claims live at most 10 minutes, so the exposure is a mixed-version fleet reading storage inside that window.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the claim protocol is exercised at the unit and storage level where the interleavings can be forced deterministically (seizure matrix in `instance.rs`, acquire/release/commit gates in `claim.rs`, a seized-row teardown skip against real durable storage in `trash.rs`, and the TUI setting the durable claim on `d` in `home/tests.rs`). An e2e cannot deterministically pause a teardown mid `docker stop` to interleave a claim seizure.

## Testing

`cargo test`: 4127 passed. One failure (`restart_selected_session_surfaces_resume_failed_after_async_restart`) fails identically on a clean `main` checkout in this environment, so it is pre-existing and unrelated. `cargo fmt` clean, `cargo clippy --all-targets` adds no new warnings, `cargo check --features serve` compiles.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Fable 5 via Claude Code

**Any Additional AI Details you'd like to share:**
Designed as the follow-up promised in the #2945 review discussion.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
