### PR TITLE
feat(trash): track the teardown as a first-class claimed operation

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -96,6 +96,11 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
         let landed = storage.update(|all_instances, _groups| {
             if let Some(stored) = all_instances.iter_mut().find(|i| i.id == removed_id) {
                 stored.trash();
+                // Mark the teardown in flight (ClaimOp::Trash) so peers
+                // observe it as durable state. Best-effort: a refused claim
+                // still tears down, gated by the pre-move re-check and the
+                // locked relocation commit.
+                let _ = stored.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now());
                 Ok(true)
             } else {
                 Ok(false)
@@ -181,8 +186,11 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
             }
             crate::session::trash::RelocateOutcome::Failed { reason } => {
                 eprintln!("  Note: left worktree in place ({reason}).");
+                release_trash_claim_best_effort(&storage, &removed_id);
             }
-            crate::session::trash::RelocateOutcome::Skipped => {}
+            crate::session::trash::RelocateOutcome::Skipped => {
+                release_trash_claim_best_effort(&storage, &removed_id);
+            }
         }
 
         println!(
@@ -362,6 +370,16 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Release the teardown's in-flight Trash claim on a no-relocation terminal
+/// path (the relocation paths release inside `commit_trash_relocation`).
+/// Ownership-guarded; best-effort, a stranded claim self-heals via the TTL.
+fn release_trash_claim_best_effort(storage: &Storage, removed_id: &str) {
+    let _ = storage.update(|all_instances, _groups| {
+        crate::session::claim::release_trash_claim(all_instances, removed_id);
+        Ok(())
+    });
 }
 
 /// Release a purge claim on a kept row (teardown or transcript failed),

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -100,7 +100,15 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                 // observe it as durable state. Best-effort: a refused claim
                 // still tears down, gated by the pre-move re-check and the
                 // locked relocation commit.
-                let _ = stored.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now());
+                if let Err(holder) =
+                    stored.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+                {
+                    tracing::info!(
+                        target: "cli.session",
+                        session = %stored.id,
+                        "trash teardown runs unclaimed; a fresh {holder:?} claim holds the row"
+                    );
+                }
                 Ok(true)
             } else {
                 Ok(false)

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2347,6 +2347,24 @@ pub async fn update_session_archive(
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
 
+/// Release the teardown's in-flight Trash claim on a no-relocation terminal
+/// path (the relocation paths release inside `commit_trash_relocation`).
+/// Ownership-guarded; best-effort, a stranded claim self-heals via the TTL.
+/// Mirrors the CLI's `release_trash_claim_best_effort` so the two surfaces
+/// stay symmetric.
+async fn release_trash_claim_best_effort(state: &Arc<AppState>, profile: String, id: &str) {
+    let release_id = id.to_string();
+    let _ = persist_session_update(
+        profile,
+        "trash-claim-release",
+        state.file_watch.clone(),
+        move |instances| {
+            crate::session::claim::release_trash_claim(instances, &release_id);
+        },
+    )
+    .await;
+}
+
 /// `POST /api/sessions/:id/trash`. Soft-delete a session into the trash
 /// bucket: persist `trashed_at`, then stop the live session the same way
 /// archive does (structured-view supervisor `shutdown`, which PRESERVES the
@@ -2386,11 +2404,17 @@ pub async fn trash_session(
                 // observe it as durable state. Best-effort: a refused claim
                 // still tears down, gated by the pre-move re-check and the
                 // locked relocation commit.
-                let _ = inst.try_claim(
+                if let Err(holder) = inst.try_claim(
                     crate::session::ClaimOp::Trash,
                     Instance::OP_CLAIM_TTL,
                     chrono::Utc::now(),
-                );
+                ) {
+                    tracing::info!(
+                        target: "http.api.sessions",
+                        session = %inst.id,
+                        "trash teardown runs unclaimed; a fresh {holder:?} claim holds the row"
+                    );
+                }
             }
         },
     )
@@ -2559,31 +2583,10 @@ pub async fn trash_session(
                     session = %id,
                     "trash worktree relocation skipped: {reason}"
                 );
-                let release_id = id.clone();
-                let _ = persist_session_update(
-                    profile,
-                    "trash-claim-release",
-                    state.file_watch.clone(),
-                    move |instances| {
-                        crate::session::claim::release_trash_claim(instances, &release_id);
-                    },
-                )
-                .await;
+                release_trash_claim_best_effort(&state, profile, &id).await;
             }
             Ok((crate::session::trash::RelocateOutcome::Skipped, _)) => {
-                // No-relocation terminal path: release the teardown's
-                // in-flight Trash claim (ownership-guarded; a claim a peer
-                // seized is untouched).
-                let release_id = id.clone();
-                let _ = persist_session_update(
-                    profile,
-                    "trash-claim-release",
-                    state.file_watch.clone(),
-                    move |instances| {
-                        crate::session::claim::release_trash_claim(instances, &release_id);
-                    },
-                )
-                .await;
+                release_trash_claim_best_effort(&state, profile, &id).await;
             }
             Err(e) => tracing::warn!(
                 target: "http.api.sessions",

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -2382,6 +2382,15 @@ pub async fn trash_session(
         move |instances| {
             if let Some(inst) = instances.iter_mut().find(|i| i.id == persist_id) {
                 inst.trash();
+                // Mark the teardown in flight (ClaimOp::Trash) so peers
+                // observe it as durable state. Best-effort: a refused claim
+                // still tears down, gated by the pre-move re-check and the
+                // locked relocation commit.
+                let _ = inst.try_claim(
+                    crate::session::ClaimOp::Trash,
+                    Instance::OP_CLAIM_TTL,
+                    chrono::Utc::now(),
+                );
             }
         },
     )
@@ -2550,8 +2559,32 @@ pub async fn trash_session(
                     session = %id,
                     "trash worktree relocation skipped: {reason}"
                 );
+                let release_id = id.clone();
+                let _ = persist_session_update(
+                    profile,
+                    "trash-claim-release",
+                    state.file_watch.clone(),
+                    move |instances| {
+                        crate::session::claim::release_trash_claim(instances, &release_id);
+                    },
+                )
+                .await;
             }
