### PR TITLE
feat(plugins): add tool-card-badge UI slot for MCP and skill cards

### DIFF
--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -40,5 +40,6 @@ pub use manifest::{
 /// actions; 9 when the host gained ACP-capability discovery, host-owned
 /// session creation / prompt delivery (with the `session.unattended` grant),
 /// plugin-private storage, and structured settings widgets (`object_list`,
-/// `dynamic_select`); 10 when the `settings-page` full-page slot was added.
+/// `dynamic_select`); 10 when the `settings-page` full-page slot and the
+/// `tool-card-badge` slot were added.
 pub const API_VERSION: u32 = 10;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -703,6 +703,11 @@ pub enum UiSlot {
     /// `blocks` vocabulary as `Pane`) so a plugin can host a full management
     /// panel without a per-session dock.
     SettingsPage,
+    /// A badge on a tool-call card in a session's transcript, matched to a
+    /// specific call by its target (per session). The payload carries a
+    /// target-keyed list so one entry can badge every MCP server or skill the
+    /// plugin knows about; the host renders the pill on the matching card.
+    ToolCardBadge,
     /// A transient notification, pushed via `ui.notify` (gated by the
     /// `notifications` capability rather than a slot declaration).
     Notification,
@@ -719,6 +724,7 @@ impl UiSlot {
                 | UiSlot::Pane
                 | UiSlot::ComposerAction
                 | UiSlot::DetailBadge
+                | UiSlot::ToolCardBadge
         )
     }
 
@@ -737,6 +743,7 @@ impl UiSlot {
             UiSlot::ComposerAction => "composer-action",
             UiSlot::DetailBadge => "detail-badge",
             UiSlot::SettingsPage => "settings-page",
+            UiSlot::ToolCardBadge => "tool-card-badge",
             UiSlot::Notification => "notification",
         }
     }
@@ -1253,12 +1260,16 @@ impl PluginManifest {
                 "dynamic_select / object_list / cron settings require api_version >= 9".into(),
             );
         }
-        // `settings-page` is an api_version 10 slot; force the bump for the same
-        // reason as the gates above.
+        // `settings-page` and `tool-card-badge` are api_version 10 slots; force
+        // the bump for the same reason as the gates above.
         if self.api_version < 10 {
             check(
                 self.ui.iter().all(|u| u.slot != UiSlot::SettingsPage),
                 "settings-page UI slots require api_version >= 10".into(),
+            );
+            check(
+                self.ui.iter().all(|u| u.slot != UiSlot::ToolCardBadge),
+                "tool-card-badge UI slots require api_version >= 10".into(),
             );
         }
         for key in self.setting_defaults.keys() {

--- a/aoe-plugin-api/tests/manifest.rs
+++ b/aoe-plugin-api/tests/manifest.rs
@@ -688,6 +688,7 @@ fn ui_slot_as_str_round_trips_the_wire_name() {
         ("pane", UiSlot::Pane),
         ("composer-action", UiSlot::ComposerAction),
         ("settings-page", UiSlot::SettingsPage),
+        ("tool-card-badge", UiSlot::ToolCardBadge),
         ("notification", UiSlot::Notification),
     ] {
         assert_eq!(slot.as_str(), toml_slot);
@@ -748,6 +749,25 @@ id = "voice"
     let err = PluginManifest::from_toml_str(toml).unwrap_err();
     assert!(
         format!("{err:?}").contains("composer-action UI slots require api_version >= 8"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn tool_card_badge_requires_api_version_10() {
+    let toml = r#"
+id = "acme.thing"
+name = "Thing"
+version = "0.1.0"
+api_version = 9
+
+[[ui]]
+slot = "tool-card-badge"
+id = "provenance"
+"#;
+    let err = PluginManifest::from_toml_str(toml).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("tool-card-badge UI slots require api_version >= 10"),
         "{err:?}"
     );
 }

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -195,7 +195,7 @@ became the dockable `pane` slot, 4 for the `status` section and the
 `aoe_version` field, 5 for screenshots, 6 for command actions, 7 for identity
 icons, 8 for the `composer-action` slot, 9 for ACP-capability discovery,
 host-owned sessions, plugin-private storage, and structured settings widgets,
-and 10 for the `settings-page` slot); an
+and 10 for the `settings-page` and `tool-card-badge` slots); an
 older `api_version` manifest still loads as long as it targets no newer field. Unknown top-level keys remain
 a hard parse error
 (`deny_unknown_fields`).
@@ -661,9 +661,9 @@ the TUI renders).
 The slots are a closed `UiSlot` set (`aoe-plugin-api`), kebab-case on the
 wire: `status-bar`, `row-badge`, `row-column`, `sort-key`, `filter-facet`,
 `card`, `pane`, `composer-action`, `detail-badge`, `settings-page`,
-`notification`. A plugin declares the `(slot, id)` pairs it may fill in its
-manifest `[[ui]]` section; an unknown slot is a hard parse error (the host must
-know how to render each).
+`tool-card-badge`, `notification`. A plugin declares the `(slot, id)` pairs it
+may fill in its manifest `[[ui]]` section; an unknown slot is a hard parse error
+(the host must know how to render each).
 
 A UI contribution is not a capability and needs no grant, but the slots a
 plugin declares are disclosed so the user knows it modifies the dashboard
@@ -678,7 +678,8 @@ manager, and the web Plugins panel (via `PluginView.ui_contributions`).
   the `(slot, id)` being declared in the manifest: no dedicated `ui` capability
   is introduced. The `payload` is validated against the slot's typed shape and
   stored normalized; an unknown field or bad tone is rejected. Per-session slots
