### PR TITLE
feat(plugin): add MCP host RPCs and config.read/write capabilities

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -590,7 +590,7 @@ a local config write that a later daemon start picks up.
 
 Each host method maps to a capability the plugin declared and was granted; the
 middleware refuses an undeclared or ungranted call before the method runs
-(`src/plugin/host_api.rs`). No new capabilities are introduced; the v1 methods
+(`src/plugin/host_api.rs`). No new capabilities are introduced; the methods
 reuse the existing taxonomy:
 
 | Method | Capability |
@@ -600,6 +600,11 @@ reuse the existing taxonomy:
 | `session.meta.set` / `session.meta.cas` | `session.write` |
 | `sessions.list` | `session.read` |
 | `config.get` | `runtime.worker` |
+| `config.read` | `config.read` |
+| `config.write` | `config.write` |
+| `mcp.list` / `mcp.resolve` | `config.read` |
+| `mcp.add` / `mcp.edit` / `mcp.delete` | `config.write` |
+| `mcp.keep` / `mcp.drop` / `mcp.resolve-conflict` | `config.write` |
 
 `events.*` run over a shared plugin event bus (a `plugin_host` schema on the
 durable event-log substrate, `src/events/`); `subscribe { topics, after_seq }`
@@ -633,8 +638,46 @@ edited on the TUI/web surfaces, falling back to its own default when the key is
 unset (the call returns null). The id is the caller's own, never a request
 parameter, so a plugin can only read its own table. Reading one's own declared
 settings needs no `config.*` capability: `config.read` / `config.write` gate
-host/global or other-plugin configuration, which no host method exposes yet, so
+host/global configuration, a different surface from a plugin's own table, so
 `config.get` rides on `runtime.worker` like `events.*`.
+
+`config.read { section, field }` (capability `config.read`) reads one
+host/global settings field. The `(section, field)` pair must be a known schema
+descriptor (`settings_schema::descriptor`), so a plugin can only read declared
+settings, never an arbitrary or non-schema blob; an unknown field is
+`INVALID_PARAMS`. The value comes from the serialized global `Config`, or null
+when unset.
+
+`config.write { patch }` (capability `config.write`) mutates host/global
+settings. The `patch` is the web-PATCH shape `{ section: { field: value } }`
+and goes through the same schema gate the web dashboard uses
+(`settings_schema::validate_patch`), but at the **non-elevated** level: a
+`config.write` plugin gets exactly what a non-elevated web client may write.
+Unlike the web path (which silently strips host-execution `local_only` leaves),
+the RPC rejects every disallowed leaf loudly so a plugin never believes a
+refused write landed: an unknown field is `INVALID_PARAMS`; a host-execution
+(`local_only`, e.g. `acp.node_path`) or elevation-required field (e.g. the
+`worktree` / `sandbox` sections) is `FORBIDDEN`. Sections with no descriptor,
+notably `hooks` (arbitrary shell), are rejected as unknown.
+
+The `mcp.*` methods manage the unified MCP surface (the merged
+agent-native / global / profile / project-local server set, resolved by
+`src/session/mcp_model.rs`), gated on `config.read` (reads) and `config.write`
+(writes) because MCP definitions are host/global config. `mcp.list` returns the redacted effective
+forwarded set (a pure resolve, no drift write); `mcp.resolve` returns the full
+management view (`effective`, `keptOnRemoval`, `conflicts`, `driftPaused`) and
+reconciles the drift snapshot as it goes, mirroring `GET /api/mcp/servers`. The
+writes touch only the AoE-owned global `mcp.json`: `mcp.add` creates a server
+(refusing a name that already exists globally; use `mcp.edit`), `mcp.edit`
+replaces an existing global server as a full replacement (omitted fields,
+including env / header secrets, are dropped), and `mcp.delete` removes a global
+server. A write that targets a name resolving from an `agent-native`, `profile`,
+or `project-local` layer is `FORBIDDEN`, because AoE never writes those files.
+`mcp.keep` / `mcp.drop` finalize a keep-on-removal decision and
+`mcp.resolve-conflict { name, winner, fingerprint }` resolves a drift conflict
+under an optimistic-concurrency token (a stale token returns
+`{ status: "stale" }`). Because the daemon runs no plugin workers in read-only
+serve mode, these writes need no separate read-only check.
 
 ### Sandboxing
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -642,11 +642,14 @@ host/global configuration, a different surface from a plugin's own table, so
 `config.get` rides on `runtime.worker` like `events.*`.
 
 `config.read { section, field }` (capability `config.read`) reads one
-host/global settings field. The `(section, field)` pair must be a known schema
-descriptor (`settings_schema::descriptor`), so a plugin can only read declared
-settings, never an arbitrary or non-schema blob; an unknown field is
-`INVALID_PARAMS`. The value comes from the serialized global `Config`, or null
-when unset.
+host/global settings field. The `(section, field)` pair must be a plain
+(non-elevated) schema descriptor (`settings_schema::descriptor`), gated
+symmetrically with `config.write`: an unknown field is `INVALID_PARAMS`, and a
+host-execution (`local_only`, e.g. `acp.node_path`) or elevation-gated field
+(e.g. the `worktree` / `sandbox` sections) is `FORBIDDEN`. The elevation-gated
+set can hold literal secrets, notably `sandbox.environment` env values, so it is
+off-limits for reads too, not just writes. The value comes from the serialized
+global `Config`, or null when unset.
 
 `config.write { patch }` (capability `config.write`) mutates host/global
 settings. The `patch` is the web-PATCH shape `{ section: { field: value } }`

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -35,6 +35,7 @@
 //! all, is enough.
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use anyhow::Context as _;
@@ -45,7 +46,10 @@ use serde_json::{json, Value};
 use crate::events::{self, Order, Schema, SeqBound};
 use crate::plugin::protocol::codes;
 use crate::plugin::ui_state::{Tone, UiError, UiSnapshot, UiStore};
-use crate::session::Storage;
+use crate::session::mcp_model::{self, McpProvenance};
+use crate::session::mcp_state::{self, ConflictWinner, ResolveStatus};
+use crate::session::settings_schema::{self, Scope, WebWritePolicy};
+use crate::session::{mcp_overrides, update_config, Storage};
 
 /// Capability required by each host method. Reused from the manifest taxonomy
 /// (`aoe_plugin_api::KNOWN_CAPABILITIES`); no new capability is introduced.
@@ -58,6 +62,12 @@ const CAP_SESSION_WRITE: &str = "session.write";
 const CAP_NOTIFICATIONS: &str = "notifications";
 const CAP_COMPOSER_WRITE: &str = "composer.write";
 const CAP_BROWSER_OPEN: &str = "browser_open";
+/// Host/global (not own-table) config: `config.read` gates reading a settings
+/// field and resolving the MCP surface; `config.write` gates every host-config
+/// and MCP mutation. Distinct from `config.get` (`runtime.worker`), which reads
+/// the calling plugin's own settings only.
+const CAP_CONFIG_READ: &str = "config.read";
+const CAP_CONFIG_WRITE: &str = "config.write";
 
 /// Plugin-private storage quotas (#2897), per plugin. A plugin cannot reach
 /// another plugin's namespace, so the store needs no user-facing capability;
@@ -237,6 +247,13 @@ impl DispatchError {
             data: None,
         }
     }
+    fn forbidden(msg: impl Into<String>) -> Self {
+        Self {
+            code: codes::FORBIDDEN,
+            message: msg.into(),
+            data: None,
+        }
+    }
     fn method_not_found(method: &str) -> Self {
         Self {
             code: codes::METHOD_NOT_FOUND,
@@ -328,6 +345,46 @@ pub fn dispatch(
         "plugin.storage.remove" => {
             ctx.require(CAP_WORKER)?;
             plugin_storage_remove(state, ctx, params)
+        }
+        "config.read" => {
+            ctx.require(CAP_CONFIG_READ)?;
+            config_read(params)
+        }
+        "config.write" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            config_write(params)
+        }
+        "mcp.list" => {
+            ctx.require(CAP_CONFIG_READ)?;
+            mcp_list(state, params)
+        }
+        "mcp.resolve" => {
+            ctx.require(CAP_CONFIG_READ)?;
+            mcp_resolve(state, params)
+        }
+        "mcp.add" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            mcp_add(params)
+        }
+        "mcp.edit" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            mcp_edit(params)
+        }
+        "mcp.delete" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            mcp_delete(state, params)
+        }
+        "mcp.keep" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            mcp_keep(state, params)
+        }
+        "mcp.drop" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            mcp_drop(state, params)
+        }
+        "mcp.resolve-conflict" => {
+            ctx.require(CAP_CONFIG_WRITE)?;
+            mcp_resolve_conflict(state, params)
         }
         other => Err(DispatchError::method_not_found(other)),
     }
