### PR TITLE
feat(status): distinguish idle-dormant structured sessions from a deliberate stop

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -31,6 +31,12 @@ pub struct SessionResponse {
     pub group_path: String,
     pub tool: String,
     pub status: String,
+    /// True when the session's structured-view worker was auto-stopped for
+    /// inactivity (resumable/dormant), as opposed to a deliberate Stop. Lets
+    /// the dashboard render a distinct dormant dot instead of a live-idle one.
+    /// A deliberate Stop keeps `status: "Stopped"` and reports `false` here.
+    /// See #2250.
+    pub dormant: bool,
     pub yolo_mode: bool,
     pub created_at: String,
     pub last_accessed_at: Option<String>,
@@ -339,6 +345,7 @@ impl SessionResponse {
             group_path: inst.group_path.clone(),
             tool: inst.tool.clone(),
             status: format!("{:?}", inst.status),
+            dormant: inst.is_shown_dormant(),
             yolo_mode: inst.yolo_mode,
             created_at: inst.created_at.to_rfc3339(),
             last_accessed_at: inst.last_accessed_at.map(|t| t.to_rfc3339()),
@@ -6878,6 +6885,24 @@ mod tests {
     }
 
     #[test]
+    fn session_response_dormant_reflects_shown_dormant() {
+        let mut inst = make_test_instance();
+
+        // Live idle: not dormant.
+        inst.status = Status::Idle;
+        assert!(!SessionResponse::from_instance(&inst, false).dormant);
+
+        // Idle-reaped (marker set, status left Idle): dormant.
+        inst.mark_idle_dormant();
+        assert!(SessionResponse::from_instance(&inst, false).dormant);
+
+        // Deliberate stop (marker set AND Stopped): reports NOT dormant so the
+        // dashboard keeps the neutral Stopped dot. See #2250.
+        inst.status = Status::Stopped;
+        assert!(!SessionResponse::from_instance(&inst, false).dormant);
+    }
+
+    #[test]
     fn session_response_branch_from_worktree() {
         let mut inst = make_test_instance();
         assert!(SessionResponse::from_instance(&inst, false)
@@ -8858,6 +8883,7 @@ mod workspace_ordering_tests {
             group_path: String::new(),
             tool: "claude".to_string(),
             status: "Idle".to_string(),
+            dormant: false,
             yolo_mode: false,
             created_at: "2025-01-01T00:00:00Z".to_string(),
             last_accessed_at: None,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1374,6 +1374,19 @@ impl Instance {
         self.idle_dormant_since = Some(Utc::now());
     }
 
+    /// Whether this session should render as "dormant" (worker auto-stopped
+    /// for inactivity, resumable) rather than with its raw `status`. This is
+    /// the single source of the deliberate-stop-vs-dormant precedence: a
+    /// deliberate Stop also sets `idle_dormant_since` (see `stop_session`),
+    /// so `Status::Stopped` must win here and keep showing the neutral
+    /// "Stopped" dot; only a non-stopped row carrying the dormant marker
+    /// (the idle-reaper's output) presents as dormant. The reaper only ever
+    /// marks structured rows, so this is structured-only in practice. See
+    /// #2250 and `idle_dormant_since`.
+    pub fn is_shown_dormant(&self) -> bool {
+        self.is_idle_dormant() && self.status != Status::Stopped
+    }
+
     /// Mutates: `status`, `sandbox_info`. Field set must match what
     /// `start_with_size_opts` writes; missing fields re-introduce the
     /// wholesale-replace clobber.
@@ -5886,6 +5899,33 @@ mod tests {
         inst.mark_idle_dormant();
         assert!(inst.is_idle_dormant());
         assert!(inst.idle_dormant_since.is_some());
+    }
+
+    #[test]
+    fn test_is_shown_dormant_precedence() {
+        // Idle + dormant marker: the idle-reaper's output, presents dormant.
+        let mut idle_reaped = Instance::new("test", "/tmp/test");
+        idle_reaped.status = Status::Idle;
+        idle_reaped.mark_idle_dormant();
+        assert!(idle_reaped.is_shown_dormant());
+
+        // Stopped + dormant marker: a deliberate Stop (which also marks
+        // dormant). Stopped must win so the row keeps the neutral "Stopped"
+        // dot, not the dormant one. See #2250.
+        let mut deliberate_stop = Instance::new("test", "/tmp/test");
+        deliberate_stop.status = Status::Stopped;
+        deliberate_stop.mark_idle_dormant();
+        assert!(!deliberate_stop.is_shown_dormant());
+
+        // Idle, no marker: a live idle session, unaffected.
+        let mut live_idle = Instance::new("test", "/tmp/test");
+        live_idle.status = Status::Idle;
+        assert!(!live_idle.is_shown_dormant());
+
+        // Running, no marker: live, unaffected.
+        let mut running = Instance::new("test", "/tmp/test");
+        running.status = Status::Running;
+        assert!(!running.is_shown_dormant());
     }
 
     #[test]

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -339,22 +339,32 @@ impl Preview {
             ]),
             Line::from(vec![
                 Span::styled("Status:  ", Style::default().fg(theme.dimmed)),
-                Span::styled(
-                    format!("{:?}", instance.status),
-                    Style::default().fg(match instance.status {
-                        crate::session::Status::Running => theme.running,
-                        crate::session::Status::Waiting => theme.waiting,
-                        crate::session::Status::Idle => {
-                            theme.idle_color_at_age(instance.idle_age(), idle_decay_window)
-                        }
-                        crate::session::Status::Unknown => theme.waiting,
-                        crate::session::Status::Stopped => theme.dimmed,
-                        crate::session::Status::Error => theme.error,
-                        crate::session::Status::Starting => theme.dimmed,
-                        crate::session::Status::Deleting => theme.waiting,
-                        crate::session::Status::Creating => theme.accent,
-                    }),
-                ),
+                {
+                    // A dormant (idle-reaped, resumable) structured worker
+                    // reads "Dormant" in dim amber, distinct from a deliberate
+                    // Stop or a live Idle. See #2250.
+                    let (label, color) = if instance.is_shown_dormant() {
+                        ("Dormant".to_string(), theme.dormant())
+                    } else {
+                        (
+                            format!("{:?}", instance.status),
+                            match instance.status {
+                                crate::session::Status::Running => theme.running,
+                                crate::session::Status::Waiting => theme.waiting,
+                                crate::session::Status::Idle => {
+                                    theme.idle_color_at_age(instance.idle_age(), idle_decay_window)
+                                }
+                                crate::session::Status::Unknown => theme.waiting,
+                                crate::session::Status::Stopped => theme.dimmed,
+                                crate::session::Status::Error => theme.error,
+                                crate::session::Status::Starting => theme.dimmed,
+                                crate::session::Status::Deleting => theme.waiting,
+                                crate::session::Status::Creating => theme.accent,
+                            },
+                        )
+                    };
+                    Span::styled(label, Style::default().fg(color))
+                },
             ]),
         ]);
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3561,11 +3561,15 @@ impl HomeView {
                     let Some(inst) = self.get_instance(id) else {
                         continue;
                     };
-                    let status_tag = match inst.status {
-                        Status::Creating => " [creating]",
-                        Status::Deleting => " [deleting]",
-                        Status::Stopped => " [stopped]",
-                        _ => "",
+                    let status_tag = if inst.is_shown_dormant() {
+                        " [dormant]"
+                    } else {
+                        match inst.status {
+                            Status::Creating => " [creating]",
+                            Status::Deleting => " [deleting]",
+                            Status::Stopped => " [stopped]",
+                            _ => "",
+                        }
                     };
                     let title = if inst.group_path.is_empty() {
                         format!("Jump to session: {}{}", inst.title, status_tag)

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -389,6 +389,11 @@ pub(super) const UNREAD_DWELL: std::time::Duration = std::time::Duration::from_s
 pub(super) const ICON_ERROR: &str = "✕";
 pub(super) const ICON_UNKNOWN: &str = "⠤";
 pub(super) const ICON_STOPPED: &str = "⠒";
+/// A structured-view session parked by the idle reaper (resumable). A distinct
+/// double-bar braille glyph so dormancy reads by shape as well as by its dim
+/// amber color, staying legible against the single-bar idle/stopped dot in
+/// monochrome terminals and for colorblind users. See #2250.
+pub(super) const ICON_DORMANT: &str = "⠶";
 pub(super) const ICON_DELETING: &str = "✕";
 pub(super) const ICON_COLLAPSED: &str = "▶";
 pub(super) const ICON_EXPANDED: &str = "▼";

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -10,7 +10,7 @@ use rattles::presets::prelude as spinners;
 
 use super::{
     get_indent, live_send, HomeView, TerminalMode, ViewMode, ICON_ARCHIVED_SECTION, ICON_COLLAPSED,
-    ICON_DELETING, ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED, ICON_STOPPED,
+    ICON_DELETING, ICON_DORMANT, ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_PINNED, ICON_STOPPED,
     ICON_TRASH_SECTION, ICON_UNKNOWN, ICON_UNREAD,
 };
 use crate::containers::image_update::ImageUpdate;
@@ -224,16 +224,23 @@ fn spinner_idle_fresh(
 /// so tests can pin the override behavior without going through the full
 /// render pipeline.
 pub(crate) fn agent_row_icon(inst: &crate::session::Instance) -> &'static str {
-    let icon = match inst.status {
-        Status::Running => spinner_running(&inst.created_at),
-        Status::Waiting => spinner_waiting(&inst.created_at),
-        Status::Idle => ICON_IDLE,
-        Status::Unknown => ICON_UNKNOWN,
-        Status::Stopped => ICON_STOPPED,
-        Status::Error => ICON_ERROR,
-        Status::Starting => spinner_starting(&inst.created_at),
-        Status::Deleting => ICON_DELETING,
-        Status::Creating => spinner_starting(&inst.created_at),
+    // A dormant (idle-reaped, resumable) structured worker gets its own glyph,
+    // taking precedence over the raw status but still yielding to the
+    // archived/snoozed/trashed sink override below. See #2250.
+    let icon = if inst.is_shown_dormant() {
+        ICON_DORMANT
+    } else {
+        match inst.status {
+            Status::Running => spinner_running(&inst.created_at),
+            Status::Waiting => spinner_waiting(&inst.created_at),
+            Status::Idle => ICON_IDLE,
+            Status::Unknown => ICON_UNKNOWN,
+            Status::Stopped => ICON_STOPPED,
+            Status::Error => ICON_ERROR,
+            Status::Starting => spinner_starting(&inst.created_at),
+            Status::Deleting => ICON_DELETING,
+            Status::Creating => spinner_starting(&inst.created_at),
+        }
     };
     // Error and Deleting are live operation states set by this TUI (a failed
     // or in-flight permanent delete), not stale persisted pane statuses, so
@@ -1301,19 +1308,30 @@ impl HomeView {
                             let idle_age = inst.idle_age();
                             let is_fresh_idle =
                                 matches!(idle_age, Some(age) if age < self.idle_decay_window);
-                            let mut icon = match inst.status {
-                                Status::Running => spinner_running(&inst.created_at),
-                                Status::Waiting => spinner_waiting(&inst.created_at),
-                                Status::Idle if is_fresh_idle => {
-                                    spinner_idle_fresh(&inst.created_at, inst.idle_entered_at)
+                            // Dormant (idle-reaped, resumable) structured
+                            // workers get their own glyph + dim amber, taking
+                            // precedence over the raw status. Unread still
+                            // wins over dormancy below (an unseen finished turn
+                            // is the more actionable signal, matching the web
+                            // sidebar's unread-dot precedence). See #2250.
+                            let is_shown_dormant = inst.is_shown_dormant();
+                            let mut icon = if is_shown_dormant {
+                                ICON_DORMANT
+                            } else {
+                                match inst.status {
+                                    Status::Running => spinner_running(&inst.created_at),
+                                    Status::Waiting => spinner_waiting(&inst.created_at),
+                                    Status::Idle if is_fresh_idle => {
+                                        spinner_idle_fresh(&inst.created_at, inst.idle_entered_at)
+                                    }
+                                    Status::Idle => ICON_IDLE,
+                                    Status::Unknown => ICON_UNKNOWN,
+                                    Status::Stopped => ICON_STOPPED,
+                                    Status::Error => ICON_ERROR,
+                                    Status::Starting => spinner_starting(&inst.created_at),
+                                    Status::Deleting => ICON_DELETING,
+                                    Status::Creating => spinner_starting(&inst.created_at),
                                 }
-                                Status::Idle => ICON_IDLE,
-                                Status::Unknown => ICON_UNKNOWN,
-                                Status::Stopped => ICON_STOPPED,
-                                Status::Error => ICON_ERROR,
-                                Status::Starting => spinner_starting(&inst.created_at),
-                                Status::Deleting => ICON_DELETING,
-                                Status::Creating => spinner_starting(&inst.created_at),
                             };
                             // Unread paints only on resting rows
                             // (Idle/Unknown): a live status (Running/Waiting/
@@ -1335,20 +1353,24 @@ impl HomeView {
                                 && !inst.is_archived()
                                 && !inst.is_snoozed()
                                 && matches!(inst.status, Status::Idle | Status::Unknown);
-                            let color = match inst.status {
-                                Status::Running => theme.running,
-                                Status::Waiting => theme.waiting,
-                                Status::Idle if unread_resting => theme.unread,
-                                Status::Idle => {
-                                    theme.idle_color_at_age(idle_age, self.idle_decay_window)
+                            let color = if is_shown_dormant && !unread_resting {
+                                theme.dormant()
+                            } else {
+                                match inst.status {
+                                    Status::Running => theme.running,
+                                    Status::Waiting => theme.waiting,
+                                    Status::Idle if unread_resting => theme.unread,
+                                    Status::Idle => {
+                                        theme.idle_color_at_age(idle_age, self.idle_decay_window)
+                                    }
+                                    Status::Unknown if unread_resting => theme.unread,
+                                    Status::Unknown => theme.waiting,
+                                    Status::Stopped => theme.dimmed,
+                                    Status::Error => theme.error,
+                                    Status::Starting => theme.dimmed,
+                                    Status::Deleting => theme.waiting,
+                                    Status::Creating => theme.accent,
                                 }
-                                Status::Unknown if unread_resting => theme.unread,
-                                Status::Unknown => theme.waiting,
-                                Status::Stopped => theme.dimmed,
-                                Status::Error => theme.error,
-                                Status::Starting => theme.dimmed,
-                                Status::Deleting => theme.waiting,
-                                Status::Creating => theme.accent,
                             };
                             let mut style = Style::default().fg(color);
                             if unread_resting {
@@ -2207,6 +2229,10 @@ impl HomeView {
                         && !matches!(inst.status, Status::Error | Status::Deleting)
                     {
                         (ICON_STOPPED, theme.dimmed)
+                    } else if inst.is_shown_dormant() {
+                        // Dormant (idle-reaped, resumable) structured worker;
+                        // distinct glyph + dim amber. See #2250.
+                        (ICON_DORMANT, theme.dormant())
                     } else {
                         match inst.status {
                             Status::Running => (spinner_running(&inst.created_at), theme.running),

--- a/src/tui/styles/resolved.rs
+++ b/src/tui/styles/resolved.rs
@@ -267,6 +267,10 @@ fn web_projection(theme: &Theme, appearance: ThemeAppearance) -> CssVarProjectio
         "--color-status-stopped".into(),
         hex(mix(theme.dimmed, BLACK, 0.1)),
     );
+    // Dormant (idle-reaped, resumable structured worker): a dim amber derived
+    // from the theme's fresh-idle + dimmed, distinct from the neutral Stopped
+    // grey and the brighter fresh-idle attention color. See #2250.
+    css.insert("--color-status-dormant".into(), hex(theme.dormant()));
 
     // Diff + extras. Diff tokens are exposed even though the current
     // diff cards use ad-hoc Tailwind classes; web can migrate to them

--- a/src/tui/styles/themes.rs
+++ b/src/tui/styles/themes.rs
@@ -263,6 +263,36 @@ impl Theme {
         }
         self.fresh_idle
     }
+
+    /// Color for a session shown as dormant: a structured-view worker that was
+    /// auto-stopped for inactivity and is resumable (see
+    /// `Instance::is_shown_dormant`). A dim amber, the `fresh_idle` attention
+    /// amber pulled halfway toward `dimmed`, so it reads as "parked, not
+    /// urgent" and stays distinct from both the bright fresh-idle amber and
+    /// the neutral `dimmed` used for a deliberate Stop. Derived from existing
+    /// theme colors (not a stored field) so it needs no per-theme definition
+    /// and stays out of the `color_fields_mut` drift guard. See #2250.
+    pub fn dormant(&self) -> Color {
+        blend(self.fresh_idle, self.dimmed, 0.5)
+    }
+}
+
+/// Linear RGB blend of `a` and `b` at `t` (0.0 = all `a`, 1.0 = all `b`).
+/// Falls back to `a` if either color is a non-RGB terminal color; theme
+/// colors are always loaded as RGB via `hex_color`, so that path is defensive
+/// only. Mirrors the private `mix` in `resolved.rs`; kept local to avoid a
+/// backwards dependency from this foundational module onto `resolved`.
+fn blend(a: Color, b: Color, t: f32) -> Color {
+    let rgb = |c: Color| match c {
+        Color::Rgb(r, g, bl) => Some((r, g, bl)),
+        _ => None,
+    };
+    let (Some((ar, ag, ab)), Some((br, bg, bb))) = (rgb(a), rgb(b)) else {
+        return a;
+    };
+    let t = t.clamp(0.0, 1.0);
+    let lerp = |x: u8, y: u8| ((x as f32) * (1.0 - t) + (y as f32) * t).round() as u8;
+    Color::Rgb(lerp(ar, br), lerp(ag, bg), lerp(ab, bb))
 }
 
 impl Theme {

--- a/web/src/components/StatusGlyph.tsx
+++ b/web/src/components/StatusGlyph.tsx
@@ -37,6 +37,11 @@ const STATIC_GLYPH: Record<SessionStatus, string> = {
   Creating: "⠀",
 };
 
+/** Glyph for a dormant (idle-reaped, resumable) structured worker. A distinct
+ *  double-bar braille dot, matching the TUI's ICON_DORMANT, so dormancy reads
+ *  by shape as well as by its dim-amber color. See #2250. */
+const DORMANT_GLYPH = "⠶";
+
 /** Slowed-down `breathe` rattle for a freshly-stopped Idle session.
  *  Reuses the same animation as Starting on purpose; differentiation is
  *  by color (Starting uses `--color-text-muted`, fresh-idle uses
@@ -59,16 +64,19 @@ export function StatusGlyph({
   status,
   createdAt,
   idleEnteredAt,
+  dormant = false,
 }: {
   status: SessionStatus;
   createdAt: string | null;
   idleEnteredAt?: string | null;
+  dormant?: boolean;
 }) {
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const isFresh =
-    status === "Idle" && isFreshIdle({ status, idle_entered_at: idleEnteredAt ?? null }, idleDecayWindowMs);
+    !dormant && status === "Idle" && isFreshIdle({ status, idle_entered_at: idleEnteredAt ?? null }, idleDecayWindowMs);
   const rattleKey = STATUS_RATTLE[status];
-  const rattle = isFresh ? FRESH_IDLE_RATTLE : rattleKey ? RATTLES[rattleKey] : undefined;
+  // A dormant worker is a resting state: no rattle, and its own static glyph.
+  const rattle = dormant ? undefined : isFresh ? FRESH_IDLE_RATTLE : rattleKey ? RATTLES[rattleKey] : undefined;
   const parsed = createdAt ? Date.parse(createdAt) : 0;
   const epoch = Number.isNaN(parsed) ? 0 : parsed;
   const [frame, setFrame] = useState(() => {
@@ -89,7 +97,7 @@ export function StatusGlyph({
   }, [rattle, epoch]);
 
   if (!rattle) {
-    return <>{STATIC_GLYPH[status]}</>;
+    return <>{dormant ? DORMANT_GLYPH : STATIC_GLYPH[status]}</>;
   }
   return <>{rattle.frames[frame]}</>;
 }

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1423,7 +1423,12 @@ export const SessionRow = memo(function SessionRow({
                 ●
               </span>
             ) : (
-              <StatusGlyph status={sessionStatus} createdAt={createdAt} idleEnteredAt={idleEnteredAt} />
+              <StatusGlyph
+                status={sessionStatus}
+                createdAt={createdAt}
+                idleEnteredAt={idleEnteredAt}
+                dormant={sessionDormant}
+              />
             )}
           </span>
           <div className="min-w-0 flex-1">

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -352,6 +352,7 @@ function bestSession(
   status: SessionStatus;
   createdAt: string | null;
   idleEnteredAt: string | null;
+  dormant: boolean;
 } {
   const running = ws.sessions.find((s) => isSessionActive(s, idleDecayWindowMs));
   if (running)
@@ -359,6 +360,7 @@ function bestSession(
       status: running.status,
       createdAt: running.created_at,
       idleEnteredAt: running.idle_entered_at ?? null,
+      dormant: running.dormant,
     };
   const error = ws.sessions.find((s) => s.status === "Error");
   if (error)
@@ -366,12 +368,14 @@ function bestSession(
       status: "Error",
       createdAt: error.created_at,
       idleEnteredAt: null,
+      dormant: false,
     };
   const first = ws.sessions[0];
   return {
     status: first?.status ?? "Unknown",
     createdAt: first?.created_at ?? null,
     idleEnteredAt: first?.idle_entered_at ?? null,
+    dormant: first?.dormant ?? false,
   };
 }
 
@@ -944,11 +948,17 @@ export const SessionRow = memo(function SessionRow({
 }) {
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const unreadIndicatorEnabled = useUnreadIndicatorEnabled();
-  const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(workspace, idleDecayWindowMs);
+  const {
+    status: sessionStatus,
+    createdAt,
+    idleEnteredAt,
+    dormant: sessionDormant,
+  } = bestSession(workspace, idleDecayWindowMs);
   const textClass = getStatusTextClass(
     {
       status: sessionStatus,
       idle_entered_at: idleEnteredAt,
+      dormant: sessionDormant,
     },
     idleDecayWindowMs,
   );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -112,6 +112,13 @@
   --color-status-error: #ef4444;
   --color-status-starting: #f59e0b;
   --color-status-stopped: #52525b;
+  /* Dormant: a structured-view worker auto-stopped for inactivity
+     (resumable), distinct from a deliberate Stop. A dim amber, brighter
+     than the slate Stopped grey but muted well below the fresh-idle
+     attention amber so it reads as "parked, not urgent". Build-time
+     cold-load default; the resolved theme projection (resolved.rs)
+     overrides it at runtime from `fresh_idle` + `dimmed`. See #2250. */
+  --color-status-dormant: #b38742;
 
   /* Extended semantic tokens populated by the resolved theme
      projection (see src/tui/styles/resolved.rs). These build-time

--- a/web/src/lib/session.test.ts
+++ b/web/src/lib/session.test.ts
@@ -26,8 +26,9 @@ afterEach(() => {
 function session(
   status: SessionStatus,
   idleEnteredAt: string | null,
-): Pick<SessionResponse, "status" | "idle_entered_at"> {
-  return { status, idle_entered_at: idleEnteredAt };
+  dormant = false,
+): Pick<SessionResponse, "status" | "idle_entered_at" | "dormant"> {
+  return { status, idle_entered_at: idleEnteredAt, dormant };
 }
 
 describe("IDLE_DECAY_WINDOW_MS default", () => {
@@ -112,6 +113,24 @@ describe("getStatusDotClass", () => {
       "bg-status-waiting",
     );
   });
+
+  it("uses the dormant class for an idle-reaped (dormant) session", () => {
+    // Structured worker parked for inactivity: distinct dim-amber dot, not
+    // the live-idle grey. See #2250.
+    expect(getStatusDotClass(session("Idle", null, true))).toBe("bg-status-dormant");
+  });
+
+  it("dormant wins over the fresh-idle window", () => {
+    expect(getStatusDotClass(session("Idle", new Date(NOW - 1_000).toISOString(), true), TEST_WINDOW_MS)).toBe(
+      "bg-status-dormant",
+    );
+  });
+
+  it("keeps the Stopped grey for a deliberate stop (dormant false)", () => {
+    // The server reports dormant=false for a deliberately-stopped row even
+    // though it carries the idle-dormant marker, so the dot stays grey.
+    expect(getStatusDotClass(session("Stopped", null, false))).toBe("bg-status-stopped");
+  });
 });
 
 describe("getStatusTextClass", () => {
@@ -127,6 +146,10 @@ describe("getStatusTextClass", () => {
 
   it("falls back to idle class when idle_entered_at is missing", () => {
     expect(getStatusTextClass(session("Idle", null), TEST_WINDOW_MS)).toBe("text-status-idle");
+  });
+
+  it("uses the dormant text class for an idle-reaped (dormant) session", () => {
+    expect(getStatusTextClass(session("Idle", null, true))).toBe("text-status-dormant");
   });
 });
 

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -69,9 +69,15 @@ export function isFreshIdle(
  *  based on `idle_entered_at`. Two tiers (rather than continuous color-mix)
  *  keeps the class set static so Tailwind's JIT picks them up reliably. */
 export function getStatusDotClass(
-  session: Pick<SessionResponse, "status" | "idle_entered_at">,
+  session: Pick<SessionResponse, "status" | "idle_entered_at" | "dormant">,
   windowMs: number = IDLE_DECAY_WINDOW_MS,
 ): string {
+  // A dormant (idle-reaped, resumable) worker gets its own dim-amber dot,
+  // taking precedence over the raw status. The server only reports `dormant`
+  // true for a non-Stopped row, so a deliberate Stop still renders grey. See #2250.
+  if (session.dormant) {
+    return "bg-status-dormant";
+  }
   if (session.status === "Idle" && isFreshIdle(session, windowMs)) {
     return "bg-status-fresh-idle";
   }
@@ -80,9 +86,12 @@ export function getStatusDotClass(
 
 /** Text-color class equivalent of `getStatusDotClass`. */
 export function getStatusTextClass(
-  session: Pick<SessionResponse, "status" | "idle_entered_at">,
+  session: Pick<SessionResponse, "status" | "idle_entered_at" | "dormant">,
   windowMs: number = IDLE_DECAY_WINDOW_MS,
 ): string {
+  if (session.dormant) {
+    return "text-status-dormant";
+  }
   if (session.status === "Idle" && isFreshIdle(session, windowMs)) {
     return "text-status-fresh-idle";
   }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -12,6 +12,11 @@ export interface SessionResponse {
   group_path: string;
   tool: string;
   status: SessionStatus;
+  /** True when the session's structured-view worker was auto-stopped for
+   *  inactivity (resumable/dormant), as opposed to a deliberate Stop. Lets the
+   *  sidebar render a distinct dormant dot instead of a live-idle one. A
+   *  deliberate Stop keeps `status: "Stopped"` and reports `false`. See #2250. */
+  dormant: boolean;
   yolo_mode: boolean;
   created_at: string;
   last_accessed_at: string | null;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -940,6 +940,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.dormant-dot",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/lib/session.test.ts"],
+      "components": ["web/src/lib/session.ts", "web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sessions.fork.round-trip",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`Status::Stopped` was visually overloaded for structured-view (ACP) sessions: a worker parked by the idle reaper rendered with the same dot as a live-idle session, so you could not tell a resumable-dormant session from one that was simply idle.

Investigation surfaced that the two states the issue wants to separate are already distinct in the data model, so no enum split or migration is needed:

- Deliberate Stop sets `status = Stopped` (and also the idle-dormant marker).
- The structured idle reaper sets `idle_dormant_since` only and never touches `status` (it stays `Idle`).

The gap was purely presentational: `idle_dormant_since` is server-only and the dot color derives solely from `status`, so dormancy was invisible.

This PR promotes that existing distinction to the surfaces instead of adding a `Status::Dormant` variant:

- `Instance::is_shown_dormant()` is the single source of the deliberate-stop-vs-dormant precedence (a deliberate Stop, which also carries the dormant marker, keeps its neutral grey dot; only a non-stopped row with the marker presents as dormant).
- The session DTO exposes it as a `dormant` bool.
- Web sidebar and TUI render a parked worker with a distinct dim-amber "Dormant" dot/glyph, derived from the theme (`fresh_idle` blended toward `dimmed`) so it needs no per-theme field and no new color slot in the drift guard.
- Unread still wins over dormancy (an unseen finished turn is the more actionable signal), matching the existing web unread-dot precedence.

Deliberately scoped to **Approach B** from the issue rather than Approach A (enum split + data migration). A `/debate` between two models independently concluded that, for structured sessions, the enum split does not reduce a real data-model overload (the idle reaper never wrote `Status::Stopped`) and its migration would do no semantic work, while adding new race/healing obligations to the `apply_status_intent` / `seed_acp_statuses` guards. The real remaining `Status::Stopped` overload lives in the legacy tmux reaper (`idle_reap.rs`); pulling that onto the same dormant-marker pattern is left as separate follow-up.

Closes #2250

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session and let it sit idle past the auto-stop window (or otherwise trigger the idle reaper). In the web sidebar, its dot turns dim amber (distinct from the live-idle grey), not the Stopped grey.
- [ ] Deliberately Stop a structured session: its dot stays the neutral grey "Stopped", not amber, and remains Stopped across a daemon restart.
- [ ] In the TUI session list, the same dormant session shows the `⠶` glyph in dim amber; the preview status line reads "Dormant" and the command palette jump entry is tagged `[dormant]`.
- [ ] A live-idle session (recently active, worker alive) is unchanged: idle grey dot.
- [ ] A dormant session that also has unread output still shows the unread dot (unread wins), and sending a prompt to it wakes the worker as before.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a test and updated `web/tests/coverage-matrix.json`
  - Per `AGENTS.md`, the dot-class mapping is pure logic, so the regression test is Vitest (`web/src/lib/session.test.ts`: dormant, deliberate-stop, and fresh-idle-precedence cases), and `web/tests/coverage-matrix.json` gained a `sidebar.dormant-dot` entry.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the dormant derivation is covered by a Rust unit test on the classifier (`is_shown_dormant` truth table) plus a DTO test; a screen-scrape e2e asserting a braille glyph and a blended color is brittle and would not add signal over the unit tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, the A-vs-B design debate, plan, and implementation were drafted by Claude under my direction. I made the design call (Approach B over the issue's Approach A), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added UI differentiation for *dormant* structured sessions that are automatically paused after inactivity, without changing the existing behavior for deliberately stopped sessions.
- Exposed dormancy via a new `dormant` flag in the session API/DTO and frontend types.
- Updated both the web sidebar and the TUI to render dormant sessions with distinct styling (dim-amber/dormant theme), a dedicated icon/glyph, and an explicit “Dormant” label in the TUI.
- Ensured precedence rules: deliberately stopped sessions still show the neutral “stopped” indicator even if dormancy markers exist, and unread output still takes precedence.
- Updated the command palette to tag dormant entries, and added/expanded tests to cover dormant classification and styling/dot/icon mappings.

## Benefits

Users can clearly tell apart resumable “paused for inactivity” sessions from intentionally stopped ones, making status understanding and recovery expectations more accurate.

## Future considerations

Separating lifecycle states at the status/enum level and adding any migration/testing for deeper backend state changes are intentionally left out of this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->