### PR TITLE
feat(acp): runner-side control channel with native turn-complete (#1054 Phase A)

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -2158,6 +2158,9 @@ impl AcpClient {
                 default_effort,
                 default_mode,
                 mcp_servers,
+                // Direct stdio agents have no runner and thus no control
+                // channel; the task owns its own terminal guard.
+                None,
             )
             .instrument(conn_span),
         );
@@ -2242,6 +2245,35 @@ impl AcpClient {
         let pending_for_task = pending_responders.clone();
         let expected_agent = ExpectedAgent::from_command(&install_binary);
 
+        // #1054 Phase A: for a mid-flight resume, the agent's response to
+        // the orphaned `session/prompt` carries an id this client never
+        // issued and the crate transport drops it, which is what the 30s
+        // resume-idle watchdog exists to paper over. Dial the runner's
+        // sibling control socket; if it speaks the control protocol, its
+        // native `prompt_complete` claims the shared terminal guard and
+        // fires `Stopped` deterministically, and the watchdog stands down.
+        // A runner too old to bind the control socket falls back to the
+        // watchdog unchanged.
+        let external_terminal_guard = if matches!(
+            mode,
+            ConnectMode::Resume {
+                in_flight_turn: true,
+                ..
+            }
+        ) {
+            let guard = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            attach_runner_control(
+                &socket_path,
+                event_tx.clone(),
+                session_label.clone(),
+                guard.clone(),
+            )
+            .await;
+            Some(guard)
+        } else {
+            None
+        };
+
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
         // See the sibling spawn in `spawn`: the connection task runs inside
@@ -2267,6 +2299,7 @@ impl AcpClient {
                 default_effort,
                 default_mode,
                 mcp_servers,
+                external_terminal_guard,
             )
             .instrument(conn_span),
         );
@@ -3167,6 +3200,125 @@ async fn wait_for_socket(
         }
         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         delay_ms = (delay_ms * 2).min(200);