@@ -826,6 +883,312 @@ fn enforce_key_quota_tx(
     key: &str,
 ) -> Result<(), DispatchError> {
     enforce_key_quota(tx, plugin_id, key)
+}
+
+/// Read one host/global settings field (`config.read`, cap `config.read`). The
+/// `(section, field)` pair must be a known schema descriptor, so a plugin can
+/// only read declared settings, never an arbitrary or non-schema secret blob;
+/// an unknown field is `INVALID_PARAMS`. Returns the value from the serialized
+/// global `Config`, or `null` when the field is unset/omitted. Distinct from
+/// `config.get`, which reads the caller's own plugin settings.
+fn config_read(params: &Value) -> Result<Value, DispatchError> {
+    let section = str_param(params, "section")?;
+    let field = str_param(params, "field")?;
+    if settings_schema::descriptor(section, field).is_none() {
+        return Err(DispatchError::invalid_params(format!(
+            "unknown config field {section}.{field}"
+        )));
+    }
+    let config =
+        crate::session::Config::load().map_err(|e| DispatchError::internal(e.to_string()))?;
+    let json = serde_json::to_value(&config).map_err(|e| DispatchError::internal(e.to_string()))?;
+    let value = json
+        .get(section)
+        .and_then(|s| s.get(field))
+        .cloned()
+        .unwrap_or(Value::Null);
+    Ok(json!({ "value": value }))
+}
+
+/// Write host/global settings (`config.write`, cap `config.write`). The `patch`
+/// is the web-PATCH shape `{ section: { field: value } }`. A plugin gets exactly
+/// the NON-elevated web write surface, but unlike the web path (which silently
+/// strips `local_only` leaves) an RPC rejects every disallowed leaf loudly so a
+/// plugin never believes a refused write landed: unknown field -> INVALID_PARAMS;
+/// host-execution (`local_only`) or elevation-required field -> FORBIDDEN. The
+/// value itself is validated through the shared schema gate.
+fn config_write(params: &Value) -> Result<Value, DispatchError> {
+    let patch = params
+        .get("patch")
+        .ok_or_else(|| DispatchError::invalid_params("missing object param \"patch\""))?;
+    let sections = patch.as_object().ok_or_else(|| {
+        DispatchError::invalid_params(
+            "\"patch\" must be an object of { section: { field: value } }",
+        )
+    })?;
+    if sections.is_empty() {
+        return Err(DispatchError::invalid_params("\"patch\" is empty"));
+    }
+    for (section, fields) in sections {
+        let fields = fields.as_object().ok_or_else(|| {
+            DispatchError::invalid_params(format!("patch section {section:?} must be an object"))
+        })?;
+        for field in fields.keys() {
+            match settings_schema::descriptor(section, field) {
+                None => {
+                    return Err(DispatchError::invalid_params(format!(
+                        "unknown config field {section}.{field}"
+                    )))
+                }
+                Some(d) => match d.web_write {
+                    WebWritePolicy::Allow => {}
+                    WebWritePolicy::LocalOnly { .. } => {
+                        return Err(DispatchError::forbidden(format!(
+                            "config field {section}.{field} is a host-execution surface and is not writable by plugins"
+                        )))
+                    }
+                    WebWritePolicy::RequiresElevation { .. } => {
+                        return Err(DispatchError::forbidden(format!(
+                            "config field {section}.{field} requires elevation and is not writable by plugins"
+                        )))
+                    }
+                },
+            }
+        }
+    }
+    // Value validation via the shared gate (elevated = false, which also
+    // re-guards the policies checked above).
+    settings_schema::validate_patch(patch, Scope::Global, false)
+        .map_err(|rej| DispatchError::invalid_params(rej.message()))?;
+
+    let patch = patch.clone();
+    update_config(|config| -> anyhow::Result<()> {
+        let mut current = serde_json::to_value(&*config)?;
+        settings_schema::merge_json(&mut current, &patch);
+        *config = serde_json::from_value(current)?;
+        Ok(())
+    })
+    .and_then(|inner| inner)
+    .map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "ok": true }))
+}
+
+/// Resolve the `(agent, profile, cwd)` an MCP call operates in. `agent` is the
+/// optional `agent` param, else the host profile's configured default tool, else
+/// `claude` (mirrors the REST surface). `profile` is the host's profile; `cwd`
+/// is the daemon working directory (from which the project-local layer resolves).
+fn mcp_context(
+    state: &HostApiState,
+    params: &Value,
+) -> Result<(String, Option<String>, PathBuf), DispatchError> {
+    let profile = state.profile.clone();
+    let agent = match optional_str_param(params, "agent")? {
+        Some(a) => a.to_string(),
+        None => crate::session::profile_config::resolve_config_or_warn(&profile)
+            .session
+            .default_tool
+            .unwrap_or_else(|| "claude".to_string()),
+    };
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let profile_opt = (!profile.is_empty()).then_some(profile);
+    Ok((agent, profile_opt, cwd))
+}
+
+/// Wrap the `{ name, ...ecosystem .mcp.json entry }` params into a one-server
+/// standard config and parse it via the shared ecosystem parser, so a plugin
+/// sends the exact `.mcp.json` shape users and other agents already use. A
+/// missing/empty name or a malformed transport is `INVALID_PARAMS`.
+fn parse_mcp_server_param(
+    params: &Value,
+) -> Result<crate::session::project_mcp::ProjectMcpServer, DispatchError> {
+    let name = str_param(params, "name")?;
+    if name.trim().is_empty() {
+        return Err(DispatchError::invalid_params(
+            "MCP server \"name\" must be non-empty",
+        ));
+    }
+    let mut entry = params
+        .as_object()
+        .ok_or_else(|| DispatchError::invalid_params("params must be an object"))?
+        .clone();
+    // `name` is the map key, not an entry field; drop it so it is not treated as
+    // an (ignored) server property.
+    entry.remove("name");
+    let wrapped = json!({ "mcpServers": { name: Value::Object(entry) } });
+    let text =
+        serde_json::to_string(&wrapped).map_err(|e| DispatchError::internal(e.to_string()))?;
+    let mut servers =
+        crate::session::project_mcp::parse_standard_mcp_servers(&text).map_err(|e| {
+            DispatchError::invalid_params(format!("invalid MCP server definition: {e}"))
+        })?;
+    servers
+        .pop()
+        .ok_or_else(|| DispatchError::internal("MCP parser returned no server"))
+}
+
+/// `mcp.list` (cap `config.read`): the pure, redacted effective forwarded set.
+/// Uses `resolve_effective` (no drift reconcile, no state write), unlike
+/// `mcp.resolve`.
+fn mcp_list(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let (agent, profile, cwd) = mcp_context(state, params)?;
+    let effective = mcp_model::resolve_effective(&agent, profile.as_deref(), &cwd);
+    Ok(json!({
+        "agent": agent,
+        "servers": effective.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+    }))
+}
+
+/// `mcp.resolve` (cap `config.read`): the full management surface (effective set,
+/// kept-on-removal, conflicts, drift-paused), redacted. Mirrors the REST
+/// `GET /api/mcp/servers`; note this reconciles the drift snapshot as a side
+/// effect (adopts newly seen native servers), which the pure `mcp.list` does not.
+fn mcp_resolve(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let (agent, profile, cwd) = mcp_context(state, params)?;
+    let view = mcp_model::resolve_surface(&agent, profile.as_deref(), &cwd);
+    Ok(json!({
+        "agent": agent,
+        "effective": view.effective.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+        "keptOnRemoval": view.kept_on_removal.iter().map(|s| s.redacted()).collect::<Vec<_>>(),
+        "conflicts": view
+            .conflicts
+            .iter()
+            .map(|c| json!({
+                "name": c.current.name,
+                "agent": c.agent,
+                "previous": c.previous.redacted_summary(),
+                "current": c.current.redacted_summary(),
+                "fingerprint": c.fingerprint(),
+            }))
+            .collect::<Vec<_>>(),
+        "driftPaused": view.drift_paused,
+    }))
+}
+
+/// `mcp.add` (cap `config.write`): create a new server in the global `mcp.json`.
+/// Refuses if a global server of that name already exists (the caller uses
+/// `mcp.edit`); the existence check is atomic under the file lock.
+fn mcp_add(params: &Value) -> Result<Value, DispatchError> {
+    let server = parse_mcp_server_param(params)?;
+    let created = mcp_overrides::insert_global_server_if_absent(&server)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    if !created {
+        return Err(DispatchError::invalid_params(format!(
+            "global MCP server {:?} already exists; use mcp.edit",
+            server.name
+        )));
+    }
+    Ok(json!({ "status": "added" }))
+}
+
+/// `mcp.edit` (cap `config.write`): replace an existing global server definition.
+/// Refuses if no global server of that name exists (the caller uses `mcp.add`).
+/// This is a full replacement: fields omitted from the entry (including env /
+/// header secrets) are dropped, matching the global `upsert` semantics.
+fn mcp_edit(params: &Value) -> Result<Value, DispatchError> {
+    let server = parse_mcp_server_param(params)?;
+    let replaced = mcp_overrides::replace_global_server_if_present(&server)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    if !replaced {
+        return Err(DispatchError::invalid_params(format!(
+            "no global MCP server {:?}; use mcp.add",
+            server.name
+        )));
+    }
+    Ok(json!({ "status": "edited" }))
+}
+
+/// `mcp.delete` (cap `config.write`): remove a server from the global `mcp.json`.
+/// Only the AoE-owned global layer is writable: a name that resolves from an
+/// agent-native / profile / project-local layer is `FORBIDDEN` (AoE never writes
+/// those files); a name present nowhere is `INVALID_PARAMS`.
+fn mcp_delete(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let name = str_param(params, "name")?.to_string();
+    let removed = mcp_overrides::remove_global_server(&name)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    if removed {
+        return Ok(json!({ "status": "deleted" }));
+    }
+    // Not in the global layer. Classify for a precise error: a non-global
+    // provenance is a forbidden target, anything else is simply not found. This
+    // is a pure read (`resolve_effective`, no drift write).
+    let (agent, profile, cwd) = mcp_context(state, params)?;
+    let effective = mcp_model::resolve_effective(&agent, profile.as_deref(), &cwd);
+    let non_global = effective
+        .iter()
+        .any(|s| s.def.name == name && s.provenance != McpProvenance::Global);
+    if non_global {
+        Err(DispatchError::forbidden(format!(
+            "MCP server {name:?} is not global; AoE cannot delete agent-native, profile, or project-local servers"
+        )))
+    } else {
+        Err(DispatchError::invalid_params(format!(
+            "unknown global MCP server {name:?}"
+        )))
+    }
+}
+
+/// `mcp.keep` (cap `config.write`): keep a server removed from a native config by
+/// promoting it into the global `mcp.json` (feature D). `INVALID_PARAMS` if no
+/// such kept-on-removal entry exists.
+fn mcp_keep(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let (agent, _profile, _cwd) = mcp_context(state, params)?;
+    let name = str_param(params, "name")?;
+    let kept = mcp_state::keep_removed(&agent, name)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    if kept {
+        Ok(json!({ "status": "kept" }))
+    } else {
+        Err(DispatchError::invalid_params(format!(
+            "no kept-on-removal MCP server {name:?} for agent {agent:?}"
+        )))
+    }
+}
+
+/// `mcp.drop` (cap `config.write`): drop a kept-on-removal server without
+/// promoting it (feature D). Idempotent: a name already gone still returns ok.
+fn mcp_drop(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let (agent, _profile, _cwd) = mcp_context(state, params)?;
+    let name = str_param(params, "name")?;
+    mcp_state::forget_native(&agent, name).map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "status": "dropped" }))
+}
+
+/// `mcp.resolve-conflict` (cap `config.write`): resolve a drift conflict for one
+/// server (feature C). Mirrors the REST resolve endpoint: re-resolve the current
+/// conflicts, find the one for `name`, and apply `winner` (`aoe` / `native`)
+/// under the `fingerprint` optimistic-concurrency token. A stale token or a
+/// conflict that no longer exists returns `{ status: "stale" }`.
+fn mcp_resolve_conflict(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
+    let (agent, _profile, _cwd) = mcp_context(state, params)?;
+    let name = str_param(params, "name")?.to_string();
+    let winner = match str_param(params, "winner")? {
+        "aoe" => ConflictWinner::Aoe,
+        "native" => ConflictWinner::Native,
+        other => {
+            return Err(DispatchError::invalid_params(format!(
+                "unknown winner {other:?} (expected \"aoe\" or \"native\")"
+            )))
+        }
+    };
+    let fingerprint = str_param(params, "fingerprint")?.to_string();
+
+    let read = mcp_model::load_native_mcp_servers_checked_from_home(&agent)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let reconcile = mcp_state::reconcile_agent(&agent, &read)
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let Some(conflict) = reconcile
+        .conflicts
+        .into_iter()
+        .find(|c| c.current.name == name)
+    else {
+        return Ok(json!({ "status": "stale" }));
+    };
+    match mcp_state::resolve_conflict(&conflict, winner, &fingerprint)
+        .map_err(|e| DispatchError::internal(e.to_string()))?
+    {
+        ResolveStatus::Applied => Ok(json!({ "status": "applied" })),
+        ResolveStatus::Stale => Ok(json!({ "status": "stale" })),
+    }
 }
 
 /// Parse the `slot` param into a typed [`UiSlot`]. An unknown slot is bad