-  (`row-badge`, `row-column`, `pane`, `composer-action`, `detail-badge`) require a
+  (`row-badge`, `row-column`, `pane`, `composer-action`, `detail-badge`,
+  `tool-card-badge`) require a
   `session_id`; global slots must not carry one. The text-based slots
   (`status-bar`, `row-badge`, `detail-badge`) accept optional `icon` (a lucide
   icon name in kebab-case, e.g. `git-pull-request-arrow`; the client maps it
@@ -707,9 +708,9 @@ manager, and the web Plugins panel (via `PluginView.ui_contributions`).
   operation once per operation id so a persistent UI-state entry cannot replay
   on every poll.
 
-#### Richer payloads: `row-badge` items and the `pane` block list
+#### Richer payloads: `row-badge` items, `tool-card-badge` items, and the `pane` block list
 
-Two slots carry more than a single value, so one entry (one declared
+These slots carry more than a single value, so one entry (one declared
 `(slot, id)`) can render a list:
 
 - `row-badge` also accepts `items: BadgeItem[]` where
@@ -717,6 +718,15 @@ Two slots carry more than a single value, so one entry (one declared
   compact, tone-tinted icon (falling back to `text`), linked when `href` is a
   safe URL. The single `{ text, tone, tooltip, icon, href }` form still works.
   An empty `items: []` clears the row.
+- `tool-card-badge` carries `items: ToolCardBadge[]` where
+  `ToolCardBadge = { target, text?, icon?, tone?, tooltip? }` and
+  `target = { kind: "mcp" | "skill", name }`. A plugin declares one `(slot, id)`
+  per session and pushes every badge it knows in this one list; the host matches
+  each item to a transcript MCP or skill tool-call card by `target`, keeping the
+  match keyed on both `kind` and the raw (uncanonicalized) `name` since an MCP
+  server and a skill can share a name. Each item needs `text` or `icon` and a
+  non-empty target name. An empty `items: []` clears the plugin's badges. The web
+  dashboard renders the pill in the card header; the TUI ignores this slot.
 - `pane` also accepts `blocks: Block[]`, an ordered list of typed
   blocks. The web renderer knows these kinds: `heading { text }`,
   `row { label, value?, sublabel?, icon?, tone?, color?, href? }`,

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `9`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `10`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot.
 
 ## Top-level fields
 
@@ -41,7 +41,7 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `9`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `10`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
@@ -329,6 +329,7 @@ id = "my_pane"
 | `detail-badge` | per-session | A badge in the session detail view. |
 | `pane` | per-session | A dockable tool-window pane (requires `api_version >= 3`). |
 | `composer-action` | per-session | A button beside the ACP composer controls (requires `api_version >= 8`). |
+| `tool-card-badge` | per-session | A pill on a transcript MCP or skill tool-call card, matched by target (requires `api_version >= 10`). |
 | `notification` | n/a | A transient notification pushed via `ui.notify`; gated by the `notifications` capability, not a slot declaration. |
 
 ### Composer action payload
@@ -382,6 +383,29 @@ requires `composer.write`.
 `kind` is `insert-text`, `replace-selection`, or `set-text`. `id` must be stable
 and non-empty; the web dashboard applies each operation id once so a persistent
 UI-state entry cannot replay the edit on every poll.
+
+### Tool-card badge payload
+
+A `tool-card-badge` entry attaches provenance pills to transcript tool-call
+cards. Declare one slot id per session and push a single entry whose `items`
+list carries every badge you want; the host matches each `item` to a card by its
+`target`. `target.kind` is `mcp` or `skill` and `target.name` is the raw MCP
+server name or skill name (matched exactly, not canonicalized), since an MCP
+server and a skill can share a name. Requires `api_version >= 10`.
+
+```json
+{
+  "items": [
+    { "target": { "kind": "mcp", "name": "github" }, "text": "Company", "tone": "info", "icon": "building-2" },
+    { "target": { "kind": "skill", "name": "deploy" }, "text": "Verified" }
+  ]
+}
+```
+
+Each item needs `text` or `icon` (a badge with neither renders nothing) and a
+non-empty target name; `tone` and `tooltip` are optional. Empty `items: []`
+clears the plugin's badges. Rendered in the web dashboard; the native TUI ignores
+this slot for now.
 
 ## Status
 

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -1706,6 +1706,39 @@ mod tests {
     }
 
     #[test]
+    fn ui_state_set_requires_declared_tool_card_badge_slot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        // The plugin declared a different slot, so pushing tool-card-badge is
+        // refused by require_declared_slot even though the payload is valid.
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::DetailBadge, "provenance");
+        let payload =
+            json!({"items": [{"target": {"kind": "mcp", "name": "github"}, "text": "MCP"}]});
+        let err = dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "tool-card-badge", "id": "provenance", "session_id": "s1", "payload": payload}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+
+        // Declaring the slot lets the same push through, and it surfaces in the
+        // snapshot.
+        let c = ui_ctx(&state, &[CAP_WORKER], UiSlot::ToolCardBadge, "provenance");
+        dispatch(
+            &state,
+            &c,
+            "ui.state.set",
+            &json!({"slot": "tool-card-badge", "id": "provenance", "session_id": "s1", "payload": payload}),
+        )
+        .unwrap();
+        let snap = state.ui_snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(snap.entries[0].slot, UiSlot::ToolCardBadge);
+    }
+
+    #[test]
     fn ui_state_set_needs_worker_capability() {
         let tmp = tempfile::tempdir().unwrap();
         let state = state(tmp.path());

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -152,6 +152,53 @@ struct RowBadgePayload {
     items: Vec<BadgeItem>,
 }
 
+/// Which tool-call card a `tool-card-badge` attaches to. MCP servers and skills
+/// share no namespace guarantee (both can be named "github"), so the card kind
+/// is part of the match key, not just the raw name. The host does not
+/// canonicalize the name: it is an external identifier the plugin resolves,
+/// matched by exact string equality against the card's target.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+enum ToolCardTarget {
+    Mcp { name: String },
+    Skill { name: String },
+}
+
+impl ToolCardTarget {
+    fn name(&self) -> &str {
+        match self {
+            ToolCardTarget::Mcp { name } | ToolCardTarget::Skill { name } => name,
+        }
+    }
+}
+
+/// One badge inside a `tool-card-badge` `items` list, keyed to a specific
+/// tool-call target. A badge with neither `text` nor `icon` renders nothing, so
+/// at least one is required.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolCardBadge {
+    target: ToolCardTarget,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tone: Option<Tone>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tooltip: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+}
+
+/// `tool-card-badge` payload: a target-keyed `items` list so one declared entry
+/// can badge every MCP server or skill the plugin knows about. Empty `items: []`
+/// is valid and clears the plugin's badges (matching `row-badge`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolCardBadgePayload {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    items: Vec<ToolCardBadge>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RowColumnPayload {
@@ -808,6 +855,19 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
             }
             serde_json::to_value(parsed).map_err(|e| e.to_string())
         }
