### PR TITLE
feat(tui): refine structured chat hierarchy

### DIFF
--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -40,10 +40,10 @@ stay in sync.
 
 ### TUI structured view keybinds
 
-The TUI structured view has three focusable regions: composer (where
-you type prompts), transcript (the activity feed), and approval cards
-(one per pending tool authorization). Tab cycles focus; the status
-banner at the bottom shows the current focus.
+The TUI structured view opens with the composer ready for typing. The
+transcript remains scrollable from the composer, while a pending tool
+authorization opens a focused approval shelf above it. The status line
+keeps the current worker state and primary controls visible.
 
 | Focus       | Key             | Action                                                |
 | ----------- | --------------- | ----------------------------------------------------- |
@@ -71,7 +71,7 @@ banner at the bottom shows the current focus.
 | Approval    | `a`             | Allow once                                            |
 | Approval    | `Shift+A`       | Allow always (session-scoped allow-list entry)        |
 | Approval    | `d`             | Deny                                                  |
-| Approval    | `Esc`           | Return focus to the transcript                        |
+| Approval    | `Esc`           | Stop the in-flight turn                               |
 | Any         | `Ctrl+C`        | Cancel the in-flight prompt                           |
 | Any         | `Ctrl+O`        | Open the session in the web dashboard                 |
 | Any         | `Ctrl+X`        | Clear every queued (not-yet-sent) prompt              |
@@ -89,6 +89,19 @@ agent has advertised commands.
 the approval card has focus. Typing "always allow" into the composer
 will never approve a pending tool; the composer captures every
 keystroke.
+
+**Compact activity.** Successful tool calls collapse to one line with
+their target and, for edits, added and removed line counts. Running and
+failed calls stay expanded so progress and errors remain visible. The
+latest agent plan is pinned as a single progress summary above the
+transcript instead of adding a new checklist for every update. Press
+`o` to inspect full tool output and plan history in the web dashboard.
+
+**Approval shelf.** A pending authorization is pinned above the composer
+with the command or path, destructive warning, and decision keys. The
+transcript records the final decision after the shelf closes, without
+showing internal approval identifiers. Multiple requests advance by
+their stable identity, so the action shown is always the action resolved.
 
 **Approval card detail.** The web approval card shows a one-line preview
 of the tool call in its header (the command for a shell call, the path

--- a/docs/structured-view/interface.md
+++ b/docs/structured-view/interface.md
@@ -45,6 +45,14 @@ transcript remains scrollable from the composer, while a pending tool
 authorization opens a focused approval shelf above it. The status line
 keeps the current worker state and primary controls visible.
 
+**Visual hierarchy.** The active session uses a compact metadata card in
+the upper-left for the agent, session, directory, and permission mode. The
+conversation stays on the terminal background instead of sitting inside a
+full-width frame: user turns use a `›` gutter, agent replies use a `•`
+gutter, and the composer repeats the same open prompt treatment. Session
+identity and readiness stay on the bottom status line. Only modal decisions,
+such as a pending approval, receive a full-width border.
+
 | Focus       | Key             | Action                                                |
 | ----------- | --------------- | ----------------------------------------------------- |
 | Composer    | `Enter`         | Send the buffered text, or queue it if a turn is active |

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -18,7 +18,6 @@ use crate::acp::protocol::{
     ApprovalDecisionWire, FilesResponse, PromptRequest, ReplayResponse, ResolveApprovalRequest,
     SwitchAgentRequest, SwitchAgentResponse,
 };
-use crate::acp::session_paths::SessionPathRoots;
 use crate::plugin::ui_state::UiSnapshot;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -434,16 +433,19 @@ impl HttpClient {
         Ok(res.json::<SessionsEnvelope<T>>().await?.sessions)
     }
 
-    /// Session root paths used to render tool-call file labels relative to the
-    /// active worktree or workspace repository.
-    pub async fn session_path_roots(
+    /// Session title, resolved ACP agent, and path roots used by the native
+    /// structured view. Kept as one list fetch so opening the view does not add
+    /// another request on top of the existing path hydration.
+    pub async fn session_view_info(
         &self,
         session_id: &str,
-    ) -> Result<SessionPathRoots, HttpError> {
-        let sessions = self.list_sessions::<SessionPathRoots>().await?;
+    ) -> Result<crate::acp::session_paths::SessionViewInfo, HttpError> {
+        let sessions = self
+            .list_sessions::<crate::acp::session_paths::SessionViewInfo>()
+            .await?;
         sessions
             .into_iter()
-            .find(|session| session.id == session_id)
+            .find(|session| session.paths.id == session_id)
             .ok_or_else(|| HttpError::SessionNotFound(session_id.to_string()))
     }
 

--- a/src/acp/session_paths.rs
+++ b/src/acp/session_paths.rs
@@ -9,6 +9,25 @@ pub struct SessionPathRoots {
     pub workspace_repos: Vec<WorkspaceRepoRoot>,
 }
 
+/// Session metadata the native structured view needs alongside its path roots.
+/// All fields come from the existing `/api/sessions` payload, so one fetch can
+/// hydrate both the friendly header and repo-relative tool paths.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SessionViewInfo {
+    pub title: String,
+    pub tool: String,
+    #[serde(default)]
+    pub acp_agent: Option<String>,
+    #[serde(flatten)]
+    pub paths: SessionPathRoots,
+}
+
+impl SessionViewInfo {
+    pub fn agent_label(&self) -> String {
+        self.acp_agent.clone().unwrap_or_else(|| self.tool.clone())
+    }
+}
+
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct WorkspaceRepoRoot {
     pub name: String,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1204,6 +1204,22 @@ impl App {
                                         v.deactivate();
                                     }
                                 }
+                                if active
+                                    && in_pane
+                                    && matches!(
+                                        mouse.kind,
+                                        MouseEventKind::Down(MouseButton::Left)
+                                    )
+                                    && !mouse.modifiers.contains(KeyModifiers::SHIFT)
+                                {
+                                    if let Some(view) = self.home.structured_preview.as_mut() {
+                                        let _ = view.handle_event(Event::Mouse(mouse)).await;
+                                    }
+                                    if !self.needs_redraw {
+                                        self.draw(terminal)?;
+                                    }
+                                    continue;
+                                }
                             }
                             // Footer toolbar: a left-click on a button
                             // synthesizes its shortcut and routes it through

--- a/src/tui/structured_view/embedded.rs
+++ b/src/tui/structured_view/embedded.rs
@@ -29,7 +29,7 @@ use super::{
     PluginPoll, ViewSetup,
 };
 use crate::acp::client::{DaemonEndpoint, WsError, WsMessage};
-use crate::acp::session_paths::SessionPathRoots;
+use crate::acp::session_paths::SessionViewInfo;
 use crate::tui::styles::Theme;
 
 /// One event surfaced by [`EmbeddedView::next_event`], applied by
@@ -39,14 +39,14 @@ pub enum EmbeddedEvent {
     /// A WebSocket message, or `None` when the ws channel closed.
     Ws(Option<Result<WsMessage, WsError>>),
     Plugin(PluginPoll),
-    PathRoots(Result<SessionPathRoots, String>),
+    SessionInfo(Result<SessionViewInfo, String>),
 }
 
 pub struct EmbeddedView {
     state: StructuredViewState,
     toast_deadline: Option<Instant>,
     plugin_rx: tokio::sync::mpsc::Receiver<PluginPoll>,
-    path_roots_rx: tokio::sync::mpsc::Receiver<Result<SessionPathRoots, String>>,
+    session_info_rx: tokio::sync::mpsc::Receiver<Result<SessionViewInfo, String>>,
     /// Preview vs. interactive. A view is mounted (streaming, rendered
     /// in the preview pane) as soon as its session is selected, but the
     /// keyboard only routes to it once activated (Enter), the same
@@ -65,13 +65,13 @@ impl EmbeddedView {
             state,
             startup_toast,
             plugin_rx,
-            path_roots_rx,
+            session_info_rx,
         } = setup_view(endpoint, session_id).await?;
         let mut view = Self {
             state,
             toast_deadline: None,
             plugin_rx,
-            path_roots_rx,
+            session_info_rx,
             active: false,
         };
         if let Some(text) = startup_toast {
@@ -130,7 +130,7 @@ impl EmbeddedView {
                 }
             } => EmbeddedEvent::Ws(msg),
             Some(poll) = self.plugin_rx.recv() => EmbeddedEvent::Plugin(poll),
-            Some(result) = self.path_roots_rx.recv() => EmbeddedEvent::PathRoots(result),
+            Some(result) = self.session_info_rx.recv() => EmbeddedEvent::SessionInfo(result),
         }
     }
 
@@ -162,12 +162,12 @@ impl EmbeddedView {
                 self.state.ingest_plugin_ui(poll.snapshot);
                 drain_plugin_toast(&mut self.state, &mut self.toast_deadline);
             }
-            EmbeddedEvent::PathRoots(result) => match result {
-                Ok(roots) => self.state.path_roots = Some(roots),
+            EmbeddedEvent::SessionInfo(result) => match result {
+                Ok(info) => super::apply_session_info(&mut self.state, info),
                 Err(e) => {
                     tracing::warn!(
                         target: "acp.tui",
-                        "session path roots fetch failed; rendering raw paths: {e}"
+                        "session info fetch failed; rendering fallback header and raw paths: {e}"
                     );
                 }
             },

--- a/src/tui/structured_view/input.rs
+++ b/src/tui/structured_view/input.rs
@@ -10,9 +10,8 @@
 //! reached with `Tab` for its power keys (scroll, mode picker, browser,
 //! elicitation answers); `Esc` there returns to the composer. The
 //! composer captures **every** typed key, including `a`/`A`/`d`, so
-//! typing "always allow" into a prompt never resolves an approval; a
-//! pending approval is resolved by `Tab`-ing to its card (or clicking
-//! it) and then pressing `a`/`A`/`d`.
+//! typing "always allow" into a prompt never resolves an approval. A
+//! pending approval opens a modal shelf and then accepts `a`/`A`/`d`.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
@@ -212,15 +211,18 @@ pub fn dispatch_mouse(mouse: &MouseEvent, layout: Option<&ViewLayout>) -> Intent
     match mouse.kind {
         MouseEventKind::ScrollUp => Intent::Scroll(-WHEEL_SCROLL_LINES),
         MouseEventKind::ScrollDown => Intent::Scroll(WHEEL_SCROLL_LINES),
-        // A click anywhere in the view focuses the composer: it is one
-        // pane, so clicking the chat to read never puts you in a
-        // separate "transcript mode" you'd have to click back out of.
-        // (`layout` is unused now but kept in the signature so a future
-        // click-target, e.g. an approval button, has the geometry.)
-        MouseEventKind::Down(MouseButton::Left) => {
-            let _ = layout;
-            Intent::SetFocus(Focus::Composer)
-        }
+        MouseEventKind::Down(MouseButton::Left) => match layout {
+            Some(layout) if layout.approval.contains((mouse.column, mouse.row).into()) => {
+                Intent::SetFocus(Focus::Approval)
+            }
+            Some(layout) if layout.composer.contains((mouse.column, mouse.row).into()) => {
+                Intent::SetFocus(Focus::Composer)
+            }
+            Some(layout) if layout.transcript.contains((mouse.column, mouse.row).into()) => {
+                Intent::SetFocus(Focus::Transcript)
+            }
+            _ => Intent::Ignore,
+        },
         _ => Intent::Ignore,
     }
 }