-            Ok((crate::session::trash::RelocateOutcome::Skipped, _)) => {}
+            Ok((crate::session::trash::RelocateOutcome::Skipped, _)) => {
+                // No-relocation terminal path: release the teardown's
+                // in-flight Trash claim (ownership-guarded; a claim a peer
+                // seized is untouched).
+                let release_id = id.clone();
+                let _ = persist_session_update(
+                    profile,
+                    "trash-claim-release",
+                    state.file_watch.clone(),
+                    move |instances| {
+                        crate::session::claim::release_trash_claim(instances, &release_id);
+                    },
+                )
+                .await;
+            }
             Err(e) => tracing::warn!(
                 target: "http.api.sessions",
                 session = %id,

--- a/src/session/claim.rs
+++ b/src/session/claim.rs
@@ -1,10 +1,11 @@
-//! Cross-process purge/restore claim decisions, shared by the CLI, the serve
-//! daemon, and the TUI. Every destructive/irreversible phase (purge teardown,
-//! restore worktree move) runs its slow work on an UNLOCKED snapshot; these
-//! helpers make the claim check-and-set (and the final commit) atomic under the
-//! storage flock, the only serialization point visible across processes. Living
-//! in the neutral `session` layer keeps the three surfaces from reaching into
-//! `cli` for shared logic. See #2534, #2541.
+//! Cross-process purge/restore/trash claim decisions, shared by the CLI, the
+//! serve daemon, and the TUI. Every destructive/irreversible phase (purge
+//! teardown, restore worktree move, trash container stop + relocation) runs
+//! its slow work on an UNLOCKED snapshot; these helpers make the claim
+//! check-and-set (and the final commit) atomic under the storage flock, the
+//! only serialization point visible across processes. Living in the neutral
+//! `session` layer keeps the three surfaces from reaching into `cli` for
+//! shared logic. See #2534, #2541.
 
 use super::{ClaimOp, Instance};
 use chrono::{DateTime, Utc};
@@ -170,49 +171,30 @@ pub(crate) fn finalize_restore_commit(
     RestoreCommit::Committed
 }
 
-/// Outcome of the trash claim acquisition, run under the flock right after
-/// the trash marker is durably written at every trash site (TUI, server,
-/// CLI). See [`decide_trash_claim`].
-#[derive(Debug, PartialEq)]
-pub(crate) enum TrashClaimDecision {
-    /// The Trash claim is set; the teardown is observable as in flight.
-    Claimed,
-    /// A fresh purge or restore claim holds the row, so the teardown runs
-    /// unclaimed and relies on its pre-move re-check and the locked
-    /// relocation commit alone.
-    PeerHeld(ClaimOp),
-    /// The row is gone from disk (a peer removed it).
-    AlreadyGone,
-}
-
-/// Mark a freshly-trashed row's teardown as in flight by taking the Trash
-/// claim, run inside a `storage.update` closure. The claim is durable state
-/// peers can observe (and that purge/restore seize, see
-/// [`Instance::try_claim`]); it is released by
-/// [`commit_trash_relocation`] on the relocation paths and
-/// [`release_trash_claim`] on the no-relocation ones, and the
-/// [`Instance::OP_CLAIM_TTL`] self-heal covers a crash in between.
-/// Best-effort by design: a `PeerHeld` row still tears down, gated by the
-/// re-check and the locked commit.
-pub(crate) fn decide_trash_claim(
-    all: &mut [Instance],
-    id: &str,
-    now: DateTime<Utc>,
-) -> TrashClaimDecision {
-    match all.iter_mut().find(|i| i.id == id) {
-        None => TrashClaimDecision::AlreadyGone,
-        Some(row) => match row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now) {
-            Ok(()) => TrashClaimDecision::Claimed,
-            Err(op) => TrashClaimDecision::PeerHeld(op),
-        },
-    }
-}
-
 /// Release the Trash claim on a teardown's no-relocation terminal paths
 /// (`Skipped` / `Failed`), run inside a `storage.update` closure.
 /// Ownership-guarded, so a claim a purge or restore seized in the meantime is
 /// never cleared. The relocation paths release through
 /// [`commit_trash_relocation`] instead.
+///
+/// Trash claim lifecycle: each trash site (TUI `trash_session_by_id` via the
+/// same-flock `apply_user_action_with` hook, the server trash handler's
+/// persist closure, CLI `remove`) sets the claim with
+/// [`Instance::try_claim`] in the SAME `storage.update` that writes the
+/// trash marker, so a peer can never read a trashed row without its
+/// in-flight claim. A refused claim (fresh peer purge/restore) still tears
+/// down, gated by the pre-move re-check and the locked relocation commit.
+///
+/// TTL asymmetries, all deliberate: the teardown's gates
+/// ([`Instance::is_seized_by_fresh_peer_claim`]) only yield to a FRESH
+/// peer claim, while seizure of a Trash claim ignores its age entirely, so
+/// both a stale seizer and a teardown whose worker died without a release
+/// (the TUI's `Disconnected` drain, the server's join-error arm) converge
+/// through the [`Instance::OP_CLAIM_TTL`] self-heal rather than an explicit
+/// handoff. The load-time `reconcile_trashed_location` pass does not consult
+/// `op_claim` at all; racing an in-flight peer teardown is benign because
+/// both sides attempt the same idempotent move and the loser fails on
+/// "target exists".
 pub(crate) fn release_trash_claim(all: &mut [Instance], id: &str) {
     if let Some(row) = all.iter_mut().find(|i| i.id == id) {
         row.clear_op_claim_if_owned(ClaimOp::Trash);
@@ -264,11 +246,7 @@ pub(crate) fn commit_trash_relocation(
             // fresh Purge or Restore claim (which seized it) does. Either
             // way this commit is a terminal teardown path, so any Trash
             // claim still owned is released (ownership-guarded).
-            let seized = matches!(
-                &row.op_claim,
-                Some(c) if c.op != ClaimOp::Trash && (now - c.at) < Instance::OP_CLAIM_TTL
-            );
-            if !row.is_trashed() || seized {
+            if !row.is_trashed() || row.is_seized_by_fresh_peer_claim(now) {
                 row.clear_op_claim_if_owned(ClaimOp::Trash);
                 return RelocationCommit::Superseded;
             }
@@ -398,32 +376,21 @@ mod tests {
     }
 
     #[test]
-    fn decide_trash_claim_claims_and_reports_peers() {
-        let mut all = vec![trashed("a")];
-        assert_eq!(
-            decide_trash_claim(&mut all, "a", Utc::now()),
-            TrashClaimDecision::Claimed
-        );
-        assert_eq!(all[0].op_claim.as_ref().map(|c| c.op), Some(ClaimOp::Trash));
-
+    fn trash_claim_never_overwrites_a_fresh_peer_claim() {
+        // The acquisition sites call `try_claim(Trash)` directly (in the same
+        // flock write as the trash marker); a fresh peer claim must refuse it
+        // and stay intact.
         let mut row = trashed("b");
         row.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, Utc::now())
             .unwrap();
-        let mut all = vec![row];
         assert_eq!(
-            decide_trash_claim(&mut all, "b", Utc::now()),
-            TrashClaimDecision::PeerHeld(ClaimOp::Purge)
+            row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now()),
+            Err(ClaimOp::Purge)
         );
         assert_eq!(
-            all[0].op_claim.as_ref().map(|c| c.op),
+            row.op_claim.as_ref().map(|c| c.op),
             Some(ClaimOp::Purge),
             "a peer-held claim is never overwritten by trash"
-        );
-
-        let mut all: Vec<Instance> = Vec::new();
-        assert_eq!(
-            decide_trash_claim(&mut all, "a", Utc::now()),
-            TrashClaimDecision::AlreadyGone
         );
     }
 

--- a/src/session/claim.rs
+++ b/src/session/claim.rs
@@ -58,8 +58,10 @@ pub(crate) fn decide_purge_claim(
         Some(stored) => match stored.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, now) {
             Ok(()) => PurgeClaimDecision::Claimed,
             Err(ClaimOp::Restore) => PurgeClaimDecision::RestoreInProgress,
-            // `try_claim(Purge)` only ever refuses with the OTHER op.
+            // `try_claim(Purge)` only ever refuses with the OTHER op, and a
+            // fresh Trash claim is seized rather than refused.
             Err(ClaimOp::Purge) => unreachable!("try_claim(Purge) cannot be refused by Purge"),
+            Err(ClaimOp::Trash) => unreachable!("try_claim seizes a fresh Trash claim"),
         },
     }
 }
@@ -127,6 +129,7 @@ pub(crate) fn decide_restore_claim(
             Err(ClaimOp::Restore) => {
                 unreachable!("try_claim(Restore) cannot be refused by Restore")
             }
+            Err(ClaimOp::Trash) => unreachable!("try_claim seizes a fresh Trash claim"),
         },
     }
 }
@@ -167,6 +170,55 @@ pub(crate) fn finalize_restore_commit(
     RestoreCommit::Committed
 }
 
