### PR TITLE
feat(plugin): add skills model and skills.*/fs.* host RPCs (#2984)

### DIFF
--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -607,6 +607,9 @@ reuse the existing taxonomy:
 | `mcp.list` / `mcp.resolve` | `config.read` |
 | `mcp.add` / `mcp.edit` / `mcp.delete` | `config.write` |
 | `mcp.keep` / `mcp.drop` / `mcp.resolve-conflict` | `config.write` |
+| `fs.read` / `fs.write` | `fs.read` / `fs.write` |
+| `skills.list` / `skills.read` | `fs.read` or `config.read` |
+| `skills.create` / `skills.edit` / `skills.delete` / `skills.adopt` / `skills.propagate` | `fs.write` |
 
 `events.*` run over a shared plugin event bus (a `plugin_host` schema on the
 durable event-log substrate, `src/events/`); `subscribe { topics, after_seq }`
@@ -683,6 +686,32 @@ or `project-local` layer is `FORBIDDEN`, because AoE never writes those files.
 under an optimistic-concurrency token (a stale token returns
 `{ status: "stale" }`). Because the daemon runs no plugin workers in read-only
 serve mode, these writes need no separate read-only check.
+
+`fs.read { root, path }` / `fs.write { root, path, content }` (#2984) implement the
+previously-declared `fs.*` capabilities. They read and write a UTF-8 file (capped
+at 1 MiB) under one of two AoE-owned roots selected by `root`: `plugin` (the
+caller's private `<app_dir>/plugins/<id>/files`, namespaced to the caller's own
+id) or `skills` (the managed `<app_dir>/skills` store). A `path` is confined to
+its root by a lexical guard (no absolute, `..`, or prefix components) plus a
+canonical-ancestor check, and symlinks are refused. No arbitrary host path is
+reachable; a host-discovered agent skills dir (`~/.claude/skills`,
+`~/.kimi-code/skills`) is not an `fs.*` root, so `fs.write` can never mutate a
+read-only host skill.
+
+`skills.*` (#2984) manage the skill set modelled in `src/session/skills_model.rs`.
+A skill's identity is its directory name, and skills are source-qualified by
+provenance, so `skills.list` returns every host-discovered and managed skill
+without shadow-merging. `skills.read { source, directory }` returns one skill's
+`SKILL.md`; the write methods (`create`, `edit`, `delete`, `adopt`, `propagate`)
+act only on the managed store and refuse a host-discovered (read-only) target
+with `FORBIDDEN` (adopt it first). `skills.propagate { directory, agent }` is the
+minimal host primitive that copies a managed skill into a supported agent's host
+skills dir; it never overwrites an existing target, and the marker/dedupe/opt-in
+policy is deferred to the plugin side.
+
+Every `fs.*`/`skills.*` write inherits read-only safety for free: the plugin host
+is not spawned at all in read-only serve mode (`src/server/mod.rs` gates
+`PluginHost::new` on `!read_only`), so no per-method read-only check is needed.
 
 ### Sandboxing
 

--- a/docs/development/internals/plugin-system.md
+++ b/docs/development/internals/plugin-system.md
@@ -702,12 +702,13 @@ read-only host skill.
 A skill's identity is its directory name, and skills are source-qualified by
 provenance, so `skills.list` returns every host-discovered and managed skill
 without shadow-merging. `skills.read { source, directory }` returns one skill's
-`SKILL.md`; the write methods (`create`, `edit`, `delete`, `adopt`, `propagate`)
-act only on the managed store and refuse a host-discovered (read-only) target
-with `FORBIDDEN` (adopt it first). `skills.propagate { directory, agent }` is the
-minimal host primitive that copies a managed skill into a supported agent's host
-skills dir; it never overwrites an existing target, and the marker/dedupe/opt-in
-policy is deferred to the plugin side.
+`SKILL.md`. `create` / `edit` / `delete` mutate the managed store in place and
+refuse a host-discovered (read-only) target with `FORBIDDEN` (adopt it first).
+`adopt` copies a host-discovered skill INTO the managed store, leaving the
+original. `skills.propagate { directory, agent }` is the one method that writes
+OUT of the store: it copies a managed skill into a supported agent's host skills
+dir; it never overwrites an existing target, and the marker/dedupe/opt-in policy
+is deferred to the plugin side.
 
 Every `fs.*`/`skills.*` write inherits read-only safety for free: the plugin host
 is not spawned at all in read-only serve mode (`src/server/mod.rs` gates

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -1547,7 +1547,7 @@ fn skills_list() -> Result<Value, DispatchError> {
                 "name": s.name,
                 "description": s.description,
                 "provenance": provenance_json(&s.provenance)?,
-                "provenanceLabel": s.provenance.label(),
+                "provenance_label": s.provenance.label(),
                 "writable": s.provenance.is_writable(),
             }))
         })
