### PR TITLE
feat(plugin): add settings-page full-page UiSlot with web renderer and settings-nav mount

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -40,5 +40,5 @@ pub use manifest::{
 /// actions; 9 when the host gained ACP-capability discovery, host-owned
 /// session creation / prompt delivery (with the `session.unattended` grant),
 /// plugin-private storage, and structured settings widgets (`object_list`,
-/// `dynamic_select`).
-pub const API_VERSION: u32 = 9;
+/// `dynamic_select`); 10 when the `settings-page` full-page slot was added.
+pub const API_VERSION: u32 = 10;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -698,6 +698,11 @@ pub enum UiSlot {
     ComposerAction,
     /// A badge in a session's detail view (per session).
     DetailBadge,
+    /// A routed full page mounted as its own entry in the dashboard settings
+    /// nav (global). The host renders the plugin's pushed page body (the same
+    /// `blocks` vocabulary as `Pane`) so a plugin can host a full management
+    /// panel without a per-session dock.
+    SettingsPage,
     /// A transient notification, pushed via `ui.notify` (gated by the
     /// `notifications` capability rather than a slot declaration).
     Notification,
@@ -731,6 +736,7 @@ impl UiSlot {
             UiSlot::Pane => "pane",
             UiSlot::ComposerAction => "composer-action",
             UiSlot::DetailBadge => "detail-badge",
+            UiSlot::SettingsPage => "settings-page",
             UiSlot::Notification => "notification",
         }
     }
@@ -1245,6 +1251,14 @@ impl PluginManifest {
                     )
                 }),
                 "dynamic_select / object_list / cron settings require api_version >= 9".into(),
+            );
+        }
+        // `settings-page` is an api_version 10 slot; force the bump for the same
+        // reason as the gates above.
+        if self.api_version < 10 {
+            check(
+                self.ui.iter().all(|u| u.slot != UiSlot::SettingsPage),
+                "settings-page UI slots require api_version >= 10".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -687,10 +687,50 @@ fn ui_slot_as_str_round_trips_the_wire_name() {
         ("row-badge", UiSlot::RowBadge),
         ("pane", UiSlot::Pane),
         ("composer-action", UiSlot::ComposerAction),
+        ("settings-page", UiSlot::SettingsPage),
         ("notification", UiSlot::Notification),
     ] {
         assert_eq!(slot.as_str(), toml_slot);
     }
+}
+
+#[test]
+fn settings_page_requires_api_version_10() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+
+[[ui]]
+slot = "settings-page"
+id = "main"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("settings-page UI slots require api_version >= 10"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn settings_page_parses_at_api_version_10() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 10
+
+[[ui]]
+slot = "settings-page"
+id = "main"
+"#;
+    let m = PluginManifest::from_toml_str(toml).expect("api 10 manifest parses");
+    assert_eq!(m.ui[0].slot, UiSlot::SettingsPage);
+    assert!(
+        !UiSlot::SettingsPage.is_per_session(),
+        "settings-page is global"
+    );
 }
 
 #[test]

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -190,10 +190,12 @@ declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
 declares; they are defined in `aoe-plugin-api` and parsed/validated by the
 host, but consumed by later issues (the settings registry in #2094, the runtime
 host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is now
-9 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
+10 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
 became the dockable `pane` slot, 4 for the `status` section and the
 `aoe_version` field, 5 for screenshots, 6 for command actions, 7 for identity
-icons, 8 for the `composer-action` slot, and 9 for the `settings-page` slot); an
+icons, 8 for the `composer-action` slot, 9 for ACP-capability discovery,
+host-owned sessions, plugin-private storage, and structured settings widgets,
+and 10 for the `settings-page` slot); an
 older `api_version` manifest still loads as long as it targets no newer field. Unknown top-level keys remain
 a hard parse error
 (`deny_unknown_fields`).
@@ -746,7 +748,7 @@ Two slots carry more than a single value, so one entry (one declared
   `row-badge`, `row-column`, `card`, `detail-badge`), so a plugin can push a full
   comment list in one pane entry without truncating to fit.
 
-- `settings-page` is a routed full page (api_version 9). It is global (no
+- `settings-page` is a routed full page (api_version 10). It is global (no
   `session_id`) and carries the same `{ title, body }` or `blocks` content as a
   pane (drawn by the same block renderer), minus `default_location`, which a full
   page has no use for and which `deny_unknown_fields` rejects. It shares the

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -190,11 +190,11 @@ declares: `capabilities`, `commands`, `keybinds`, `settings`, `ui`, and a
 declares; they are defined in `aoe-plugin-api` and parsed/validated by the
 host, but consumed by later issues (the settings registry in #2094, the runtime
 host in #2095, the command/keybind/UI surfaces in #2366). `api_version` is now
-8 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
+9 (bumped to 2 for the contribution sections, 3 when the `detail-panel` slot
 became the dockable `pane` slot, 4 for the `status` section and the
 `aoe_version` field, 5 for screenshots, 6 for command actions, 7 for identity
-icons, and 8 for the `composer-action` slot); an older `api_version` manifest
-still loads as long as it targets no newer field. Unknown top-level keys remain
+icons, 8 for the `composer-action` slot, and 9 for the `settings-page` slot); an
+older `api_version` manifest still loads as long as it targets no newer field. Unknown top-level keys remain
 a hard parse error
 (`deny_unknown_fields`).
 
@@ -658,9 +658,10 @@ the TUI renders).
 
 The slots are a closed `UiSlot` set (`aoe-plugin-api`), kebab-case on the
 wire: `status-bar`, `row-badge`, `row-column`, `sort-key`, `filter-facet`,
-`card`, `pane`, `composer-action`, `detail-badge`, `notification`. A plugin
-declares the `(slot, id)` pairs it may fill in its manifest `[[ui]]` section;
-an unknown slot is a hard parse error (the host must know how to render each).
+`card`, `pane`, `composer-action`, `detail-badge`, `settings-page`,
+`notification`. A plugin declares the `(slot, id)` pairs it may fill in its
+manifest `[[ui]]` section; an unknown slot is a hard parse error (the host must
+know how to render each).
 
 A UI contribution is not a capability and needs no grant, but the slots a
 plugin declares are disclosed so the user knows it modifies the dashboard