+        UiSlot::ToolCardBadge => {
+            let parsed: ToolCardBadgePayload =
+                serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
+            for badge in &parsed.items {
+                if badge.target.name().is_empty() {
+                    return Err("tool-card badge target name is required".into());
+                }
+                if badge.text.is_none() && badge.icon.is_none() {
+                    return Err("tool-card badge requires text or icon".into());
+                }
+            }
+            serde_json::to_value(parsed).map_err(|e| e.to_string())
+        }
         UiSlot::Notification => Err("notification is pushed via ui.notify".into()),
     }
 }
@@ -1117,6 +1177,91 @@ mod tests {
                         "text": "x".repeat(MAX_COMPOSER_DRAFT_TEXT_BYTES + 1)
                     }
                 })
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn tool_card_badge_payload_validated() {
+        let s = store();
+        let g = s.begin_generation("acme.kit");
+        // A valid target-keyed list normalizes and stores.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::ToolCardBadge,
+            "provenance",
+            Some("s1"),
+            &json!({"items": [
+                {"target": {"kind": "mcp", "name": "github"}, "text": "MCP", "tone": "info"},
+                {"target": {"kind": "skill", "name": "deploy"}, "icon": "sparkles"}
+            ]}),
+        )
+        .unwrap();
+        let snap = s.snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(
+            snap.entries[0].payload["items"][0]["target"]["kind"],
+            json!("mcp")
+        );
+
+        // Empty items is a valid clear.
+        s.set(
+            "acme.kit",
+            g,
+            UiSlot::ToolCardBadge,
+            "provenance",
+            Some("s1"),
+            &json!({"items": []}),
+        )
+        .unwrap();
+
+        // Per-session slot needs a session_id.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ToolCardBadge,
+                "provenance",
+                None,
+                &json!({"items": [{"target": {"kind": "mcp", "name": "x"}, "text": "y"}]})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Empty target name rejected.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ToolCardBadge,
+                "provenance",
+                Some("s1"),
+                &json!({"items": [{"target": {"kind": "mcp", "name": ""}, "text": "y"}]})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // A badge with neither text nor icon renders nothing, so it is rejected.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ToolCardBadge,
+                "provenance",
+                Some("s1"),
+                &json!({"items": [{"target": {"kind": "skill", "name": "deploy"}}]})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Unknown target kind rejected (closed tagged enum).
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ToolCardBadge,
+                "provenance",
+                Some("s1"),
+                &json!({"items": [{"target": {"kind": "tool", "name": "x"}, "text": "y"}]})
             ),
             Err(UiError::BadRequest(_))
         ));

--- a/src/plugin/ui_state.rs
+++ b/src/plugin/ui_state.rs
@@ -862,7 +862,12 @@ fn validate_payload(slot: UiSlot, raw: &Value) -> Result<Value, String> {
                 if badge.target.name().is_empty() {
                     return Err("tool-card badge target name is required".into());
                 }
-                if badge.text.is_none() && badge.icon.is_none() {
+                // An empty or whitespace-only string is absent as far as the
+                // web BadgeChip is concerned (it renders nothing), so treat it
+                // the same as a missing field rather than storing a blank pill.
+                let has_text = badge.text.as_deref().is_some_and(|t| !t.trim().is_empty());
+                let has_icon = badge.icon.as_deref().is_some_and(|i| !i.trim().is_empty());
+                if !has_text && !has_icon {
                     return Err("tool-card badge requires text or icon".into());
                 }
             }
@@ -1250,6 +1255,19 @@ mod tests {
                 "provenance",
                 Some("s1"),
                 &json!({"items": [{"target": {"kind": "skill", "name": "deploy"}}]})
+            ),
+            Err(UiError::BadRequest(_))
+        ));
+        // Empty or whitespace-only text/icon is absent to the web renderer, so
+        // it is rejected just like an omitted field.
+        assert!(matches!(
+            s.set(
+                "acme.kit",
+                g,
+                UiSlot::ToolCardBadge,
+                "provenance",
+                Some("s1"),
+                &json!({"items": [{"target": {"kind": "mcp", "name": "github"}, "text": "", "icon": "  "}]})
             ),
             Err(UiError::BadRequest(_))
         ));

--- a/src/tui/plugin_ui.rs
+++ b/src/tui/plugin_ui.rs
@@ -3,9 +3,11 @@
 //! narrowed to what a terminal can render: the structured view shows
 //! `StatusBar` (global) and `DetailBadge` (per-session) text, tone-colored,
 //! plus `Notification` toasts. Icons, tooltips, hrefs, and the
-//! `Card`/`Pane`/`RowBadge`/`RowColumn`/`SortKey`/`FilterFacet`/`SettingsPage`
-//! slots have no TUI surface here and are ignored (a terminal cannot render a
-//! routed full page).
+//! `Card`/`Pane`/`RowBadge`/`RowColumn`/`SortKey`/`FilterFacet`/`SettingsPage`/
+//! `ToolCardBadge` slots have no TUI surface here and are ignored (a terminal
+//! cannot render a routed full page). `ToolCardBadge` renders on the web
+//! tool-call cards only; the TUI would need MCP/skill target classification it
+//! does not carry today, tracked as a follow-up.
 //!
 //! Kept side-effect-free so the render layer can borrow the snapshot and so the
 //! filtering / tone-mapping logic is unit-testable without a daemon.