+/// Outcome of the trash claim acquisition, run under the flock right after
+/// the trash marker is durably written at every trash site (TUI, server,
+/// CLI). See [`decide_trash_claim`].
+#[derive(Debug, PartialEq)]
+pub(crate) enum TrashClaimDecision {
+    /// The Trash claim is set; the teardown is observable as in flight.
+    Claimed,
+    /// A fresh purge or restore claim holds the row, so the teardown runs
+    /// unclaimed and relies on its pre-move re-check and the locked
+    /// relocation commit alone.
+    PeerHeld(ClaimOp),
+    /// The row is gone from disk (a peer removed it).
+    AlreadyGone,
+}
+
+/// Mark a freshly-trashed row's teardown as in flight by taking the Trash
+/// claim, run inside a `storage.update` closure. The claim is durable state
+/// peers can observe (and that purge/restore seize, see
+/// [`Instance::try_claim`]); it is released by
+/// [`commit_trash_relocation`] on the relocation paths and
+/// [`release_trash_claim`] on the no-relocation ones, and the
+/// [`Instance::OP_CLAIM_TTL`] self-heal covers a crash in between.
+/// Best-effort by design: a `PeerHeld` row still tears down, gated by the
+/// re-check and the locked commit.
+pub(crate) fn decide_trash_claim(
+    all: &mut [Instance],
+    id: &str,
+    now: DateTime<Utc>,
+) -> TrashClaimDecision {
+    match all.iter_mut().find(|i| i.id == id) {
+        None => TrashClaimDecision::AlreadyGone,
+        Some(row) => match row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now) {
+            Ok(()) => TrashClaimDecision::Claimed,
+            Err(op) => TrashClaimDecision::PeerHeld(op),
+        },
+    }
+}
+
+/// Release the Trash claim on a teardown's no-relocation terminal paths
+/// (`Skipped` / `Failed`), run inside a `storage.update` closure.
+/// Ownership-guarded, so a claim a purge or restore seized in the meantime is
+/// never cleared. The relocation paths release through
+/// [`commit_trash_relocation`] instead.
+pub(crate) fn release_trash_claim(all: &mut [Instance], id: &str) {
+    if let Some(row) = all.iter_mut().find(|i| i.id == id) {
+        row.clear_op_claim_if_owned(ClaimOp::Trash);
+    }
+}
+
 /// Outcome of the final locked commit of a background trash relocation. See
 /// [`commit_trash_relocation`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -187,7 +239,7 @@ pub(crate) enum RelocationCommit {
 /// relocation, run inside a `storage.update` closure at every surface that
 /// persists one (TUI poller drain, server trash handler, CLI remove).
 ///
-/// The teardown's pre-move re-check (`durable_row_still_trashed`) narrows the
+/// The teardown's pre-move re-check (`teardown_may_relocate`) narrows the
 /// restore race to the span between that check and this commit; this gate
 /// closes the pointer half of it by re-taking the decision on the durable row
 /// under the flock. A restore that landed in between wins: the caller gets