@@ -744,6 +745,16 @@ Two slots carry more than a single value, so one entry (one declared
   JSON may be up to 64KB, against 8KB for every other slot (`status-bar`,
   `row-badge`, `row-column`, `card`, `detail-badge`), so a plugin can push a full
   comment list in one pane entry without truncating to fit.
+
+- `settings-page` is a routed full page (api_version 9). It is global (no
+  `session_id`) and carries the same `{ title, body }` or `blocks` content as a
+  pane (drawn by the same block renderer), minus `default_location`, which a full
+  page has no use for and which `deny_unknown_fields` rejects. It shares the
+  pane's 64KB budget. The web mounts one Settings nav entry per declared
+  `(settings-page, id)` contribution, routed under `/settings/plugin-page:<...>`;
+  the entry's page body is the plugin's pushed state. The nav entry appears on
+  declaration, so the page shows a "waiting for the plugin" state until the
+  worker pushes its first entry.
 
 **Block parsing is forward-compatible by design.** The host stores `blocks` as
 opaque JSON (`Vec<Value>`); it validates only that the payload envelope is
@@ -834,8 +845,9 @@ can show: global `status-bar` segments and the open session's `detail-badge`
 entries, tone-colored, in its status line, plus `notification`s as toasts
 (deduped by `seq`, queued so a burst shows one at a time). It renders text and
 tone only; `icon`, `tooltip`, and `href` are dropped, and `card`, `pane`,
-`row-badge`, `row-column`, `sort-key`, and `filter-facet` have no structured-view
-surface. The standalone home screen reads local session storage and has no
+`row-badge`, `row-column`, `sort-key`, `filter-facet`, and `settings-page` have
+no structured-view surface (a terminal cannot render a routed full page; it is a
+documented web-only no-op). The standalone home screen reads local session storage and has no
 daemon link, so it renders no plugin slots; rendering there is a follow-up
 (#2402).
 

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -1674,6 +1674,38 @@ mod tests {
     }
 
     #[test]
+    fn ui_state_set_settings_page_requires_declaration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        // Declared settings-page/"main"; an undeclared settings-page/"other" is
+        // refused by the same generic (slot, id) guard.
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::SettingsPage, "main");
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "settings-page", "id": "other", "payload": {"title": "x"}}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        // The declared global page succeeds and surfaces in the snapshot.
+        dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "settings-page", "id": "main", "payload": {"title": "MCP", "blocks": [{"kind": "heading", "text": "Servers"}]}}),
+        )
+        .unwrap();
+        let snap = state.ui_snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert!(
+            snap.entries[0].session_id.is_none(),
+            "settings-page is global"
+        );
+    }
+
+    #[test]
     fn ui_state_set_needs_worker_capability() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state(tmp.path());

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -234,6 +234,28 @@ struct PanePayload {
     icon: Option<String>,
 }
 
+/// `settings-page` payload (the routed full-page slot). Mirrors `PanePayload`'s
+/// content shape, the simple `{ title, body }` form or an ordered forward-
+/// compatible `blocks` list, so the web renders it through the same block
+/// vocabulary. It drops `default_location`: a full page is not docked, so a
+/// dock hint would be meaningless, and `deny_unknown_fields` rejects it rather
+/// than silently accepting a no-op field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SettingsPagePayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    blocks: Option<Vec<Value>>,
+    /// Lucide icon name for the page's nav entry. Opaque to the host (the web
+    /// resolves it against its allowlist); kept only so `deny_unknown_fields`
+    /// accepts it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ComposerActionPayload {
@@ -726,7 +748,7 @@ impl UiStore {
 /// it gets a larger budget than the small single-value slots.
 fn max_payload_bytes(slot: UiSlot) -> usize {
     match slot {
-        UiSlot::Pane => MAX_PANE_PAYLOAD_BYTES,
+        UiSlot::Pane | UiSlot::SettingsPage => MAX_PANE_PAYLOAD_BYTES,
         UiSlot::ComposerAction => MAX_COMPOSER_ACTION_PAYLOAD_BYTES,
         _ => MAX_PAYLOAD_BYTES,
     }
@@ -767,6 +789,7 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
         UiSlot::FilterFacet => normalize::<FilterFacetPayload>(raw),
         UiSlot::Card => normalize::<CardPayload>(raw),
         UiSlot::Pane => normalize::<PanePayload>(raw),
+        UiSlot::SettingsPage => normalize::<SettingsPagePayload>(raw),
         UiSlot::ComposerAction => {
             let parsed: ComposerActionPayload =
                 serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
@@ -885,6 +908,38 @@ mod tests {
         s.remove("acme.kit", g, UiSlot::StatusBar, "build", None)
             .unwrap();
         assert_eq!(s.snapshot().entries.len(), 0);
+    }
+
+    #[test]
+    fn settings_page_accepts_blocks_and_rejects_unknown_field() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // Global page with a block list is accepted and stored.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::SettingsPage,
+            "main",
+            None,
+            &json!({"title": "MCP", "blocks": [{"kind": "heading", "text": "Servers"}]}),
+        )
+        .unwrap();
+        let snap = s.snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(snap.entries[0].slot, UiSlot::SettingsPage);
+        // `default_location` is a pane-only field; the dedicated payload rejects
+        // it via deny_unknown_fields.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::SettingsPage,
+                "main",
+                None,
+                &json!({"title": "MCP", "default_location": "right"}),
+            ),
+            Err(UiError::BadRequest(_))
+        ));
     }
 
     #[test]

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -3,8 +3,9 @@
 //! narrowed to what a terminal can render: the structured view shows
 //! `StatusBar` (global) and `DetailBadge` (per-session) text, tone-colored,
 //! plus `Notification` toasts. Icons, tooltips, hrefs, and the
-//! `Card`/`Pane`/`RowBadge`/`RowColumn`/`SortKey`/`FilterFacet` slots have no
-//! TUI surface here and are ignored.
+//! `Card`/`Pane`/`RowBadge`/`RowColumn`/`SortKey`/`FilterFacet`/`SettingsPage`
+//! slots have no TUI surface here and are ignored (a terminal cannot render a
+//! routed full page).
 //!
 //! Kept side-effect-free so the render layer can borrow the snapshot and so the
 //! filtering / tone-mapping logic is unit-testable without a daemon.

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -65,7 +65,7 @@ const PLUGIN_PAGE_PREFIX = "plugin-page:";
 // percent-encoded, so it carries no literal `:` and the first `:` after the
 // prefix is an unambiguous delimiter. Round-trips as a single `/settings/:tab`
 // URL segment.
