### PR TITLE
feat(session): smart-rename terminal (non-ACP) sessions from their first turn

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,25 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Hidden internal helper for terminal (non-ACP) smart rename:
+    // `aoe __smart-rename <profile> <session-id>` runs the one-shot title
+    // generator for a session and writes the title back to storage. Spawned
+    // detached by the status pollers on a session's first `Running -> Idle`
+    // edge; handled before clap so it never appears on the CLI/docs surface.
+    // Best-effort: any failure just leaves the auto-generated name in place.
+    {
+        let mut a = std::env::args();
+        let _ = a.next();
+        if a.next().as_deref() == Some("__smart-rename") {
+            let profile = a.next().unwrap_or_default();
+            let session_id = a.next().unwrap_or_default();
+            let _ =
+                agent_of_empires::session::smart_rename::run_terminal_rename(&profile, &session_id)
+                    .await;
+            return Ok(());
+        }
+    }
+
     // Parse the core clap tree first. On success (every valid core command,
     // including the app-data-free ones like completion/init/agents) this never
     // touches the plugin registry. Only an error, --help/--version, or an

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3935,6 +3935,12 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 if *old == inst.status {
                     continue;
                 }
+                // First turn's `Running -> Idle` edge: best-effort auto-name a
+                // still-default-named terminal session. Detached and
+                // self-gating, so ineligible sessions cost only the cheap gate.
+                if *old == Status::Running && inst.status == Status::Idle {
+                    crate::session::smart_rename::maybe_spawn_terminal_smart_rename(inst);
+                }
                 let _ = state.status_tx.send(StatusChange {
                     instance_id: inst.id.clone(),
                     instance_title: inst.title.clone(),

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -842,8 +842,10 @@ pub struct SessionConfig {
     )]
     pub merge_hooks_into_selected_agent: bool,
 
-    /// Auto-rename a new session from its first turn, using the session's own
-    /// agent in one-shot mode (e.g. `claude -p`). Covers both structured-view
+    /// Auto-rename a new session from its first turn, using the configured
+    /// utility agent (the `smart_rename_agent` setting, falling back to the
+    /// session's own agent) in one-shot mode (e.g. `claude -p`). Covers both
+    /// structured-view
     /// (ACP) sessions, renamed at the end of the first turn, and terminal
     /// sessions, renamed when the poller first sees the pane go idle (so it
     /// works for a native `tmux attach` too). Only applies while the session

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -842,13 +842,15 @@ pub struct SessionConfig {
     )]
     pub merge_hooks_into_selected_agent: bool,
 