@@ -208,13 +260,21 @@ pub(crate) fn commit_trash_relocation(
     match all.iter_mut().find(|i| i.id == id) {
         None => RelocationCommit::AlreadyGone,
         Some(row) => {
-            let claim_held =
-                matches!(&row.op_claim, Some(c) if (now - c.at) < Instance::OP_CLAIM_TTL);
-            if !row.is_trashed() || claim_held {
+            // The teardown's own Trash claim does not block its commit; a
+            // fresh Purge or Restore claim (which seized it) does. Either
+            // way this commit is a terminal teardown path, so any Trash
+            // claim still owned is released (ownership-guarded).
+            let seized = matches!(
+                &row.op_claim,
+                Some(c) if c.op != ClaimOp::Trash && (now - c.at) < Instance::OP_CLAIM_TTL
+            );
+            if !row.is_trashed() || seized {
+                row.clear_op_claim_if_owned(ClaimOp::Trash);
                 return RelocationCommit::Superseded;
             }
             row.project_path = relocation.new_project_path.clone();
             row.pre_trash_project_path = relocation.pre_trash_project_path.clone();
+            row.clear_op_claim_if_owned(ClaimOp::Trash);
             RelocationCommit::Persisted
         }
     }
@@ -302,6 +362,89 @@ mod tests {
         assert_eq!(
             commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
             RelocationCommit::AlreadyGone
+        );
+    }
+
+    #[test]
+    fn commit_relocation_persists_over_own_trash_claim_and_releases_it() {
+        let mut row = trashed("a");
+        row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Persisted,
+            "the teardown's own Trash claim must not block its commit"
+        );
+        assert_eq!(all[0].project_path, "/wt/.aoe-trash/a");
+        assert_eq!(all[0].op_claim, None, "commit is terminal: claim released");
+    }
+
+    #[test]
+    fn commit_relocation_superseded_releases_leftover_trash_claim() {
+        // A restored row that somehow still carries the teardown's Trash claim
+        // (restore raced between seize and commit) is cleaned up here; a claim
+        // a peer owns is never touched (ownership-guarded clear).
+        let mut row = trashed("a");
+        row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        row.untrash();
+        let mut all = vec![row];
+        assert_eq!(
+            commit_trash_relocation(&mut all, "a", &reloc(), Utc::now()),
+            RelocationCommit::Superseded
+        );
+        assert_eq!(all[0].op_claim, None, "leftover own Trash claim released");
+    }
+
+    #[test]
+    fn decide_trash_claim_claims_and_reports_peers() {
+        let mut all = vec![trashed("a")];
+        assert_eq!(
+            decide_trash_claim(&mut all, "a", Utc::now()),
+            TrashClaimDecision::Claimed
+        );
+        assert_eq!(all[0].op_claim.as_ref().map(|c| c.op), Some(ClaimOp::Trash));
+
+        let mut row = trashed("b");
+        row.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        assert_eq!(
+            decide_trash_claim(&mut all, "b", Utc::now()),
+            TrashClaimDecision::PeerHeld(ClaimOp::Purge)
+        );
+        assert_eq!(
+            all[0].op_claim.as_ref().map(|c| c.op),
+            Some(ClaimOp::Purge),
+            "a peer-held claim is never overwritten by trash"
+        );
+
+        let mut all: Vec<Instance> = Vec::new();
+        assert_eq!(
+            decide_trash_claim(&mut all, "a", Utc::now()),
+            TrashClaimDecision::AlreadyGone
+        );
+    }
+
+    #[test]
+    fn release_trash_claim_is_ownership_guarded() {
+        let mut row = trashed("a");
+        row.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        release_trash_claim(&mut all, "a");
+        assert_eq!(all[0].op_claim, None);
+
+        let mut row = trashed("b");
+        row.try_claim(ClaimOp::Restore, Instance::OP_CLAIM_TTL, Utc::now())
+            .unwrap();
+        let mut all = vec![row];
+        release_trash_claim(&mut all, "b");
+        assert_eq!(
+            all[0].op_claim.as_ref().map(|c| c.op),
+            Some(ClaimOp::Restore),
+            "a seized (Restore-owned) claim must survive the release"
         );
     }
 

--- a/src/session/claim.rs
+++ b/src/session/claim.rs
@@ -6,6 +6,27 @@
 //! only serialization point visible across processes. Living in the neutral
 //! `session` layer keeps the three surfaces from reaching into `cli` for
 //! shared logic. See #2534, #2541.
+//!
+//! Trash claim lifecycle: each trash site (TUI `trash_session_by_id` via the
+//! same-flock `apply_user_action_with` hook, the server trash handler's
+//! persist closure, CLI `remove`) sets the claim with `Instance::try_claim`
+//! in the SAME `storage.update` that writes the trash marker, so a peer can
+//! never read a trashed row without its in-flight claim. A refused claim
+//! (fresh peer purge/restore) still tears down, gated by the pre-move
+//! re-check and the locked relocation commit. Release happens on every
+//! terminal teardown path: [`commit_trash_relocation`] for relocation
+//! outcomes, [`release_trash_claim`] for the no-relocation ones.
+//!
+//! TTL asymmetries, all deliberate: the teardown's gates
+//! (`Instance::is_seized_by_fresh_peer_claim`) only yield to a FRESH peer
+//! claim, while seizure of a Trash claim ignores its age entirely, so both a
+//! stale seizer and a teardown whose worker died without a release (the
+//! TUI's `Disconnected` drain, the server's join-error arm) converge through
+//! the `Instance::OP_CLAIM_TTL` self-heal rather than an explicit handoff.
+//! The load-time `reconcile_trashed_location` pass does not consult
+//! `op_claim` at all; racing an in-flight peer teardown is benign because
+//! both sides attempt the same idempotent move and the loser fails on
+//! "target exists".
 
 use super::{ClaimOp, Instance};
 use chrono::{DateTime, Utc};
@@ -175,26 +196,8 @@ pub(crate) fn finalize_restore_commit(
 /// (`Skipped` / `Failed`), run inside a `storage.update` closure.
 /// Ownership-guarded, so a claim a purge or restore seized in the meantime is
 /// never cleared. The relocation paths release through
-/// [`commit_trash_relocation`] instead.
-///
-/// Trash claim lifecycle: each trash site (TUI `trash_session_by_id` via the
-/// same-flock `apply_user_action_with` hook, the server trash handler's
-/// persist closure, CLI `remove`) sets the claim with
-/// [`Instance::try_claim`] in the SAME `storage.update` that writes the
-/// trash marker, so a peer can never read a trashed row without its
-/// in-flight claim. A refused claim (fresh peer purge/restore) still tears
-/// down, gated by the pre-move re-check and the locked relocation commit.
-///
-/// TTL asymmetries, all deliberate: the teardown's gates
-/// ([`Instance::is_seized_by_fresh_peer_claim`]) only yield to a FRESH
-/// peer claim, while seizure of a Trash claim ignores its age entirely, so
-/// both a stale seizer and a teardown whose worker died without a release
-/// (the TUI's `Disconnected` drain, the server's join-error arm) converge
-/// through the [`Instance::OP_CLAIM_TTL`] self-heal rather than an explicit
-/// handoff. The load-time `reconcile_trashed_location` pass does not consult
-/// `op_claim` at all; racing an in-flight peer teardown is benign because
-/// both sides attempt the same idempotent move and the loser fails on
-/// "target exists".
+/// [`commit_trash_relocation`] instead. The full claim lifecycle and its TTL
+/// asymmetries are documented on the module header.
 pub(crate) fn release_trash_claim(all: &mut [Instance], id: &str) {
     if let Some(row) = all.iter_mut().find(|i| i.id == id) {
         row.clear_op_claim_if_owned(ClaimOp::Trash);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -454,15 +454,28 @@ pub enum SessionBucket {
 }
 
 /// Which irreversible operation currently owns a session's `op_claim`. The
-/// purge (permanent teardown) and restore (worktree move-back) paths run their
-/// slow work on an unlocked snapshot; the claim is the durable, cross-process
-/// primitive that serializes the two so neither tears down (or moves) state the
-/// other is authoritative over. See #2541.
+/// purge (permanent teardown), restore (worktree move-back), and trash
+/// (container stop + worktree relocation into the holding area) paths run
+/// their slow work on an unlocked snapshot; the claim is the durable,
+/// cross-process primitive that serializes them so none tears down (or moves)
+/// state another is authoritative over. See #2541.
+///
+/// `Trash` is deliberately the weakest claim: it marks "teardown in flight"
+/// so peers can observe it, but it never blocks user intent. A purge or
+/// restore seizes a fresh `Trash` claim (see [`Instance::try_claim`]) and the
+/// teardown yields via its pre-move re-check and the locked relocation
+/// commit, so a `d` followed by an immediate restore stays instant.
+///
+/// Compat: `trash` claims in `sessions.json` are not parseable by aoe
+/// binaries that predate the variant. A claim lives at most
+/// [`Instance::OP_CLAIM_TTL`] (10 minutes), so the exposure is a mixed
+/// version fleet reading storage inside that window.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ClaimOp {
     Purge,
     Restore,
+    Trash,
 }
 
 /// A durable ownership marker for an in-flight purge or restore. `at` serves
@@ -1748,14 +1761,23 @@ impl Instance {
     pub const OP_CLAIM_TTL: chrono::Duration = chrono::Duration::minutes(10);
 
     /// Atomically acquire or keep the op claim for `want`. Returns `Ok` when
-    /// the claim is free, already ours, or expired (self-heal), and
-    /// `Err(holder)` when the other operation holds a still-fresh claim.
+    /// the claim is free, already ours, expired (self-heal), or held by a
+    /// fresh `Trash` claim being seized by a purge or restore; returns
+    /// `Err(holder)` when another operation holds a still-fresh claim that
+    /// `want` may not seize.
+    ///
+    /// Seizure order: `Trash` is the weakest claim. A teardown marks state,
+    /// it does not gate user intent, so `Purge` and `Restore` take over a
+    /// fresh `Trash` claim and the teardown yields via its pre-move re-check
+    /// and the locked relocation commit. `Trash` itself never seizes a fresh
+    /// `Purge` or `Restore` claim, and `Purge`/`Restore` still exclude each
+    /// other as before.
     ///
     /// Must be called inside a `Storage::update` closure so the check-and-set
     /// runs under the storage flock, the only cross-process serialization
     /// point. The whole destructive/irreversible phase (purge teardown, restore
-    /// worktree move) must win this before running unlocked, and clear the
-    /// claim when it finishes. See #2541.
+    /// worktree move, trash relocation) must win this before running unlocked,
+    /// and clear the claim when it finishes. See #2541.
     pub fn try_claim(
         &mut self,
         want: ClaimOp,
@@ -1763,7 +1785,7 @@ impl Instance {
         now: DateTime<Utc>,
     ) -> Result<(), ClaimOp> {
         match &self.op_claim {
-            Some(c) if c.op != want && (now - c.at) < ttl => Err(c.op),
+            Some(c) if c.op != want && c.op != ClaimOp::Trash && (now - c.at) < ttl => Err(c.op),
             _ => {
                 self.op_claim = Some(OpClaim { op: want, at: now });
                 Ok(())
@@ -6295,6 +6317,55 @@ mod tests {
         assert_eq!(
             inst.try_claim(ClaimOp::Purge, Instance::OP_CLAIM_TTL, now),
             Err(ClaimOp::Restore),
+        );
+    }
+
+    // Trash is the weakest claim: a fresh Trash claim is seized by both
+    // Purge and Restore (teardown state never blocks user intent), while
+    // Trash itself is refused by a fresh Purge or Restore claim.
+    #[test]
+    fn trash_claim_seizure_matrix() {
+        let now = Utc::now();
+        for seizer in [ClaimOp::Purge, ClaimOp::Restore] {
+            let mut inst = Instance::new("s", "/tmp/x");
+            inst.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now)
+                .expect("trash wins the free row");
+            inst.try_claim(seizer, Instance::OP_CLAIM_TTL, now)
+                .unwrap_or_else(|holder| {
+                    panic!("{seizer:?} must seize a fresh Trash claim, refused by {holder:?}")
+                });
+            assert_eq!(inst.op_claim.as_ref().map(|c| c.op), Some(seizer));
+        }
+        for holder in [ClaimOp::Purge, ClaimOp::Restore] {
+            let mut inst = Instance::new("s", "/tmp/x");
+            inst.try_claim(holder, Instance::OP_CLAIM_TTL, now)
+                .expect("holder wins the free row");
+            assert_eq!(
+                inst.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now),
+                Err(holder),
+                "a fresh {holder:?} claim must refuse a Trash claim"
+            );
+        }
+    }
+
+    // The Trash variant round-trips on the wire as "trash" (compat note on
+    // ClaimOp: binaries predating the variant cannot parse it; TTL bounds
+    // the exposure window).
+    #[test]
+    fn trash_claim_serde_roundtrip() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        let now = Utc::now();
+        inst.try_claim(ClaimOp::Trash, Instance::OP_CLAIM_TTL, now)
+            .expect("free row grants the claim");
+        let json = serde_json::to_string(&inst).expect("serialize");
+        assert!(json.contains("\"trash\""), "lowercase wire form");
+        let back: Instance = serde_json::from_str(&json).expect("round-trip");
+        assert_eq!(
+            back.op_claim,
+            Some(OpClaim {
+                op: ClaimOp::Trash,
+                at: now
+            })
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -466,10 +466,17 @@ pub enum SessionBucket {
 /// teardown yields via its pre-move re-check and the locked relocation
 /// commit, so a `d` followed by an immediate restore stays instant.
 ///
-/// Compat: `trash` claims in `sessions.json` are not parseable by aoe
-/// binaries that predate the variant. A claim lives at most
-/// [`Instance::OP_CLAIM_TTL`] (10 minutes), so the exposure is a mixed
-/// version fleet reading storage inside that window.
+/// Compat: `ClaimOp` has no `#[serde(other)]` fallback, so an aoe binary
+/// that predates the `Trash` variant fails to deserialize the whole
+/// `Instance` row carrying `op:"trash"`; `Storage::load` then skips the row
+/// and quarantines it to `sessions.corrupt.jsonl`, making the session
+/// temporarily invisible to that binary for the life of the claim (at most
+/// [`Instance::OP_CLAIM_TTL`], 10 minutes, after which a newer binary clears
+/// the claim and the row parses again). If the older binary *writes* storage
+/// while the row is invisible, its save drops the row from `sessions.json`
+/// entirely (it survives only in the quarantine sidecar). Same exposure
+/// class as the #2541 Purge/Restore variants against pre-#2541 binaries: a
+/// mixed-version fleet touching storage inside a claim's TTL window.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ClaimOp {
@@ -478,10 +485,11 @@ pub enum ClaimOp {
     Trash,
 }
 
-/// A durable ownership marker for an in-flight purge or restore. `at` serves
-/// double duty: ownership plus the base for the TTL self-heal (a claim older
-/// than the TTL is treated as absent, so a crash mid-operation cannot strand a
-/// row permanently). Written on disk under the storage flock via
+/// A durable ownership marker for an in-flight purge, restore, or trash
+/// teardown. `at` serves double duty: ownership plus the base for the TTL
+/// self-heal (a claim older than the TTL is treated as absent, so a crash
+/// mid-operation cannot strand a row permanently). Written on disk under the
+/// storage flock via
 /// [`Instance::try_claim`], the only serialization point visible across the
 /// CLI, the serve daemon, and the TUI. See #2541.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -631,12 +639,15 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pre_trash_project_path: Option<String>,
 
-    /// Durable ownership of an in-flight purge or restore, acquired under the
-    /// storage flock via [`Self::try_claim`] before either path runs its slow
-    /// unlocked phase (purge teardown, restore worktree move). It closes the
-    /// cross-process purge/restore race (#2541): a purge refuses to tear down a
-    /// row a fresh restore claim holds, and a restore refuses to move a row a
-    /// fresh purge claim holds. Deliberately NOT copied by
+    /// Durable ownership of an in-flight purge, restore, or trash teardown,
+    /// acquired under the storage flock via [`Self::try_claim`] before each
+    /// path runs its slow unlocked phase (purge teardown, restore worktree
+    /// move, trash container stop + relocation). It closes the cross-process
+    /// purge/restore race (#2541): a purge refuses to tear down a row a fresh
+    /// restore claim holds, and a restore refuses to move a row a fresh purge
+    /// claim holds. A `Trash` claim is weaker: it marks the teardown as
+    /// observable in-flight state and is seized by either of the other two
+    /// (see [`ClaimOp`]). Deliberately NOT copied by
     /// [`Self::merge_user_action_diff`]: keeping it out of the peer-diff set is
     /// exactly what stops a concurrent user action from clobbering a live claim.
     /// Additive: absent in older `sessions.json` rows, so no migration is
@@ -1791,6 +1802,20 @@ impl Instance {
                 Ok(())
             }
         }
+    }
+
+    /// True when a fresh (unexpired) Purge or Restore claim holds this row,
+    /// i.e. a peer seized the trash teardown's claim (or claimed the row
+    /// outright while the teardown ran unclaimed). The teardown's two
+    /// decision points share this predicate: the pre-move gate
+    /// (`teardown_may_relocate`) and the locked relocation commit
+    /// (`commit_trash_relocation`). `try_claim` keeps its own inline
+    /// predicate because it additionally excludes the op being acquired.
+    pub fn is_seized_by_fresh_peer_claim(&self, now: DateTime<Utc>) -> bool {
+        matches!(
+            &self.op_claim,
+            Some(c) if c.op != ClaimOp::Trash && (now - c.at) < Self::OP_CLAIM_TTL
+        )
     }
 
     /// Drop the op claim only when it is owned by `op`. Ownership-guarding the
@@ -6348,9 +6373,10 @@ mod tests {
         }
     }
 
-    // The Trash variant round-trips on the wire as "trash" (compat note on
-    // ClaimOp: binaries predating the variant cannot parse it; TTL bounds
-    // the exposure window).
+    // The Trash variant round-trips on the wire as "trash". Compat (see the
+    // ClaimOp doc): a binary predating the variant fails the whole-row
+    // deserialize, so Storage::load quarantines the row and the session is
+    // temporarily invisible to that binary until the TTL clears the claim.
     #[test]
     fn trash_claim_serde_roundtrip() {
         let mut inst = Instance::new("s", "/tmp/x");

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -470,9 +470,12 @@ pub enum SessionBucket {
 /// that predates the `Trash` variant fails to deserialize the whole
 /// `Instance` row carrying `op:"trash"`; `Storage::load` then skips the row
 /// and quarantines it to `sessions.corrupt.jsonl`, making the session
-/// temporarily invisible to that binary for the life of the claim (at most
-/// [`Instance::OP_CLAIM_TTL`], 10 minutes, after which a newer binary clears
-/// the claim and the row parses again). If the older binary *writes* storage
+/// temporarily invisible to that binary for the life of the claim. The TTL
+/// ([`Instance::OP_CLAIM_TTL`], 10 minutes) bounds how long the claim stays
+/// FRESH, but the field itself only clears when a newer binary next rewrites
+/// that row (a release path or the load-time expired-claim sweep), so the
+/// invisibility ends at that rewrite, not on a timer. If the older binary
+/// *writes* storage
 /// while the row is invisible, its save drops the row from `sessions.json`
 /// entirely (it survives only in the quarantine sidecar). Same exposure
 /// class as the #2541 Purge/Restore variants against pre-#2541 binaries: a
@@ -1660,9 +1663,12 @@ impl Instance {
             self.status = post.status;
         }
         // `op_claim` is intentionally NOT spliced here. It is a cross-process
-        // ownership marker for an in-flight purge/restore, not a user-action
-        // field; excluding it from the peer diff is what stops a concurrent
-        // user action from clobbering a live claim on disk. See #2541.
+        // ownership marker for an in-flight purge, restore, or trash
+        // teardown, not a user-action field; excluding it from the peer diff
+        // is what stops a concurrent user action from clobbering a live claim
+        // on disk. The trash path relies on this same drop: its claim is
+        // written by a same-flock post-mutation hook instead
+        // (`apply_user_action_with`). See #2541.
         self.last_accessed_at = self.last_accessed_at.max(post.last_accessed_at);
 
         let archived_changed = pre.archived_at != post.archived_at;
@@ -6376,7 +6382,8 @@ mod tests {
     // The Trash variant round-trips on the wire as "trash". Compat (see the
     // ClaimOp doc): a binary predating the variant fails the whole-row
     // deserialize, so Storage::load quarantines the row and the session is
-    // temporarily invisible to that binary until the TTL clears the claim.
+    // temporarily invisible to that binary until a newer binary next
+    // rewrites the row without the claim.
     #[test]
     fn trash_claim_serde_roundtrip() {
         let mut inst = Instance::new("s", "/tmp/x");

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -239,13 +239,7 @@ fn teardown_may_relocate(inst: &Instance) -> bool {
                 );
                 false
             }
-            Some(row)
-                if matches!(
-                    &row.op_claim,
-                    Some(c) if c.op != crate::session::ClaimOp::Trash
-                        && (chrono::Utc::now() - c.at) < Instance::OP_CLAIM_TTL
-                ) =>
-            {
+            Some(row) if row.is_seized_by_fresh_peer_claim(chrono::Utc::now()) => {
                 tracing::info!(
                     target: "session.trash",
                     session = %inst.id,

--- a/src/session/trash.rs
+++ b/src/session/trash.rs
@@ -189,12 +189,13 @@ pub fn relocate_worktree_to_trash(inst: &mut Instance) -> RelocateOutcome {
 /// by accident restores immediately; the restore itself is a NoChange because
 /// no relocation has been recorded yet). The durable row is therefore
 /// re-checked between the stop and the move, and the move is skipped when the
-/// row is no longer trashed (or is gone, or storage cannot be read; fail
-/// closed, since a skipped move on a still-trashed row is healed by the next
-/// reconcile pass, while a move on a restored row strands a live session's
-/// worktree in the holding area). The re-check reads storage via
-/// `inst.source_profile`, so callers must pass an instance whose profile is
-/// stamped and must have durably trashed the row before calling.
+/// row is no longer trashed, was seized by a fresh purge/restore claim, is
+/// gone, or storage cannot be read (fail closed, since a skipped move on a
+/// still-trashed row is healed by the next reconcile pass, while a move on a
+/// restored row strands a live session's worktree in the holding area). The
+/// re-check reads storage via `inst.source_profile`, so callers must pass an
+/// instance whose profile is stamped and must have durably trashed the row
+/// before calling.
 ///
 /// BLOCKING: the container stop shells out to `docker stop` (~10s grace period)
 /// and the relocation runs `git worktree move`, so never call this on an event
@@ -214,22 +215,23 @@ pub fn prepare_trashed_worktree(inst: &mut Instance) -> RelocateOutcome {
                 );
             }
         },
-        durable_row_still_trashed,
+        teardown_may_relocate,
     )
 }
 
-/// Whether the durable row for `inst` still reads trashed. Consulted after the
-/// (slow) container stop and immediately before the worktree move; see
-/// [`prepare_trashed_worktree`]. Fail-closed: an unreadable storage, a missing
-/// row (purged by a peer), or an untrashed row (restored by a peer or by the
-/// user mid-teardown) all answer `false` and skip the move.
-fn durable_row_still_trashed(inst: &Instance) -> bool {
+/// Whether the teardown still owns the durable row for `inst`. Consulted after
+/// the (slow) container stop and immediately before the worktree move; see
+/// [`prepare_trashed_worktree`]. The row must still read trashed AND not be
+/// held by a fresh purge/restore claim that seized the teardown's Trash claim
+/// (the teardown's own Trash claim, or no claim at all, passes). Fail-closed:
+/// an unreadable storage, a missing row (purged by a peer), a restored row, or
+/// a seized row all answer `false` and skip the move.
+fn teardown_may_relocate(inst: &Instance) -> bool {
     let loaded = crate::session::Storage::open_unwatched(&inst.source_profile)
         .and_then(|storage| storage.load());
     match loaded {
         Ok(rows) => match rows.iter().find(|r| r.id == inst.id) {
-            Some(row) if row.is_trashed() => true,
-            Some(_) => {
+            Some(row) if !row.is_trashed() => {
                 tracing::info!(
                     target: "session.trash",
                     session = %inst.id,
@@ -237,6 +239,22 @@ fn durable_row_still_trashed(inst: &Instance) -> bool {
                 );
                 false
             }
+            Some(row)
+                if matches!(
+                    &row.op_claim,
+                    Some(c) if c.op != crate::session::ClaimOp::Trash
+                        && (chrono::Utc::now() - c.at) < Instance::OP_CLAIM_TTL
+                ) =>
+            {
+                tracing::info!(
+                    target: "session.trash",
+                    session = %inst.id,
+                    claim = ?row.op_claim,
+                    "a purge/restore claim seized the row mid-teardown; leaving the worktree in place"
+                );
+                false
+            }
+            Some(_) => true,
             None => {
                 tracing::info!(
                     target: "session.trash",
@@ -260,10 +278,10 @@ fn durable_row_still_trashed(inst: &Instance) -> bool {
 fn prepare_trashed_worktree_with(
     inst: &mut Instance,
     stop_container: impl FnOnce(&str, bool),
-    still_trashed: impl FnOnce(&Instance) -> bool,
+    may_relocate: impl FnOnce(&Instance) -> bool,
 ) -> RelocateOutcome {
     stop_container(&inst.id, is_sandboxed(inst));
-    if !still_trashed(inst) {
+    if !may_relocate(inst) {
         return RelocateOutcome::Skipped;
     }
     relocate_worktree_to_trash(inst)
@@ -1132,6 +1150,56 @@ mod tests {
         assert!(
             PathBuf::from(&original).exists(),
             "the worktree must stay at its original path when a restore raced the teardown"
+        );
+    }
+
+    /// A purge (or restore) that seized the teardown's Trash claim mid-flight
+    /// owns the row: the teardown's pre-move re-check must observe the seized
+    /// claim on the still-trashed durable row and leave the worktree in
+    /// place for the claim owner to handle.
+    #[test]
+    #[serial_test::serial]
+    fn teardown_skips_relocation_when_claim_was_seized_mid_flight() {
+        if !git_available() {
+            return;
+        }
+        let _app = crate::session::test_support::isolate_app_dir();
+        let (_tmp, mut inst) = real_worktree_instance();
+        inst.source_profile = "default".to_string();
+        let original = inst.project_path.clone();
+        inst.trash();
+
+        // Durable row: still trashed, but a purge seized the Trash claim
+        // while the teardown was stopping the container.
+        let storage = crate::session::Storage::new_unwatched("default").unwrap();
+        let mut durable = inst.clone();
+        durable
+            .try_claim(
+                crate::session::ClaimOp::Purge,
+                Instance::OP_CLAIM_TTL,
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        storage
+            .update(|rows, _groups| {
+                rows.push(durable.clone());
+                Ok(())
+            })
+            .unwrap();
+
+        let result = perform_trash(&TrashRequest {
+            session_id: inst.id.clone(),
+            instance: inst.clone(),
+        });
+
+        assert!(
+            result.relocation.is_none(),
+            "a seized row's worktree must not be relocated: {:?}",
+            result.relocation
+        );
+        assert!(
+            PathBuf::from(&original).exists(),
+            "the worktree must stay in place for the claim owner"
         );
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5881,6 +5881,26 @@ impl HomeView {
     where
         F: FnOnce(&mut Instance),
     {
+        self.apply_user_action_with(id, mutate, |_| {})
+    }
+
+    /// [`Self::apply_user_action`] with a same-flock post-mutation hook on the
+    /// DISK row, run inside the same `storage.update` closure after
+    /// `merge_user_action_diff`. For durable state the diff-merge deliberately
+    /// drops (`op_claim`, #2541) that must still land atomically with the
+    /// action: the trash path uses it so a peer can never read a trashed row
+    /// without its in-flight Trash claim. The hook mutates the disk row only;
+    /// in-memory rows never carry claims.
+    pub(super) fn apply_user_action_with<F, H>(
+        &mut self,
+        id: &str,
+        mutate: F,
+        post_disk: H,
+    ) -> anyhow::Result<()>
+    where
+        F: FnOnce(&mut Instance),
+        H: FnOnce(&mut Instance),
+    {
         let Some(profile) = self.instances.get(id).map(|i| i.source_profile.clone()) else {
             return Ok(());
         };
@@ -5896,6 +5916,7 @@ impl HomeView {
             storage.update(|insts, _groups| {
                 if let Some(disk) = insts.iter_mut().find(|i| i.id == id_owned) {
                     disk.merge_user_action_diff(&pre, &post);
+                    post_disk(disk);
                     Ok(true)
                 } else {
                     Ok(false)

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3148,6 +3148,30 @@ impl HomeView {
                 // skips too. The relocation is best-effort regardless: a later
                 // reconcile pass heals a still-trashed row whose move was
                 // dropped here.
+                if result.relocation.is_none() {
+                    // Skipped/Failed teardown: nothing moved, but the drain is
+                    // this teardown's terminal path, so release its in-flight
+                    // Trash claim (ownership-guarded; a claim a purge/restore
+                    // seized is untouched). The row stays trashed in place and
+                    // the next reconcile pass relocates it.
+                    if let Some(storage) = self
+                        .instances
+                        .get(&result.session_id)
+                        .map(|i| i.source_profile.clone())
+                        .and_then(|profile| self.storages.get(&profile))
+                    {
+                        if let Err(e) = storage.update(|insts, _groups| {
+                            crate::session::claim::release_trash_claim(insts, &result.session_id);
+                            Ok(())
+                        }) {
+                            tracing::warn!(
+                                target: "tui.session",
+                                session = %result.session_id,
+                                "could not release the Trash claim: {e}"
+                            );
+                        }
+                    }
+                }
                 if let Some(reloc) = result.relocation {
                     // Atomic durable check-and-commit under the storage flock.
                     // The worker's pre-move re-check leaves a window before

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1585,45 +1585,34 @@ impl HomeView {
     /// `Instance::stop` runs on the `StopPoller`, #1496). A structured-view
     /// worker is reaped by the daemon reconciler once the row reads trashed.
     pub(super) fn trash_session_by_id(&mut self, id: &str) {
-        if let Err(e) = self.apply_user_action(id, |inst| inst.trash()) {
-            tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
-            return;
-        }
-        // Mark the teardown as in flight with the durable Trash claim, so
-        // peers observe it as state rather than inferring it. Driven directly
-        // against storage because `merge_user_action_diff` deliberately drops
-        // `op_claim` (#2541). Best-effort: an unclaimed teardown still runs,
-        // gated by its re-check and the locked relocation commit.
-        if let Some(storage) = self
-            .instances
-            .get(id)
-            .map(|i| i.source_profile.clone())
-            .and_then(|profile| self.storages.get(&profile))
-        {
-            let claim = storage.update(|insts, _groups| {
-                Ok(crate::session::claim::decide_trash_claim(
-                    insts,
-                    id,
+        // The trash marker and the in-flight Trash claim land in ONE flock
+        // acquisition (the same-flock post_disk hook), mirroring the CLI and
+        // server sites, so a peer can never read a trashed row without its
+        // claim. The claim goes through the hook rather than the mutate
+        // because `merge_user_action_diff` deliberately drops `op_claim`
+        // (#2541). Best-effort: a refused claim (fresh peer purge/restore)
+        // still tears down, gated by the pre-move re-check and the locked
+        // relocation commit.
+        let outcome = self.apply_user_action_with(
+            id,
+            |inst| inst.trash(),
+            |disk| {
+                if let Err(holder) = disk.try_claim(
+                    crate::session::ClaimOp::Trash,
+                    crate::session::Instance::OP_CLAIM_TTL,
                     chrono::Utc::now(),
-                ))
-            });
-            match claim {
-                Ok(crate::session::claim::TrashClaimDecision::PeerHeld(op)) => {
+                ) {
                     tracing::info!(
                         target: "tui.session",
-                        session = %id,
-                        "trash teardown runs unclaimed; a fresh {op:?} claim holds the row"
+                        session = %disk.id,
+                        "trash teardown runs unclaimed; a fresh {holder:?} claim holds the row"
                     );
                 }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        target: "tui.session",
-                        session = %id,
-                        "could not set the Trash claim: {e}"
-                    );
-                }
-            }
+            },
+        );
+        if let Err(e) = outcome {
+            tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
+            return;
         }
         // The row is durably trashed; hand the blocking teardown (tmux kill,
         // container stop, worktree relocation) to the worker. The relocated

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -1589,6 +1589,42 @@ impl HomeView {
             tracing::warn!(target: "tui.session", session = %id, "trash failed: {e}");
             return;
         }
+        // Mark the teardown as in flight with the durable Trash claim, so
+        // peers observe it as state rather than inferring it. Driven directly
+        // against storage because `merge_user_action_diff` deliberately drops
+        // `op_claim` (#2541). Best-effort: an unclaimed teardown still runs,
+        // gated by its re-check and the locked relocation commit.
+        if let Some(storage) = self
+            .instances
+            .get(id)
+            .map(|i| i.source_profile.clone())
+            .and_then(|profile| self.storages.get(&profile))
+        {
+            let claim = storage.update(|insts, _groups| {
+                Ok(crate::session::claim::decide_trash_claim(
+                    insts,
+                    id,
+                    chrono::Utc::now(),
+                ))
+            });
+            match claim {
+                Ok(crate::session::claim::TrashClaimDecision::PeerHeld(op)) => {
+                    tracing::info!(
+                        target: "tui.session",
+                        session = %id,
+                        "trash teardown runs unclaimed; a fresh {op:?} claim holds the row"
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        target: "tui.session",
+                        session = %id,
+                        "could not set the Trash claim: {e}"
+                    );
+                }
+            }
+        }
         // The row is durably trashed; hand the blocking teardown (tmux kill,
         // container stop, worktree relocation) to the worker. The relocated
         // path persists later via apply_trash_results. Best-effort: if the

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7894,6 +7894,103 @@ fn trash_sets_durable_teardown_claim() {
     );
 }
 
+/// The teardown's no-relocation terminal path releases the durable Trash
+/// claim: a plain (non-worktree) session's teardown ends in `Skipped`, and
+/// draining that result must clear the claim set at `d` time, leaving a
+/// trashed row with no in-flight marker.
+#[test]
+#[serial]
+fn trash_teardown_release_clears_durable_claim() {
+    let mut env = create_test_env_with_sessions(2);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    env.view.trash_session_by_id(&id);
+    let row = |view: &HomeView| {
+        view.storages
+            .get("test")
+            .unwrap()
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == id)
+            .unwrap()
+    };
+    assert_eq!(
+        row(&env.view).op_claim.as_ref().map(|c| c.op),
+        Some(crate::session::ClaimOp::Trash),
+        "claim set at d time"
+    );
+
+    // Drain the worker's (Skipped) teardown result; the drain is the
+    // terminal path and must release the claim.
+    let mut drained = false;
+    for _ in 0..100 {
+        env.view.apply_trash_results();
+        if !env.view.trash_poller.is_pending(&id) {
+            drained = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(drained, "teardown result never drained");
+    let final_row = row(&env.view);
+    assert!(final_row.is_trashed(), "row stays trashed");
+    assert_eq!(
+        final_row.op_claim, None,
+        "Skipped teardown must release the Trash claim"
+    );
+}
+
+/// End-to-end `d`-then-restore handoff through the TUI: the restore seizes
+/// the teardown's fresh Trash claim (instant, no lockout), commits untrash,
+/// and releases; the teardown's later result then finds nothing to do and
+/// never re-trashes or re-claims the row.
+#[test]
+#[serial]
+fn trash_then_immediate_restore_hands_off_cleanly() {
+    let mut env = create_test_env_with_sessions(2);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    env.view.trash_session_by_id(&id);
+    // Immediate restore, well inside the teardown window.
+    env.view.selected_session = Some(id.clone());
+    env.view.restore_selected_from_trash();
+
+    let row = |view: &HomeView| {
+        view.storages
+            .get("test")
+            .unwrap()
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == id)
+            .unwrap()
+    };
+    let restored = row(&env.view);
+    assert!(!restored.is_trashed(), "restore must win instantly");
+    assert_eq!(
+        restored.op_claim, None,
+        "restore seized the Trash claim and released it on commit"
+    );
+
+    // Let the stale teardown result drain; it must not resurrect anything.
+    let mut drained = false;
+    for _ in 0..100 {
+        env.view.apply_trash_results();
+        if !env.view.trash_poller.is_pending(&id) {
+            drained = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(drained, "teardown result never drained");
+    let final_row = row(&env.view);
+    assert!(!final_row.is_trashed(), "row stays restored");
+    assert_eq!(final_row.op_claim, None, "no claim resurrected");
+}
+
 /// Right-clicking the synthetic Trash section header opens the bulk menu
 /// (Empty Trash / Restore All / Collapse), not the meaningless "Rename Group /
 /// Delete Group" a real group would show.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7871,6 +7871,29 @@ fn trash_offloads_blocking_teardown_to_poller() {
     );
 }
 
+/// Trashing marks the teardown as in flight on the durable row: `d` sets the
+/// Trash claim under the storage flock so peer processes observe the teardown
+/// as state instead of inferring it. Driven directly against storage because
+/// `merge_user_action_diff` deliberately drops `op_claim` (#2541).
+#[test]
+#[serial]
+fn trash_sets_durable_teardown_claim() {
+    let mut env = create_test_env_with_sessions(2);
+    let id = env.view.instance_at(0).id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    env.view.trash_session_by_id(&id);
+
+    let rows = env.view.storages.get("test").unwrap().load().unwrap();
+    let row = rows.iter().find(|i| i.id == id).unwrap();
+    assert!(row.is_trashed());
+    assert_eq!(
+        row.op_claim.as_ref().map(|c| c.op),
+        Some(crate::session::ClaimOp::Trash),
+        "the durable row must carry the in-flight Trash claim"
+    );
+}
+
 /// Right-clicking the synthetic Trash section header opens the bulk menu
 /// (Empty Trash / Restore All / Collapse), not the meaningless "Rename Group /
 /// Delete Group" a real group would show.

--- a/src/tui/trash_poller.rs
+++ b/src/tui/trash_poller.rs
@@ -54,6 +54,13 @@ impl TrashPoller {
     pub fn take_pending(&mut self) -> Vec<String> {
         self.pending.drain().collect()
     }
+
+    /// Non-destructive pending probe for tests that need to wait for a
+    /// specific teardown's result to drain without consuming the set.
+    #[cfg(test)]
+    pub(crate) fn is_pending(&self, id: &str) -> bool {
+        self.pending.contains(id)
+    }
 }
 
 impl Default for TrashPoller {


### PR DESCRIPTION
## Description

Follow-up to #2945, closing the gap @jerome-benoit identified there: the trash teardown ran as fire-and-forget compensation, observable only through its side effects. It now participates in the #2541 claim protocol as durable state.

Replaces #2960, which was auto-closed when its base branch was deleted on #2945's merge; same content, now based on `main`.

- `ClaimOp::Trash` is written under the storage flock right after the trash marker at all three trash sites (TUI, server handler, CLI remove), so "teardown in flight" is durable state peers can observe.
- It is deliberately the weakest claim. `try_claim` lets Purge and Restore seize a fresh Trash claim, so hitting `d` and immediately restoring stays instant; Trash never seizes a fresh Purge or Restore.
- The teardown yields to a seizure at both of its decision points: the pre-move gate skips the move when a fresh non-Trash claim holds the still-trashed row, and `commit_trash_relocation` treats a seized row as superseded (undoing the move) while releasing the teardown's own claim on every relocation outcome. No-relocation terminal paths release through `release_trash_claim`; a crash mid-teardown falls back to the existing 10 minute `OP_CLAIM_TTL` self-heal.

Compat note: `ClaimOp` has no `#[serde(other)]` fallback, so an aoe binary predating the variant fails the whole-row deserialize on `op:"trash"`; `Storage::load` quarantines the row to `sessions.corrupt.jsonl` and the session is temporarily invisible to that binary for the life of the claim. The 10 minute TTL bounds how long the claim stays fresh, but the field only clears when a newer binary next rewrites the row, so the invisibility ends at that rewrite, not on a timer. If the older binary writes storage while the row is invisible, its save drops the row from `sessions.json` (it survives only in the quarantine sidecar). Same exposure class as the #2541 Purge/Restore variants against pre-#2541 binaries.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the claim protocol is exercised at the unit and storage level where the interleavings can be forced deterministically (seizure matrix in `instance.rs`, acquire/release/commit gates in `claim.rs`, a seized-row teardown skip against real durable storage in `trash.rs`, and the TUI setting the durable claim on `d` in `home/tests.rs`). An e2e cannot deterministically pause a teardown mid `docker stop` to interleave a claim seizure.

## Testing

`cargo test`: 4127 passed. One failure (`restart_selected_session_surfaces_resume_failed_after_async_restart`) fails identically on a clean `main` checkout in this environment, so it is pre-existing and unrelated. `cargo fmt` clean, `cargo clippy --all-targets` adds no new warnings, `cargo check --features serve` compiles.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
Claude Fable 5 via Claude Code

**Any Additional AI Details you'd like to share:**
Designed as the follow-up promised in the #2945 review discussion.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a durable, persisted “trash teardown” operation claim (`ClaimOp::Trash`) so in-progress trash cleanup is observable and recoverable across processes and crashes.
- Wired this new claim into the main entry points (TUI, server, and CLI) so they all mark “trash teardown in flight” using the same atomic storage/lock flow.
- Updated teardown behavior so trash cleanup can be safely superseded by newer purge/restore work, and so teardown won’t leave behind stranded claims.
- Ensured the in-flight trash claim is best-effort released on terminal outcomes (including when relocation is skipped/fails), with centralized release logic.
- Strengthened relocation safety by re-checking durable state after stopping the container, and skipping relocation if the durable record shows the work was no longer safe to move.
- Expanded storage/session claim logic and added tests for interleavings, teardown handling, and TUI claim operations; also updated compatibility documentation for older binaries that can’t parse `op:"trash"` during the TTL window.

## Benefits

- More reliable crash recovery and concurrency handling for trash cleanup.
- Reduced risk of conflicting cleanup operations and stranded worktrees during purge/restore races.
- Clearer operational visibility into what “trash teardown” is doing and whether it completed, skipped, or was superseded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

