### PR TITLE
fix: keep local TUI on loopback for remote daemons

### DIFF
--- a/src/acp/client/discovery.rs
+++ b/src/acp/client/discovery.rs
@@ -17,7 +17,7 @@ use std::env;
 
 use thiserror::Error;
 
-use crate::cli::serve::{daemon_pid, read_serve_urls};
+use crate::cli::serve::{daemon_pid, read_serve_urls, ServeUrl};
 
 /// A located daemon endpoint. `base_url` carries no query string so it
 /// is safe to log; the auth token (if any) travels separately and is
@@ -98,11 +98,7 @@ pub fn discover_local() -> Result<DaemonEndpoint, DiscoveryError> {
     if urls.is_empty() {
         return Err(DiscoveryError::NoLocalDaemon);
     }
-    let pick = urls
-        .iter()
-        .find(|u| is_loopback(&u.url))
-        .or_else(|| urls.first())
-        .ok_or(DiscoveryError::Malformed)?;
+    let pick = preferred_daemon_url(&urls).ok_or(DiscoveryError::Malformed)?;
     let token = extract_token(&pick.url).map(str::to_string);
     let base_url = trim_query(&pick.url).trim_end_matches('/').to_string();
     if base_url.is_empty() {
@@ -113,6 +109,12 @@ pub fn discover_local() -> Result<DaemonEndpoint, DiscoveryError> {
         token,
         source: Source::LocalDaemon,
     })
+}
+
+fn preferred_daemon_url(urls: &[ServeUrl]) -> Option<&ServeUrl> {
+    urls.iter()
+        .find(|u| is_loopback(&u.url))
+        .or_else(|| urls.first())
 }
 
 fn is_loopback(url: &str) -> bool {
@@ -213,6 +215,34 @@ mod tests {
         assert!(is_loopback("http://[::1]:8080"));
         assert!(!is_loopback("https://example.com"));
         assert!(!is_loopback("http://192.168.1.50:8080"));
+    }
+
+    #[test]
+    fn preferred_daemon_url_uses_loopback_alternate() {
+        let urls = vec![
+            ServeUrl {
+                label: None,
+                url: "https://aoe.example.test/?token=secret".into(),
+            },
+            ServeUrl {
+                label: Some("localhost".into()),
+                url: "http://127.0.0.1:8080/?token=secret".into(),
+            },
+        ];
+
+        let selected = preferred_daemon_url(&urls).expect("a daemon URL should be selected");
+        assert_eq!(selected.url, urls[1].url);
+    }
+
+    #[test]
+    fn preferred_daemon_url_keeps_single_url_backward_compatibility() {
+        let urls = vec![ServeUrl {
+            label: None,
+            url: "https://aoe.example.test/?token=secret".into(),
+        }];
+
+        let selected = preferred_daemon_url(&urls).expect("a daemon URL should be selected");
+        assert_eq!(selected.url, urls[0].url);
     }
 
     // Env-touching tests must run serially; cargo test runs in

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -529,13 +529,14 @@ fn recall_serve_passphrase() -> Option<String> {
     None
 }
 
-/// One URL we can show in the Active state. Tunnel mode has exactly one.
-/// Local mode may have multiple (Tailscale + LAN + localhost), and the
-/// user can Tab-cycle between them.
+/// One URL we can show in the Active state. Tunnel mode has a public primary
+/// plus a loopback alternate for same-host clients. Local mode may have
+/// multiple entries (Tailscale + LAN + localhost), and the user can Tab-cycle
+/// between them.
 #[derive(Debug, Clone)]
 pub struct ServeUrl {
     /// Optional human-readable label ("tailscale", "lan", "localhost").
-    /// None for the single tunnel URL, which doesn't need one.
+    /// None for the primary URL, which does not need one.
     pub label: Option<String>,
     pub url: String,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -179,6 +179,29 @@ impl TokenManager {
     }
 }
 
+/// Build the owner-only `serve.url` contents for a remotely exposed daemon.
+/// The public tunnel stays first for backwards-compatible display/QR consumers,
+/// while the loopback alternate lets same-host clients (notably the TUI) use the
+/// auth middleware's filesystem-trusted loopback bypass instead of round-tripping
+/// through the tunnel and getting challenged for a browser passphrase session.
+fn remote_serve_url_contents(
+    remote_base_url: &str,
+    local_port: u16,
+    token: Option<&str>,
+) -> String {
+    let with_token = |base_url: &str| {
+        let base_url = base_url.trim_end_matches('/');
+        match token {
+            Some(token) => format!("{base_url}/?token={token}"),
+            None => format!("{base_url}/"),
+        }
+    };
+
+    let remote_url = with_token(remote_base_url);
+    let loopback_url = with_token(&format!("http://127.0.0.1:{local_port}"));
+    format!("{remote_url}\nlocalhost\t{loopback_url}\n")
+}
+
 /// Read `AOE_TEST_TOKEN_LIFETIME_SECS`. Debug builds only; ignored in
 /// release so production cannot be forced into a short rotation cycle
 /// by a stray env var.
@@ -924,11 +947,13 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             }
         }
 