-    /// Auto-rename a new structured-view (ACP) session from its first message,
-    /// using the session's own agent in one-shot mode (e.g. `claude -p`). Only
-    /// applies while the session still carries its auto-generated name; a
-    /// manually named session is never touched. Title only: the worktree
-    /// directory is not moved (the running agent holds it). Agents without a
-    /// one-shot mode, sandboxed sessions, and command-overridden agents keep
-    /// the generated name.
+    /// Auto-rename a new session from its first turn, using the session's own
+    /// agent in one-shot mode (e.g. `claude -p`). Covers both structured-view
+    /// (ACP) sessions, renamed at the end of the first turn, and terminal
+    /// sessions, renamed when the poller first sees the pane go idle (so it
+    /// works for a native `tmux attach` too). Only applies while the session
+    /// still carries its auto-generated name; a manually named session is never
+    /// touched. Title only: the worktree directory is not moved (the running
+    /// agent holds it). Agents without a one-shot mode, sandboxed sessions, and
+    /// command-overridden agents keep the generated name.
     #[serde(default = "default_true")]
     #[setting(label = "Smart Session Rename", widget = "toggle", category = "Agents")]
     pub smart_rename: bool,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -489,6 +489,15 @@ pub struct Instance {
     /// `None` on legacy records and freshly created sessions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_auto_title: Option<String>,
+    /// Set once a terminal (non-ACP) smart-rename one-shot has produced output
+    /// for this session, so the poller-driven trigger never respawns a title
+    /// generator on every later turn. Set only after the one-shot returns
+    /// stdout (usable or sanitizer-rejected), never on a transient spawn/timeout
+    /// failure, so a slow first turn can still be renamed by a later turn. ACP
+    /// sessions use the in-memory `AppState` attempted set instead and never
+    /// touch this.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub smart_rename_attempted: bool,
     pub project_path: String,
     #[serde(default)]
     pub group_path: String,
@@ -1233,6 +1242,7 @@ impl Instance {
             id: generate_id(),
             title: title.to_string(),
             last_auto_title: None,
+            smart_rename_attempted: false,
             project_path: project_path.to_string(),
             group_path: String::new(),
             parent_session_id: None,

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -20,8 +20,7 @@ use crate::session::civilizations::is_default_civ_name;
 use crate::session::config::SessionConfig;
 use serde::Serialize;
 use std::collections::HashMap;
-#[cfg(feature = "serve")]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Cap on concurrent smart-rename one-shots across the process. Two slots keep
 /// steady-state throughput on multi-core hosts without letting N stuck
@@ -373,8 +372,406 @@ pub(crate) fn truncate_bytes(s: &str, max: usize) -> &str {
     &s[..end]
 }
 
-#[cfg(feature = "serve")]
-pub(crate) use serve::run_oneshot;
+// Since #2348 the ACP one-shot is deferred to the first `prompt_complete`
+// `Event::Stopped`, so it no longer races the live worker for the same
+// provider API. The terminal path (below) fires only after the poller sees the
+// pane go idle, so it likewise runs post-turn. Standalone the call finishes
+// well under 12s; 60s is a conservative ceiling that leaves headroom for cold
+// agent starts. The child is killed on drop, so a timed-out call leaves no
+// orphan.
+pub(crate) const ONESHOT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Run the agent one-shot in the session's working directory, capturing
+/// stdout. Returns `None` on spawn error, non-zero exit, or timeout. The
+/// child is killed on drop, so a timed-out call leaves no orphan. Shared with
+/// the serve ACP path, the terminal `__smart-rename` runner, and
+/// `session::conversation_summary` (which passes a longer `timeout` for its
+/// larger transcript input).
+pub(crate) async fn run_oneshot(
+    session_id: &str,
+    argv: &[String],
+    cwd: &str,
+    timeout: std::time::Duration,
+) -> Option<String> {
+    use tokio::process::Command;
+    let mut cmd = Command::new(&argv[0]);
+    cmd.args(&argv[1..])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        // Capture stderr so a non-zero exit logs WHY (e.g. codex's
+        // "Not inside a trusted directory"); without it the failure is an
+        // opaque exit code.
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    if !cwd.is_empty() {
+        cmd.current_dir(cwd);
+    }
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(target: "smart_rename", session = %session_id, "one-shot spawn failed: {e}");
+            return None;
+        }
+    };
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(out)) if out.status.success() => {
+            Some(String::from_utf8_lossy(&out.stdout).into_owned())
+        }
+        Ok(Ok(out)) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let tail: String = stderr
+                .trim()
+                .chars()
+                .rev()
+                .take(300)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            tracing::debug!(target: "smart_rename", session = %session_id, code = ?out.status.code(), stderr = %tail, "one-shot exited non-zero");
+            None
+        }
+        Ok(Err(e)) => {
+            tracing::debug!(target: "smart_rename", session = %session_id, "one-shot io error: {e}");
+            None
+        }
+        Err(_) => {
+            tracing::debug!(target: "smart_rename", session = %session_id, "one-shot timed out");
+            None
+        }
+    }
+}
+
+/// Whether an automatic renamer may overwrite this session's title: either it
+/// is still a default civ name (never explicitly set), or it still matches the
+/// last title an auto renamer wrote. A manual rename leaves `title` diverged
+/// from `last_auto_title`, which freezes it against auto writes.
+pub(crate) fn title_is_auto_overwritable(inst: &crate::session::instance::Instance) -> bool {
+    is_default_civ_name(&inst.title) || inst.last_auto_title.as_deref() == Some(inst.title.as_str())
+}
+
+// ---------------------------------------------------------------------------
+// Terminal (non-ACP) smart rename.
+//
+// ACP sessions rename from a typed turn-boundary event inside the daemon.
+// Terminal sessions have no such event and no clean first-message chokepoint
+// (native `tmux attach` types straight into the pane, invisible to AoE at
+// input time). Instead the status poller (both the TUI's and the daemon's)
+// fires `maybe_spawn_terminal_smart_rename` on the `Running -> Idle` edge of a
+// still-default-named session: that single edge covers every input path
+// (native attach, web live-view, `aoe send`) and fires only once the pane
+// agent is idle, so the one-shot never races it for the provider API. The work
+// runs in a detached `aoe __smart-rename` child so it never blocks the poller
+// and is identical in the TUI-only and serve builds. Cross-process guards (a
+// per-session advisory lock, MAX_CONCURRENT global slot locks, and the
+// persisted `Instance.smart_rename_attempted` marker) coordinate the TUI, the
+// daemon, and sibling children, which are all separate processes.
+// ---------------------------------------------------------------------------
+
+/// Head/tail byte budgets for the captured first-turn transcript handed to the
+/// one-shot. The user's opening intent sits near the top and the agent's
+/// result near the bottom, so a middle-elided head+tail keeps both while
+/// staying well under `MAX_PROMPT_BYTES`.
+const CONTEXT_HEAD_BYTES: usize = 3072;
+const CONTEXT_TAIL_BYTES: usize = 1024;
+
+/// Cheap poll-hot-path gate: fire a detached terminal rename for this session
+/// iff it is a still-default-named, non-structured, not-yet-attempted session
+/// whose resolved config has smart rename on. The full eligibility check
+/// (sandbox, one-shot support, command override) runs in the detached child,
+/// which re-reads storage so it can never act on the stale snapshot the poller
+/// held. Called from both status pollers on the `Running -> Idle` edge.
+pub fn maybe_spawn_terminal_smart_rename(inst: &crate::session::instance::Instance) {
+    if inst.is_structured() || inst.smart_rename_attempted || !is_default_civ_name(&inst.title) {
+        return;
+    }
+    // Resolve config and run the FULL eligibility check on the (rare)
+    // turn-completion edge, never per tick. Doing the whole check here (not just
+    // the setting) matters: an ineligible session (disabled, sandboxed, no
+    // one-shot, overridden command) never marks itself attempted, so a cheaper
+    // gate would re-fork a child on every later turn. The child re-checks
+    // against fresh storage anyway, so this is a fork-avoidance filter, not the
+    // authority.
+    let resolved = crate::session::repo_config::resolve_config_with_repo_or_warn(
+        &inst.source_profile,
+        Path::new(&inst.project_path),
+    );
+    let cfg = resolve_smart_rename_config(&resolved.session);
+    if check_eligible_resolved(
+        true,
+        cfg.setting_on,
+        &inst.title,
+        &inst.tool,
+        cfg.rename_agent,
+        inst.is_sandboxed(),
+        &inst.command,
+        cfg.overrides,
+    )
+    .is_err()
+    {
+        return;
+    }
+    spawn_detached(&inst.source_profile, &inst.id);
+}
+
+/// Re-exec `aoe __smart-rename <profile> <id>` as a detached child (setsid,
+/// null stdio, dropped handle), mirroring the `__acp-runner` launcher. Never
+/// blocks and never fails the caller.
+fn spawn_detached(profile: &str, session_id: &str) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("__smart-rename").arg(profile).arg(session_id);
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: setsid is async-signal-safe and the closure touches no other
+        // state; matches the __acp-runner detach.
+        unsafe {
+            cmd.pre_exec(|| {
+                nix::unistd::setsid().map_err(std::io::Error::other)?;
+                Ok(())
+            });
+        }
+    }
+    if let Err(e) = cmd.spawn() {
+        tracing::debug!(target: "smart_rename", session = %session_id, "terminal rename spawn failed: {e}");
+    }
+    // Child handle dropped: std::process::Command does not wait on drop, so the
+    // detached child outlives us.
+}
+
+/// Directory holding the advisory lock files, under the app data dir so the
+/// path is identical across the TUI, the daemon, and detached children in the
+/// same build namespace.
+fn lock_dir() -> Option<PathBuf> {
+    let dir = crate::session::get_app_dir().ok()?.join("smart-rename");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
+/// Try to take an exclusive advisory (`flock`) lock on `path`, returning the
+/// held file on success. Dropping the returned file releases the lock, so a
+/// crash also releases it (unlike a `create_new` sentinel).
+fn try_lock(path: &Path) -> Option<std::fs::File> {
+    use fs2::FileExt;
+    let f = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .ok()?;
+    f.try_lock_exclusive().ok().map(|()| f)
+}
+
+/// Non-blocking per-session lock: prevents the TUI and daemon (and repeated
+/// poll ticks) from running concurrent one-shots for one session.
+fn try_session_lock(id: &str) -> Option<std::fs::File> {
+    try_lock(&lock_dir()?.join(format!("{id}.lock")))
+}
+
+/// Non-blocking global slot lock preserving `MAX_CONCURRENT` across processes,
+/// so a burst of sessions going idle at once (e.g. a batch launch) cannot fan
+/// out into one host agent process per session.
+fn try_global_slot() -> Option<std::fs::File> {
+    let dir = lock_dir()?;
+    (0..MAX_CONCURRENT).find_map(|n| try_lock(&dir.join(format!("slot-{n}.lock"))))
+}
+
+/// Capture the pane's full first-turn transcript and reduce it to a bounded,
+/// middle-elided head+tail block, or `None` when the capture is empty or looks
+/// like garbage (so the caller keeps the civ name without paying for a
+/// one-shot).
+fn capture_terminal_context(tmux: &crate::tmux::Session) -> Option<String> {
+    let raw = tmux.capture_pane_full().ok()?;
+    let cleaned = strip_ansi(&raw);
+    let trimmed = cleaned.trim();
+    if !context_looks_usable(trimmed) {
+        return None;
+    }
+    Some(head_tail(trimmed, CONTEXT_HEAD_BYTES, CONTEXT_TAIL_BYTES))
+}
+
+/// Reject a pane capture that is empty, has no letters, or is dominated by
+/// control characters (a garbled/binary pane). Syntactic only: a semantically
+/// useless capture can still pass here and is caught later by `sanitize_title`.
+fn context_looks_usable(s: &str) -> bool {
+    if s.is_empty() || !s.chars().any(|c| c.is_alphabetic()) {
+        return false;
+    }
+    let control = s
+        .chars()
+        .filter(|c| c.is_control() && *c != '\n' && *c != '\t')
+        .count();
+    let total = s.chars().count().max(1);
+    control * 100 / total < 30
+}
+
+/// Bounded head + `...` + tail on char boundaries. Whole string if it already
+/// fits.
+fn head_tail(s: &str, head: usize, tail: usize) -> String {
+    if s.len() <= head + tail {
+        return s.to_string();
+    }
+    let h = truncate_bytes(s, head);
+    let mut start = s.len().saturating_sub(tail);
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("{h}\n...\n{}", &s[start..])
+}
+
+/// First non-empty line of the transcript, the best proxy for the user's
+/// opening message, used only as the echo baseline so `sanitize_title` rejects
+/// a title that merely parrots the prompt.
+fn extract_echo_baseline(context: &str) -> String {
+    context
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Persist the outcome of a terminal one-shot. Always marks the session
+/// attempted (the one-shot returned output, usable or not, so we must not
+/// respawn on every later turn), and writes the new title only while the
+/// current title is still auto-overwritable, so a manual rename that landed
+/// during the one-shot always wins.
+fn apply_terminal_title(
+    storage: &crate::session::storage::Storage,
+    id: &str,
+    new_title: Option<&str>,
+) -> anyhow::Result<()> {
+    let id = id.to_string();
+    let new_title = new_title.map(str::to_string);
+    storage.update(|instances, _groups| {
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+            inst.smart_rename_attempted = true;
+            if let Some(t) = &new_title {
+                if title_is_auto_overwritable(inst) {
+                    tracing::info!(target: "smart_rename", session = %id, old = %inst.title, new = %t, "auto-renamed terminal session");
+                    inst.title = t.clone();
+                    inst.last_auto_title = Some(t.clone());
+                }
+            }
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+/// Body of the detached `aoe __smart-rename <profile> <id>` child. Best-effort
+/// and fire-and-forget: every early return leaves the civ name in place. All
+/// gates are re-checked against freshly loaded storage so a rename that landed
+/// (or a deletion, or a config change) since the poller observed the edge
+/// always wins.
+pub async fn run_terminal_rename(profile: &str, session_id: &str) -> anyhow::Result<()> {
+    // Per-session lock first: if another process is already handling this
+    // session, exit immediately (do not queue).
+    let Some(_session_lock) = try_session_lock(session_id) else {
+        return Ok(());
+    };
+
+    let storage = crate::session::storage::Storage::open_unwatched(profile)?;
+    let (instances, _groups) = storage.load_with_groups()?;
+    let Some((title, tool, command, project_path, sandboxed, detect_as, already, structured)) =
+        instances.iter().find(|i| i.id == session_id).map(|i| {
+            (
+                i.title.clone(),
+                i.tool.clone(),
+                i.command.clone(),
+                i.project_path.clone(),
+                i.is_sandboxed(),
+                i.detect_as.clone(),
+                i.smart_rename_attempted,
+                i.is_structured(),
+            )
+        })
+    else {
+        return Ok(());
+    };
+    drop(instances);
+    // Durable double-check: storage may have propagated a completed attempt (or
+    // a manual rename) since the poller observed the edge.
+    if already || structured {
+        return Ok(());
+    }
+
+    let resolved = crate::session::repo_config::resolve_config_with_repo_or_warn(
+        profile,
+        Path::new(&project_path),
+    );
+    let cfg = resolve_smart_rename_config(&resolved.session);
+    let agent = match check_eligible_resolved(
+        // Terminal owned turns are an eligible session kind; the `structured`
+        // gate exists only so the daemon's generic ACP listener skips
+        // non-structured sessions, which does not apply to this deliberate
+        // terminal trigger.
+        true,
+        cfg.setting_on,
+        &title,
+        &tool,
+        cfg.rename_agent,
+        sandboxed,
+        &command,
+        cfg.overrides,
+    ) {
+        Ok(agent) => agent,
+        Err(reason) => {
+            tracing::debug!(target: "smart_rename", session = %session_id, reason = reason.as_str(), "terminal skip");
+            return Ok(());
+        }
+    };
+
+    let tmux = crate::tmux::Session::new(session_id, &title)?;
+    let detect_tool = if detect_as.is_empty() {
+        tool.as_str()
+    } else {
+        detect_as.as_str()
+    };
+
+    // Best-effort no-race: the poller fired on Running -> Idle, but the user may
+    // have started another turn since. Only proceed while the pane still reads
+    // idle; a later idle edge retries.
+    if let Ok(content) = tmux.capture_pane(50) {
+        if crate::tmux::detect_status_from_content(&content, detect_tool)
+            == crate::session::Status::Running
+        {
+            return Ok(());
+        }
+    }
+
+    let Some(context) = capture_terminal_context(&tmux) else {
+        tracing::debug!(target: "smart_rename", session = %session_id, "terminal skip: unusable pane capture");
+        return Ok(());
+    };
+
+    // Global concurrency slot, taken only once real work is imminent so
+    // early-return paths never hold one.
+    let Some(_slot) = try_global_slot() else {
+        return Ok(());
+    };
+
+    let baseline = extract_echo_baseline(&context);
+    let prompt = build_prompt(&context);
+    let Some(argv) = build_oneshot_argv(agent, &prompt) else {
+        return Ok(());
+    };
+    let Some(raw) = run_oneshot(session_id, &argv, &project_path, ONESHOT_TIMEOUT).await else {
+        // Transient failure (spawn / timeout / non-zero exit): leave the session
+        // un-attempted so a later turn can retry.
+        return Ok(());
+    };
+    let new_title = sanitize_title(&raw, &baseline);
+    apply_terminal_title(&storage, session_id, new_title.as_deref())?;
+    Ok(())
+}
+
 #[cfg(feature = "serve")]
 pub use serve::{should_trigger_smart_rename, try_smart_rename};
 
@@ -384,15 +781,6 @@ mod serve {
     use crate::server::AppState;
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
-    use std::time::Duration;
-
-    // Since #2348 the one-shot is deferred to the first `prompt_complete`
-    // `Event::Stopped`, so it no longer races the live worker for the same
-    // provider API. Standalone the call finishes well under 12s; 60s is a
-    // conservative ceiling that leaves headroom for cold agent starts without
-    // holding a global-semaphore slot as long as #2347's 120s band-aid did.
-    // The child is killed on drop, so a timed-out call leaves no orphan.
-    const ONESHOT_TIMEOUT: Duration = Duration::from_secs(60);
 
     /// Should this ACP broadcast event trigger a smart-rename one-shot for its
     /// session? Cheap sync predicate: reason-allowlists `prompt_complete` (all
@@ -572,66 +960,6 @@ mod serve {
         apply_auto_title(&state, &session_id, &profile, &new_title).await;
     }
 
-    /// Run the agent one-shot in the session's working directory, capturing
-    /// stdout. Returns `None` on spawn error, non-zero exit, or timeout. The
-    /// child is killed on drop, so a timed-out call leaves no orphan. Shared
-    /// with `session::conversation_summary`, which passes a longer `timeout`
-    /// for its larger transcript input.
-    pub(crate) async fn run_oneshot(
-        session_id: &str,
-        argv: &[String],
-        cwd: &str,
-        timeout: Duration,
-    ) -> Option<String> {
-        use tokio::process::Command;
-        let mut cmd = Command::new(&argv[0]);
-        cmd.args(&argv[1..])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            // Capture stderr so a non-zero exit logs WHY (e.g. codex's
-            // "Not inside a trusted directory"); without it the failure is an
-            // opaque exit code.
-            .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true);
-        if !cwd.is_empty() {
-            cmd.current_dir(cwd);
-        }
-        let child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!(target: "smart_rename", session = %session_id, "one-shot spawn failed: {e}");
-                return None;
-            }
-        };
-        match tokio::time::timeout(timeout, child.wait_with_output()).await {
-            Ok(Ok(out)) if out.status.success() => {
-                Some(String::from_utf8_lossy(&out.stdout).into_owned())
-            }
-            Ok(Ok(out)) => {
-                let stderr = String::from_utf8_lossy(&out.stderr);
-                let tail: String = stderr
-                    .trim()
-                    .chars()
-                    .rev()
-                    .take(300)
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .rev()
-                    .collect();
-                tracing::debug!(target: "smart_rename", session = %session_id, code = ?out.status.code(), stderr = %tail, "one-shot exited non-zero");
-                None
-            }
-            Ok(Err(e)) => {
-                tracing::debug!(target: "smart_rename", session = %session_id, "one-shot io error: {e}");
-                None
-            }
-            Err(_) => {
-                tracing::debug!(target: "smart_rename", session = %session_id, "one-shot timed out");
-                None
-            }
-        }
-    }
-
     /// Apply an automatically-generated title to a session, persisting to
     /// storage and mirroring the in-memory instance list so connected clients
     /// see it without a reload. The write happens only while the current title
@@ -696,19 +1024,10 @@ mod serve {
         }
     }
 
-    /// Whether an automatic renamer may overwrite this session's title: either
-    /// it is still a default civ name (never explicitly set), or it still
-    /// matches the last title an auto renamer wrote. A manual rename leaves
-    /// `title` diverged from `last_auto_title`, which freezes it against auto
-    /// writes.
-    pub(crate) fn title_is_auto_overwritable(inst: &crate::session::instance::Instance) -> bool {
-        is_default_civ_name(&inst.title)
-            || inst.last_auto_title.as_deref() == Some(inst.title.as_str())
-    }
-
     #[cfg(test)]
     mod tests {
         use super::*;
+        use std::time::Duration;
 
         #[tokio::test]
         async fn run_oneshot_returns_none_on_spawn_failure() {
@@ -1259,5 +1578,124 @@ claude = "my-wrapper"
         )
         .expect("eligible");
         assert_eq!(agent.binary, "opencode");
+    }
+
+    // ---- Terminal (non-ACP) smart rename ----
+
+    #[test]
+    fn terminal_eligibility_reasons() {
+        // A terminal session is not "structured", but the terminal trigger is a
+        // deliberate opt-in, so the call site passes `true`; the remaining gates
+        // (user story 3) still keep the civ name where they must.
+        let overrides = HashMap::new();
+        assert!(check_eligible_resolved(
+            true, true, "Vikings", "claude", "", false, "", &overrides
+        )
+        .is_ok());
+        assert!(matches!(
+            check_eligible_resolved(true, true, "Vikings", "claude", "", true, "", &overrides),
+            Err(SkipReason::Sandboxed)
+        ));
+        assert!(matches!(
+            check_eligible_resolved(true, true, "Vikings", "cursor", "", false, "", &overrides),
+            Err(SkipReason::NoOneshot)
+        ));
+        let mut ov = HashMap::new();
+        ov.insert("claude".to_string(), "my-wrapper".to_string());
+        assert!(matches!(
+            check_eligible_resolved(true, true, "Vikings", "claude", "", false, "", &ov),
+            Err(SkipReason::CommandOverridden)
+        ));
+        // A manually-named session (user story 2) is never a candidate.
+        assert!(matches!(
+            check_eligible_resolved(
+                true,
+                true,
+                "Fix login bug",
+                "claude",
+                "",
+                false,
+                "",
+                &overrides
+            ),
+            Err(SkipReason::NameNotDefault)
+        ));
+    }
+
+    #[test]
+    fn context_usable_rejects_garbage() {
+        assert!(context_looks_usable("Fix the login bug in auth.rs"));
+        assert!(!context_looks_usable(""));
+        // No letters.
+        assert!(!context_looks_usable("12345 6789 %%%"));
+        // Control-char dominated (garbled/binary pane): keep the civ name.
+        let garbled: String = std::iter::repeat_n('\u{7}', 50)
+            .chain("ab".chars())
+            .collect();
+        assert!(!context_looks_usable(&garbled));
+    }
+
+    #[test]
+    fn head_tail_keeps_both_ends() {
+        let short = "just a short line";
+        assert_eq!(head_tail(short, 3072, 1024), short);
+        let long = format!("HEAD{}TAIL", "x".repeat(5000));
+        let r = head_tail(&long, 10, 10);
+        assert!(r.starts_with("HEAD"));
+        assert!(r.ends_with("TAIL"));
+        assert!(r.contains("\n...\n"));
+        assert!(r.len() < long.len());
+    }
+
+    #[test]
+    fn echo_baseline_is_first_nonempty_line() {
+        assert_eq!(
+            extract_echo_baseline("\n\n  fix the bug  \nmore"),
+            "fix the bug"
+        );
+        assert_eq!(extract_echo_baseline(""), "");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_terminal_title_marks_attempted_and_respects_manual_rename() {
+        use crate::session::instance::Instance;
+        use crate::session::storage::Storage;
+        let home = tempfile::tempdir().expect("tempdir HOME");
+        // SAFETY: serialized by `#[serial]`; matches the sibling config test.
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::set_var("XDG_CONFIG_HOME", home.path().join(".config"));
+        }
+        let storage = Storage::new_unwatched("default").expect("storage");
+
+        // Story 1: a still-civ-named session gets renamed and marked attempted.
+        let civ = Instance::new("Vikings", "/tmp/x");
+        let civ_id = civ.id.clone();
+        // Story 2: a manually-named session must never be overwritten.
+        let mut manual = Instance::new("Britons", "/tmp/y");
+        manual.title = "Hand-picked".to_string();
+        let manual_id = manual.id.clone();
+        storage
+            .update(|instances, _groups| {
+                instances.push(civ);
+                instances.push(manual);
+                Ok(())
+            })
+            .unwrap();
+
+        apply_terminal_title(&storage, &civ_id, Some("Fix login bug")).unwrap();
+        apply_terminal_title(&storage, &manual_id, Some("Should Not Apply")).unwrap();
+
+        let (instances, _) = storage.load_with_groups().unwrap();
+        let civ = instances.iter().find(|i| i.id == civ_id).unwrap();
+        assert_eq!(civ.title, "Fix login bug");
+        assert_eq!(civ.last_auto_title.as_deref(), Some("Fix login bug"));
+        assert!(civ.smart_rename_attempted);
+
+        let manual = instances.iter().find(|i| i.id == manual_id).unwrap();
+        assert_eq!(manual.title, "Hand-picked");
+        // Still marked attempted so the poller does not respawn on every turn.
+        assert!(manual.smart_rename_attempted);
     }
 }

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -538,11 +538,21 @@ fn spawn_detached(profile: &str, session_id: &str) {
             });
         }
     }