--- a/web/src/components/acp/StructuredView.tsx
+++ b/web/src/components/acp/StructuredView.tsx
@@ -52,6 +52,7 @@ import {
 // hatch for a likely missed-Stopped wedge. See #1100, #1112.
 const FORCE_END_TURN_THRESHOLD_SECS = 30;
 import { AgentProfileProvider, useAgentProfile } from "../../lib/agentProfileContext";
+import { AcpSessionContext } from "../../lib/acpSessionContext";
 import { isClearAlias } from "../../lib/agentProfiles";
 import { AttentionChime } from "./AttentionChime";
 import { useRespawnSession, type RespawnState } from "../../hooks/useRespawnSession";
@@ -160,39 +161,41 @@ export function StructuredView(props: Props) {
   const [toolDensity, toggleToolDensity] = useToolDensityPref();
   return (
     <AcpFileRefContext.Provider value={{ onOpenFileRef, fileRefSession }}>
-      <AgentProfileProvider toolKey={tool}>
-        <ToolDisplayModeProvider density={toolDensity}>
-          <AcpRuntime
-            sessionId={sessionId}
-            acpWorkerState={acpWorkerState}
-            archivedAt={archivedAt}
-            snoozedUntil={snoozedUntil}
-            showClearedTurns={showClearedTurns}
-          >
-            {(ctx) => (
-              <BackgroundAgentsContext.Provider
-                value={{ agents: ctx.state.backgroundAgents, openPane: onOpenAgentsPane }}
-              >
-                <AcpChrome
-                  sessionId={sessionId}
-                  acpWorkerState={acpWorkerState}
-                  acpAgent={acpAgent}
-                  showClearedTurns={showClearedTurns}
-                  onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
-                  toolDensity={toolDensity}
-                  onToggleToolDensity={toggleToolDensity}
-                  archivedAt={archivedAt}
-                  snoozedUntil={snoozedUntil}
-                  trashedAt={trashedAt}
-                  onRestore={onRestore}
-                  isSandboxed={isSandboxed}
-                  {...ctx}
-                />
-              </BackgroundAgentsContext.Provider>
-            )}
-          </AcpRuntime>
-        </ToolDisplayModeProvider>
-      </AgentProfileProvider>
+      <AcpSessionContext.Provider value={sessionId}>
+        <AgentProfileProvider toolKey={tool}>
+          <ToolDisplayModeProvider density={toolDensity}>
+            <AcpRuntime
+              sessionId={sessionId}
+              acpWorkerState={acpWorkerState}
+              archivedAt={archivedAt}
+              snoozedUntil={snoozedUntil}
+              showClearedTurns={showClearedTurns}
+            >
+              {(ctx) => (
+                <BackgroundAgentsContext.Provider
+                  value={{ agents: ctx.state.backgroundAgents, openPane: onOpenAgentsPane }}
+                >
+                  <AcpChrome
+                    sessionId={sessionId}
+                    acpWorkerState={acpWorkerState}
+                    acpAgent={acpAgent}
+                    showClearedTurns={showClearedTurns}
+                    onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
+                    toolDensity={toolDensity}
+                    onToggleToolDensity={toggleToolDensity}
+                    archivedAt={archivedAt}
+                    snoozedUntil={snoozedUntil}
+                    trashedAt={trashedAt}
+                    onRestore={onRestore}
+                    isSandboxed={isSandboxed}
+                    {...ctx}
+                  />
+                </BackgroundAgentsContext.Provider>
+              )}
+            </AcpRuntime>
+          </ToolDisplayModeProvider>
+        </AgentProfileProvider>
+      </AcpSessionContext.Provider>
     </AcpFileRefContext.Provider>
   );
 }

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -60,6 +60,8 @@ import { marked } from "marked";
 import { reclassifyBash } from "../../lib/toolReclassify";
 import { useAgentProfile } from "../../lib/agentProfileContext";
 import { useAcpFileRef } from "./AcpFileRefContext";
+import { useAcpSessionId } from "../../lib/acpSessionContext";
+import { PluginToolCardBadges } from "../plugin/PluginSlots";
 import { useBackgroundAgentFor, useOpenBackgroundAgentsPane } from "./backgroundAgentsContext";
 import { relativeDisplayPath } from "../../lib/fileRef";
 import { useToolDisplayMode, type ToolDensity } from "./ToolDisplayMode";
@@ -1318,6 +1320,7 @@ interface SkillProps extends Props {
 
 function SkillToolCard({ tool, result, skillName }: SkillProps) {
   const status = statusFor(result);
+  const sessionId = useAcpSessionId();
   const [open, setOpen] = useToolCardExpansion(status);
   // Memo on the raw string so downstream memos see a stable args reference
   // and don't recompute every render.
@@ -1344,6 +1347,7 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
       icon={<Sparkles className="h-3.5 w-3.5" />}
       label="skill"
       primary={skillName}
+      meta={sessionId && <PluginToolCardBadges sessionId={sessionId} kind="skill" target={skillName} />}
       expanded={open}
       onToggle={status === "err" || hasBody ? () => setOpen((v) => !v) : undefined}
       startedAt={tool.started_at}
@@ -1624,6 +1628,7 @@ interface McpProps extends Props {
 
 function McpToolCard({ tool, result, server, verb }: McpProps) {
   const status = statusFor(result);
+  const sessionId = useAcpSessionId();
   const [open, setOpen] = useToolCardExpansion(status);
   // Memo on the raw string so downstream memos see a stable args reference
   // and don't recompute every render.
@@ -1673,6 +1678,7 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
           {argPreview && <span className="ml-2 text-text-dim">· {argPreview}</span>}
         </>
       }
+      meta={sessionId && <PluginToolCardBadges sessionId={sessionId} kind="mcp" target={server} />}
       expanded={open}
       onToggle={status === "err" || hasBody ? () => setOpen((v) => !v) : undefined}
       body={

--- a/web/src/components/acp/__tests__/ToolCards.test.tsx
+++ b/web/src/components/acp/__tests__/ToolCards.test.tsx
@@ -9,7 +9,7 @@
 // AgentProfileProvider keyed to a profile that enables it.
 
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, within } from "@testing-library/react";
 import {
   ToolCard,
@@ -21,7 +21,17 @@ import {
 } from "../ToolCards";
 import { BackgroundAgentsContext } from "../backgroundAgentsContext";
 import { AgentProfileProvider } from "../../../lib/agentProfileContext";
+import { AcpSessionContext } from "../../../lib/acpSessionContext";
 import type { ActivityRow, BackgroundAgent, ToolCall, ToolOutputBlock } from "../../../lib/acpTypes";
+import type { PluginUiEntry } from "../../../lib/api";
+
+// The tool-card-badge renderer reads the plugin ui snapshot from context; mock
+// it so the badge tests drive a fixed set of entries. Defaults to empty, so
+// every other card test renders unchanged (no badges).
+const { pluginEntriesRef } = vi.hoisted(() => ({ pluginEntriesRef: { current: [] as PluginUiEntry[] } }));
+vi.mock("../../../lib/pluginUiContext", () => ({
+  usePluginUiEntries: () => pluginEntriesRef.current,
+}));
 
 function toolWith(overrides: Partial<ToolCall> = {}): ToolCall {
   return {
@@ -725,5 +735,60 @@ describe("DurationLabel", () => {
     // running card has no result; duration ticks from start to now
     expect(container.textContent).toContain("running");
     expect(/\ds/.test(container.textContent ?? "")).toBe(true);
+  });
+});
+
+describe("plugin tool-card-badge on cards", () => {
+  afterEach(() => {
+    pluginEntriesRef.current = [];
+  });
+
+  const provenance = (target: { kind: string; name: string }, text: string): PluginUiEntry => ({
+    plugin_id: "acme.prov",
+    slot: "tool-card-badge",
+    id: "provenance",
+    session_id: "s1",
+    payload: { items: [{ target, text }] },
+  });
+
+  it("shows the plugin badge on the matching MCP card", () => {
+    pluginEntriesRef.current = [provenance({ kind: "mcp", name: "github" }, "Company MCP")];
+    const tool = toolWith({ kind: "other", name: "mcp__github__get_issue" });
+    const { container } = render(
+      <AcpSessionContext.Provider value="s1">
+        <ToolCard tool={tool} result={completeRow()} />
+      </AcpSessionContext.Provider>,
+    );
+    expect(container.textContent).toContain("MCP · Github");
+    expect(container.textContent).toContain("Company MCP");
+  });
+
+  it("shows the plugin badge on the matching skill card", () => {
+    pluginEntriesRef.current = [provenance({ kind: "skill", name: "investigate" }, "Bundled")];
+    const tool = toolWith({
+      kind: "other",
+      name: "Skill",
+      args_preview: JSON.stringify({ skill: "investigate", _aoe_title: "Skill" }),
+    });
+    const { container } = render(
+      <AgentProfileProvider toolKey="claude">
+        <AcpSessionContext.Provider value="s1">
+          <ToolCard tool={tool} result={completeRow({ text: "ran" })} />
+        </AcpSessionContext.Provider>
+      </AgentProfileProvider>,
+    );
+    expect(container.textContent).toContain("investigate");
+    expect(container.textContent).toContain("Bundled");
+  });
+
+  it("does not badge a card whose target does not match", () => {
+    pluginEntriesRef.current = [provenance({ kind: "mcp", name: "gitlab" }, "wrong")];
+    const tool = toolWith({ kind: "other", name: "mcp__github__get_issue" });
+    const { container } = render(
+      <AcpSessionContext.Provider value="s1">
+        <ToolCard tool={tool} result={completeRow()} />
+      </AcpSessionContext.Provider>,
+    );
+    expect(container.textContent).not.toContain("wrong");
   });
 });

--- a/web/src/components/plugin/PluginSlots.tsx
+++ b/web/src/components/plugin/PluginSlots.tsx
@@ -263,6 +263,46 @@ export function PluginDetailBadges({ sessionId }: { sessionId: string }) {
   );
 }
 
+/** tool-card-badge: per-session pills on a transcript tool-call card, matched to
+ *  the card by its target `(kind, name)`. One entry carries an `items` list so a
+ *  plugin can badge every MCP server / skill it knows in one push; this renders
+ *  only the items whose target matches this card. Renders nothing when no plugin
+ *  badges this target, so a card is byte-identical without a plugin. */
+export function PluginToolCardBadges({
+  sessionId,
+  kind,
+  target,
+}: {
+  sessionId: string;
+  kind: "mcp" | "skill";
+  target: string;
+}) {
+  const entries = sessionEntries(usePluginUiEntries(), "tool-card-badge", sessionId);
+  if (entries.length === 0) return null;
+  const chips = entries.flatMap((e) => {
+    const items = objectList(e.payload, "items");
+    if (!items) return [];
+    return items
+      .filter((it) => {
+        const t = it.target;
+        return isObject(t) && str(t, "kind") === kind && str(t, "name") === target;
+      })
+      .map((it, i) => (
+        <BadgeChip
+          key={`${e.plugin_id}:${e.id}:${i}`}
+          text={str(it, "text")}
+          icon={str(it, "icon")}
+          tone={validTone(it.tone)}
+          tooltip={str(it, "tooltip")}
+          slot="tool-card-badge"
+          pluginId={e.plugin_id}
+        />
+      ));
+  });
+  if (chips.length === 0) return null;
+  return <span className="flex shrink-0 items-center gap-1">{chips}</span>;
+}
+
 export function PluginComposerActions({
   sessionId,
   getSnapshot,

--- a/web/src/components/plugin/__tests__/PluginSlots.test.tsx
+++ b/web/src/components/plugin/__tests__/PluginSlots.test.tsx
@@ -10,6 +10,7 @@ import {
   PluginRowBadges,
   PluginSettingsPage,
   PluginStatusBarSegments,
+  PluginToolCardBadges,
 } from "../PluginSlots";
 import { composerDraftOperation } from "../composerDraftOperation";
 
@@ -633,5 +634,47 @@ describe("plugin slot renderers", () => {
     expect(screen.queryByText("Other")).toBeNull();
     expect(screen.queryByText("Wrong page")).toBeNull();
     expect(screen.queryByText("Scoped")).toBeNull();
+  });
+});
+
+describe("tool-card-badge renderer", () => {
+  beforeEach(() => {
+    entriesRef.current = [];
+  });
+
+  const badge = (target: { kind: string; name: string }, text: string): PluginUiEntry => ({
+    plugin_id: "acme.prov",
+    slot: "tool-card-badge",
+    id: "provenance",
+    session_id: "s1",
+    payload: { items: [{ target, text }] },
+  });
+
+  it("renders the pill whose target matches the card kind and name", () => {
+    set([badge({ kind: "mcp", name: "github" }, "MCP")]);
+    render(<PluginToolCardBadges sessionId="s1" kind="mcp" target="github" />);
+    expect(screen.getByText("MCP")).toBeTruthy();
+  });
+
+  it("ignores badges whose target name differs", () => {
+    set([badge({ kind: "mcp", name: "github" }, "MCP")]);
+    const { container } = render(<PluginToolCardBadges sessionId="s1" kind="mcp" target="gitlab" />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("does not cross-render an mcp badge onto a same-named skill card", () => {
+    set([badge({ kind: "mcp", name: "deploy" }, "from-mcp")]);
+    const { container } = render(<PluginToolCardBadges sessionId="s1" kind="skill" target="deploy" />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders only the addressed session's badges", () => {
+    set([
+      { ...badge({ kind: "mcp", name: "github" }, "mine"), session_id: "s1" },
+      { ...badge({ kind: "mcp", name: "github" }, "other"), session_id: "s2" },
+    ]);
+    render(<PluginToolCardBadges sessionId="s1" kind="mcp" target="github" />);
+    expect(screen.getByText("mine")).toBeTruthy();
+    expect(screen.queryByText("other")).toBeNull();
   });
 });

--- a/web/src/lib/acpSessionContext.tsx
+++ b/web/src/lib/acpSessionContext.tsx
@@ -1,0 +1,17 @@
+// Bridges the active session id down to the transcript's tool-call cards
+// (#2986). assistant-ui mounts those card nodes itself, so props cannot be
+// drilled to McpToolCard / SkillToolCard; a dedicated context is the injection
+// point. StructuredView provides the id; the tool cards consume it to render
+// per-session plugin `tool-card-badge` slots. Kept separate from
+// AcpFileRefContext so plugin badges do not silently vanish when file-ref
+// metadata happens to be absent.
+
+import { createContext, useContext } from "react";
+
+/** The id of the session whose transcript is mounted, or undefined when no
+ *  session is active (in which case per-session slot renderers show nothing). */
+export const AcpSessionContext = createContext<string | undefined>(undefined);
+
+export function useAcpSessionId(): string | undefined {
+  return useContext(AcpSessionContext);
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -715,6 +715,7 @@ export type PluginUiSlot =
   | "composer-action"
   | "detail-badge"
   | "settings-page"
+  | "tool-card-badge"
   | "notification";
 
 /** One piece of UI state a worker pushed. `payload` shape is determined by

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3184,6 +3184,13 @@
         "src/components/acp/Composer.pluginComposerActions.test.tsx"
       ],
       "components": ["web/src/components/plugin/PluginSlots.tsx", "web/src/components/acp/Composer.tsx"]
+    },
+    {
+      "id": "plugins.tool-card-badge",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/plugin-tool-card-badge.spec.ts"],
+      "components": ["web/src/components/plugin/PluginSlots.tsx", "web/src/components/acp/ToolCards.tsx"]
     }
   ]
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -3170,9 +3170,10 @@
       "specs": [
         "src/components/plugin/__tests__/PluginSlots.test.tsx",
         "src/lib/__tests__/pluginUi.test.ts",
-        "src/hooks/usePluginUiState.test.tsx"
+        "src/hooks/usePluginUiState.test.tsx",
+        "src/components/acp/__tests__/ToolCards.test.tsx"
       ],
-      "components": ["web/src/components/plugin/PluginSlots.tsx"]
+      "components": ["web/src/components/plugin/PluginSlots.tsx", "web/src/components/acp/ToolCards.tsx"]
     },
     {
       "id": "plugins.composer-actions",

--- a/web/tests/fixtures/tool-card-badge-plugin/aoe-plugin.toml
+++ b/web/tests/fixtures/tool-card-badge-plugin/aoe-plugin.toml
@@ -1,0 +1,18 @@
+# Minimal fake plugin for the live tool-card-badge test (#2986). Its worker
+# lists sessions and pushes a provenance badge targeting the MCP server the
+# fake ACP agent emits, so the live test can assert the pill renders on the
+# real MCP tool card. api_version 9 is required to declare the slot.
+id = "acme.provenance"
+name = "Provenance"
+version = "0.1.0"
+api_version = 9
+capabilities = ["runtime.worker", "session.read"]
+
+[[ui]]
+slot = "tool-card-badge"
+id = "provenance"
+
+[runtime]
+kind = "command"
+command = ["node", "worker.mjs"]
+system = true

--- a/web/tests/fixtures/tool-card-badge-plugin/aoe-plugin.toml
+++ b/web/tests/fixtures/tool-card-badge-plugin/aoe-plugin.toml
@@ -1,11 +1,11 @@
 # Minimal fake plugin for the live tool-card-badge test (#2986). Its worker
 # lists sessions and pushes a provenance badge targeting the MCP server the
 # fake ACP agent emits, so the live test can assert the pill renders on the
-# real MCP tool card. api_version 9 is required to declare the slot.
+# real MCP tool card. api_version 10 is required to declare the slot.
 id = "acme.provenance"
 name = "Provenance"
 version = "0.1.0"
-api_version = 9
+api_version = 10
 capabilities = ["runtime.worker", "session.read"]
 
 [[ui]]

--- a/web/tests/fixtures/tool-card-badge-plugin/worker.mjs
+++ b/web/tests/fixtures/tool-card-badge-plugin/worker.mjs
@@ -1,0 +1,61 @@
+// Worker for the fake provenance plugin used by the live tool-card-badge test
+// (#2986). The plugin worker is the JSON-RPC client: it writes one request per
+// line to stdout and reads one response per line on stdin (see
+// src/plugin/protocol.rs). It lists sessions and pushes a tool-card-badge entry
+// targeting the `acmecorp` MCP server, matching the tool call the fake ACP agent
+// emits. It loops forever (re-pushing for any new session) so the host does not
+// clear its ui-state on exit.
+
+import { createInterface } from "node:readline";
+
+let nextId = 1;
+const pending = new Map();
+
+createInterface({ input: process.stdin }).on("line", (line) => {
+  if (!line.trim()) return;
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  // Only responses to our own requests matter; ignore host-initiated
+  // notifications (e.g. composer-action forwards) this plugin does not use.
+  if (msg.id != null && pending.has(msg.id)) {
+    const resolve = pending.get(msg.id);
+    pending.delete(msg.id);
+    resolve(msg);
+  }
+});
+
+function call(method, params) {
+  return new Promise((resolve) => {
+    const id = nextId++;
+    pending.set(id, resolve);
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+  });
+}
+
+async function pushBadges() {
+  const res = await call("sessions.list", {});
+  const sessions = res.result?.sessions ?? [];
+  for (const s of sessions) {
+    await call("ui.state.set", {
+      slot: "tool-card-badge",
+      id: "provenance",
+      session_id: s.id,
+      payload: {
+        items: [{ target: { kind: "mcp", name: "acmecorp" }, text: "Company MCP", tone: "info" }],
+      },
+    });
+  }
+}
+
+for (;;) {
+  try {
+    await pushBadges();
+  } catch {
+    // Transient; retry on the next tick.
+  }
+  await new Promise((r) => setTimeout(r, 1000));
+}

--- a/web/tests/live/plugin-tool-card-badge.spec.ts
+++ b/web/tests/live/plugin-tool-card-badge.spec.ts
@@ -1,0 +1,104 @@
+// Live-backend spec: a plugin's tool-card-badge slot renders on a real MCP
+// tool card (#2986).
+//
+// Stands up a real fake plugin whose worker declares the `tool-card-badge` slot
+// and pushes a provenance badge targeting the `acmecorp` MCP server, then
+// scripts the fake ACP agent to emit an `mcp__acmecorp__get_issue` tool call.
+// Asserts the plugin's pill renders in the MCP card header. There is no
+// ui-state seeding endpoint (workers push it over RPC), so a real worker is the
+// only correct way to exercise this end to end.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, resolveAoeBinary } from "../helpers/aoeServe";
+import { enableStructuredViewAndWait, waitForStructuredView } from "../helpers/acp";
+
+const pluginDir = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "tool-card-badge-plugin");
+
+base("plugin tool-card-badge pill renders on the matching MCP card", async ({ page }, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-tool-card-badge-"));
+  const scriptPath = join(scriptDir, "script.json");
+
+  // claude-agent-acp ships MCP calls as kind "other" with the raw
+  // `mcp__<server>__<verb>` string as the title; the frontend reclassifies it
+  // into an MCP card. The worker badges the `acmecorp` server, so the target
+  // name here (server slug) must match.
+  writeFileSync(
+    scriptPath,
+    JSON.stringify({
+      turns: [
+        {
+          updates: [
+            {
+              sessionUpdate: "tool_call",
+              toolCallId: "mcp-1",
+              title: "mcp__acmecorp__get_issue",
+              kind: "other",
+              status: "completed",
+              content: [{ type: "content", content: { type: "text", text: "ok" } }],
+            },
+          ],
+          stopReason: "end_turn",
+        },
+      ],
+    }),
+  );
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      const addRes = spawnSync(resolveAoeBinary(), ["add", projectDir, "-t", "tool-card-badge", "-c", "claude"], {
+        env,
+      });
+      if (addRes.status !== 0) {
+        throw new Error(`aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`);
+      }
+      // Install + auto-grant the fake plugin so its worker launches at daemon
+      // boot and pushes the badge over ui.state.set.
+      const installRes = spawnSync(resolveAoeBinary(), ["plugin", "install", pluginDir, "--yes"], { env });
+      if (installRes.status !== 0) {
+        throw new Error(
+          `aoe plugin install failed: status=${installRes.status} stderr=${installRes.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    },
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionId: string = sessions[0]!.id;
+    await enableStructuredViewAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+    await waitForStructuredView(page);
+
+    const promptRes = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "call the mcp tool" }),
+    });
+    expect(promptRes.status).toBeGreaterThanOrEqual(200);
+    expect(promptRes.status).toBeLessThan(300);
+
+    // The MCP card renders from the scripted tool call.
+    await expect(page.getByText("MCP · Acmecorp")).toBeVisible({ timeout: 15_000 });
+
+    // The plugin worker pushes ui-state and the dashboard polls it, so the pill
+    // appears a poll later; wait for it on the tool-card-badge slot.
+    const pill = page.locator('[data-plugin-slot="tool-card-badge"]');
+    await expect(pill).toContainText("Company MCP", { timeout: 15_000 });
+    expect(await pill.getAttribute("data-plugin-id")).toBe("acme.provenance");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/plugin-tool-card-badge.spec.ts
+++ b/web/tests/live/plugin-tool-card-badge.spec.ts
@@ -9,7 +9,7 @@
 // only correct way to exercise this end to end.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -61,14 +61,16 @@ base("plugin tool-card-badge pill renders on the matching MCP card", async ({ pa
         env,
       });
       if (addRes.status !== 0) {
-        throw new Error(`aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`);
+        throw new Error(
+          `aoe add failed: status=${addRes.status} error=${addRes.error ?? "<none>"} stderr=${addRes.stderr?.toString() ?? "<none>"}`,
+        );
       }
       // Install + auto-grant the fake plugin so its worker launches at daemon
       // boot and pushes the badge over ui.state.set.
       const installRes = spawnSync(resolveAoeBinary(), ["plugin", "install", pluginDir, "--yes"], { env });
       if (installRes.status !== 0) {
         throw new Error(
-          `aoe plugin install failed: status=${installRes.status} stderr=${installRes.stderr?.toString() ?? "<none>"}`,
+          `aoe plugin install failed: status=${installRes.status} error=${installRes.error ?? "<none>"} stderr=${installRes.stderr?.toString() ?? "<none>"}`,
         );
       }
     },
@@ -97,8 +99,9 @@ base("plugin tool-card-badge pill renders on the matching MCP card", async ({ pa
     // appears a poll later; wait for it on the tool-card-badge slot.
     const pill = page.locator('[data-plugin-slot="tool-card-badge"]');
     await expect(pill).toContainText("Company MCP", { timeout: 15_000 });
-    expect(await pill.getAttribute("data-plugin-id")).toBe("acme.provenance");
+    await expect(pill).toHaveAttribute("data-plugin-id", "acme.provenance");
   } finally {
     await serve.stop();
+    rmSync(scriptDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a new per-session plugin UI slot, `tool-card-badge`, so a plugin can attach a provenance pill to MCP and skill tool-call cards in the transcript. This is the shared badge slot the MCP and skills plugins both want (`agent-of-empires/plugin-mcp#6`, `agent-of-empires/plugin-skills#3`); until now no `UiSlot` targeted tool cards.

A plugin declares the slot once per session and pushes a single entry whose payload is a target-keyed `items` list (mirroring the existing `row-badge` `items[]` precedent, since `(slot, id)` declarations are matched exactly and a plugin cannot predeclare a dynamic id per server or skill). Each item carries a structured target `{ kind: "mcp" | "skill", name }`. The `kind` is part of the match key on purpose: an MCP server and a skill can share a raw name (both `git`, both `github`), so a bare string target would cross-contaminate. Names are matched by exact string equality and never canonicalized, since they are external identifiers the plugin resolves.

On the web dashboard the pill renders in the tool card header (`CardChrome`'s existing `meta` slot, no change to `CardChrome` itself). The session id reaches the assistant-ui-mounted tool nodes through a dedicated `AcpSessionContext`, so plugin badges do not depend on file-ref metadata being present. With no plugin, cards render exactly as before.

`API_VERSION` bumps 8 to 9 with a parse-time gate rejecting the slot on older manifests, matching how `composer-action` was gated at 8.

The host stores the slot cross-platform, but this PR renders it on the **web dashboard only**. The native TUI structured view documents it as an ignored no-op: matched rendering there needs MCP/skill target classification the TUI does not carry today, tracked as a follow-up in #2990.

Closes #2986

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Install a plugin that declares `[[ui]] slot = "tool-card-badge"` (api_version 9) and pushes `ui.state.set` with `{ items: [{ target: { kind: "mcp", name: "<server>" }, text: "MCP" }] }` for the active session.
- [ ] Open a session in the web dashboard structured view and trigger an MCP tool call from that server; confirm the pill shows in the card header.
- [ ] Trigger a skill tool call and confirm a `{ kind: "skill", name: "<skill>" }` badge shows on the skill card.
- [ ] Confirm an MCP server and a skill sharing a name do not cross-render each other's badge.
- [ ] Confirm a manifest that uses the slot with `api_version < 9` is rejected at install/parse time.
- [ ] Confirm a session with no such plugin renders tool cards unchanged.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/plugin-tool-card-badge.spec.ts` (a real fake plugin worker pushes the badge; the fake ACP agent emits an MCP call; asserts the pill on the card) plus Vitest coverage in `PluginSlots.test.tsx` and `ToolCards.test.tsx`. Rust unit tests cover the payload validation and the `require_declared_slot` guard.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The only TUI change is a doc comment marking the slot as an ignored no-op; real TUI rendering is deferred to #2990.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` design pass on the payload shape and session-id plumbing. I made the design calls (target `{kind,name}` disambiguation, dedicated session context, deferring the TUI), reviewed each commit, and ran the manual and automated test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added a new per-session `tool-card-badge` UI slot so plugins can display “badge pills” on transcript tool-call cards for both MCP servers and skill tool calls, keyed by target kind + exact name to prevent collisions.
- Enforced compatibility via `api_version` gating: manifests using `tool-card-badge` must declare `api_version >= 10`, with stronger validation of badge targets and payload shape.
- Wired badge rendering into the web dashboard by introducing session-scoped context and rendering only the badge entries that match the current session and the card’s MCP/skill target.
- Implemented the web badge renderer as a dedicated component and added unit tests for correct matching (including cross-kind non-rendering) plus a Playwright live end-to-end test using a new fixture plugin.
- Updated plugin API docs and internal plugin-system documentation to cover the new slot/payload and clarified that native TUI handling is currently an ignored no-op pending follow-up.
- Bumped the plugin API schema version accordingly and added/expanded test coverage for manifest round-trips, host dispatch enforcement, and payload normalization.

## Benefits
Plugins can now surface contextual provenance (or similar signals) directly on the correct MCP/skill tool-call cards for the active session, with safer manifest/version checks and more reliable targeting.

## Follow-up / Potential enhancements
- Implement the same `tool-card-badge` rendering behavior in the native TUI (it’s currently documented as an ignored no-op pending target classification support).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->