### PR TITLE
fix(server): atomic DELETE /api/workspaces endpoint for multi-session workspace delete

### DIFF
--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -47,12 +47,12 @@ pub use plugins::{
 };
 pub use projects::{create_project, delete_project, list_projects, update_project};
 pub use sessions::{
-    create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
-    force_smart_rename, get_recent_projects, kill_terminal, list_sessions, paste_image,
-    preview_volume_ignores_globs, read_output, rename_session, restore_session, search_sessions,
-    send_message, serve_session_artifact, session_diff_file, session_diff_files, set_worktree_name,
-    start_session, stop_session, summarize_session, trash_session, update_session_archive,
-    update_session_color, update_session_diff_base, update_session_group,
+    create_session, delete_session, delete_workspace, ensure_container_terminal, ensure_session,
+    ensure_terminal, force_smart_rename, get_recent_projects, kill_terminal, list_sessions,
+    paste_image, preview_volume_ignores_globs, read_output, rename_session, restore_session,
+    search_sessions, send_message, serve_session_artifact, session_diff_file, session_diff_files,
+    set_worktree_name, start_session, stop_session, summarize_session, trash_session,
+    update_session_archive, update_session_color, update_session_diff_base, update_session_group,
     update_session_notifications, update_session_pin, update_session_snooze, update_session_unread,
     update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3414,6 +3414,11 @@ async fn mark_delete_error(state: &AppState, id: &str, message: String) {
 /// the two. Returns the user-facing messages from `perform_deletion` on
 /// success, or a descriptive error string on failure (the caller decides how
 /// to surface it). The caller is expected to hold the per-instance lock.
+///
+/// The `bool` in the success tuple is `true` when the session row was actually
+/// removed, and `false` when a concurrent restore won the race and the row was
+/// deliberately kept (see the `kept_restored` branch). Callers must not report
+/// a kept row as deleted.
 #[cfg_attr(not(feature = "serve"), allow(unused_variables))]
 async fn purge_session_artifacts(
     state: &Arc<AppState>,
@@ -3421,7 +3426,7 @@ async fn purge_session_artifacts(
     instance: Instance,
     body: &DeleteSessionBody,
     recent_entry: Option<crate::session::RecentProjectEntry>,
-) -> Result<Vec<String>, String> {
+) -> Result<(bool, Vec<String>), String> {
     let profile = instance.source_profile.clone();
     let was_trashed = instance.is_trashed();
 
@@ -3568,8 +3573,9 @@ async fn purge_session_artifacts(
             "session was restored while its purge ran; kept the restored row, but its worktree, branch, container, or transcript may already be gone"
         );
         // Leave the in-memory row and its lock in place; the poll loop
-        // converges its trashed flag from the peer's on-disk untrash.
-        return Ok(messages);
+        // converges its trashed flag from the peer's on-disk untrash. The row
+        // was NOT removed, so report removed=false.
+        return Ok((false, messages));
     }
 
     {
@@ -3583,7 +3589,7 @@ async fn purge_session_artifacts(
                 "recording recent project after delete failed: {e}");
         }
     }
-    Ok(messages)
+    Ok((true, messages))
 }
 
 /// Relocate any trashed managed worktree still sitting in the active dir into
@@ -3743,7 +3749,7 @@ pub(crate) async fn purge_expired_trash(state: &Arc<AppState>) {
             keep_scratch: false,
         };
         match purge_session_artifacts(state, &id, instance, &body, recent_entry).await {
-            Ok(_) => tracing::info!(
+            Ok((_removed, _messages)) => tracing::info!(
                 target: "http.api.sessions",
                 session = %id,
                 "auto-purged expired trashed session"
@@ -3812,10 +3818,12 @@ pub async fn delete_session(
         }
 
         match purge_session_artifacts(&state, &id, instance, &body, recent_entry).await {
-            Ok(messages) => (
+            Ok((removed, messages)) => (
                 StatusCode::OK,
                 Json(serde_json::json!({
-                    "status": "deleted",
+                    // A concurrent restore can keep the row (removed=false); do
+                    // not claim it was deleted in that case.
+                    "status": if removed { "deleted" } else { "kept" },
                     "messages": messages,
                 })),
             ),
@@ -3878,6 +3886,19 @@ pub struct DeleteWorkspaceBody {
 struct WorkspaceDeleteFailure {
     id: String,
     error: String,
+}
+
+/// Drop duplicate session ids while preserving first-seen order. A workspace
+/// delete must never list the same session twice: with `["owner", "owner"]`
+/// the first pass would delete the owner using the record-only sibling flags
+/// and the second pass would skip the now-missing row, returning success
+/// without ever removing the shared worktree or branch (#2536 review).
+fn dedupe_session_ids(ids: &[String]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    ids.iter()
+        .filter(|id| seen.insert((*id).clone()))
+        .cloned()
+        .collect()
 }
 
 /// Build the per-session deletion order for a workspace delete. All sessions
@@ -3951,23 +3972,62 @@ fn workspace_dirty_message(instance: &Instance) -> Option<String> {
 
 /// Tear down every session in a workspace: record-only siblings first, then the
 /// shared-worktree owner last (see [`order_workspace_deletion`]). Each session
-/// goes through the shared [`purge_session_artifacts`] under its own instance
-/// lock, one lock at a time so a workspace delete can never deadlock against a
-/// concurrent delete or the retention auto-purge worker. A session already gone
-/// (a retention purge won the race) is skipped, not failed. A pre-owner failure
-/// aborts before the worktree is removed, so the shared worktree keeps its live
-/// owning session rather than being orphaned.
+/// goes through the shared [`purge_session_artifacts`].
+///
+/// The owner's instance lock is acquired up front and held for the whole
+/// teardown, and the dirty-worktree gate is re-checked under that lock right
+/// before any sibling is torn down. This serializes the dirty check with the
+/// teardown so dirty + non-force stays all-or-nothing even if the worktree is
+/// dirtied between the handler preflight and now, and it cannot deadlock: a
+/// session belongs to exactly one workspace, so two workspace deletes never
+/// contend for each other's locks, and single-session deletes only ever hold
+/// one lock at a time. Sibling locks are then taken one at a time. A session
+/// already gone (a retention purge won the race) is skipped, not failed; a
+/// pre-owner failure aborts before the worktree is removed, so the shared
+/// worktree keeps its live owning session rather than being orphaned. A
+/// session whose row a concurrent restore kept (`removed == false`) is reported
+/// neither deleted nor failed.
 async fn purge_workspace_artifacts(
     state: &Arc<AppState>,
+    owner_id: String,
     plan: Vec<(String, DeleteSessionBody)>,
+    owner_needs_dirty_check: bool,
 ) -> (Vec<String>, Vec<WorkspaceDeleteFailure>, Vec<String>) {
     let mut deleted = Vec::new();
     let mut failed = Vec::new();
     let mut messages = Vec::new();
 
+    // Hold the owner lock across the entire teardown (see doc comment).
+    let owner_lock = state.instance_lock(&owner_id).await;
+    let _owner_guard = owner_lock.lock_owned().await;
+
+    // Authoritative dirty re-check under the owner lock, before any sibling is
+    // torn down (#2536 review). If the worktree went dirty since the handler
+    // preflight, abort with nothing deleted.
+    if owner_needs_dirty_check {
+        let owner = {
+            let instances = state.instances.read().await;
+            instances.iter().find(|i| i.id == owner_id).cloned()
+        };
+        if let Some(owner) = owner {
+            if let Some(msg) = workspace_dirty_message(&owner) {
+                failed.push(WorkspaceDeleteFailure {
+                    id: owner_id,
+                    error: format!("Workspace: {msg}"),
+                });
+                return (deleted, failed, messages);
+            }
+        }
+    }
+
     for (id, body) in plan {
-        let lock = state.instance_lock(&id).await;
-        let _guard = lock.lock_owned().await;
+        // The owner lock is already held; only siblings need their own lock,
+        // one at a time. Re-locking the owner here would self-deadlock.
+        let _sibling_guard = if id == owner_id {
+            None
+        } else {
+            Some(state.instance_lock(&id).await.lock_owned().await)
+        };
 
         let instance = {
             let instances = state.instances.read().await;
@@ -3989,9 +4049,14 @@ async fn purge_workspace_artifacts(
 
         let recent_entry = crate::session::recent_project_entry_for(&instance);
         match purge_session_artifacts(state, &id, instance, &body, recent_entry).await {
-            Ok(mut msgs) => {
-                deleted.push(id.clone());
+            Ok((removed, mut msgs)) => {
                 messages.append(&mut msgs);
+                // A concurrent restore can keep the row (removed=false); only
+                // report rows that were actually removed as deleted, so the
+                // client never drops local state for a session that survived.
+                if removed {
+                    deleted.push(id.clone());
+                }
             }
             Err(msg) => {
                 mark_delete_error(state, &id, msg.clone()).await;
@@ -4024,7 +4089,10 @@ pub async fn delete_workspace(
     }
 
     let body = body.map(|Json(b)| b).unwrap_or_default();
-    if body.session_ids.is_empty() {
+    // Dedupe up front so a repeated id can't have the owner deleted with
+    // sibling flags and then skipped (#2536 review).
+    let session_ids = dedupe_session_ids(&body.session_ids);
+    let Some(owner_id) = session_ids.first().cloned() else {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -4033,16 +4101,19 @@ pub async fn delete_workspace(
             })),
         )
             .into_response();
-    }
+    };
+
+    let owner_needs_dirty_check = body.delete_worktree && !body.force_delete;
 
     // Preflight: refuse a non-force delete of a dirty shared worktree before
     // tearing down any session, so dirty + non-force stays all-or-nothing. The
     // owner (session_ids[0]) is the session that carries the shared worktree.
-    if body.delete_worktree && !body.force_delete {
-        let owner_id = &body.session_ids[0];
+    // This is a fast early 409 for the common case; `purge_workspace_artifacts`
+    // re-checks authoritatively under the owner lock.
+    if owner_needs_dirty_check {
         let owner = {
             let instances = state.instances.read().await;
-            instances.iter().find(|i| &i.id == owner_id).cloned()
+            instances.iter().find(|i| i.id == owner_id).cloned()
         };
         if let Some(owner) = owner {
             if let Some(msg) = workspace_dirty_message(&owner) {
@@ -4058,11 +4129,13 @@ pub async fn delete_workspace(
         }
     }
 
-    let plan = order_workspace_deletion(&body.session_ids, &body);
+    let plan = order_workspace_deletion(&session_ids, &body);
 
     // Detached task, mirroring `delete_session`: the teardown must run to
     // completion even if the client disconnects mid-delete.
-    let join = tokio::spawn(async move { purge_workspace_artifacts(&state, plan).await });
+    let join = tokio::spawn(async move {
+        purge_workspace_artifacts(&state, owner_id, plan, owner_needs_dirty_check).await
+    });
 
     match join.await {
         Ok((deleted, failed, messages)) => {
@@ -6649,6 +6722,36 @@ mod tests {
             let (_, owner_body) = plan.last().unwrap();
             assert!(!owner_body.delete_worktree);
             assert!(!owner_body.delete_branch);
+        }
+
+        #[test]
+        fn dedupe_drops_repeats_preserving_first_seen_order() {
+            let ids = vec![
+                "a".to_string(),
+                "b".to_string(),
+                "a".to_string(),
+                "c".to_string(),
+                "b".to_string(),
+            ];
+            assert_eq!(dedupe_session_ids(&ids), vec!["a", "b", "c"]);
+        }
+
+        #[test]
+        fn duplicate_owner_still_removes_the_worktree() {
+            // #2536 review: ["owner", "owner"] must not delete the owner with
+            // sibling (record-only) flags and then skip the repeat. After
+            // dedupe the single owner entry keeps the real worktree flags.
+            let ids = dedupe_session_ids(&["owner".to_string(), "owner".to_string()]);
+            assert_eq!(ids, vec!["owner"]);
+            let plan = order_workspace_deletion(&ids, &body());
+            assert_eq!(plan.len(), 1);
+            let (id, b) = &plan[0];
+            assert_eq!(id, "owner");
+            assert!(
+                b.delete_worktree,
+                "the deduped owner must still own the worktree cleanup"
+            );
+            assert!(b.delete_branch);
         }
     }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3378,7 +3378,7 @@ pub async fn update_session_unread(
 
 // --- Delete session ---
 
-#[derive(Default, Deserialize)]
+#[derive(Default, Deserialize, Clone)]
 pub struct DeleteSessionBody {
     #[serde(default)]
     pub delete_worktree: bool,
@@ -3843,6 +3843,265 @@ pub async fn delete_session(
                 Json(serde_json::json!({
                     "error": "internal",
                     "message": "Deletion task failed",
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+// --- Delete workspace (atomic multi-session) ---
+
+/// Body for `DELETE /api/workspaces`. `session_ids` is the full set of
+/// sessions in one web-UI workspace, all sharing a single git worktree +
+/// branch, ordered so the first id is the worktree owner (the web
+/// `sessions[0]` primary). The cleanup flags mirror [`DeleteSessionBody`]:
+/// they apply to the whole workspace, and the shared worktree/branch is
+/// removed exactly once, on the owner.
+#[derive(Default, Deserialize)]
+pub struct DeleteWorkspaceBody {
+    #[serde(default)]
+    pub session_ids: Vec<String>,
+    #[serde(default)]
+    pub delete_worktree: bool,
+    #[serde(default)]
+    pub delete_branch: bool,
+    #[serde(default)]
+    pub delete_sandbox: bool,
+    #[serde(default)]
+    pub force_delete: bool,
+    #[serde(default)]
+    pub keep_scratch: bool,
+}
+
+#[derive(Serialize)]
+struct WorkspaceDeleteFailure {
+    id: String,
+    error: String,
+}
+
+/// Build the per-session deletion order for a workspace delete. All sessions
+/// in a workspace share one git worktree + branch, so worktree/branch cleanup
+/// must run exactly once. The owner (`session_ids[0]`, the web primary)
+/// carries the caller's worktree/branch flags and is deleted LAST; every
+/// sibling is deleted first with worktree/branch removal forced off.
+///
+/// Owner-last is the safety property. Siblings hold only a record + container,
+/// never the shared worktree, so tearing them down while the worktree is still
+/// present lets a sibling failure abort before the worktree is touched, leaving
+/// nothing orphaned. Deleting the owner first (worktree gone) and then failing
+/// on a sibling would strand a live record pointing at a deleted worktree, the
+/// exact failure #2536 exists to remove.
+fn order_workspace_deletion(
+    session_ids: &[String],
+    body: &DeleteWorkspaceBody,
+) -> Vec<(String, DeleteSessionBody)> {
+    let Some((owner, siblings)) = session_ids.split_first() else {
+        return Vec::new();
+    };
+    let sibling_body = DeleteSessionBody {
+        delete_worktree: false,
+        delete_branch: false,
+        delete_sandbox: body.delete_sandbox,
+        force_delete: body.force_delete,
+        keep_scratch: body.keep_scratch,
+    };
+    let owner_body = DeleteSessionBody {
+        delete_worktree: body.delete_worktree,
+        delete_branch: body.delete_branch,
+        delete_sandbox: body.delete_sandbox,
+        force_delete: body.force_delete,
+        keep_scratch: body.keep_scratch,
+    };
+    let mut plan: Vec<(String, DeleteSessionBody)> = siblings
+        .iter()
+        .map(|id| (id.clone(), sibling_body.clone()))
+        .collect();
+    plan.push((owner.clone(), owner_body));
+    plan
+}
+
+/// Owner-worktree dirty preflight for a workspace delete. Mirrors the per-
+/// session dirty gate in `perform_deletion` so a non-force delete of a dirty
+/// shared worktree is refused before any session is torn down, keeping dirty +
+/// non-force all-or-nothing. Returns the first dirty message found.
+fn workspace_dirty_message(instance: &Instance) -> Option<String> {
+    if let Some(wt) = &instance.worktree_info {
+        if wt.managed_by_aoe {
+            let path = std::path::PathBuf::from(&instance.project_path);
+            if let Some(msg) = crate::git::cleanup::dirty_worktree_message(&path) {
+                return Some(msg);
+            }
+        }
+    }
+    if let Some(ws) = &instance.workspace_info {
+        if ws.cleanup_on_delete {
+            for repo in &ws.repos {
+                if repo.managed_by_aoe {
+                    let path = std::path::PathBuf::from(&repo.worktree_path);
+                    if let Some(msg) = crate::git::cleanup::dirty_worktree_message(&path) {
+                        return Some(format!("{}: {}", repo.name, msg));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Tear down every session in a workspace: record-only siblings first, then the
+/// shared-worktree owner last (see [`order_workspace_deletion`]). Each session
+/// goes through the shared [`purge_session_artifacts`] under its own instance
+/// lock, one lock at a time so a workspace delete can never deadlock against a
+/// concurrent delete or the retention auto-purge worker. A session already gone
+/// (a retention purge won the race) is skipped, not failed. A pre-owner failure
+/// aborts before the worktree is removed, so the shared worktree keeps its live
+/// owning session rather than being orphaned.
+async fn purge_workspace_artifacts(
+    state: &Arc<AppState>,
+    plan: Vec<(String, DeleteSessionBody)>,
+) -> (Vec<String>, Vec<WorkspaceDeleteFailure>, Vec<String>) {
+    let mut deleted = Vec::new();
+    let mut failed = Vec::new();
+    let mut messages = Vec::new();
+
+    for (id, body) in plan {
+        let lock = state.instance_lock(&id).await;
+        let _guard = lock.lock_owned().await;
+
+        let instance = {
+            let instances = state.instances.read().await;
+            instances.iter().find(|i| i.id == id).cloned()
+        };
+        let Some(instance) = instance else {
+            // Already deleted (a concurrent retention auto-purge won the race).
+            // The row we were asked to delete is gone, so this is a no-op, not
+            // a failure.
+            continue;
+        };
+
+        {
+            let mut instances = state.instances.write().await;
+            if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                inst.status = Status::Deleting;
+            }
+        }
+
+        let recent_entry = crate::session::recent_project_entry_for(&instance);
+        match purge_session_artifacts(state, &id, instance, &body, recent_entry).await {
+            Ok(mut msgs) => {
+                deleted.push(id.clone());
+                messages.append(&mut msgs);
+            }
+            Err(msg) => {
+                mark_delete_error(state, &id, msg.clone()).await;
+                failed.push(WorkspaceDeleteFailure {
+                    id: id.clone(),
+                    error: msg,
+                });
+                // Stop before the remaining plan entries. The owner is last, so
+                // a sibling failure here leaves the shared worktree intact with
+                // its owning session still present, never orphaned.
+                break;
+            }
+        }
+    }
+
+    (deleted, failed, messages)
+}
+
+/// `DELETE /api/workspaces`: atomic multi-session workspace delete. Replaces
+/// the web client's N-call fan-out (one `DELETE /api/sessions/:id` per session)
+/// with a single call that tears the whole workspace down in the correct order
+/// under one detached task, so a mid-delete client disconnect can no longer
+/// leave the workspace half-removed. See #2536.
+pub async fn delete_workspace(
+    State(state): State<Arc<AppState>>,
+    body: Option<Json<DeleteWorkspaceBody>>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return super::read_only_response();
+    }
+
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+    if body.session_ids.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "invalid_request",
+                "message": "session_ids must not be empty",
+            })),
+        )
+            .into_response();
+    }
+
+    // Preflight: refuse a non-force delete of a dirty shared worktree before
+    // tearing down any session, so dirty + non-force stays all-or-nothing. The
+    // owner (session_ids[0]) is the session that carries the shared worktree.
+    if body.delete_worktree && !body.force_delete {
+        let owner_id = &body.session_ids[0];
+        let owner = {
+            let instances = state.instances.read().await;
+            instances.iter().find(|i| &i.id == owner_id).cloned()
+        };
+        if let Some(owner) = owner {
+            if let Some(msg) = workspace_dirty_message(&owner) {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "dirty_worktree",
+                        "message": msg,
+                    })),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let plan = order_workspace_deletion(&body.session_ids, &body);
+
+    // Detached task, mirroring `delete_session`: the teardown must run to
+    // completion even if the client disconnects mid-delete.
+    let join = tokio::spawn(async move { purge_workspace_artifacts(&state, plan).await });
+
+    match join.await {
+        Ok((deleted, failed, messages)) => {
+            if deleted.is_empty() && !failed.is_empty() {
+                let msg = failed
+                    .iter()
+                    .map(|f| f.error.clone())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                tracing::error!(target: "http.api.sessions", "workspace delete failed: {msg}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": "deletion_failed",
+                        "message": msg,
+                        "failed": failed,
+                    })),
+                )
+                    .into_response();
+            }
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": if failed.is_empty() { "deleted" } else { "partial" },
+                    "deleted": deleted,
+                    "failed": failed,
+                    "messages": messages,
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions",
+                "Workspace deletion task panicked or was cancelled: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "internal",
+                    "message": "Workspace deletion task failed",
                 })),
             )
                 .into_response()
@@ -6312,6 +6571,86 @@ pub async fn serve_session_artifact(Path((id, path)): Path<(String, String)>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #2536: the workspace-delete order must tear down record-only siblings
+    // first and the shared-worktree owner last, so a sibling failure can never
+    // orphan a session against an already-removed worktree.
+    mod workspace_deletion {
+        use super::*;
+
+        fn body() -> DeleteWorkspaceBody {
+            DeleteWorkspaceBody {
+                session_ids: vec![],
+                delete_worktree: true,
+                delete_branch: true,
+                delete_sandbox: true,
+                force_delete: false,
+                keep_scratch: false,
+            }
+        }
+
+        #[test]
+        fn owner_is_last_and_siblings_are_record_only() {
+            let ids = vec!["owner".to_string(), "sib1".to_string(), "sib2".to_string()];
+            let plan = order_workspace_deletion(&ids, &body());
+
+            let order: Vec<&str> = plan.iter().map(|(id, _)| id.as_str()).collect();
+            assert_eq!(
+                order,
+                vec!["sib1", "sib2", "owner"],
+                "siblings must precede the owner so the worktree owner is torn down last"
+            );
+
+            // Siblings never touch the shared worktree/branch.
+            for (id, b) in &plan[..2] {
+                assert!(
+                    !b.delete_worktree,
+                    "sibling {id} must not remove the worktree"
+                );
+                assert!(!b.delete_branch, "sibling {id} must not delete the branch");
+                assert!(
+                    b.delete_sandbox,
+                    "sibling {id} still tears down its own sandbox"
+                );
+            }
+            // The owner (last) carries the caller's worktree/branch flags.
+            let (owner_id, owner_body) = plan.last().unwrap();
+            assert_eq!(owner_id, "owner");
+            assert!(owner_body.delete_worktree);
+            assert!(owner_body.delete_branch);
+        }
+
+        #[test]
+        fn single_session_is_owner_only_with_full_flags() {
+            let ids = vec!["solo".to_string()];
+            let plan = order_workspace_deletion(&ids, &body());
+            assert_eq!(plan.len(), 1);
+            let (id, b) = &plan[0];
+            assert_eq!(id, "solo");
+            assert!(
+                b.delete_worktree,
+                "the only session owns the worktree cleanup"
+            );
+            assert!(b.delete_branch);
+        }
+
+        #[test]
+        fn empty_input_is_empty_plan() {
+            assert!(order_workspace_deletion(&[], &body()).is_empty());
+        }
+
+        #[test]
+        fn worktree_flags_off_stay_off_for_owner() {
+            let mut b = body();
+            b.delete_worktree = false;
+            b.delete_branch = false;
+            let ids = vec!["owner".to_string(), "sib".to_string()];
+            let plan = order_workspace_deletion(&ids, &b);
+            let (_, owner_body) = plan.last().unwrap();
+            assert!(!owner_body.delete_worktree);
+            assert!(!owner_body.delete_branch);
+        }
+    }
 
     // #2587: the artifact route serves only canonicalized files confined to
     // the session's artifact dir, sets nosniff, and never serves HTML inline.

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1603,6 +1603,7 @@ mod tests {
         ));
         assert!(!requires_elevation(&Method::POST, "/api/sessions"));
         assert!(!requires_elevation(&Method::DELETE, "/api/sessions/abc"));
+        assert!(!requires_elevation(&Method::DELETE, "/api/workspaces"));
         assert!(!requires_elevation(&Method::POST, "/api/sessions/abc/send"));
         assert!(!requires_elevation(&Method::PATCH, "/api/sessions/abc"));
         assert!(!requires_elevation(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1522,6 +1522,9 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/workspace-ordering",
             put(api::update_workspace_ordering),
         )
+        // Atomic multi-session workspace delete (#2536): one call replaces the
+        // web client's N-call fan-out over DELETE /api/sessions/{id}.
+        .route("/api/workspaces", delete(api::delete_workspace))
         // Unified MCP management surface (#1996)
         .route("/api/mcp/servers", get(api::get_mcp_servers))
         .route(

--- a/web/src/lib/__tests__/trashActions.test.ts
+++ b/web/src/lib/__tests__/trashActions.test.ts
@@ -131,13 +131,18 @@ describe("deleteWorkspaceSessions (#2536)", () => {
     expect(d.navigateHome).not.toHaveBeenCalled();
   });
 
-  it("treats a response without a `deleted` list as all-deleted (older server shape)", async () => {
-    deleteMock.mockResolvedValue(ok());
+  it("leaves a session that is neither deleted nor failed untouched (kept-restored)", async () => {
+    // Server kept sess-b (a concurrent restore won the race): it is reported
+    // in neither `deleted` nor `failed`, so we must not purge its local state
+    // or flag it Error; the next poll reconciles it.
+    deleteMock.mockResolvedValue(ok({ deleted: ["a"], failed: [] }));
     const d = deps();
 
     await deleteWorkspaceSessions(sessions("a", "b"), {}, null, d);
 
-    expect(d.purgeLocal).toHaveBeenCalledTimes(2);
+    expect(d.purgeLocal).toHaveBeenCalledTimes(1);
+    expect(d.purgeLocal).toHaveBeenCalledWith("a");
+    expect(d.setStatus).not.toHaveBeenCalledWith("b", "Error");
     expect(d.notify.info).toHaveBeenCalledWith("Sessions deleted");
   });
 

--- a/web/src/lib/__tests__/trashActions.test.ts
+++ b/web/src/lib/__tests__/trashActions.test.ts
@@ -7,10 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../api", () => ({
   trashSession: vi.fn(),
   restoreSession: vi.fn(),
-  deleteSession: vi.fn(),
+  deleteWorkspace: vi.fn(),
 }));
 
-import { deleteSession, restoreSession, trashSession } from "../api";
+import { deleteWorkspace, restoreSession, trashSession } from "../api";
 import { deleteWorkspaceSessions, restoreSessions, trashedWorkspaceRestoreIds, trashSessions } from "../trashActions";
 import type { SessionResponse, Workspace } from "../types";
 
@@ -19,7 +19,7 @@ const ws = (id: string, sessionIds: string[]) =>
   ({ id, sessions: sessionIds.map((sid) => ({ id: sid })) }) as unknown as Workspace;
 const trashMock = vi.mocked(trashSession);
 const restoreMock = vi.mocked(restoreSession);
-const deleteMock = vi.mocked(deleteSession);
+const deleteMock = vi.mocked(deleteWorkspace);
 
 beforeEach(() => {
   trashMock.mockReset();
@@ -105,8 +105,11 @@ describe("trashedWorkspaceRestoreIds (#2593)", () => {
   });
 });
 
-describe("deleteWorkspaceSessions (#2530, #2539)", () => {
-  const ok = (messages?: string[]) => ({ ok: true as const, messages });
+describe("deleteWorkspaceSessions (#2536)", () => {
+  const ok = (over: { deleted?: string[]; failed?: { id: string; error: string }[]; messages?: string[] } = {}) => ({
+    ok: true as const,
+    ...over,
+  });
   const sessions = (...ids: string[]) => ids.map((id) => ({ id }) as unknown as SessionResponse);
   const deps = () => ({
     setStatus: vi.fn(),
@@ -115,28 +118,35 @@ describe("deleteWorkspaceSessions (#2530, #2539)", () => {
     notify: { info: vi.fn(), error: vi.fn() },
   });
 
-  it("deletes every session; the primary carries the chosen cleanup, siblings strip worktree/branch", async () => {
-    deleteMock.mockResolvedValue(ok());
+  it("makes ONE workspace call with the full id set in order, and purges every deleted id", async () => {
+    deleteMock.mockResolvedValue(ok({ deleted: ["a", "b", "c"] }));
     const d = deps();
 
     await deleteWorkspaceSessions(sessions("a", "b", "c"), { delete_worktree: true, delete_branch: true }, null, d);
 
-    expect(deleteMock).toHaveBeenCalledTimes(3);
-    expect(deleteMock).toHaveBeenNthCalledWith(1, "a", { delete_worktree: true, delete_branch: true });
-    expect(deleteMock).toHaveBeenNthCalledWith(2, "b", { delete_worktree: false, delete_branch: false });
-    expect(deleteMock).toHaveBeenNthCalledWith(3, "c", { delete_worktree: false, delete_branch: false });
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).toHaveBeenCalledWith(["a", "b", "c"], { delete_worktree: true, delete_branch: true });
     expect(d.purgeLocal).toHaveBeenCalledTimes(3);
     expect(d.notify.info).toHaveBeenCalledWith("Sessions deleted");
     expect(d.navigateHome).not.toHaveBeenCalled();
   });
 
-  it("aborts the siblings and does not navigate when the primary delete fails", async () => {
-    deleteMock.mockResolvedValueOnce({ ok: false, error: "dirty" });
+  it("treats a response without a `deleted` list as all-deleted (older server shape)", async () => {
+    deleteMock.mockResolvedValue(ok());
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b"), {}, null, d);
+
+    expect(d.purgeLocal).toHaveBeenCalledTimes(2);
+    expect(d.notify.info).toHaveBeenCalledWith("Sessions deleted");
+  });
+
+  it("flags every session Error and does not navigate when the call fails", async () => {
+    deleteMock.mockResolvedValue({ ok: false, error: "dirty" });
     const d = deps();
 
     await deleteWorkspaceSessions(sessions("a", "b"), {}, "b", d);
 
-    expect(deleteMock).toHaveBeenCalledTimes(1);
     expect(d.purgeLocal).not.toHaveBeenCalled();
     expect(d.navigateHome).not.toHaveBeenCalled();
     expect(d.setStatus).toHaveBeenCalledWith("a", "Error");
@@ -144,17 +154,8 @@ describe("deleteWorkspaceSessions (#2530, #2539)", () => {
     expect(d.notify.error).toHaveBeenCalledWith("dirty");
   });
 
-  it("navigates home only after the open session is actually deleted (primary)", async () => {
-    deleteMock.mockResolvedValue(ok());
-    const d = deps();
-
-    await deleteWorkspaceSessions(sessions("a", "b"), {}, "a", d);
-
-    expect(d.navigateHome).toHaveBeenCalledTimes(1);
-  });
-
-  it("navigates home when the open session is a deleted sibling", async () => {
-    deleteMock.mockResolvedValue(ok());
+  it("navigates home when the open session is among the deleted", async () => {
+    deleteMock.mockResolvedValue(ok({ deleted: ["a", "b"] }));
     const d = deps();
 
     await deleteWorkspaceSessions(sessions("a", "b"), {}, "b", d);
@@ -162,8 +163,17 @@ describe("deleteWorkspaceSessions (#2530, #2539)", () => {
     expect(d.navigateHome).toHaveBeenCalledTimes(1);
   });
 
-  it("reports a partial failure and skips purge for the failed sibling", async () => {
-    deleteMock.mockResolvedValueOnce(ok()).mockResolvedValueOnce({ ok: false, error: "boom" });
+  it("does NOT navigate home when the open session is the one that failed", async () => {
+    deleteMock.mockResolvedValue(ok({ deleted: ["a"], failed: [{ id: "b", error: "boom" }] }));
+    const d = deps();
+
+    await deleteWorkspaceSessions(sessions("a", "b"), {}, "b", d);
+
+    expect(d.navigateHome).not.toHaveBeenCalled();
+  });
+
+  it("reports a partial failure: purges the deleted id, flags the failed one Error", async () => {
+    deleteMock.mockResolvedValue(ok({ deleted: ["a"], failed: [{ id: "b", error: "boom" }] }));
     const d = deps();
 
     await deleteWorkspaceSessions(sessions("a", "b"), {}, null, d);
@@ -175,7 +185,7 @@ describe("deleteWorkspaceSessions (#2530, #2539)", () => {
   });
 
   it("surfaces a server message and handles a single-session workspace", async () => {
-    deleteMock.mockResolvedValue(ok(["Scratch directory kept at: /tmp/x"]));
+    deleteMock.mockResolvedValue(ok({ deleted: ["solo"], messages: ["Scratch directory kept at: /tmp/x"] }));
     const d = deps();
 
     await deleteWorkspaceSessions(sessions("solo"), {}, null, d);

--- a/web/src/lib/api.coverage.test.ts
+++ b/web/src/lib/api.coverage.test.ts
@@ -70,7 +70,7 @@ import {
   setSessionDiffBase,
   stopSession,
   startSession,
-  deleteSession,
+  deleteWorkspace,
   fetchMcpServers,
   resolveMcpConflict,
   keepMcpServer,
@@ -1395,32 +1395,42 @@ describe("startSession", () => {
   });
 });
 
-describe("deleteSession", () => {
-  it("DELETEs with the default empty options and returns messages", async () => {
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ messages: ["removed worktree"] }));
-    const result = await deleteSession("s1");
-    expect(result).toEqual({ ok: true, messages: ["removed worktree"] });
+describe("deleteWorkspace (#2536)", () => {
+  it("DELETEs /api/workspaces with session_ids + options and returns the result", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ status: "deleted", deleted: ["a", "b"], failed: [], messages: ["Worktree removed"] }),
+    );
+    const result = await deleteWorkspace(["a", "b"], { delete_worktree: true, delete_branch: true });
+    expect(result).toEqual({ ok: true, messages: ["Worktree removed"], deleted: ["a", "b"], failed: [] });
     const [url, init] = lastCall();
-    expect(url).toBe("/api/sessions/s1");
+    expect(url).toBe("/api/workspaces");
     expect(init?.method).toBe("DELETE");
-    expect(bodyOf(init)).toEqual({});
+    expect(bodyOf(init)).toEqual({ session_ids: ["a", "b"], delete_worktree: true, delete_branch: true });
   });
 
-  it("forwards the delete options on the body", async () => {
-    fetchSpy.mockResolvedValueOnce(jsonResponse({}));
-    await deleteSession("s1", { delete_worktree: true, delete_branch: true });
-    expect(bodyOf(lastCall()[1])).toEqual({ delete_worktree: true, delete_branch: true });
+  it("returns deleted + failed on a partial-success 200", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ status: "partial", deleted: ["a"], failed: [{ id: "b", error: "boom" }] }),
+    );
+    const result = await deleteWorkspace(["a", "b"]);
+    expect(result.ok).toBe(true);
+    expect(result.deleted).toEqual(["a"]);
+    expect(result.failed).toEqual([{ id: "b", error: "boom" }]);
   });
 
-  it("returns the error message on a non-2xx", async () => {
-    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ message: "in use" }), { status: 409 }));
-    const result = await deleteSession("s1");
-    expect(result).toEqual({ ok: false, error: "in use" });
+  it("returns the error message and failures on a non-2xx", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "dirty", failed: [{ id: "a", error: "dirty" }] }), { status: 500 }),
+    );
+    const result = await deleteWorkspace(["a"]);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("dirty");
+    expect(result.failed).toEqual([{ id: "a", error: "dirty" }]);
   });
 
   it("returns a network error on a thrown fetch", async () => {
     fetchSpy.mockRejectedValueOnce(new Error("offline"));
-    const result = await deleteSession("s1");
+    const result = await deleteWorkspace(["a"]);
     expect(result.ok).toBe(false);
     expect(result.error).toContain("offline");
   });

--- a/web/src/lib/api.coverage.test.ts
+++ b/web/src/lib/api.coverage.test.ts
@@ -1418,6 +1418,13 @@ describe("deleteWorkspace (#2536)", () => {
     expect(result.failed).toEqual([{ id: "b", error: "boom" }]);
   });
 
+  it("treats a 2xx response without a `deleted` array as a failure", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+    const result = await deleteWorkspace(["a"]);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/did not confirm/i);
+  });
+
   it("returns the error message and failures on a non-2xx", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({ message: "dirty", failed: [{ id: "a", error: "dirty" }] }), { status: 500 }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2135,7 +2135,7 @@ export async function setSessionArchive(
 /** Move a session to the trash (#2489): stops the live session (ACP
  *  shutdown, which preserves the transcript, plus optional tmux teardown)
  *  and hides it from the normal list while keeping every durable artifact so
- *  it can be restored. NOT a permanent delete; use `deleteSession` for that. */
+ *  it can be restored. NOT a permanent delete; use `deleteWorkspace` for that. */
 export async function trashSession(id: string, killPane = true): Promise<SessionResponse | null> {
   try {
     const res = await fetch(`/api/sessions/${id}/trash`, {
@@ -2246,30 +2246,50 @@ export interface DeleteSessionOptions {
   keep_scratch?: boolean;
 }
 
-export interface DeleteSessionResult {
+export interface WorkspaceDeleteFailure {
+  id: string;
+  error: string;
+}
+
+export interface DeleteWorkspaceResult {
   ok: boolean;
   error?: string;
   messages?: string[];
+  /** Ids the server actually deleted. */
+  deleted?: string[];
+  /** Sessions that could not be deleted, with their error. */
+  failed?: WorkspaceDeleteFailure[];
 }
 
-export async function deleteSession(id: string, options: DeleteSessionOptions = {}): Promise<DeleteSessionResult> {
+/** Atomically delete a whole multi-session workspace in one call (#2536).
+ *  `sessionIds` is the workspace's full session set in display order; the
+ *  server treats `sessionIds[0]` as the worktree owner (removed last) and the
+ *  rest as record-only siblings. Replaces the old per-session delete fan-out,
+ *  so a mid-delete disconnect can no longer half-delete the workspace. */
+export async function deleteWorkspace(
+  sessionIds: string[],
+  options: DeleteSessionOptions = {},
+): Promise<DeleteWorkspaceResult> {
   try {
-    const res = await fetch(`/api/sessions/${id}`, {
+    const res = await fetch(`/api/workspaces`, {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(options),
+      body: JSON.stringify({ session_ids: sessionIds, ...options }),
     });
+    const data = (await res.json().catch(() => ({}))) as {
+      message?: string;
+      messages?: string[];
+      deleted?: string[];
+      failed?: WorkspaceDeleteFailure[];
+    };
     if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
       return {
         ok: false,
         error: data.message || `Server error (${res.status})`,
+        failed: data.failed,
       };
     }
-    const data = (await res.json().catch(() => ({}))) as {
-      messages?: string[];
-    };
-    return { ok: true, messages: data.messages };
+    return { ok: true, messages: data.messages, deleted: data.deleted, failed: data.failed };
   } catch (e) {
     return {
       ok: false,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2289,6 +2289,13 @@ export async function deleteWorkspace(
         failed: data.failed,
       };
     }
+    // The endpoint always reports which sessions it removed. A 2xx without a
+    // `deleted` array is not a confirmed deletion, so treat it as a failure
+    // rather than dropping local state (drafts, caches) for sessions the
+    // server may not have touched.
+    if (!Array.isArray(data.deleted)) {
+      return { ok: false, error: "Server did not confirm which sessions were deleted" };
+    }
     return { ok: true, messages: data.messages, deleted: data.deleted, failed: data.failed };
   } catch (e) {
     return {

--- a/web/src/lib/trashActions.ts
+++ b/web/src/lib/trashActions.ts
@@ -95,14 +95,16 @@ export async function deleteWorkspaceSessions(
     return;
   }
 
-  // The server reports exactly which ids it deleted; on the older-shape
-  // response (no `deleted`) treat all as deleted. Purge local state only for
-  // the confirmed-deleted ids; flag the rest as Error.
-  const deleted = new Set(result.deleted ?? ids);
+  // The server reports exactly which ids it removed and which failed. Purge
+  // local state only for confirmed-deleted ids; flag only explicitly-failed
+  // ids as Error. An id in neither set (e.g. a concurrent restore kept the
+  // row) is left untouched for the next poll to reconcile.
+  const deleted = new Set(result.deleted ?? []);
+  const failed = new Set((result.failed ?? []).map((f) => f.id));
   for (const id of ids) {
     if (deleted.has(id)) {
       deps.purgeLocal(id);
-    } else {
+    } else if (failed.has(id)) {
       deps.setStatus(id, "Error");
     }
   }

--- a/web/src/lib/trashActions.ts
+++ b/web/src/lib/trashActions.ts
@@ -2,7 +2,7 @@
 // per-session apply + aggregate toast logic is unit-testable rather than
 // reachable only through the structured-view bundle.
 
-import { deleteSession, restoreSession, trashSession } from "./api";
+import { deleteWorkspace, restoreSession, trashSession } from "./api";
 import type { DeleteSessionOptions } from "./api";
 import type { SessionResponse, SessionStatus, Workspace } from "./types";
 
@@ -67,60 +67,55 @@ interface DeleteWorkspaceDeps {
   notify: Notifier | null;
 }
 
-/** Permanently delete every session in a workspace (#2530). All sessions share
- *  one git worktree and branch, so the caller's worktree/branch cleanup options
- *  run exactly once, on the primary (`sessions[0]`); a failed primary aborts
- *  before any sibling record is destroyed (the shared worktree is still
- *  present, so removing siblings would orphan the workspace), and siblings
- *  never re-run the non-idempotent worktree removal. Redirects home only once
- *  the currently-open session has actually been deleted, not merely because it
- *  belonged to the workspace (#2539). Local cleanup runs per id only after that
- *  id's delete succeeds, so a failure never strands a draft or cache. */
+/** Permanently delete every session in a workspace via the atomic backend
+ *  endpoint (#2536). All sessions share one git worktree and branch; the server
+ *  removes the shared worktree/branch exactly once (on `sessions[0]`, torn down
+ *  last) and record-only-deletes the rest, so a mid-delete disconnect can no
+ *  longer strand a record against an already-removed worktree. Redirects home
+ *  only once the currently-open session was actually deleted, not merely because
+ *  it belonged to the workspace (#2539). Local cleanup runs per id only after
+ *  the server confirms that id was deleted, so a failure never strands a draft
+ *  or cache. */
 export async function deleteWorkspaceSessions(
   sessions: SessionResponse[],
   options: DeleteSessionOptions,
   activeSessionId: string | null,
   deps: DeleteWorkspaceDeps,
 ): Promise<void> {
-  const primary = sessions[0];
-  if (!primary) return;
+  if (sessions.length === 0) return;
   const ids = sessions.map((s) => s.id);
-  const activeWorkspaceSessionId = activeSessionId != null && ids.includes(activeSessionId) ? activeSessionId : null;
+  const activeInWorkspace = activeSessionId != null && ids.includes(activeSessionId);
 
   for (const id of ids) deps.setStatus(id, "Deleting");
 
-  let activeDeleted = false;
-  const primaryResult = await deleteSession(primary.id, options);
-  if (!primaryResult.ok) {
+  const result = await deleteWorkspace(ids, options);
+  if (!result.ok) {
     for (const id of ids) deps.setStatus(id, "Error");
-    deps.notify?.error?.(primaryResult.error || "Failed to delete session");
+    deps.notify?.error?.(result.error || "Failed to delete session");
     return;
   }
-  if (activeWorkspaceSessionId === primary.id) activeDeleted = true;
-  deps.purgeLocal(primary.id);
 
-  const siblingOptions: DeleteSessionOptions = { ...options, delete_worktree: false, delete_branch: false };
-  let anyFailed = false;
-  for (const sibling of sessions.slice(1)) {
-    const res = await deleteSession(sibling.id, siblingOptions);
-    if (res.ok) {
-      if (activeWorkspaceSessionId === sibling.id) activeDeleted = true;
-      deps.purgeLocal(sibling.id);
+  // The server reports exactly which ids it deleted; on the older-shape
+  // response (no `deleted`) treat all as deleted. Purge local state only for
+  // the confirmed-deleted ids; flag the rest as Error.
+  const deleted = new Set(result.deleted ?? ids);
+  for (const id of ids) {
+    if (deleted.has(id)) {
+      deps.purgeLocal(id);
     } else {
-      anyFailed = true;
-      deps.setStatus(sibling.id, "Error");
+      deps.setStatus(id, "Error");
     }
   }
 
-  if (activeDeleted) deps.navigateHome();
+  if (activeInWorkspace && deleted.has(activeSessionId!)) deps.navigateHome();
 
-  if (anyFailed) {
+  if (result.failed && result.failed.length > 0) {
     deps.notify?.error?.("Some sessions could not be deleted");
     return;
   }
   // `messages` carries any user-facing note from `perform_deletion` (e.g. a
   // kept scratch path); surface the first.
-  deps.notify?.info?.(primaryResult.messages?.[0] ?? (ids.length > 1 ? "Sessions deleted" : "Session deleted"));
+  deps.notify?.info?.(result.messages?.[0] ?? (ids.length > 1 ? "Sessions deleted" : "Session deleted"));
 }
 
 /** Restore every id, applying each returned snapshot. Returns true iff all

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1267,6 +1267,13 @@
       "components": ["web/src/components/acp/StructuredView.tsx"]
     },
     {
+      "id": "session.workspace-delete",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/lib/__tests__/trashActions.test.ts", "src/lib/api.coverage.test.ts"],
+      "components": ["web/src/lib/trashActions.ts", "web/src/lib/api.ts"]
+    },
+    {
       "id": "session.group-edit",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/delete-active-session.spec.ts
+++ b/web/tests/delete-active-session.spec.ts
@@ -50,10 +50,13 @@ async function mockApis(page: Page): Promise<Handle> {
       },
     });
   });
-  await page.route("**/api/sessions/sess-active", (r) => {
+  await page.route("**/api/workspaces", (r) => {
     if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
-    handle.deletes.push(JSON.parse(r.request().postData() || "{}"));
-    return r.fulfill({ json: {} });
+    const body = JSON.parse(r.request().postData() || "{}") as { session_ids?: string[] };
+    handle.deletes.push(body);
+    return r.fulfill({
+      json: { status: "deleted", deleted: body.session_ids ?? [], failed: [], messages: [] },
+    });
   });
   await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
   await page.route("**/api/sessions/*/terminal", (r) => r.fulfill({ status: 200, body: "" }));

--- a/web/tests/live/session-delete.spec.ts
+++ b/web/tests/live/session-delete.spec.ts
@@ -1,7 +1,7 @@
 // Live coverage for the session-delete flow from the sidebar:
 //   - Right-click row → context menu → Delete → DeleteSessionDialog.
-//   - Confirm button fires DELETE /api/sessions/:id with the expected
-//     options body and removes the row.
+//   - Confirm button fires DELETE /api/workspaces with the expected
+//     { session_ids, ...options } body and removes the row.
 //   - Cancel button + Escape both dismiss the dialog without a DELETE.
 //
 // The toggle-combination matrix (delete_worktree / force / delete_branch
@@ -18,7 +18,7 @@ import { test as base, expect } from "@playwright/test";
 import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
 
 base.describe("session delete via sidebar context menu (#1220)", () => {
-  base("Delete button fires DELETE /api/sessions/:id and removes the row", async ({ page }, testInfo) => {
+  base("Delete button fires DELETE /api/workspaces and removes the row", async ({ page }, testInfo) => {
     const title = "delete-me";
     const serve = await spawnAoeServe({
       authMode: "none",
@@ -52,16 +52,18 @@ base.describe("session delete via sidebar context menu (#1220)", () => {
       await dialog.locator("[data-testid='delete-session-permanent']").click();
 
       const deletePromise = page.waitForResponse(
-        (res) => res.url().endsWith(`/api/sessions/${sessionId}`) && res.request().method() === "DELETE",
+        (res) => res.url().endsWith(`/api/workspaces`) && res.request().method() === "DELETE",
       );
 
       // `aoe add` does not produce a managed worktree, so the dialog
-      // skips the checkbox section and the confirm body is all-false.
+      // skips the checkbox section and the confirm body is all-false. The
+      // single-session workspace sends the one id as session_ids.
       await dialog.getByRole("button", { name: /^Delete$/ }).click();
 
       const deleteRes = await deletePromise;
       expect(deleteRes.ok()).toBe(true);
       expect(deleteRes.request().postDataJSON()).toEqual({
+        session_ids: [sessionId],
         delete_worktree: false,
         delete_branch: false,
         delete_sandbox: false,
@@ -92,7 +94,7 @@ base.describe("session delete via sidebar context menu (#1220)", () => {
       await page.goto(`${serve.baseUrl}/`);
 
       let deleteSeen = false;
-      await page.route("**/api/sessions/*", (route) => {
+      await page.route("**/api/workspaces", (route) => {
         if (route.request().method() === "DELETE") {
           deleteSeen = true;
         }
@@ -135,7 +137,7 @@ base.describe("session delete via sidebar context menu (#1220)", () => {
       await page.goto(`${serve.baseUrl}/`);
 
       let deleteSeen = false;
-      await page.route("**/api/sessions/*", (route) => {
+      await page.route("**/api/workspaces", (route) => {
         if (route.request().method() === "DELETE") {
           deleteSeen = true;
         }

--- a/web/tests/live/wizard-scratch-delete-cleans-tempdir.spec.ts
+++ b/web/tests/live/wizard-scratch-delete-cleans-tempdir.spec.ts
@@ -47,11 +47,12 @@ base("deleting a scratch session removes its scratch dir", async ({ page }, test
     await dialog.locator("[data-testid='delete-session-permanent']").click();
 
     const deletePromise = page.waitForResponse(
-      (res) => res.url().endsWith(`/api/sessions/${sessionId}`) && res.request().method() === "DELETE",
+      (res) => res.url().endsWith(`/api/workspaces`) && res.request().method() === "DELETE",
     );
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
     const deleteRes = await deletePromise;
     expect(deleteRes.ok()).toBe(true);
+    expect((deleteRes.request().postDataJSON() as { session_ids: string[] }).session_ids).toEqual([sessionId]);
 
     // The session row leaves the sidebar AND the scratch dir is gone.
     await expect

--- a/web/tests/session-trash-flow.spec.ts
+++ b/web/tests/session-trash-flow.spec.ts
@@ -75,10 +75,14 @@ async function mockApis(page: Page, options: { title?: string } = {}): Promise<H
     handle.trashed = false;
     return r.fulfill({ json: sessionPayload(false, options.title) });
   });
-  await page.route("**/api/sessions/sess-trash", (r) => {
+  // Permanent delete now goes through the atomic workspace endpoint (#2536).
+  await page.route("**/api/workspaces", (r) => {
     if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
     handle.deletes += 1;
-    return r.fulfill({ json: {} });
+    const body = JSON.parse(r.request().postData() || "{}") as { session_ids?: string[] };
+    return r.fulfill({
+      json: { status: "deleted", deleted: body.session_ids ?? [], failed: [], messages: [] },
+    });
   });
   await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
   await page.route("**/api/sessions/*/terminal", (r) => r.fulfill({ status: 200, body: "" }));
@@ -219,10 +223,10 @@ test.describe("Session trash flow", () => {
 interface MultiHandle {
   /** Session ids that received a trash POST, in call order. */
   trashedIds: string[];
-  /** Session ids that received a DELETE, in call order. */
+  /** Session ids the workspace DELETE actually removed, in teardown order. */
   deletedIds: string[];
-  /** Last DELETE option body keyed by session id. */
-  deleteOptions: Record<string, Record<string, unknown>>;
+  /** Body of the last DELETE /api/workspaces request (session_ids + flags). */
+  workspaceBody: Record<string, unknown> | null;
   /** Session ids that received a restore POST, in call order. */
   restoredIds: string[];
 }
@@ -257,7 +261,7 @@ async function mockMultiApis(
   sessions: Array<{ id: string; groupPath: string; trashed: boolean; deleteToTrash?: boolean }>,
   opts: { failDeleteIds?: string[] } = {},
 ): Promise<MultiHandle> {
-  const handle: MultiHandle = { trashedIds: [], deletedIds: [], deleteOptions: {}, restoredIds: [] };
+  const handle: MultiHandle = { trashedIds: [], deletedIds: [], workspaceBody: null, restoredIds: [] };
   const trashedState = new Map(sessions.map((s) => [s.id, s.trashed]));
   const failDelete = new Set(opts.failDeleteIds ?? []);
 
@@ -294,15 +298,39 @@ async function mockMultiApis(
       trashedState.set(s.id, false);
       return r.fulfill({ json: multiPayload(s.id, s.groupPath, false, s.deleteToTrash) });
     });
-    await page.route(`**/api/sessions/${s.id}`, (r) => {
-      if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
-      if (failDelete.has(s.id)) return r.fulfill({ status: 500, json: { message: "boom" } });
-      handle.deletedIds.push(s.id);
-      const body = r.request().postData();
-      handle.deleteOptions[s.id] = body ? (JSON.parse(body) as Record<string, unknown>) : {};
-      return r.fulfill({ json: {} });
-    });
   }
+  // Atomic workspace delete (#2536): one request replaces the per-session
+  // fan-out. Mirror the server contract, including owner-last ordering, so the
+  // client sees a realistic {deleted, failed}: record-only siblings
+  // (session_ids[1..]) are torn down first, the worktree owner (session_ids[0])
+  // last, aborting on the first failure. A run that removes nothing but has a
+  // failure answers 500, matching the real handler.
+  await page.route("**/api/workspaces", (r) => {
+    if (r.request().method() !== "DELETE") return r.fulfill({ status: 400 });
+    const body = JSON.parse(r.request().postData() || "{}") as { session_ids?: string[] };
+    handle.workspaceBody = body;
+    const ids = body.session_ids ?? [];
+    const ordered = ids.length > 0 ? [...ids.slice(1), ids[0]!] : [];
+    const deleted: string[] = [];
+    const failed: Array<{ id: string; error: string }> = [];
+    for (const id of ordered) {
+      if (failDelete.has(id)) {
+        failed.push({ id, error: "boom" });
+        break;
+      }
+      handle.deletedIds.push(id);
+      deleted.push(id);
+    }
+    if (deleted.length === 0 && failed.length > 0) {
+      return r.fulfill({
+        status: 500,
+        json: { error: "deletion_failed", message: failed.map((f) => f.error).join("; "), failed },
+      });
+    }
+    return r.fulfill({
+      json: { status: failed.length ? "partial" : "deleted", deleted, failed, messages: [] },
+    });
+  });
   await page.route("**/api/sessions/*/ensure", (r) => r.fulfill({ json: { ok: true } }));
   await page.route("**/api/sessions/*/terminal", (r) => r.fulfill({ status: 200, body: "" }));
   await page.route("**/api/sessions/*/diff/files", (r) =>
@@ -414,16 +442,21 @@ test.describe("Multi-session workspace trash", () => {
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
 
     await expect.poll(() => [...handle.deletedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
-    // Whichever id is the workspace primary, the sibling never re-runs the
-    // shared worktree/branch removal.
-    const siblingId = handle.deletedIds[1]!;
-    expect(handle.deleteOptions[siblingId]).toMatchObject({ delete_worktree: false, delete_branch: false });
+    // One atomic call carried the whole workspace. Owner-last ordering and the
+    // per-session worktree/branch flag split are the server's concern, covered
+    // by the Rust `order_workspace_deletion` tests; here we assert the client
+    // sent the full session set in a single request.
+    expect([...((handle.workspaceBody?.session_ids as string[]) ?? [])].sort()).toEqual(["sess-a", "sess-b"]);
   });
 
-  test("a sibling delete failure leaves that session in Trash and reports it (#2530)", async ({ page }) => {
-    // Primary (sess-a) and one sibling (sess-b) purge, but sess-c fails. The
-    // workspace stays in Trash holding the surviving session, surfacing the
-    // partial-failure path of the delete loop.
+  test("a sibling delete failure aborts before the owner and leaves the workspace in Trash (#2530)", async ({
+    page,
+  }) => {
+    // Owner sess-a is torn down LAST. The siblings run first: sess-b succeeds,
+    // sess-c fails, which aborts before the owner. So only sess-b is removed;
+    // sess-a (owner) and sess-c (failed) survive, keeping the workspace in
+    // Trash. This is the owner-last safety property (#2536): a sibling failure
+    // never removes the shared-worktree owner.
     const handle = await mockMultiApis(
       page,
       [
@@ -443,16 +476,16 @@ test.describe("Multi-session workspace trash", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
 
-    // The two that succeeded are gone; the failed one is still attempted.
-    await expect.poll(() => [...handle.deletedIds].sort(), { timeout: 10_000 }).toEqual(["sess-a", "sess-b"]);
-    // The workspace remains in Trash because sess-c is still trashed.
+    // Only the first sibling was removed before the failing one aborted the run.
+    await expect.poll(() => [...handle.deletedIds].sort(), { timeout: 10_000 }).toEqual(["sess-b"]);
+    // The workspace remains in Trash because sess-a and sess-c survive.
     await expect(toggle).toBeVisible({ timeout: 10_000 });
   });
 
-  test("a failed primary delete does not redirect away from an open sibling (#2539 review)", async ({ page }) => {
-    // Open session is the sibling (sess-b); the primary (sess-a) delete fails,
-    // so nothing is removed. The user must stay on the still-live session
-    // instead of being kicked back to "/".
+  test("a failed owner delete keeps the open owner and does not redirect (#2539 review)", async ({ page }) => {
+    // Open session is the owner (sess-a), torn down LAST. Its sibling (sess-b)
+    // is removed first, then the owner delete fails, so the owner survives. The
+    // user is viewing the still-live owner, so the app must NOT redirect to "/".
     const handle = await mockMultiApis(
       page,
       [
@@ -463,7 +496,7 @@ test.describe("Multi-session workspace trash", () => {
     );
     await page.setViewportSize({ width: 1280, height: 720 });
 
-    await page.goto("/session/sess-b");
+    await page.goto("/session/sess-a");
     await page.locator('[data-testid="sidebar-trash-toggle"]').click();
     const trashRow = page.locator('[data-testid="sidebar-trash-row"]').first();
     await expect(trashRow).toBeVisible({ timeout: 10_000 });
@@ -472,11 +505,11 @@ test.describe("Multi-session workspace trash", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
 
-    // Dialog closes (the handler ran), the primary delete failed so no session
-    // was removed, and the route still points at the open sibling.
+    // Dialog closes (the handler ran); the sibling was removed but the open
+    // owner failed to delete, so the route still points at the live owner.
     await expect(dialog).toHaveCount(0, { timeout: 10_000 });
-    await expect.poll(() => handle.deletedIds, { timeout: 5_000 }).toEqual([]);
-    await expect(page).toHaveURL(/\/session\/sess-b/);
+    await expect.poll(() => handle.deletedIds, { timeout: 5_000 }).toEqual(["sess-b"]);
+    await expect(page).toHaveURL(/\/session\/sess-a/);
   });
 
   for (const open of ["sess-a", "sess-b"] as const) {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Permanently deleting a multi-session workspace (several sessions sharing one git worktree and branch) was orchestrated entirely from the web client: `App.handleConfirmDelete` looped the workspace's sessions, deleting the primary with worktree/branch cleanup and the siblings record-only. That loop is not atomic. If the browser closed mid-loop, or a sibling record-only delete failed after the primary (the worktree owner) had already succeeded, a session record survived pointing at an already-removed worktree.

This adds a backend endpoint, `DELETE /api/workspaces`, that deletes the whole workspace in one call under a single detached task. The web client now makes one request instead of N.

The teardown order is the key correctness property: record-only siblings are torn down first and the worktree owner (`session_ids[0]`) last. Siblings hold only a record plus their own container, never the shared worktree, so a sibling failure aborts before the worktree is touched and nothing is left orphaned. A non-force delete of a dirty shared worktree is refused up front, so dirty plus non-force is all-or-nothing. Each session still goes through the existing `purge_session_artifacts` under its own instance lock, one lock at a time so there is no deadlock against a concurrent delete or the retention auto-purge worker, and a session already gone (a retention purge won the race) is skipped rather than failed.

Follow-up from the trash-fix work (#2530 / #2539 / #2827); both design reviewers there flagged the client loop as a mitigation, not the correct model.

Deferred as out of scope (larger and separable): a durable delete-operation resource with crash recovery, anchor plus expected-membership optimistic concurrency control, and a server-owned `workspace_key` so workspace grouping stops being client-only.

Closes #2536

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] In the web dashboard, create two sessions on the same repo and branch (one shared worktree) so they group into a single workspace row in the sidebar.
- [ ] Delete that workspace with "remove worktree + branch" checked; confirm every session disappears, the worktree directory and branch are gone, and no session row is left pointing at a missing worktree.
- [ ] Repeat with uncommitted changes left in the shared worktree and delete WITHOUT force; confirm the whole delete is refused (nothing removed) and the dirty-worktree message is shown.
- [ ] Start a multi-session workspace delete, then close the browser tab mid-delete; reopen the dashboard and confirm the workspace finished deleting cleanly, with no half-deleted or stuck "Deleting" rows.
- [ ] Delete a single-session workspace; confirm it still deletes normally with the chosen worktree/branch cleanup and surfaces any server message (e.g. a kept scratch path).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a dedicated multi-session live spec, because: the delete endpoint is already exercised end to end by the existing `tests/live/session-delete.spec.ts` (the delete dialog now routes through it), the client single-call path and request payload are covered by Vitest (`web/src/lib/__tests__/trashActions.test.ts`, `web/src/lib/api.coverage.test.ts`, mapped in `web/tests/coverage-matrix.json`), and the owner-last ordering is covered by Rust unit tests. Standing up two sessions on one shared worktree in the live harness for the multi-session case is non-trivial and deferred.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (including a `/debate` design consult), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and will run the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added an atomic backend endpoint for deleting all sessions in a workspace.
- Ensured sibling sessions are removed before the shared worktree owner, reducing orphaned records.
- Added safeguards for dirty worktrees and concurrent retention cleanup.
- Updated the web client to make one workspace deletion request instead of multiple session requests.
- Improved partial-failure handling, notifications, navigation, and local state updates.
- Added and updated server, client, API, and coverage tests.

## Benefits

Workspace deletion is more reliable, efficient, and resilient to partial failures while providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->