+    }
+}
+
+/// Dial the runner's sibling control socket (#1054 Phase A) and, if it
+/// speaks the control protocol, spawn a reader that turns the runner's
+/// native `PromptCompleted` into `Event::Stopped { reason }`. The reader
+/// CAS-claims `terminal_guard` so the caller's resume-idle and
+/// between-prompt watchdogs stand down for the adopted turn. Best-effort:
+/// a connect failure or an unrecognized/absent control socket (a runner
+/// too old to bind it) leaves the guard unclaimed so the legacy watchdog
+/// still fires.
+async fn attach_runner_control(
+    main_socket: &std::path::Path,
+    event_tx: mpsc::Sender<Event>,
+    session_label: String,
+    terminal_guard: Arc<std::sync::atomic::AtomicBool>,
+) {
+    use super::control_protocol::{self, ControlBody};
+    use std::sync::atomic::Ordering;
+
+    let control_path = crate::process::worker::control_socket_sibling(main_socket);
+    // The runner binds the control socket before the main relay socket,
+    // which the caller already waited for, so this connect is effectively
+    // immediate; the bound only guards a wedged runner.
+    let bound = std::time::Duration::from_secs(5);
+
+    let stream =
+        match tokio::time::timeout(bound, tokio::net::UnixStream::connect(&control_path)).await {
+            Ok(Ok(s)) => s,
+            _ => {
+                debug!(
+                    target: "acp.protocol",
+                    session = %session_label,
+                    "no runner control socket; using resume-idle watchdog"
+                );
+                return;
+            }
+        };
+
+    let (mut read_half, mut write_half) = stream.into_split();
+
+    // The runner greets with Hello on accept; require a matching version
+    // before trusting the channel.
+    let handshake_ok = matches!(
+        tokio::time::timeout(bound, control_protocol::read_frame(&mut read_half)).await,
+        Ok(Ok(Some(ControlBody::Hello { control_protocol_version, .. })))
+            if control_protocol_version == control_protocol::CONTROL_PROTOCOL_VERSION
+    );
+    if !handshake_ok {
+        debug!(
+            target: "acp.protocol",
+            session = %session_label,
+            "runner control handshake failed; using resume-idle watchdog"
+        );
+        return;
+    }
+    let _ = control_protocol::write_frame(
+        &mut write_half,
+        &ControlBody::Attach {
+            control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
+        },
+    )
+    .await;
+
+    info!(
+        target: "acp.protocol",
+        session = %session_label,
+        "runner control channel attached; native turn-complete active"
+    );
+
+    tokio::spawn(async move {
+        // Hold the write half so the runner does not observe the control
+        // socket close; Phase A sends nothing further on it.
+        let _keep_alive = write_half;
+        loop {
+            match control_protocol::read_frame(&mut read_half).await {
+                Ok(Some(ControlBody::PromptCompleted {
+                    stop_reason,
+                    is_error,
+                    ..
+                })) => {
+                    // Claim the one-shot terminal guard. Winning means the
+                    // watchdogs stand down; losing means one already fired,
+                    // so do not double-emit Stopped.
+                    if terminal_guard
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        let reason = control_stop_reason(stop_reason.as_deref(), is_error);
+                        let _ = event_tx.send(Event::Stopped { reason }).await;
+                    }
+                    // The adopted turn is resolved; the control channel's
+                    // Phase A duty for this attach is done. Subsequent turns
+                    // complete through the crate's own prompt future.
+                    break;
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(e) => {
+                    debug!(
+                        target: "acp.protocol",
+                        session = %session_label,
+                        "runner control read ended: {e}"
+                    );
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Map a runner-reported prompt outcome to an `Event::Stopped` reason. A
+/// completed turn renders as Idle regardless of stop reason, so the
+/// default is `prompt_complete`; the one reason with special downstream
+/// handling (`rate_limited`) is preserved when the agent reports it.
+fn control_stop_reason(stop_reason: Option<&str>, _is_error: bool) -> String {
+    match stop_reason {
+        Some("rate_limited") | Some("rate_limit") => "rate_limited".to_string(),
+        _ => "prompt_complete".to_string(),
     }
 }
 
@@ -4917,6 +5069,13 @@ async fn run_connection_task<W, R>(
     default_effort: Option<String>,
     default_mode: Option<String>,
     mcp_servers: Vec<McpServer>,
+    // Shared terminal-Stopped guard, supplied when a runner control
+    // channel (#1054 Phase A) may deliver the adopted turn's completion
+    // natively. The control reader CAS-claims it before emitting
+    // `Stopped`, so the resume-idle and between-prompt watchdogs below
+    // see it already fired and stand down. `None` on paths with no
+    // control channel (direct stdio), where the task owns its own guard.
+    external_terminal_guard: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) where
     W: futures_util::AsyncWrite + Send + 'static,
     R: futures_util::AsyncRead + Send + 'static,
@@ -5012,7 +5171,11 @@ async fn run_connection_task<W, R>(
     let last_event_at = Arc::new(AtomicI64::new(now_ms));
     let first_event_after_attach = Arc::new(AtomicBool::new(false));
     let prompt_sent_since_attach = Arc::new(AtomicBool::new(false));
-    let watchdog_fired = Arc::new(AtomicBool::new(false));
+    // Shared with the runner control reader (#1054 Phase A) when present,
+    // so a native `prompt_complete` from the runner and the resume-idle /
+    // between-prompt watchdogs all claim the same one-shot terminal guard.
+    let watchdog_fired =
+        external_terminal_guard.unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
     // True for a turn adopted mid-flight via `Resume { in_flight_turn: true }`:
     // a prior connection issued the `session/prompt`, so this connection has no
     // owning `prompt_fut` and no real `ClientCmd::Prompt` will emit the turn's

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3221,48 +3221,46 @@ async fn attach_runner_control(
     use std::sync::atomic::Ordering;
 
     let control_path = crate::process::worker::control_socket_sibling(main_socket);
-    // The runner binds the control socket before the main relay socket,
-    // which the caller already waited for, so this connect is effectively
-    // immediate; the bound only guards a wedged runner.
-    let bound = std::time::Duration::from_secs(5);
 
-    let stream =
-        match tokio::time::timeout(bound, tokio::net::UnixStream::connect(&control_path)).await {
-            Ok(Ok(s)) => s,
-            _ => {
-                debug!(
-                    target: "acp.protocol",
-                    session = %session_label,
-                    "no runner control socket; using resume-idle watchdog"
-                );
-                return;
-            }
-        };
-
-    let (mut read_half, mut write_half) = stream.into_split();
-
-    // The runner greets with Hello on accept; require a matching version
-    // before trusting the channel.
-    let handshake_ok = matches!(
-        tokio::time::timeout(bound, control_protocol::read_frame(&mut read_half)).await,
-        Ok(Ok(Some(ControlBody::Hello { control_protocol_version, .. })))
-            if control_protocol_version == control_protocol::CONTROL_PROTOCOL_VERSION
-    );
-    if !handshake_ok {
-        debug!(
-            target: "acp.protocol",
-            session = %session_label,
-            "runner control handshake failed; using resume-idle watchdog"
-        );
-        return;
-    }
-    let _ = control_protocol::write_frame(
-        &mut write_half,
-        &ControlBody::Attach {
-            control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
-        },
-    )
-    .await;
+    // A single deadline covers connect plus the Hello read. The runner
+    // binds the control socket before the main relay socket the caller
+    // already waited for, so both steps are effectively immediate; the
+    // bound only caps a wedged runner that bound the socket but never
+    // greets, so it cannot stall the whole resume path. An old socketless
+    // runner fails connect at once and falls back to the watchdog.
+    let bound = std::time::Duration::from_secs(2);
+    let dial = async {
+        let stream = tokio::net::UnixStream::connect(&control_path).await.ok()?;
+        let (mut read_half, mut write_half) = stream.into_split();
+        // The runner greets with Hello on accept; require a matching
+        // version before trusting the channel.
+        match control_protocol::read_frame(&mut read_half).await {
+            Ok(Some(ControlBody::Hello {
+                control_protocol_version,
+                ..
+            })) if control_protocol_version == control_protocol::CONTROL_PROTOCOL_VERSION => {}
+            _ => return None,
+        }
+        let _ = control_protocol::write_frame(
+            &mut write_half,
+            &ControlBody::Attach {
+                control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
+            },
+        )
+        .await;
+        Some((read_half, write_half))
+    };
+    let (mut read_half, write_half) = match tokio::time::timeout(bound, dial).await {
+        Ok(Some(halves)) => halves,
+        _ => {
+            debug!(
+                target: "acp.protocol",
+                session = %session_label,
+                "no usable runner control socket; using resume-idle watchdog"
+            );
+            return;
+        }
+    };
 
     info!(
         target: "acp.protocol",
@@ -3271,16 +3269,16 @@ async fn attach_runner_control(
     );
 
     tokio::spawn(async move {
-        // Hold the write half so the runner does not observe the control
-        // socket close; Phase A sends nothing further on it.
-        let _keep_alive = write_half;
+        // Hold the write half open so the runner does not see EOF before
+        // it delivers the adopted turn's completion. Dropped when this
+        // task returns (below), which closes the socket so the runner
+        // clears its own control outbound. The runner also tears its side
+        // down one-shot after a single delivered completion, so it never
+        // writes to a stale socket regardless.
+        let _write_half = write_half;
         loop {
             match control_protocol::read_frame(&mut read_half).await {
-                Ok(Some(ControlBody::PromptCompleted {
-                    stop_reason,
-                    is_error,
-                    ..
-                })) => {
+                Ok(Some(ControlBody::PromptCompleted { stop_reason, .. })) => {
                     // Claim the one-shot terminal guard. Winning means the
                     // watchdogs stand down; losing means one already fired,
                     // so do not double-emit Stopped.
@@ -3288,23 +3286,24 @@ async fn attach_runner_control(
                         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                         .is_ok()
                     {
-                        let reason = control_stop_reason(stop_reason.as_deref(), is_error);
+                        let reason = control_stop_reason(stop_reason.as_deref());
                         let _ = event_tx.send(Event::Stopped { reason }).await;
                     }
                     // The adopted turn is resolved; the control channel's
-                    // Phase A duty for this attach is done. Subsequent turns
-                    // complete through the crate's own prompt future.
-                    break;
+                    // Phase A duty for this attach is done. Return so the
+                    // write half drops and the socket closes. Subsequent
+                    // turns complete through the crate's own prompt future.
+                    return;
                 }
                 Ok(Some(_)) => {}
-                Ok(None) => break,
+                Ok(None) => return,
                 Err(e) => {
                     debug!(
                         target: "acp.protocol",
                         session = %session_label,
                         "runner control read ended: {e}"
                     );
-                    break;
+                    return;
                 }
             }
         }
@@ -3315,7 +3314,7 @@ async fn attach_runner_control(
 /// completed turn renders as Idle regardless of stop reason, so the
 /// default is `prompt_complete`; the one reason with special downstream
 /// handling (`rate_limited`) is preserved when the agent reports it.
-fn control_stop_reason(stop_reason: Option<&str>, _is_error: bool) -> String {
+fn control_stop_reason(stop_reason: Option<&str>) -> String {
     match stop_reason {
         Some("rate_limited") | Some("rate_limit") => "rate_limited".to_string(),
         _ => "prompt_complete".to_string(),

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3217,7 +3217,7 @@ async fn attach_runner_control(
     session_label: String,
     terminal_guard: Arc<std::sync::atomic::AtomicBool>,
 ) {
-    use super::control_protocol::{self, ControlBody};
+    use crate::acp::control_protocol::{self, ControlBody};
     use std::sync::atomic::Ordering;
 
     let control_path = crate::process::worker::control_socket_sibling(main_socket);
@@ -3314,6 +3314,13 @@ async fn attach_runner_control(
 /// completed turn renders as Idle regardless of stop reason, so the
 /// default is `prompt_complete`; the one reason with special downstream
 /// handling (`rate_limited`) is preserved when the agent reports it.
+///
+/// Phase A deliberately collapses the other ACP stop reasons (`cancelled`,
+/// `max_tokens`, `refusal`, `max_turn_requests`) into `prompt_complete`,
+/// since they all render Idle today. Preserving their identity for the UI
+/// is tracked as a follow-up on the Phase C runner-terminator work (#2977),
+/// where the runner owns the protocol and can forward the typed stop reason
+/// natively.
 fn control_stop_reason(stop_reason: Option<&str>) -> String {
     match stop_reason {
         Some("rate_limited") | Some("rate_limit") => "rate_limited".to_string(),
@@ -11822,5 +11829,127 @@ mod tests {
         for line in lines {
             assert_eq!(scrub_stderr_secrets(line), line);
         }
+    }
+
+    /// Daemon-side control consumer (#1054 Phase A): a runner that greets
+    /// with a matching `Hello` and then reports `PromptCompleted` drives an
+    /// `Event::Stopped { reason: "prompt_complete" }` and claims the shared
+    /// terminal guard so the resume-idle watchdog stands down.
+    #[tokio::test]
+    async fn runner_control_native_completion_fires_stopped() {
+        use crate::acp::control_protocol::{self, ControlBody};
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let main_socket = tmp.path().join("s.sock");
+        let control = crate::process::worker::control_socket_sibling(&main_socket);
+
+        let listener = UnixListener::bind(&control).unwrap();
+        let fake = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (mut r, mut w) = stream.into_split();
+            control_protocol::write_frame(
+                &mut w,
+                &ControlBody::Hello {
+                    control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
+                    session_id: "s".into(),
+                },
+            )
+            .await
+            .unwrap();
+            // Drain the daemon's Attach ack, then report completion.
+            let _ = control_protocol::read_frame(&mut r).await;
+            control_protocol::write_frame(
+                &mut w,
+                &ControlBody::PromptCompleted {
+                    prompt_req_id: 5,
+                    stop_reason: Some("end_turn".into()),
+                },
+            )
+            .await
+            .unwrap();
+            // Hold the socket open so the reader delivers before EOF.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        });
+
+        let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
+        let guard = Arc::new(AtomicBool::new(false));
+        attach_runner_control(&main_socket, event_tx, "s".into(), guard.clone()).await;
+
+        let ev = tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv())
+            .await
+            .expect("timed out waiting for Stopped")
+            .expect("event channel closed");
+        assert!(matches!(ev, Event::Stopped { reason } if reason == "prompt_complete"));
+        assert!(
+            guard.load(Ordering::Relaxed),
+            "terminal guard must be claimed"
+        );
+        let _ = fake.await;
+    }
+
+    /// A runner whose `Hello` advertises an unknown control-protocol version
+    /// is not trusted: no `Stopped` is emitted and the guard stays unclaimed
+    /// so the legacy resume-idle watchdog still fires.
+    #[tokio::test]
+    async fn runner_control_version_mismatch_leaves_guard_unclaimed() {
+        use crate::acp::control_protocol::{self, ControlBody};
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::net::UnixListener;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let main_socket = tmp.path().join("s.sock");
+        let control = crate::process::worker::control_socket_sibling(&main_socket);
+
+        let listener = UnixListener::bind(&control).unwrap();
+        let fake = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_r, mut w) = stream.into_split();
+            let _ = control_protocol::write_frame(
+                &mut w,
+                &ControlBody::Hello {
+                    control_protocol_version: 999,
+                    session_id: "s".into(),
+                },
+            )
+            .await;
+        });
+
+        let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
+        let guard = Arc::new(AtomicBool::new(false));
+        attach_runner_control(&main_socket, event_tx, "s".into(), guard.clone()).await;
+
+        assert!(
+            !guard.load(Ordering::Relaxed),
+            "unknown control version must not claim the guard"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "no Stopped emitted on version mismatch"
+        );
+        let _ = fake.await;
+    }
+
+    /// The load-bearing backward-compat path: an old runner that never binds
+    /// the control socket leaves the guard unclaimed, so the resume-idle
+    /// watchdog remains the terminal authority.
+    #[tokio::test]
+    async fn runner_control_absent_socket_leaves_guard_unclaimed() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let tmp = tempfile::tempdir().unwrap();
+        // No control listener is bound at the sibling path.
+        let main_socket = tmp.path().join("s.sock");
+
+        let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
+        let guard = Arc::new(AtomicBool::new(false));
+        attach_runner_control(&main_socket, event_tx, "s".into(), guard.clone()).await;
+
+        assert!(
+            !guard.load(Ordering::Relaxed),
+            "absent control socket must fall back to the watchdog"
+        );
+        assert!(event_rx.try_recv().is_err());
     }
 }

--- a/src/acp/control_protocol.rs
+++ b/src/acp/control_protocol.rs
@@ -48,12 +48,11 @@ pub enum ControlBody {
     /// The runner observed the agent's response to the tracked
     /// `session/prompt` request. `prompt_req_id` is the JSON-RPC id the
     /// daemon issued for that prompt. `stop_reason` is the ACP
-    /// `stopReason` from the response result when present; `is_error` is
-    /// set when the response was a JSON-RPC error envelope instead.
+    /// `stopReason` from the response result when present (None for an
+    /// error-envelope response, which still ends the turn).
     PromptCompleted {
         prompt_req_id: i64,
         stop_reason: Option<String>,
-        is_error: bool,
     },
 
     // ---- daemon -> runner ----
@@ -132,7 +131,6 @@ mod tests {
         let body = ControlBody::PromptCompleted {
             prompt_req_id: 42,
             stop_reason: Some("end_turn".into()),
-            is_error: false,
         };
         assert_eq!(roundtrip(body.clone()), body);
     }
@@ -142,7 +140,6 @@ mod tests {
         let body = ControlBody::PromptCompleted {
             prompt_req_id: 7,
             stop_reason: None,
-            is_error: true,
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &body).await.expect("write");
@@ -160,7 +157,6 @@ mod tests {
         let b = ControlBody::PromptCompleted {
             prompt_req_id: 1,
             stop_reason: Some("cancelled".into()),
-            is_error: false,
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &a).await.unwrap();

--- a/src/acp/control_protocol.rs
+++ b/src/acp/control_protocol.rs
@@ -1,0 +1,200 @@
+//! Typed control channel between the daemon and the `aoe __acp-runner`
+//! shim, carried on a sibling `<id>.control.sock` alongside the raw ACP
+//! byte relay on `<id>.sock`.
+//!
+//! Phase A of #1054 (runner-side ACP protocol termination): the runner
+//! observes the agent's response to the daemon-issued `session/prompt`
+//! request and reports a native turn-complete signal over this channel,
+//! so the daemon fires `Stopped { reason: "prompt_complete" }`
+//! deterministically instead of guessing with the 30s resume-idle
+//! watchdog. Later phases move the ACP handshake and the agent's
+//! server-method callbacks onto this channel too.
+//!
+//! Wire format: each frame is a 4-byte big-endian length prefix followed
+//! by that many bytes of JSON (a serialized [`ControlBody`]). The byte
+//! relay on `<id>.sock` stays newline-delimited JSON; this channel uses
+//! length framing so a future opaque, possibly-nested payload cannot be
+//! confused with a newline in the body.
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Bumped when the frame set changes in a wire-incompatible way. The
+/// runner announces it in [`ControlBody::Hello`]; a daemon that does not
+/// recognize the version keeps the legacy resume-idle watchdog rather
+/// than trusting the channel.
+pub const CONTROL_PROTOCOL_VERSION: u32 = 1;
+
+/// Hard cap on a single control frame. Phase A frames are tiny; reject
+/// anything larger as a framing error instead of allocating a huge
+/// buffer for a corrupt length prefix.
+pub const MAX_CONTROL_FRAME_BYTES: u32 = 16 * 1024 * 1024;
+
+/// A single control frame. `kind` tags the variant so the wire form is
+/// self-describing and forward-compatible: an unknown variant fails to
+/// deserialize rather than being silently misread.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ControlBody {
+    // ---- runner -> daemon ----
+    /// First frame the runner sends on a fresh control connection. Lets
+    /// the daemon confirm the protocol version and the session identity
+    /// it dialed.
+    Hello {
+        control_protocol_version: u32,
+        session_id: String,
+    },
+    /// The runner observed the agent's response to the tracked
+    /// `session/prompt` request. `prompt_req_id` is the JSON-RPC id the
+    /// daemon issued for that prompt. `stop_reason` is the ACP
+    /// `stopReason` from the response result when present; `is_error` is
+    /// set when the response was a JSON-RPC error envelope instead.
+    PromptCompleted {
+        prompt_req_id: i64,
+        stop_reason: Option<String>,
+        is_error: bool,
+    },
+
+    // ---- daemon -> runner ----
+    /// First frame the daemon sends after [`ControlBody::Hello`],
+    /// acknowledging the version it will speak. Phase A carries no other
+    /// daemon-to-runner traffic.
+    Attach { control_protocol_version: u32 },
+}
+
+/// Encode a frame: 4-byte big-endian length prefix, then the JSON body.
+pub fn encode_frame(body: &ControlBody) -> Result<Vec<u8>> {
+    let json = serde_json::to_vec(body)?;
+    let len = u32::try_from(json.len())
+        .map_err(|_| anyhow::anyhow!("control frame exceeds u32 length"))?;
+    if len > MAX_CONTROL_FRAME_BYTES {
+        bail!("control frame {len} bytes exceeds cap {MAX_CONTROL_FRAME_BYTES}");
+    }
+    let mut buf = Vec::with_capacity(4 + json.len());
+    buf.extend_from_slice(&len.to_be_bytes());
+    buf.extend_from_slice(&json);
+    Ok(buf)
+}
+
+/// Write one frame and flush.
+pub async fn write_frame<W: AsyncWrite + Unpin>(w: &mut W, body: &ControlBody) -> Result<()> {
+    let buf = encode_frame(body)?;
+    w.write_all(&buf).await?;
+    w.flush().await?;
+    Ok(())
+}
+
+/// Read one frame. Returns `Ok(None)` on a clean EOF at a frame boundary
+/// (the peer closed the socket), so callers can treat that as a normal
+/// disconnect rather than an error.
+pub async fn read_frame<R: AsyncRead + Unpin>(r: &mut R) -> Result<Option<ControlBody>> {
+    let mut len_buf = [0u8; 4];
+    match r.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e.into()),
+    }
+    let len = u32::from_be_bytes(len_buf);
+    if len > MAX_CONTROL_FRAME_BYTES {
+        bail!("control frame length {len} exceeds cap {MAX_CONTROL_FRAME_BYTES}");
+    }
+    let mut body = vec![0u8; len as usize];
+    r.read_exact(&mut body).await?;
+    let parsed: ControlBody = serde_json::from_slice(&body)?;
+    Ok(Some(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn roundtrip(body: ControlBody) -> ControlBody {
+        let encoded = encode_frame(&body).expect("encode");
+        // Length prefix plus a body that deserializes back to the same value.
+        let len = u32::from_be_bytes([encoded[0], encoded[1], encoded[2], encoded[3]]);
+        assert_eq!(len as usize, encoded.len() - 4);
+        serde_json::from_slice(&encoded[4..]).expect("decode")
+    }
+
+    #[test]
+    fn hello_roundtrips() {
+        let body = ControlBody::Hello {
+            control_protocol_version: CONTROL_PROTOCOL_VERSION,
+            session_id: "abc-123".into(),
+        };
+        assert_eq!(roundtrip(body.clone()), body);
+    }
+
+    #[test]
+    fn prompt_completed_roundtrips() {
+        let body = ControlBody::PromptCompleted {
+            prompt_req_id: 42,
+            stop_reason: Some("end_turn".into()),
+            is_error: false,
+        };
+        assert_eq!(roundtrip(body.clone()), body);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_frame() {
+        let body = ControlBody::PromptCompleted {
+            prompt_req_id: 7,
+            stop_reason: None,
+            is_error: true,
+        };
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &body).await.expect("write");
+        let mut cursor = Cursor::new(buf);
+        let got = read_frame(&mut cursor).await.expect("read");
+        assert_eq!(got, Some(body));
+    }
+
+    #[tokio::test]
+    async fn multiple_frames_in_one_stream() {
+        let a = ControlBody::Hello {
+            control_protocol_version: 1,
+            session_id: "s".into(),
+        };
+        let b = ControlBody::PromptCompleted {
+            prompt_req_id: 1,
+            stop_reason: Some("cancelled".into()),
+            is_error: false,
+        };
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &a).await.unwrap();
+        write_frame(&mut buf, &b).await.unwrap();
+        let mut cursor = Cursor::new(buf);
+        assert_eq!(read_frame(&mut cursor).await.unwrap(), Some(a));
+        assert_eq!(read_frame(&mut cursor).await.unwrap(), Some(b));
+        assert_eq!(read_frame(&mut cursor).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn clean_eof_returns_none() {
+        let mut cursor = Cursor::new(Vec::new());
+        assert_eq!(read_frame(&mut cursor).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn oversized_length_prefix_is_rejected() {
+        // Length prefix past the cap, with no body: must error, not
+        // attempt a multi-gigabyte allocation.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(MAX_CONTROL_FRAME_BYTES + 1).to_be_bytes());
+        let mut cursor = Cursor::new(buf);
+        assert!(read_frame(&mut cursor).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn truncated_body_is_error_not_eof() {
+        // A full length prefix but a short body is a corrupt frame, not a
+        // clean close.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"only-4"); // fewer than 16 bytes
+        let mut cursor = Cursor::new(buf);
+        assert!(read_frame(&mut cursor).await.is_err());
+    }
+}

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -21,6 +21,7 @@ pub mod approvals;
 pub mod background_agent;
 pub mod client;
 pub mod context_primer;
+pub mod control_protocol;
 pub mod elicitations;
 pub mod event_store;
 pub mod fs_handler;

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -730,6 +730,32 @@ const PERMISSION_METHOD: &str = "session/request_permission";
 /// the agent to daemon path. Phase A of #1054.
 const PROMPT_METHOD: &str = "session/prompt";
 
+/// Deadline for a single control-channel frame write. `emit_control`
+/// holds the `control` mutex across the write and runs on the sole
+/// stdout-relay task, so an unbounded write to a stalled control peer (a
+/// slow reader or a full socket buffer) would freeze the mutex and the
+/// whole session's relay. Capping it bounds that blast radius; a timeout
+/// is treated as a write failure so the existing drop/buffer cleanup
+/// runs. Phase A of #1054.
+const CONTROL_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Write a control frame with a bounded deadline. Returns `true` on a
+/// successful write, `false` on a write error or timeout; callers treat
+/// `false` as a dead/stalled socket and run their drop/buffer cleanup.
+async fn write_control_frame(
+    out: &mut tokio::net::unix::OwnedWriteHalf,
+    body: &ControlBody,
+) -> bool {
+    matches!(
+        tokio::time::timeout(
+            CONTROL_WRITE_TIMEOUT,
+            control_protocol::write_frame(out, body)
+        )
+        .await,
+        Ok(Ok(()))
+    )
+}
+
 /// Soft cap on `outstanding_requests`. Hit only if the daemon stops
 /// answering non-permission requests (which a healthy ACP daemon
 /// always does); a misbehaving daemon shouldn't be able to grow the
@@ -987,12 +1013,13 @@ impl RunnerShared {
     async fn emit_control(&self, body: ControlBody) {
         let mut ch = self.control.lock().await;
         if let Some(out) = ch.outbound.as_mut() {
-            let ok = control_protocol::write_frame(out, &body).await.is_ok();
+            let ok = write_control_frame(out, &body).await;
             ch.outbound = None;
             if ok {
                 return;
             }
-            // Dead socket: fall through to maybe-buffer for a later attach.
+            // Dead or stalled socket: fall through to maybe-buffer for a
+            // later attach.
         }
         if self
             .main_attached
@@ -1016,22 +1043,16 @@ impl RunnerShared {
             control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
             session_id: session_id.to_string(),
         };
-        if control_protocol::write_frame(&mut out, &hello)
-            .await
-            .is_err()
-        {
+        if !write_control_frame(&mut out, &hello).await {
             return;
         }
         let mut ch = self.control.lock().await;
         if let Some(body) = ch.pending.take() {
-            if control_protocol::write_frame(&mut out, &body)
-                .await
-                .is_err()
-            {
+            if !write_control_frame(&mut out, &body).await {
                 ch.pending = Some(body);
             }
-            // Delivered (or failed on a dead socket); one completion per
-            // attach, so do not retain the outbound.
+            // Delivered (or failed on a dead/stalled socket); one completion
+            // per attach, so do not retain the outbound.
             return;
         }
         ch.outbound = Some(out);

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -59,6 +59,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
 use super::worker_registry::{self, WorkerRecord};
+use crate::acp::control_protocol::{self, ControlBody};
 use crate::process::worker::RunnerRecordState;
 
 /// How often the abandonment watchdog inspects its own registry record.
@@ -227,14 +228,33 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         "structured view runner starting"
     );
 
-    // Bind the socket BEFORE spawning the agent so the daemon's
-    // post-spawn connect doesn't race the listener creation.
-    if args.socket.exists() {
-        let _ = std::fs::remove_file(&args.socket);
-    }
+    // Bind the sibling control socket BEFORE the main relay socket, and
+    // both before spawning the agent. The daemon waits for the main
+    // socket to appear, then dials the control socket; binding control
+    // first guarantees it is connectable by the time the main socket is,
+    // so no capability handshake or record field is needed to advertise
+    // it. Phase A of #1054.
+    let control_socket = crate::process::worker::control_socket_sibling(&args.socket);
     if let Some(parent) = args.socket.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating socket dir {}", parent.display()))?;
+    }
+    if control_socket.exists() {
+        let _ = std::fs::remove_file(&control_socket);
+    }
+    let control_listener = UnixListener::bind(&control_socket)
+        .with_context(|| format!("bind {}", control_socket.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&control_socket, std::fs::Permissions::from_mode(0o600));
+    }
+
+    // Bind the main relay socket. The runner binds before it spawns the
+    // agent so the daemon's post-spawn connect doesn't race the listener
+    // creation.
+    if args.socket.exists() {
+        let _ = std::fs::remove_file(&args.socket);
     }
     let listener = UnixListener::bind(&args.socket)
         .with_context(|| format!("bind {}", args.socket.display()))?;
@@ -322,6 +342,42 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         Arc::clone(&shared),
         args.session_id.clone(),
     ));
+
+    // Control-channel accept loop (#1054 Phase A). Serves the sibling
+    // `<id>.control.sock`, over which the runner reports native
+    // turn-complete signals. Independent of the main byte-relay accept
+    // loop; a daemon attaches to both. Detached like the stderr drainer:
+    // the process teardown drops it.
+    let control_shared = Arc::clone(&shared);
+    let control_session = args.session_id.clone();
+    let control_accept_task = tokio::spawn(async move {
+        loop {
+            match control_listener.accept().await {
+                Ok((stream, _addr)) => {
+                    info!(
+                        target: "acp.runner",
+                        session = %control_session,
+                        "daemon connected (control channel)"
+                    );
+                    handle_control_connection(
+                        stream,
+                        Arc::clone(&control_shared),
+                        control_session.clone(),
+                    )
+                    .await;
+                    info!(
+                        target: "acp.runner",
+                        session = %control_session,
+                        "daemon disconnected (control channel)"
+                    );
+                }
+                Err(e) => {
+                    warn!(target: "acp.runner", "control accept error: {e}");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    });
 
     // Wrap agent stdin in a tokio Mutex so the accept loop can hand it
     // to one connection at a time. Wrapping (not splitting) keeps stdin
@@ -461,6 +517,7 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
 
     watchdog_handle.abort();
     agent_stdout_task.abort();
+    control_accept_task.abort();
     if !preserve_registry {
         worker_registry::delete(&session_id).ok();
     }
@@ -614,6 +671,21 @@ struct RunnerShared {
     /// `session/request_permission`, a JSON-RPC error for other methods.
     /// See #1099.
     outstanding_requests: Mutex<HashMap<i64, String>>,
+    /// JSON-RPC ids of daemon-issued `session/prompt` requests awaiting a
+    /// response. Populated from daemon to agent traffic; drained when the
+    /// matching response is seen on the agent to daemon path, which fires
+    /// a `PromptCompleted` control event. Lives on `RunnerShared` (not a
+    /// connection) so a prompt issued by one daemon still reports
+    /// completion to whichever daemon is attached when the agent
+    /// responds. Phase A of #1054.
+    prompt_requests: Mutex<HashSet<i64>>,
+    /// The currently-attached daemon's control-channel write half. The
+    /// runner writes `PromptCompleted` frames here when set.
+    control_outbound: Mutex<Option<tokio::net::unix::OwnedWriteHalf>>,
+    /// Control events produced while no daemon was attached to the
+    /// control socket. Replayed on the next control attach so a turn that
+    /// completes during a daemon restart is not lost.
+    pending_control: Mutex<VecDeque<ControlBody>>,
 }
 
 /// JSON-RPC peek for outstanding-request tracking. Pulls only the
@@ -635,6 +707,17 @@ struct JsonRpcPeek {
 /// non-error control-flow signal the agent expects.
 const PERMISSION_METHOD: &str = "session/request_permission";
 
+/// The daemon-issued request whose response marks a turn complete. The
+/// runner tracks its id (seen on the daemon to agent path) and surfaces
+/// a native `PromptCompleted` when the matching response comes back on
+/// the agent to daemon path. Phase A of #1054.
+const PROMPT_METHOD: &str = "session/prompt";
+
+/// Cap on control-channel completion events buffered while no daemon is
+/// attached to the control socket. These are terminal turn markers, one
+/// per prompt, so the bound is generous; oldest are dropped past it.
+const CONTROL_PENDING_CAP: usize = 64;
+
 /// Soft cap on `outstanding_requests`. Hit only if the daemon stops
 /// answering non-permission requests (which a healthy ACP daemon
 /// always does); a misbehaving daemon shouldn't be able to grow the
@@ -650,6 +733,9 @@ impl RunnerShared {
             active_outbound: Mutex::new(None),
             pending: Mutex::new(VecDeque::with_capacity(NOTIFICATION_BUFFER_LINES)),
             outstanding_requests: Mutex::new(HashMap::new()),
+            prompt_requests: Mutex::new(HashSet::new()),
+            control_outbound: Mutex::new(None),
+            pending_control: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -675,6 +761,21 @@ impl RunnerShared {
                 );
             }
             map.insert(id, method);
+        }
+
+        // Phase A #1054: if this is the agent's response to a tracked
+        // `session/prompt`, surface a native turn-complete over the
+        // control channel. Runs regardless of the byte-relay outbound
+        // state below, since the control channel is a separate socket.
+        if let Some((id, stop_reason, is_error)) = parse_response(line) {
+            if self.prompt_requests.lock().await.remove(&id) {
+                self.emit_control(ControlBody::PromptCompleted {
+                    prompt_req_id: id,
+                    stop_reason,
+                    is_error,
+                })
+                .await;
+            }
         }
 
         let mut guard = self.active_outbound.lock().await;
@@ -839,6 +940,73 @@ impl RunnerShared {
         let mut guard = self.active_outbound.lock().await;
         *guard = None;
     }
+
+    /// Peek a daemon to agent line: if it is a `session/prompt` request,
+    /// record its id so the matching response (agent to daemon) reports a
+    /// native turn-complete. Phase A of #1054.
+    async fn note_prompt_request(&self, line: &[u8]) {
+        if let Some((id, method)) = parse_request(line) {
+            if method == PROMPT_METHOD {
+                self.prompt_requests.lock().await.insert(id);
+            }
+        }
+    }
+
+    /// Send a control frame to the attached daemon, or buffer it for the
+    /// next control attach if none is connected. A write failure drops
+    /// the stale writer and buffers, mirroring `deliver_line`.
+    async fn emit_control(&self, body: ControlBody) {
+        {
+            let mut guard = self.control_outbound.lock().await;
+            if let Some(out) = guard.as_mut() {
+                if control_protocol::write_frame(out, &body).await.is_ok() {
+                    return;
+                }
+                *guard = None;
+            }
+        }
+        let mut pending = self.pending_control.lock().await;
+        while pending.len() >= CONTROL_PENDING_CAP {
+            pending.pop_front();
+        }
+        pending.push_back(body);
+    }
+
+    /// Install a control-channel write half: greet with `Hello`, drain any
+    /// buffered completion events, then store it as the active outbound.
+    async fn install_control_outbound(
+        &self,
+        mut out: tokio::net::unix::OwnedWriteHalf,
+        session_id: &str,
+    ) {
+        let hello = ControlBody::Hello {
+            control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
+            session_id: session_id.to_string(),
+        };
+        if control_protocol::write_frame(&mut out, &hello)
+            .await
+            .is_err()
+        {
+            return;
+        }
+        {
+            let mut pending = self.pending_control.lock().await;
+            while let Some(body) = pending.pop_front() {
+                if control_protocol::write_frame(&mut out, &body)
+                    .await
+                    .is_err()
+                {
+                    pending.push_front(body);
+                    return;
+                }
+            }
+        }
+        *self.control_outbound.lock().await = Some(out);
+    }
+
+    async fn clear_control_outbound(&self) {
+        *self.control_outbound.lock().await = None;
+    }
 }
 
 /// Extract `(id, method)` from a JSON-RPC request line. Returns None
@@ -905,6 +1073,42 @@ async fn read_frame_bounded<R: AsyncBufRead + Unpin>(
     }
 }
 
+/// Peek fields of a JSON-RPC response line for turn-complete detection:
+/// the `result.stopReason` (when the response succeeded) and whether it
+/// carried an `error` envelope instead.
+#[derive(Deserialize)]
+struct JsonRpcResponsePeek {
+    #[serde(default)]
+    id: Option<serde_json::Value>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    result: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<serde_json::Value>,
+}
+
+/// Parse a JSON-RPC response line into `(id, stop_reason, is_error)`.
+/// Returns None for requests (a `method` is present), notifications (no
+/// `id`), non-numeric ids, and malformed lines. `stop_reason` is the
+/// ACP `result.stopReason` when present; `is_error` is set when the
+/// response is a JSON-RPC error envelope.
+fn parse_response(line: &[u8]) -> Option<(i64, Option<String>, bool)> {
+    let peek: JsonRpcResponsePeek = serde_json::from_slice(line).ok()?;
+    if peek.method.is_some() {
+        return None;
+    }
+    let id = peek.id?.as_i64()?;
+    let is_error = peek.error.is_some();
+    let stop_reason = peek
+        .result
+        .as_ref()
+        .and_then(|r| r.get("stopReason"))
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string());
+    Some((id, stop_reason, is_error))
+}
+
 /// Read agent stdout line-by-line (ndjson) and either forward to the
 /// daemon or buffer.
 async fn fanout_agent_stdout(
@@ -961,6 +1165,7 @@ async fn handle_connection(
             Ok(0) => break, // EOF: daemon closed the connection.
             Ok(_) => {
                 shared.note_daemon_response(&line).await;
+                shared.note_prompt_request(&line).await;
                 let mut stdin = agent_stdin.lock().await;
                 if stdin.write_all(&line).await.is_err() || stdin.flush().await.is_err() {
                     warn!(
@@ -986,6 +1191,38 @@ async fn handle_connection(
         .cancel_outstanding_requests(&agent_stdin, &session_id)
         .await;
     shared.clear_outbound().await;
+}
+
+/// Handle one control-channel connection: install its write half
+/// (greeting with `Hello` and draining buffered completion events), then
+/// read daemon to runner frames until EOF so a disconnect is detected.
+/// Phase A of #1054 has no daemon to runner frames that require action
+/// (the daemon's `Attach` just confirms the version), so the read loop
+/// exists only to observe the socket closing.
+async fn handle_control_connection(
+    stream: UnixStream,
+    shared: Arc<RunnerShared>,
+    session_id: String,
+) {
+    let (mut read_half, write_half) = stream.into_split();
+    shared
+        .install_control_outbound(write_half, &session_id)
+        .await;
+    loop {
+        match control_protocol::read_frame(&mut read_half).await {
+            Ok(Some(_body)) => {}
+            Ok(None) => break, // clean EOF: daemon closed the control socket.
+            Err(e) => {
+                warn!(
+                    target: "acp.runner",
+                    session = %session_id,
+                    "control read error: {e}"
+                );
+                break;
+            }
+        }
+    }
+    shared.clear_control_outbound().await;
 }
 
 fn spawn_agent(
@@ -1202,6 +1439,83 @@ mod tests {
     fn parse_helpers_tolerate_malformed_json() {
         assert_eq!(parse_request(b"not json"), None);
         assert_eq!(parse_response_id(b"not json"), None);
+        assert_eq!(parse_response(b"not json"), None);
+    }
+
+    #[test]
+    fn parse_response_extracts_stop_reason() {
+        let line = br#"{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}"#;
+        assert_eq!(
+            parse_response(line),
+            Some((3, Some("end_turn".into()), false))
+        );
+    }
+
+    #[test]
+    fn parse_response_flags_error_envelope() {
+        let line = br#"{"jsonrpc":"2.0","id":4,"error":{"code":-32000,"message":"boom"}}"#;
+        assert_eq!(parse_response(line), Some((4, None, true)));
+    }
+
+    #[test]
+    fn parse_response_ignores_requests_and_notifications() {
+        assert_eq!(
+            parse_response(br#"{"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{}}"#),
+            None
+        );
+        assert_eq!(
+            parse_response(br#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_request_detects_prompt() {
+        let line = br#"{"jsonrpc":"2.0","id":11,"method":"session/prompt","params":{}}"#;
+        assert_eq!(parse_request(line), Some((11, PROMPT_METHOD.into())));
+    }
+
+    /// The core Phase A invariant: a tracked `session/prompt` request id,
+    /// seen on the daemon to agent path, produces a `PromptCompleted`
+    /// control event when the matching response arrives on the agent to
+    /// daemon path. With no control daemon attached the event is buffered
+    /// in `pending_control`, which is exactly the mid-restart case the
+    /// change exists to cover.
+    #[tokio::test]
+    async fn prompt_response_emits_completed_control_event() {
+        let shared = RunnerShared::new();
+        let prompt = br#"{"jsonrpc":"2.0","id":5,"method":"session/prompt","params":{}}
+"#;
+        shared.note_prompt_request(prompt).await;
+        assert!(shared.prompt_requests.lock().await.contains(&5));
+
+        let resp = br#"{"jsonrpc":"2.0","id":5,"result":{"stopReason":"end_turn"}}
+"#;
+        shared.deliver_line(resp).await;
+
+        // The prompt id is drained and a completion event is buffered.
+        assert!(shared.prompt_requests.lock().await.is_empty());
+        let pending = shared.pending_control.lock().await;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending.front(),
+            Some(&ControlBody::PromptCompleted {
+                prompt_req_id: 5,
+                stop_reason: Some("end_turn".into()),
+                is_error: false,
+            })
+        );
+    }
+
+    /// A response id the runner never tracked as a prompt (e.g. a reply to
+    /// an fs/terminal request) must not produce a completion event.
+    #[tokio::test]
+    async fn untracked_response_emits_nothing() {
+        let shared = RunnerShared::new();
+        let resp = br#"{"jsonrpc":"2.0","id":77,"result":{}}
+"#;
+        shared.deliver_line(resp).await;
+        assert!(shared.pending_control.lock().await.is_empty());
     }
 
     /// `deliver_line` populates the outstanding-requests map on the

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -679,13 +679,30 @@ struct RunnerShared {
     /// completion to whichever daemon is attached when the agent
     /// responds. Phase A of #1054.
     prompt_requests: Mutex<HashSet<i64>>,
-    /// The currently-attached daemon's control-channel write half. The
-    /// runner writes `PromptCompleted` frames here when set.
-    control_outbound: Mutex<Option<tokio::net::unix::OwnedWriteHalf>>,
-    /// Control events produced while no daemon was attached to the
-    /// control socket. Replayed on the next control attach so a turn that
-    /// completes during a daemon restart is not lost.
-    pending_control: Mutex<VecDeque<ControlBody>>,
+    /// Control-channel outbound and the single completion buffered across
+    /// a no-daemon gap, under one lock so emit and attach are mutually
+    /// exclusive (no drain-then-set TOCTOU).
+    control: Mutex<ControlChannel>,
+    /// Mirror of `active_outbound.is_some()`, read lock-free by
+    /// `emit_control` to decide whether a completion is owned by a live
+    /// main-relay daemon (drop it) or occurred during a genuine no-daemon
+    /// gap (buffer it for the next control attach). Set/cleared alongside
+    /// `active_outbound`.
+    main_attached: std::sync::atomic::AtomicBool,
+}
+
+/// Control-channel state for the sibling `<id>.control.sock`. A single
+/// mutex covers both fields so `emit_control` (check outbound, else
+/// buffer) and `install_control_outbound` (drain buffer, set outbound)
+/// cannot interleave and strand a completion.
+#[derive(Default)]
+struct ControlChannel {
+    /// Write half to the attached daemon, or None when detached.
+    outbound: Option<tokio::net::unix::OwnedWriteHalf>,
+    /// The one completion produced during a no-daemon gap, awaiting the
+    /// next control attach. ACP is serial per session, so at most one turn
+    /// is ever legitimately pending; a newer completion supersedes.
+    pending: Option<ControlBody>,
 }
 
 /// JSON-RPC peek for outstanding-request tracking. Pulls only the
@@ -713,11 +730,6 @@ const PERMISSION_METHOD: &str = "session/request_permission";
 /// the agent to daemon path. Phase A of #1054.
 const PROMPT_METHOD: &str = "session/prompt";
 
-/// Cap on control-channel completion events buffered while no daemon is
-/// attached to the control socket. These are terminal turn markers, one
-/// per prompt, so the bound is generous; oldest are dropped past it.
-const CONTROL_PENDING_CAP: usize = 64;
-
 /// Soft cap on `outstanding_requests`. Hit only if the daemon stops
 /// answering non-permission requests (which a healthy ACP daemon
 /// always does); a misbehaving daemon shouldn't be able to grow the
@@ -734,8 +746,8 @@ impl RunnerShared {
             pending: Mutex::new(VecDeque::with_capacity(NOTIFICATION_BUFFER_LINES)),
             outstanding_requests: Mutex::new(HashMap::new()),
             prompt_requests: Mutex::new(HashSet::new()),
-            control_outbound: Mutex::new(None),
-            pending_control: Mutex::new(VecDeque::new()),
+            control: Mutex::new(ControlChannel::default()),
+            main_attached: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -765,16 +777,19 @@ impl RunnerShared {
 
         // Phase A #1054: if this is the agent's response to a tracked
         // `session/prompt`, surface a native turn-complete over the
-        // control channel. Runs regardless of the byte-relay outbound
-        // state below, since the control channel is a separate socket.
-        if let Some((id, stop_reason, is_error)) = parse_response(line) {
-            if self.prompt_requests.lock().await.remove(&id) {
-                self.emit_control(ControlBody::PromptCompleted {
-                    prompt_req_id: id,
-                    stop_reason,
-                    is_error,
-                })
-                .await;
+        // control channel. Gated on actually tracking a prompt so a busy
+        // session does not JSON-parse every agent line twice (this on top
+        // of `note_daemon_response`). Independent of the byte-relay
+        // outbound below, since the control channel is a separate socket.
+        if !self.prompt_requests.lock().await.is_empty() {
+            if let Some((id, stop_reason)) = parse_response(line) {
+                if self.prompt_requests.lock().await.remove(&id) {
+                    self.emit_control(ControlBody::PromptCompleted {
+                        prompt_req_id: id,
+                        stop_reason,
+                    })
+                    .await;
+                }
             }
         }
 
@@ -933,12 +948,19 @@ impl RunnerShared {
         }
         drop(pending);
         *guard = Some(out);
+        self.main_attached
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         prev
     }
 
     async fn clear_outbound(&self) {
-        let mut guard = self.active_outbound.lock().await;
-        *guard = None;
+        *self.active_outbound.lock().await = None;
+        self.main_attached
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        // A main-relay disconnect starts a no-daemon gap. Drop any
+        // completion left un-drained from a prior gap so only the current
+        // gap's completion is ever replayed to the next resuming daemon.
+        self.control.lock().await.pending = None;
     }
 
     /// Peek a daemon to agent line: if it is a `session/prompt` request,
@@ -952,28 +974,39 @@ impl RunnerShared {
         }
     }
 
-    /// Send a control frame to the attached daemon, or buffer it for the
-    /// next control attach if none is connected. A write failure drops
-    /// the stale writer and buffers, mirroring `deliver_line`.
+    /// Deliver a control frame to the attached daemon, else buffer it for
+    /// the next control attach. Phase A delivers exactly one completion
+    /// per control attach (the adopted turn), so a successful live write
+    /// tears the outbound down: no later frame is written to a socket the
+    /// daemon has stopped reading. A completion is only buffered during a
+    /// genuine no-daemon gap; while a main-relay daemon is attached it
+    /// already owns that turn's completion via its own prompt future, so
+    /// buffering it would replay a stale completion onto a future adopted
+    /// turn. One lock over both fields keeps this mutually exclusive with
+    /// `install_control_outbound`.
     async fn emit_control(&self, body: ControlBody) {
-        {
-            let mut guard = self.control_outbound.lock().await;
-            if let Some(out) = guard.as_mut() {
-                if control_protocol::write_frame(out, &body).await.is_ok() {
-                    return;
-                }
-                *guard = None;
+        let mut ch = self.control.lock().await;
+        if let Some(out) = ch.outbound.as_mut() {
+            let ok = control_protocol::write_frame(out, &body).await.is_ok();
+            ch.outbound = None;
+            if ok {
+                return;
             }
+            // Dead socket: fall through to maybe-buffer for a later attach.
         }
-        let mut pending = self.pending_control.lock().await;
-        while pending.len() >= CONTROL_PENDING_CAP {
-            pending.pop_front();
+        if self
+            .main_attached
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
         }
-        pending.push_back(body);
+        ch.pending = Some(body);
     }
 
-    /// Install a control-channel write half: greet with `Hello`, drain any
-    /// buffered completion events, then store it as the active outbound.
+    /// Install a control-channel write half: greet with `Hello`, then under
+    /// the same lock either hand off the one buffered completion (and leave
+    /// the outbound unset, since that is the adopted turn's single frame)
+    /// or store the write half to deliver the completion live later.
     async fn install_control_outbound(
         &self,
         mut out: tokio::net::unix::OwnedWriteHalf,
@@ -989,23 +1022,23 @@ impl RunnerShared {
         {
             return;
         }
-        {
-            let mut pending = self.pending_control.lock().await;
-            while let Some(body) = pending.pop_front() {
-                if control_protocol::write_frame(&mut out, &body)
-                    .await
-                    .is_err()
-                {
-                    pending.push_front(body);
-                    return;
-                }
+        let mut ch = self.control.lock().await;
+        if let Some(body) = ch.pending.take() {
+            if control_protocol::write_frame(&mut out, &body)
+                .await
+                .is_err()
+            {
+                ch.pending = Some(body);
             }
+            // Delivered (or failed on a dead socket); one completion per
+            // attach, so do not retain the outbound.
+            return;
         }
-        *self.control_outbound.lock().await = Some(out);
+        ch.outbound = Some(out);
     }
 
     async fn clear_control_outbound(&self) {
-        *self.control_outbound.lock().await = None;
+        self.control.lock().await.outbound = None;
     }
 }
 
@@ -1074,8 +1107,7 @@ async fn read_frame_bounded<R: AsyncBufRead + Unpin>(
 }
 
 /// Peek fields of a JSON-RPC response line for turn-complete detection:
-/// the `result.stopReason` (when the response succeeded) and whether it
-/// carried an `error` envelope instead.
+/// the `result.stopReason` when the response succeeded.
 #[derive(Deserialize)]
 struct JsonRpcResponsePeek {
     #[serde(default)]
@@ -1084,29 +1116,26 @@ struct JsonRpcResponsePeek {
     method: Option<String>,
     #[serde(default)]
     result: Option<serde_json::Value>,
-    #[serde(default)]
-    error: Option<serde_json::Value>,
 }
 
-/// Parse a JSON-RPC response line into `(id, stop_reason, is_error)`.
-/// Returns None for requests (a `method` is present), notifications (no
-/// `id`), non-numeric ids, and malformed lines. `stop_reason` is the
-/// ACP `result.stopReason` when present; `is_error` is set when the
-/// response is a JSON-RPC error envelope.
-fn parse_response(line: &[u8]) -> Option<(i64, Option<String>, bool)> {
+/// Parse a JSON-RPC response line into `(id, stop_reason)`. Returns None
+/// for requests (a `method` is present), notifications (no `id`),
+/// non-numeric ids, and malformed lines. An error-envelope response (no
+/// `result`) still counts as a completion, with `stop_reason` None; the
+/// turn ended either way, so the UI should stop showing "thinking".
+fn parse_response(line: &[u8]) -> Option<(i64, Option<String>)> {
     let peek: JsonRpcResponsePeek = serde_json::from_slice(line).ok()?;
     if peek.method.is_some() {
         return None;
     }
     let id = peek.id?.as_i64()?;
-    let is_error = peek.error.is_some();
     let stop_reason = peek
         .result
         .as_ref()
         .and_then(|r| r.get("stopReason"))
         .and_then(|s| s.as_str())
         .map(|s| s.to_string());
-    Some((id, stop_reason, is_error))
+    Some((id, stop_reason))
 }
 
 /// Read agent stdout line-by-line (ndjson) and either forward to the
@@ -1445,16 +1474,15 @@ mod tests {
     #[test]
     fn parse_response_extracts_stop_reason() {
         let line = br#"{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}"#;
-        assert_eq!(
-            parse_response(line),
-            Some((3, Some("end_turn".into()), false))
-        );
+        assert_eq!(parse_response(line), Some((3, Some("end_turn".into()))));
     }
 
     #[test]
-    fn parse_response_flags_error_envelope() {
+    fn parse_response_treats_error_envelope_as_completion() {
+        // An error response still ends the turn; detected as a completion
+        // with no stopReason.
         let line = br#"{"jsonrpc":"2.0","id":4,"error":{"code":-32000,"message":"boom"}}"#;
-        assert_eq!(parse_response(line), Some((4, None, true)));
+        assert_eq!(parse_response(line), Some((4, None)));
     }
 
     #[test]
@@ -1478,9 +1506,10 @@ mod tests {
     /// The core Phase A invariant: a tracked `session/prompt` request id,
     /// seen on the daemon to agent path, produces a `PromptCompleted`
     /// control event when the matching response arrives on the agent to
-    /// daemon path. With no control daemon attached the event is buffered
-    /// in `pending_control`, which is exactly the mid-restart case the
-    /// change exists to cover.
+    /// daemon path. With no control daemon attached (and no main daemon
+    /// attached, i.e. a genuine gap) the event is buffered in
+    /// `control.pending`, which is exactly the mid-restart case the change
+    /// exists to cover.
     #[tokio::test]
     async fn prompt_response_emits_completed_control_event() {
         let shared = RunnerShared::new();
@@ -1495,15 +1524,34 @@ mod tests {
 
         // The prompt id is drained and a completion event is buffered.
         assert!(shared.prompt_requests.lock().await.is_empty());
-        let pending = shared.pending_control.lock().await;
-        assert_eq!(pending.len(), 1);
         assert_eq!(
-            pending.front(),
-            Some(&ControlBody::PromptCompleted {
+            shared.control.lock().await.pending,
+            Some(ControlBody::PromptCompleted {
                 prompt_req_id: 5,
                 stop_reason: Some("end_turn".into()),
-                is_error: false,
             })
+        );
+    }
+
+    /// The gate: a completion produced while a main-relay daemon is
+    /// attached is owned by that daemon's own prompt future, so it must
+    /// NOT be buffered (buffering would replay it onto a future adopted
+    /// turn, prematurely stopping it). See PR #2975 review.
+    #[tokio::test]
+    async fn completion_not_buffered_while_main_daemon_attached() {
+        let shared = RunnerShared::new();
+        shared
+            .main_attached
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let prompt = br#"{"jsonrpc":"2.0","id":8,"method":"session/prompt","params":{}}
+"#;
+        shared.note_prompt_request(prompt).await;
+        let resp = br#"{"jsonrpc":"2.0","id":8,"result":{"stopReason":"end_turn"}}
+"#;
+        shared.deliver_line(resp).await;
+        assert!(
+            shared.control.lock().await.pending.is_none(),
+            "a live main-relay daemon owns the completion; nothing should buffer"
         );
     }
 
@@ -1515,7 +1563,7 @@ mod tests {
         let resp = br#"{"jsonrpc":"2.0","id":77,"result":{}}
 "#;
         shared.deliver_line(resp).await;
-        assert!(shared.pending_control.lock().await.is_empty());
+        assert!(shared.control.lock().await.pending.is_none());
     }
 
     /// `deliver_line` populates the outstanding-requests map on the

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1587,6 +1587,40 @@ mod tests {
         );
     }
 
+    /// Regression for PR #2975: when a live control write fails (dead or
+    /// stalled socket), the completion must be buffered for the next attach
+    /// rather than dropped through the `main_attached` gate. A control
+    /// daemon had dialed in, so the completion is real and unreceived.
+    #[tokio::test]
+    async fn emit_control_buffers_on_write_failure_even_when_main_attached() {
+        use std::sync::atomic::Ordering;
+
+        let shared = RunnerShared::new();
+        // A control outbound whose peer is gone: writes to it fail. For an
+        // AF_UNIX stream, a write after the peer closes returns an error
+        // rather than buffering, so this is deterministic.
+        let (peer, ours) = tokio::net::UnixStream::pair().unwrap();
+        drop(peer);
+        let (_r, w) = ours.into_split();
+        shared.control.lock().await.outbound = Some(w);
+        // Main relay attached: the pre-fix code would drop here.
+        shared.main_attached.store(true, Ordering::Relaxed);
+
+        let body = ControlBody::PromptCompleted {
+            prompt_req_id: 9,
+            stop_reason: Some("end_turn".into()),
+        };
+        shared.emit_control(body.clone()).await;
+
+        let ch = shared.control.lock().await;
+        assert!(ch.outbound.is_none(), "a failed write clears the outbound");
+        assert_eq!(
+            ch.pending,
+            Some(body),
+            "completion buffered despite main_attached, not dropped through the gate"
+        );
+    }
+
     /// A response id the runner never tracked as a prompt (e.g. a reply to
     /// an fs/terminal request) must not produce a completion event.
     #[tokio::test]

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1018,9 +1018,20 @@ impl RunnerShared {
             if ok {
                 return;
             }
-            // Dead or stalled socket: fall through to maybe-buffer for a
-            // later attach.
+            // Dead or stalled control socket. A control daemon had dialed
+            // in (this is the resume/adopted-turn path), so this completion
+            // is real and was not received: buffer it unconditionally for
+            // the next control attach to replay. Do NOT fall through to the
+            // main_attached gate, which would drop it (the write timing out
+            // is exactly when the fast path matters most). See PR #2975.
+            ch.pending = Some(body);
+            return;
         }
+        // No control daemon was ever attached on this channel. Only buffer
+        // during a genuine no-daemon gap; while a main-relay daemon is
+        // attached it owns this turn's completion via its own prompt
+        // future, so buffering would replay a stale completion onto a
+        // future adopted turn.
         if self
             .main_attached
             .load(std::sync::atomic::Ordering::Relaxed)

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -291,6 +291,14 @@ pub fn log_path(dir: &Path, id: &str) -> Result<PathBuf> {
 /// `-`, `_`) so they never carry a `.` that would confuse the extension
 /// swap. Phase A of #1054.
 pub fn control_socket_sibling(main_socket: &Path) -> PathBuf {
+    // Guard against self-application: feeding an already-derived control
+    // path would silently yield `x.control.control.sock`. All callers pass
+    // the main `.sock`; this makes future misuse loud in debug builds.
+    debug_assert!(
+        !main_socket.to_string_lossy().ends_with(".control.sock"),
+        "control_socket_sibling called on an already-derived control path: {}",
+        main_socket.display()
+    );
     main_socket.with_extension("control.sock")
 }
 

--- a/src/process/worker.rs
+++ b/src/process/worker.rs
@@ -283,6 +283,17 @@ pub fn log_path(dir: &Path, id: &str) -> Result<PathBuf> {
     Ok(dir.join(format!("{id}.log")))
 }
 
+/// `<dir>/<id>.control.sock`, the typed control channel that rides
+/// alongside the raw ACP relay `<id>.sock`. Deriving it from the main
+/// socket keeps the runner (which binds it) and the daemon (which dials
+/// it) in agreement without either needing the workers dir: `x.sock`
+/// becomes `x.control.sock`. Session ids are validated (alphanumeric,
+/// `-`, `_`) so they never carry a `.` that would confuse the extension
+/// swap. Phase A of #1054.
+pub fn control_socket_sibling(main_socket: &Path) -> PathBuf {
+    main_socket.with_extension("control.sock")
+}
+
 /// `<dir>/<id>.restart`, a sentinel that distinguishes a restart-driven
 /// teardown from a stop/kill so the reaper can react accordingly.
 pub fn restart_marker_path(dir: &Path, id: &str) -> Result<PathBuf> {

--- a/src/process/worker_registry.rs
+++ b/src/process/worker_registry.rs
@@ -283,6 +283,9 @@ pub fn delete(session_id: &str) -> Result<()> {
     }
     if let Ok(p) = socket_path_for(session_id) {
         let _ = std::fs::remove_file(&p);
+        // Sibling control socket (Phase A of #1054); best-effort, absent
+        // for runners that predate the control channel.
+        let _ = std::fs::remove_file(crate::process::worker::control_socket_sibling(&p));
     }
     if let Ok(p) = log_path_for(session_id) {
         if matches!(std::fs::metadata(&p), Ok(m) if m.len() == 0) {

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -106,7 +106,10 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
             "--cwd",
             home.to_str().unwrap(),
             "--",
-            "cat",
+            // Absolute path: relying on the runner's inherited PATH makes a
+            // non-standard PATH (e.g. nix-first) surface as a confusing
+            // "registry record never appeared" instead of a clear failure.
+            "/bin/cat",
         ])
         .env("HOME", &home)
         .env("XDG_CONFIG_HOME", &xdg)
@@ -127,9 +130,11 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
     assert_eq!(hello["kind"], "hello", "first control frame is Hello");
     assert_eq!(hello["session_id"], session_id);
 
-    // Let the runner finish installing the control outbound before driving
-    // the prompt, so the completion event is written live rather than
-    // buffered for a future attach.
+    // Reading Hello proves the runner has started installing the control
+    // outbound, but the write half is stored just after Hello is sent, so
+    // this short wait lets that store land before we drive the prompt,
+    // exercising the live-write path rather than the buffered path. This is
+    // an ordering wait, not the closed emit/install TOCTOU race.
     std::thread::sleep(Duration::from_millis(150));
 
     // Act as the daemon on the relay socket: issue a session/prompt request

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -152,7 +152,6 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
     assert_eq!(completed["kind"], "prompt_completed");
     assert_eq!(completed["prompt_req_id"], 5);
     assert_eq!(completed["stop_reason"], "end_turn");
-    assert_eq!(completed["is_error"], false);
 
     let _ = child.kill();
     let _ = child.wait();

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -1,0 +1,159 @@
+//! Integration test for #1054 Phase A: the `aoe __acp-runner` shim binds a
+//! sibling `<id>.control.sock` and reports a native turn-complete signal
+//! over it when it observes the agent's response to the daemon-issued
+//! `session/prompt` request.
+//!
+//! This spawns a real runner with `cat` as the fake agent. `cat` echoes
+//! its stdin to stdout verbatim, which lets the test drive the full
+//! round-trip through real sockets: writing a `session/prompt` request and
+//! then a matching response line to the main relay socket makes the runner
+//! forward each to `cat`, echo them back on the agent-to-daemon path, and
+//! (for the response) fire `PromptCompleted` on the control socket. No real
+//! ACP agent is needed to exercise the runner's control-channel wiring.
+//!
+//! Before this change the control socket did not exist, so the control
+//! connect below fails outright; that is the red state the fix turns green.
+
+#![cfg(feature = "serve")]
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// App data dir for the debug binary under this test's env, mirroring the
+/// XDG resolution the runner uses.
+fn app_dir(home: &Path, xdg: &Path) -> PathBuf {
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
+        xdg.join("agent-of-empires-dev")
+    } else {
+        home.join(".agent-of-empires-dev")
+    }
+}
+
+/// Short-lived scratch dir under `/tmp` so the unix socket path stays
+/// within the macOS `SUN_LEN` limit. Removed on drop.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let base = if cfg!(unix) {
+            PathBuf::from("/tmp")
+        } else {
+            std::env::temp_dir()
+        };
+        let dir = base.join(format!("aoc{}{label}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        Scratch(dir)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn wait_for(path: &Path, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !path.exists() {
+        if Instant::now() > deadline {
+            panic!("{what} never appeared at {}", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Read one length-prefixed control frame (4-byte big-endian length, then
+/// that many JSON bytes) and parse it as a generic JSON value.
+fn read_frame(stream: &mut UnixStream) -> serde_json::Value {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).expect("read frame length");
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body).expect("read frame body");
+    serde_json::from_slice(&body).expect("parse frame json")
+}
+
+#[test]
+fn runner_reports_native_prompt_complete_over_control_socket() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    let scratch = Scratch::new("ctl");
+    let home = scratch.0.join("home");
+    let xdg = scratch.0.join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    let session_id = "sctl0001";
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let socket = workers.join(format!("{session_id}.sock"));
+    let control = workers.join(format!("{session_id}.control.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let mut child: Child = Command::new(bin)
+        .args([
+            "__acp-runner",
+            "--socket",
+            socket.to_str().unwrap(),
+            "--session-id",
+            session_id,
+            "--agent-name",
+            "fake-agent",
+            "--cwd",
+            home.to_str().unwrap(),
+            "--",
+            "cat",
+        ])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+        .spawn()
+        .expect("spawn acp runner");
+
+    // The runner binds the control socket before the main relay socket, so
+    // both exist once the record is written.
+    wait_for(&record, "registry record");
+    wait_for(&control, "control socket");
+    wait_for(&socket, "relay socket");
+
+    // Attach the control channel and read the runner's Hello greeting.
+    let mut ctl = UnixStream::connect(&control).expect("connect control socket");
+    ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    let hello = read_frame(&mut ctl);
+    assert_eq!(hello["kind"], "hello", "first control frame is Hello");
+    assert_eq!(hello["session_id"], session_id);
+
+    // Let the runner finish installing the control outbound before driving
+    // the prompt, so the completion event is written live rather than
+    // buffered for a future attach.
+    std::thread::sleep(Duration::from_millis(150));
+
+    // Act as the daemon on the relay socket: issue a session/prompt request
+    // (records the id), then a matching response (cat echoes it back on the
+    // agent-to-daemon path, where the runner detects turn completion).
+    let mut relay = UnixStream::connect(&socket).expect("connect relay socket");
+    relay
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"session/prompt\",\"params\":{}}\n")
+        .unwrap();
+    relay
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":5,\"result\":{\"stopReason\":\"end_turn\"}}\n")
+        .unwrap();
+    relay.flush().unwrap();
+
+    // The runner surfaces a native turn-complete for prompt id 5. The relay
+    // echoes the two request/response lines first, but those flow on the
+    // relay socket, not the control socket, so the next control frame is the
+    // PromptCompleted.
+    let completed = read_frame(&mut ctl);
+    assert_eq!(completed["kind"], "prompt_completed");
+    assert_eq!(completed["prompt_req_id"], 5);
+    assert_eq!(completed["stop_reason"], "end_turn");
+    assert_eq!(completed["is_error"], false);
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Phase A of runner-side ACP protocol termination (#1054). Today, when the daemon reattaches to a runner whose agent was mid-turn across an `aoe serve` restart, the agent's response to the orphaned `session/prompt` carries a JSON-RPC id the new daemon's client never issued, so the transport drops it silently. The daemon papers over this with a 30s resume-idle watchdog that synthesizes `Stopped { reason: "reattach_idle" }`, leaving the UI stuck on "thinking" for up to 30s after the turn has actually finished.

This introduces a typed control channel between the daemon and the `aoe __acp-runner` shim so the runner reports turn completion natively instead of the daemon guessing:

- The runner binds a sibling `<id>.control.sock` (before the main relay socket, so it is connectable by the time the daemon dials in). Frames are length-prefixed JSON (`ControlBody`: `Hello` / `PromptCompleted` / `Attach`).
- The runner tracks the daemon-issued `session/prompt` request id and, when it observes the agent's matching response, emits a `PromptCompleted` frame carrying the ACP `stopReason`. Completion events produced while no daemon is attached are buffered and replayed on the next control attach, so a turn that finishes during a daemon restart is not lost.
- On a mid-flight resume the daemon dials the control socket; a native `prompt_complete` claims the shared terminal guard and fires `Stopped { reason: "prompt_complete" }`, and the 30s resume-idle watchdog stands down. A runner too old to bind the control socket leaves the guard unclaimed, so the watchdog behaves exactly as before (fully backward compatible).

The full design (7 resolved architecture questions, phases A through D) was worked out via a three-model design debate. This PR is Phase A. It does not close - #1054; follow-up sub-issues track Phase B (runner owns the ACP handshake), Phase C (server-method proxying, `<id>.sock` retirement, `RUNNER_VERSION` bump + migration), and Phase D (long-detach durability + cleanup).

Relates to #1054

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view ACP session and send a prompt that keeps the agent working for a bit.
- [ ] While the turn is in flight, stop the daemon (`aoe serve --stop`) and start it again (`aoe serve`).
- [ ] Confirm the session clears "thinking" as soon as the agent's response lands (goes Idle promptly), rather than after the ~30s pause the old resume-idle watchdog imposed.
- [ ] Confirm a normal turn (no restart) still completes exactly once, with no duplicate stop.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

<!-- Coverage detail: added `tests/acp_runner_control.rs`, a full-binary integration test that spawns a real `aoe __acp-runner`, attaches the control socket, and asserts the native PromptCompleted frame over real sockets and framing, plus unit tests for the frame codec and the runner's prompt-response detection. A full daemon-restart-mid-turn structured-view e2e is deferred to a Phase B/C follow-up. -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a three-model design debate, the plan, and the implementation were drafted by Claude under my direction. I made the scope and design calls (full runner-terminator target, phased rollout, in-memory over disk durability, hand-rolled router over the crate), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a sibling Unix “control” socket for `aoe __acp-runner` so the runner can notify the daemon when an in-flight `session/prompt` turn finishes.
- Implemented a small typed, length-prefixed JSON control protocol (versioned hello/attach handshake) over that socket, including safe frame sizing and EOF handling.
- Updated runner/daemon reattach for in-flight turns: when supported, the daemon now uses the runner’s native `prompt_completed` notification to end the turn promptly with the correct stop reason (for example `prompt_complete`, or `rate_limited` when applicable), instead of the older idle/timeout-based fallback.
- Added runner-side prompt request tracking plus an in-memory “no-daemon gap” buffer so completions aren’t lost while the daemon detaches and reconnects; buffering is intentionally gated to avoid interfering when the daemon is still attached.
- Extended connection setup/teardown logic: control sockets are created as `<id>.control.sock`, runner control accept loops are managed cleanly, and stale sibling control sockets are removed during session deletion for older runners.
- Added unit and real-socket integration tests for control framing, version mismatch behavior, completion delivery/buffering, and legacy/socketless fallback; mid-turn restart coverage is deferred to later phases.

## Benefits

Reattached sessions can now complete faster and more accurately using real runner completion signals and correct stop reasons, while maintaining compatibility with older runners that don’t implement the control channel.

## Future enhancement

Phase A buffers completions only in memory for the daemon-detach gap; durable completion storage and full “restart mid-turn” end-to-end coverage are planned for later phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->