@@ -1100,6 +1102,7 @@ mod tests {
         ViewLayout {
             transcript: Rect::new(0, 0, 80, 20),
             status: Rect::new(0, 20, 80, 1),
+            approval: Rect::new(0, 21, 80, 0),
             queue: Rect::new(0, 21, 80, 0),
             composer: Rect::new(0, 21, 80, 3),
         }
@@ -1126,33 +1129,39 @@ mod tests {
     }
 
     #[test]
-    fn left_click_always_focuses_composer() {
-        // One pane: a click anywhere (transcript, composer, status row)
-        // focuses the composer, so reading the chat never drops you into
-        // a separate mode you'd have to click back out of.
+    fn left_click_focuses_the_pane_under_pointer() {
         let l = layout();
-        for row in [3u16, 20, 22] {
-            assert_eq!(
-                dispatch_mouse(
-                    &mouse(MouseEventKind::Down(MouseButton::Left), 10, row),
-                    Some(&l)
-                ),
-                Intent::SetFocus(Focus::Composer),
-                "click at row {row}"
-            );
-        }
+        assert_eq!(
+            dispatch_mouse(
+                &mouse(MouseEventKind::Down(MouseButton::Left), 10, 3),
+                Some(&l)
+            ),
+            Intent::SetFocus(Focus::Transcript)
+        );
+        assert_eq!(
+            dispatch_mouse(
+                &mouse(MouseEventKind::Down(MouseButton::Left), 10, 22),
+                Some(&l)
+            ),
+            Intent::SetFocus(Focus::Composer)
+        );
+        assert_eq!(
+            dispatch_mouse(
+                &mouse(MouseEventKind::Down(MouseButton::Left), 10, 20),
+                Some(&l)
+            ),
+            Intent::Ignore
+        );
     }
 
     #[test]
-    fn click_before_first_draw_focuses_composer() {
-        // No layout yet: a click still just focuses the composer (there
-        // is only one focus target), no hit-test needed.
+    fn click_before_first_draw_is_ignored() {
         assert_eq!(
             dispatch_mouse(
                 &mouse(MouseEventKind::Down(MouseButton::Left), 10, 10),
                 None
             ),
-            Intent::SetFocus(Focus::Composer)
+            Intent::Ignore
         );
     }
 

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -225,7 +225,7 @@ async fn offer_daemon_start(
 /// has already done it.
 /// Everything a structured-view surface needs after connecting: the
 /// hydrated state, the folded startup error (if any), and the two
-/// side-channel receivers (plugin UI snapshots, session path roots).
+/// side-channel receivers (plugin UI snapshots, session view metadata).
 /// Shared by the full-screen loop and the embedded (preview-pane)
 /// variant so the two cannot drift.
 /// One plugin poll tick from the daemon: the UI-state snapshot plus, when the
@@ -240,12 +240,12 @@ struct ViewSetup {
     state: StructuredViewState,
     startup_toast: Option<String>,
     plugin_rx: tokio::sync::mpsc::Receiver<PluginPoll>,
-    path_roots_rx:
-        tokio::sync::mpsc::Receiver<Result<crate::acp::session_paths::SessionPathRoots, String>>,
+    session_info_rx:
+        tokio::sync::mpsc::Receiver<Result<crate::acp::session_paths::SessionViewInfo, String>>,
 }
 
 /// Hydrate the transcript via /replay, open the WebSocket, and spawn
-/// the side-channel tasks (path roots fetch, plugin UI-state poll).
+/// the side-channel tasks (session-info fetch, plugin UI-state poll).
 /// Both spawned tasks exit once their receiver is dropped, so the
 /// setup owns no cleanup obligations beyond dropping the `ViewSetup`.
 async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSetup> {
@@ -268,16 +268,16 @@ async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSe
     // focus switch, so there is no "which pane am I in" juggling.
     state.focus = Focus::Composer;
 
-    let (path_roots_tx, path_roots_rx) = tokio::sync::mpsc::channel(1);
+    let (session_info_tx, session_info_rx) = tokio::sync::mpsc::channel(1);
     {
         let http = state.http.clone();
         let session_id = state.session_id.clone();
         tokio::spawn(async move {
             let result = http
-                .session_path_roots(&session_id)
+                .session_view_info(&session_id)
                 .await
                 .map_err(|e| e.to_string());
-            let _ = path_roots_tx.send(result).await;
+            let _ = session_info_tx.send(result).await;
         });
     }
 
@@ -363,7 +363,7 @@ async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSe
         state,
         startup_toast,
         plugin_rx,
-        path_roots_rx,
+        session_info_rx,
     })
 }
 
@@ -378,7 +378,7 @@ pub async fn run_for_endpoint(
         mut state,
         startup_toast,
         mut plugin_rx,
-        mut path_roots_rx,
+        mut session_info_rx,
     } = setup_view(endpoint, session_id).await?;
 
     let mut toast_deadline: Option<Instant> = None;
@@ -431,11 +431,11 @@ pub async fn run_for_endpoint(
                 drain_plugin_toast(&mut state, &mut toast_deadline);
                 redraw(terminal, theme, &mut state)?;
             }
-            Some(result) = path_roots_rx.recv() => {
+            Some(result) = session_info_rx.recv() => {
                 match result {
-                    Ok(roots) => state.path_roots = Some(roots),
+                    Ok(info) => apply_session_info(&mut state, info),
                     Err(e) => {
-                        tracing::warn!(target: "acp.tui", "session path roots fetch failed; rendering raw paths: {e}");
+                        tracing::warn!(target: "acp.tui", "session info fetch failed; rendering fallback header and raw paths: {e}");
                     }
                 }
                 redraw(terminal, theme, &mut state)?;
@@ -454,6 +454,15 @@ pub async fn run_for_endpoint(
             }
         }
     }
+}
+
+fn apply_session_info(
+    state: &mut StructuredViewState,
+    info: crate::acp::session_paths::SessionViewInfo,
+) {
+    state.transcript.session_title = Some(info.title.clone());
+    state.transcript.agent_name = Some(info.agent_label());
+    state.path_roots = Some(info.paths);
 }
 
 /// Apply one WebSocket message to the view state: reduce a frame (with
@@ -823,10 +832,16 @@ async fn handle_terminal_event(
             Ok(false)
         }
         Intent::ResolveApproval(decision) => {
-            let Some(idx) = state.selected_approval else {
+            let Some(nonce) = state.selected_approval.as_deref() else {
                 return Ok(false);
             };
-            let Some(pending) = state.transcript.pending_approvals.get(idx).cloned() else {
+            let Some(pending) = state
+                .transcript
+                .pending_approvals
+                .iter()
+                .find(|pending| pending.nonce == nonce)
+                .cloned()
+            else {
                 return Ok(false);
             };
             match state
@@ -1314,11 +1329,14 @@ fn open_link_picker(state: &mut StructuredViewState, links: Vec<(String, String)
 /// Insert pasted text into the composer at the caret, normalizing CRLF /
 /// CR line endings to the `\n` the textarea expects, and run the same
 /// post-edit bookkeeping as typed input (slash-picker highlight reset,
-/// `@`-mention recompute). Focus moves to the composer first so the
-/// pasted text is visible where it landed.
+/// `@`-mention recompute). A modal approval or choice keeps focus while
+/// the paste is safely retained as a composer draft.
 fn paste_into_composer(state: &mut StructuredViewState, text: &str) {
     let text = text.replace("\r\n", "\n").replace('\r', "\n");
-    if state.focus != Focus::Composer {
+    if state.focus != Focus::Composer
+        && state.choice.is_none()
+        && state.transcript.pending_approvals.is_empty()
+    {
         state.focus = Focus::Composer;
     }
     let before = state.slash_query();
@@ -1624,6 +1642,24 @@ mod tests {
         state.composer.insert_str("fix this: ");
         paste_into_composer(&mut state, "Error: thing broke");
         assert_eq!(composer_text(&state), "fix this: Error: thing broke");
+    }
+
+    #[test]
+    fn paste_keeps_modal_approval_focus_and_saves_draft() {
+        let mut state = test_state();
+        state
+            .transcript
+            .pending_approvals
+            .push(reducer::PendingApproval {
+                nonce: "approval-1".into(),
+            });
+        state.reconcile_selection();
+        assert_eq!(state.focus, Focus::Approval);
+
+        paste_into_composer(&mut state, "draft for later");
+
+        assert_eq!(composer_text(&state), "draft for later");
+        assert_eq!(state.focus, Focus::Approval);
     }
 
     #[test]

--- a/src/tui/structured_view/queue.rs
+++ b/src/tui/structured_view/queue.rs
@@ -23,6 +23,7 @@ impl PromptQueue {
         self.items.len()
     }
 
+    #[cfg(test)]
     pub fn iter(&self) -> impl Iterator<Item = &String> {
         self.items.iter()
     }

--- a/src/tui/structured_view/reducer.rs
+++ b/src/tui/structured_view/reducer.rs
@@ -54,6 +54,11 @@ fn summarize_output_blocks(blocks: &[ToolOutputBlock]) -> String {
 #[derive(Debug, Clone)]
 pub struct AcpTranscript {
     pub session_id: String,
+    /// Friendly session title hydrated from `/api/sessions`.
+    pub session_title: Option<String>,
+    /// Resolved ACP registry key shown in the header. Updated when the backend
+    /// switches mid-session.
+    pub agent_name: Option<String>,
     pub rows: Vec<ActivityRow>,
     pub pending_approvals: Vec<PendingApproval>,
     /// Pending `AskUserQuestion` elicitations. The native TUI does not
@@ -87,6 +92,10 @@ pub struct AcpTranscript {
     /// Rendered as a token meter in the status line, mirroring the web
     /// composer's usage chip.
     pub usage: Option<SessionUsage>,
+    /// Latest plan snapshot. Kept separate from the append-only transcript so
+    /// repeated progress updates render as one sticky summary instead of a
+    /// growing stack of near-identical checklists.
+    pub current_plan: Vec<PlanLine>,
     /// Set when the WS layer reports `{"kind":"lagged"}`; the view
     /// layer should clear and rehydrate via HTTP /replay.
     pub lagged: bool,
@@ -113,7 +122,6 @@ pub enum ActivityRow {
     AgentMessage(String),
     ToolCall(ToolCallRow),
     Approval(ApprovalRow),
-    Plan(Vec<PlanLine>),
     /// The user's answers to an AskUserQuestion / elicitation form, kept
     /// in the transcript so the picked answer survives the card closing.
     /// See #2209.
@@ -153,6 +161,8 @@ pub struct ToolCompletion {
 pub struct ApprovalRow {
     pub nonce: String,
     pub title: String,
+    pub kind: String,
+    pub args: String,
     pub destructive: bool,
     pub decision: Option<ApprovalDecision>,
 }
@@ -190,6 +200,8 @@ impl AcpTranscript {
     pub fn new(session_id: impl Into<String>) -> Self {
         Self {
             session_id: session_id.into(),
+            session_title: None,
+            agent_name: None,
             rows: Vec::new(),
             pending_approvals: Vec::new(),
             pending_elicitations: Vec::new(),
@@ -200,6 +212,7 @@ impl AcpTranscript {
             context_primer_pending: false,
             turn_active: false,
             usage: None,
+            current_plan: Vec::new(),
             lagged: false,
             last_seq: 0,
             pending_message_idx: None,
@@ -213,7 +226,11 @@ impl AcpTranscript {
     /// rehydrate via HTTP /replay.
     pub fn reset(&mut self) {
         let session_id = std::mem::take(&mut self.session_id);
+        let session_title = self.session_title.take();
+        let agent_name = self.agent_name.take();
         *self = Self::new(session_id);
+        self.session_title = session_title;
+        self.agent_name = agent_name;
     }
 
     /// Optimistically clear an approval card by nonce after the resolve
@@ -268,8 +285,8 @@ impl AcpTranscript {
 
     fn apply_event(&mut self, event: &Event) {
         match event {
-            // Session title is shown in the session list/header, not the
-            // activity transcript; the daemon applies it to Instance.title.
+            // The daemon applies this legacy suggestion to Instance.title.
+            // The authoritative current title is hydrated from /api/sessions.
             Event::SessionTitleSuggested { .. } => {}
             Event::AgentMessageChunk { text } => {
                 if let Some(idx) = self.pending_message_idx {
@@ -417,6 +434,8 @@ impl AcpTranscript {
                 let row = ApprovalRow {
                     nonce: nonce.clone(),
                     title: approval.tool_call.name.clone(),
+                    kind: approval.tool_call.kind.clone(),
+                    args: approval.tool_call.args_preview.clone(),
                     destructive: approval.destructive,
                     decision: None,
                 };
@@ -484,7 +503,7 @@ impl AcpTranscript {
             }
             Event::PlanUpdated { plan } => {
                 self.flush_pending_chunk();
-                let lines: Vec<PlanLine> = plan
+                self.current_plan = plan
                     .steps
                     .iter()
                     .map(|s| PlanLine {
@@ -492,7 +511,6 @@ impl AcpTranscript {
                         status: s.status.clone(),
                     })
                     .collect();
-                self.rows.push(ActivityRow::Plan(lines));
             }
             Event::TodoListUpdated { todos: _ } => {
                 // TUI MVP omits the parallel todo list; agents almost
@@ -648,11 +666,14 @@ impl AcpTranscript {
             | Event::MonitorArmed { .. }
             | Event::CancelRequested { .. }
             | Event::PromptCapabilities { .. }
-            | Event::AgentSwitched { .. }
             | Event::ConfigOptionsUpdated { .. }
             | Event::ConfigOptionSwitchFailed { .. } => {
                 // Surface as info notes for now; richer renderers are
                 // followup work tracked in the plan's "out of scope".
+            }
+            Event::AgentSwitched { to, .. } => {
+                self.agent_name = Some(to.clone());
+                self.current_plan.clear();
             }
         }
     }
@@ -1082,7 +1103,7 @@ mod tests {
     }
 
     #[test]
-    fn plan_update_creates_plan_row() {
+    fn plan_update_replaces_sticky_plan_snapshot() {
         let mut t = AcpTranscript::new("s-1");
         let plan = Plan {
             plan_id: "p-1".into(),
@@ -1095,7 +1116,9 @@ mod tests {
             }],
         };
         t.apply(&frame(1, Event::PlanUpdated { plan }));
-        assert!(matches!(&t.rows[0], ActivityRow::Plan(lines) if lines.len() == 1));
+        assert!(t.rows.is_empty());
+        assert_eq!(t.current_plan.len(), 1);
+        assert_eq!(t.current_plan[0].title, "Step one");
     }
 
     #[test]

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -1,13 +1,10 @@
-//! Render of a structured view session, stacked top to bottom: transcript /
-//! status banner / queued-prompts strip (zero height when empty) /
-//! composer. The slash and `@` mention pickers float above the composer
-//! when open rather than taking a pane. Tool calls render through a
-//! per-kind dispatcher (`render_tool_lines`): edit/write show a compact
-//! line diff, execute shows the command and an output preview, read
-//! shows the path and a content preview, delete shows the path, and any
-//! other kind falls back to the generic one-liner. Image previews and
-//! syntax highlighting stay deferred to the web structured view; press `o` from
-//! the transcript pane to open it for full-fidelity inspection.
+//! Render of a structured view session, stacked top to bottom: transcript,
+//! status, action shelves, and composer. The slash and `@` mention pickers
+//! float above the composer when open rather than taking a pane. Successful
+//! tools collapse to target-aware summaries; running and failed tools use the
+//! per-kind detail renderer. Image previews and syntax highlighting stay
+//! deferred to the web structured view; press `o` from the transcript pane to
+//! open it for full-fidelity inspection.
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -47,6 +44,9 @@ pub fn render(
 
     let geometry = render_transcript(frame, layout.transcript, theme, state, active);
     render_status(frame, layout.status, theme, state, active);
+    if layout.approval.height > 0 {
+        render_approval_shelf(frame, layout.approval, theme, state, active);
+    }
     if layout.queue.height > 0 {
         render_queue(frame, layout.queue, theme, state);
     }
@@ -60,9 +60,9 @@ pub fn render(
     // tie defensively.
     if let Some(picker) = &state.choice {
         render_choice_picker(frame, layout.composer, theme, picker);
-    } else if state.slash_picker_open() {
+    } else if matches!(state.focus, Focus::Composer) && state.slash_picker_open() {
         render_slash_picker(frame, layout.composer, theme, state);
-    } else if state.mention.is_some() {
+    } else if matches!(state.focus, Focus::Composer) && state.mention.is_some() {
         render_mention_picker(frame, layout.composer, theme, state);
     }
     geometry
@@ -136,11 +136,13 @@ fn render_choice_picker(
 /// while `render` recomputes it per frame.
 pub(super) fn compute_layout(area: Rect, state: &StructuredViewState) -> ViewLayout {
     let queue_height = queued_strip_height(state);
+    let approval_height = u16::from(!state.transcript.pending_approvals.is_empty()) * 3;
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(5),               // transcript
-            Constraint::Length(1),            // status line
+            Constraint::Min(5),    // transcript
+            Constraint::Length(1), // status line
+            Constraint::Length(approval_height),
             Constraint::Length(queue_height), // queued prompts strip (0 when empty)
             Constraint::Length(composer_height(state)),
         ])
@@ -148,64 +150,121 @@ pub(super) fn compute_layout(area: Rect, state: &StructuredViewState) -> ViewLay
     ViewLayout {
         transcript: chunks[0],
         status: chunks[1],
-        queue: chunks[2],
-        composer: chunks[3],
+        approval: chunks[2],
+        queue: chunks[3],
+        composer: chunks[4],
     }
 }
 
-/// Up to this many queued prompts are previewed in the strip; the rest
-/// collapse into a "(+N more)" line so a large backlog can't squeeze the
-/// transcript off-screen.
-const QUEUE_PREVIEW_ROWS: usize = 3;
-
-/// Height of the queued-prompts strip: zero when the queue is empty,
-/// otherwise the previewed rows plus the block's top and bottom borders.
+/// The queue is a compact shelf rather than another boxed transcript. Recall
+/// keeps the individual messages reachable without permanently spending rows.
 fn queued_strip_height(state: &StructuredViewState) -> u16 {
-    if state.queue.is_empty() {
-        return 0;
-    }
-    let shown = state.queue.len().min(QUEUE_PREVIEW_ROWS);
-    let overflow = usize::from(state.queue.len() > QUEUE_PREVIEW_ROWS);
-    (shown + overflow) as u16 + 2
+    u16::from(!state.queue.is_empty())
 }
 
 fn render_queue(frame: &mut Frame, area: Rect, theme: &Theme, state: &StructuredViewState) {
-    let title = format!(
-        " Queued ({}) · drains on idle · Ctrl-x clears ",
-        state.queue.len()
-    );
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" Queued {} ", state.queue.len()),
+            Style::default()
+                .fg(theme.title)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            "↑ edit latest · Ctrl+X clear · sends when ready",
+            Style::default().fg(theme.hint),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+fn render_approval_shelf(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    state: &StructuredViewState,
+    active: bool,
+) {
+    let Some(selected) = state.selected_approval.as_deref() else {
+        return;
+    };
+    let Some(row) = state
+        .transcript
+        .rows
+        .iter()
+        .find_map(|activity| match activity {
+            ActivityRow::Approval(row) if row.nonce == selected && row.decision.is_none() => {
+                Some(row)
+            }
+            _ => None,
+        })
+    else {
+        return;
+    };
+    let position = state
+        .transcript
+        .pending_approvals
+        .iter()
+        .position(|pending| pending.nonce == selected)
+        .unwrap_or_default()
+        + 1;
+    let total = state.transcript.pending_approvals.len();
+    let accent = if row.destructive {
+        theme.error
+    } else {
+        theme.waiting
+    };
+    let target = approval_target(row, state.path_roots.as_ref());
+    let mut title = format!(" Approval {position}/{total} · {}", row.title);
+    if !target.is_empty() {
+        title.push_str(&format!(" · {target}"));
+    }
+    if row.destructive {
+        title.push_str(" · destructive");
+    }
+    title.push(' ');
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .padding(Padding::horizontal(1))
         .title(title)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(Style::default().fg(accent));
     let inner = block.inner(area);
     frame.render_widget(block, area);
+    let actions = if active {
+        Line::from(vec![
+            Span::styled("[a] Allow once", Style::default().fg(theme.running)),
+            Span::raw("   "),
+            Span::styled("[A] Always", Style::default().fg(theme.running)),
+            Span::raw("   "),
+            Span::styled("[d] Deny", Style::default().fg(theme.error)),
+            Span::raw("   "),
+            Span::styled("[Esc] Stop", Style::default().fg(theme.hint)),
+        ])
+    } else {
+        Line::from(Span::styled(
+            "Press Enter to respond",
+            Style::default().fg(theme.hint),
+        ))
+    };
+    frame.render_widget(Paragraph::new(actions), inner);
+}
 
-    let mut lines: Vec<Line> = Vec::new();
-    for (i, prompt) in state.queue.iter().take(QUEUE_PREVIEW_ROWS).enumerate() {
-        // Queued prompts can hold newlines (Shift+Enter in the composer);
-        // ratatui's Line strips them, so collapse whitespace first to keep
-        // the preview on one tidy line and truncate predictably.
-        let one_line = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
-        let preview = match truncate_chars(&one_line, 80) {
-            Some(head) => format!("{}. {head}…", i + 1),
-            None => format!("{}. {one_line}", i + 1),
-        };
-        lines.push(Line::from(Span::styled(
-            preview,
-            Style::default().add_modifier(Modifier::DIM),
-        )));
+fn approval_target(
+    row: &super::reducer::ApprovalRow,
+    path_roots: Option<&SessionPathRoots>,
+) -> String {
+    let args = parse_args_object(&row.args);
+    match row.kind.as_str() {
+        "edit" | "write" | "read" | "delete" | "move" => pick_str(args.as_ref(), PATH_KEYS)
+            .map(|path| relative_display_path(path, path_roots))
+            .unwrap_or_default(),
+        "execute" => pick_str(args.as_ref(), CMD_KEYS)
+            .and_then(|command| command.lines().next())
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
     }
-    if state.queue.len() > QUEUE_PREVIEW_ROWS {
-        let extra = state.queue.len() - QUEUE_PREVIEW_ROWS;
-        lines.push(Line::from(Span::styled(
-            format!("(+{extra} more)"),
-            Style::default().add_modifier(Modifier::DIM),
-        )));
-    }
-    frame.render_widget(Paragraph::new(lines), inner);
 }
 
 /// Most picker rows visible at once before the list windows around the
@@ -251,6 +310,8 @@ fn render_slash_picker(
     }
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
         .title(" Commands (↑/↓ or Ctrl+n/p · Enter/Tab select · Esc dismiss) ")
         .border_style(Style::default().fg(theme.title));
     let inner = block.inner(area);
@@ -421,14 +482,30 @@ fn render_transcript(
     state: &StructuredViewState,
     active: bool,
 ) -> TranscriptGeometry {
-    let title = format!(
-        " Acp · {}{} ",
-        state.session_id,
-        match state.transcript.current_mode.as_deref() {
-            Some(m) => format!(" · mode: {m}"),
-            None => String::new(),
-        }
-    );
+    let friendly_title = state
+        .transcript
+        .session_title
+        .as_deref()
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or(&state.session_id);
+    let mut title = vec![Span::styled(
+        format!(" {friendly_title} "),
+        Style::default()
+            .fg(theme.title)
+            .add_modifier(Modifier::BOLD),
+    )];
+    if let Some(agent) = state.transcript.agent_name.as_deref() {
+        title.push(Span::styled(
+            format!("· {agent} "),
+            Style::default().fg(theme.hint),
+        ));
+    }
+    if let Some(mode) = state.transcript.current_mode.as_deref() {
+        title.push(Span::styled(
+            format!("· {mode} "),
+            Style::default().fg(theme.hint),
+        ));
+    }
     // The outer box is the "you are interacting here" cue, mirroring how
     // live view highlights the preview pane border when entered: bright
     // while active, calm while merely previewing.
@@ -439,25 +516,40 @@ fn render_transcript(
     };
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(title)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .title(Line::from(title))
         .border_style(outer_border);
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let text = wrapped_transcript(state, theme, inner.width);
+    let (plan_area, text_area) = if state.transcript.current_plan.is_empty() || inner.height < 2 {
+        (Rect::default(), inner)
+    } else {
+        let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(inner);
+        (chunks[0], chunks[1])
+    };
+    if plan_area.height > 0 {
+        frame.render_widget(
+            Paragraph::new(plan_summary_line(&state.transcript.current_plan, theme)),
+            plan_area,
+        );
+    }
+
+    let text = wrapped_transcript(state, theme, text_area.width);
     // The lines are pre-wrapped at the render width, so visual rows ARE
     // logical rows: the scroll clamp is exact (no wrap estimation), and
     // the same geometry serves the home view's drag-select machinery.
     let total = text.lines.len().min(u16::MAX as usize) as u16;
-    let max = total.saturating_sub(inner.height);
+    let max = total.saturating_sub(text_area.height);
     // Record the concrete max so a wheel/PageUp step can resolve the
     // stick-to-bottom sentinel before moving (see `apply_scroll`).
     state.last_scroll_max.set(max);
     let first = state.scroll_offset.min(max);
     let para = Paragraph::new(text).scroll((first, 0));
-    frame.render_widget(para, inner);
+    frame.render_widget(para, text_area);
     TranscriptGeometry {
-        text_area: inner,
+        text_area,
         first_line: first as usize,
         total_lines: total as usize,
     }
@@ -484,18 +576,49 @@ pub(crate) fn wrapped_transcript(
     theme: &Theme,
     width: u16,
 ) -> Text<'static> {
-    let lines = transcript_lines(
-        &state.transcript,
-        state.selected_approval,
-        state.focus,
-        theme,
-        state.path_roots.as_ref(),
-    );
+    let lines = transcript_lines(&state.transcript, theme, state.path_roots.as_ref());
     let mut wrapped: Vec<Line<'static>> = Vec::with_capacity(lines.len());
     for line in lines {
         wrap_line_into(own_line(line), width, &mut wrapped);
     }
     Text::from(wrapped)
+}
+
+fn plan_summary_line(plan: &[super::reducer::PlanLine], theme: &Theme) -> Line<'static> {
+    use crate::acp::state::PlanStepStatus;
+
+    let done = plan
+        .iter()
+        .filter(|step| {
+            matches!(
+                step.status,
+                PlanStepStatus::Done | PlanStepStatus::Cancelled
+            )
+        })
+        .count();
+    let current = plan
+        .iter()
+        .find(|step| matches!(step.status, PlanStepStatus::InProgress))
+        .or_else(|| {
+            plan.iter()
+                .find(|step| matches!(step.status, PlanStepStatus::Pending))
+        });
+    let complete = done == plan.len();
+    let marker = if complete { "✓" } else { "◐" };
+    let color = if complete { theme.running } else { theme.title };
+    let mut spans = vec![Span::styled(
+        format!(" {marker} Plan · {done}/{}", plan.len()),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )];
+    if let Some(step) = current {
+        spans.push(Span::styled(
+            format!(" · {}", step.title),
+            Style::default().fg(theme.hint),
+        ));
+    } else if complete {
+        spans.push(Span::styled(" · complete", Style::default().fg(theme.hint)));
+    }
+    Line::from(spans)
 }
 
 /// Detach a line from whatever transcript strings it borrows so the
@@ -586,10 +709,21 @@ fn render_status(
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ));
     }
-    if let Some(banner) = &state.transcript.status_text {
+    if state.transcript.turn_active {
+        let banner = state.transcript.status_text.as_deref().unwrap_or("working");
         spans.push(Span::styled(
-            format!(" {banner} "),
-            Style::default().fg(theme.title),
+            format!(" ● {banner} "),
+            Style::default().fg(theme.running),
+        ));
+    } else if state.ws.is_none() {
+        spans.push(Span::styled(
+            " ○ Disconnected ",
+            Style::default().fg(theme.error),
+        ));
+    } else {
+        spans.push(Span::styled(
+            " ● Ready ",
+            Style::default().fg(theme.running),
         ));
     }
     if state.transcript.context_primer_pending {
@@ -604,16 +738,10 @@ fn render_status(
             Style::default().fg(theme.error),
         ));
     }
-    if !state.transcript.pending_approvals.is_empty() {
-        let n = state.transcript.pending_approvals.len();
-        // The prompt is modal (it already has the keyboard), so the hint
-        // names the decision keys, not a focus switch.
+    if state.scroll_offset != u16::MAX {
         spans.push(Span::styled(
-            format!(
-                " {n} pending approval{}: a allow · A always · d deny ",
-                if n == 1 { "" } else { "s" }
-            ),
-            Style::default().fg(theme.error),
+            " · G latest ",
+            Style::default().fg(theme.hint),
         ));
     }
     // Plugin host-rendered slots (#2402): global status-bar segments and this
@@ -628,16 +756,6 @@ fn render_status(
                 plugin_ui::tone_style(plugin_ui::entry_tone(entry), theme),
             ));
         }
-    }
-    if spans.is_empty() {
-        // Footer help when nothing else is going on. A preview points at
-        // how to start interacting; an active view shows the live hint.
-        let hint = if active {
-            help_hint(state.focus)
-        } else {
-            " Enter to reply · scroll to read "
-        };
-        spans.push(Span::styled(hint, Style::default().fg(theme.hint)));
     }
     // Context-window token meter, mirroring the web composer's usage
     // chip (`formatTokens` / `formatCost` in Composer.tsx). Rendered
@@ -666,6 +784,28 @@ fn render_status(
                 meter_area,
             );
         }
+    }
+    let hint = if active {
+        help_hint(state.focus)
+    } else {
+        " Enter reply · wheel history "
+    };
+    let hint_width = hint.chars().count() as u16;
+    if left_area.width > hint_width.saturating_add(24) {
+        let hint_area = Rect {
+            x: left_area.x + left_area.width - hint_width,
+            y: left_area.y,
+            width: hint_width,
+            height: left_area.height,
+        };
+        left_area.width -= hint_width;
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                hint,
+                Style::default().fg(theme.hint),
+            ))),
+            hint_area,
+        );
     }
     let para = Paragraph::new(Line::from(spans));
     frame.render_widget(para, left_area);
@@ -1047,13 +1187,10 @@ impl MarkdownBuilder {
 
 fn transcript_lines<'a>(
     transcript: &'a AcpTranscript,
-    selected_approval: Option<usize>,
-    focus: Focus,
     theme: &Theme,
     path_roots: Option<&SessionPathRoots>,
 ) -> Vec<Line<'a>> {
     let mut out: Vec<Line<'a>> = Vec::new();
-    let mut approval_render_idx: usize = 0;
     for row in &transcript.rows {
         match row {
             ActivityRow::UserPrompt(text) => {
@@ -1069,56 +1206,19 @@ fn transcript_lines<'a>(
                 out.push(Line::default());
             }
             ActivityRow::Approval(row) => {
-                let highlighted = focus == Focus::Approval
-                    && selected_approval
-                        .map(|i| i == approval_render_idx)
-                        .unwrap_or(false);
-                approval_render_idx += 1;
-                let mut header = Vec::new();
-                header.push(Span::raw(if highlighted { "▶ " } else { "  " }));
-                header.push(Span::styled(
-                    format!("approval · {} ", row.title),
-                    Style::default().add_modifier(Modifier::BOLD),
-                ));
-                if row.destructive {
-                    header.push(Span::styled(
-                        "[destructive] ",
-                        Style::default().add_modifier(Modifier::BOLD),
-                    ));
-                }
-                header.push(Span::styled(
-                    format!("nonce={}", row.nonce),
-                    Style::default().add_modifier(Modifier::DIM),
-                ));
-                out.push(Line::from(header));
-                let body = match row.decision {
-                    Some(ApprovalDecision::Allow) => "  → allowed",
-                    Some(ApprovalDecision::AllowAlways) => "  → allow-always",
-                    Some(ApprovalDecision::Deny) => "  → denied",
-                    Some(ApprovalDecision::Cancelled) => "  → cancelled",
-                    // The prompt is modal and already holds the keyboard
-                    // (no Tab): the active one shows the decision keys,
-                    // any others queued behind it read as pending.
-                    None if highlighted => "  press a / A / d to resolve · Esc to stop",
-                    None => "  pending…",
+                let (marker, label) = match row.decision {
+                    Some(ApprovalDecision::Allow) => ("✓", "Allowed once"),
+                    Some(ApprovalDecision::AllowAlways) => ("✓", "Always allowed"),
+                    Some(ApprovalDecision::Deny) => ("✕", "Denied"),
+                    Some(ApprovalDecision::Cancelled) => ("·", "Cancelled"),
+                    // Pending approvals live in the modal shelf below the
+                    // transcript, so they do not duplicate here.
+                    None => continue,
                 };
-                out.push(Line::from(body));
-                out.push(Line::default());
-            }
-            ActivityRow::Plan(steps) => {
                 out.push(Line::from(Span::styled(
-                    "plan",
-                    Style::default().add_modifier(Modifier::BOLD),
+                    format!("{marker} {label} · {}", row.title),
+                    Style::default().fg(theme.hint),
                 )));
-                for step in steps {
-                    let marker = match step.status {
-                        crate::acp::state::PlanStepStatus::Pending => "[ ]",
-                        crate::acp::state::PlanStepStatus::InProgress => "[~]",
-                        crate::acp::state::PlanStepStatus::Done => "[x]",
-                        crate::acp::state::PlanStepStatus::Cancelled => "[-]",
-                    };
-                    out.push(Line::from(format!("  {marker} {}", step.title)));
-                }
                 out.push(Line::default());
             }
             ActivityRow::ElicitationAnswer(answers) => {
@@ -1192,6 +1292,13 @@ fn render_tool_lines(
     theme: &Theme,
     path_roots: Option<&SessionPathRoots>,
 ) -> Vec<Line<'static>> {
+    if tool
+        .completed
+        .as_ref()
+        .is_some_and(|completion| completion.ok)
+    {
+        return vec![compact_tool_line(tool, theme, path_roots)];
+    }
     let mut lines = Vec::new();
     let header = format!(
         "tool {} · {}",
@@ -1225,6 +1332,77 @@ fn render_tool_lines(
     };
     lines.extend(body.unwrap_or_else(|| render_generic_body(tool)));
     lines
+}
+
+fn compact_tool_line(
+    tool: &ToolCallRow,
+    theme: &Theme,
+    path_roots: Option<&SessionPathRoots>,
+) -> Line<'static> {
+    let args = parse_args_object(&tool.args);
+    let target = if let Some(diff) = tool.diffs.first() {
+        Some(relative_display_path(&diff.path, path_roots))
+    } else {
+        match tool.kind.as_str() {
+            "edit" | "write" | "read" | "delete" | "move" => pick_str(args.as_ref(), PATH_KEYS)
+                .map(|path| relative_display_path(path, path_roots)),
+            "execute" => pick_str(args.as_ref(), CMD_KEYS)
+                .and_then(|command| command.lines().next())
+                .map(ToString::to_string),
+            _ => None,
+        }
+    };
+    let mut spans = vec![
+        Span::styled("✓ ", Style::default().fg(theme.running)),
+        Span::styled(
+            tool.name.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+    ];
+    if let Some(target) = target.filter(|target| !target.is_empty()) {
+        spans.push(Span::styled(
+            format!(" · {target}"),
+            Style::default().fg(theme.hint),
+        ));
+    }
+    let (added, removed) = tool_diff_counts(tool, args.as_ref());
+    if added > 0 || removed > 0 {
+        spans.push(Span::styled(
+            format!(" · +{added} -{removed}"),
+            Style::default().fg(theme.hint),
+        ));
+    }
+    Line::from(spans)
+}
+
+fn tool_diff_counts(
+    tool: &ToolCallRow,
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> (usize, usize) {
+    let mut added = 0;
+    let mut removed = 0;
+    let mut count = |old: &str, new: &str| {
+        for change in TextDiff::from_lines(old, new).iter_all_changes() {
+            match change.tag() {
+                ChangeTag::Insert => added += 1,
+                ChangeTag::Delete => removed += 1,
+                ChangeTag::Equal => {}
+            }
+        }
+    };
+    if tool.diffs.is_empty() {
+        if let Some(new) = pick_str(args, NEW_KEYS) {
+            count(pick_str(args, OLD_KEYS).unwrap_or(""), new);
+        }
+    } else {
+        for diff in &tool.diffs {
+            count(
+                diff.old_text.as_deref().unwrap_or(""),
+                diff.new_text.as_deref().unwrap_or(""),
+            );
+        }
+    }
+    (added, removed)
 }
 
 /// Per-file compact diffs from the structured `tool_call.diffs` payload:
@@ -1496,21 +1674,16 @@ mod tests {
     }
 
     #[test]
-    fn queued_strip_height_grows_with_entries_then_caps() {
+    fn queued_strip_stays_one_row_with_any_number_of_entries() {
         let mut state = test_state();
         state.queue.push("one".into());
-        assert_eq!(queued_strip_height(&state), 1 + 2);
+        assert_eq!(queued_strip_height(&state), 1);
         state.queue.push("two".into());
         state.queue.push("three".into());
-        assert_eq!(queued_strip_height(&state), 3 + 2);
-        // Beyond the preview cap, an extra "+N more" row is added but the
-        // height stays bounded.
+        assert_eq!(queued_strip_height(&state), 1);
         state.queue.push("four".into());
         state.queue.push("five".into());
-        assert_eq!(
-            queued_strip_height(&state),
-            QUEUE_PREVIEW_ROWS as u16 + 1 + 2
-        );
+        assert_eq!(queued_strip_height(&state), 1);
     }
 
     /// Wrap one line and return the resulting row count.
@@ -1927,17 +2100,41 @@ mod tests {
                 answer: "Fast".into(),
             },
         ]));
-        let out = joined(&transcript_lines(
-            &t,
-            None,
-            Focus::Transcript,
-            &Theme::default(),
-            None,
-        ));
+        let out = joined(&transcript_lines(&t, &Theme::default(), None));
         // Rendered as user turns: highlighted text, no "you" label.
         assert!(out.contains("Proceed?: Yes"), "{out:?}");
         assert!(out.contains("Mode: Fast"), "{out:?}");
         assert!(!out.contains("you  ▸"), "{out:?}");
+    }
+
+    #[test]
+    fn transcript_hides_pending_approval_and_records_resolved_without_nonce() {
+        use super::super::reducer::ApprovalRow;
+
+        let mut t = AcpTranscript::new("s-1");
+        t.rows.push(ActivityRow::Approval(ApprovalRow {
+            nonce: "internal-pending".into(),
+            title: "Read file".into(),
+            kind: "read".into(),
+            args: r#"{"path":"src/lib.rs"}"#.into(),
+            destructive: false,
+            decision: None,
+        }));
+        t.rows.push(ActivityRow::Approval(ApprovalRow {
+            nonce: "internal-resolved".into(),
+            title: "Edit file".into(),
+            kind: "edit".into(),
+            args: r#"{"path":"src/lib.rs"}"#.into(),
+            destructive: false,
+            decision: Some(ApprovalDecision::Allow),
+        }));
+        let out = joined(&transcript_lines(&t, &Theme::default(), None));
+        assert!(
+            !out.contains("Read file"),
+            "pending request duplicated: {out:?}"
+        );
+        assert!(out.contains("Allowed once · Edit file"), "{out:?}");
+        assert!(!out.contains("internal-"), "nonce leaked: {out:?}");
     }
 
     #[test]
@@ -1990,20 +2187,22 @@ mod tests {
     }
 
     #[test]
-    fn execute_kind_renders_command_and_output_preview() {
+    fn successful_execute_collapses_to_command_summary() {
         let row = tool_row(
             "execute",
             r#"{"command":"ls -la"}"#,
             Some((true, "file_a\nfile_b")),
         );
         let out = joined(&render_tool_lines(&row, &Theme::default(), None));
-        assert!(out.contains("$ ls -la"), "command missing: {out:?}");
-        assert!(out.contains("file_a"), "output preview missing: {out:?}");
-        assert!(out.contains("file_b"), "{out:?}");
+        assert!(out.contains("✓ Tool · ls -la"), "summary missing: {out:?}");
+        assert!(
+            !out.contains("file_a"),
+            "output should be collapsed: {out:?}"
+        );
     }
 
     #[test]
-    fn read_kind_renders_path_and_content_preview() {
+    fn successful_read_collapses_to_path_summary() {
         let row = tool_row(
             "read",
             r#"{"path":"src/lib.rs"}"#,
@@ -2012,8 +2211,8 @@ mod tests {
         let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(out.contains("src/lib.rs"), "path missing: {out:?}");
         assert!(
-            out.contains("pub fn main()"),
-            "content preview missing: {out:?}"
+            !out.contains("pub fn main()"),
+            "content should be collapsed: {out:?}"
         );
     }
 
@@ -2178,7 +2377,7 @@ mod tests {
         let row = tool_row(
             "execute",
             r#"{"command":"cargo test"}"#,
-            Some((true, "test result: \u{1b}[31mFAILED\u{1b}[0m. 1 failed")),
+            Some((false, "test result: \u{1b}[31mFAILED\u{1b}[0m. 1 failed")),
         );
         let lines = render_tool_lines(&row, &Theme::default(), None);
         let out = joined(&lines);
@@ -2195,7 +2394,7 @@ mod tests {
         let row = tool_row(
             "fetch",
             "https://example.com",
-            Some((true, "\u{1b}[32m200 OK\u{1b}[0m")),
+            Some((false, "\u{1b}[32m200 OK\u{1b}[0m")),
         );
         let out = joined(&render_tool_lines(&row, &Theme::default(), None));
         assert!(!out.contains('\u{1b}'), "escape bytes leaked: {out:?}");
@@ -2211,12 +2410,11 @@ mod tests {
     }
 
     #[test]
-    fn unknown_kind_falls_back_to_generic_one_liner() {
-        let row = tool_row("fetch", "https://example.com", Some((true, "200 OK")));
+    fn running_unknown_kind_falls_back_to_generic_one_liner() {
+        let row = tool_row("fetch", "https://example.com", None);
         let out = joined(&render_tool_lines(&row, &Theme::default(), None));
-        // Generic body shows the raw args prefixed with `$ ` and the output.
+        // Generic body shows the raw args prefixed with `$ ` while running.
         assert!(out.contains("$ https://example.com"), "{out:?}");
-        assert!(out.contains("200 OK"), "{out:?}");
     }
 
     #[test]

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -231,23 +231,48 @@ fn render_approval_shelf(
         .border_style(Style::default().fg(accent));
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    let actions = if active {
-        Line::from(vec![
-            Span::styled("[a] Allow once", Style::default().fg(theme.running)),
-            Span::raw("   "),
-            Span::styled("[A] Always", Style::default().fg(theme.running)),
-            Span::raw("   "),
-            Span::styled("[d] Deny", Style::default().fg(theme.error)),
-            Span::raw("   "),
-            Span::styled("[Esc] Stop", Style::default().fg(theme.hint)),
-        ])
-    } else {
-        Line::from(Span::styled(
-            "Press Enter to respond",
-            Style::default().fg(theme.hint),
-        ))
-    };
+    let actions = approval_actions_line(theme, active);
     frame.render_widget(Paragraph::new(actions), inner);
+}
+
+fn approval_actions_line(theme: &Theme, active: bool) -> Line<'static> {
+    if !active {
+        return Line::from(Span::styled(
+            "Enter to respond",
+            Style::default().fg(theme.hint),
+        ));
+    }
+    Line::from(vec![
+        Span::styled(
+            "a",
+            Style::default()
+                .fg(theme.running)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" allow once", Style::default().fg(theme.hint)),
+        Span::styled("  ·  ", Style::default().fg(theme.border)),
+        Span::styled(
+            "A",
+            Style::default()
+                .fg(theme.running)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" always", Style::default().fg(theme.hint)),
+        Span::styled("  ·  ", Style::default().fg(theme.border)),
+        Span::styled(
+            "d",
+            Style::default()
+                .fg(theme.error)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" deny", Style::default().fg(theme.hint)),
+        Span::styled("  ·  ", Style::default().fg(theme.border)),
+        Span::styled(
+            "Esc",
+            Style::default().fg(theme.hint).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" stop", Style::default().fg(theme.hint)),
+    ])
 }
 
 fn approval_target(
@@ -459,20 +484,19 @@ fn render_mention_picker(
     frame.render_widget(Paragraph::new(lines), inner);
 }
 
-/// Top + bottom border rows wrapping the composer textarea.
-const COMPOSER_BORDER_ROWS: u16 = 2;
+/// One separator row above the terminal-native prompt rail.
+const COMPOSER_CHROME_ROWS: u16 = 1;
 /// Maximum content rows the composer is allowed to take before the
 /// transcript starts losing space. Multi-line prompts beyond this
 /// scroll inside the textarea instead of growing the pane.
 const COMPOSER_MAX_CONTENT_ROWS: u16 = 6;
 
 fn composer_height(state: &StructuredViewState) -> u16 {
-    // Composer is `1 + COMPOSER_BORDER_ROWS = 3` rows tall by default,
-    // growing one row per typed newline up to
-    // `COMPOSER_MAX_CONTENT_ROWS + COMPOSER_BORDER_ROWS = 8` rows so
-    // multi-line prompts don't squash the transcript.
+    // Composer is two rows tall by default: one separator and one prompt
+    // row. Multi-line prompts grow up to the content cap, then scroll
+    // inside the textarea instead of squeezing the transcript.
     let lines = state.composer.lines().len().max(1) as u16;
-    lines.clamp(1, COMPOSER_MAX_CONTENT_ROWS) + COMPOSER_BORDER_ROWS
+    lines.clamp(1, COMPOSER_MAX_CONTENT_ROWS) + COMPOSER_CHROME_ROWS
 }
 
 fn render_transcript(
@@ -488,12 +512,18 @@ fn render_transcript(
         .as_deref()
         .filter(|title| !title.trim().is_empty())
         .unwrap_or(&state.session_id);
-    let mut title = vec![Span::styled(
-        format!(" {friendly_title} "),
-        Style::default()
-            .fg(theme.title)
-            .add_modifier(Modifier::BOLD),
-    )];
+    let mut title = vec![
+        Span::styled(
+            if active { " ● " } else { " ○ " },
+            Style::default().fg(if active { theme.running } else { theme.hint }),
+        ),
+        Span::styled(
+            format!("{friendly_title} "),
+            Style::default()
+                .fg(if active { theme.title } else { theme.hint })
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
     if let Some(agent) = state.transcript.agent_name.as_deref() {
         title.push(Span::styled(
             format!("· {agent} "),
@@ -506,20 +536,12 @@ fn render_transcript(
             Style::default().fg(theme.hint),
         ));
     }
-    // The outer box is the "you are interacting here" cue, mirroring how
-    // live view highlights the preview pane border when entered: bright
-    // while active, calm while merely previewing.
-    let outer_border = if active {
-        Style::default().fg(theme.title)
-    } else {
-        Style::default().fg(theme.border)
-    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .padding(Padding::horizontal(1))
         .title(Line::from(title))
-        .border_style(outer_border);
+        .border_style(Style::default().fg(theme.border));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -867,11 +889,8 @@ fn render_composer(
     state: &StructuredViewState,
     active: bool,
 ) {
-    // No "Composer" label: the box sits at the bottom and (when active)
-    // holds the caret, so it is self-evidently the input. The one title
-    // worth showing is the queue-edit banner, which changes what Enter
-    // does. When inactive (a preview of the selected session), the box
-    // reads as a prompt to enter.
+    // The composer is a prompt rail rather than another card. The only
+    // title is contextual state that changes what Enter does.
     let title: String = if let Some(recall) = &state.recall {
         let total = state.queue.len();
         let pos = total.saturating_sub(recall.index);
@@ -883,33 +902,62 @@ fn render_composer(
     } else {
         " Press Enter to reply ".to_string()
     };
-    // Both boxes (transcript + composer) carry the golden active border
-    // together, so the whole embedded view reads as one entered pane,
-    // the same "you are here" cue live view puts on the preview border.
-    // A preview keeps the calm border; queue-edit keeps its own accent.
-    let composer_border = if state.recall.is_some() || active {
-        Style::default().fg(theme.title)
+    let separator = if state.recall.is_some() {
+        theme.title
     } else {
-        Style::default().fg(theme.border)
+        theme.border
     };
     let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
+        .borders(Borders::TOP)
         .title(title)
-        .border_style(composer_border);
-    // ratatui-textarea borrows the Frame's buffer indirectly via
-    // widget impl; render the block first, then the textarea inside.
+        .border_style(Style::default().fg(separator));
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    frame.render_widget(&state.composer, inner);
+    let prompt_width = inner.width.min(2);
+    let prompt_area = Rect {
+        width: prompt_width,
+        ..inner
+    };
+    let input_area = Rect {
+        x: inner.x.saturating_add(prompt_width),
+        width: inner.width.saturating_sub(prompt_width),
+        ..inner
+    };
+    let prompt_color = if state.recall.is_some() {
+        theme.waiting
+    } else if active {
+        theme.title
+    } else {
+        theme.hint
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "❯ ",
+            Style::default()
+                .fg(prompt_color)
+                .add_modifier(Modifier::BOLD),
+        ))),
+        prompt_area,
+    );
+    if input_area.width > 0 {
+        frame.render_widget(&state.composer, input_area);
+    }
     // Only show the caret when the view is active: a preview must not
     // plant a blinking cursor in a box the keyboard isn't routed to.
-    if active && matches!(state.focus, Focus::Composer) && inner.width > 0 && inner.height > 0 {
+    if active
+        && matches!(state.focus, Focus::Composer)
+        && input_area.width > 0
+        && input_area.height > 0
+    {
         let cursor = state.composer.screen_cursor();
-        let max_x = inner.x.saturating_add(inner.width.saturating_sub(1));
-        let max_y = inner.y.saturating_add(inner.height.saturating_sub(1));
-        let cursor_x = inner.x.saturating_add(cursor.col as u16).min(max_x);
-        let cursor_y = inner.y.saturating_add(cursor.row as u16).min(max_y);
+        let max_x = input_area
+            .x
+            .saturating_add(input_area.width.saturating_sub(1));
+        let max_y = input_area
+            .y
+            .saturating_add(input_area.height.saturating_sub(1));
+        let cursor_x = input_area.x.saturating_add(cursor.col as u16).min(max_x);
+        let cursor_y = input_area.y.saturating_add(cursor.row as u16).min(max_y);
         frame.set_cursor_position((cursor_x, cursor_y));
     }
 }
@@ -1686,6 +1734,37 @@ mod tests {
         assert_eq!(queued_strip_height(&state), 1);
     }
 
+    #[test]
+    fn composer_height_reserves_one_prompt_separator() {
+        let mut state = test_state();
+        assert_eq!(composer_height(&state), 2);
+        state.composer.insert_newline();
+        state.composer.insert_newline();
+        assert_eq!(composer_height(&state), 4);
+        for _ in 0..10 {
+            state.composer.insert_newline();
+        }
+        assert_eq!(
+            composer_height(&state),
+            COMPOSER_MAX_CONTENT_ROWS + COMPOSER_CHROME_ROWS
+        );
+    }
+
+    #[test]
+    fn approval_actions_read_as_key_hints_not_buttons() {
+        let line = approval_actions_line(&Theme::default(), true);
+        let text: String = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(text.contains("a allow once"), "{text:?}");
+        assert!(text.contains("A always"), "{text:?}");
+        assert!(text.contains("d deny"), "{text:?}");
+        assert!(!text.contains('['), "button chrome leaked: {text:?}");
+        assert!(!text.contains(']'), "button chrome leaked: {text:?}");
+    }
+
     /// Wrap one line and return the resulting row count.
     fn wrap_rows(line: Line<'static>, width: u16) -> usize {
         let mut out = Vec::new();
@@ -2439,17 +2518,58 @@ mod tests {
         state
     }
 
-    fn render_dump(state: &StructuredViewState, w: u16, h: u16) -> String {
+    fn render_rows(state: &StructuredViewState, w: u16, h: u16, active: bool) -> Vec<String> {
         let theme = crate::tui::styles::load_theme_with_mode("empire", false);
         let backend = TestBackend::new(w, h);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal
             .draw(|f| {
-                render(f, f.area(), &theme, state, true);
+                render(f, f.area(), &theme, state, active);
             })
             .expect("draw");
         let buf = terminal.backend().buffer().clone();
-        buf.content().iter().map(|c| c.symbol()).collect()
+        buf.content()
+            .chunks(w as usize)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect())
+            .collect()
+    }
+
+    fn render_dump(state: &StructuredViewState, w: u16, h: u16) -> String {
+        render_rows(state, w, h, true).concat()
+    }
+
+    #[test]
+    fn composer_renders_as_prompt_rail_without_bottom_box() {
+        let state = test_state();
+        let rows = render_rows(&state, 60, 12, true);
+        assert!(rows[0].contains("● s-1"), "active header missing: {rows:?}");
+        let prompt = rows.last().expect("prompt row");
+        assert!(
+            prompt.trim_start().starts_with('❯') && prompt.contains("Message the agent"),
+            "prompt rail missing: {prompt:?}"
+        );
+        assert!(
+            !prompt.contains('╰'),
+            "composer still has a box: {prompt:?}"
+        );
+        assert!(
+            !prompt.contains('╯'),
+            "composer still has a box: {prompt:?}"
+        );
+    }
+
+    #[test]
+    fn inactive_header_and_prompt_keep_calm_affordances() {
+        let state = test_state();
+        let rows = render_rows(&state, 60, 12, false);
+        assert!(
+            rows[0].contains("○ s-1"),
+            "preview marker missing: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|row| row.contains("Press Enter to reply")),
+            "entry hint missing: {rows:?}"
+        );
     }
 
     #[test]

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -140,19 +140,19 @@ pub(super) fn compute_layout(area: Rect, state: &StructuredViewState) -> ViewLay
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(5),    // transcript
-            Constraint::Length(1), // status line
+            Constraint::Min(5), // transcript
             Constraint::Length(approval_height),
             Constraint::Length(queue_height), // queued prompts strip (0 when empty)
             Constraint::Length(composer_height(state)),
+            Constraint::Length(1), // status line
         ])
         .split(area);
     ViewLayout {
         transcript: chunks[0],
-        status: chunks[1],
-        approval: chunks[2],
-        queue: chunks[3],
-        composer: chunks[4],
+        approval: chunks[1],
+        queue: chunks[2],
+        composer: chunks[3],
+        status: chunks[4],
     }
 }
 
@@ -512,43 +512,48 @@ fn render_transcript(
         .as_deref()
         .filter(|title| !title.trim().is_empty())
         .unwrap_or(&state.session_id);
-    let mut title = vec![
-        Span::styled(
-            if active { " ● " } else { " ○ " },
+    let body = if active && area.width >= 28 && area.height >= 8 {
+        let card_width = metadata_card_width(state, friendly_title, area.width);
+        let card_area = Rect {
+            width: card_width,
+            height: 6,
+            ..area
+        };
+        render_metadata_card(frame, card_area, theme, state, friendly_title);
+        Rect {
+            y: area.y.saturating_add(7),
+            height: area.height.saturating_sub(7),
+            ..area
+        }
+    } else {
+        let mut identity = vec![Span::styled(
+            if active { "● " } else { "○ " },
             Style::default().fg(if active { theme.running } else { theme.hint }),
-        ),
-        Span::styled(
-            format!("{friendly_title} "),
+        )];
+        identity.push(Span::styled(
+            friendly_title.to_string(),
             Style::default()
                 .fg(if active { theme.title } else { theme.hint })
                 .add_modifier(Modifier::BOLD),
-        ),
-    ];
-    if let Some(agent) = state.transcript.agent_name.as_deref() {
-        title.push(Span::styled(
-            format!("· {agent} "),
-            Style::default().fg(theme.hint),
         ));
-    }
-    if let Some(mode) = state.transcript.current_mode.as_deref() {
-        title.push(Span::styled(
-            format!("· {mode} "),
-            Style::default().fg(theme.hint),
-        ));
-    }
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .padding(Padding::horizontal(1))
-        .title(Line::from(title))
-        .border_style(Style::default().fg(theme.border));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+        if let Some(agent) = state.transcript.agent_name.as_deref() {
+            identity.push(Span::styled(
+                format!(" · {agent}"),
+                Style::default().fg(theme.hint),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(identity)), area);
+        Rect {
+            y: area.y.saturating_add(2),
+            height: area.height.saturating_sub(2),
+            ..area
+        }
+    };
 
-    let (plan_area, text_area) = if state.transcript.current_plan.is_empty() || inner.height < 2 {
-        (Rect::default(), inner)
+    let (plan_area, text_area) = if state.transcript.current_plan.is_empty() || body.height < 2 {
+        (Rect::default(), body)
     } else {
-        let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(inner);
+        let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(body);
         (chunks[0], chunks[1])
     };
     if plan_area.height > 0 {
@@ -575,6 +580,134 @@ fn render_transcript(
         first_line: first as usize,
         total_lines: total as usize,
     }
+}
+
+const METADATA_CARD_MAX_WIDTH: u16 = 72;
+
+fn metadata_card_width(
+    state: &StructuredViewState,
+    friendly_title: &str,
+    available_width: u16,
+) -> u16 {
+    use unicode_width::UnicodeWidthStr;
+
+    let agent = state.transcript.agent_name.as_deref().unwrap_or("agent");
+    let directory = state
+        .path_roots
+        .as_ref()
+        .map(|roots| roots.project_path.as_str())
+        .unwrap_or("loading…");
+    let mode = state
+        .transcript
+        .current_mode
+        .as_deref()
+        .unwrap_or("default");
+    let widest = [
+        format!(
+            "❯ Agent of Empires · {agent} (v{})",
+            env!("CARGO_PKG_VERSION")
+        ),
+        format!("session:     {friendly_title}"),
+        format!("directory:   {directory}"),
+        format!("permissions: {mode}"),
+    ]
+    .into_iter()
+    .map(|line| UnicodeWidthStr::width(line.as_str()))
+    .max()
+    .unwrap_or_default() as u16;
+    widest
+        .saturating_add(4)
+        .clamp(36, METADATA_CARD_MAX_WIDTH)
+        .min(available_width)
+}
+
+fn render_metadata_card(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    state: &StructuredViewState,
+    friendly_title: &str,
+) {
+    let inner_width = area.width.saturating_sub(4) as usize;
+    let agent = state.transcript.agent_name.as_deref().unwrap_or("agent");
+    let directory = state
+        .path_roots
+        .as_ref()
+        .map(|roots| roots.project_path.as_str())
+        .unwrap_or("loading…");
+    let mode = state
+        .transcript
+        .current_mode
+        .as_deref()
+        .unwrap_or("default");
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("❯ ", Style::default().fg(theme.title)),
+            Span::styled(
+                fit_display(
+                    &format!(
+                        "Agent of Empires · {agent} (v{})",
+                        env!("CARGO_PKG_VERSION")
+                    ),
+                    inner_width.saturating_sub(2),
+                ),
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        metadata_line("session:", friendly_title, theme, inner_width),
+        metadata_line("directory:", directory, theme, inner_width),
+        metadata_line("permissions:", mode, theme, inner_width),
+    ];
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .border_style(Style::default().fg(theme.border));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn metadata_line(
+    label: &'static str,
+    value: &str,
+    theme: &Theme,
+    available_width: usize,
+) -> Line<'static> {
+    const LABEL_WIDTH: usize = 13;
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<LABEL_WIDTH$}"),
+            Style::default().fg(theme.hint),
+        ),
+        Span::styled(
+            fit_display(value, available_width.saturating_sub(LABEL_WIDTH)),
+            Style::default().fg(theme.text),
+        ),
+    ])
+}
+
+fn fit_display(value: &str, max_width: usize) -> String {
+    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+    if UnicodeWidthStr::width(value) <= max_width {
+        return value.to_string();
+    }
+    if max_width == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut width = 0usize;
+    for ch in value.chars() {
+        let ch_width = ch.width().unwrap_or_default();
+        if width.saturating_add(ch_width).saturating_add(1) > max_width {
+            break;
+        }
+        out.push(ch);
+        width += ch_width;
+    }
+    out.push('…');
+    out
 }
 
 /// Where the transcript text landed in the last render: the inner text
@@ -731,20 +864,42 @@ fn render_status(
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ));
     }
+    spans.push(Span::styled(
+        format!(" {} ", state.session_id),
+        Style::default().fg(theme.accent),
+    ));
+    if let Some(roots) = state.path_roots.as_ref() {
+        spans.push(Span::styled(
+            format!("· {} ", roots.project_path),
+            Style::default().fg(theme.branch),
+        ));
+    }
+    if let Some(agent) = state.transcript.agent_name.as_deref() {
+        spans.push(Span::styled(
+            format!("· {agent} "),
+            Style::default().fg(theme.hint),
+        ));
+    }
+    if let Some(mode) = state.transcript.current_mode.as_deref() {
+        spans.push(Span::styled(
+            format!("· {mode} "),
+            Style::default().fg(theme.title),
+        ));
+    }
     if state.transcript.turn_active {
         let banner = state.transcript.status_text.as_deref().unwrap_or("working");
         spans.push(Span::styled(
-            format!(" ● {banner} "),
+            format!("· ● {banner} "),
             Style::default().fg(theme.running),
         ));
     } else if state.ws.is_none() {
         spans.push(Span::styled(
-            " ○ Disconnected ",
+            "· ○ Disconnected ",
             Style::default().fg(theme.error),
         ));
     } else {
         spans.push(Span::styled(
-            " ● Ready ",
+            "· ● Ready ",
             Style::default().fg(theme.running),
         ));
     }
@@ -889,30 +1044,41 @@ fn render_composer(
     state: &StructuredViewState,
     active: bool,
 ) {
-    // The composer is a prompt rail rather than another card. The only
-    // title is contextual state that changes what Enter does.
-    let title: String = if let Some(recall) = &state.recall {
+    // Leave one open spacer row above the input. Recall / inactive state can
+    // use it for context without drawing a divider across the terminal.
+    let context: String = if let Some(recall) = &state.recall {
         let total = state.queue.len();
         let pos = total.saturating_sub(recall.index);
         format!(
-            " Editing queued message {pos} of {total} (Enter=save, Esc=restore draft, ↑/↓=browse) "
+            "Editing queued message {pos} of {total} (Enter=save, Esc=restore draft, ↑/↓=browse)"
         )
     } else if active {
         String::new()
     } else {
-        " Press Enter to reply ".to_string()
+        "Press Enter to reply".to_string()
     };
-    let separator = if state.recall.is_some() {
-        theme.title
-    } else {
-        theme.border
+    let chrome_rows = COMPOSER_CHROME_ROWS.min(area.height);
+    if !context.is_empty() && chrome_rows > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                context,
+                Style::default().fg(if state.recall.is_some() {
+                    theme.title
+                } else {
+                    theme.hint
+                }),
+            ))),
+            Rect {
+                height: chrome_rows,
+                ..area
+            },
+        );
+    }
+    let inner = Rect {
+        y: area.y.saturating_add(chrome_rows),
+        height: area.height.saturating_sub(chrome_rows),
+        ..area
     };
-    let block = Block::default()
-        .borders(Borders::TOP)
-        .title(title)
-        .border_style(Style::default().fg(separator));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
     let prompt_width = inner.width.min(2);
     let prompt_area = Rect {
         width: prompt_width,
@@ -932,7 +1098,7 @@ fn render_composer(
     };
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "❯ ",
+            "› ",
             Style::default()
                 .fg(prompt_color)
                 .add_modifier(Modifier::BOLD),
@@ -962,18 +1128,40 @@ fn render_composer(
     }
 }
 
-/// Render one of the user's turns the way Claude Code shows the
-/// human's messages: no "you" speaker label, just the text on a
-/// highlighted background so it stands apart from the agent's plain
-/// replies. Embedded newlines (Shift+Enter multi-line input) are split
-/// into one highlighted line each, with a space of padding on both
-/// sides so the highlight reads as a block rather than tight-wrapping
-/// the glyphs. A blank input line keeps a highlighted gap so the break
-/// is visible.
+/// User turns use the same open chevron gutter as Codex: one marker on the
+/// first line, continuation indentation on subsequent lines, and no filled
+/// background that would turn the message into a card.
 fn user_message_lines<'a>(text: &str, theme: &Theme) -> Vec<Line<'a>> {
-    let style = Style::default().bg(theme.selection).fg(theme.text);
     text.split('\n')
-        .map(|line| Line::from(Span::styled(format!(" {line} "), style)))
+        .enumerate()
+        .map(|(index, line)| {
+            Line::from(vec![
+                Span::styled(
+                    if index == 0 { "› " } else { "  " },
+                    Style::default()
+                        .fg(theme.title)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(line.to_string(), Style::default().fg(theme.text)),
+            ])
+        })
+        .collect()
+}
+
+fn agent_message_lines(text: &str, theme: &Theme) -> Vec<Line<'static>> {
+    render_agent_message_lines(text)
+        .into_iter()
+        .enumerate()
+        .map(|(index, mut line)| {
+            line.spans.insert(
+                0,
+                Span::styled(
+                    if index == 0 { "• " } else { "  " },
+                    Style::default().fg(theme.hint),
+                ),
+            );
+            line
+        })
         .collect()
 }
 
@@ -985,7 +1173,7 @@ fn user_message_lines<'a>(text: &str, theme: &Theme) -> Vec<Line<'a>> {
 /// only (BOLD/ITALIC/DIM), so the output tracks the app theme rather than
 /// carrying hardcoded colors. The agent's reply is rendered as plain
 /// body text with no speaker label, the way a native agent prints its
-/// response; the user's turns are what stand out (highlighted), not the
+/// response; the user's turns are what stand out through their chevron gutter, not the
 /// agent's. Empty or marker-only input falls back to a bare `…`.
 fn render_agent_message_lines(text: &str) -> Vec<Line<'static>> {
     if text.trim().is_empty() {
@@ -1246,7 +1434,7 @@ fn transcript_lines<'a>(
                 out.push(Line::default());
             }
             ActivityRow::AgentMessage(text) => {
-                out.extend(render_agent_message_lines(text));
+                out.extend(agent_message_lines(text, theme));
                 out.push(Line::default());
             }
             ActivityRow::ToolCall(tool) => {
@@ -1937,17 +2125,21 @@ mod tests {
     }
 
     #[test]
-    fn user_message_is_highlighted_and_splits_newlines() {
+    fn user_message_uses_one_chevron_and_no_background() {
         use crate::tui::styles::load_theme;
         let theme = load_theme("empire");
         let lines = user_message_lines("first\nsecond", &theme);
-        // One line per input line, no "you" label, text preserved.
         assert_eq!(lines.len(), 2);
-        assert!(line_text(&lines[0]).contains("first"));
-        assert!(line_text(&lines[1]).contains("second"));
+        assert_eq!(line_text(&lines[0]), "› first");
+        assert_eq!(line_text(&lines[1]), "  second");
         assert!(!line_text(&lines[0]).contains("you"));
-        // The highlight is a background style on the text span.
-        assert_eq!(lines[0].spans[0].style.bg, Some(theme.selection));
+        assert!(
+            lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .all(|span| span.style.bg.is_none()),
+            "user turns must stay open, not render as filled cards: {lines:?}"
+        );
     }
 
     use crate::acp::state::AvailableCommand;
@@ -2180,7 +2372,7 @@ mod tests {
             },
         ]));
         let out = joined(&transcript_lines(&t, &Theme::default(), None));
-        // Rendered as user turns: highlighted text, no "you" label.
+        // Rendered as user turns: chevron gutter, no "you" label.
         assert!(out.contains("Proceed?: Yes"), "{out:?}");
         assert!(out.contains("Mode: Fast"), "{out:?}");
         assert!(!out.contains("you  ▸"), "{out:?}");
@@ -2542,10 +2734,12 @@ mod tests {
     fn composer_renders_as_prompt_rail_without_bottom_box() {
         let state = test_state();
         let rows = render_rows(&state, 60, 12, true);
-        assert!(rows[0].contains("● s-1"), "active header missing: {rows:?}");
-        let prompt = rows.last().expect("prompt row");
+        let prompt = rows
+            .iter()
+            .find(|row| row.contains("Message the agent"))
+            .expect("prompt row");
         assert!(
-            prompt.trim_start().starts_with('❯') && prompt.contains("Message the agent"),
+            prompt.trim_start().starts_with('›') && prompt.contains("Message the agent"),
             "prompt rail missing: {prompt:?}"
         );
         assert!(
@@ -2555,6 +2749,61 @@ mod tests {
         assert!(
             !prompt.contains('╯'),
             "composer still has a box: {prompt:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_card_is_compact_and_transcript_is_unframed() {
+        let mut state = test_state();
+        state.transcript.session_title = Some("virtual-wardrobe".into());
+        state.transcript.agent_name = Some("codex".into());
+        state.transcript.current_mode = Some("yolo".into());
+        state.path_roots = Some(SessionPathRoots {
+            id: "s-1".into(),
+            project_path: "/workspace/virtual-wardrobe".into(),
+            main_repo_path: None,
+            workspace_repos: Vec::new(),
+        });
+        state
+            .transcript
+            .rows
+            .push(ActivityRow::UserPrompt("Hello.".into()));
+        state
+            .transcript
+            .rows
+            .push(ActivityRow::AgentMessage("What should we build?".into()));
+
+        let rows = render_rows(&state, 80, 20, true);
+        let card_right = rows[0]
+            .chars()
+            .position(|ch| ch == '╮')
+            .expect("metadata card right edge");
+        assert!(card_right < 79, "card still spans the viewport: {rows:?}");
+        assert!(rows
+            .iter()
+            .any(|row| row.contains("Agent of Empires · codex")));
+        assert!(rows.iter().any(|row| row.contains("virtual-wardrobe")));
+        assert!(rows
+            .iter()
+            .any(|row| row.contains("/workspace/virtual-wardrobe")));
+        assert!(rows.iter().any(|row| row.contains("permissions: yolo")));
+
+        let prompt = rows
+            .iter()
+            .find(|row| row.contains("› Hello."))
+            .expect("user turn");
+        assert!(
+            !prompt.starts_with('│'),
+            "transcript kept a left frame: {prompt:?}"
+        );
+        assert!(
+            !prompt.ends_with('│'),
+            "transcript kept a right frame: {prompt:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("• What should we build?")),
+            "agent gutter missing: {rows:?}"
         );
     }
 

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -1,5 +1,6 @@
 //! Render of a structured view session, stacked top to bottom: transcript,
-//! status, action shelves, and composer. The slash and `@` mention pickers
+//! approval shelf, queue, composer, and a status line pinned at the bottom.
+//! The slash and `@` mention pickers
 //! float above the composer when open rather than taking a pane. Successful
 //! tools collapse to target-aware summaries; running and failed tools use the
 //! per-kind detail renderer. Image previews and syntax highlighting stay

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -201,7 +201,7 @@ pub struct RecallState {
 /// composer means swapping in a fresh one from here.
 fn new_composer_textarea() -> TextArea<'static> {
     let mut ta = TextArea::default();
-    ta.set_placeholder_text(" Message the agent…  @ for files, / for commands");
+    ta.set_placeholder_text("Message the agent…  @ files  / commands");
     ta.set_cursor_line_style(ratatui::style::Style::default());
     ta
 }

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -33,10 +33,10 @@ pub struct StructuredViewState {
     pub composer: TextArea<'static>,
     pub focus: Focus,
     pub scroll_offset: u16,
-    /// Index into `transcript.pending_approvals` for the highlighted
-    /// approval card when focus is `Approval`. None when the list is
-    /// empty.
-    pub selected_approval: Option<usize>,
+    /// Nonce of the approval currently holding the modal action shelf. Identity
+    /// is used instead of a list index so historical resolved rows can never
+    /// make the highlighted request diverge from the request the keys resolve.
+    pub selected_approval: Option<String>,
     pub ws: Option<WsHandle>,
     /// Toast banner that appears briefly above the composer, e.g.
     /// "prompt sent" or an HTTP error.
@@ -164,6 +164,7 @@ impl ChoicePicker {
 pub struct ViewLayout {
     pub transcript: Rect,
     pub status: Rect,
+    pub approval: Rect,
     pub queue: Rect,
     pub composer: Rect,
 }
@@ -525,12 +526,10 @@ impl StructuredViewState {
         }
     }
 
-    /// Bring the selected-approval index back into bounds whenever the
-    /// pending list changes underneath us (a resolution removed one,
-    /// a new request added one, etc.).
+    /// Keep the selected approval tied to a pending nonce whenever the list
+    /// changes underneath us.
     pub fn reconcile_selection(&mut self) {
-        let len = self.transcript.pending_approvals.len();
-        if len == 0 {
+        if self.transcript.pending_approvals.is_empty() {
             self.selected_approval = None;
             // The prompt is gone; hand the keyboard back to the composer.
             if matches!(self.focus, Focus::Approval) {
@@ -538,16 +537,24 @@ impl StructuredViewState {
             }
             return;
         }
-        match self.selected_approval {
-            Some(i) if i >= len => self.selected_approval = Some(len - 1),
-            None => self.selected_approval = Some(0),
-            _ => {}
+        let selected_still_pending = self.selected_approval.as_ref().is_some_and(|selected| {
+            self.transcript
+                .pending_approvals
+                .iter()
+                .any(|pending| pending.nonce == *selected)
+        });
+        if !selected_still_pending {
+            self.selected_approval = self
+                .transcript
+                .pending_approvals
+                .first()
+                .map(|pending| pending.nonce.clone());
         }
         // A pending approval is modal, like a native agent's permission
         // prompt: it grabs focus so the decision keys work with no Tab
         // into the chat. A menu the user opened themselves (mode) keeps
         // the keyboard until dismissed.
-        if matches!(self.focus, Focus::Composer) && self.choice.is_none() {
+        if self.choice.is_none() {
             self.focus = Focus::Approval;
         }
     }
@@ -875,5 +882,32 @@ mod tests {
         ])));
         assert!(state.next_plugin_toast().is_none());
         assert_eq!(state.plugin_notify.last_seen_seq, 1);
+    }
+
+    #[test]
+    fn approval_selection_tracks_nonce_as_pending_list_advances() {
+        use super::super::reducer::PendingApproval;
+
+        let mut state = test_state(None);
+        state.transcript.pending_approvals = vec![
+            PendingApproval {
+                nonce: "approval-b".into(),
+            },
+            PendingApproval {
+                nonce: "approval-c".into(),
+            },
+        ];
+        state.reconcile_selection();
+        assert_eq!(state.selected_approval.as_deref(), Some("approval-b"));
+        assert_eq!(state.focus, Focus::Approval);
+
+        state.transcript.pending_approvals.remove(0);
+        state.reconcile_selection();
+        assert_eq!(state.selected_approval.as_deref(), Some("approval-c"));
+
+        state.transcript.pending_approvals.clear();
+        state.reconcile_selection();
+        assert!(state.selected_approval.is_none());
+        assert_eq!(state.focus, Focus::Composer);
     }
 }

--- a/tests/e2e/acp_focus_isolation_e2e.rs
+++ b/tests/e2e/acp_focus_isolation_e2e.rs
@@ -87,8 +87,8 @@ fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration
 
 /// Stand up a live daemon, attach the native TUI structured view to a session
 /// with a real pending approval, and prove the modal-approval model:
-///   1. A pending approval grabs focus on its own (no Tab): the card shows
-///      the decision hint immediately.
+///   1. A pending approval grabs focus on its own (no Tab): the shelf shows
+///      the decision hints immediately.
 ///   2. A non-decision key does NOT resolve it (only a/A/d act).
 ///   3. Pressing `a` resolves it, with no focus switch anywhere.
 #[test]
@@ -179,20 +179,20 @@ fn tui_acp_modal_approval_with_live_daemon() {
     // The approval must surface through the full stack (replay + WS).
     // It is modal: it grabs focus on its own, so the decision hint shows
     // with no Tab or other gesture.
-    h.wait_for(" pending approval");
-    h.wait_for("press a / A / d to resolve");
+    h.wait_for("Approval 1/1 · Edit a file");
+    h.wait_for("a allow once");
 
     // --- Negative path: a non-decision key does not resolve ---
     // Only a/A/d act while the prompt is up; a stray letter is ignored
     // (the modal approval owns the keyboard, so it can't leak into a
     // composer draft either).
     h.send_keys("z");
-    h.assert_screen_not_contains("→ allowed");
-    h.assert_screen_contains(" pending approval");
+    h.assert_screen_not_contains("Allowed once · Edit a file");
+    h.assert_screen_contains("Approval 1/1 · Edit a file");
 
     // --- Positive path: `a` resolves it directly, no focus switch ---
     h.send_keys("a"); // resolve: allow
-    h.wait_for("→ allowed");
+    h.wait_for("Allowed once · Edit a file");
     // Neither the ignored `z` nor the resolving `a` may leak into the
     // composer: the empty-composer placeholder proves the modal owned
     // both keys end to end.

--- a/tests/e2e/acp_tool_cards_e2e.rs
+++ b/tests/e2e/acp_tool_cards_e2e.rs
@@ -1,11 +1,11 @@
-//! Full-stack e2e: the native TUI structured view renders a per-kind Edit card
-//! (a compact +/- line diff) instead of a generic one-liner. #1702.
+//! Full-stack e2e: the native TUI structured view renders a completed Edit as
+//! a compact path and line-count summary instead of an expanded output card.
 //!
 //! Per-kind dispatch is unit-tested at `src/tui/structured_view/render.rs`;
 //! this proves the same end-to-end: a real `aoe serve --daemon`, a real
 //! structured view worker bridging a scripted ACP `tool_call` (kind `edit`,
 //! carrying `old_string`/`new_string` in `rawInput`), and the native TUI
-//! attached over tmux rendering the diff through the production path.
+//! attached over tmux rendering the summary through the production path.
 //!
 //! Mirrors the web Edit-card story `edit-card-diff-scroll.spec.ts`: the
 //! fake-ACP `tool_call` shape (toolCallId / kind / status / rawInput) is
@@ -36,12 +36,18 @@ const EDIT_SCRIPT: &str = r#"{
           "toolCallId": "tc-edit-1",
           "title": "edit greeting.txt",
           "kind": "edit",
-          "status": "completed",
+          "status": "pending",
           "rawInput": {
             "file_path": "greeting.txt",
             "old_string": "hello from before",
             "new_string": "hello from after"
           }
+        },
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-edit-1",
+          "status": "completed",
+          "rawOutput": { "content": "updated greeting.txt" }
         }
       ],
       "stopReason": "end_turn"
@@ -85,10 +91,10 @@ fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration
 
 /// Stand up a live daemon, drive one scripted `edit` tool call, attach
 /// the native TUI structured view, and assert the transcript shows the compact
-/// added/removed line diff rather than the generic one-liner.
+/// target and change counts rather than the expanded diff.
 #[test]
 #[serial]
-fn tui_acp_renders_edit_diff_with_live_daemon() {
+fn tui_acp_renders_compact_edit_summary_with_live_daemon() {
     require_tmux!();
     require_node!();
 
@@ -171,9 +177,13 @@ fn tui_acp_renders_edit_diff_with_live_daemon() {
     // discovers the local daemon via serve.url / serve.pid.
     h.spawn(&["acp", "attach", &session_id]);
 
-    // The edit card must surface through the full stack (replay + WS):
-    // header + path + a removed line + an added line.
+    // The edit summary must surface through the full stack (replay + WS):
+    // tool label, target path, and added/removed counts.
     h.wait_for("greeting.txt");
-    h.assert_screen_contains("- hello from before");
-    h.assert_screen_contains("+ hello from after");
+    h.assert_screen_contains("+1 -1");
+    let screen = h.capture_screen();
+    assert!(
+        !screen.contains("hello from before"),
+        "diff should be collapsed"
+    );
 }


### PR DESCRIPTION
## Description

Refines the native structured-chat TUI so conversation and activity remain the visual focus while session state stays easy to scan.

The full-width transcript frame gave metadata the same visual weight as the conversation and made the TUI feel nested. This change replaces it with a compact upper-left metadata card, keeps the transcript and composer on the terminal background, and moves session identity and readiness to the bottom status line. Full-width borders are reserved for modal decisions such as approvals.

### What changed

- Shows the active agent, session title, directory, permission mode, and AoE version in a compact metadata card.
- Uses a `›` gutter for user turns and a `•` gutter for agent replies without filled message backgrounds.
- Keeps the latest plan pinned as one progress summary instead of appending repeated snapshots.
- Collapses successful tools to target-aware summaries while keeping running and failed calls expanded.
- Places pending permissions in a modal approval shelf with command or path context.
- Resolves approvals by nonce, so historical rows cannot shift the action behind the selected prompt.
- Keeps the composer open and borderless, with session identity, worker state, usage, and controls on the bottom rail.
- Preserves pane-aware clicks, Shift-drag selection, queued-prompt editing, and pasted drafts behind modal prompts.
- Documents the final visual hierarchy and extends renderer and live ACP coverage.
- Preserves current-main daemon-sourced plugin commands, keybind execution, and link handling after the rebase.

### Screenshots

#### Conversation, plan, and tool summaries

![Structured TUI with compact metadata, open transcript, plan, and tool summaries](https://raw.githubusercontent.com/amanzainal/agent-of-empires/pr-assets/pr-2966/conversation.png)

#### Pending approval

![Structured TUI with a modal approval shelf](https://raw.githubusercontent.com/amanzainal/agent-of-empires/pr-assets/pr-2966/approval.png)

<details>
<summary>Completed approval</summary>

![Structured TUI after approval resolution](https://raw.githubusercontent.com/amanzainal/agent-of-empires/pr-assets/pr-2966/completed.png)

</details>

The screenshots use a deterministic fake ACP agent, isolated HOME and XDG state, a private tmux socket, and a dedicated daemon port. No real credentials or installed AoE state were used.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `git diff --check upstream/main...HEAD`
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test --features serve tui::structured_view --lib`: 185 passed
- `cargo +1.95.0 test --features 'serve,e2e-tests' --test e2e -- tui_acp_ --nocapture --test-threads=1`: 2 passed
- `cargo +1.95.0 test --features 'serve,e2e-tests' --test e2e -- wizard_created_structured_session_opens_structured_view --nocapture --test-threads=1`: passed
- `cargo +1.95.0 test --features 'serve,e2e-tests' --test e2e -- keyboard_confirmed_view_switch_fires_immediately --nocapture --test-threads=1`: passed
- `cargo +1.95.0 test --features 'serve,e2e-tests' --test e2e -- tui_executes_plugin_commands_with_live_daemon --nocapture --test-threads=1`: passed
- `cargo +1.95.0 clippy --features serve --all-targets -- -A clippy::collapsible-match -A clippy::items-after-test-module -D warnings`
  - both allowances cover unchanged Rust 1.95 findings on current `main`
- `umask 077; TMPDIR=<owner-only temp dir> CARGO_BUILD_JOBS=1 cargo +1.95.0 test --features serve`
  - library: 5,648 passed, 2 ignored
  - integration main: 159 passed, 5 ignored
  - all remaining test binaries passed; aggregate: 5,901 passed, 8 ignored, 0 failed; doc tests: 0 passed, 1 ignored

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** OpenAI Codex

**Any Additional AI Details you'd like to share:**

Codex audited the existing TUI and web structured-view behavior, implemented the scoped changes in an isolated worktree, exercised the production TUI against a deterministic fake ACP agent, captured the screenshots above, rebased the branch while preserving current plugin command behavior, and ran the checks above.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Refined the structured-chat TUI with a compact session metadata card, cleaner transcript hierarchy, gutter-based turns, compact tool summaries, pinned plans, and a borderless composer.
- Added a dedicated approval shelf with modal decision prompts and nonce-based approval tracking, improving focus, selection, and approval reliability.
- Moved session and worker status into the footer while preserving pane-aware mouse interaction, queued-prompt editing, and draft handling.
- Added session metadata APIs and updated embedded-view event handling to hydrate titles, agents, and paths.
- Updated documentation, unit tests, and end-to-end coverage for the redesigned layout, approval flow, and compact tool rendering.

## Benefits

The interface is less visually crowded, makes active plans and approvals easier to find, and provides clearer session status without overwhelming the transcript. Coverage and documentation were updated to support the new behavior.

## Potential follow-ups

- Continue validating layout behavior across narrow terminals and unusual metadata lengths.
- Consider further consolidating shared rendering and interaction logic as the structured view evolves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->