@@ -3060,7 +3060,7 @@ mod tests {
             .iter()
             .find(|s| s["directory"] == json!("my-skill"))
             .expect("created skill appears in list");
-        assert_eq!(entry["provenanceLabel"], json!("aoe-managed"));
+        assert_eq!(entry["provenance_label"], json!("aoe-managed"));
         assert_eq!(entry["writable"], json!(true));
 
         let read = dispatch(

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -30,9 +30,12 @@
 //!   `<app_dir>/skills` store). Confined to the root; no arbitrary host path.
 //! - `skills.list` / `skills.read { source, directory }` (`fs.read` OR
 //!   `config.read`): the discovered skill set, source-qualified by provenance.
-//! - `skills.create` / `skills.edit` / `skills.delete` / `skills.adopt` /
-//!   `skills.propagate` (`fs.write`): mutate the AoE-managed skills store; a
-//!   host-discovered (read-only) skill target is refused with `FORBIDDEN`.
+//! - `skills.create` / `skills.edit` / `skills.delete` (`fs.write`): mutate the
+//!   AoE-managed skills store in place. `skills.adopt` (`fs.write`) copies a
+//!   host-discovered skill INTO the managed store, leaving the original.
+//!   `skills.propagate` (`fs.write`) copies a managed skill OUT into a supported
+//!   agent's host skills dir. A host-discovered (read-only) skill target for a
+//!   create/edit/delete is refused with `FORBIDDEN`.
 //!
 //! Per-plugin namespace: session metadata is always read and written under the
 //! calling plugin's own `Instance.plugin_meta[<plugin-id>]` slot, and
@@ -1384,6 +1387,54 @@ fn ensure_under_root(root: &Path, path: &Path) -> Result<(), DispatchError> {
     }
 }
 
+/// Create every missing directory from `root` down to `target`, refusing to
+/// create through or follow a symlink component. Unlike a bare
+/// `create_dir_all` followed by a containment check, this validates each
+/// component before the mkdir, so a pre-existing symlink inside the root can
+/// never make `fs.write` materialize a directory outside it.
+fn create_dirs_confined(root: &Path, target: &Path) -> Result<(), DispatchError> {
+    std::fs::create_dir_all(root).map_err(|e| DispatchError::internal(e.to_string()))?;
+    let rel = target.strip_prefix(root).map_err(|_| {
+        DispatchError::with_kind(
+            codes::FORBIDDEN,
+            "path_escapes_root",
+            "path escapes its root",
+        )
+    })?;
+    let mut cur = root.to_path_buf();
+    for comp in rel.components() {
+        match comp {
+            Component::Normal(c) => cur.push(c),
+            Component::CurDir => continue,
+            _ => {
+                return Err(DispatchError::invalid_params(
+                    "path may not contain \"..\" or absolute/prefix components",
+                ))
+            }
+        }
+        match std::fs::symlink_metadata(&cur) {
+            Ok(m) if m.file_type().is_symlink() => {
+                return Err(DispatchError::with_kind(
+                    codes::FORBIDDEN,
+                    "is_symlink",
+                    "refusing to create through a symlink",
+                ))
+            }
+            Ok(m) if m.is_dir() => {}
+            Ok(_) => {
+                return Err(DispatchError::invalid_params(
+                    "path component is not a directory",
+                ))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(&cur).map_err(|e| DispatchError::internal(e.to_string()))?;
+            }
+            Err(e) => return Err(DispatchError::internal(e.to_string())),
+        }
+    }
+    Ok(())
+}
+
 /// Read a UTF-8 file from one of the two `fs.*` roots. Refuses symlinks and
 /// non-regular files; bounded by [`MAX_FS_BYTES`].
 fn fs_read(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchError> {
@@ -1401,9 +1452,6 @@ fn fs_read(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchErro
         Ok(m) if !m.is_file() => {
             return Err(DispatchError::invalid_params("path is not a regular file"))
         }
-        Ok(m) if m.len() > MAX_FS_BYTES => {
-            return Err(DispatchError::invalid_params("file is too large"))
-        }
         Ok(_) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Err(DispatchError::invalid_params("no such file"))
@@ -1411,8 +1459,10 @@ fn fs_read(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchErro
         Err(e) => return Err(DispatchError::internal(e.to_string())),
     }
     ensure_under_root(&root, &target)?;
-    let content =
-        std::fs::read_to_string(&target).map_err(|e| DispatchError::internal(e.to_string()))?;
+    // Bounded single-handle read so a file that grows after the metadata check
+    // above cannot exceed the cap (the metadata-then-read TOCTOU).
+    let content = crate::session::skills_model::read_file_capped(&target, MAX_FS_BYTES)
+        .map_err(|e| DispatchError::invalid_params(e.to_string()))?;
     Ok(json!({ "content": content }))
 }
 
@@ -1426,10 +1476,11 @@ fn fs_write(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchErr
         return Err(DispatchError::invalid_params("content is too large"));
     }
     let target = confine_lexical(&root, rel)?;
-    std::fs::create_dir_all(&root).map_err(|e| DispatchError::internal(e.to_string()))?;
+    // Create parent dirs component-by-component, validating containment BEFORE
+    // each mkdir, so a symlink component cannot make us materialize a directory
+    // outside the root before a later containment check would reject it.
     let parent = target.parent().unwrap_or(&root);
-    std::fs::create_dir_all(parent).map_err(|e| DispatchError::internal(e.to_string()))?;
-    ensure_under_root(&root, parent)?;
+    create_dirs_confined(&root, parent)?;
     if let Ok(m) = std::fs::symlink_metadata(&target) {
         if m.file_type().is_symlink() {
             return Err(DispatchError::with_kind(
@@ -3161,5 +3212,37 @@ mod tests {
         dispatch(&state, &ctx(&[CAP_FS_READ]), "skills.list", &json!({})).unwrap();
         let err = dispatch(&state, &ctx(&[CAP_WORKER]), "skills.list", &json!({})).unwrap_err();
         assert_eq!(err.code, codes::FORBIDDEN);
+    }
+
+    /// `fs.write` must not create any directory outside the root when a path
+    /// component is a symlink pointing out: containment is checked before each
+    /// mkdir, so the escape is refused with no filesystem side effect.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn fs_write_refuses_to_create_through_symlink() {
+        use std::os::unix::fs::symlink;
+        let _env = SkillsEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_FS_WRITE]);
+
+        let app_dir = crate::session::get_app_dir().unwrap();
+        let files = app_dir.join("plugins").join("acme.worker").join("files");
+        std::fs::create_dir_all(&files).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, files.join("link")).unwrap();
+
+        let err = dispatch(
+            &state,
+            &c,
+            "fs.write",
+            &json!({"root": "plugin", "path": "link/new/file.txt", "content": "x"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+        // No directory was materialized through the symlink.
+        assert!(!outside.join("new").exists());
     }
 }

--- a/src/plugin/host_api.rs
+++ b/src/plugin/host_api.rs
@@ -24,6 +24,15 @@
 //!   `cas { key, expected, value }` / `remove { key }` (`runtime.worker`):
 //!   a host-backed durable key/value store, namespaced by the calling
 //!   plugin's id (#2897). Survives daemon and worker restarts; quota-bounded.
+//! - `fs.read { root, path }` (`fs.read`) and `fs.write { root, path, content }`
+//!   (`fs.write`): a UTF-8 file under one of two AoE-owned roots, `plugin` (the
+//!   caller's private `<app_dir>/plugins/<id>/files`) or `skills` (the managed
+//!   `<app_dir>/skills` store). Confined to the root; no arbitrary host path.
+//! - `skills.list` / `skills.read { source, directory }` (`fs.read` OR
+//!   `config.read`): the discovered skill set, source-qualified by provenance.
+//! - `skills.create` / `skills.edit` / `skills.delete` / `skills.adopt` /
+//!   `skills.propagate` (`fs.write`): mutate the AoE-managed skills store; a
+//!   host-discovered (read-only) skill target is refused with `FORBIDDEN`.
 //!
 //! Per-plugin namespace: session metadata is always read and written under the
 //! calling plugin's own `Instance.plugin_meta[<plugin-id>]` slot, and
@@ -35,7 +44,7 @@
 //! all, is enough.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 use anyhow::Context as _;
@@ -75,6 +84,16 @@ const CAP_CONFIG_WRITE: &str = "config.write";
 const STORAGE_MAX_KEYS: usize = 64;
 const STORAGE_MAX_KEY_BYTES: usize = 256;
 const STORAGE_MAX_VALUE_BYTES: usize = 64 * 1024;
+
+/// The declared-but-previously-unwired filesystem capabilities (#2984). `fs.*`
+/// and the skills write RPCs gate on these; skills reads accept `fs.read` or
+/// `config.read` (declared above).
+const CAP_FS_READ: &str = "fs.read";
+const CAP_FS_WRITE: &str = "fs.write";
+
+/// Cap a single `fs.*` read/write and a `SKILL.md` body at 1 MiB, so a plugin
+/// cannot make the host buffer an unbounded blob over the worker protocol.
+const MAX_FS_BYTES: u64 = 1024 * 1024;
 
 /// Shared, host-owned state behind the API: the plugin event bus and the
 /// profile whose session storage the API reads and writes. One per running
@@ -216,6 +235,30 @@ impl PluginRpcContext {
                 data: Some(serde_json::json!({
                     "kind": "capability_missing",
                     "required_capability": capability,
+                })),
+            })
+        }
+    }
+
+    /// Refuse the call unless the plugin holds at least one of `capabilities`.
+    /// Used where either of two grants suffices (e.g. `skills.list` accepts
+    /// `fs.read` OR `config.read`).
+    fn require_any(&self, capabilities: &[&str]) -> Result<(), DispatchError> {
+        if capabilities
+            .iter()
+            .any(|cap| self.granted_capabilities.iter().any(|c| c == cap))
+        {
+            Ok(())
+        } else {
+            Err(DispatchError {
+                code: codes::FORBIDDEN,
+                message: format!(
+                    "plugin {} holds none of the required capabilities {capabilities:?}",
+                    self.plugin_id
+                ),
+                data: Some(serde_json::json!({
+                    "kind": "capability_missing",
+                    "required_capabilities": capabilities,
                 })),
             })
         }
@@ -385,6 +428,46 @@ pub fn dispatch(
         "mcp.resolve-conflict" => {
             ctx.require(CAP_CONFIG_WRITE)?;
             mcp_resolve_conflict(state, params)
+        }
+        // Filesystem and skills RPCs (#2984). Every mutating arm below inherits
+        // read-only safety for free: the plugin host is never spawned in
+        // read-only serve mode (`src/server/mod.rs` gates `PluginHost::new` on
+        // `!read_only`), so no per-arm read-only check is needed here.
+        "fs.read" => {
+            ctx.require(CAP_FS_READ)?;
+            fs_read(ctx, params)
+        }
+        "fs.write" => {
+            ctx.require(CAP_FS_WRITE)?;
+            fs_write(ctx, params)
+        }
+        "skills.list" => {
+            ctx.require_any(&[CAP_FS_READ, CAP_CONFIG_READ])?;
+            skills_list()
+        }
+        "skills.read" => {
+            ctx.require_any(&[CAP_FS_READ, CAP_CONFIG_READ])?;
+            skills_read(params)
+        }
+        "skills.create" => {
+            ctx.require(CAP_FS_WRITE)?;
+            skills_create(params)
+        }
+        "skills.edit" => {
+            ctx.require(CAP_FS_WRITE)?;
+            skills_edit(params)
+        }
+        "skills.delete" => {
+            ctx.require(CAP_FS_WRITE)?;
+            skills_delete(params)
+        }
+        "skills.adopt" => {
+            ctx.require(CAP_FS_WRITE)?;
+            skills_adopt(params)
+        }
+        "skills.propagate" => {
+            ctx.require(CAP_FS_WRITE)?;
+            skills_propagate(params)
         }
         other => Err(DispatchError::method_not_found(other)),
     }
@@ -1220,6 +1303,266 @@ fn mcp_resolve_conflict(state: &HostApiState, params: &Value) -> Result<Value, D
         ResolveStatus::Applied => Ok(json!({ "status": "applied" })),
         ResolveStatus::Stale => Ok(json!({ "status": "stale" })),
     }
+}
+
+/// The two roots the `fs.*` RPCs may touch. Both are AoE-owned dirs under the
+/// app dir; a host-discovered agent skills dir (`~/.claude/skills`, ...) is
+/// deliberately NOT reachable, so `fs.write` can never mutate a read-only host
+/// skill. That path exists only through the constrained `skills.propagate`.
+enum FsRoot {
+    /// The calling plugin's private storage, `<app_dir>/plugins/<id>/files`.
+    /// Scoped to the caller's own id, never a request parameter.
+    Plugin,
+    /// The AoE-managed skills store, `<app_dir>/skills`.
+    Skills,
+}
+
+/// Resolve the requested `root` param to an [`FsRoot`].
+fn parse_fs_root(params: &Value) -> Result<FsRoot, DispatchError> {
+    match str_param(params, "root")? {
+        "plugin" => Ok(FsRoot::Plugin),
+        "skills" => Ok(FsRoot::Skills),
+        other => Err(DispatchError::invalid_params(format!(
+            "unknown fs root {other:?}; expected \"plugin\" or \"skills\""
+        ))),
+    }
+}
+
+/// The on-disk directory for an [`FsRoot`]. The plugin root is namespaced to the
+/// caller's own id.
+fn fs_root_dir(ctx: &PluginRpcContext, root: FsRoot) -> Result<PathBuf, DispatchError> {
+    let app_dir =
+        crate::session::get_app_dir().map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(match root {
+        FsRoot::Plugin => app_dir.join("plugins").join(&ctx.plugin_id).join("files"),
+        FsRoot::Skills => app_dir.join("skills"),
+    })
+}
+
+/// Join `rel` onto `root` after a lexical containment check: `rel` must be
+/// relative and contain only normal / current-dir components. This rejects
+/// `..`, absolute paths, and Windows prefixes before any filesystem access.
+fn confine_lexical(root: &Path, rel: &str) -> Result<PathBuf, DispatchError> {
+    if rel.is_empty() {
+        return Err(DispatchError::invalid_params("param \"path\" is empty"));
+    }
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute() {
+        return Err(DispatchError::invalid_params("path must be relative"));
+    }
+    for comp in rel_path.components() {
+        match comp {
+            Component::Normal(_) | Component::CurDir => {}
+            _ => {
+                return Err(DispatchError::invalid_params(
+                    "path may not contain \"..\" or absolute/prefix components",
+                ))
+            }
+        }
+    }
+    Ok(root.join(rel_path))
+}
+
+/// After the lexical guard, confirm `path` (which must exist) canonicalizes to
+/// somewhere under `root`, catching an ancestor symlink that redirects out of
+/// the root. This is the honest-cooperative bound (a TOCTOU race remains between
+/// this check and the open); the plugin host is a cooperative-plugin boundary,
+/// not adversarial containment.
+fn ensure_under_root(root: &Path, path: &Path) -> Result<(), DispatchError> {
+    let canon_root =
+        std::fs::canonicalize(root).map_err(|e| DispatchError::internal(e.to_string()))?;
+    let canon_path =
+        std::fs::canonicalize(path).map_err(|e| DispatchError::internal(e.to_string()))?;
+    if canon_path.starts_with(&canon_root) {
+        Ok(())
+    } else {
+        Err(DispatchError::with_kind(
+            codes::FORBIDDEN,
+            "path_escapes_root",
+            "path escapes its root",
+        ))
+    }
+}
+
+/// Read a UTF-8 file from one of the two `fs.*` roots. Refuses symlinks and
+/// non-regular files; bounded by [`MAX_FS_BYTES`].
+fn fs_read(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchError> {
+    let root = fs_root_dir(ctx, parse_fs_root(params)?)?;
+    let rel = str_param(params, "path")?;
+    let target = confine_lexical(&root, rel)?;
+    match std::fs::symlink_metadata(&target) {
+        Ok(m) if m.file_type().is_symlink() => {
+            return Err(DispatchError::with_kind(
+                codes::FORBIDDEN,
+                "is_symlink",
+                "refusing to read a symlink",
+            ))
+        }
+        Ok(m) if !m.is_file() => {
+            return Err(DispatchError::invalid_params("path is not a regular file"))
+        }
+        Ok(m) if m.len() > MAX_FS_BYTES => {
+            return Err(DispatchError::invalid_params("file is too large"))
+        }
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(DispatchError::invalid_params("no such file"))
+        }
+        Err(e) => return Err(DispatchError::internal(e.to_string())),
+    }
+    ensure_under_root(&root, &target)?;
+    let content =
+        std::fs::read_to_string(&target).map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "content": content }))
+}
+
+/// Write a UTF-8 file into one of the two `fs.*` roots, creating parent dirs.
+/// Refuses to overwrite through a symlink; bounded by [`MAX_FS_BYTES`].
+fn fs_write(ctx: &PluginRpcContext, params: &Value) -> Result<Value, DispatchError> {
+    let root = fs_root_dir(ctx, parse_fs_root(params)?)?;
+    let rel = str_param(params, "path")?;
+    let content = str_param(params, "content")?;
+    if content.len() as u64 > MAX_FS_BYTES {
+        return Err(DispatchError::invalid_params("content is too large"));
+    }
+    let target = confine_lexical(&root, rel)?;
+    std::fs::create_dir_all(&root).map_err(|e| DispatchError::internal(e.to_string()))?;
+    let parent = target.parent().unwrap_or(&root);
+    std::fs::create_dir_all(parent).map_err(|e| DispatchError::internal(e.to_string()))?;
+    ensure_under_root(&root, parent)?;
+    if let Ok(m) = std::fs::symlink_metadata(&target) {
+        if m.file_type().is_symlink() {
+            return Err(DispatchError::with_kind(
+                codes::FORBIDDEN,
+                "is_symlink",
+                "refusing to overwrite a symlink",
+            ));
+        }
+    }
+    std::fs::write(&target, content).map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok(json!({ "ok": true }))
+}
+
+/// Resolve `(home, app_dir)` for the skills-store operations.
+fn skills_dirs() -> Result<(PathBuf, PathBuf), DispatchError> {
+    let home =
+        dirs::home_dir().ok_or_else(|| DispatchError::internal("could not resolve home dir"))?;
+    let app_dir =
+        crate::session::get_app_dir().map_err(|e| DispatchError::internal(e.to_string()))?;
+    Ok((home, app_dir))
+}
+
+/// Map a [`skills_model::SkillError`](crate::session::skills_model::SkillError)
+/// to a JSON-RPC error: a read-only target is `FORBIDDEN`, an I/O failure is
+/// `INTERNAL_ERROR`, everything else is caller input (`INVALID_PARAMS`).
+fn skill_dispatch_error(e: crate::session::skills_model::SkillError) -> DispatchError {
+    use crate::session::skills_model::SkillError as E;
+    match e {
+        E::InvalidInput(m) => DispatchError::invalid_params(m),
+        E::NotFound(m) => DispatchError::invalid_params(format!("skill not found: {m}")),
+        E::Collision(m) => DispatchError::invalid_params(format!("skill already exists: {m}")),
+        E::ReadOnly(m) => DispatchError::with_kind(codes::FORBIDDEN, "read_only", m),
+        E::Io(err) => DispatchError::internal(err.to_string()),
+    }
+}
+
+/// Parse the source-qualified `source` param into a
+/// [`SkillProvenance`](crate::session::skills_model::SkillProvenance).
+fn parse_skill_source(
+    params: &Value,
+) -> Result<crate::session::skills_model::SkillProvenance, DispatchError> {
+    let raw = params
+        .get("source")
+        .ok_or_else(|| DispatchError::invalid_params("missing param \"source\""))?;
+    serde_json::from_value(raw.clone())
+        .map_err(|e| DispatchError::invalid_params(format!("invalid \"source\": {e}")))
+}
+
+/// JSON view of one discovered/read skill's provenance.
+fn provenance_json(
+    p: &crate::session::skills_model::SkillProvenance,
+) -> Result<Value, DispatchError> {
+    serde_json::to_value(p).map_err(|e| DispatchError::internal(e.to_string()))
+}
+
+fn skills_list() -> Result<Value, DispatchError> {
+    let skills = crate::session::skills_model::discover_all()
+        .map_err(|e| DispatchError::internal(e.to_string()))?;
+    let out = skills
+        .iter()
+        .map(|s| {
+            Ok(json!({
+                "directory": s.directory,
+                "name": s.name,
+                "description": s.description,
+                "provenance": provenance_json(&s.provenance)?,
+                "provenanceLabel": s.provenance.label(),
+                "writable": s.provenance.is_writable(),
+            }))
+        })
+        .collect::<Result<Vec<_>, DispatchError>>()?;
+    Ok(json!({ "skills": out }))
+}
+
+fn skills_read(params: &Value) -> Result<Value, DispatchError> {
+    let source = parse_skill_source(params)?;
+    let directory = str_param(params, "directory")?;
+    let (home, app_dir) = skills_dirs()?;
+    let read = crate::session::skills_model::read_skill(&home, &app_dir, &source, directory)
+        .map_err(skill_dispatch_error)?;
+    Ok(json!({
+        "directory": read.directory,
+        "name": read.name,
+        "description": read.description,
+        "content": read.content,
+        "provenance": provenance_json(&read.provenance)?,
+    }))
+}
+
+fn skills_create(params: &Value) -> Result<Value, DispatchError> {
+    let directory = str_param(params, "directory")?;
+    let description = optional_str_param(params, "description")?;
+    let (_home, app_dir) = skills_dirs()?;
+    crate::session::skills_model::create_skill(&app_dir, directory, description)
+        .map_err(skill_dispatch_error)?;
+    Ok(json!({ "ok": true, "directory": directory }))
+}
+
+fn skills_edit(params: &Value) -> Result<Value, DispatchError> {
+    let directory = str_param(params, "directory")?;
+    let content = str_param(params, "content")?;
+    let (home, app_dir) = skills_dirs()?;
+    crate::session::skills_model::edit_skill(&home, &app_dir, directory, content)
+        .map_err(skill_dispatch_error)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn skills_delete(params: &Value) -> Result<Value, DispatchError> {
+    let directory = str_param(params, "directory")?;
+    let (home, app_dir) = skills_dirs()?;
+    crate::session::skills_model::delete_skill(&home, &app_dir, directory)
+        .map_err(skill_dispatch_error)?;
+    Ok(json!({ "ok": true }))
+}
+
+fn skills_adopt(params: &Value) -> Result<Value, DispatchError> {
+    let source = parse_skill_source(params)?;
+    let directory = str_param(params, "directory")?;
+    let dest = optional_str_param(params, "dest")?;
+    let (home, app_dir) = skills_dirs()?;
+    let dest_name =
+        crate::session::skills_model::adopt_skill(&home, &app_dir, &source, directory, dest)
+            .map_err(skill_dispatch_error)?;
+    Ok(json!({ "ok": true, "directory": dest_name }))
+}
+
+fn skills_propagate(params: &Value) -> Result<Value, DispatchError> {
+    let directory = str_param(params, "directory")?;
+    let agent = str_param(params, "agent")?;
+    let (home, app_dir) = skills_dirs()?;
+    crate::session::skills_model::propagate_skill(&home, &app_dir, directory, agent)
+        .map_err(skill_dispatch_error)?;
+    Ok(json!({ "ok": true }))
 }
 
 /// Parse the `slot` param into a typed [`UiSlot`]. An unknown slot is bad
@@ -2320,6 +2663,47 @@ mod tests {
         }
     }
 