@@ -1840,5 +2203,221 @@ mod tests {
             }),
         )
         .unwrap();
+    }
+
+    /// Restore HOME + XDG_CONFIG_HOME on drop so a failing assertion never leaks
+    /// the temp override into the rest of the test process.
+    struct HomeGuard {
+        home: Option<std::ffi::OsString>,
+        xdg: Option<std::ffi::OsString>,
+    }
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match self.home.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.xdg.take() {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
+    fn set_tmp_home(dir: &std::path::Path) -> HomeGuard {
+        let guard = HomeGuard {
+            home: std::env::var_os("HOME"),
+            xdg: std::env::var_os("XDG_CONFIG_HOME"),
+        };
+        std::env::set_var("HOME", dir);
+        std::env::set_var("XDG_CONFIG_HOME", dir.join(".config"));
+        guard
+    }
+
+    /// Story: a plugin with `config.write` calls `mcp.add`, and `mcp.list`
+    /// returns the server on the next call, resolved from the `global` layer.
+    #[test]
+    #[serial_test::serial]
+    fn mcp_add_then_list_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_tmp_home(tmp.path());
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_CONFIG_READ, CAP_CONFIG_WRITE]);
+
+        let added = dispatch(
+            &state,
+            &c,
+            "mcp.add",
+            &json!({"name": "fs", "command": "mcp-fs", "args": ["--root", "."]}),
+        )
+        .unwrap();
+        assert_eq!(added["status"], json!("added"));
+
+        // A second add of the same name is refused (use edit).
+        let dup = dispatch(
+            &state,
+            &c,
+            "mcp.add",
+            &json!({"name": "fs", "command": "x"}),
+        )
+        .unwrap_err();
+        assert_eq!(dup.code, codes::INVALID_PARAMS);
+
+        let list = dispatch(&state, &c, "mcp.list", &json!({"agent": "claude"})).unwrap();
+        let servers = list["servers"].as_array().unwrap();
+        let fs = servers.iter().find(|s| s["name"] == json!("fs")).unwrap();
+        assert_eq!(fs["command"], json!("mcp-fs"));
+        assert_eq!(fs["provenance"], json!("global"));
+    }
+
+    /// Story: `mcp.delete` removes a `global` server; targeting an `agent-native`
+    /// server returns FORBIDDEN and writes nothing; an unknown name is
+    /// INVALID_PARAMS.
+    #[test]
+    #[serial_test::serial]
+    fn mcp_delete_global_removes_but_agent_native_is_forbidden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_tmp_home(tmp.path());
+        // A native (claude) server that AoE does not own.
+        std::fs::write(
+            tmp.path().join(".claude.json"),
+            r#"{ "mcpServers": { "native": { "command": "n" } } }"#,
+        )
+        .unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_CONFIG_READ, CAP_CONFIG_WRITE]);
+
+        dispatch(
+            &state,
+            &c,
+            "mcp.add",
+            &json!({"name": "g", "command": "gcmd"}),
+        )
+        .unwrap();
+        let deleted = dispatch(&state, &c, "mcp.delete", &json!({"name": "g"})).unwrap();
+        assert_eq!(deleted["status"], json!("deleted"));
+
+        // The agent-native server is not AoE-owned: refused, and no global write.
+        let forbidden = dispatch(
+            &state,
+            &c,
+            "mcp.delete",
+            &json!({"name": "native", "agent": "claude"}),
+        )
+        .unwrap_err();
+        assert_eq!(forbidden.code, codes::FORBIDDEN);
+        // The forbidden delete wrote nothing to the global layer.
+        assert!(!crate::session::mcp_overrides::remove_global_server("native").unwrap());
+
+        let missing = dispatch(
+            &state,
+            &c,
+            "mcp.delete",
+            &json!({"name": "nope", "agent": "claude"}),
+        )
+        .unwrap_err();
+        assert_eq!(missing.code, codes::INVALID_PARAMS);
+    }
+
+    /// Story: a plugin without `config.write` cannot perform any MCP write or a
+    /// `config.write`; the host refuses on capability before the handler runs.
+    #[test]
+    fn mcp_and_config_writes_require_config_write_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        // Holds config.read but not config.write.
+        let c = ctx(&[CAP_CONFIG_READ]);
+
+        for (method, params) in [
+            ("mcp.add", json!({"name": "fs", "command": "c"})),
+            ("mcp.edit", json!({"name": "fs", "command": "c"})),
+            ("mcp.delete", json!({"name": "fs"})),
+            ("mcp.keep", json!({"name": "fs"})),
+            ("mcp.drop", json!({"name": "fs"})),
+            (
+                "mcp.resolve-conflict",
+                json!({"name": "fs", "winner": "aoe", "fingerprint": "x"}),
+            ),
+            (
+                "config.write",
+                json!({"patch": {"session": {"yolo_mode_default": true}}}),
+            ),
+        ] {
+            let err = dispatch(&state, &c, method, &params).unwrap_err();
+            assert_eq!(
+                err.code,
+                codes::FORBIDDEN,
+                "{method} must require config.write"
+            );
+        }
+    }
+
+    /// Story: `config.write` refuses an unknown section, a host-execution
+    /// (`local_only`) field, and an elevation-required field, then accepts a
+    /// plain field which round-trips through `config.read`.
+    #[test]
+    #[serial_test::serial]
+    fn config_write_gates_fields_and_round_trips_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_tmp_home(tmp.path());
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_CONFIG_READ, CAP_CONFIG_WRITE]);
+
+        // Unknown section (`hooks` = arbitrary shell, no descriptor) -> rejected.
+        let unknown = dispatch(
+            &state,
+            &c,
+            "config.write",
+            &json!({"patch": {"hooks": {"on_start": "rm -rf /"}}}),
+        )
+        .unwrap_err();
+        assert_eq!(unknown.code, codes::INVALID_PARAMS);
+
+        // local_only host-execution surface -> FORBIDDEN.
+        let local_only = dispatch(
+            &state,
+            &c,
+            "config.write",
+            &json!({"patch": {"acp": {"node_path": "/tmp/node"}}}),
+        )
+        .unwrap_err();
+        assert_eq!(local_only.code, codes::FORBIDDEN);
+
+        // Elevation-required field -> FORBIDDEN (a plugin gets the unelevated set).
+        let elevated = dispatch(
+            &state,
+            &c,
+            "config.write",
+            &json!({"patch": {"worktree": {"enabled": true}}}),
+        )
+        .unwrap_err();
+        assert_eq!(elevated.code, codes::FORBIDDEN);
+
+        // A plain Allow field writes and reads back.
+        dispatch(
+            &state,
+            &c,
+            "config.write",
+            &json!({"patch": {"session": {"yolo_mode_default": true}}}),
+        )
+        .unwrap();
+        let read = dispatch(
+            &state,
+            &c,
+            "config.read",
+            &json!({"section": "session", "field": "yolo_mode_default"}),
+        )
+        .unwrap();
+        assert_eq!(read["value"], json!(true));
+
+        // An unknown field is rejected on read too.
+        let bad = dispatch(
+            &state,
+            &c,
+            "config.read",
+            &json!({"section": "session", "field": "nope"}),
+        )
+        .unwrap_err();
+        assert_eq!(bad.code, codes::INVALID_PARAMS);
     }
 }

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -364,11 +364,11 @@ pub fn dispatch(
         }
         "mcp.add" => {
             ctx.require(CAP_CONFIG_WRITE)?;
-            mcp_add(params)
+            mcp_add(state, params)
         }
         "mcp.edit" => {
             ctx.require(CAP_CONFIG_WRITE)?;
-            mcp_edit(params)
+            mcp_edit(state, params)
         }
         "mcp.delete" => {
             ctx.require(CAP_CONFIG_WRITE)?;
@@ -1064,11 +1064,38 @@ fn mcp_resolve(state: &HostApiState, params: &Value) -> Result<Value, DispatchEr
     }))
 }
 
