### PR TITLE
fix: auto-escalate stop when the agent ignores session/cancel

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -730,23 +730,33 @@ impl LifecycleSignal {
 /// without the connection loop.
 ///
 /// Returns `Some(deadline)` when fast escalation should be armed for the
-/// first time: `user_cancel_at` is set, `already_armed` is false, and `sig`
-/// is post-cancel progress. The deadline is anchored to the user's Stop
-/// click (`user_cancel_at + POST_CANCEL_PROGRESS_GRACE`) and clamped with
-/// `min(current_deadline, ...)` so it can only shorten the standing grace,
-/// never extend it (a late first signal, or a user Stop that lands well
-/// after a silent-orphan cancel already armed the 10s grace, must not push
-/// escalation further out). Returns `None` when nothing should change.
+/// first time: `user_cancel_at` is set, `already_armed` is false, `sig` is
+/// post-cancel progress, and the signal was observed at or after the Stop
+/// click (`signal_observed_at >= user_cancel_at`). The `observed_at` gate
+/// rejects an envelope that was already queued in the lifecycle channel
+/// before `ClientCmd::Cancel` won the select loop: such a signal reflects
+/// pre-cancel activity, so accelerating on it could force-restart a
+/// cooperative agent after 2s despite no post-cancel progress. The deadline
+/// is anchored to the user's Stop click (`user_cancel_at +
+/// POST_CANCEL_PROGRESS_GRACE`) and clamped with `min(current_deadline, ...)`
+/// so it can only shorten the standing grace, never extend it (a late first
+/// signal, or a user Stop that lands well after a silent-orphan cancel
+/// already armed the 10s grace, must not push escalation further out).
+/// Returns `None` when nothing should change.
 fn post_cancel_fast_deadline(
     user_cancel_at: Option<tokio::time::Instant>,
     already_armed: bool,
     sig: &LifecycleSignal,
+    signal_observed_at: tokio::time::Instant,
     current_deadline: tokio::time::Instant,
 ) -> Option<tokio::time::Instant> {
     if already_armed || !sig.is_post_cancel_progress() {
         return None;
     }
     let cancel_at = user_cancel_at?;
+    if signal_observed_at < cancel_at {
+        return None;
+    }
     let fast = cancel_at + POST_CANCEL_PROGRESS_GRACE;
     Some(fast.min(current_deadline))
 }
@@ -1381,6 +1391,13 @@ fn between_prompt_stop_reason(adopted: bool, cost_seen: bool) -> &'static str {
 pub(crate) struct LifecycleEnvelope {
     pub epoch: u64,
     pub signal: LifecycleSignal,
+    /// Monotonic instant the notification handler observed this signal
+    /// (before it entered the channel). The prompt loop uses it to tell a
+    /// signal genuinely produced after the user's Stop click from one that
+    /// was already queued before it: only the former may accelerate cancel
+    /// escalation (#1908). Stamping at observation, not at dequeue, is what
+    /// makes the comparison meaningful under channel backpressure.
+    pub observed_at: tokio::time::Instant,
 }
 
 /// Deliver a lifecycle envelope from the notification handler to the
@@ -1454,8 +1471,18 @@ async fn forward_lifecycle_signals(
     if !prompt_active {
         return;
     }
+    let observed_at = tokio::time::Instant::now();
     for signal in [lifecycle, wakeup].into_iter().flatten() {
-        send_lifecycle_signal(tx, LifecycleEnvelope { epoch, signal }, session_label).await;
+        send_lifecycle_signal(
+            tx,
+            LifecycleEnvelope {
+                epoch,
+                signal,
+                observed_at,
+            },
+            session_label,
+        )
+        .await;
     }
 }
 
@@ -6576,6 +6603,7 @@ async fn run_connection_task<W, R>(
                                                 user_cancel_at,
                                                 cancel_progress_escalation_armed,
                                                 &env.signal,
+                                                env.observed_at,
                                                 cancel_grace.deadline(),
                                             ) {
                                                 cancel_progress_escalation_armed = true;
@@ -7906,15 +7934,26 @@ mod tests {
     fn post_cancel_fast_deadline_arms_on_progress_after_user_cancel() {
         let cancel_at = tokio::time::Instant::now();
         let current = cancel_at + CANCEL_ESCALATION_GRACE;
-        let d =
-            post_cancel_fast_deadline(Some(cancel_at), false, &LifecycleSignal::Progress, current)
-                .expect("should arm");
+        // Signal observed at the click (>= cancel_at), so it is genuine
+        // post-cancel progress.
+        let d = post_cancel_fast_deadline(
+            Some(cancel_at),
+            false,
+            &LifecycleSignal::Progress,
+            cancel_at,
+            current,
+        )
+        .expect("should arm");
         assert_eq!(d, cancel_at + POST_CANCEL_PROGRESS_GRACE);
         // A fresh tool call arms it too.
-        assert!(
-            post_cancel_fast_deadline(Some(cancel_at), false, &tool_started_sig(), current)
-                .is_some()
-        );
+        assert!(post_cancel_fast_deadline(
+            Some(cancel_at),
+            false,
+            &tool_started_sig(),
+            cancel_at,
+            current
+        )
+        .is_some());
     }
 
     #[test]
@@ -7924,6 +7963,7 @@ mod tests {
             None,
             false,
             &LifecycleSignal::Progress,
+            now,
             now + CANCEL_ESCALATION_GRACE
         )
         .is_none());
@@ -7936,6 +7976,26 @@ mod tests {
             Some(cancel_at),
             true,
             &LifecycleSignal::Progress,
+            cancel_at,
+            cancel_at + CANCEL_ESCALATION_GRACE,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_ignores_signal_observed_before_cancel() {
+        // #1908 review (CodeRabbit): an envelope observed before the Stop
+        // click can still be sitting in the lifecycle channel when
+        // ClientCmd::Cancel wins the select loop. Processing it afterward
+        // must NOT arm fast escalation, or a cooperative agent that honored
+        // the cancel gets force-restarted after 2s on pre-cancel activity.
+        let cancel_at = tokio::time::Instant::now();
+        let observed_before = cancel_at - std::time::Duration::from_millis(1);
+        assert!(post_cancel_fast_deadline(
+            Some(cancel_at),
+            false,
+            &LifecycleSignal::Progress,
+            observed_before,
             cancel_at + CANCEL_ESCALATION_GRACE,
         )
         .is_none());
@@ -7954,7 +8014,10 @@ mod tests {
                 off_protocol_work: None,
             },
         ] {
-            assert!(post_cancel_fast_deadline(Some(cancel_at), false, &sig, current).is_none());
+            assert!(
+                post_cancel_fast_deadline(Some(cancel_at), false, &sig, cancel_at, current)
+                    .is_none()
+            );
         }
     }
 
@@ -7969,6 +8032,7 @@ mod tests {
             Some(cancel_at),
             false,
             &LifecycleSignal::Progress,
+            cancel_at,
             orphan_deadline,
         )
         .expect("should arm");
@@ -7982,9 +8046,16 @@ mod tests {
         // deadline is already in the past, so the timer fires immediately.
         let cancel_at = tokio::time::Instant::now();
         let current = cancel_at + CANCEL_ESCALATION_GRACE;
-        let fast =
-            post_cancel_fast_deadline(Some(cancel_at), false, &LifecycleSignal::Progress, current)
-                .unwrap();
+        // Observed well after the click (still >= cancel_at, so it qualifies).
+        let observed_late = cancel_at + std::time::Duration::from_secs(5);
+        let fast = post_cancel_fast_deadline(
+            Some(cancel_at),
+            false,
+            &LifecycleSignal::Progress,
+            observed_late,
+            current,
+        )
+        .unwrap();
         // Deadline is anchored to the click + 2s, independent of when the
         // signal was observed, so a signal seen at +5s still escalates at +2s.
         assert_eq!(fast, cancel_at + POST_CANCEL_PROGRESS_GRACE);
@@ -8006,6 +8077,7 @@ mod tests {
                     id: format!("fill-{i}"),
                     is_background_task: false,
                 },
+                observed_at: tokio::time::Instant::now(),
             })
             .expect("pre-fill fits the channel");
         }
