### PR TITLE
test: cover passive-status flush routing and equal-ts guard observability (#2756)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "tui-input",
  "unicode-normalization",
  "unicode-width",
@@ -4657,6 +4658,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,14 @@ serve = [
 
 [dev-dependencies]
 serial_test = "3.4"
+# Test-only: captures `tracing` events so a test can assert a log fired.
+# Used to prove `merge_passive_status_patch`'s equal-timestamp guard drop
+# branch executed (#2756, I4); it bundles its own `tracing-subscriber`. The
+# guard log uses a custom `target: "session.store"`, which the default
+# per-crate env filter (`agent_of_empires=trace`) rejects, so `no-env-filter`
+# is required for the event to reach the capture buffer; the test scopes to
+# its own span and matches the message substring, so wider capture is safe.
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 # Integration tests are separate crates and don't inherit the normal
 # `serde_json` dependency; the acp-runner orphan test parses a worker
 # registry record to mutate its pid structurally.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,13 +238,10 @@ serve = [
 
 [dev-dependencies]
 serial_test = "3.4"
-# Test-only: captures `tracing` events so a test can assert a log fired.
-# Used to prove `merge_passive_status_patch`'s equal-timestamp guard drop
-# branch executed (#2756, I4); it bundles its own `tracing-subscriber`. The
-# guard log uses a custom `target: "session.store"`, which the default
-# per-crate env filter (`agent_of_empires=trace`) rejects, so `no-env-filter`
-# is required for the event to reach the capture buffer; the test scopes to
-# its own span and matches the message substring, so wider capture is safe.
+# Test-only tracing capture (#2756, I4): asserts the equal-timestamp guard's
+# drop branch logged. Its target `session.store` is rejected by the default
+# `agent_of_empires=trace` env filter, so `no-env-filter` is required; the
+# test scopes to its own span and matches the message, so wide capture is safe.
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 # Integration tests are separate crates and don't inherit the normal
 # `serde_json` dependency; the acp-runner orphan test parses a worker

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6421,7 +6421,12 @@ mod tests {
     /// bundle must merge onto that profile's own storage and nowhere else. The
     /// two adjacent tests above already cover the `unread_ids` mirror, so this
     /// test asserts only the `patches` write (status / last_accessed_at) and
-    /// its per-profile routing, never unread. The instance-to-bundle assignment
+    /// its per-profile routing, never unread. Each profile is seeded with the
+    /// opposite status it is patched to, so a mis-routed bundle leaves a row at
+    /// its seeded status and fails the status assertion: that is the routing
+    /// discriminator. The trailing `id`-isolation checks guard profile storage
+    /// separation (persist merges by `id` and never inserts, so a stray row
+    /// cannot appear) rather than routing. The instance-to-bundle assignment
     /// in `status_poll_loop` (bundles.entry(inst.source_profile)) stays out of
     /// unit-test reach: it needs an `AppState`, which has no test constructor.
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6417,6 +6417,139 @@ mod tests {
         );
     }
 
+    /// Closes I1's patches-routing half from #2756: each profile's `patches`
+    /// bundle must merge onto that profile's own storage and nowhere else. The
+    /// two adjacent tests above already cover the `unread_ids` mirror, so this
+    /// test asserts only the `patches` write (status / last_accessed_at) and
+    /// its per-profile routing, never unread. The instance-to-bundle assignment
+    /// in `status_poll_loop` (bundles.entry(inst.source_profile)) stays out of
+    /// unit-test reach: it needs an `AppState`, which has no test constructor.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn flush_passive_transition_routes_patches_per_profile() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: serialized test; no other test mutates HOME concurrently.
+        unsafe { std::env::set_var("HOME", temp.path()) };
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+
+        let old = chrono::Utc::now() - chrono::Duration::minutes(1);
+        let new_ts = chrono::Utc::now();
+
+        let mut a1 = Instance::new("session-a", "/tmp/a");
+        a1.source_profile = "flush-a".to_string();
+        a1.status = Status::Running;
+        a1.last_accessed_at = Some(old);
+        let a1_id = a1.id.clone();
+
+        let mut b1 = Instance::new("session-b", "/tmp/b");
+        b1.source_profile = "flush-b".to_string();
+        b1.status = Status::Idle;
+        b1.last_accessed_at = Some(old);
+        let b1_id = b1.id.clone();
+
+        let seed_a = a1.clone();
+        crate::session::Storage::new_unwatched("flush-a")
+            .expect("storage")
+            .update(move |instances, _groups| {
+                *instances = vec![seed_a];
+                Ok(())
+            })
+            .expect("seed write");
+        let seed_b = b1.clone();
+        crate::session::Storage::new_unwatched("flush-b")
+            .expect("storage")
+            .update(move |instances, _groups| {
+                *instances = vec![seed_b];
+                Ok(())
+            })
+            .expect("seed write");
+
+        let mut bundles: std::collections::HashMap<String, PassiveTransitionWrites> =
+            std::collections::HashMap::new();
+        bundles
+            .entry("flush-a".to_string())
+            .or_default()
+            .patches
+            .insert(
+                a1_id.clone(),
+                crate::session::PassiveStatusPatch {
+                    status: Status::Idle,
+                    idle_entered_at: None,
+                    last_accessed_at: Some(new_ts),
+                },
+            );
+        bundles
+            .entry("flush-b".to_string())
+            .or_default()
+            .patches
+            .insert(
+                b1_id.clone(),
+                crate::session::PassiveStatusPatch {
+                    status: Status::Running,
+                    idle_entered_at: None,
+                    last_accessed_at: Some(new_ts),
+                },
+            );
+
+        let mut instances = vec![a1, b1];
+        flush_passive_transition_writes(
+            crate::file_watch::FileWatchService::noop(),
+            &mut instances,
+            bundles,
+        )
+        .await;
+
+        let disk_a = crate::session::Storage::new_unwatched("flush-a")
+            .expect("storage")
+            .load()
+            .expect("load");
+        let row_a = disk_a
+            .iter()
+            .find(|i| i.id == a1_id)
+            .expect("a1 on flush-a disk");
+        assert_eq!(
+            row_a.status,
+            Status::Idle,
+            "profile A's patch must merge its status onto profile A's storage"
+        );
+        assert_eq!(
+            row_a.last_accessed_at,
+            Some(new_ts),
+            "profile A's patch must merge its last_accessed_at onto profile A's storage"
+        );
+
+        let disk_b = crate::session::Storage::new_unwatched("flush-b")
+            .expect("storage")
+            .load()
+            .expect("load");
+        let row_b = disk_b
+            .iter()
+            .find(|i| i.id == b1_id)
+            .expect("b1 on flush-b disk");
+        assert_eq!(
+            row_b.status,
+            Status::Running,
+            "profile B's patch must merge its status onto profile B's storage"
+        );
+        assert_eq!(
+            row_b.last_accessed_at,
+            Some(new_ts),
+            "profile B's patch must merge its last_accessed_at onto profile B's storage"
+        );
+
+        assert!(
+            disk_a.iter().all(|i| i.id != b1_id),
+            "profile A's storage must not gain profile B's row"
+        );
+        assert!(
+            disk_b.iter().all(|i| i.id != a1_id),
+            "profile B's storage must not gain profile A's row"
+        );
+    }
+
     #[test]
     fn extract_web_build_id_finds_entry_bundle() {
         let html = r#"<head><script type="module" crossorigin src="/assets/index-DKenwdW0.js"></script>

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6424,11 +6424,9 @@ mod tests {
     /// its per-profile routing, never unread. Each profile is seeded with the
     /// opposite status it is patched to, so a mis-routed bundle leaves a row at
     /// its seeded status and fails the status assertion: that is the routing
-    /// discriminator. The trailing `id`-isolation checks guard profile storage
-    /// separation (persist merges by `id` and never inserts, so a stray row
-    /// cannot appear) rather than routing. The instance-to-bundle assignment
-    /// in `status_poll_loop` (bundles.entry(inst.source_profile)) stays out of
-    /// unit-test reach: it needs an `AppState`, which has no test constructor.
+    /// discriminator. The instance-to-bundle assignment in `status_poll_loop`
+    /// (bundles.entry(inst.source_profile)) stays out of unit-test reach: it
+    /// needs an `AppState`, which has no test constructor.
     #[tokio::test]
     #[serial_test::serial]
     async fn flush_passive_transition_routes_patches_per_profile() {
@@ -6543,15 +6541,6 @@ mod tests {
             row_b.last_accessed_at,
             Some(new_ts),
             "profile B's patch must merge its last_accessed_at onto profile B's storage"
-        );
-
-        assert!(
-            disk_a.iter().all(|i| i.id != b1_id),
-            "profile A's storage must not gain profile B's row"
-        );
-        assert!(
-            disk_b.iter().all(|i| i.id != a1_id),
-            "profile B's storage must not gain profile A's row"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -5176,6 +5176,7 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
 mod tests {
     use super::*;
     use crate::session::test_support::EnvGuard;
+    use tracing_test::traced_test;
 
     /// Force the tmux session cache into a fresh "server reachable, but this
     /// session is not in its list" snapshot so `Session::existence()` resolves
@@ -6628,6 +6629,78 @@ mod tests {
         // equal to `ts` either way (disk == incoming), so the assertion
         // does not change; the point of the guard is skipping the write.
         assert_eq!(disk.last_accessed_at, Some(ts));
+    }
+
+    /// Closes I4 from #2756: the equal-timestamp guard's observability gap.
+    /// Under `disk == incoming` the drop branch and the write branch leave the
+    /// same observable `last_accessed_at`, so the boundary_equal test above
+    /// cannot prove the drop branch ran. Here `disk == incoming` must fire the
+    /// `session.store` drop log exactly once, matched on the message substring
+    /// so unrelated `session.store` events cannot inflate the count.
+    #[traced_test]
+    #[test]
+    fn test_merge_passive_status_patch_equal_ts_logs_drop_event() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        let ts = Utc::now();
+        disk.last_accessed_at = Some(ts);
+
+        let patch = PassiveStatusPatch {
+            status: Status::Idle,
+            idle_entered_at: None,
+            last_accessed_at: Some(ts),
+        };
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
+
+        logs_assert(|lines: &[&str]| {
+            let n = lines
+                .iter()
+                .filter(|l| {
+                    l.contains("dropped passive status patch's last_accessed_at as a no-op")
+                })
+                .count();
+            if n == 1 {
+                Ok(())
+            } else {
+                Err(format!("expected 1 drop event, got {n}"))
+            }
+        });
+    }
+
+    /// Closes I4 from #2756 (write side): a strictly newer incoming timestamp
+    /// skips the guard, so the drop log must fire zero times and the value is
+    /// written. Pairing the zero-count write case with the exactly-once drop
+    /// case above proves the log is a faithful drop-vs-write signal, not a line
+    /// that fires regardless. Uses an explicit minute offset (as
+    /// `boundary_newer_applies` does) to avoid a same-instant flake.
+    #[traced_test]
+    #[test]
+    fn test_merge_passive_status_patch_newer_ts_no_drop_event() {
+        let mut disk = Instance::new("session", "/tmp/test");
+        let older = Utc::now() - chrono::Duration::minutes(1);
+        let newer = Utc::now();
+        disk.last_accessed_at = Some(older);
+
+        let patch = PassiveStatusPatch {
+            status: Status::Idle,
+            idle_entered_at: None,
+            last_accessed_at: Some(newer),
+        };
+        disk.merge_passive_status_patch(&disk.id.clone(), &patch);
+
+        logs_assert(|lines: &[&str]| {
+            let n = lines
+                .iter()
+                .filter(|l| {
+                    l.contains("dropped passive status patch's last_accessed_at as a no-op")
+                })
+                .count();
+            if n == 0 {
+                Ok(())
+            } else {
+                Err(format!("expected 0 drop events, got {n}"))
+            }
+        });
+        assert_eq!(disk.last_accessed_at, Some(newer));
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -6631,15 +6631,25 @@ mod tests {
         assert_eq!(disk.last_accessed_at, Some(ts));
     }
 
+    /// Count the guard's drop-event log lines. `logs_assert` hands us lines
+    /// already scoped to the calling test's span, and the message is unique to
+    /// the drop branch, so matching the substring cannot be inflated by other
+    /// `session.store` events.
+    fn drop_log_count(lines: &[&str]) -> usize {
+        lines
+            .iter()
+            .filter(|l| l.contains("dropped passive status patch's last_accessed_at as a no-op"))
+            .count()
+    }
+
     /// Closes I4 from #2756: the equal-timestamp guard's observability gap.
     /// Under `disk == incoming` the drop branch and the write branch leave the
-    /// same observable `last_accessed_at`, so the boundary_equal test above
+    /// same observable `last_accessed_at`, so `boundary_equal_is_a_noop` above
     /// cannot prove the drop branch ran. Here `disk == incoming` must fire the
-    /// `session.store` drop log exactly once, matched on the message substring
-    /// so unrelated `session.store` events cannot inflate the count.
+    /// `session.store` drop log exactly once.
     #[traced_test]
     #[test]
-    fn test_merge_passive_status_patch_equal_ts_logs_drop_event() {
+    fn test_merge_passive_status_patch_last_accessed_at_boundary_equal_logs_drop_event() {
         let mut disk = Instance::new("session", "/tmp/test");
         let ts = Utc::now();
         disk.last_accessed_at = Some(ts);
@@ -6651,18 +6661,9 @@ mod tests {
         };
         disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
-        logs_assert(|lines: &[&str]| {
-            let n = lines
-                .iter()
-                .filter(|l| {
-                    l.contains("dropped passive status patch's last_accessed_at as a no-op")
-                })
-                .count();
-            if n == 1 {
-                Ok(())
-            } else {
-                Err(format!("expected 1 drop event, got {n}"))
-            }
+        logs_assert(|lines: &[&str]| match drop_log_count(lines) {
+            1 => Ok(()),
+            n => Err(format!("expected 1 drop event, got {n}")),
         });
     }
 
@@ -6674,7 +6675,7 @@ mod tests {
     /// `boundary_newer_applies` does) to avoid a same-instant flake.
     #[traced_test]
     #[test]
-    fn test_merge_passive_status_patch_newer_ts_no_drop_event() {
+    fn test_merge_passive_status_patch_last_accessed_at_boundary_newer_no_drop_event() {
         let mut disk = Instance::new("session", "/tmp/test");
         let older = Utc::now() - chrono::Duration::minutes(1);
         let newer = Utc::now();
@@ -6687,18 +6688,9 @@ mod tests {
         };
         disk.merge_passive_status_patch(&disk.id.clone(), &patch);
 
-        logs_assert(|lines: &[&str]| {
-            let n = lines
-                .iter()
-                .filter(|l| {
-                    l.contains("dropped passive status patch's last_accessed_at as a no-op")
-                })
-                .count();
-            if n == 0 {
-                Ok(())
-            } else {
-                Err(format!("expected 0 drop events, got {n}"))
-            }
+        logs_assert(|lines: &[&str]| match drop_log_count(lines) {
+            0 => Ok(()),
+            n => Err(format!("expected 0 drop events, got {n}")),
         });
         assert_eq!(disk.last_accessed_at, Some(newer));
     }


### PR DESCRIPTION
## Description

Partial coverage for #2756. Adds three test-only checks to the passive-status pipeline landed by #2729, with no production change. Two close I4 (equal-timestamp guard observability): `merge_passive_status_patch` drops the incoming `last_accessed_at` under `disk >= incoming` and logs a `session.store` debug event, but under `disk == incoming` the observable value is identical whether the guard fired or not, so a paired drop-case (drop-count == 1) and write-case (drop-count == 0, value written) assert the log is a faithful drop-vs-write signal. One closes the uncovered half of I1: per-profile routing of `flush_passive_transition_writes`'s `patches` map across two profiles, asserting profile A's patch lands on profile A's storage and never on B's. Both invariants compiled clean but were untested, so a mis-routed patch bundle or a silently-skipped guard would not be caught today.

This PR is deliberately partial, so #2756 stays open: the `unread_ids` half of I1 is already covered by two adjacent flush tests; I2 (panic containment on `poll_statuses_once`) is already covered structurally by `worker_try_recv_surfaces_disconnected_after_handler_panic` in `src/tui/worker.rs`, since the poller runs inside a `Worker` thread with no panic-injection seam of its own; and I3 (cross-writer interleave race) needs a flake-prone concurrency harness and is deferred to its own issue.

The only non-test edit is the `[dev-dependencies]` addition of `tracing-test` (with `no-env-filter`, required because the guard log uses a custom `target: "session.store"` that the default per-crate env filter rejects).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle; this adds unit/integration coverage of existing library code
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:** OpenCode with Anthropic Claude (Opus)


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<details>
<summary>Verification output</summary>

```
$ cargo fmt --check
(clean, no output)

$ cargo test --lib test_merge_passive_status_patch_last_accessed_at_boundary_equal_logs_drop_event
running 1 test
test session::instance::tests::test_merge_passive_status_patch_last_accessed_at_boundary_equal_logs_drop_event ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4127 filtered out

$ cargo test --lib test_merge_passive_status_patch_last_accessed_at_boundary_newer_no_drop_event
running 1 test
test session::instance::tests::test_merge_passive_status_patch_last_accessed_at_boundary_newer_no_drop_event ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4127 filtered out

$ cargo test --features serve --lib flush_passive_transition_routes_patches_per_profile
running 1 test
test server::tests::flush_passive_transition_routes_patches_per_profile ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5448 filtered out

$ cargo clippy --features serve --all-targets
Finished `dev` profile; the only two warnings are pre-existing
(src/acp/acp_client.rs, src/tui/home/mod.rs) and untouched by this PR.

$ cargo test --features serve --lib
test result: ok. 5447 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

$ cargo build
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added test-only coverage for passive-status timestamp handling, including equal-timestamp no-op behavior and newer timestamp writes.
- Added routing tests to ensure passive-status updates are written to the correct profile.
- Added `tracing-test` as a development dependency to verify relevant debug logs.
- No production code or public APIs were changed.

## Benefits

Improves confidence in passive-status persistence, logging, and multi-profile isolation while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->