-    if let Err(e) = cmd.spawn() {
-        tracing::debug!(target: "smart_rename", session = %session_id, "terminal rename spawn failed: {e}");
+    match cmd.spawn() {
+        // The child is setsid-detached and does its own work; we only need to
+        // reap it so it does not linger as a zombie in the long-lived poller
+        // process (unlike __acp-runner, this child exits quickly). A short
+        // dedicated thread waits for it, then ends.
+        Ok(child) => {
+            std::thread::spawn(move || {
+                let mut child = child;
+                let _ = child.wait();
+            });
+        }
+        Err(e) => {
+            tracing::debug!(target: "smart_rename", session = %session_id, "terminal rename spawn failed: {e}");
+        }
     }
-    // Child handle dropped: std::process::Command does not wait on drop, so the
-    // detached child outlives us.
 }
 
 /// Directory holding the advisory lock files, under the app data dir so the
@@ -653,7 +663,14 @@ fn apply_terminal_title(
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
             inst.smart_rename_attempted = true;
             if let Some(t) = &new_title {
-                if title_is_auto_overwritable(inst) {
+                if title_is_auto_overwritable(inst) && &inst.title != t {
+                    // The tmux session name embeds the title
+                    // (Session::generate_name), and both status pollers derive
+                    // the name from the current title. Rekey the live session
+                    // to match, else attach/stop/poll would target a name the
+                    // running pane no longer has. Best-effort, mirroring the
+                    // manual TUI rename (src/tui/home/operations.rs).
+                    rekey_tmux_session(&id, &inst.title, t);
                     tracing::info!(target: "smart_rename", session = %id, old = %inst.title, new = %t, "auto-renamed terminal session");
                     inst.title = t.clone();
                     inst.last_auto_title = Some(t.clone());
@@ -663,6 +680,26 @@ fn apply_terminal_title(
         Ok(())
     })?;
     Ok(())
+}
+
+/// Rename the live tmux session from its old title-derived name to the new one,
+/// keeping the pane reachable after the stored title changes. Best-effort: a
+/// missing session or a failed rename is logged, not fatal (matches the manual
+/// rename path).
+fn rekey_tmux_session(id: &str, old_title: &str, new_title: &str) {
+    let Ok(session) = crate::tmux::Session::new(id, old_title) else {
+        return;
+    };
+    if !session.exists() {
+        return;
+    }
+    let new_name = crate::tmux::Session::generate_name(id, new_title);
+    match session.rename(&new_name) {
+        Ok(()) => crate::tmux::refresh_session_cache(),
+        Err(e) => {
+            tracing::warn!(target: "smart_rename", session = %id, "tmux rename failed: {e}")
+        }
+    }
 }
 
 /// Body of the detached `aoe __smart-rename <profile> <id>` child. Best-effort

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -479,9 +479,10 @@ impl Session {
 
     /// Capture the pane's full scrollback (from session start) with wrapped
     /// lines joined (`-J`) and no escape sequences (`-e` omitted), for
-    /// summarizing the first turn in smart-rename. Unlike [`capture_pane`],
-    /// which caps at the last N lines, this uses `-S -` so a first prompt that
-    /// has scrolled up is still included.
+    /// summarizing the first turn in smart-rename. Unlike
+    /// [`capture_pane`](Self::capture_pane), which caps at the last N lines,
+    /// this uses `-S -` so a first prompt that has scrolled up is still
+    /// included.
     pub fn capture_pane_full(&self) -> Result<String> {
         if !self.exists() {
             return Ok(String::new());

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -477,6 +477,26 @@ impl Session {
         }
     }
 
+    /// Capture the pane's full scrollback (from session start) with wrapped
+    /// lines joined (`-J`) and no escape sequences (`-e` omitted), for
+    /// summarizing the first turn in smart-rename. Unlike [`capture_pane`],
+    /// which caps at the last N lines, this uses `-S -` so a first prompt that
+    /// has scrolled up is still included.
+    pub fn capture_pane_full(&self) -> Result<String> {
+        if !self.exists() {
+            return Ok(String::new());
+        }
+        let target = format!("{}:^.0", self.name);
+        let output = crate::tmux::tmux_command()
+            .args(["capture-pane", "-t", &target, "-p", "-J", "-S", "-"])
+            .output()?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Ok(String::new())
+        }
+    }
+
     /// Capture the pane like [`capture_pane`](Self::capture_pane), but in the
     /// same `tmux` fork also query the cursor position + visibility, so the
     /// live-send preview can paint a real cursor without paying a second fork

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -216,7 +216,14 @@ pub(super) fn poll_statuses_once(
             let metadata = pane_metadata.get(&session_name);
             let pane_dead = metadata.map(|m| m.pane_dead).unwrap_or(false);
 
+            let prev_status = inst.status;
             inst.update_status_with_metadata(metadata);
+            // On the first turn's `Running -> Idle` edge, best-effort auto-name a
+            // still-default-named terminal session from its first turn. Detached
+            // and self-gating, so this is cheap for the common (ineligible) case.
+            if prev_status == Status::Running && inst.status == Status::Idle {
+                crate::session::smart_rename::maybe_spawn_terminal_smart_rename(&inst);
+            }
 
             Some(StatusUpdate {
                 id: inst.id,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -25,6 +25,8 @@ mod session_id_acquisition;
 mod session_lifecycle;
 mod status_detection;
 mod storage_concurrency;
+#[cfg(feature = "serve")]
+mod terminal_smart_rename;
 mod tmux_reachability;
 mod tui_attach_detach;
 mod update_command;

--- a/tests/integration/terminal_smart_rename.rs
+++ b/tests/integration/terminal_smart_rename.rs
@@ -1,0 +1,163 @@
+//! End-to-end coverage for terminal (non-ACP) smart rename (issue #2222).
+//!
+//! Exercises the detached `run_terminal_rename` runner against a real tmux pane
+//! and a fake `claude` one-shot shim: a still-civ-named session is renamed from
+//! its first turn (user story 1), and a manually-named session is never touched
+//! (user story 2). Runs under `serve` only because that is where the async test
+//! harness (`#[tokio::test]`) is wired; the code under test is not serve-gated.
+
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt as _;
+use std::process::Command;
+
+use agent_of_empires::session::smart_rename;
+use agent_of_empires::session::{Instance, Storage};
+use agent_of_empires::tmux;
+use serial_test::serial;
+use tempfile::TempDir;
+
+use crate::common::{setup_temp_home, tmux_socket};
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+struct TmuxCleanup(String);
+
+impl Drop for TmuxCleanup {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .arg("-S")
+            .arg(tmux_socket())
+            .args(["kill-session", "-t", &self.0])
+            .output();
+    }
+}
+
+/// Write a fake `claude` onto a temp dir at the front of `PATH` so the one-shot
+/// (`claude -p <prompt>`) resolves to it and prints a deterministic title. The
+/// returned guard keeps the dir alive for the test.
+fn install_fake_claude(title: &str) -> TempDir {
+    let bin = TempDir::new().unwrap();
+    let shim = bin.path().join("claude");
+    let mut f = std::fs::File::create(&shim).unwrap();
+    // Ignore args; emit the title and exit 0.
+    writeln!(f, "#!/bin/sh\necho '{title}'").unwrap();
+    let mut perm = std::fs::metadata(&shim).unwrap().permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&shim, perm).unwrap();
+    let path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", format!("{}:{}", bin.path().display(), path));
+    bin
+}
+
+/// Seed one claude session into the (temp-home) default profile and return it.
+fn seed_instance(title: &str) -> Instance {
+    let storage = Storage::new_unwatched("default").expect("storage");
+    let mut inst = Instance::new(title, "/tmp");
+    inst.tool = "claude".to_string();
+    let seeded = inst.clone();
+    storage
+        .update(|instances, _| {
+            instances.push(inst);
+            Ok(())
+        })
+        .unwrap();
+    seeded
+}
+
+/// Create a real tmux pane and type a line into it (no Enter, so it is not run
+/// as a shell command) so the capture has first-turn text.
+fn create_pane(name: &str, typed: &str) {
+    let status = Command::new("tmux")
+        .arg("-S")
+        .arg(tmux_socket())
+        .args(["new-session", "-d", "-s", name])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success(), "tmux new-session failed for {name}");
+    let _ = Command::new("tmux")
+        .arg("-S")
+        .arg(tmux_socket())
+        .args(["send-keys", "-t", name, "-l", typed])
+        .output();
+    tmux::refresh_session_cache();
+}
+
+fn reload_title(id: &str) -> (String, bool) {
+    let (instances, _) = Storage::new_unwatched("default")
+        .unwrap()
+        .load_with_groups()
+        .unwrap();
+    let inst = instances.iter().find(|i| i.id == id).unwrap();
+    (inst.title.clone(), inst.smart_rename_attempted)
+}
+
+#[tokio::test]
+#[serial]
+async fn renames_civ_named_terminal_session_from_first_turn() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let _home = setup_temp_home();
+    let _bin = install_fake_claude("Fix login redirect");
+
+    let inst = seed_instance("Vikings"); // civ default name
+    let name = tmux::Session::generate_name(&inst.id, &inst.title);
+    create_pane(&name, "implement the login redirect fix please");
+    let _cleanup = TmuxCleanup(name);
+
+    smart_rename::run_terminal_rename("default", &inst.id)
+        .await
+        .expect("run_terminal_rename");
+
+    let (title, attempted) = reload_title(&inst.id);
+    assert_eq!(title, "Fix login redirect");
+    assert!(
+        attempted,
+        "a produced title must mark the session attempted"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn never_overwrites_a_manual_title() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not on PATH");
+        return;
+    }
+    let _home = setup_temp_home();
+    let _bin = install_fake_claude("Should Not Apply");
+
+    let inst = seed_instance("Zulu");
+    let id = inst.id.clone();
+    // Manually rename: diverges title from last_auto_title, freezing it.
+    Storage::new_unwatched("default")
+        .unwrap()
+        .update(|instances, _| {
+            if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+                i.title = "Hand picked".to_string();
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    let name = tmux::Session::generate_name(&id, "Hand picked");
+    create_pane(&name, "do something else entirely");
+    let _cleanup = TmuxCleanup(name);
+
+    smart_rename::run_terminal_rename("default", &id)
+        .await
+        .expect("run_terminal_rename");
+
+    let (title, _) = reload_title(&id);
+    assert_eq!(
+        title, "Hand picked",
+        "a manual title must never be overwritten"
+    );
+}

--- a/tests/integration/terminal_smart_rename.rs
+++ b/tests/integration/terminal_smart_rename.rs
@@ -26,22 +26,43 @@ fn tmux_available() -> bool {
         .unwrap_or(false)
 }
 
-struct TmuxCleanup(String);
+/// Kills every named session on drop. A successful rename leaves the live
+/// session under the NEW title-derived name, so tests register both the
+/// pre- and post-rename names.
+struct TmuxCleanup(Vec<String>);
 
 impl Drop for TmuxCleanup {
     fn drop(&mut self) {
-        let _ = Command::new("tmux")
-            .arg("-S")
-            .arg(tmux_socket())
-            .args(["kill-session", "-t", &self.0])
-            .output();
+        for name in &self.0 {
+            let _ = Command::new("tmux")
+                .arg("-S")
+                .arg(tmux_socket())
+                .args(["kill-session", "-t", name])
+                .output();
+        }
+    }
+}
+
+/// RAII guard for the fake-agent install: keeps the temp bin dir alive and
+/// restores the original `PATH` on drop, so a later `#[serial]` test never sees
+/// a `PATH` entry pointing at a deleted directory.
+struct FakeAgent {
+    _dir: TempDir,
+    orig_path: Option<std::ffi::OsString>,
+}
+
+impl Drop for FakeAgent {
+    fn drop(&mut self) {
+        match &self.orig_path {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
     }
 }
 
 /// Write a fake `claude` onto a temp dir at the front of `PATH` so the one-shot
-/// (`claude -p <prompt>`) resolves to it and prints a deterministic title. The
-/// returned guard keeps the dir alive for the test.
-fn install_fake_claude(title: &str) -> TempDir {
+/// (`claude -p <prompt>`) resolves to it and prints a deterministic title.
+fn install_fake_claude(title: &str) -> FakeAgent {
     let bin = TempDir::new().unwrap();
     let shim = bin.path().join("claude");
     let mut f = std::fs::File::create(&shim).unwrap();
@@ -50,9 +71,16 @@ fn install_fake_claude(title: &str) -> TempDir {
     let mut perm = std::fs::metadata(&shim).unwrap().permissions();
     perm.set_mode(0o755);
     std::fs::set_permissions(&shim, perm).unwrap();
-    let path = std::env::var("PATH").unwrap_or_default();
-    std::env::set_var("PATH", format!("{}:{}", bin.path().display(), path));
-    bin
+    let orig_path = std::env::var_os("PATH");
+    let joined = match &orig_path {
+        Some(p) => format!("{}:{}", bin.path().display(), p.to_string_lossy()),
+        None => bin.path().display().to_string(),
+    };
+    std::env::set_var("PATH", joined);
+    FakeAgent {
+        _dir: bin,
+        orig_path,
+    }
 }
 
 /// Seed one claude session into the (temp-home) default profile and return it.
@@ -110,7 +138,9 @@ async fn renames_civ_named_terminal_session_from_first_turn() {
     let inst = seed_instance("Vikings"); // civ default name
     let name = tmux::Session::generate_name(&inst.id, &inst.title);
     create_pane(&name, "implement the login redirect fix please");
-    let _cleanup = TmuxCleanup(name);
+    // The rename rekeys the live session, so also clean up the post-rename name.
+    let renamed = tmux::Session::generate_name(&inst.id, "Fix login redirect");
+    let _cleanup = TmuxCleanup(vec![name, renamed]);
 
     smart_rename::run_terminal_rename("default", &inst.id)
         .await
@@ -149,7 +179,8 @@ async fn never_overwrites_a_manual_title() {
 
     let name = tmux::Session::generate_name(&id, "Hand picked");
     create_pane(&name, "do something else entirely");
-    let _cleanup = TmuxCleanup(name);
+    // A manual title is not eligible, so no rename/rekey happens here.
+    let _cleanup = TmuxCleanup(vec![name]);
 
     smart_rename::run_terminal_rename("default", &id)
         .await


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Extends smart rename to non-ACP (tmux/terminal) sessions, so a still-civ-named terminal session auto-names itself from its first turn, the same way structured-view (ACP) sessions already do (#2201, #2266). Title only, matching ACP: the worktree directory is never moved and a manually-set title is never overwritten.

The hard part was that terminal sessions have no first-message chokepoint: native `tmux attach` (the dominant flow) types straight into the pane, invisible to AoE at input time. Rather than parse the first message out of the pane per agent, the trigger is the status poller's first `Running -> Idle` edge on a still-default-named session. That single edge covers every input path at once (native attach, web live-view, `aoe send`) and fires only once the pane agent is idle, so the one-shot never races it for the provider API (the same post-turn deferral ACP got in #2348).

The work runs in a detached `aoe __smart-rename <profile> <id>` child (mirrors `__acp-runner`: `setsid`, null stdio, dropped handle), so it never blocks the poll loop and behaves identically in a TUI-only build and under `aoe serve`. The existing pipeline is reused wholesale; `run_oneshot` and `title_is_auto_overwritable` are ungated from the `serve` feature (they never needed `AppState`).

Because the detached child, the TUI, and the daemon are separate processes, dedup is cross-process: a per-session advisory `flock`, `MAX_CONCURRENT` global slot locks (so a batch of sessions going idle at once cannot fan out into one agent process each), and a new persisted `Instance.smart_rename_attempted` marker so the poller never respawns a generator on later turns. A transient one-shot failure (spawn error, timeout, non-zero exit) leaves the session un-attempted so a later turn retries; a garbled or empty pane capture keeps the civ name.

Design was settled via a two-round `/debate` (gemini-3.1-pro + gpt-5.6-sol): both converged on the poller edge + detached child + storage-only writeback; the debate resolved the attempted-guard (explicit field over a `last_auto_title` tombstone), keeping the global slot locks, and deferring prompt-capture hooks as a later quality-only follow-up.

Config: reuses the existing `smart_rename` toggle (no new setting). Agents without a one-shot mode, sandboxed sessions, and command-overridden agents keep the generated name.

Closes #2222

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a fresh terminal session with a default (civ) name using a one-shot-capable agent (e.g. `aoe add --cmd claude`), attach natively with tmux, send a first message; when the turn finishes, the sidebar title updates to a short summary and the session keeps running.
- [ ] Manually rename a terminal session first, then send a message; the title is never overwritten.
- [ ] Use an agent with no one-shot mode (e.g. cursor), a sandboxed session, or an overridden agent command; the civ name is kept.
- [ ] Turn "Smart Session Rename" off in settings; no terminal session is auto-renamed.
- [ ] Confirm both paths: with `aoe serve` running, and in a TUI-only build with no daemon.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (the `smart_rename` toggle already exists and is schema-driven; only its description copy changed)

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit tests in `src/session/smart_rename.rs` (eligibility reasons, capture validation, head/tail bounding, echo baseline, title writeback + manual-title preservation) and a tmux-driven integration test in `tests/integration/terminal_smart_rename.rs` that drives `run_terminal_rename` end to end with a fake agent shim (renames a civ-named session; never overwrites a manual title).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill; design cross-checked with a `/debate` between gemini-3.1-pro and gpt-5.6-sol)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation were drafted by Claude under my direction. I made the design calls (full coverage via the poller edge, reuse the existing toggle, defer prompt hooks) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Extended smart session renaming beyond ACP to also cover non-ACP terminal sessions (including native tmux).
- Renaming is now triggered automatically right after the session’s first work cycle: when the poller first observes a session transition from **Running → Idle** while the title is still the default.
- Added a **detached rename worker** flow that runs via a hidden internal subcommand (`aoe __smart-rename ...`), with concurrency limits, cross-process locking, and persisted “attempt already done” tracking to avoid repeated renames.
- Added terminal-specific title generation:
  - Captures terminal/tmux pane scrollback for context.
  - Writes the new title back only when it’s safe (won’t overwrite manual titles, sandboxed sessions, command-overridden agents, or agents lacking one-shot support; ignores empty/invalid captures).
  - Includes improved sanitization and retry eligibility for transient failures.
- After renaming tmux-backed sessions, the code **rekeys live tmux sessions** so the updated state is reflected correctly.
- Updated configuration docs (`smart_rename` / fallback behavior), added unit tests for eligibility and persistence, and added a tmux-based integration test that validates renaming behavior and the “don’t overwrite manual title” rule.
- Refactored shared one-shot execution so the terminal rename path can reuse the same underlying logic (moving the timeout/runner code to a shared implementation and removing the duplicate serve-scoped version).

## Benefits

Session titles for terminal/tmux work now become meaningful based on the first user-visible activity, instead of staying as random default names—while still protecting user intent (manual titles) and avoiding renames in ineligible or unreliable scenarios.

## Potential follow-up

Expand end-to-end coverage for more terminal environments/agents where pane capture or tmux attachment semantics may vary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->