### PR TITLE
fix(acp): reject deprecated Codex adapter

### DIFF
--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -17,8 +17,8 @@
 //! `rawInput` on `external_directory` permission requests so the approval
 //! card shows the path and command; AoE issue #1907, upstream #30567). The
 //! Codex validates the maintained adapter package name but has no minimum
-//! version floor. The remaining agents get a permissive policy (protocol
-//! check only). Long-term aoe should
+//! version floor. aoe-agent, Gemini, Pi ACP, and unknown adapters get a
+//! permissive policy (protocol check only). Long-term aoe should
 //! prefer ACP capability flags over package-version gating; until upstream
 //! exposes those, package versions are the only precise contract.
 //!

--- a/src/acp/agent_compat.rs
+++ b/src/acp/agent_compat.rs
@@ -16,8 +16,9 @@
 //! `OPENCODE_MIN_VERSION`, the release that stopped sending empty
 //! `rawInput` on `external_directory` permission requests so the approval
 //! card shows the path and command; AoE issue #1907, upstream #30567). The
-//! remaining agents
-//! get a permissive policy (protocol check only). Long-term aoe should
+//! Codex validates the maintained adapter package name but has no minimum
+//! version floor. The remaining agents get a permissive policy (protocol
+//! check only). Long-term aoe should
 //! prefer ACP capability flags over package-version gating; until upstream
 //! exposes those, package versions are the only precise contract.
 //!
@@ -166,16 +167,24 @@ impl ExpectedAgent {
                 required_protocol: ProtocolVersion::V1,
                 fail_on_missing_agent_info: true,
             },
+            Self::CodexAcp => CompatibilityPolicy {
+                // The deprecated @zed-industries package still exposes the
+                // same binary name, but lacks current Codex model metadata.
+                // Match the maintained package when agent_info is present;
+                // tolerate missing info because Codex has no version floor.
+                expected_name: Some("@agentclientprotocol/codex-acp"),
+                min_version: None,
+                required_protocol: ProtocolVersion::V1,
+                fail_on_missing_agent_info: false,
+            },
             // Other adapters: protocol check only. aoe doesn't yet
             // depend on a version-gated behavior in any of them.
-            Self::CodexAcp | Self::AoeAgent | Self::Gemini | Self::PiAcp | Self::Other => {
-                CompatibilityPolicy {
-                    expected_name: None,
-                    min_version: None,
-                    required_protocol: ProtocolVersion::V1,
-                    fail_on_missing_agent_info: false,
-                }
-            }
+            Self::AoeAgent | Self::Gemini | Self::PiAcp | Self::Other => CompatibilityPolicy {
+                expected_name: None,
+                min_version: None,
+                required_protocol: ProtocolVersion::V1,
+                fail_on_missing_agent_info: false,
+            },
         }
     }
 }
@@ -666,9 +675,22 @@ mod tests {
     }
 
     #[test]
-    fn non_claude_permissive_on_old_version() {
+    fn codex_accepts_current_package_without_a_version_floor() {
         let init = make_init("@agentclientprotocol/codex-acp", "0.0.1");
         validate(ExpectedAgent::CodexAcp, &init).unwrap();
+    }
+
+    #[test]
+    fn codex_rejects_legacy_adapter_reported_name() {
+        let init = make_init("codex-acp", "0.16.0");
+        let err = validate(ExpectedAgent::CodexAcp, &init).unwrap_err();
+        assert_eq!(err.kind(), "mismatched_agent_name");
+        assert!(err
+            .user_message()
+            .contains("@agentclientprotocol/codex-acp"));
+        assert!(err
+            .user_message()
+            .contains("npm install -g @agentclientprotocol/codex-acp@latest"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Reject the deprecated `@zed-industries/codex-acp` adapter during ACP initialization. The old package exposes the same `codex-acp` binary and protocol version, and reports `agent_info.name = "codex-acp"`, so AoE previously accepted it even though it lacks current Codex model metadata. That produces the `Model metadata for gpt-5.6-sol not found` fallback warning and can degrade GPT-5.6 sessions.

AoE now requires the maintained `@agentclientprotocol/codex-acp` identity when the adapter reports `agent_info`. It remains version-permissive and continues tolerating adapters that omit `agent_info` because Codex ACP has no minimum version floor. The regression test models the deprecated adapter's real reported identity.

### Validation

- `git diff --check`
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test --features serve -q codex_accepts_current_package_without_a_version_floor`
- `cargo +1.95.0 test --features serve -q codex_rejects_legacy_adapter_reported_name`
- `cargo +1.95.0 clippy --features serve --all-targets -- -A clippy::collapsible-match -A clippy::items-after-test-module -D warnings`
  - Both allowances are for unchanged Rust 1.95 findings on current `main`: `src/acp/event_store.rs:1191` and `src/tui/home/mod.rs:5213`.
- `cargo +1.95.0 test --features serve`
  - 5,894 passed, 0 failed, and 8 ignored with `umask 077`, an owner-only `TMPDIR`, and `CARGO_BUILD_JOBS=1`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:**

Codex identified the real legacy adapter identity, corrected the regression fixture, rebased the focused change onto current `main`, and ran the validation above in isolated worktrees.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated ACP initialization’s Codex adapter compatibility check to reject the deprecated `@zed-industries/codex-acp` adapter identity.
- Ensured adapters that don’t report `agent_info` are still accepted, and no new minimum adapter version requirement was added.
- Updated and strengthened the regression tests to verify that the maintained Codex adapter name (`@agentclientprotocol/codex-acp`) is accepted and that the deprecated identity is rejected with clear guidance on what to install instead.

## Benefits

- Prevents deprecated Codex adapters from causing incorrect fallback warnings in GPT-5.6 sessions.
- Keeps compatibility for non-`agent_info` adapters while enforcing the correct maintained Codex identity.

## Validation

Formatting, targeted tests, Clippy, and the full test suite passed: 5,894 passed, 8 ignored, 0 failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->