### PR TITLE
docs(website): link CityHall page to the CityHall docs

### DIFF
--- a/website/src/pages/cityhall.astro
+++ b/website/src/pages/cityhall.astro
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.astro';
 import FeatureCard from '../components/FeatureCard.astro';
 
 const repo = 'https://github.com/agent-of-empires/cityhall';
+const docs = 'https://cityhall.agent-of-empires.com/docs/';
 
 const features = [
   { n: '01', title: 'User management', description: 'Accounts, authentication, email invites, password reset, and a forced password change on first login.' },
@@ -42,6 +43,7 @@ const features = [
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
           View on GitHub
         </a>
+        <a href={docs} target="_blank" rel="noopener" class="btn-secondary text-base inline-flex items-center gap-2">Read the docs</a>
         <a href="/" class="btn-secondary text-base inline-flex items-center gap-2">Back to aoe</a>
       </div>
       <p class="font-mono text-xs text-gray-500 max-w-xl">
@@ -76,6 +78,7 @@ const features = [
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
           View on GitHub
         </a>
+        <a href={docs} target="_blank" rel="noopener" class="btn-secondary text-base inline-flex items-center gap-2">Read the docs</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The CityHall page on the aoe website (`website/src/pages/cityhall.astro`) linked only to the CityHall GitHub repo. The CTA band copy even promised "Read the setup guide and the source on GitHub", but no link to any docs or setup guide existed, so readers had no way to reach the CityHall documentation.

This adds a "Read the docs" link pointing at `https://cityhall.agent-of-empires.com/docs/` in two spots: the hero button row (next to "View on GitHub") and the CTA band (making the promised setup-guide link real). The URL is factored into a single `docs` const at the top of the page.

Closes #2943

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Build the site: `cd website && npm install && npm run build`, then open `dist/cityhall/index.html`.
- [ ] In the hero, click "Read the docs" and confirm it opens `https://cityhall.agent-of-empires.com/docs/` in a new tab.
- [ ] In the bottom CTA band, confirm a "Read the docs" button links to the same URL.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This is a static Astro marketing page under `website/`, not the `web/` dashboard; it has no Playwright/Vitest harness. Verified via `npm run build` (page builds, docs URL renders twice).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls and approved the plan before any code was written.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added a shared CityHall documentation URL.
- Added “Read the docs” links to the hero and bottom CTA sections.

## Benefits
- Makes CityHall documentation easier to discover from the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->