-function pluginPageTabId(pluginId: string, contribId: string): string {
+export function pluginPageTabId(pluginId: string, contribId: string): string {
   return `${PLUGIN_PAGE_PREFIX}${encodeURIComponent(pluginId)}:${encodeURIComponent(contribId)}`;
 }
 
@@ -301,18 +301,33 @@ export function SettingsView({
   // manifest ui_contributions (not the live UI-state snapshot) so a nav entry
   // appears on declaration and does not vanish when the worker restarts.
   const [pluginPages, setPluginPages] = useState<PluginPageNav[]>([]);
+  // Whether the installed-plugin list has resolved at least once. A parametric
+  // plugin-page route that matches no entry is only an invalid route once we
+  // know the list is loaded; before that it may just be a not-yet-fetched valid
+  // page, so we hold a loading state rather than rejecting it.
+  const [pluginsLoaded, setPluginsLoaded] = useState(false);
+  const refreshPluginPages = useCallback(
+    () =>
+      fetchPlugins().then((res) => {
+        if (res) setPluginPages(pluginSettingsPages(res.plugins));
+        setPluginsLoaded(true);
+      }),
+    [],
+  );
   useEffect(() => {
-    fetchPlugins().then((res) => {
-      if (res) setPluginPages(pluginSettingsPages(res.plugins));
-    });
-  }, []);
+    void refreshPluginPages();
+  }, [refreshPluginPages]);
   const sidebar = buildSidebar(pluginPages);
   const tabs = sidebar.filter((s): s is { kind: "tab"; id: string; label: string } => s.kind === "tab");
   const pluginPageDest = parsePluginPageTab(tab);
+  // The declared nav entry a plugin-page route resolves to, or undefined when
+  // the route matches no enabled contribution (typo, removed, or disabled).
+  const pluginPageNav = pluginPageDest ? pluginPages.find((p) => p.tabId === tab) : undefined;
   const activeTab: TabId = isTabId(tab) ? tab : "session";
-  // The nav highlight/label id: the raw parametric tab for a plugin page, else
-  // the resolved built-in TabId.
-  const activeNavId: string = pluginPageDest ? (tab as string) : activeTab;
+  // The nav highlight/label id: the raw parametric tab only for a route that
+  // matches a real plugin page, else the resolved built-in TabId (so an invalid
+  // plugin-page route highlights the fallback tab, not a phantom entry).
+  const activeNavId: string = pluginPageNav ? (tab as string) : activeTab;
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   // Settings schema (single source of truth, #1692). The generic SchemaSection
   // renderer builds sandbox/worktree from this; empty until the one-shot fetch
@@ -474,16 +489,24 @@ export function SettingsView({
   const renderTabContent = () => {
     // A plugin settings page (#2985) renders from the plugin UI-state snapshot,
     // not the host `settings`, so it short-circuits before the settings-load
-    // guard and the built-in tab switch.
+    // guard and the built-in tab switch. Only a route that resolves to a
+    // declared, enabled contribution renders the page; an unmatched route waits
+    // while the plugin list loads, then falls through to the built-in default
+    // rather than showing a permanent "waiting" page for a stale or typo'd URL.
     if (pluginPageDest) {
-      const nav = pluginPages.find((p) => p.tabId === tab);
-      return (
-        <PluginSettingsPage
-          pluginId={pluginPageDest.pluginId}
-          contribId={pluginPageDest.contribId}
-          pluginName={nav?.label ?? pluginPageDest.pluginId}
-        />
-      );
+      if (pluginPageNav) {
+        return (
+          <PluginSettingsPage
+            pluginId={pluginPageDest.pluginId}
+            contribId={pluginPageDest.contribId}
+            pluginName={pluginPageNav.label}
+          />
+        );
+      }
+      if (!pluginsLoaded) {
+        return <div className="text-sm text-text-dim">Loading settings...</div>;
+      }
+      // Loaded with no match: fall through to the built-in default tab.
     }
     if (
       !settings &&
@@ -653,7 +676,7 @@ export function SettingsView({
       case "plugins":
         return (
           <div className="space-y-6" {...tourAnchor(TOUR_ANCHORS.settingsPlugins)}>
-            <PluginsSettings />
+            <PluginsSettings onPluginsChanged={refreshPluginPages} />
             {schemaGuard() ?? <PluginSettingsSections schema={schema} settings={settings} onSaved={loadSettings} />}
           </div>
         );

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -7,6 +7,7 @@ import { NotificationSettings } from "./NotificationSettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { TerminalSettings } from "./TerminalSettings";
 import {
+  fetchPlugins,
   fetchProfiles,
   fetchSettings,
   getSettingsSchema,
@@ -14,6 +15,7 @@ import {
   updateProfileSettings,
   updateTheme,
 } from "../lib/api";
+import { PluginSettingsPage } from "./plugin/PluginSlots";
 import type { ProfileInfo, SettingsFieldDescriptor } from "../lib/types";
 import { SchemaSection } from "./settings/SchemaSection";
 import { SelectField } from "./settings/FormFields";
@@ -46,7 +48,70 @@ export type TabId =
   | "logging"
   | "plugins";
 
-type SidebarItem = { kind: "tab"; id: TabId; label: string; icon?: ReactNode } | { kind: "divider"; label: string };
+// A plugin-contributed settings page (#2985): one nav entry per declared
+// `settings-page` UI contribution. The tab id is a parametric string outside the
+// closed `TabId` union, so it is kept as `string` here and parsed back with
+// `parsePluginPageTab` rather than polluting `ALL_TAB_IDS`/`isTabId`.
+export interface PluginPageNav {
+  tabId: string;
+  label: string;
+  pluginId: string;
+  contribId: string;
+}
+
+const PLUGIN_PAGE_PREFIX = "plugin-page:";
+
+// `plugin-page:<encodedPluginId>:<encodedContribId>`. Each id part is
+// percent-encoded, so it carries no literal `:` and the first `:` after the
+// prefix is an unambiguous delimiter. Round-trips as a single `/settings/:tab`
+// URL segment.
+function pluginPageTabId(pluginId: string, contribId: string): string {
+  return `${PLUGIN_PAGE_PREFIX}${encodeURIComponent(pluginId)}:${encodeURIComponent(contribId)}`;
+}
+
+export function parsePluginPageTab(tab: string | null): { pluginId: string; contribId: string } | null {
+  if (!tab || !tab.startsWith(PLUGIN_PAGE_PREFIX)) return null;
+  const rest = tab.slice(PLUGIN_PAGE_PREFIX.length);
+  const idx = rest.indexOf(":");
+  if (idx < 0) return null;
+  try {
+    return {
+      pluginId: decodeURIComponent(rest.slice(0, idx)),
+      contribId: decodeURIComponent(rest.slice(idx + 1)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Derive the settings-page nav entries from the installed-plugin list: one per
+// enabled plugin's declared `settings-page` UI contribution. Sorted
+// deterministically (name, then contribution id) so the sidebar order is stable
+// across reloads. When a plugin declares more than one page, the contribution id
+// disambiguates the label.
+export function pluginSettingsPages(
+  plugins: { id: string; name: string; enabled: boolean; ui_contributions: { slot: string; id: string }[] }[],
+): PluginPageNav[] {
+  const pages: PluginPageNav[] = [];
+  for (const p of plugins) {
+    if (!p.enabled) continue;
+    const contribs = p.ui_contributions.filter((u) => u.slot === "settings-page");
+    for (const c of contribs) {
+      pages.push({
+        tabId: pluginPageTabId(p.id, c.id),
+        label: contribs.length > 1 ? `${p.name}: ${c.id}` : p.name,
+        pluginId: p.id,
+        contribId: c.id,
+      });
+    }
+  }
+  pages.sort((a, b) => a.label.localeCompare(b.label) || a.contribId.localeCompare(b.contribId));
+  return pages;
+}
+
+type SidebarItem =
+  | { kind: "tab"; id: TabId | string; label: string; icon?: ReactNode }
+  | { kind: "divider"; label: string };
 
 // ID-card / badge glyph for the Profiles tab. Profiles is the only Settings
 // tab that carries an icon; it sits at the top as a meta-section over the
@@ -81,8 +146,8 @@ const PROFILES_ICON = (
 // StatusHooks) are intentionally not surfaced here. Exported for unit testing
 // the exact divider/tab order without fighting the duplicated mobile + desktop
 // tab strips in the DOM.
-export function buildSidebar(): SidebarItem[] {
-  return [
+export function buildSidebar(pluginPages: PluginPageNav[] = []): SidebarItem[] {
+  const items: SidebarItem[] = [
     { kind: "tab", id: "profiles", label: "Profiles", icon: PROFILES_ICON },
     { kind: "divider", label: "Appearance" },
     { kind: "tab", id: "theme", label: "Theme" },
@@ -108,12 +173,19 @@ export function buildSidebar(): SidebarItem[] {
     { kind: "tab", id: "logging", label: "Logging" },
     { kind: "tab", id: "plugins", label: "Plugins" },
   ];
+  if (pluginPages.length > 0) {
+    items.push({ kind: "divider", label: "Plugin pages" });
+    for (const page of pluginPages) {
+      items.push({ kind: "tab", id: page.tabId, label: page.label });
+    }
+  }
+  return items;
 }
 
 interface Props {
   onClose: () => void;
   tab: string | null;
-  onSelectTab: (tab: TabId) => void;
+  onSelectTab: (tab: TabId | string) => void;
   onServerAboutRefresh: () => Promise<void> | void;
   onSettingsRefresh?: () => Promise<void> | void;
   /** Profile to preselect, sourced from the `?profile=` query so the
@@ -225,9 +297,22 @@ export function SettingsView({
     },
     [onSelectProfile],
   );
-  const sidebar = buildSidebar();
-  const tabs = sidebar.filter((s): s is { kind: "tab"; id: TabId; label: string } => s.kind === "tab");
+  // Settings pages contributed by installed plugins (#2985), sourced from the
+  // manifest ui_contributions (not the live UI-state snapshot) so a nav entry
+  // appears on declaration and does not vanish when the worker restarts.
+  const [pluginPages, setPluginPages] = useState<PluginPageNav[]>([]);
+  useEffect(() => {
+    fetchPlugins().then((res) => {
+      if (res) setPluginPages(pluginSettingsPages(res.plugins));
+    });
+  }, []);
+  const sidebar = buildSidebar(pluginPages);
+  const tabs = sidebar.filter((s): s is { kind: "tab"; id: string; label: string } => s.kind === "tab");
+  const pluginPageDest = parsePluginPageTab(tab);
   const activeTab: TabId = isTabId(tab) ? tab : "session";
+  // The nav highlight/label id: the raw parametric tab for a plugin page, else
+  // the resolved built-in TabId.
+  const activeNavId: string = pluginPageDest ? (tab as string) : activeTab;
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   // Settings schema (single source of truth, #1692). The generic SchemaSection
   // renderer builds sandbox/worktree from this; empty until the one-shot fetch
@@ -387,6 +472,19 @@ export function SettingsView({
   );
 
   const renderTabContent = () => {
+    // A plugin settings page (#2985) renders from the plugin UI-state snapshot,
+    // not the host `settings`, so it short-circuits before the settings-load
+    // guard and the built-in tab switch.
+    if (pluginPageDest) {
+      const nav = pluginPages.find((p) => p.tabId === tab);
+      return (
+        <PluginSettingsPage
+          pluginId={pluginPageDest.pluginId}
+          contribId={pluginPageDest.contribId}
+          pluginName={nav?.label ?? pluginPageDest.pluginId}
+        />
+      );
+    }
     if (
       !settings &&
       activeTab !== "profiles" &&
@@ -626,7 +724,7 @@ export function SettingsView({
     }
   };
 
-  const currentTabLabel = tabs.find((t) => t.id === activeTab)?.label ?? "";
+  const currentTabLabel = tabs.find((t) => t.id === activeNavId)?.label ?? "";
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
@@ -652,7 +750,7 @@ export function SettingsView({
                 key={item.id}
                 onClick={() => onSelectTab(item.id)}
                 className={`flex items-center gap-1.5 px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
-                  activeTab === item.id
+                  activeNavId === item.id
                     ? "text-brand-500 border-b-2 border-brand-500"
                     : "text-text-secondary hover:text-text-primary"
                 }`}
@@ -682,7 +780,7 @@ export function SettingsView({
                 key={item.id}
                 onClick={() => onSelectTab(item.id)}
                 className={`flex items-center gap-2 px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
-                  activeTab === item.id
+                  activeNavId === item.id
                     ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"
                     : "text-text-secondary hover:text-text-primary hover:bg-surface-800/50"
                 }`}
@@ -716,7 +814,7 @@ export function SettingsView({
                 selectedProfile from its "" seed to the default does not remount
                 mid-interaction and collapse a just-expanded fold. */}
             <fieldset
-              key={`${activeTab}-${profileEpoch}-${focusRequest?.nonce ?? 0}`}
+              key={`${activeNavId}-${profileEpoch}-${focusRequest?.nonce ?? 0}`}
               disabled={offline}
               className="space-y-5 disabled:opacity-50 border-0 m-0 p-0 min-w-0"
             >

--- a/web/src/components/__tests__/SettingsView.diffTab.test.tsx
+++ b/web/src/components/__tests__/SettingsView.diffTab.test.tsx
@@ -7,6 +7,7 @@ const PROFILES = [{ name: "main", is_default: true }];
 
 vi.mock("../../lib/api", () => ({
   fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: vi.fn(() => Promise.resolve(null)),
   fetchSettings: vi.fn(() => Promise.resolve({ acp: {}, sandbox: {}, worktree: {} })),
   updateProfileSettings: vi.fn(() => Promise.resolve(true)),
   setDefaultProfile: vi.fn(() => Promise.resolve(true)),

--- a/web/src/components/__tests__/SettingsView.folds.test.tsx
+++ b/web/src/components/__tests__/SettingsView.folds.test.tsx
@@ -219,6 +219,7 @@ const MOCK_SCHEMA = RAW_SCHEMA.map((d) => ({
 
 vi.mock("../../lib/api", () => ({
   fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: vi.fn(() => Promise.resolve(null)),
   fetchSettings: vi.fn(() => Promise.resolve({ acp: {}, sandbox: {}, worktree: {} })),
   getSettingsSchema: vi.fn(() => Promise.resolve(MOCK_SCHEMA)),
   updateProfileSettings: vi.fn(() => Promise.resolve(true)),

--- a/web/src/components/__tests__/SettingsView.pluginPageRoute.test.tsx
+++ b/web/src/components/__tests__/SettingsView.pluginPageRoute.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+//
+// Route-gating for plugin settings pages (#2985): a `plugin-page:` URL only
+// renders the page when it resolves to a declared, enabled contribution. A
+// stale/typo'd/disabled route must fall back to the built-in default once the
+// plugin list has loaded, never a permanent "Waiting…" page.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { SettingsView } from "../SettingsView";
+import { pluginPageTabId } from "../SettingsView";
+
+const PROFILES = [{ name: "main", is_default: true }];
+
+const PLUGINS = {
+  plugins: [
+    {
+      id: "acme.mcp",
+      name: "MCP",
+      enabled: true,
+      ui_contributions: [{ slot: "settings-page", id: "servers" }],
+    },
+  ],
+  load_errors: [],
+};
+
+const { fetchPluginsMock } = vi.hoisted(() => ({ fetchPluginsMock: vi.fn() }));
+
+vi.mock("../../lib/api", () => ({
+  fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: fetchPluginsMock,
+  fetchSettings: vi.fn(() => Promise.resolve({ acp: {}, sandbox: {}, worktree: {} })),
+  updateProfileSettings: vi.fn(() => Promise.resolve(true)),
+  setDefaultProfile: vi.fn(() => Promise.resolve(true)),
+}));
+
+afterEach(() => {
+  fetchPluginsMock.mockReset();
+  window.localStorage.clear();
+});
+
+describe("SettingsView plugin-page route gating", () => {
+  it("renders the page (waiting state) for a route matching a declared contribution", async () => {
+    fetchPluginsMock.mockResolvedValue(PLUGINS);
+    render(
+      <SettingsView
+        onClose={() => {}}
+        tab={pluginPageTabId("acme.mcp", "servers")}
+        onSelectTab={vi.fn()}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    // No UI-state pushed yet, so the page shows its explicit waiting state.
+    expect(await screen.findByTestId("plugin-settings-page-waiting")).toBeTruthy();
+  });
+
+  it("falls back (no permanent waiting page) for a route absent from the loaded nav", async () => {
+    fetchPluginsMock.mockResolvedValue(PLUGINS);
+    render(
+      <SettingsView
+        onClose={() => {}}
+        tab={pluginPageTabId("ghost.kit", "nope")}
+        onSelectTab={vi.fn()}
+        onServerAboutRefresh={() => {}}
+      />,
+    );
+    // Once the plugin list resolves, an unmatched route must not show the
+    // plugin-page waiting state; it falls through to the built-in default tab.
+    await waitFor(() => expect(fetchPluginsMock).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByTestId("plugin-settings-page-waiting")).toBeNull());
+    expect(screen.queryByTestId("plugin-settings-page")).toBeNull();
+  });
+});

--- a/web/src/components/__tests__/SettingsView.pluginPages.test.tsx
+++ b/web/src/components/__tests__/SettingsView.pluginPages.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+//
+// Unit coverage for the plugin settings-page nav derivation and routing helpers
+// (#2985): a plugin declaring the `settings-page` UI slot gets one Settings nav
+// entry per declared contribution, addressed by a parametric `plugin-page:<...>`
+// tab id that round-trips as a single URL segment.
+
+import { describe, expect, it } from "vitest";
+import { buildSidebar, parsePluginPageTab, pluginSettingsPages } from "../SettingsView";
+
+type Plugin = Parameters<typeof pluginSettingsPages>[0][number];
+
+function plugin(over: Partial<Plugin>): Plugin {
+  return {
+    id: "acme.mcp",
+    name: "MCP",
+    enabled: true,
+    ui_contributions: [{ slot: "settings-page", id: "main" }],
+    ...over,
+  };
+}
+
+describe("pluginSettingsPages", () => {
+  it("derives one nav entry per declared settings-page contribution", () => {
+    const pages = pluginSettingsPages([plugin({})]);
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toMatchObject({ label: "MCP", pluginId: "acme.mcp", contribId: "main" });
+    // Parses back to the same identifiers.
+    expect(parsePluginPageTab(pages[0].tabId)).toEqual({ pluginId: "acme.mcp", contribId: "main" });
+  });
+
+  it("ignores disabled plugins and non-settings-page slots", () => {
+    const pages = pluginSettingsPages([
+      plugin({ id: "acme.off", enabled: false }),
+      plugin({ id: "acme.pane", ui_contributions: [{ slot: "pane", id: "x" }] }),
+    ]);
+    expect(pages).toHaveLength(0);
+  });
+
+  it("disambiguates the label when a plugin declares multiple pages", () => {
+    const pages = pluginSettingsPages([
+      plugin({
+        ui_contributions: [
+          { slot: "settings-page", id: "servers" },
+          { slot: "settings-page", id: "tools" },
+        ],
+      }),
+    ]);
+    expect(pages.map((p) => p.label)).toEqual(["MCP: servers", "MCP: tools"]);
+  });
+
+  it("sorts entries deterministically by label", () => {
+    const pages = pluginSettingsPages([plugin({ id: "z.kit", name: "Zeta" }), plugin({ id: "a.kit", name: "Alpha" })]);
+    expect(pages.map((p) => p.label)).toEqual(["Alpha", "Zeta"]);
+  });
+});
+
+describe("parsePluginPageTab", () => {
+  it("returns null for built-in tabs and malformed ids", () => {
+    expect(parsePluginPageTab("mcp")).toBeNull();
+    expect(parsePluginPageTab(null)).toBeNull();
+    expect(parsePluginPageTab("plugin-page:onlyone")).toBeNull();
+  });
+
+  it("round-trips ids containing dots and reserved chars", () => {
+    // A plugin id has dots; encodeURIComponent keeps the delimiter unambiguous
+    // even if a contribution id itself contains a colon.
+    const [page] = pluginSettingsPages([
+      plugin({ id: "acme.mcp.v2", ui_contributions: [{ slot: "settings-page", id: "a:b" }] }),
+    ]);
+    expect(parsePluginPageTab(page.tabId)).toEqual({ pluginId: "acme.mcp.v2", contribId: "a:b" });
+  });
+});
+
+describe("buildSidebar", () => {
+  it("appends a Plugin pages divider and one tab per page", () => {
+    const pages = pluginSettingsPages([plugin({})]);
+    const sidebar = buildSidebar(pages);
+    const divider = sidebar.find((s) => s.kind === "divider" && s.label === "Plugin pages");
+    expect(divider).toBeTruthy();
+    expect(sidebar.some((s) => s.kind === "tab" && s.id === pages[0].tabId)).toBe(true);
+  });
+
+  it("adds no divider when there are no plugin pages", () => {
+    const sidebar = buildSidebar([]);
+    expect(sidebar.some((s) => s.kind === "divider" && s.label === "Plugin pages")).toBe(false);
+  });
+});

--- a/web/src/components/__tests__/SettingsView.schema-load.test.tsx
+++ b/web/src/components/__tests__/SettingsView.schema-load.test.tsx
@@ -28,6 +28,7 @@ const WORKTREE_SCHEMA = [
 
 vi.mock("../../lib/api", () => ({
   fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: vi.fn(() => Promise.resolve(null)),
   fetchSettings: vi.fn(() => Promise.resolve({ worktree: {} })),
   // First load fails (returns null), retry succeeds. Closure reads
   // WORKTREE_SCHEMA lazily (the mock factory is hoisted above the const).

--- a/web/src/components/__tests__/SettingsView.session.test.tsx
+++ b/web/src/components/__tests__/SettingsView.session.test.tsx
@@ -77,6 +77,7 @@ const SESSION_SCHEMA = [
 
 vi.mock("../../lib/api", () => ({
   fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: vi.fn(() => Promise.resolve(null)),
   fetchSettings: vi.fn(() => Promise.resolve({ session: {}, acp: {}, sandbox: {}, worktree: {} })),
   getSettingsSchema: vi.fn(() => Promise.resolve(SESSION_SCHEMA)),
   updateProfileSettings: vi.fn(() => Promise.resolve(true)),

--- a/web/src/components/__tests__/SettingsView.themeSave.test.tsx
+++ b/web/src/components/__tests__/SettingsView.themeSave.test.tsx
@@ -64,6 +64,7 @@ const updateProfileSettings = vi.fn(() => Promise.resolve(true));
 
 vi.mock("../../lib/api", () => ({
   fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: vi.fn(() => Promise.resolve(null)),
   fetchSettings: vi.fn(() => Promise.resolve({ theme: { name: "empire", idle_decay_minutes: 0 } })),
   getSettingsSchema: vi.fn(() => Promise.resolve(THEME_SCHEMA)),
   setDefaultProfile: vi.fn(() => Promise.resolve(true)),

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -2,7 +2,7 @@
 // typed display state; these components draw it. No plugin code runs here.
 // Each reads the shared snapshot via context and the pure selectors in
 // `pluginUi.ts`. Slots shipped here: status-bar, row-badge, row-column, card,
-// pane, detail-badge, composer-action. Notifications surface as toasts via the hook; the
+// pane, detail-badge, composer-action, settings-page. Notifications surface as toasts via the hook; the
 // sort-key and filter-facet slots render as sidebar sort options and a facet
 // filter (the sidebar owns those; see SidebarSortPicker / WorkspaceSidebar, #2401).
 
@@ -681,6 +681,45 @@ export function PluginPaneBody({ entry }: { entry: PluginUiEntry }) {
           {body && <div className="mt-1 text-xs text-text-secondary whitespace-pre-wrap">{body}</div>}
         </>
       )}
+    </div>
+  );
+}
+
+/** The routed full-page slot (#2985). A plugin declaring `settings-page` gets a
+ *  Settings nav entry (see SettingsView); this renders the global UI-state entry
+ *  it pushed for that `(plugin_id, id)` through the same block vocabulary as a
+ *  pane. The nav entry exists on declaration, so the entry may not be pushed yet
+ *  (worker still starting, or nothing to show): render an explicit waiting state
+ *  rather than a blank page. The entry is global (no `session_id`), so the reused
+ *  PluginPaneBody dispatches its `action` blocks session-lessly. */
+export function PluginSettingsPage({
+  pluginId,
+  contribId,
+  pluginName,
+}: {
+  pluginId: string;
+  contribId: string;
+  pluginName: string;
+}) {
+  const entries = usePluginUiEntries();
+  const entry = globalEntries(entries, "settings-page").find((e) => e.plugin_id === pluginId && e.id === contribId);
+  if (!entry) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-text-dim" data-testid="plugin-settings-page-waiting">
+        <Spinner className="size-3.5" />
+        Waiting for {pluginName} to load this page…
+      </div>
+    );
+  }
+  return <PluginSettingsPageBody entry={entry} />;
+}
+
+/** Separate component so the reused PluginPaneBody is only mounted once an entry
+ *  exists; it renders in a full-width settings container, not the docked pane. */
+function PluginSettingsPageBody({ entry }: { entry: PluginUiEntry }) {
+  return (
+    <div className="flex flex-col min-h-0" data-testid="plugin-settings-page" data-plugin-id={entry.plugin_id}>
+      <PluginPaneBody entry={entry} />
     </div>
   );
 }

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -8,6 +8,7 @@ import {
   PluginComposerActions,
   PluginPaneBody,
   PluginRowBadges,
+  PluginSettingsPage,
   PluginStatusBarSegments,
 } from "../PluginSlots";
 import { composerDraftOperation } from "../composerDraftOperation";
@@ -582,5 +583,55 @@ describe("plugin slot renderers", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     fireEvent.click(toggle);
     expect(body.className).toContain("line-clamp-3");
+  });
+
+  it("settings-page shows a waiting state until its global entry is pushed", () => {
+    // Nav appears on declaration, so before the worker pushes anything the page
+    // is empty: render an explicit waiting state, not a blank page.
+    set([]);
+    const { rerender } = render(<PluginSettingsPage pluginId="acme.mcp" contribId="servers" pluginName="MCP" />);
+    expect(screen.getByTestId("plugin-settings-page-waiting")).toBeTruthy();
+    expect(screen.getByText(/Waiting for MCP/)).toBeTruthy();
+
+    // Once the plugin pushes its global (session-less) settings-page entry, the
+    // page body renders through the shared block vocabulary.
+    set([
+      {
+        plugin_id: "acme.mcp",
+        slot: "settings-page",
+        id: "servers",
+        payload: { blocks: [{ kind: "heading", text: "Servers" }] },
+      },
+    ]);
+    rerender(<PluginSettingsPage pluginId="acme.mcp" contribId="servers" pluginName="MCP" />);
+    expect(screen.queryByTestId("plugin-settings-page-waiting")).toBeNull();
+    expect(screen.getByTestId("plugin-settings-page")).toBeTruthy();
+    expect(screen.getByText("Servers")).toBeTruthy();
+  });
+
+  it("settings-page selects only the matching (plugin_id, id) global entry", () => {
+    // A different plugin's or contribution's entry must not fill this page, and
+    // a per-session entry (session_id set) is never a settings-page match.
+    set([
+      { plugin_id: "other.kit", slot: "settings-page", id: "servers", payload: { title: "Other" } },
+      {
+        plugin_id: "acme.mcp",
+        slot: "settings-page",
+        id: "other",
+        payload: { title: "Wrong page" },
+      },
+      {
+        plugin_id: "acme.mcp",
+        slot: "settings-page",
+        id: "servers",
+        session_id: "s1",
+        payload: { title: "Scoped" },
+      },
+    ]);
+    render(<PluginSettingsPage pluginId="acme.mcp" contribId="servers" pluginName="MCP" />);
+    expect(screen.getByTestId("plugin-settings-page-waiting")).toBeTruthy();
+    expect(screen.queryByText("Other")).toBeNull();
+    expect(screen.queryByText("Wrong page")).toBeNull();
+    expect(screen.queryByText("Scoped")).toBeNull();
   });
 });

--- a/web/src/components/settings/PluginsSettings.tsx
+++ b/web/src/components/settings/PluginsSettings.tsx
@@ -50,7 +50,7 @@ interface DetailTarget {
 /// global passphrase prompt via the fetch interceptor, the same as any other
 /// elevated setting; other failures surface their message inline. `load_errors`
 /// are shown as a warning line.
-export function PluginsSettings() {
+export function PluginsSettings({ onPluginsChanged }: { onPluginsChanged?: () => void } = {}) {
   const [data, setData] = useState<PluginListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -137,6 +137,9 @@ export function PluginsSettings() {
       if (result.kind === "ok") {
         // The server returns the refreshed list, so adopt it directly.
         setData(result.data);
+        // Enabling/disabling changes which plugins contribute a settings-page,
+        // so tell the parent to refresh its plugin-nav (#2985).
+        onPluginsChanged?.();
         // The serve gate is startup-only: disabling aoe.web rewrites config
         // but the running daemon keeps serving until it restarts. Say so,
         // otherwise the toggle looks like a no-op (#2311 testing feedback).
@@ -317,6 +320,9 @@ export function PluginsSettings() {
   const onJobClose = async () => {
     setJob(null);
     await reload();
+    // Install/update/uninstall can add or remove a settings-page contribution,
+    // so refresh the parent's plugin-nav too (#2985).
+    onPluginsChanged?.();
   };
 
   const onDiscover = async () => {

--- a/web/src/components/settings/__tests__/SchemaFieldPatches.test.tsx
+++ b/web/src/components/settings/__tests__/SchemaFieldPatches.test.tsx
@@ -105,6 +105,7 @@ const SCHEMA = [
 
 vi.mock("../../../lib/api", () => ({
   fetchProfiles: vi.fn(() => Promise.resolve(PROFILES)),
+  fetchPlugins: vi.fn(() => Promise.resolve(null)),
   fetchSettings: vi.fn(() => Promise.resolve({ tmux: {}, logging: {}, session: {}, sound: {} })),
   getSettingsSchema: vi.fn(() => Promise.resolve(SCHEMA)),
   updateProfileSettings: vi.fn(() => Promise.resolve(true)),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -714,6 +714,7 @@ export type PluginUiSlot =
   | "pane"
   | "composer-action"
   | "detail-badge"
+  | "settings-page"
   | "notification";
 
 /** One piece of UI state a worker pushed. `payload` shape is determined by

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -307,9 +307,14 @@
       "risk": "medium",
       "specs": [
         "src/components/__tests__/SettingsView.pluginPages.test.tsx",
+        "src/components/__tests__/SettingsView.pluginPageRoute.test.tsx",
         "src/components/plugin/__tests__/PluginSlots.test.tsx"
       ],
-      "components": ["web/src/components/SettingsView.tsx", "web/src/components/plugin/PluginSlots.tsx"]
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/plugin/PluginSlots.tsx",
+        "web/src/components/settings/PluginsSettings.tsx"
+      ]
     },
     {
       "id": "settings.mobile-header",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -302,6 +302,16 @@
       ]
     },
     {
+      "id": "settings.plugin-settings-page",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SettingsView.pluginPages.test.tsx",
+        "src/components/plugin/__tests__/PluginSlots.test.tsx"
+      ],
+      "components": ["web/src/components/SettingsView.tsx", "web/src/components/plugin/PluginSlots.tsx"]
+    },
+    {
       "id": "settings.mobile-header",
       "kind": "mocked-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a `settings-page` full-page `UiSlot` (#2985) so a plugin (MCP, Skills) can host a full management panel as a routed settings-nav page, rather than being limited to a per-session pane or a badge. The slot is the closed-enum replacement for the retiring built-in MCP tab.

Rust (`aoe-plugin-api` + host): a new global `SettingsPage` variant on the closed `UiSlot` enum, gated behind a bumped `API_VERSION` 9 with a manifest-parse check (mirroring how `composer-action` gated at 8), so an unrenderable slot is still rejected at parse time. The host validates it with a dedicated `SettingsPagePayload` (`title`, `body`, `blocks`, `icon`) that mirrors the pane's forward-compatible block list but drops `default_location` (meaningless for a full page, rejected via `deny_unknown_fields`), and gives it the pane-sized 64KB payload budget since it carries block lists. The existing `require_declared_slot` guard gates it generically.

Web: `PluginSettingsPage` renders the plugin's pushed global UI-state entry through the existing `PluginPaneBody` block vocabulary. Because a global entry carries no `session_id`, its action blocks POST session-lessly, which the action endpoint already supports (no new protocol). `SettingsView` derives one nav entry per enabled plugin's declared `settings-page` contribution (sourced from the manifest `ui_contributions`, so the entry appears on declaration and survives a worker restart), sorts them deterministically, and routes them under a parametric `plugin-page:<...>` tab id that round-trips as a single `/settings/:tab` URL segment. The closed `TabId` union and its deep-link guard stay static; plugin pages parse through a separate discriminated path. Before the worker pushes its first entry, the page shows an explicit waiting state.

TUI: a documented web-only no-op (a terminal cannot render a routed full page), added to the existing narrowed-slot list.

Design was pressure-tested with a two-model debate (dedicated payload vs pane reuse, routing scheme, global action wiring, nav source, slot naming); the notable finding was that the action plumbing already accepts a null session, so reusing `PluginPaneBody` for a global page is correct with no new endpoint.

Closes #2985

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Install a plugin declaring `[[ui]] slot = "settings-page"` with `api_version = 9`; open the web dashboard Settings and confirm a "Plugin pages" nav entry appears for it.
- [ ] Select that nav entry before the plugin pushes state; confirm a "Waiting for <plugin> to load this page…" state renders (not a blank panel).
- [ ] Have the plugin push a `settings-page` entry with `blocks`; confirm the page body renders the blocks, and any `action` block POSTs its worker method without a session id.
- [ ] Declare the slot with `api_version = 8`; confirm the manifest is rejected with "settings-page UI slots require api_version >= 9".
- [ ] From a plugin that did not declare `settings-page`, call `ui.state.set` for it; confirm the host returns FORBIDDEN.
- [ ] Deep-link `/settings/plugin-page:<encoded-id>` and reload; confirm the correct plugin page is selected and highlighted.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec under `web/src/**/__tests__/` and updated `web/tests/coverage-matrix.json`

The changed surface is the settings-nav derivation, the parametric routing round-trip, and the page renderer, all deterministic client logic; those are covered by Vitest (`SettingsView.pluginPages.test.tsx`, `PluginSlots.test.tsx`) per the repo's guidance that request/rendering permutations belong in Vitest rather than a live backend. The host slot guard and manifest gating are covered by Rust unit tests.

**TUI / CLI (e2e test)**
- [x] N/A: the TUI treats the slot as a documented no-op (a terminal cannot render a full page); no rendering or lifecycle change.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, `/debate` consultation, and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and will run the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new full-page `settings-page` UI slot for plugins so they can contribute routed settings screens inside the web app’s **Settings** view.
- Bumped the plugin UI API version (to **10**) and updated documentation/manifest validation so `settings-page` is only accepted on supported API versions.
- Added stronger host-side enforcement:
  - Validates the `settings-page` payload shape (with stricter field handling) and enforces a **64 KiB** size limit.
  - Treats `settings-page` contributions as **global** (not session-scoped).
  - Rejects undeclared or unknown `(slot, id)` contributions and disallows pane-only fields.
- Implemented web navigation and rendering:
  - Automatically creates deterministic sidebar entries (one per enabled plugin contribution) and supports deep-linkable routes.
  - Renders the correct plugin page content when available, with a clear “waiting/loading for plugin” state, and avoids hanging when a requested route isn’t found.
  - Refreshes navigation after plugin enable/disable changes.
- Extended web UI support and tests:
  - Added a dedicated `PluginSettingsPage` component with explicit waiting behavior.
  - Updated routing/navigation logic, added route parsing helpers, and added Vitest coverage (including navigation, rendering, and rejection cases).
  - Updated the coverage matrix and clarified that the terminal/TUI version is a documented **no-op** for this web-only routed page.

## Benefits

Plugins can now deliver rich, full-page, deep-linkable settings panels directly within the dashboard’s Settings UI, with predictable routing, safe validation, and clear loading behavior—without requiring custom host UI work.

## Potential follow-up

If terminal/TUI rendering for routed full pages becomes possible, the documented “web-only no-op” behavior could be replaced with a real terminal implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->