+/// True if `name` resolves in the effective set from a layer other than the
+/// AoE-owned global one (agent-native / profile / project-local). Such a name is
+/// not AoE's to write, so `mcp.add` / `mcp.edit` / `mcp.delete` reject it with
+/// `FORBIDDEN`. A pure read (`resolve_effective`, no drift write).
+fn resolves_non_global(
+    state: &HostApiState,
+    params: &Value,
+    name: &str,
+) -> Result<bool, DispatchError> {
+    let (agent, profile, cwd) = mcp_context(state, params)?;
+    let effective = mcp_model::resolve_effective(&agent, profile.as_deref(), &cwd);
+    Ok(effective
+        .iter()
+        .any(|s| s.def.name == name && s.provenance != McpProvenance::Global))
+}
+
+fn not_global_forbidden(name: &str) -> DispatchError {
+    DispatchError::forbidden(format!(
+        "MCP server {name:?} is owned by a non-global layer (agent-native, profile, or project-local); AoE only writes the global layer"
+    ))
+}
+
 /// `mcp.add` (cap `config.write`): create a new server in the global `mcp.json`.
-/// Refuses if a global server of that name already exists (the caller uses
-/// `mcp.edit`); the existence check is atomic under the file lock.
-fn mcp_add(params: &Value) -> Result<Value, DispatchError> {
+/// A name owned by a non-global layer is `FORBIDDEN` (AoE will not add a global
+/// override that shadows it); a name that already exists globally is
+/// `INVALID_PARAMS` (the caller uses `mcp.edit`). The global existence check is
+/// atomic under the file lock.
+fn mcp_add(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
     let server = parse_mcp_server_param(params)?;
+    if resolves_non_global(state, params, &server.name)? {
+        return Err(not_global_forbidden(&server.name));
+    }
     let created = mcp_overrides::insert_global_server_if_absent(&server)
         .map_err(|e| DispatchError::internal(e.to_string()))?;
     if !created {
@@ -1081,20 +1108,24 @@ fn mcp_add(params: &Value) -> Result<Value, DispatchError> {
 }
 
 /// `mcp.edit` (cap `config.write`): replace an existing global server definition.
-/// Refuses if no global server of that name exists (the caller uses `mcp.add`).
-/// This is a full replacement: fields omitted from the entry (including env /
-/// header secrets) are dropped, matching the global `upsert` semantics.
-fn mcp_edit(params: &Value) -> Result<Value, DispatchError> {
+/// A full replacement: fields omitted from the entry (including env / header
+/// secrets) are dropped, matching the global `upsert` semantics. A name owned by
+/// a non-global layer is `FORBIDDEN`; a name that exists nowhere globally is
+/// `INVALID_PARAMS` (the caller uses `mcp.add`).
+fn mcp_edit(state: &HostApiState, params: &Value) -> Result<Value, DispatchError> {
     let server = parse_mcp_server_param(params)?;
     let replaced = mcp_overrides::replace_global_server_if_present(&server)
         .map_err(|e| DispatchError::internal(e.to_string()))?;
-    if !replaced {
-        return Err(DispatchError::invalid_params(format!(
-            "no global MCP server {:?}; use mcp.add",
-            server.name
-        )));
+    if replaced {
+        return Ok(json!({ "status": "edited" }));
     }
-    Ok(json!({ "status": "edited" }))
+    if resolves_non_global(state, params, &server.name)? {
+        return Err(not_global_forbidden(&server.name));
+    }
+    Err(DispatchError::invalid_params(format!(
+        "no global MCP server {:?}; use mcp.add",
+        server.name
+    )))
 }
 
 /// `mcp.delete` (cap `config.write`): remove a server from the global `mcp.json`.
@@ -1109,17 +1140,9 @@ fn mcp_delete(state: &HostApiState, params: &Value) -> Result<Value, DispatchErr
         return Ok(json!({ "status": "deleted" }));
     }
     // Not in the global layer. Classify for a precise error: a non-global
-    // provenance is a forbidden target, anything else is simply not found. This
-    // is a pure read (`resolve_effective`, no drift write).
-    let (agent, profile, cwd) = mcp_context(state, params)?;
-    let effective = mcp_model::resolve_effective(&agent, profile.as_deref(), &cwd);
-    let non_global = effective
-        .iter()
-        .any(|s| s.def.name == name && s.provenance != McpProvenance::Global);
-    if non_global {
-        Err(DispatchError::forbidden(format!(
-            "MCP server {name:?} is not global; AoE cannot delete agent-native, profile, or project-local servers"
-        )))
+    // provenance is a forbidden target, anything else is simply not found.
+    if resolves_non_global(state, params, &name)? {
+        Err(not_global_forbidden(&name))
     } else {
         Err(DispatchError::invalid_params(format!(
             "unknown global MCP server {name:?}"
@@ -2317,6 +2340,55 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(missing.code, codes::INVALID_PARAMS);
+    }
+
+    /// Story: `mcp.add` / `mcp.edit` refuse a name owned by a non-global layer
+    /// with FORBIDDEN (AoE only writes the global layer), and `mcp.edit` on a
+    /// name that exists nowhere globally is INVALID_PARAMS.
+    #[test]
+    #[serial_test::serial]
+    fn mcp_add_and_edit_reject_non_global_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = set_tmp_home(tmp.path());
+        // An agent-native server AoE does not own.
+        std::fs::write(
+            tmp.path().join(".claude.json"),
+            r#"{ "mcpServers": { "native": { "command": "n" } } }"#,
+        )
+        .unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_CONFIG_READ, CAP_CONFIG_WRITE]);
+
+        // add of a native-owned name: FORBIDDEN, and no global override written.
+        let add_forbidden = dispatch(
+            &state,
+            &c,
+            "mcp.add",
+            &json!({"name": "native", "command": "x", "agent": "claude"}),
+        )
+        .unwrap_err();
+        assert_eq!(add_forbidden.code, codes::FORBIDDEN);
+        assert!(!crate::session::mcp_overrides::remove_global_server("native").unwrap());
+
+        // edit of a native-owned name: FORBIDDEN (not INVALID_PARAMS).
+        let edit_forbidden = dispatch(
+            &state,
+            &c,
+            "mcp.edit",
+            &json!({"name": "native", "command": "x", "agent": "claude"}),
+        )
+        .unwrap_err();
+        assert_eq!(edit_forbidden.code, codes::FORBIDDEN);
+
+        // edit of a name that exists nowhere globally: INVALID_PARAMS (use add).
+        let edit_missing = dispatch(
+            &state,
+            &c,
+            "mcp.edit",
+            &json!({"name": "ghost", "command": "x", "agent": "claude"}),
+        )
+        .unwrap_err();
+        assert_eq!(edit_missing.code, codes::INVALID_PARAMS);
     }
 
     /// Story: a plugin without `config.write` cannot perform any MCP write or a

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -885,20 +885,43 @@ fn enforce_key_quota_tx(
     enforce_key_quota(tx, plugin_id, key)
 }
 
+/// Gate a `(section, field)` to the non-elevated host-config surface shared by
+/// `config.read` / `config.write`: the field must be a known schema descriptor
+/// a non-elevated web client may also write (`WebWritePolicy::Allow`). An
+/// unknown field is `INVALID_PARAMS`; a host-execution (`local_only`) or
+/// elevation-gated field is `FORBIDDEN`. The elevation-gated set can carry
+/// literal secrets (e.g. `sandbox.environment` env values), so it is off-limits
+/// for reads too, not just writes. `verb` (`"readable"` / `"writable"`) tailors
+/// the message.
+fn require_non_elevated_field(section: &str, field: &str, verb: &str) -> Result<(), DispatchError> {
+    match settings_schema::descriptor(section, field) {
+        None => Err(DispatchError::invalid_params(format!(
+            "unknown config field {section}.{field}"
+        ))),
+        Some(d) => match d.web_write {
+            WebWritePolicy::Allow => Ok(()),
+            WebWritePolicy::LocalOnly { .. } => Err(DispatchError::forbidden(format!(
+                "config field {section}.{field} is a host-execution surface and is not {verb} by plugins"
+            ))),
+            WebWritePolicy::RequiresElevation { .. } => Err(DispatchError::forbidden(format!(
+                "config field {section}.{field} is elevation-gated and is not {verb} by plugins"
+            ))),
+        },
+    }
+}
+
 /// Read one host/global settings field (`config.read`, cap `config.read`). The
-/// `(section, field)` pair must be a known schema descriptor, so a plugin can
-/// only read declared settings, never an arbitrary or non-schema secret blob;
-/// an unknown field is `INVALID_PARAMS`. Returns the value from the serialized
-/// global `Config`, or `null` when the field is unset/omitted. Distinct from
-/// `config.get`, which reads the caller's own plugin settings.
+/// `(section, field)` pair must be a plain (non-elevated) schema descriptor, so
+/// a plugin can only read declared, non-secret settings: an unknown field is
+/// `INVALID_PARAMS`, and a host-execution (`local_only`) or elevation-gated
+/// field, which can carry literal secrets, is `FORBIDDEN` (symmetric with
+/// `config.write`). Returns the value from the serialized global `Config`, or
+/// `null` when the field is unset/omitted. Distinct from `config.get`, which
+/// reads the caller's own plugin settings.
 fn config_read(params: &Value) -> Result<Value, DispatchError> {
     let section = str_param(params, "section")?;
     let field = str_param(params, "field")?;
-    if settings_schema::descriptor(section, field).is_none() {
-        return Err(DispatchError::invalid_params(format!(
-            "unknown config field {section}.{field}"
-        )));
-    }
+    require_non_elevated_field(section, field, "readable")?;
     let config =
         crate::session::Config::load().map_err(|e| DispatchError::internal(e.to_string()))?;
     let json = serde_json::to_value(&config).map_err(|e| DispatchError::internal(e.to_string()))?;
@@ -934,30 +957,15 @@ fn config_write(params: &Value) -> Result<Value, DispatchError> {
             DispatchError::invalid_params(format!("patch section {section:?} must be an object"))
         })?;
         for field in fields.keys() {
-            match settings_schema::descriptor(section, field) {
-                None => {
-                    return Err(DispatchError::invalid_params(format!(
-                        "unknown config field {section}.{field}"
-                    )))
-                }
-                Some(d) => match d.web_write {
-                    WebWritePolicy::Allow => {}
-                    WebWritePolicy::LocalOnly { .. } => {
-                        return Err(DispatchError::forbidden(format!(
-                            "config field {section}.{field} is a host-execution surface and is not writable by plugins"
-                        )))
-                    }
-                    WebWritePolicy::RequiresElevation { .. } => {
-                        return Err(DispatchError::forbidden(format!(
-                            "config field {section}.{field} requires elevation and is not writable by plugins"
-                        )))
-                    }
-                },
-            }
+            require_non_elevated_field(section, field, "writable")?;
         }
     }
-    // Value validation via the shared gate (elevated = false, which also
-    // re-guards the policies checked above).
+    // Value validation via the shared gate. `require_non_elevated_field` above
+    // already rejected unknown / local_only / elevation fields; this pass checks
+    // each value against its schema rule. `elevated = false` re-guards the
+    // elevation policy, but `validate_patch` does NOT reject `local_only` (it
+    // expects the web caller to have stripped it first), so the loud rejection
+    // above is what keeps a host-execution leaf out.
     settings_schema::validate_patch(patch, Scope::Global, false)
         .map_err(|rej| DispatchError::invalid_params(rej.message()))?;
 
@@ -2491,5 +2499,28 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(bad.code, codes::INVALID_PARAMS);
+
+        // config.read is gated symmetrically with config.write: a host-execution
+        // (`local_only`) field and an elevation-gated field, which can carry
+        // literal secrets (e.g. `sandbox.environment`), are FORBIDDEN to read,
+        // not just to write.
+        for (section, field) in [
+            ("acp", "node_path"),       // local_only host-execution surface
+            ("worktree", "enabled"),    // elevation-gated
+            ("sandbox", "environment"), // elevation-gated, may hold secrets
+        ] {
+            let err = dispatch(
+                &state,
+                &c,
+                "config.read",
+                &json!({"section": section, "field": field}),
+            )
+            .unwrap_err();
+            assert_eq!(
+                err.code,
+                codes::FORBIDDEN,
+                "config.read of {section}.{field} must be FORBIDDEN"
+            );
+        }
     }
 }

--- a/src/session/mcp_overrides.rs
+++ b/src/session/mcp_overrides.rs
@@ -84,21 +84,24 @@ fn read_root(content: &str) -> Result<Map<String, Value>> {
 
 /// Apply a mutation to the `mcpServers` object of the global `mcp.json` under an
 /// exclusive lock, preserving every other server and any unknown top-level keys.
-fn mutate_servers(mutate: impl FnOnce(&mut Map<String, Value>)) -> Result<()> {
+/// The closure's return value is passed back to the caller, so an existence
+/// check and the mutation it gates run inside the same lock (no check-then-act
+/// race against a concurrent surface write).
+fn mutate_servers<T>(mutate: impl FnOnce(&mut Map<String, Value>) -> T) -> Result<T> {
     let path = global_mcp_path()?;
     super::storage::locked_update(
         &path,
         read_root,
         |root| Ok(serde_json::to_string_pretty(root)?),
-        |root| -> Result<()> {
+        |root| -> Result<T> {
             let mut servers = match root.remove("mcpServers") {
                 Some(Value::Object(m)) => m,
                 Some(_) => anyhow::bail!("mcpServers in global mcp.json is not an object"),
                 None => Map::new(),
             };
-            mutate(&mut servers);
+            let out = mutate(&mut servers);
             root.insert("mcpServers".into(), Value::Object(servers));
-            Ok(())
+            Ok(out)
         },
     )?
 }
@@ -112,6 +115,50 @@ pub fn upsert_global_server(server: &ProjectMcpServer) -> Result<()> {
     let name = server.name.clone();
     mutate_servers(move |servers| {
         servers.insert(name, entry);
+    })
+}
+
+/// Remove a server from the global `mcp.json` by name. Returns `true` if a
+/// server of that name was present and removed, `false` if it was already
+/// absent. The existence check runs inside the same exclusive lock as the
+/// removal, so a concurrent surface write cannot slip between the two.
+pub fn remove_global_server(name: &str) -> Result<bool> {
+    let name = name.to_string();
+    mutate_servers(move |servers| servers.remove(&name).is_some())
+}
+
+/// Insert a server into the global `mcp.json` only if no server of that name is
+/// already present. Returns `true` on insert, `false` if the name already
+/// existed (the caller then reports "already exists; use edit"). Existence is
+/// checked on the raw server map under the lock, so a malformed existing entry
+/// still counts as present and is never silently overwritten.
+pub fn insert_global_server_if_absent(server: &ProjectMcpServer) -> Result<bool> {
+    let entry = server_to_entry(server);
+    let name = server.name.clone();
+    mutate_servers(move |servers| {
+        if servers.contains_key(&name) {
+            false
+        } else {
+            servers.insert(name, entry);
+            true
+        }
+    })
+}
+
+/// Replace an existing global server definition, only if a server of that name
+/// is already present. Returns `true` on replace, `false` if absent (the caller
+/// then reports "no such global server; use add"). Checked under the lock on the
+/// raw map, mirroring [`insert_global_server_if_absent`].
+pub fn replace_global_server_if_present(server: &ProjectMcpServer) -> Result<bool> {
+    let entry = server_to_entry(server);
+    let name = server.name.clone();
+    mutate_servers(move |servers| {
+        if servers.contains_key(&name) {
+            servers.insert(name, entry);
+            true
+        } else {
+            false
+        }
     })
 }
 
@@ -217,6 +264,61 @@ mod tests {
                 );
             }
             other => panic!("expected http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_returns_whether_present_and_preserves_others() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+        upsert_global_server(&stdio("keep", "k")).unwrap();
+        upsert_global_server(&stdio("gone", "g")).unwrap();
+
+        assert!(remove_global_server("gone").unwrap(), "present -> removed");
+        assert!(
+            !remove_global_server("gone").unwrap(),
+            "absent -> false, idempotent"
+        );
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        let names: Vec<_> = servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["keep"], "other servers untouched");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn insert_if_absent_creates_once_and_never_overwrites() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+
+        assert!(insert_global_server_if_absent(&stdio("fs", "first")).unwrap());
+        // Second insert of the same name refuses and leaves the definition intact.
+        assert!(!insert_global_server_if_absent(&stdio("fs", "second")).unwrap());
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        assert_eq!(servers.len(), 1);
+        match &servers[0].transport {
+            ProjectMcpTransport::Stdio { command, .. } => assert_eq!(command, "first"),
+            other => panic!("expected stdio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn replace_if_present_edits_only_existing() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+
+        // Absent -> refused, nothing written.
+        assert!(!replace_global_server_if_present(&stdio("fs", "x")).unwrap());
+        assert!(load_global_mcp_servers(&app_dir).unwrap().is_empty());
+
+        upsert_global_server(&stdio("fs", "old")).unwrap();
+        assert!(replace_global_server_if_present(&stdio("fs", "new")).unwrap());
+        let servers = load_global_mcp_servers(&app_dir).unwrap();
+        assert_eq!(servers.len(), 1);
+        match &servers[0].transport {
+            ProjectMcpTransport::Stdio { command, .. } => assert_eq!(command, "new"),
+            other => panic!("expected stdio, got {other:?}"),
         }
     }
 }

--- a/src/session/mcp_overrides.rs
+++ b/src/session/mcp_overrides.rs
@@ -94,16 +94,58 @@ fn mutate_servers<T>(mutate: impl FnOnce(&mut Map<String, Value>) -> T) -> Resul
         read_root,
         |root| Ok(serde_json::to_string_pretty(root)?),
         |root| -> Result<T> {
-            let mut servers = match root.remove("mcpServers") {
-                Some(Value::Object(m)) => m,
-                Some(_) => anyhow::bail!("mcpServers in global mcp.json is not an object"),
-                None => Map::new(),
-            };
+            let mut servers = take_servers(root)?;
             let out = mutate(&mut servers);
             root.insert("mcpServers".into(), Value::Object(servers));
             Ok(out)
         },
     )?
+}
+
+/// Take the `mcpServers` object out of the parsed root, defaulting a missing key
+/// to an empty map and rejecting a non-object value.
+fn take_servers(root: &mut Map<String, Value>) -> Result<Map<String, Value>> {
+    match root.remove("mcpServers") {
+        Some(Value::Object(m)) => Ok(m),
+        Some(_) => anyhow::bail!("mcpServers in global mcp.json is not an object"),
+        None => Ok(Map::new()),
+    }
+}
+
+/// Reason a conditional mutation did not persist, carried through
+/// `locked_update`'s error channel (it writes only on `Ok`). `Unchanged` means
+/// the operation was a no-op, so the file is left byte-for-byte untouched (no
+/// create, no rewrite); `Corrupt` propagates a malformed-file error.
+enum SkipWrite {
+    Unchanged,
+    Corrupt(anyhow::Error),
+}
+
+/// Run a conditional mutation on the global `mcpServers` map under the exclusive
+/// lock. `mutate` returns whether it changed anything; when it did not, the file
+/// is left exactly as it was (a rejected or idempotent op performs no write) and
+/// `false` is returned. This is what lets a forbidden delete or a duplicate add
+/// touch nothing on disk.
+fn try_mutate_servers(mutate: impl FnOnce(&mut Map<String, Value>) -> bool) -> Result<bool> {
+    let path = global_mcp_path()?;
+    let outcome = super::storage::locked_update(
+        &path,
+        read_root,
+        |root| Ok(serde_json::to_string_pretty(root)?),
+        |root| -> std::result::Result<(), SkipWrite> {
+            let mut servers = take_servers(root).map_err(SkipWrite::Corrupt)?;
+            if !mutate(&mut servers) {
+                return Err(SkipWrite::Unchanged);
+            }
+            root.insert("mcpServers".into(), Value::Object(servers));
+            Ok(())
+        },
+    )?;
+    match outcome {
+        Ok(()) => Ok(true),
+        Err(SkipWrite::Unchanged) => Ok(false),
+        Err(SkipWrite::Corrupt(e)) => Err(e),
+    }
 }
 
 /// Insert or replace a server in the global `mcp.json` by name. Used by both
@@ -121,21 +163,23 @@ pub fn upsert_global_server(server: &ProjectMcpServer) -> Result<()> {
 /// Remove a server from the global `mcp.json` by name. Returns `true` if a
 /// server of that name was present and removed, `false` if it was already
 /// absent. The existence check runs inside the same exclusive lock as the
-/// removal, so a concurrent surface write cannot slip between the two.
+/// removal, so a concurrent surface write cannot slip between the two; an absent
+/// name leaves the file untouched (no write).
 pub fn remove_global_server(name: &str) -> Result<bool> {
     let name = name.to_string();
-    mutate_servers(move |servers| servers.remove(&name).is_some())
+    try_mutate_servers(move |servers| servers.remove(&name).is_some())
 }
 
 /// Insert a server into the global `mcp.json` only if no server of that name is
 /// already present. Returns `true` on insert, `false` if the name already
 /// existed (the caller then reports "already exists; use edit"). Existence is
 /// checked on the raw server map under the lock, so a malformed existing entry
-/// still counts as present and is never silently overwritten.
+/// still counts as present and is never silently overwritten; a duplicate leaves
+/// the file untouched (no write).
 pub fn insert_global_server_if_absent(server: &ProjectMcpServer) -> Result<bool> {
     let entry = server_to_entry(server);
     let name = server.name.clone();
-    mutate_servers(move |servers| {
+    try_mutate_servers(move |servers| {
         if servers.contains_key(&name) {
             false
         } else {
@@ -148,11 +192,12 @@ pub fn insert_global_server_if_absent(server: &ProjectMcpServer) -> Result<bool>
 /// Replace an existing global server definition, only if a server of that name
 /// is already present. Returns `true` on replace, `false` if absent (the caller
 /// then reports "no such global server; use add"). Checked under the lock on the
-/// raw map, mirroring [`insert_global_server_if_absent`].
+/// raw map, mirroring [`insert_global_server_if_absent`]; an absent name leaves
+/// the file untouched (no write).
 pub fn replace_global_server_if_present(server: &ProjectMcpServer) -> Result<bool> {
     let entry = server_to_entry(server);
     let name = server.name.clone();
-    mutate_servers(move |servers| {
+    try_mutate_servers(move |servers| {
         if servers.contains_key(&name) {
             servers.insert(name, entry);
             true
@@ -320,5 +365,27 @@ mod tests {
             ProjectMcpTransport::Stdio { command, .. } => assert_eq!(command, "new"),
             other => panic!("expected stdio, got {other:?}"),
         }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unchanged_ops_do_not_write_the_file() {
+        let _home = set_tmp_home();
+        let app_dir = crate::session::get_app_dir().unwrap();
+        let mcp = app_dir.join("mcp.json");
+
+        // No file yet: an absent remove and an absent replace must not create it.
+        assert!(!remove_global_server("nope").unwrap());
+        assert!(!replace_global_server_if_present(&stdio("nope", "x")).unwrap());
+        assert!(!mcp.exists(), "a no-op must not create mcp.json");
+
+        // With a known file, a duplicate insert and an absent remove leave the
+        // exact bytes untouched (no spurious rewrite).
+        upsert_global_server(&stdio("fs", "c")).unwrap();
+        let before = std::fs::read(&mcp).unwrap();
+        assert!(!insert_global_server_if_absent(&stdio("fs", "other")).unwrap());
+        assert!(!remove_global_server("nope").unwrap());
+        let after = std::fs::read(&mcp).unwrap();
+        assert_eq!(before, after, "unchanged ops must not rewrite mcp.json");
     }
 }

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -58,13 +58,15 @@ pub struct McpConflict {
 }
 
 impl McpConflict {
-    /// Optimistic-concurrency token: the fingerprint of the AoE (snapshot) side
-    /// as this surface saw it when it opened the conflict modal. [`resolve_conflict`]
-    /// rejects the resolution as stale if the on-disk snapshot no longer matches
-    /// this token, i.e. another surface (web vs TUI) resolved the same conflict
-    /// first.
+    /// Optimistic-concurrency token binding BOTH sides of the conflict as this
+    /// surface saw them: the AoE snapshot side (`previous`) and the native side
+    /// (`current`). [`resolve_conflict`] rejects the resolution as stale if this
+    /// token no longer matches the freshly reconciled conflict, so a change to
+    /// EITHER side after the surface captured the token, another surface
+    /// re-baselining the snapshot, or the native config changing again, is caught
+    /// rather than silently applying the user's old decision to new state.
     pub fn fingerprint(&self) -> String {
-        super::project_mcp::fingerprint(std::slice::from_ref(&self.previous))
+        super::project_mcp::fingerprint(&[self.previous.clone(), self.current.clone()])
     }
 }
 
@@ -223,13 +225,18 @@ pub fn forget_native(agent: &str, name: &str) -> Result<()> {
 /// Resolve a conflict between AoE's snapshot and the native config (feature C).
 ///
 /// `expected_fingerprint` is the optimistic-concurrency token the surface
-/// captured when it opened the modal ([`McpConflict::fingerprint`]). Under the
-/// store lock, if the snapshot entry is gone or no longer matches that token
-/// (another surface already resolved it), nothing changes and [`ResolveStatus::Stale`]
-/// is returned. Otherwise the snapshot is re-baselined to the native definition
-/// (so the conflict does not re-surface), and for [`ConflictWinner::Aoe`] the
-/// AoE-side definition is additionally promoted into the global `mcp.json` so it
-/// keeps forwarding. AoE never writes the native config either way.
+/// captured when it opened the modal ([`McpConflict::fingerprint`]), binding
+/// BOTH the snapshot (`previous`) and native (`current`) sides. The caller is
+/// expected to pass a freshly reconciled `conflict`; if its token no longer
+/// matches `expected_fingerprint`, either side moved since the surface captured
+/// it (the native config changed again, or another surface re-baselined the
+/// snapshot), so nothing changes and [`ResolveStatus::Stale`] is returned. Under
+/// the store lock this is re-checked against the on-disk snapshot to close the
+/// window between the caller's reconcile and this write. Otherwise the snapshot
+/// is re-baselined to the native definition (so the conflict does not
+/// re-surface), and for [`ConflictWinner::Aoe`] the AoE-side definition is
+/// additionally promoted into the global `mcp.json`. AoE never writes the native
+/// config either way.
 pub fn resolve_conflict(
     conflict: &McpConflict,
     winner: ConflictWinner,
@@ -237,8 +244,18 @@ pub fn resolve_conflict(
 ) -> Result<ResolveStatus> {
     let name = conflict.current.name.clone();
 
-    // Phase 1, under the store lock: verify the token, re-baseline the snapshot,
-    // and report whether the AoE side must still be promoted to global.
+    // The token binds both sides of the conflict as the surface saw them.
+    // Recompute from the freshly reconciled conflict the caller passed: if
+    // either side moved since the token was captured, it no longer matches and
+    // the resolution is stale (the user's decision was made against old state).
+    if conflict.fingerprint() != expected_fingerprint {
+        return Ok(ResolveStatus::Stale);
+    }
+
+    // Phase 1, under the store lock: re-verify the snapshot still holds the
+    // previous side the caller resolved against (closing the window between the
+    // caller's reconcile and this write), re-baseline it, and report whether the
+    // AoE side must still be promoted to global.
     enum Decision {
         Stale,
         Applied { promote: Option<ProjectMcpServer> },
@@ -251,7 +268,7 @@ pub fn resolve_conflict(
         else {
             return Decision::Stale;
         };
-        if super::project_mcp::fingerprint(std::slice::from_ref(snap)) != expected_fingerprint {
+        if snap != &conflict.previous {
             return Decision::Stale;
         }
         let promote = match winner {
@@ -489,6 +506,33 @@ mod tests {
             1,
             "stale resolution must not clear the conflict"
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_conflict_stale_when_native_changes_after_token_captured() {
+        let _home = set_tmp_home();
+        // Surface sees old->new and captures a token binding both sides.
+        let conflict = make_conflict("claude");
+        let token = conflict.fingerprint();
+
+        // The native config then changes AGAIN (new -> newer) before the user's
+        // resolution lands; the caller reconciles and finds the newer conflict.
+        let r = reconcile_agent(
+            "claude",
+            &read(r#"{ "mcpServers": { "fs": { "command": "newer" } } }"#),
+        )
+        .unwrap();
+        let newer = r.conflicts.into_iter().next().unwrap();
+
+        // Applying the stale token against the newer native definition is
+        // rejected, and nothing is promoted to global.
+        let status = resolve_conflict(&newer, ConflictWinner::Aoe, &token).unwrap();
+        assert_eq!(status, ResolveStatus::Stale);
+        let app_dir = crate::session::get_app_dir().unwrap();
+        assert!(crate::session::mcp_model::load_global_mcp_servers(&app_dir)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Implements the plugin host RPC surface for MCP management and wires the two declared-but-unused `config.read` / `config.write` capabilities to real host methods (part of epic #2983). A management plugin (`agent-of-empires/plugin-mcp`) can now list, resolve, add, edit, and delete MCP servers, and read/write host-global config, all capability-gated.

Backend: generalizes `mutate_servers` in `src/session/mcp_overrides.rs` to return the closure's value, then adds `remove_global_server`, `insert_global_server_if_absent`, and `replace_global_server_if_present`. These check existence on the raw server map *inside* the same exclusive file lock as the mutation, so `mcp.add` / `mcp.edit` / `mcp.delete` have no check-then-act race against a concurrent surface write.

Host RPCs (`src/plugin/host_api.rs`):

- `config.read { section, field }` (cap `config.read`): reads one host/global settings field, restricted to known schema descriptors so a plugin cannot read an arbitrary or non-schema blob.
- `config.write { patch }` (cap `config.write`): mutates host/global settings through the same schema gate the web dashboard uses (`settings_schema::validate_patch`), but at the **non-elevated** level. Unlike the web path (which silently strips `local_only` leaves), the RPC rejects every disallowed leaf loudly: an unknown field is `INVALID_PARAMS`; a host-execution (`local_only`) or elevation-required field is `FORBIDDEN`. Sections with no descriptor, notably `hooks`, are rejected.
- `mcp.list` (cap `config.read`): the pure redacted effective forwarded set (no drift write).
- `mcp.resolve` (cap `config.read`): the full management view (effective, keptOnRemoval, conflicts, driftPaused), mirroring `GET /api/mcp/servers`.
- `mcp.add` / `mcp.edit` / `mcp.delete` (cap `config.write`): write only the AoE-owned global `mcp.json`. A name resolving from an `agent-native`, `profile`, or `project-local` layer is `FORBIDDEN`, because AoE never writes those files.
- `mcp.keep` / `mcp.drop` / `mcp.resolve-conflict` (cap `config.write`): expose the existing drift primitives.

Writes need no separate read-only check: the daemon runs no plugin workers in read-only serve mode (`plugin_host = None`).

Threat model: a `config.write` grant gives a plugin exactly the non-elevated web-dashboard write surface, so `hooks`, host-execution surfaces, and elevation-only fields (sandbox / worktree) stay off-limits without introducing a new policy. The plan for this PR was pressure-tested with a two-model design debate; the key correctness fix that came out of it was moving the add/edit/delete existence checks inside the file lock.

Design was validated against the ecosystem `.mcp.json` wire shape (`mcp.add` / `mcp.edit` accept the exact `.mcp.json` entry users already write, parsed via the shared `parse_standard_mcp_servers`).

Follow-ups deliberately left out of scope: the plugin UI that calls these (plugin-mcp#4), removal of the old REST routes (#2987), and live status / authenticate (plugin-mcp#3).

Closes #2988

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

Backend RPC surface with no direct UI in this PR (the UI consumer is plugin-mcp#4), so verification is the RPC contract:

- [ ] `cargo test --features serve --lib plugin::host_api session::mcp_overrides` is green.
- [ ] A plugin holding `config.write` calls `mcp.add` with a stdio or http server, then `mcp.list` returns it resolved from the `global` layer.
- [ ] `mcp.delete` on a `global` server removes it; the same call against an `agent-native` server returns `FORBIDDEN` and writes nothing.
- [ ] A plugin without `config.write` gets `FORBIDDEN` on any `mcp.*` write or `config.write`.
- [ ] `config.write` refuses `hooks` (unknown), `acp.node_path` (`local_only`), and `worktree.enabled` (elevation), and round-trips a plain field (`session.yolo_mode_default`) readable back via `config.read`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Rust unit and host-API dispatch tests cover each user story from the issue (add/list round-trip, delete global vs FORBIDDEN on agent-native, capability enforcement, and the config.write field gate).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a two-model design debate, and implementation drafted by Claude under my direction. I made the design calls (generic config.read/write scope, ecosystem wire shape) and reviewed each commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added capability-gated plugin host RPCs for **host/global configuration** (`config.read` and `config.write`), with schema-checked reads and patch updates.
- Added capability-gated **MCP management** RPCs (`mcp.list`, `mcp.resolve`, `mcp.add`, `mcp.edit`, `mcp.delete`, `mcp.keep`, `mcp.drop`, `mcp.resolve-conflict`) for a unified MCP server surface.
- Implemented **safe, lock-scoped global MCP mutations** (add/edit/delete) that update only the intended global server entries while preserving unrelated data in `mcp.json` (no accidental rewrites on no-ops).
- Enforced strong write restrictions: plugins can’t modify **non-global / protected layers** (e.g., agent-native/profile/project-local MCP servers) and aren’t allowed to write **unknown, forbidden, elevation-required, or undeclared configuration fields**.
- Improved MCP conflict handling with **optimistic concurrency** so stale conflict decisions are rejected rather than incorrectly applied.
- Expanded **documentation** and **Rust tests** to cover the new RPC behavior, enforcement rules, and MCP add/delete/conflict flows.

## Benefits

Plugins can manage supported MCP servers and specific host/global settings through a consistent permission model, reducing misconfiguration risk, preventing unauthorized edits, and avoiding race conditions during concurrent configuration/MCP changes.

UI integration, removal of existing REST routes, and live MCP status/authentication remain out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->