@@ -10770,6 +10842,7 @@ mod tests {
             signal: LifecycleSignal::WakeupPending {
                 at: chrono::Utc::now(),
             },
+            observed_at: tokio::time::Instant::now(),
         };
         assert_eq!(env.epoch, 42);
         assert!(matches!(env.signal, LifecycleSignal::WakeupPending { .. }));

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -458,6 +458,19 @@ const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from
 /// `OFF_PROTOCOL_WORK_GRACE_FLOOR` below before recovering.
 pub(crate) const CANCEL_ESCALATION_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Shortened escalation grace applied when the user cancelled a turn but
+/// the agent keeps producing new progress (text chunks or a fresh tool
+/// call) afterwards, i.e. it is ignoring `session/cancel` the way opencode
+/// 1.15.13 did (#1908). The deadline is anchored to the user's Stop click
+/// (`cancel_at + POST_CANCEL_PROGRESS_GRACE`) and clamped to never extend
+/// the standing 10s grace, so a cooperative agent that emits one in-flight
+/// chunk queued before it saw the cancel still gets a brief window to
+/// resolve the prompt as `Cancelled` (no worker restart), while an agent
+/// that keeps streaming past the window is force-restarted in ~2s instead
+/// of 10s.
+pub(crate) const POST_CANCEL_PROGRESS_GRACE: std::time::Duration =
+    std::time::Duration::from_secs(2);
+
 /// Vendor-agnostic silent-orphan grace fallback used when no config
 /// value is available. Mirrors `AcpConfig::silent_orphan_grace_secs`
 /// default. Bumped from 60s to 120s in #1360 so async-agent flows