-        // Write tunnel URL for daemon discovery. Single-line content:
-        // backward-compatible with any consumer that does `head -1 serve.url`,
-        // and the TUI parses both single- and multi-URL formats.
+        // Keep the public tunnel URL first for backwards-compatible consumers,
+        // plus a loopback alternate so same-host clients do not round-trip
+        // through the tunnel and hit the passphrase wall.
         if let Ok(app_dir) = crate::session::get_app_dir() {
-            write_secret_file(&app_dir.join("serve.url"), &tunnel_url_with_token).await;
+            let contents =
+                remote_serve_url_contents(&handle.url, local_port, auth_token.as_deref());
+            write_secret_file(&app_dir.join("serve.url"), &contents).await;
             // serve.mode lets the TUI reattach to a running daemon and
             // render the right transport label: "tunnel" for Cloudflare,
             // "tailscale" for Tailscale Funnel, "local" for local-only.
@@ -1343,9 +1368,9 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 if let (Some(base_url), Some(token)) =
                     (rot_base_url.as_ref(), post_rotate_current.as_ref())
                 {
-                    let url_with_token = format!("{}/?token={}", base_url, token);
                     if let Ok(app_dir) = crate::session::get_app_dir() {
-                        write_secret_file(&app_dir.join("serve.url"), &url_with_token).await;
+                        let contents = remote_serve_url_contents(base_url, local_port, Some(token));
+                        write_secret_file(&app_dir.join("serve.url"), &contents).await;
                     }
                 }
 
@@ -5546,6 +5571,23 @@ mod tests {
         assert_eq!(strip_host_port("[::1]"), "::1");
         assert_eq!(strip_host_port("::1"), "::1");
         assert_eq!(strip_host_port("example.com"), "example.com");
+    }
+
+    #[test]
+    fn remote_serve_url_contents_keeps_public_primary_and_loopback_alternate() {
+        assert_eq!(
+            remote_serve_url_contents("https://aoe.example.test", 8080, Some("secret")),
+            "https://aoe.example.test/?token=secret\n\
+             localhost\thttp://127.0.0.1:8080/?token=secret\n"
+        );
+    }
+
+    #[test]
+    fn remote_serve_url_contents_handles_trailing_slash_and_no_auth() {
+        assert_eq!(
+            remote_serve_url_contents("https://aoe.example.test/", 8080, None),
+            "https://aoe.example.test/\nlocalhost\thttp://127.0.0.1:8080/\n"
+        );
     }
 
     #[test]

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -2873,7 +2873,7 @@ mod tests {
 
     #[test]
     fn serve_url_parses_single_line_backward_compat() {
-        // Tunnel mode writes a single URL on line 1.
+        // Older tunnel daemons wrote only the public URL on line 1.
         let out = parse_serve_url_contents("https://foo.trycloudflare.com/?token=abc\n");
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].label, None);
@@ -2882,7 +2882,7 @@ mod tests {
 
     #[test]
     fn serve_url_parses_multi_line_with_labels() {
-        // Local mode writes primary on line 1, `kind\turl` on alternates.
+        // Current daemons write primary on line 1, `kind\turl` on alternates.
         let raw = "\
 http://100.64.0.5:54321/?token=abc\n\
 lan\thttp://192.168.1.20:54321/?token=abc\n\


### PR DESCRIPTION
## Description

`aoe serve --remote` requires token auth plus a passphrase session for tunneled clients. The auth middleware intentionally bypasses that browser-session requirement for filesystem-trusted loopback callers so the local TUI can attach.

Remote mode currently writes only the public tunnel URL to `serve.url`. Local TUI discovery therefore falls back to that URL, round-trips through Tailscale or Cloudflare, and arrives with a non-loopback client IP. Its token is valid, but it has no browser session cookie, so replay and WebSocket requests receive `401 login_required` and structured chats cannot open.

This change:

- Persists the public tunnel URL as the primary `serve.url` entry and adds a token-matched `127.0.0.1` alternate for same-host clients.
- Rebuilds both entries when the remote daemon rotates its auth token.
- Keeps backward compatibility with older single-URL files while testing that daemon discovery prefers loopback when available.
- Updates comments that previously described tunnel mode as single-URL only.

This aligns discovery with the existing auth policy: local TUI traffic stays local, while remote PWA traffic continues to require both authentication factors. Public URLs, QR/status consumers, and remote authentication behavior remain unchanged.

### Validation

- `cargo +1.95.0 fmt --check`
- `git diff --check`
- `cargo +1.95.0 test --features serve --lib remote_serve_url_contents`
- `cargo +1.95.0 test --features serve --lib acp::client::discovery::tests`
- `cargo +1.95.0 test --features serve --lib serve_url_parses`
- `cargo +1.95.0 test --features serve --lib post_token_auth_action`
- `cargo +1.95.0 check --features serve`
- `cargo +1.95.0 clippy --features serve --lib -- -D warnings -A clippy::collapsible-match`

The explicit Clippy allowance is for an existing `collapsible_match` warning in `src/acp/event_store.rs`; this change introduces no new Clippy warnings.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: exercising the failure end-to-end requires a live Tailscale or Cloudflare tunnel plus passphrase auth. Unit tests cover remote URL persistence, token rotation output, loopback preference, single-URL backward compatibility, URL parsing, and the loopback auth policy.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex (GPT-5)

**Any Additional AI Details you'd like to share:** The agent diagnosed the issue from live daemon logs and upstream source, implemented the fix in an isolated worktree, added regression tests, and ran the validation commands listed above.

- [x] I am an AI Agent filling out this form (check box if true)