+    /// Point `$HOME` and `$XDG_CONFIG_HOME` at a temp dir so `get_app_dir` and
+    /// skills discovery resolve under it, on both Linux and macOS. Restores both
+    /// on drop; serialized by `#[serial]` because it mutates process env.
+    struct SkillsEnvGuard {
+        _tmp: tempfile::TempDir,
+        prev_home: Option<std::ffi::OsString>,
+        prev_xdg: Option<std::ffi::OsString>,
+    }
+
+    impl SkillsEnvGuard {
+        fn new() -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let prev_home = std::env::var_os("HOME");
+            let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+            Self {
+                _tmp: tmp,
+                prev_home,
+                prev_xdg,
+            }
+        }
+
+        fn home(&self) -> PathBuf {
+            self._tmp.path().to_path_buf()
+        }
+    }
+
+    impl Drop for SkillsEnvGuard {
+        fn drop(&mut self) {
+            match self.prev_home.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.prev_xdg.take() {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
     fn set_tmp_home(dir: &std::path::Path) -> HomeGuard {
         let guard = HomeGuard {
             home: std::env::var_os("HOME"),
@@ -2587,5 +2971,195 @@ mod tests {
                 "config.read of {section}.{field} must be FORBIDDEN"
             );
         }
+    }
+
+    fn write_host_skill(home: &Path, agent_rel: &str, directory: &str) {
+        let d = home.join(agent_rel).join(directory);
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(
+            d.join("SKILL.md"),
+            format!("---\nname: {directory}\ndescription: host skill\n---\n\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    /// User story 1: with `fs.write`, `skills.create` writes a scaffolded
+    /// SKILL.md to the managed store and `skills.list` returns it as
+    /// `aoe-managed` and writable.
+    #[test]
+    #[serial_test::serial]
+    fn skills_create_then_list_is_managed() {
+        let _env = SkillsEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_FS_WRITE, CAP_FS_READ]);
+
+        dispatch(
+            &state,
+            &c,
+            "skills.create",
+            &json!({"directory": "my-skill", "description": "use for X"}),
+        )
+        .unwrap();
+
+        let list = dispatch(&state, &c, "skills.list", &json!({})).unwrap();
+        let entry = list["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["directory"] == json!("my-skill"))
+            .expect("created skill appears in list");
+        assert_eq!(entry["provenanceLabel"], json!("aoe-managed"));
+        assert_eq!(entry["writable"], json!(true));
+
+        let read = dispatch(
+            &state,
+            &c,
+            "skills.read",
+            &json!({"source": {"kind": "aoe-managed"}, "directory": "my-skill"}),
+        )
+        .unwrap();
+        assert_eq!(read["name"], json!("my-skill"));
+        assert!(read["content"].as_str().unwrap().contains("use for X"));
+    }
+
+    /// User story 2: `skills.adopt` copies a host skill into the managed store,
+    /// leaves the host original untouched, and editing a still-host-only skill
+    /// is FORBIDDEN.
+    #[test]
+    #[serial_test::serial]
+    fn skills_adopt_leaves_host_and_host_edit_is_forbidden() {
+        let env = SkillsEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_FS_WRITE, CAP_FS_READ]);
+
+        write_host_skill(&env.home(), ".claude/skills", "review");
+        write_host_skill(&env.home(), ".claude/skills", "hostonly");
+        let src = env.home().join(".claude/skills/review/SKILL.md");
+        let before = std::fs::read_to_string(&src).unwrap();
+
+        dispatch(
+            &state,
+            &c,
+            "skills.adopt",
+            &json!({"source": {"kind": "agent-native", "agent": "claude"}, "directory": "review"}),
+        )
+        .unwrap();
+        // Host original untouched; managed copy now readable.
+        assert_eq!(std::fs::read_to_string(&src).unwrap(), before);
+        dispatch(
+            &state,
+            &c,
+            "skills.read",
+            &json!({"source": {"kind": "aoe-managed"}, "directory": "review"}),
+        )
+        .unwrap();
+
+        // Editing a skill that exists only host-side is refused.
+        let err = dispatch(
+            &state,
+            &c,
+            "skills.edit",
+            &json!({"directory": "hostonly", "content": "---\nname: hostonly\ndescription: d\n---\n\nx\n"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
+    }
+
+    /// User story 3: a plugin without `fs.write` is refused on every skills
+    /// write and on `fs.write`.
+    #[test]
+    #[serial_test::serial]
+    fn skills_writes_require_fs_write() {
+        let _env = SkillsEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_FS_READ]);
+
+        for (method, params) in [
+            ("skills.create", json!({"directory": "x"})),
+            (
+                "skills.edit",
+                json!({"directory": "x", "content": "---\nname: x\ndescription: d\n---\n"}),
+            ),
+            ("skills.delete", json!({"directory": "x"})),
+            (
+                "skills.adopt",
+                json!({"source": {"kind": "agent-native", "agent": "claude"}, "directory": "x"}),
+            ),
+            (
+                "skills.propagate",
+                json!({"directory": "x", "agent": "kimi"}),
+            ),
+            (
+                "fs.write",
+                json!({"root": "plugin", "path": "a.txt", "content": "hi"}),
+            ),
+        ] {
+            let err = dispatch(&state, &c, method, &params).unwrap_err();
+            assert_eq!(err.code, codes::FORBIDDEN, "{method} should be forbidden");
+        }
+    }
+
+    /// `fs.*` round-trips within a root and rejects traversal / absolute paths.
+    #[test]
+    #[serial_test::serial]
+    fn fs_read_write_roundtrip_and_rejects_escape() {
+        let _env = SkillsEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+        let c = ctx(&[CAP_FS_READ, CAP_FS_WRITE]);
+
+        dispatch(
+            &state,
+            &c,
+            "fs.write",
+            &json!({"root": "plugin", "path": "notes/a.txt", "content": "hello"}),
+        )
+        .unwrap();
+        let got = dispatch(
+            &state,
+            &c,
+            "fs.read",
+            &json!({"root": "plugin", "path": "notes/a.txt"}),
+        )
+        .unwrap();
+        assert_eq!(got["content"], json!("hello"));
+
+        for bad in ["../escape.txt", "/etc/passwd", "a/../../b"] {
+            let err = dispatch(
+                &state,
+                &c,
+                "fs.write",
+                &json!({"root": "plugin", "path": bad, "content": "x"}),
+            )
+            .unwrap_err();
+            assert_eq!(err.code, codes::INVALID_PARAMS, "{bad} should be rejected");
+        }
+        // Unknown root is caller error.
+        let err = dispatch(
+            &state,
+            &c,
+            "fs.read",
+            &json!({"root": "bogus", "path": "a"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    /// `skills.list` accepts `config.read` as an alternative to `fs.read`, and is
+    /// refused with neither.
+    #[test]
+    #[serial_test::serial]
+    fn skills_list_accepts_fs_read_or_config_read() {
+        let _env = SkillsEnvGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state(tmp.path());
+
+        dispatch(&state, &ctx(&[CAP_CONFIG_READ]), "skills.list", &json!({})).unwrap();
+        dispatch(&state, &ctx(&[CAP_FS_READ]), "skills.list", &json!({})).unwrap();
+        let err = dispatch(&state, &ctx(&[CAP_WORKER]), "skills.list", &json!({})).unwrap_err();
+        assert_eq!(err.code, codes::FORBIDDEN);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -34,6 +34,7 @@ pub mod restart;
 pub mod scratch;
 pub(crate) mod serde_helpers;
 pub mod settings_schema;
+pub mod skills_model;
 pub mod smart_rename;
 pub mod stop;
 mod storage;

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -1,0 +1,810 @@
+//! Always-compiled, plugin-facing model of the agent-skill set (#2984).
+//!
+//! A "skill" is a `SKILL.md` folder (the Claude Code / kimi concept): YAML
+//! frontmatter (`name`, `description`, plus optional metadata) between `---`
+//! fences, then a markdown body, living in a per-skill directory. AoE has never
+//! had a Rust model for these; they were only bulk-copied into sandboxes
+//! (`src/session/container_config.rs`). This module is the single resolver the
+//! plugin host RPCs (`src/plugin/host_api.rs`) read and mutate.
+//!
+//! Two provenance layers, mirroring [`super::mcp_model::McpProvenance`]:
+//! host-discovered skills in each agent's own skills dir (`~/.claude/skills`,
+//! `~/.kimi-code/skills`) are READ-ONLY; the AoE-managed store at
+//! `<app_dir>/skills` is the only WRITABLE layer. Editing a host-discovered
+//! skill requires adopting it into the managed store first.
+//!
+//! Identity is the skill's DIRECTORY name, never the frontmatter `name` (which
+//! is mutable display metadata and can collide or diverge). The same directory
+//! name can exist under several provenances, so read/adopt/propagate are always
+//! source-qualified. This module does NOT define precedence/shadowing between
+//! layers: [`discover`] returns every source-qualified entry as-is.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+use uuid::Uuid;
+
+/// Reject a `SKILL.md` larger than this before parsing, so a pathological file
+/// cannot make the host read an unbounded amount into memory.
+pub const MAX_SKILL_MD_BYTES: u64 = 1024 * 1024;
+
+/// Host-discovered skill dirs, keyed by agent registry name. The `agent` string
+/// is both the provenance label and the `skills.propagate` target key. Same
+/// small-const-table pattern as [`super::mcp_model`]'s `native_config_for`.
+const AGENT_SKILL_DIRS: &[(&str, &str)] =
+    &[("claude", ".claude/skills"), ("kimi", ".kimi-code/skills")];
+
+/// Where a skill was discovered. The read-only host layers carry the agent key;
+/// the single writable layer is [`SkillProvenance::AoeManaged`]. Serializes to a
+/// tagged object (`{ "kind": "agent-native", "agent": "claude" }` /
+/// `{ "kind": "aoe-managed" }`) so it round-trips as both `skills.list` output
+/// and a source-qualified `skills.read` / `skills.adopt` parameter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum SkillProvenance {
+    AgentNative { agent: String },
+    AoeManaged,
+}
+
+impl SkillProvenance {
+    /// The provenance string shown in logs, e.g. `agent-native:claude`,
+    /// `aoe-managed`.
+    pub fn label(&self) -> String {
+        match self {
+            SkillProvenance::AgentNative { agent } => format!("agent-native:{agent}"),
+            SkillProvenance::AoeManaged => "aoe-managed".to_string(),
+        }
+    }
+
+    /// Only the AoE-managed layer accepts writes; host-discovered skills are
+    /// read-only and must be adopted before editing.
+    pub fn is_writable(&self) -> bool {
+        matches!(self, SkillProvenance::AoeManaged)
+    }
+}
+
+/// One discovered skill's list-safe metadata: its identity (`directory`), its
+/// frontmatter `name`/`description`, and where it came from. The body is not
+/// included; `skills.read` returns that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredSkill {
+    pub provenance: SkillProvenance,
+    pub directory: String,
+    pub name: String,
+    pub description: String,
+}
+
+/// A skill read in full: its metadata plus the raw `SKILL.md` content.
+#[derive(Debug, Clone)]
+pub struct ReadSkill {
+    pub provenance: SkillProvenance,
+    pub directory: String,
+    pub name: String,
+    pub description: String,
+    pub content: String,
+}
+
+/// A skills store operation that failed for a caller-attributable reason. The
+/// plugin host maps each variant to a JSON-RPC code: [`Self::ReadOnly`] to
+/// `FORBIDDEN`, [`Self::Io`] to `INTERNAL_ERROR`, everything else to
+/// `INVALID_PARAMS`.
+#[derive(Debug)]
+pub enum SkillError {
+    /// Bad directory/agent name, unparseable content, or a name/directory
+    /// mismatch: the caller's input is wrong.
+    InvalidInput(String),
+    /// No skill with that identity exists.
+    NotFound(String),
+    /// The managed destination already exists; the operation never overwrites.
+    Collision(String),
+    /// The target is a host-discovered (read-only) skill; adopt it first.
+    ReadOnly(String),
+    /// A filesystem failure the caller cannot fix.
+    Io(anyhow::Error),
+}
+
+impl From<std::io::Error> for SkillError {
+    fn from(e: std::io::Error) -> Self {
+        SkillError::Io(e.into())
+    }
+}
+
+/// Frontmatter fields AoE reads. Unknown keys (`version`, `author`, `metadata`,
+/// vendor blocks) are ignored on read and dropped on scaffold.
+#[derive(Debug, Serialize, Deserialize)]
+struct Frontmatter {
+    name: String,
+    description: String,
+}
+
+/// A parsed `SKILL.md`: the two required frontmatter fields plus the verbatim
+/// markdown body.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParsedSkill {
+    pub name: String,
+    pub description: String,
+    pub body: String,
+}
+
+/// Parse a `SKILL.md`: an opening `---` fence on the first line, a closing `---`
+/// line, YAML frontmatter with non-empty `name` and `description`, then the
+/// verbatim body. An optional UTF-8 BOM and CRLF line endings are tolerated.
+pub fn parse_skill_md(content: &str) -> Result<ParsedSkill> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let after_open = content
+        .strip_prefix("---\n")
+        .or_else(|| content.strip_prefix("---\r\n"))
+        .context("SKILL.md must begin with a \"---\" frontmatter fence")?;
+    let (frontmatter, body) = split_closing_fence(after_open)
+        .context("SKILL.md frontmatter is not closed by a \"---\" line")?;
+    let fm: Frontmatter = serde_yaml::from_str(frontmatter)
+        .context("failed to parse SKILL.md frontmatter as YAML")?;
+    if fm.name.trim().is_empty() {
+        bail!("SKILL.md frontmatter \"name\" is empty");
+    }
+    if fm.description.trim().is_empty() {
+        bail!("SKILL.md frontmatter \"description\" is empty");
+    }
+    Ok(ParsedSkill {
+        name: fm.name,
+        description: fm.description,
+        body: body.to_string(),
+    })
+}
+
+/// Split the post-opening-fence text at the first line that is exactly `---`
+/// (CRLF tolerated), returning `(frontmatter, body)`. `None` if no closing fence
+/// exists.
+fn split_closing_fence(after_open: &str) -> Option<(&str, &str)> {
+    let mut idx = 0;
+    for line in after_open.split_inclusive('\n') {
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            return Some((&after_open[..idx], &after_open[idx + line.len()..]));
+        }
+        idx += line.len();
+    }
+    None
+}
+
+/// The AoE-managed skills store directory, `<app_dir>/skills`. This is the only
+/// writable layer and one of the two roots the `fs.*` RPCs may touch.
+pub fn managed_skills_dir() -> Result<PathBuf> {
+    Ok(super::get_app_dir()?.join("skills"))
+}
+
+fn home_dir() -> Result<PathBuf> {
+    dirs::home_dir().context("could not resolve home dir for skills discovery")
+}
+
+/// Discover every skill across all host-discovered agent dirs and the managed
+/// store, source-qualified and sorted deterministically (by provenance label,
+/// then directory). A malformed or unreadable skill warns and is skipped; it
+/// never fails the whole scan. Roots are injected so tests need no real `$HOME`.
+pub fn discover(home: &Path, app_dir: &Path) -> Vec<DiscoveredSkill> {
+    let mut out = Vec::new();
+    for (agent, rel) in AGENT_SKILL_DIRS {
+        collect_from_dir(
+            &home.join(rel),
+            &SkillProvenance::AgentNative {
+                agent: (*agent).to_string(),
+            },
+            &mut out,
+        );
+    }
+    collect_from_dir(
+        &app_dir.join("skills"),
+        &SkillProvenance::AoeManaged,
+        &mut out,
+    );
+    out.sort_by(|a, b| {
+        a.provenance
+            .label()
+            .cmp(&b.provenance.label())
+            .then_with(|| a.directory.cmp(&b.directory))
+    });
+    out
+}
+
+/// Convenience wrapper resolving the real `$HOME` and app dir.
+pub fn discover_all() -> Result<Vec<DiscoveredSkill>> {
+    Ok(discover(&home_dir()?, &super::get_app_dir()?))
+}
+
+/// Enumerate immediate child dirs of `root` that hold a `SKILL.md`, parse each,
+/// and push the metadata. Symlinked children, dot-directories (including our own
+/// `.tmp-*` staging dirs), and symlinked `SKILL.md` files are skipped.
+fn collect_from_dir(root: &Path, provenance: &SkillProvenance, out: &mut Vec<DiscoveredSkill>) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            warn!(target: "session.skills", root = %root.display(), error = %e, "failed to read skills dir");
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => {}
+            _ => continue,
+        }
+        let skill_md = entry.path().join("SKILL.md");
+        match std::fs::symlink_metadata(&skill_md) {
+            Ok(m) if m.file_type().is_file() => {}
+            _ => continue,
+        }
+        let content = match std::fs::read_to_string(&skill_md) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(target: "session.skills", path = %skill_md.display(), error = %e, "failed to read SKILL.md");
+                continue;
+            }
+        };
+        match parse_skill_md(&content) {
+            Ok(parsed) => out.push(DiscoveredSkill {
+                provenance: provenance.clone(),
+                directory: name,
+                name: parsed.name,
+                description: parsed.description,
+            }),
+            Err(e) => {
+                warn!(target: "session.skills", path = %skill_md.display(), error = %e, "skipping malformed SKILL.md");
+            }
+        }
+    }
+}
+
+/// Read one source-qualified skill in full.
+pub fn read_skill(
+    home: &Path,
+    app_dir: &Path,
+    provenance: &SkillProvenance,
+    directory: &str,
+) -> Result<ReadSkill, SkillError> {
+    validate_dir_name(directory)?;
+    let dir = skill_dir_for(home, app_dir, provenance, directory)?;
+    let skill_md = dir.join("SKILL.md");
+    match std::fs::symlink_metadata(&skill_md) {
+        Ok(m) if m.file_type().is_file() => {}
+        Ok(_) => return Err(SkillError::NotFound(directory.to_string())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SkillError::NotFound(directory.to_string()))
+        }
+        Err(e) => return Err(e.into()),
+    }
+    if skill_md.metadata()?.len() > MAX_SKILL_MD_BYTES {
+        return Err(SkillError::InvalidInput(
+            "SKILL.md is too large".to_string(),
+        ));
+    }
+    let content = std::fs::read_to_string(&skill_md)?;
+    let parsed = parse_skill_md(&content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
+    Ok(ReadSkill {
+        provenance: provenance.clone(),
+        directory: directory.to_string(),
+        name: parsed.name,
+        description: parsed.description,
+        content,
+    })
+}
+
+/// Create a new managed skill with a scaffolded `SKILL.md` (frontmatter `name`
+/// equal to the directory). Rejects an unsafe name or a collision; never
+/// overwrites. Built in a staging dir and renamed into place.
+pub fn create_skill(
+    app_dir: &Path,
+    directory: &str,
+    description: Option<&str>,
+) -> Result<(), SkillError> {
+    validate_dir_name(directory)?;
+    let managed = app_dir.join("skills");
+    let final_path = managed.join(directory);
+    if final_path.exists() {
+        return Err(SkillError::Collision(directory.to_string()));
+    }
+    let description = description
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .unwrap_or("Describe when this skill should be used.");
+    let content = scaffold(directory, description).map_err(SkillError::Io)?;
+    std::fs::create_dir_all(&managed)?;
+    let staging = new_staging_dir(&managed)?;
+    let result = (|| {
+        std::fs::write(staging.join("SKILL.md"), &content)?;
+        std::fs::rename(&staging, &final_path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+    result.map_err(Into::into)
+}
+
+/// Overwrite a managed skill's `SKILL.md` with validated content. A
+/// host-discovered target is [`SkillError::ReadOnly`] (adopt first); an unknown
+/// one is [`SkillError::NotFound`]. Content must parse and its frontmatter
+/// `name` must equal the directory.
+pub fn edit_skill(
+    home: &Path,
+    app_dir: &Path,
+    directory: &str,
+    content: &str,
+) -> Result<(), SkillError> {
+    validate_dir_name(directory)?;
+    let managed_md = app_dir.join("skills").join(directory).join("SKILL.md");
+    if !managed_md.is_file() {
+        return Err(absent_write_target(home, directory));
+    }
+    if content.len() as u64 > MAX_SKILL_MD_BYTES {
+        return Err(SkillError::InvalidInput(
+            "SKILL.md is too large".to_string(),
+        ));
+    }
+    let parsed = parse_skill_md(content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
+    if parsed.name != directory {
+        return Err(SkillError::InvalidInput(format!(
+            "frontmatter name {:?} must equal the skill directory {directory:?}",
+            parsed.name
+        )));
+    }
+    write_atomic(&managed_md, content)?;
+    Ok(())
+}
+
+/// Delete a managed skill directory. A host-discovered target is
+/// [`SkillError::ReadOnly`]; an unknown one is [`SkillError::NotFound`]; a
+/// symlinked managed entry is refused.
+pub fn delete_skill(home: &Path, app_dir: &Path, directory: &str) -> Result<(), SkillError> {
+    validate_dir_name(directory)?;
+    let managed_path = app_dir.join("skills").join(directory);
+    let meta = match std::fs::symlink_metadata(&managed_path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(absent_write_target(home, directory))
+        }
+        Err(e) => return Err(e.into()),
+    };
+    if meta.file_type().is_symlink() {
+        return Err(SkillError::InvalidInput(
+            "refusing to delete a symlinked skill entry".to_string(),
+        ));
+    }
+    std::fs::remove_dir_all(&managed_path)?;
+    Ok(())
+}
+
+/// Copy a host-discovered skill into the managed store, leaving the original
+/// untouched. `dest` defaults to the source directory name. Rejects adopting an
+/// already-managed skill, an unknown source, or a colliding destination;
+/// symlinks in the source tree are refused. Copied through a staging dir.
+pub fn adopt_skill(
+    home: &Path,
+    app_dir: &Path,
+    source: &SkillProvenance,
+    directory: &str,
+    dest: Option<&str>,
+) -> Result<String, SkillError> {
+    validate_dir_name(directory)?;
+    let agent = match source {
+        SkillProvenance::AgentNative { agent } => agent,
+        SkillProvenance::AoeManaged => {
+            return Err(SkillError::InvalidInput(
+                "cannot adopt an already AoE-managed skill".to_string(),
+            ))
+        }
+    };
+    let src_dir = agent_skill_dir(home, agent)?.join(directory);
+    match std::fs::symlink_metadata(src_dir.join("SKILL.md")) {
+        Ok(m) if m.file_type().is_file() => {}
+        _ => return Err(SkillError::NotFound(directory.to_string())),
+    }
+    let dest_name = dest.unwrap_or(directory);
+    validate_dir_name(dest_name)?;
+    let managed = app_dir.join("skills");
+    let final_path = managed.join(dest_name);
+    if final_path.exists() {
+        return Err(SkillError::Collision(dest_name.to_string()));
+    }
+    std::fs::create_dir_all(&managed)?;
+    let staging = new_staging_dir(&managed)?;
+    let result = copy_tree_no_symlinks(&src_dir, &staging)
+        .and_then(|()| std::fs::rename(&staging, &final_path).map_err(Into::into));
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+    result.map_err(SkillError::Io)?;
+    Ok(dest_name.to_string())
+}
+
+/// Copy a managed skill into a target agent's host skills dir. The minimal host
+/// primitive behind `plugin-skills#4`: managed source only, known agent key
+/// only, destination must not already exist (no overwrite, no merge). Copied
+/// through a staging dir; symlinks in the source are refused. Marker/dedupe and
+/// opt-in policy are deliberately NOT handled here.
+pub fn propagate_skill(
+    home: &Path,
+    app_dir: &Path,
+    directory: &str,
+    agent: &str,
+) -> Result<(), SkillError> {
+    validate_dir_name(directory)?;
+    let src = app_dir.join("skills").join(directory);
+    if !src.join("SKILL.md").is_file() {
+        return Err(SkillError::NotFound(directory.to_string()));
+    }
+    let target_root = agent_skill_dir(home, agent)?;
+    let dest = target_root.join(directory);
+    if dest.exists() {
+        return Err(SkillError::Collision(format!("{agent}:{directory}")));
+    }
+    std::fs::create_dir_all(&target_root)?;
+    let staging = new_staging_dir(&target_root)?;
+    let result = copy_tree_no_symlinks(&src, &staging)
+        .and_then(|()| std::fs::rename(&staging, &dest).map_err(Into::into));
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+    result.map_err(SkillError::Io)
+}
+
+/// Resolve the on-disk directory for a source-qualified skill.
+fn skill_dir_for(
+    home: &Path,
+    app_dir: &Path,
+    provenance: &SkillProvenance,
+    directory: &str,
+) -> Result<PathBuf, SkillError> {
+    match provenance {
+        SkillProvenance::AgentNative { agent } => Ok(agent_skill_dir(home, agent)?.join(directory)),
+        SkillProvenance::AoeManaged => Ok(app_dir.join("skills").join(directory)),
+    }
+}
+
+/// The host skills dir for a known agent key, or [`SkillError::InvalidInput`]
+/// for an unsupported agent.
+fn agent_skill_dir(home: &Path, agent: &str) -> Result<PathBuf, SkillError> {
+    AGENT_SKILL_DIRS
+        .iter()
+        .find(|(a, _)| *a == agent)
+        .map(|(_, rel)| home.join(rel))
+        .ok_or_else(|| SkillError::InvalidInput(format!("unsupported skills agent {agent:?}")))
+}
+
+/// Classify a write whose managed target does not exist: a host-discovered
+/// skill of the same directory is read-only (adopt first), otherwise it is
+/// simply absent.
+fn absent_write_target(home: &Path, directory: &str) -> SkillError {
+    for (_, rel) in AGENT_SKILL_DIRS {
+        if home.join(rel).join(directory).join("SKILL.md").is_file() {
+            return SkillError::ReadOnly(format!(
+                "skill {directory:?} is host-discovered and read-only; adopt it first"
+            ));
+        }
+    }
+    SkillError::NotFound(directory.to_string())
+}
+
+/// A fresh, uniquely named staging dir under `parent`, created empty. Renamed
+/// into its final place by the caller; the `.tmp-` prefix keeps discovery from
+/// ever surfacing a half-built skill.
+fn new_staging_dir(parent: &Path) -> Result<PathBuf, SkillError> {
+    let path = parent.join(format!(".tmp-{}", Uuid::new_v4()));
+    std::fs::create_dir(&path)?;
+    Ok(path)
+}
+
+/// Recursively copy `src` into `dst`, refusing symlinks and special files so a
+/// skill package can never smuggle a link that escapes the destination tree.
+fn copy_tree_no_symlinks(src: &Path, dst: &Path) -> Result<(), anyhow::Error> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if ft.is_symlink() {
+            bail!("refusing to copy symlink {}", from.display());
+        } else if ft.is_dir() {
+            copy_tree_no_symlinks(&from, &to)?;
+        } else if ft.is_file() {
+            std::fs::copy(&from, &to)?;
+        } else {
+            bail!("refusing to copy special file {}", from.display());
+        }
+    }
+    Ok(())
+}
+
+/// Atomically replace `path`'s contents by writing a sibling temp file and
+/// renaming over it.
+fn write_atomic(path: &Path, content: &str) -> Result<(), SkillError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| SkillError::Io(anyhow::anyhow!("SKILL.md path has no parent")))?;
+    let tmp = parent.join(format!(".tmp-{}", Uuid::new_v4()));
+    std::fs::write(&tmp, content)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e.into())
+        }
+    }
+}
+
+/// Build a scaffolded `SKILL.md` with the frontmatter emitted by `serde_yaml`
+/// (so a `description` with YAML-significant characters is quoted correctly).
+fn scaffold(directory: &str, description: &str) -> Result<String> {
+    let fm = serde_yaml::to_string(&Frontmatter {
+        name: directory.to_string(),
+        description: description.to_string(),
+    })?;
+    Ok(format!("---\n{fm}---\n\n# {directory}\n\n{description}\n"))
+}
+
+/// A skill directory name is the on-disk identity and is joined onto host paths,
+/// so it is confined to a conservative portable grammar: 1..=64 chars of ASCII
+/// alphanumerics plus `-` and `_`. This forbids `.`, `..`, path separators, and
+/// leading dots, which is what keeps a name from escaping its store.
+fn validate_dir_name(name: &str) -> Result<(), SkillError> {
+    if name.is_empty() || name.len() > 64 {
+        return Err(SkillError::InvalidInput(format!(
+            "skill name {name:?} must be 1..=64 characters"
+        )));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(SkillError::InvalidInput(format!(
+            "skill name {name:?} may contain only ASCII letters, digits, '-', and '_'"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_skill(dir: &Path, directory: &str, name: &str, description: &str) {
+        let d = dir.join(directory);
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(
+            d.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\nbody\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn parse_extracts_fields_and_preserves_body() {
+        let p =
+            parse_skill_md("---\nname: foo\ndescription: does foo\n---\n\n# Foo\n\nbody text\n")
+                .unwrap();
+        assert_eq!(p.name, "foo");
+        assert_eq!(p.description, "does foo");
+        assert_eq!(p.body, "\n# Foo\n\nbody text\n");
+    }
+
+    #[test]
+    fn parse_tolerates_crlf_and_bom() {
+        let p = parse_skill_md("\u{feff}---\r\nname: foo\r\ndescription: d\r\n---\r\nbody\r\n")
+            .unwrap();
+        assert_eq!(p.name, "foo");
+        assert_eq!(p.body, "body\r\n");
+    }
+
+    #[test]
+    fn parse_rejects_missing_or_unclosed_fence_and_empty_fields() {
+        assert!(parse_skill_md("no frontmatter here").is_err());
+        assert!(parse_skill_md("---\nname: foo\ndescription: d\n").is_err());
+        assert!(parse_skill_md("---\nname: \"\"\ndescription: d\n---\n").is_err());
+        assert!(parse_skill_md("---\nname: foo\n---\n").is_err());
+    }
+
+    #[test]
+    fn discover_is_source_qualified_and_sorted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        write_skill(&home.join(".claude/skills"), "review", "review", "d");
+        write_skill(&home.join(".kimi-code/skills"), "review", "review", "d");
+        write_skill(&app.join("skills"), "mine", "mine", "d");
+
+        let found = discover(&home, &app);
+        let ids: Vec<(String, String)> = found
+            .iter()
+            .map(|s| (s.provenance.label(), s.directory.clone()))
+            .collect();
+        // Sorted by provenance label then directory; the two "review" folders
+        // coexist under different provenances (no shadow-merge).
+        assert_eq!(
+            ids,
+            vec![
+                ("agent-native:claude".to_string(), "review".to_string()),
+                ("agent-native:kimi".to_string(), "review".to_string()),
+                ("aoe-managed".to_string(), "mine".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn discover_skips_malformed_without_failing_siblings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = tmp.path().join("app");
+        write_skill(&app.join("skills"), "good", "good", "d");
+        let bad = app.join("skills").join("bad");
+        std::fs::create_dir_all(&bad).unwrap();
+        std::fs::write(bad.join("SKILL.md"), "not frontmatter").unwrap();
+
+        let found = discover(tmp.path(), &app);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].directory, "good");
+    }
+
+    #[test]
+    fn create_then_read_round_trips_as_managed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = tmp.path().to_path_buf();
+        create_skill(&app, "my-skill", Some("use for testing")).unwrap();
+
+        let read = read_skill(tmp.path(), &app, &SkillProvenance::AoeManaged, "my-skill").unwrap();
+        assert_eq!(read.name, "my-skill");
+        assert_eq!(read.description, "use for testing");
+        assert!(read.content.contains("name: my-skill"));
+
+        // Collision is refused.
+        assert!(matches!(
+            create_skill(&app, "my-skill", None),
+            Err(SkillError::Collision(_))
+        ));
+    }
+
+    #[test]
+    fn create_rejects_unsafe_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        for bad in ["..", ".", "a/b", "has space", "", &"x".repeat(65)] {
+            assert!(matches!(
+                create_skill(tmp.path(), bad, None),
+                Err(SkillError::InvalidInput(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn edit_requires_name_equals_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = tmp.path().to_path_buf();
+        create_skill(&app, "s", None).unwrap();
+        let good = "---\nname: s\ndescription: d\n---\n\nbody\n";
+        edit_skill(tmp.path(), &app, "s", good).unwrap();
+        let bad = "---\nname: other\ndescription: d\n---\n\nbody\n";
+        assert!(matches!(
+            edit_skill(tmp.path(), &app, "s", bad),
+            Err(SkillError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn adopt_copies_and_leaves_original_then_edit_host_is_read_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        write_skill(&home.join(".claude/skills"), "review", "review", "d");
+
+        let src = home.join(".claude/skills/review/SKILL.md");
+        let before = std::fs::read_to_string(&src).unwrap();
+
+        let dest = adopt_skill(
+            &home,
+            &app,
+            &SkillProvenance::AgentNative {
+                agent: "claude".to_string(),
+            },
+            "review",
+            None,
+        )
+        .unwrap();
+        assert_eq!(dest, "review");
+        assert!(app.join("skills/review/SKILL.md").is_file());
+        // Host original untouched.
+        assert_eq!(std::fs::read_to_string(&src).unwrap(), before);
+
+        // Editing the managed copy works; editing a host-only skill is FORBIDDEN.
+        edit_skill(
+            &home,
+            &app,
+            "review",
+            "---\nname: review\ndescription: d2\n---\n\nb\n",
+        )
+        .unwrap();
+        std::fs::remove_dir_all(app.join("skills/review")).unwrap();
+        assert!(matches!(
+            edit_skill(
+                &home,
+                &app,
+                "review",
+                "---\nname: review\ndescription: d\n---\n\nb\n"
+            ),
+            Err(SkillError::ReadOnly(_))
+        ));
+    }
+
+    #[test]
+    fn adopt_rejects_managed_source_and_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        write_skill(&home.join(".claude/skills"), "review", "review", "d");
+        create_skill(&app, "review", None).unwrap();
+
+        assert!(matches!(
+            adopt_skill(&home, &app, &SkillProvenance::AoeManaged, "review", None),
+            Err(SkillError::InvalidInput(_))
+        ));
+        assert!(matches!(
+            adopt_skill(
+                &home,
+                &app,
+                &SkillProvenance::AgentNative {
+                    agent: "claude".to_string()
+                },
+                "review",
+                None
+            ),
+            Err(SkillError::Collision(_))
+        ));
+    }
+
+    #[test]
+    fn propagate_lands_in_target_and_refuses_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        create_skill(&app, "shared", Some("d")).unwrap();
+
+        propagate_skill(&home, &app, "shared", "kimi").unwrap();
+        assert!(home.join(".kimi-code/skills/shared/SKILL.md").is_file());
+
+        // No overwrite: a second propagate to the same target is a collision.
+        assert!(matches!(
+            propagate_skill(&home, &app, "shared", "kimi"),
+            Err(SkillError::Collision(_))
+        ));
+        // Unknown agent is rejected.
+        assert!(matches!(
+            propagate_skill(&home, &app, "shared", "codex"),
+            Err(SkillError::InvalidInput(_))
+        ));
+        // Missing managed source is NotFound.
+        assert!(matches!(
+            propagate_skill(&home, &app, "absent", "kimi"),
+            Err(SkillError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn delete_managed_and_refuses_host_and_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        create_skill(&app, "gone", None).unwrap();
+        delete_skill(&home, &app, "gone").unwrap();
+        assert!(!app.join("skills/gone").exists());
+
+        write_skill(&home.join(".claude/skills"), "hostonly", "hostonly", "d");
+        assert!(matches!(
+            delete_skill(&home, &app, "hostonly"),
+            Err(SkillError::ReadOnly(_))
+        ));
+        assert!(matches!(
+            delete_skill(&home, &app, "nope"),
+            Err(SkillError::NotFound(_))
+        ));
+    }
+}

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -238,7 +238,7 @@ fn collect_from_dir(root: &Path, provenance: &SkillProvenance, out: &mut Vec<Dis
             Ok(m) if m.file_type().is_file() => {}
             _ => continue,
         }
-        let content = match std::fs::read_to_string(&skill_md) {
+        let content = match read_file_capped(&skill_md, MAX_SKILL_MD_BYTES) {
             Ok(c) => c,
             Err(e) => {
                 warn!(target: "session.skills", path = %skill_md.display(), error = %e, "failed to read SKILL.md");
@@ -267,7 +267,8 @@ pub fn read_skill(
     directory: &str,
 ) -> Result<ReadSkill, SkillError> {
     validate_dir_name(directory)?;
-    let dir = skill_dir_for(home, app_dir, provenance, directory)?;
+    let root = skill_root_for(home, app_dir, provenance)?;
+    let dir = resolve_skill_dir(&root, directory)?;
     let skill_md = dir.join("SKILL.md");
     match std::fs::symlink_metadata(&skill_md) {
         Ok(m) if m.file_type().is_file() => {}
@@ -277,12 +278,8 @@ pub fn read_skill(
         }
         Err(e) => return Err(e.into()),
     }
-    if skill_md.metadata()?.len() > MAX_SKILL_MD_BYTES {
-        return Err(SkillError::InvalidInput(
-            "SKILL.md is too large".to_string(),
-        ));
-    }
-    let content = std::fs::read_to_string(&skill_md)?;
+    let content = read_file_capped(&skill_md, MAX_SKILL_MD_BYTES)
+        .map_err(|e| SkillError::InvalidInput(e.to_string()))?;
     let parsed = parse_skill_md(&content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
     Ok(ReadSkill {
         provenance: provenance.clone(),
@@ -312,6 +309,12 @@ pub fn create_skill(
         .filter(|d| !d.is_empty())
         .unwrap_or("Describe when this skill should be used.");
     let content = scaffold(directory, description).map_err(SkillError::Io)?;
+    if content.len() as u64 > MAX_SKILL_MD_BYTES {
+        return Err(SkillError::InvalidInput(
+            "scaffolded SKILL.md exceeds the size limit".to_string(),
+        ));
+    }
+    parse_skill_md(&content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
     std::fs::create_dir_all(&managed)?;
     let staging = new_staging_dir(&managed)?;
     let result = (|| {
@@ -335,7 +338,14 @@ pub fn edit_skill(
     content: &str,
 ) -> Result<(), SkillError> {
     validate_dir_name(directory)?;
-    let managed_md = app_dir.join("skills").join(directory).join("SKILL.md");
+    let managed_root = app_dir.join("skills");
+    if !managed_root.join(directory).exists() {
+        return Err(absent_write_target(home, directory));
+    }
+    // The managed dir exists: confirm it is a real, in-store directory (not a
+    // symlink pointing at a host path) before writing SKILL.md into it.
+    let managed_dir = resolve_skill_dir(&managed_root, directory)?;
+    let managed_md = managed_dir.join("SKILL.md");
     if !managed_md.is_file() {
         return Err(absent_write_target(home, directory));
     }
@@ -397,11 +407,8 @@ pub fn adopt_skill(
             ))
         }
     };
-    let src_dir = agent_skill_dir(home, agent)?.join(directory);
-    match std::fs::symlink_metadata(src_dir.join("SKILL.md")) {
-        Ok(m) if m.file_type().is_file() => {}
-        _ => return Err(SkillError::NotFound(directory.to_string())),
-    }
+    let src_dir = resolve_skill_dir(&agent_skill_dir(home, agent)?, directory)?;
+    validate_skill_md_at(&src_dir, directory)?;
     let dest_name = dest.unwrap_or(directory);
     validate_dir_name(dest_name)?;
     let managed = app_dir.join("skills");
@@ -432,10 +439,8 @@ pub fn propagate_skill(
     agent: &str,
 ) -> Result<(), SkillError> {
     validate_dir_name(directory)?;
-    let src = app_dir.join("skills").join(directory);
-    if !src.join("SKILL.md").is_file() {
-        return Err(SkillError::NotFound(directory.to_string()));
-    }
+    let src = resolve_skill_dir(&app_dir.join("skills"), directory)?;
+    validate_skill_md_at(&src, directory)?;
     let target_root = agent_skill_dir(home, agent)?;
     let dest = target_root.join(directory);
     if dest.exists() {
@@ -451,19 +456,6 @@ pub fn propagate_skill(
     result.map_err(SkillError::Io)
 }
 
-/// Resolve the on-disk directory for a source-qualified skill.
-fn skill_dir_for(
-    home: &Path,
-    app_dir: &Path,
-    provenance: &SkillProvenance,
-    directory: &str,
-) -> Result<PathBuf, SkillError> {
-    match provenance {
-        SkillProvenance::AgentNative { agent } => Ok(agent_skill_dir(home, agent)?.join(directory)),
-        SkillProvenance::AoeManaged => Ok(app_dir.join("skills").join(directory)),
-    }
-}
-
 /// The host skills dir for a known agent key, or [`SkillError::InvalidInput`]
 /// for an unsupported agent.
 fn agent_skill_dir(home: &Path, agent: &str) -> Result<PathBuf, SkillError> {
@@ -472,6 +464,76 @@ fn agent_skill_dir(home: &Path, agent: &str) -> Result<PathBuf, SkillError> {
         .find(|(a, _)| *a == agent)
         .map(|(_, rel)| home.join(rel))
         .ok_or_else(|| SkillError::InvalidInput(format!("unsupported skills agent {agent:?}")))
+}
+
+/// The designated root that a source-qualified skill's directory must live
+/// under (the agent's host skills dir, or the managed store).
+fn skill_root_for(
+    home: &Path,
+    app_dir: &Path,
+    provenance: &SkillProvenance,
+) -> Result<PathBuf, SkillError> {
+    match provenance {
+        SkillProvenance::AgentNative { agent } => agent_skill_dir(home, agent),
+        SkillProvenance::AoeManaged => Ok(app_dir.join("skills")),
+    }
+}
+
+/// Read a file as UTF-8, refusing more than `max` bytes. Reads through one
+/// handle and rejects an overflow byte, so a file that grows after a metadata
+/// check cannot slip past the bound (the metadata-then-read TOCTOU).
+pub fn read_file_capped(path: &Path, max: u64) -> Result<String> {
+    use std::io::Read;
+    let file = std::fs::File::open(path)?;
+    let mut buf = Vec::new();
+    file.take(max + 1).read_to_end(&mut buf)?;
+    if buf.len() as u64 > max {
+        bail!("file exceeds the {max}-byte limit");
+    }
+    String::from_utf8(buf).context("file is not valid UTF-8")
+}
+
+/// Resolve `root/directory` to a real, non-symlink directory that canonicalizes
+/// beneath `root`. This is the guard that stops a symlinked skill directory
+/// (e.g. a `<app_dir>/skills/<dir>` symlink pointing at a host path) from
+/// letting read/edit/adopt/propagate escape the designated store.
+fn resolve_skill_dir(root: &Path, directory: &str) -> Result<PathBuf, SkillError> {
+    let dir = root.join(directory);
+    let meta = match std::fs::symlink_metadata(&dir) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SkillError::NotFound(directory.to_string()))
+        }
+        Err(e) => return Err(e.into()),
+    };
+    if meta.file_type().is_symlink() || !meta.is_dir() {
+        return Err(SkillError::InvalidInput(format!(
+            "skill {directory:?} is not a real directory"
+        )));
+    }
+    let canon_root = std::fs::canonicalize(root)?;
+    let canon_dir = std::fs::canonicalize(&dir)?;
+    if !canon_dir.starts_with(&canon_root) {
+        return Err(SkillError::InvalidInput(format!(
+            "skill {directory:?} resolves outside its store"
+        )));
+    }
+    Ok(dir)
+}
+
+/// Confirm `dir/SKILL.md` is a regular (non-symlink) file that stays within the
+/// byte cap and parses, before an adopt/propagate finalizes. Keeps the store
+/// from committing a skill that discovery would skip and `read_skill` reject.
+fn validate_skill_md_at(dir: &Path, directory: &str) -> Result<(), SkillError> {
+    let md = dir.join("SKILL.md");
+    match std::fs::symlink_metadata(&md) {
+        Ok(m) if m.file_type().is_file() => {}
+        Ok(_) | Err(_) => return Err(SkillError::NotFound(directory.to_string())),
+    }
+    let content = read_file_capped(&md, MAX_SKILL_MD_BYTES)
+        .map_err(|e| SkillError::InvalidInput(e.to_string()))?;
+    parse_skill_md(&content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
+    Ok(())
 }
 
 /// Classify a write whose managed target does not exist: a host-discovered
@@ -805,6 +867,99 @@ mod tests {
         assert!(matches!(
             delete_skill(&home, &app, "nope"),
             Err(SkillError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn create_rejects_oversized_scaffold() {
+        let tmp = tempfile::tempdir().unwrap();
+        let huge = "x".repeat((MAX_SKILL_MD_BYTES + 10) as usize);
+        assert!(matches!(
+            create_skill(tmp.path(), "big", Some(&huge)),
+            Err(SkillError::InvalidInput(_))
+        ));
+        assert!(!tmp.path().join("skills/big").exists());
+    }
+
+    #[test]
+    fn adopt_and_propagate_reject_oversized_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        // A host skill whose SKILL.md exceeds the cap must not be adoptable.
+        let d = home.join(".claude/skills/big");
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(
+            d.join("SKILL.md"),
+            format!(
+                "---\nname: big\ndescription: {}\n---\n",
+                "x".repeat((MAX_SKILL_MD_BYTES + 10) as usize)
+            ),
+        )
+        .unwrap();
+        assert!(matches!(
+            adopt_skill(
+                &home,
+                &app,
+                &SkillProvenance::AgentNative {
+                    agent: "claude".to_string()
+                },
+                "big",
+                None
+            ),
+            Err(SkillError::InvalidInput(_))
+        ));
+        assert!(!app.join("skills/big").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn store_ops_reject_symlinked_skill_directory() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+
+        // An out-of-store dir holding a valid SKILL.md the attacker wants reached.
+        let outside = tmp.path().join("outside");
+        write_skill(&outside, "target", "target", "d");
+
+        // Symlink `<app>/skills/evil` -> the outside/target dir.
+        let managed = app.join("skills");
+        std::fs::create_dir_all(&managed).unwrap();
+        symlink(outside.join("target"), managed.join("evil")).unwrap();
+
+        // edit must refuse to write through the symlinked managed dir.
+        assert!(matches!(
+            edit_skill(
+                &home,
+                &app,
+                "evil",
+                "---\nname: evil\ndescription: d\n---\n"
+            ),
+            Err(SkillError::InvalidInput(_))
+        ));
+        // The outside SKILL.md is untouched.
+        assert_eq!(
+            std::fs::read_to_string(outside.join("target/SKILL.md")).unwrap(),
+            "---\nname: target\ndescription: d\n---\n\n# target\n\nbody\n"
+        );
+
+        // adopt must refuse a symlinked host source dir too.
+        let host_skills = home.join(".claude/skills");
+        std::fs::create_dir_all(&host_skills).unwrap();
+        symlink(outside.join("target"), host_skills.join("evil")).unwrap();
+        assert!(matches!(
+            adopt_skill(
+                &home,
+                &app,
+                &SkillProvenance::AgentNative {
+                    agent: "claude".to_string()
+                },
+                "evil",
+                None
+            ),
+            Err(SkillError::InvalidInput(_))
         ));
     }
 }

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -329,8 +329,10 @@ pub fn create_skill(
 
 /// Overwrite a managed skill's `SKILL.md` with validated content. A
 /// host-discovered target is [`SkillError::ReadOnly`] (adopt first); an unknown
-/// one is [`SkillError::NotFound`]. Content must parse and its frontmatter
-/// `name` must equal the directory.
+/// one is [`SkillError::NotFound`]. Content must parse; the frontmatter `name`
+/// need not equal the directory (identity is the folder, and discovery already
+/// allows the two to diverge), so an adopted skill whose name differs from its
+/// directory stays editable.
 pub fn edit_skill(
     home: &Path,
     app_dir: &Path,
@@ -354,13 +356,7 @@ pub fn edit_skill(
             "SKILL.md is too large".to_string(),
         ));
     }
-    let parsed = parse_skill_md(content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
-    if parsed.name != directory {
-        return Err(SkillError::InvalidInput(format!(
-            "frontmatter name {:?} must equal the skill directory {directory:?}",
-            parsed.name
-        )));
-    }
+    parse_skill_md(content).map_err(|e| SkillError::InvalidInput(e.to_string()))?;
     write_atomic(&managed_md, content)?;
     Ok(())
 }
@@ -759,17 +755,63 @@ mod tests {
     }
 
     #[test]
-    fn edit_requires_name_equals_directory() {
+    fn edit_allows_name_diverging_from_directory() {
         let tmp = tempfile::tempdir().unwrap();
         let app = tmp.path().to_path_buf();
         create_skill(&app, "s", None).unwrap();
-        let good = "---\nname: s\ndescription: d\n---\n\nbody\n";
-        edit_skill(tmp.path(), &app, "s", good).unwrap();
-        let bad = "---\nname: other\ndescription: d\n---\n\nbody\n";
+        // The frontmatter name need not match the directory: identity is the
+        // folder, so an edit that keeps a divergent name succeeds.
+        let diverging = "---\nname: other\ndescription: d\n---\n\nbody\n";
+        edit_skill(tmp.path(), &app, "s", diverging).unwrap();
+        assert_eq!(
+            read_skill(tmp.path(), &app, &SkillProvenance::AoeManaged, "s")
+                .unwrap()
+                .name,
+            "other"
+        );
+        // Malformed content is still refused.
         assert!(matches!(
-            edit_skill(tmp.path(), &app, "s", bad),
+            edit_skill(tmp.path(), &app, "s", "not frontmatter"),
             Err(SkillError::InvalidInput(_))
         ));
+    }
+
+    #[test]
+    fn adopt_with_diverging_name_stays_editable() {
+        // A host skill whose frontmatter name differs from its directory (which
+        // the folder-identity model allows), adopted into the managed store,
+        // must remain editable while keeping that divergent name.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+        write_skill(&home.join(".claude/skills"), "review", "Code Review", "d");
+
+        adopt_skill(
+            &home,
+            &app,
+            &SkillProvenance::AgentNative {
+                agent: "claude".to_string(),
+            },
+            "review",
+            None,
+        )
+        .unwrap();
+        // The adopted copy keeps the source's divergent name, not the directory.
+        assert_eq!(
+            read_skill(&home, &app, &SkillProvenance::AoeManaged, "review")
+                .unwrap()
+                .name,
+            "Code Review"
+        );
+        // Editing it while preserving that name succeeds (previously rejected).
+        let edited = "---\nname: Code Review\ndescription: updated\n---\n\nnew body\n";
+        edit_skill(&home, &app, "review", edited).unwrap();
+        assert_eq!(
+            read_skill(&home, &app, &SkillProvenance::AoeManaged, "review")
+                .unwrap()
+                .description,
+            "updated"
+        );
     }
 
     #[test]

--- a/src/session/skills_model.rs
+++ b/src/session/skills_model.rs
@@ -498,6 +498,22 @@ pub fn read_file_capped(path: &Path, max: u64) -> Result<String> {
 /// (e.g. a `<app_dir>/skills/<dir>` symlink pointing at a host path) from
 /// letting read/edit/adopt/propagate escape the designated store.
 fn resolve_skill_dir(root: &Path, directory: &str) -> Result<PathBuf, SkillError> {
+    // Reject a symlinked or non-directory root FIRST. Otherwise, if `root`
+    // itself is a symlink pointing outside, both `root` and `root/directory`
+    // canonicalize beneath the attacker target and the `starts_with` check below
+    // would spuriously pass.
+    match std::fs::symlink_metadata(root) {
+        Ok(m) if m.file_type().is_symlink() || !m.is_dir() => {
+            return Err(SkillError::InvalidInput(
+                "skills store root is not a real directory".to_string(),
+            ))
+        }
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SkillError::NotFound(directory.to_string()))
+        }
+        Err(e) => return Err(e.into()),
+    }
     let dir = root.join(directory);
     let meta = match std::fs::symlink_metadata(&dir) {
         Ok(m) => m,
@@ -528,7 +544,11 @@ fn validate_skill_md_at(dir: &Path, directory: &str) -> Result<(), SkillError> {
     let md = dir.join("SKILL.md");
     match std::fs::symlink_metadata(&md) {
         Ok(m) if m.file_type().is_file() => {}
-        Ok(_) | Err(_) => return Err(SkillError::NotFound(directory.to_string())),
+        Ok(_) => return Err(SkillError::NotFound(directory.to_string())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(SkillError::NotFound(directory.to_string()))
+        }
+        Err(e) => return Err(e.into()),
     }
     let content = read_file_capped(&md, MAX_SKILL_MD_BYTES)
         .map_err(|e| SkillError::InvalidInput(e.to_string()))?;
@@ -959,6 +979,29 @@ mod tests {
                 "evil",
                 None
             ),
+            Err(SkillError::InvalidInput(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_rejects_symlinked_store_root() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let app = tmp.path().join("app");
+
+        // A valid skill outside the store, reachable only if the store root is
+        // trusted as a symlink.
+        let outside = tmp.path().join("outside");
+        write_skill(&outside, "target", "target", "d");
+
+        // Make the managed store root itself a symlink pointing outside.
+        std::fs::create_dir_all(&app).unwrap();
+        symlink(&outside, app.join("skills")).unwrap();
+
+        assert!(matches!(
+            read_skill(&home, &app, &SkillProvenance::AoeManaged, "target"),
             Err(SkillError::InvalidInput(_))
         ));
     }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Ships the host-side primitives a skills plugin needs: a Rust skills model with discovery, the `skills.*` host RPCs, and the declared-but-unwired `fs.read` / `fs.write` RPCs. Skills previously existed only as a directory bulk-copied into sandboxes, with no model, discovery, or API, so `agent-of-empires/plugin-skills` had nothing to build on. This is the skills counterpart of the MCP RPC work (#2988) under the plugin-API epic (#2983).

New `src/session/skills_model.rs` (always-compiled, mirroring `mcp_model.rs`) parses `SKILL.md` frontmatter and discovers skills across two provenance layers: host-discovered dirs (`~/.claude/skills`, `~/.kimi-code/skills`) are read-only, and the AoE-managed store at `<app_dir>/skills` is the only writable layer. Identity is the skill's directory name (not the mutable frontmatter `name`), so the same name can coexist across provenances; discovery is source-qualified with no shadow-merge. The store provides create / edit / delete / adopt / propagate, each atomic (staging dir + rename) and symlink-refusing.

The plugin host (`src/plugin/host_api.rs`) gains `fs.read { root, path }` / `fs.write { root, path, content }` over two AoE-owned roots selected by `root`: `plugin` (the caller's private `<app_dir>/plugins/<id>/files`) and `skills` (the managed store). Paths are confined by a lexical guard plus a canonical-ancestor check, symlinks are refused, and a host-discovered agent skills dir is never a reachable root, so `fs.write` can never touch a read-only host skill. The seven `skills.*` methods bridge to the model: reads accept `fs.read` or `config.read`, writes require `fs.write` and refuse a read-only host-discovered target with `FORBIDDEN` (adopt it first). Every mutating arm inherits read-only safety for free, because the plugin host is never spawned in read-only serve mode.

Scope is deliberately host primitives only: the plugin UI (`plugin-skills#2`), the full propagation opt-in / marker / dedupe policy (`plugin-skills#4`), and the provenance badge (#2986) are out of scope. `skills.propagate` ships as the minimal non-overwriting copy-into-agent-dir primitive those issues will drive.

Closes #2984

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cargo test --features serve --lib plugin::host_api` and `cargo test --lib session::skills_model` pass (dispatch + model unit tests covering the user stories).
- [ ] With a `fs.write` grant, a `skills.create { directory }` call writes `<app_dir>/skills/<directory>/SKILL.md` and `skills.list` returns it with `provenance_label: "aoe-managed"` and `writable: true`.
- [ ] `skills.adopt` on a host skill (`{ source: { kind: "agent-native", agent: "claude" }, directory }`) creates a managed copy and leaves the original `~/.claude/skills/<directory>/SKILL.md` byte-identical; a later `skills.edit` on a still-host-only skill returns `FORBIDDEN`.
- [ ] A plugin lacking `fs.write` is refused (`FORBIDDEN`) on every `skills.*` write and on `fs.write`.
- [ ] `fs.write { root: "plugin", path: "../escape" }` (and an absolute path) is rejected with `INVALID_PARAMS`; a normal `plugin`-root path round-trips through `fs.read`.
- [ ] `skills.propagate { directory, agent: "kimi" }` lands the managed skill in `~/.kimi-code/skills/<directory>/` and a second call to the same target returns a collision error.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult (Gemini + GPT-5) shaping the folder-identity, source-qualified, non-destructive-propagate, and dual-root `fs.*` decisions. I reviewed each commit and made the design calls.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added an always-compiled Rust “skills model” that parses `SKILL.md`, discovers skills from agent-local directories and from the AoE-managed skills store, and records provenance (where each skill came from).
- Introduced new capability-gated host RPCs:
  - `fs.read` / `fs.write` to let plugins read and (mutating operations) write only within plugin-private and managed skills-store roots, with strong path/symlink safety and bounded UTF-8 content.
  - Seven `skills.*` RPCs (`list`, `read`, `create`, `edit`, `delete`, `adopt`, `propagate`) to manage the managed skills store and copy skills between the managed store and agent-local locations.
- Enforced a clear ownership model:
  - Host-discovered skills are treated as read-only.
  - Plugins must `adopt` a host-discovered skill into the managed store before they can `edit` or `delete` it.
  - `propagate` copies a managed skill into an agent directory without overwriting existing targets.
- Strengthened managed-store mutation safety with atomic update patterns (staging + replacement) and symlink/path-escape resistance, including protections against editing host-only skills and against unsafe deletes.
- Expanded plugin-system documentation and added dispatch + model tests covering capability enforcement, adoption/edit behavior (including adopted skills remaining editable even when frontmatter name differs from directory), propagation rules, and write-safety scenarios (including symlink hardening).
- Updated related naming in emitted skill provenance fields (`provenance_label`) to match the test expectations.

## Benefits

- Plugins can manage skills through the host with explicit, predictable ownership boundaries (adopt before mutate).
- Atomic, symlink-resistant managed-store writes reduce the risk of corruption and security issues.
- Capability gating and scoped filesystem access help ensure plugins only read/write what they’re allowed to.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->