@@ -693,6 +706,49 @@ pub(crate) enum LifecycleSignal {
     /// Clears the compaction suppression so any continued work in the same
     /// turn recovers on the normal grace. See #2898.
     CompactionCompleted,
+}
+
+impl LifecycleSignal {
+    /// True for signals that mean the agent is actively generating *new*
+    /// work: a text/thought/plan chunk (`Progress`) or a freshly started
+    /// tool call (`ToolStarted`). Used to detect an agent that keeps
+    /// working after the user's `session/cancel`, i.e. one that ignores the
+    /// ACP cancel notification (#1908). Accounting (`TerminalUsage`), tool
+    /// completion, and compaction markers are winding-down or ambient, not
+    /// new work, so they must not count.
+    fn is_post_cancel_progress(&self) -> bool {
+        matches!(
+            self,
+            LifecycleSignal::Progress | LifecycleSignal::ToolStarted { .. }
+        )
+    }
+}
+
+/// Decide the shortened cancel-escalation deadline when the user has
+/// cancelled a turn and the agent is still producing progress after the
+/// `session/cancel` (#1908). Pure so the deadline math is unit-testable
+/// without the connection loop.
+///
+/// Returns `Some(deadline)` when fast escalation should be armed for the
+/// first time: `user_cancel_at` is set, `already_armed` is false, and `sig`
+/// is post-cancel progress. The deadline is anchored to the user's Stop
+/// click (`user_cancel_at + POST_CANCEL_PROGRESS_GRACE`) and clamped with
+/// `min(current_deadline, ...)` so it can only shorten the standing grace,
+/// never extend it (a late first signal, or a user Stop that lands well
+/// after a silent-orphan cancel already armed the 10s grace, must not push
+/// escalation further out). Returns `None` when nothing should change.
+fn post_cancel_fast_deadline(
+    user_cancel_at: Option<tokio::time::Instant>,
+    already_armed: bool,
+    sig: &LifecycleSignal,
+    current_deadline: tokio::time::Instant,
+) -> Option<tokio::time::Instant> {
+    if already_armed || !sig.is_post_cancel_progress() {
+        return None;
+    }
+    let cancel_at = user_cancel_at?;
+    let fast = cancel_at + POST_CANCEL_PROGRESS_GRACE;
+    Some(fast.min(current_deadline))
 }
 
 /// Classify a `SessionUpdate` into a `LifecycleSignal`, or `None` for
