### PR TITLE
feat(cli): make aoe serve not-found when the aoe.web plugin is disabled

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -38,7 +38,7 @@ survives every config save.
 
 | Plugin | What it does | Disabled behavior |
 |---|---|---|
-| `aoe.web` | The web dashboard management marker. Present whenever the dashboard is compiled in (`--features serve`), so every released binary ships it, enabled by default. | `aoe serve` refuses to start until re-enabled (`aoe plugin enable aoe.web`). |
+| `aoe.web` | The web dashboard management marker. Present whenever the dashboard is compiled in (`--features serve`), so every released binary ships it, enabled by default. | When disabled, `aoe serve` is an unrecognized subcommand (hidden from `aoe --help`); re-enable with `aoe plugin enable aoe.web`. `--stop` / `--status` / `--restart` still reach a running daemon. |
 
 `aoe.web` is the only bundled plugin today, and it rides along with the web
 dashboard. So a release binary (or any `cargo build --features serve`) shows it

--- a/src/cli/graft.rs
+++ b/src/cli/graft.rs
@@ -41,9 +41,50 @@ pub fn plugin_commands() -> Vec<PluginCommand> {
 
 /// The clap command augmented with active plugins' commands. A plugin command
 /// whose name collides with a core subcommand (or an already-grafted plugin
-/// command) is skipped, so core always wins.
+/// command) is skipped, so core always wins. When the `aoe.web` plugin is
+/// disabled, `serve` is hidden from `--help` (it is rejected as unrecognized at
+/// invocation, see `serve_start_blocked`); this path already loads the registry,
+/// so no extra cost is added to the fast parse path.
 pub fn augmented_command() -> Command {
-    graft_onto(Cli::command(), plugin_commands())
+    let cmd = graft_onto(Cli::command(), plugin_commands());
+    #[cfg(feature = "serve")]
+    let cmd = hide_disabled_serve(cmd, web_disabled());
+    cmd
+}
+
+/// True when the builtin `aoe.web` plugin is present and disabled.
+#[cfg(feature = "serve")]
+pub fn web_disabled() -> bool {
+    crate::plugin::registry()
+        .get("aoe.web")
+        .is_some_and(|p| !p.enabled)
+}
+
+/// Hide `serve` from `--help` when the dashboard plugin is off. It stays
+/// parseable, since the lifecycle verbs must keep working; a fresh start is
+/// rejected as unrecognized in `main` (see `serve_start_blocked`).
+#[cfg(feature = "serve")]
+fn hide_disabled_serve(cmd: Command, web_disabled: bool) -> Command {
+    if web_disabled {
+        cmd.mut_subcommand("serve", |c| c.hide(true))
+    } else {
+        cmd
+    }
+}
+
+/// Whether a fresh `aoe serve` start must be rejected as an unrecognized
+/// subcommand: the command is `serve`, it is not a daemon lifecycle verb
+/// (`--stop` / `--status` / `--restart`, which must always reach a running
+/// daemon), and the `aoe.web` plugin is disabled.
+#[cfg(feature = "serve")]
+pub fn serve_start_blocked(cli: &Cli, web_disabled: bool) -> bool {
+    let Some(super::definition::Commands::Serve(args)) = &cli.command else {
+        return false;
+    };
+    if args.stop || args.status || args.restart {
+        return false;
+    }
+    web_disabled
 }
 
 /// Graft `commands` onto `cmd`, skipping any whose name collides with an
@@ -139,5 +180,49 @@ mod tests {
         // `agents` is a core command, not a plugin one: dispatch refuses it
         // rather than claiming it as a plugin command.
         assert!(dispatch_plugin_command(&matches).is_err());
+    }
+
+    #[cfg(feature = "serve")]
+    fn parse(args: &[&str]) -> Cli {
+        use clap::FromArgMatches;
+        Cli::from_arg_matches(
+            &Cli::command()
+                .try_get_matches_from(args)
+                .expect("args parse"),
+        )
+        .expect("into Cli")
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn serve_start_blocked_only_when_web_off_and_not_lifecycle() {
+        let start = parse(&["aoe", "serve"]);
+        assert!(serve_start_blocked(&start, true));
+        assert!(!serve_start_blocked(&start, false));
+        // Lifecycle verbs always reach the daemon, even with the plugin off.
+        for verb in ["--stop", "--status", "--restart"] {
+            let c = parse(&["aoe", "serve", verb]);
+            assert!(
+                !serve_start_blocked(&c, true),
+                "{verb} must bypass the gate"
+            );
+        }
+        // A non-serve command is never blocked.
+        assert!(!serve_start_blocked(&parse(&["aoe", "agents"]), true));
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn hide_disabled_serve_hides_only_when_disabled() {
+        let shown = hide_disabled_serve(Cli::command(), false);
+        assert!(!shown
+            .find_subcommand("serve")
+            .expect("serve present")
+            .is_hide_set());
+        let hidden = hide_disabled_serve(Cli::command(), true);
+        assert!(hidden
+            .find_subcommand("serve")
+            .expect("serve present")
+            .is_hide_set());
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -711,17 +711,9 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
         return restart_daemon().await;
     }
 
-    // The dashboard is managed as the aoe.web default plugin: disabling it
-    // turns off the serve surface at runtime without recompiling (#268).
-    // Stop/status/restart above stay available so a running daemon can
-    // always be inspected and brought down.
-    if let Some(plugin) = crate::plugin::registry().get("aoe.web") {
-        if !plugin.enabled {
-            anyhow::bail!(
-                "the web dashboard plugin is disabled; run `aoe plugin enable aoe.web` first"
-            );
-        }
-    }
+    // A fresh start with `aoe.web` disabled never reaches here: `main` rejects
+    // it as an unrecognized subcommand before dispatch (the lifecycle verbs
+    // above are exempt so a running daemon can always be brought down).
 
     // Refuse to start a second instance (daemon or foreground) while another
     // aoe serve is already running. Without this gate, a foreground

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,23 @@ fn is_serve_daemon_child(_cli: &Cli) -> bool {
     false
 }
 
+/// When the `aoe.web` plugin is disabled, a fresh `aoe serve` start behaves as
+/// an unrecognized subcommand rather than starting the dashboard (the dashboard
+/// surface is a plugin, so a disabled plugin means the command is not available).
+/// The daemon lifecycle verbs (`--stop` / `--status` / `--restart`) stay usable
+/// so a running daemon can always be inspected and brought down. Returns the
+/// clap error to raise, or `None` when the invocation is allowed. Only the
+/// caller calls `.exit()`, so the decision stays unit-testable.
+#[cfg(feature = "serve")]
+fn serve_unavailable_error(cli: &Cli) -> Option<clap::Error> {
+    cli::graft::serve_start_blocked(cli, cli::graft::web_disabled()).then(|| {
+        Cli::command().error(
+            clap::error::ErrorKind::InvalidSubcommand,
+            "unrecognized subcommand 'serve'",
+        )
+    })
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Hidden internal helper for the VT live-preview path (`[tmux] vt_live`,
@@ -69,6 +86,14 @@ async fn main() -> Result<()> {
             }
         }
     };
+
+    // With the `aoe.web` plugin disabled, a fresh `aoe serve` start is treated
+    // as an unrecognized subcommand. Done here, before any logging/app-dir side
+    // effects, so a rejected start creates no serve log or ProcessContext.
+    #[cfg(feature = "serve")]
+    if let Some(err) = serve_unavailable_error(&cli) {
+        err.exit();
+    }
 
     // If the user passed --daemon-url, mirror the value into the env
     // var so the acp::client::discovery layer (used by both the

--- a/tests/e2e/plugins.rs
+++ b/tests/e2e/plugins.rs
@@ -128,8 +128,8 @@ fn test_plugin_info_prints_manifest_details() {
 }
 
 /// `aoe.web` is a default plugin; disabling it must turn off the serve surface
-/// at runtime. The gate bails in the foreground invocation before any daemon
-/// spawn, and re-enabling restores it.
+/// at runtime. A fresh `aoe serve` start is then rejected as an unrecognized
+/// subcommand before any daemon spawn, and re-enabling restores it.
 #[test]
 #[serial]
 fn test_serve_refuses_when_web_plugin_disabled() {
@@ -150,8 +150,8 @@ fn test_serve_refuses_when_web_plugin_disabled() {
         "serve must refuse while aoe.web is disabled"
     );
     assert!(
-        String::from_utf8_lossy(&refused.stderr).contains("web dashboard plugin is disabled"),
-        "refusal must name the fix:\n{}",
+        String::from_utf8_lossy(&refused.stderr).contains("unrecognized subcommand 'serve'"),
+        "refusal must read as an unrecognized subcommand:\n{}",
         String::from_utf8_lossy(&refused.stderr)
     );
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #2090, and the runtime portion of #2170.

The web dashboard is the default-on `aoe.web` plugin, gated at runtime. Previously, with `aoe.web` disabled, `aoe serve` still parsed and then bailed with a message. This makes it behave as an **unrecognized subcommand** instead: rejected at invocation and hidden from `aoe --help`, consistent with the command simply not being available when its plugin is off. The daemon lifecycle verbs `aoe serve --stop` / `--status` / `--restart` still reach a running daemon, so a live daemon can always be inspected and brought down.

The decision lives in two small, unit-tested helpers in `cli::graft` (`serve_start_blocked`, `hide_disabled_serve`); `main` raises clap's native `InvalidSubcommand` error before any logging or app-dir side effect. Everything is gated behind `feature = "serve"`, so the Node-free `--no-default-features` (TUI-only) build is unchanged.

**Scope note:** #2170 originally proposed removing the `serve` cargo feature entirely (one binary, Node/npm as a hard build requirement). Per the discussion on this PR, we are keeping the feature and the Node-free source build, and landing only this runtime behavior. Full one-binary removal is left as a separate decision, so this PR references #2170 rather than closing it.

Refs #2170

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `aoe plugin disable aoe.web`, then `aoe serve`: prints an "unrecognized subcommand 'serve'" error and exits non-zero; `aoe --help` no longer lists `serve`.
- [ ] With `aoe.web` still disabled, `aoe serve --stop`, `aoe serve --status`, and `aoe serve --restart` still run and reach the daemon.
- [ ] `aoe plugin enable aoe.web`, then `aoe serve` starts the dashboard again and `aoe --help` lists `serve`.
- [ ] A `--no-default-features` build still compiles with no Node toolchain (the new code is `feature = "serve"`-gated).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

The gate logic (`--stop`/`--status`/`--restart` carve-out and hiding `serve` from `--help`) is covered by unit tests in `src/cli/graft.rs`, and the existing `tests/e2e/plugins.rs` gate test now asserts the unrecognized-subcommand behavior.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, design consultation (`/debate`), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and decided the scope pivot after the discussion with @njbrake.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Made `aoe serve` appear unavailable when the `aoe.web` plugin is disabled.
- Preserved `--stop`, `--status`, and `--restart` daemon lifecycle commands.
- Added CLI validation and help visibility handling for the disabled dashboard.
- Updated documentation and end-to-end tests to reflect the new behavior.
- Retained the existing feature-gated, Node-free build path.

### Benefits
This provides clearer runtime behavior for disabled dashboards while preserving existing daemon management and source-build flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->