@@ -6418,6 +6474,20 @@ async fn run_connection_task<W, R>(
                         // process group + respawns, instead of waiting out
                         // the 10s grace. See #1727.
                         let mut force_stopped = false;
+                        // #1908: the monotonic instant of the user's first
+                        // Stop click this turn (its presence also means "a
+                        // user cancel is pending"). Recorded unconditionally,
+                        // even when the silent-orphan path already set
+                        // `cancelling`, so a user Stop during an orphan cancel
+                        // still arms fast escalation rather than being swallowed
+                        // by the `if !cancelling` guard below. Distinct from
+                        // `cancelling`, which the silent-orphan path also sets.
+                        let mut user_cancel_at: Option<tokio::time::Instant> = None;
+                        // #1908: once-guard so continued post-cancel progress
+                        // shortens the escalation deadline exactly once; it must
+                        // never re-extend, or a continuously-streaming agent
+                        // would push escalation forever.
+                        let mut cancel_progress_escalation_armed = false;
                         let cancel_grace = tokio::time::sleep(CANCEL_ESCALATION_GRACE);
                         tokio::pin!(cancel_grace);
 
@@ -6490,6 +6560,33 @@ async fn run_connection_task<W, R>(
                                                 "discarding stale lifecycle envelope across prompt boundary"
                                             );
                                         } else {
+                                            // #1908: the user cancelled but the
+                                            // agent is still emitting new work
+                                            // (text chunk or fresh tool call), so
+                                            // it is ignoring session/cancel.
+                                            // Shorten the escalation deadline once
+                                            // to the user's Stop click + 2s (never
+                                            // extending), so the turn is
+                                            // force-restarted in ~2s instead of
+                                            // waiting the full 10s watchdog. A
+                                            // cooperative agent's single in-flight
+                                            // chunk still leaves the window for its
+                                            // clean Cancelled to land first.
+                                            if let Some(deadline) = post_cancel_fast_deadline(
+                                                user_cancel_at,
+                                                cancel_progress_escalation_armed,
+                                                &env.signal,
+                                                cancel_grace.deadline(),
+                                            ) {
+                                                cancel_progress_escalation_armed = true;
+                                                warn!(
+                                                    target: "acp.protocol",
+                                                    session = %session_label,
+                                                    grace_secs = POST_CANCEL_PROGRESS_GRACE.as_secs(),
+                                                    "agent still producing progress after session/cancel; shortening escalation to force-restart the worker"
+                                                );
+                                                cancel_grace.as_mut().reset(deadline);
+                                            }
                                             watchdog.apply_signal(
                                                 env.signal,
                                                 tokio::time::Instant::now(),
@@ -6608,6 +6705,15 @@ async fn run_connection_task<W, R>(
                                             connection.send_notification(
                                                 CancelNotification::new(acp_session_id.clone()),
                                             )?;
+                                            // #1908: record the first user Stop
+                                            // click unconditionally (even if the
+                                            // silent-orphan path already set
+                                            // `cancelling`) so post-cancel
+                                            // progress can arm fast escalation.
+                                            if user_cancel_at.is_none() {
+                                                user_cancel_at =
+                                                    Some(tokio::time::Instant::now());
+                                            }
                                             // Arm the escalation watchdog on
                                             // the first cancel only; later
                                             // cancels just resend the
@@ -7768,6 +7874,121 @@ async fn handle_elicitation_request(
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    // #1908: an agent that ignores session/cancel keeps streaming; the
+    // prompt loop must fast-escalate on continued post-cancel progress.
+
+    fn tool_started_sig() -> LifecycleSignal {
+        LifecycleSignal::ToolStarted {
+            id: "tc-1".to_string(),
+            is_background_task: false,
+        }
+    }
+
+    #[test]
+    fn is_post_cancel_progress_only_flags_new_work() {
+        // New agent work: counts.
+        assert!(LifecycleSignal::Progress.is_post_cancel_progress());
+        assert!(tool_started_sig().is_post_cancel_progress());
+        // Accounting / wind-down / ambient: does not count.
+        assert!(!LifecycleSignal::TerminalUsage.is_post_cancel_progress());
+        assert!(!LifecycleSignal::CompactionStarted.is_post_cancel_progress());
+        assert!(!LifecycleSignal::CompactionCompleted.is_post_cancel_progress());
+        assert!(!LifecycleSignal::ToolCompleted {
+            id: "tc-1".to_string(),
+            succeeded: true,
+            off_protocol_work: None,
+        }
+        .is_post_cancel_progress());
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_arms_on_progress_after_user_cancel() {
+        let cancel_at = tokio::time::Instant::now();
+        let current = cancel_at + CANCEL_ESCALATION_GRACE;
+        let d =
+            post_cancel_fast_deadline(Some(cancel_at), false, &LifecycleSignal::Progress, current)
+                .expect("should arm");
+        assert_eq!(d, cancel_at + POST_CANCEL_PROGRESS_GRACE);
+        // A fresh tool call arms it too.
+        assert!(
+            post_cancel_fast_deadline(Some(cancel_at), false, &tool_started_sig(), current)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_ignores_when_no_user_cancel() {
+        let now = tokio::time::Instant::now();
+        assert!(post_cancel_fast_deadline(
+            None,
+            false,
+            &LifecycleSignal::Progress,
+            now + CANCEL_ESCALATION_GRACE
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_short_circuits_when_already_armed() {
+        let cancel_at = tokio::time::Instant::now();
+        assert!(post_cancel_fast_deadline(
+            Some(cancel_at),
+            true,
+            &LifecycleSignal::Progress,
+            cancel_at + CANCEL_ESCALATION_GRACE,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_ignores_non_progress_signals() {
+        let cancel_at = tokio::time::Instant::now();
+        let current = cancel_at + CANCEL_ESCALATION_GRACE;
+        for sig in [
+            LifecycleSignal::TerminalUsage,
+            LifecycleSignal::CompactionStarted,
+            LifecycleSignal::ToolCompleted {
+                id: "tc-1".to_string(),
+                succeeded: false,
+                off_protocol_work: None,
+            },
+        ] {
+            assert!(post_cancel_fast_deadline(Some(cancel_at), false, &sig, current).is_none());
+        }
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_never_extends_the_standing_grace() {
+        // A user Stop that lands well after a silent-orphan cancel already
+        // armed the 10s grace must not push escalation further out: the
+        // returned deadline is clamped to the (earlier) current deadline.
+        let orphan_deadline = tokio::time::Instant::now() + POST_CANCEL_PROGRESS_GRACE;
+        let cancel_at = orphan_deadline; // user clicked "now", 2s window would land past orphan
+        let d = post_cancel_fast_deadline(
+            Some(cancel_at),
+            false,
+            &LifecycleSignal::Progress,
+            orphan_deadline,
+        )
+        .expect("should arm");
+        assert_eq!(d, orphan_deadline);
+        assert!(d <= cancel_at + POST_CANCEL_PROGRESS_GRACE);
+    }
+
+    #[test]
+    fn post_cancel_fast_deadline_late_signal_yields_past_deadline() {
+        // First qualifying signal arrives after the 2s window: the returned
+        // deadline is already in the past, so the timer fires immediately.
+        let cancel_at = tokio::time::Instant::now();
+        let current = cancel_at + CANCEL_ESCALATION_GRACE;
+        let fast =
+            post_cancel_fast_deadline(Some(cancel_at), false, &LifecycleSignal::Progress, current)
+                .unwrap();
+        // Deadline is anchored to the click + 2s, independent of when the
+        // signal was observed, so a signal seen at +5s still escalates at +2s.
+        assert_eq!(fast, cancel_at + POST_CANCEL_PROGRESS_GRACE);
+    }
 
     #[tokio::test]
     async fn between_prompt_signals_do_not_block_on_a_full_lifecycle_channel() {

--- a/tests/e2e/acp_stop_ignored_cancel_e2e.rs
+++ b/tests/e2e/acp_stop_ignored_cancel_e2e.rs
@@ -1,0 +1,203 @@
+//! Full-stack e2e for #1908: the Stop button must end a turn promptly even
+//! when the agent ignores ACP `session/cancel`.
+//!
+//! opencode 1.15.13 ignored `session/cancel` and kept streaming, so the first
+//! Stop click appeared to do nothing and the user had to force-stop or wait
+//! the full 10s escalation watchdog. The fix (agent-agnostic): once the user
+//! has cancelled and the agent keeps producing new progress, the prompt loop
+//! shortens the escalation deadline to the Stop click + 2s and force-restarts
+//! the worker, ending the turn as `Stopped { reason: "agent_unresponsive" }`.
+//!
+//! This proves it end-to-end against a real `aoe serve --daemon`: the shared
+//! Node fake-ACP agent is put in `FAKE_ACP_IGNORE_CANCEL` mode so it streams
+//! through the cancel like opencode did, and the terminal `agent_unresponsive`
+//! event is asserted to land well under the old 10s baseline. The pure
+//! deadline logic is unit-tested in `src/acp/acp_client.rs`.
+//!
+//! Compiled only with the default `serve` feature. Run via:
+//!
+//! ```sh
+//! cargo test --features e2e-tests --test e2e -- acp_stop_ignored_cancel
+//! ```
+#![cfg(feature = "serve")]
+
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+
+use crate::harness::{pick_free_port, require_node, require_tmux, wait_for_port, TuiTestHarness};
+
+/// Build a long, steady stream: 40 text chunks spaced 500ms apart (~20s of
+/// output). The agent keeps emitting progress right through a mid-turn
+/// cancel, which is exactly what arms the post-cancel escalation; the worker
+/// is force-restarted long before the script would naturally end.
+fn streaming_script() -> String {
+    let mut updates = String::new();
+    for i in 0..40 {
+        if i > 0 {
+            updates.push(',');
+        }
+        updates.push_str(
+            r#"{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"tok "}},{"sessionUpdate":"wait_ms","ms":500}"#,
+        );
+    }
+    format!(r#"{{"turns":[{{"updates":[{updates}],"stopReason":"end_turn"}}]}}"#)
+}
+
+fn parse_session_id(add_stdout: &str) -> String {
+    add_stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ID:"))
+        .map(|rest| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("could not find session ID in `aoe add` output:\n{add_stdout}"))
+}
+
+/// Retry `aoe acp prompt` until accepted; the POST 404s until the worker is
+/// live and handshaked, so a success is the readiness oracle.
+fn prompt_until_accepted(h: &TuiTestHarness, session_id: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["acp", "prompt", session_id, "please write a long answer"]);
+        if out.status.success() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            let ps = h.run_cli(&["acp", "ps", "--json"]);
+            panic!(
+                "structured view worker never accepted a prompt within {:?}.\n\
+                 last prompt stdout: {}\n last prompt stderr: {}\n acp ps: {}",
+                timeout,
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+                String::from_utf8_lossy(&ps.stdout),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Poll `aoe acp history --json` until its output contains `needle`, or panic
+/// on timeout. Returns once found.
+fn wait_for_history_contains(
+    h: &TuiTestHarness,
+    session_id: &str,
+    needle: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = h.run_cli(&["acp", "history", session_id, "--json"]);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        if stdout.contains(needle) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "history never contained {:?} within {:?}.\nlast history stdout:\n{}",
+                needle, timeout, stdout
+            );
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
+/// A single Stop click against a cancel-ignoring agent ends the turn as
+/// `agent_unresponsive` in ~2s, not the old 10s watchdog and not requiring a
+/// second (force-stop) click.
+#[test]
+#[serial]
+fn stop_escalates_when_agent_ignores_cancel() {
+    require_tmux!();
+    require_node!();
+
+    let mut h = TuiTestHarness::new_in_tmp("acp_stop_ignored_cancel");
+
+    // Put the fake agent in cancel-ignoring mode BEFORE installing the shim so
+    // the knob is baked in (the daemon strips arbitrary env when spawning the
+    // worker).
+    h.set_acp_ignore_cancel();
+    let script_path = h.home_path().join("streaming-script.json");
+    std::fs::write(&script_path, streaming_script()).expect("write fake-acp script");
+    h.install_acp_shim(&script_path);
+    h.stop_daemon_on_drop();
+
+    // A structured view session needs a git repo workspace.
+    let project = h.project_path();
+    for args in [
+        vec!["init", "-q"],
+        vec!["commit", "--allow-empty", "-q", "-m", "init"],
+    ] {
+        let out = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(&project)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let port = pick_free_port();
+    let port_s = port.to_string();
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    let add = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "stop-ignored-cancel",
+        "-c",
+        "claude",
+        "--structured-view",
+    ]);
+    assert!(
+        add.status.success(),
+        "aoe add --structured-view failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add.stdout),
+        String::from_utf8_lossy(&add.stderr),
+    );
+    let session_id = parse_session_id(&String::from_utf8_lossy(&add.stdout));
+
+    // Kick off the long-streaming turn and wait until the agent is actively
+    // producing output, so the cancel lands mid-turn.
+    prompt_until_accepted(&h, &session_id, Duration::from_secs(30));
+    wait_for_history_contains(&h, &session_id, "tok ", Duration::from_secs(15));
+
+    // One Stop click. The agent ignores it and keeps streaming.
+    let cancel = h.run_cli(&["acp", "cancel", &session_id]);
+    assert!(
+        cancel.status.success(),
+        "aoe acp cancel failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&cancel.stdout),
+        String::from_utf8_lossy(&cancel.stderr),
+    );
+
+    // The turn must terminate as agent_unresponsive well under the old 10s
+    // baseline (escalation fires ~2s after the click). An 8s bound proves the
+    // fast-escalation path ran, not the full-grace watchdog; without the fix
+    // this event would not arrive until ~10s.
+    wait_for_history_contains(
+        &h,
+        &session_id,
+        "agent_unresponsive",
+        Duration::from_secs(8),
+    );
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -258,6 +258,11 @@ pub struct TuiTestHarness {
     /// daemon env) because the daemon `env_clear`s and allowlists env before
     /// spawning the worker, so a `set_env` knob would never reach the fake.
     acp_fork_fail: bool,
+    /// When true, `install_acp_shim` bakes `FAKE_ACP_IGNORE_CANCEL=1` into the
+    /// shim so the fake agent ignores `session/cancel` and keeps streaming,
+    /// modelling opencode 1.15.13 (#1908). Baked into the shim for the same
+    /// reason as `acp_fork_fail`.
+    acp_ignore_cancel: bool,
 }
 
 #[allow(dead_code)]
@@ -358,6 +363,7 @@ last_seen_version = "{}"
             extra_path_dirs: Vec::new(),
             stop_daemon_on_drop: false,
             acp_fork_fail: false,
+            acp_ignore_cancel: false,
         }
     }
 
@@ -390,6 +396,14 @@ last_seen_version = "{}"
         self.acp_fork_fail = true;
     }
 
+    /// Make the fake ACP agent ignore `session/cancel` and keep streaming
+    /// (models opencode 1.15.13, #1908). Must be called BEFORE
+    /// `install_acp_shim` so the knob is baked into the shim, for the same
+    /// reason as `set_acp_fork_fail`.
+    pub fn set_acp_ignore_cancel(&mut self) {
+        self.acp_ignore_cancel = true;
+    }
+
     /// Install the shared Node fake-ACP agent as the `claude`,
     /// `claude-agent-acp`, and `aoe-agent` commands on PATH. The structured view
     /// supervisor resolves the `claude` tool key to the `claude-agent-acp`
@@ -416,11 +430,17 @@ last_seen_version = "{}"
         } else {
             ""
         };
+        let ignore_cancel_line = if self.acp_ignore_cancel {
+            "export FAKE_ACP_IGNORE_CANCEL=\"1\"\n"
+        } else {
+            ""
+        };
         let script = format!(
-            "#!/bin/sh\nexport FAKE_ACP_SCRIPT=\"{}\"\nexport FAKE_ACP_DEBUG_LOG=\"{}\"\n{}exec node \"{}\" \"$@\"\n",
+            "#!/bin/sh\nexport FAKE_ACP_SCRIPT=\"{}\"\nexport FAKE_ACP_DEBUG_LOG=\"{}\"\n{}{}exec node \"{}\" \"$@\"\n",
             fake_acp_script.display(),
             debug_log.display(),
             fork_fail_line,
+            ignore_cancel_line,
             fake_agent.display(),
         );
         for name in ["claude", "claude-agent-acp", "aoe-agent"] {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -20,6 +20,7 @@ mod harness;
 mod acp_focus_isolation_e2e;
 mod acp_orphan_runner_recovery_e2e;
 mod acp_session_log_tee_e2e;
+mod acp_stop_ignored_cancel_e2e;
 mod acp_tool_cards_e2e;
 mod archive_restore;
 mod archive_structured;

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -222,6 +222,12 @@ const DEFAULT_PERMISSION_OPTIONS = [
 // "cancelled" instead of running the rest of the scripted updates.
 const cancelFlags = new Map();
 
+// #1908: when FAKE_ACP_IGNORE_CANCEL is set, the fake models an agent
+// (opencode 1.15.13) that ignores session/cancel entirely: it keeps
+// emitting scripted updates instead of short-circuiting on the cancel
+// flag, so aoe's post-cancel-progress escalation is exercised.
+const IGNORE_CANCEL = process.env.FAKE_ACP_IGNORE_CANCEL === "1";
+
 // OpenCode-shaped mode advertisement (#1764). When
 // FAKE_ACP_MODE_VIA_CONFIG_OPTION is set, the fake advertises its modes
 // ONLY as a `category:"mode"` config option (no ACP SessionModeState
@@ -288,7 +294,7 @@ function buildSessionConfigOptions(sessionId) {
 
 async function emitSessionUpdates(sessionId, updates) {
   for (const u of updates) {
-    if (cancelFlags.get(sessionId)) return;
+    if (!IGNORE_CANCEL && cancelFlags.get(sessionId)) return;
     if (u && u.sessionUpdate === "wait_ms") {
       // Story-spec helper: pause emission inside a turn so the UI
       // observes the turn as active long enough to click Stop, queue a
@@ -304,7 +310,7 @@ async function emitSessionUpdates(sessionId, updates) {
       const sliceMs = 50;
       let remaining = ms;
       while (remaining > 0) {
-        if (cancelFlags.get(sessionId)) return;
+        if (!IGNORE_CANCEL && cancelFlags.get(sessionId)) return;
         const slice = Math.min(sliceMs, remaining);
         await new Promise((resolve) => setTimeout(resolve, slice));
         remaining -= slice;


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The composer Stop button did not reliably end a running turn when the structured-view agent ignored ACP `session/cancel`. opencode 1.15.13 ignored the notification and kept generating text and starting new tool calls, so the first Stop click looked like a no-op: the agent kept streaming and nothing stopped until the user either clicked Stop a second time (force stop) or waited out the full 10s escalation watchdog.

This ships Proposal A from the issue, the agent-agnostic runtime detection. Once the user has cancelled, the first new progress the agent produces (a text/thought/plan chunk or a fresh tool call) is treated as evidence it is ignoring cancel, and the escalation deadline is shortened to the Stop click + 2s. The deadline is anchored to the click and clamped so it can only shorten the standing 10s grace, never extend it. A cooperative agent that emits one in-flight chunk queued before it processed the cancel still gets the window to resolve the prompt as `Cancelled` (no worker restart); an agent that keeps streaming is force-restarted in ~2s instead of 10s, ending the turn as `Stopped { reason: "agent_unresponsive" }` (worker SIGTERM + respawn via `session/load`).

I deliberately did not implement Proposal B (a hardcoded `supports_cancel = false` flag on the opencode profile that would always force-stop opencode): the issue comments confirm opencode fixed `session/cancel` upstream (PR #30145, shipped in the github-v1.2.25 release), so a hardcoded stale flag would be wrong. Runtime detection is correct regardless of agent or version. Proposal C (upstream opencode fix) is already done.

The deadline math is extracted into a pure `post_cancel_fast_deadline` helper so the clamp/never-extend logic is unit-testable without the connection loop. The user-cancel timestamp is recorded unconditionally, so a Stop click that lands after the silent-orphan path already armed the grace still enables fast escalation.

Closes #1908

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view session against an agent that ignores `session/cancel` (opencode 1.15.13, or any build predating the upstream fix). Send a prompt that produces a long streaming answer.
- [ ] While it is streaming, click Stop once. Confirm the turn ends within ~2s (worker restarts) instead of continuing to stream or requiring a second click.
- [ ] Start a structured-view session against a cooperative agent (recent claude-agent-acp). Send a long prompt, click Stop once. Confirm the turn ends as a clean `cancelled` with no worker restart (the 2s window lets the clean cancel land).
- [ ] `cargo test --features serve --lib -- post_cancel` passes (pure deadline + classification unit tests).
- [ ] `cargo test --features serve,e2e-tests --test e2e -- stop_escalates_when_agent_ignores_cancel` passes (live daemon + cancel-ignoring fake agent, one Stop click ends the turn as `agent_unresponsive` under the old 10s baseline).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the change is server-side (ACP prompt loop); no `web/src` flow changed. The behavior is proven end-to-end by the Rust e2e below. The live Playwright cancel spec (`web/tests/live/acp-cancel.spec.ts`) that would otherwise cover this is `base.skip`ped pending #1237, so it cannot drive an in-flight prompt yet.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)


**Any Additional AI Details you'd like to share:** Investigation, plan, and implementation drafted by Claude under my direction (with a `/debate` design consult on the escalation mechanism). I made the design calls, reviewed each commit, and ran the test steps.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed ACP Stop timing when an agent ignores `session/cancel`.
- Added a “post-cancel progress” grace window so the turn escalates much faster (~2s) after the user clicks Stop and new work shows up afterward—while ensuring the normal deadline behavior isn’t inadvertently extended.
- Kept cooperative agents working normally so clean cancellation still completes without being force-restarted.
- Improved reporting for unresponsive agents, marking them as `Stopped { reason: "agent_unresponsive" }`.
- Added unit tests for the new deadline/escalation logic and an end-to-end test that uses a fake ACP agent capable of ignoring cancel.
- Extended the e2e test harness and fake ACP agent to support an “ignore cancel” mode via a configuration toggle.

## Benefits

Stops now finish much sooner for unresponsive agents, improving responsiveness and user trust, while cooperative agents are not disrupted. The change is regression-tested both at the unit level and in a full end-to-end scenario.

## (Optional) Implementation notes (lightweight)

- Introduced a small, unit-testable helper for computing the shortened “post-cancel progress” escalation deadline (anchored to the first Stop click and clamped to never extend the existing deadline).
- Added timestamping on lifecycle signals (`observed_at`) to ensure only progress observed after cancellation can trigger fast escalation (ignoring queued pre-cancel signals).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->