### PR TITLE
fix(acp): honor auto-approve for Codex structured sessions

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -2434,7 +2434,9 @@ impl AcpClient {
             .map_err(|_| AcpError::AgentExited)
     }
 
-    /// Switch the active session mode via ACP `session/set_mode`.
+    /// Switch the active session mode through the mode channel advertised
+    /// by the adapter. Config-option mode takes precedence over the legacy
+    /// `session/set_mode` channel when both are present.
     pub async fn set_mode(&self, mode_id: &str) -> Result<(), AcpError> {
         let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
         cmd_tx
@@ -4274,19 +4276,62 @@ fn config_options_event(
     })
 }
 
-/// Route a `SetConfigOption` command to `session/set_config_option` and
-/// emit the resulting UI update. claude-agent-acp returns the full
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigOptionDispatchPurpose {
+    Generic,
+    Mode,
+}
+
+fn config_option_success_events(
+    options: Vec<agent_client_protocol::schema::v1::SessionConfigOption>,
+    value: String,
+    purpose: ConfigOptionDispatchPurpose,
+) -> Vec<Event> {
+    let mut events = config_options_event(Some(options))
+        .into_iter()
+        .collect::<Vec<_>>();
+    if purpose == ConfigOptionDispatchPurpose::Mode {
+        events.push(Event::CurrentModeChanged {
+            current_mode_id: value,
+        });
+    }
+    events
+}
+
+fn config_option_failure_event(
+    config_id: String,
+    value: String,
+    reason: String,
+    purpose: ConfigOptionDispatchPurpose,
+) -> Event {
+    match purpose {
+        ConfigOptionDispatchPurpose::Generic => Event::ConfigOptionSwitchFailed {
+            config_id,
+            value,
+            reason,
+        },
+        ConfigOptionDispatchPurpose::Mode => Event::ModeSwitchFailed {
+            mode_id: value,
+            reason,
+        },
+    }
+}
+
+/// Route a config-option change to `session/set_config_option` and emit
+/// the resulting UI update. claude-agent-acp returns the full
 /// updated config_options list in the response but does NOT emit a
 /// follow-up `config_option_update` notification (see
 /// acp-agent.js:1358-1410), so the success path re-emits a
 /// `ConfigOptionsUpdated` snapshot from the response and the frontend
-/// reducer clears pending state. The round-trip is spawned detached so
-/// the command loop never blocks on it. See #1403.
+/// reducer clears pending state. Mode changes also preserve the semantic
+/// mode events consumed by the native structured view. The round-trip is
+/// spawned detached so the command loop never blocks on it. See #1403.
 fn dispatch_set_config_option(
     connection: &ConnectionTo<Agent>,
     acp_session_id: &SessionId,
     config_id: String,
     value: String,
+    purpose: ConfigOptionDispatchPurpose,
     event_tx: mpsc::Sender<Event>,
 ) {
     info!(
@@ -4301,7 +4346,7 @@ fn dispatch_set_config_option(
     tokio::spawn(async move {
         match sent.block_task().await {
             Ok(resp) => {
-                if let Some(event) = config_options_event(Some(resp.config_options)) {
+                for event in config_option_success_events(resp.config_options, value, purpose) {
                     let _ = event_tx.send(event).await;
                 }
             }
@@ -4311,13 +4356,8 @@ fn dispatch_set_config_option(
                     target: "cockpit.acp",
                     "session/set_config_option failed: {reason}"
                 );
-                let _ = event_tx
-                    .send(Event::ConfigOptionSwitchFailed {
-                        config_id,
-                        value,
-                        reason,
-                    })
-                    .await;
+                let event = config_option_failure_event(config_id, value, reason, purpose);
+                let _ = event_tx.send(event).await;
             }
         }
     });
@@ -4912,6 +4952,7 @@ fn dispatch_set_mode(
             acp_session_id,
             config_id.to_string(),
             mode_id,
+            ConfigOptionDispatchPurpose::Mode,
             event_tx,
         );
         return;
@@ -5720,8 +5761,8 @@ async fn run_connection_task<W, R>(
                                 // Capture available mode info and config-option
                                 // mode category from the fork response (it carries
                                 // the same modes/config_options as session/new), so
-                                // the SetMode handlers below skip modes the agent
-                                // has not advertised and the pickers hydrate.
+                                // SetMode chooses the authoritative channel and the
+                                // pickers hydrate.
                                 if let Some(modes) = resp.modes.as_ref() {
                                     available_mode_ids = Some(
                                         modes
@@ -5946,8 +5987,8 @@ async fn run_connection_task<W, R>(
                         );
 
                         // Capture available mode IDs and config-option mode
-                        // category so the SetMode handlers below can skip
-                        // modes the agent has not advertised.
+                        // category so SetMode can choose the authoritative
+                        // channel and gate legacy values.
                         if let Some(modes) = &new_session.modes {
                             available_mode_ids = Some(
                                 modes
@@ -6702,6 +6743,7 @@ async fn run_connection_task<W, R>(
                                                 &acp_session_id,
                                                 config_id,
                                                 value,
+                                                ConfigOptionDispatchPurpose::Generic,
                                                 event_tx_for_block.clone(),
                                             );
                                         }
@@ -6976,6 +7018,7 @@ async fn run_connection_task<W, R>(
                             &acp_session_id,
                             config_id,
                             value,
+                            ConfigOptionDispatchPurpose::Generic,
                             event_tx_for_block.clone(),
                         );
                     }
@@ -10908,6 +10951,49 @@ mod tests {
             resolve_mode_set_target("plan", &None, None),
             Some(ModeSetTarget::SessionMode)
         );
+    }
+
+    #[test]
+    fn mode_config_dispatch_preserves_semantic_mode_events() {
+        let events = config_option_success_events(
+            Vec::new(),
+            "agent-full-access".to_string(),
+            ConfigOptionDispatchPurpose::Mode,
+        );
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0],
+            Event::ConfigOptionsUpdated { options } if options.is_empty()
+        ));
+        assert!(matches!(
+            &events[1],
+            Event::CurrentModeChanged { current_mode_id }
+                if current_mode_id == "agent-full-access"
+        ));
+
+        let failure = config_option_failure_event(
+            "mode".to_string(),
+            "agent-full-access".to_string(),
+            "rejected".to_string(),
+            ConfigOptionDispatchPurpose::Mode,
+        );
+        assert!(matches!(
+            failure,
+            Event::ModeSwitchFailed { mode_id, reason }
+                if mode_id == "agent-full-access" && reason == "rejected"
+        ));
+
+        let generic_failure = config_option_failure_event(
+            "model".to_string(),
+            "gpt-5".to_string(),
+            "rejected".to_string(),
+            ConfigOptionDispatchPurpose::Generic,
+        );
+        assert!(matches!(
+            generic_failure,
+            Event::ConfigOptionSwitchFailed { config_id, value, reason }
+                if config_id == "model" && value == "gpt-5" && reason == "rejected"
+        ));
     }
 
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4858,29 +4858,102 @@ fn truncate_for_log(s: &str, max_bytes: usize) -> String {
     out
 }
 
-/// Whether the agent advertised the given mode ID in its session modes
-/// or config-option mode category.
-///
-/// Returns `false` (skip) when:
-/// - `available_mode_ids` is `Some` and the normalized mode_id is not in the list, or
-/// - `available_mode_ids` is `None` and the agent uses config-option modes
-///   (session/set_mode won't work for arbitrary mode IDs).
-///
-/// Returns `true` (allow) only when there is no mode information at all
-/// (e.g. the test shim, which handles all set_mode requests).
-fn is_mode_advertised(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModeSetTarget<'a> {
+    ConfigOption(&'a str),
+    SessionMode,
+}
+
+/// Pick the protocol method for a requested mode. Config-option modes
+/// take precedence because adapters that advertise both channels report
+/// their authoritative current value through config options. With no mode
+/// metadata, retain the legacy set_mode fallback for older adapters.
+fn resolve_mode_set_target<'a>(
     mode_id: &str,
     available_mode_ids: &Option<Vec<String>>,
-    has_config_option_mode: bool,
-) -> bool {
+    mode_config_option_id: Option<&'a str>,
+) -> Option<ModeSetTarget<'a>> {
+    if let Some(config_id) = mode_config_option_id {
+        return Some(ModeSetTarget::ConfigOption(config_id));
+    }
+
     match available_mode_ids {
         Some(ids) => {
             let normalized = mode_id.replace('_', "").to_lowercase();
             ids.iter()
                 .any(|id| id.replace('_', "").to_lowercase() == normalized)
+                .then_some(ModeSetTarget::SessionMode)
         }
-        None => !has_config_option_mode,
+        None => Some(ModeSetTarget::SessionMode),
     }
+}
+
+fn dispatch_set_mode(
+    connection: &ConnectionTo<Agent>,
+    acp_session_id: &SessionId,
+    mode_id: String,
+    available_mode_ids: &Option<Vec<String>>,
+    mode_config_option_id: Option<&str>,
+    event_tx: mpsc::Sender<Event>,
+    while_prompting: bool,
+) {
+    let Some(target) = resolve_mode_set_target(&mode_id, available_mode_ids, mode_config_option_id)
+    else {
+        debug!(
+            target: "acp.protocol",
+            "skipping mode switch mode={mode_id}: not advertised"
+        );
+        return;
+    };
+
+    if let ModeSetTarget::ConfigOption(config_id) = target {
+        dispatch_set_config_option(
+            connection,
+            acp_session_id,
+            config_id.to_string(),
+            mode_id,
+            event_tx,
+        );
+        return;
+    }
+
+    if while_prompting {
+        info!(
+            target: "acp.protocol",
+            "sending session/set_mode mode={mode_id} during in-flight prompt"
+        );
+    } else {
+        info!(target: "acp.protocol", "sending session/set_mode mode={mode_id}");
+    }
+    let sent = connection.send_request(SetSessionModeRequest::new(
+        acp_session_id.clone(),
+        mode_id.clone(),
+    ));
+    tokio::spawn(async move {
+        match sent.block_task().await {
+            Ok(_) => {
+                let _ = event_tx
+                    .send(Event::CurrentModeChanged {
+                        current_mode_id: mode_id,
+                    })
+                    .await;
+            }
+            Err(e) => {
+                let reason = format!("{e}");
+                if while_prompting {
+                    warn!(
+                        target: "acp.protocol",
+                        "session/set_mode failed mid-turn: {reason}"
+                    );
+                } else {
+                    warn!(target: "acp.protocol", "session/set_mode failed: {reason}");
+                }
+                let _ = event_tx
+                    .send(Event::ModeSwitchFailed { mode_id, reason })
+                    .await;
+            }
+        }
+    });
 }
 
 /// The `cwd` to send on `session/new` / `session/load` / `session/fork`.
@@ -5542,15 +5615,11 @@ async fn run_connection_task<W, R>(
                 let _ = tx.send(Ok(()));
             }
 
-            // Track the mode channels the agent advertised so we can skip
-            // session/set_mode requests for modes the agent doesn't support.
-            // When new_session.modes is present, only those IDs are valid.
-            // When config-options have a Mode category, the agent uses
-            // session/set_config_option for modes instead of session/set_mode.
-            // If neither is present (e.g. test shim), allow all set_mode
-            // requests through.
+            // Track the mode channels the agent advertised so each switch uses
+            // the matching protocol method. Config-option mode is authoritative
+            // when present; otherwise SessionModeState constrains valid ids.
             let mut available_mode_ids: Option<Vec<String>> = None;
-            let mut has_config_option_mode: bool = false;
+            let mut mode_config_option_id: Option<String> = None;
 
             // Drop any http/sse servers the agent did not advertise before they
             // reach session/new or session/load; stdio is always kept. Computed
@@ -5662,17 +5731,11 @@ async fn run_connection_task<W, R>(
                                             .collect(),
                                     );
                                 }
-                                if resp.config_options.as_ref().is_some_and(|opts| {
-                                    opts.iter().any(|o| {
-                                        o.category
-                                            == Some(
-                                                agent_client_protocol::schema::v1::
-                                                    SessionConfigOptionCategory::Mode,
-                                            )
-                                    })
-                                }) {
-                                    has_config_option_mode = true;
-                                }
+                                mode_config_option_id = resp
+                                    .config_options
+                                    .as_deref()
+                                    .and_then(mode_config_id)
+                                    .map(|id| id.0.to_string());
                                 // Surface agent-advertised modes (when carried in
                                 // the ACP `modes` field rather than the `mode`
                                 // config option), mirroring session/new so a fork
@@ -5794,21 +5857,11 @@ async fn run_connection_task<W, R>(
                                     if modes.is_some() {
                                         available_mode_ids = modes;
                                     }
-                                    if resp
+                                    mode_config_option_id = resp
                                         .config_options
-                                        .as_ref()
-                                        .is_some_and(|opts| {
-                                            opts.iter().any(|o| {
-                                                o.category
-                                                    == Some(
-                                                        agent_client_protocol::schema::v1::
-                                                            SessionConfigOptionCategory::Mode,
-                                                    )
-                                            })
-                                        })
-                                    {
-                                        has_config_option_mode = true;
-                                    }
+                                        .as_deref()
+                                        .and_then(mode_config_id)
+                                        .map(|id| id.0.to_string());
                                     // Emit AcpSessionAssigned even on resume so the
                                     // frontend reducer can clear any sticky
                                     // `startupError` / `lastError` from a prior crash
@@ -5904,21 +5957,11 @@ async fn run_connection_task<W, R>(
                                     .collect(),
                             );
                         }
-                        if new_session
+                        mode_config_option_id = new_session
                             .config_options
-                            .as_ref()
-                            .is_some_and(|opts| {
-                                opts.iter().any(|o| {
-                                    o.category
-                                        == Some(
-                                            agent_client_protocol::schema::v1::
-                                                SessionConfigOptionCategory::Mode,
-                                        )
-                                })
-                            })
-                        {
-                            has_config_option_mode = true;
-                        }
+                            .as_deref()
+                            .and_then(mode_config_id)
+                            .map(|id| id.0.to_string());
 
                         // Surface the agent-advertised modes (if any) so the UI
                         // can render the actual modes the agent supports rather
@@ -6663,71 +6706,15 @@ async fn run_connection_task<W, R>(
                                             );
                                         }
                                         Some(ClientCmd::SetMode(mode_id)) => {
-                                            // Skip when the agent has not
-                                            // advertised this mode (see the
-                                            // mode-tracking comments above).
-                                            if !is_mode_advertised(
-                                                &mode_id,
+                                            dispatch_set_mode(
+                                                &connection,
+                                                &acp_session_id,
+                                                mode_id,
                                                 &available_mode_ids,
-                                                has_config_option_mode,
-                                            ) {
-                                                debug!(
-                                                    target: "acp.protocol",
-                                                    "skipping session/set_mode mode={mode_id}: not advertised (mid-turn)"
-                                                );
-                                                continue;
-                                            }
-                                            info!(
-                                                target: "acp.protocol",
-                                                "sending session/set_mode mode={mode_id} during in-flight prompt"
+                                                mode_config_option_id.as_deref(),
+                                                event_tx_for_block.clone(),
+                                                true,
                                             );
-                                            // Fire the request and hand the
-                                            // response handling to a detached
-                                            // task. Awaiting it here would
-                                            // freeze this select loop for the
-                                            // duration of the round-trip,
-                                            // defeating the point of polling
-                                            // cmd_rx concurrently; a Cancel
-                                            // arriving while set_mode is in
-                                            // flight would queue. The detached
-                                            // task mirrors the success into the
-                                            // event stream so the UI flips even
-                                            // when the adapter (e.g.
-                                            // claude-agent-acp) treats the
-                                            // response as authoritative and
-                                            // skips the follow-up
-                                            // current_mode_update notification.
-                                            let sent = connection.send_request(
-                                                SetSessionModeRequest::new(
-                                                    acp_session_id.clone(),
-                                                    mode_id.clone(),
-                                                ),
-                                            );
-                                            let tx = event_tx_for_block.clone();
-                                            tokio::spawn(async move {
-                                                match sent.block_task().await {
-                                                    Ok(_) => {
-                                                        let _ = tx
-                                                            .send(Event::CurrentModeChanged {
-                                                                current_mode_id: mode_id,
-                                                            })
-                                                            .await;
-                                                    }
-                                                    Err(e) => {
-                                                        let reason = format!("{e}");
-                                                        warn!(
-                                                            target: "acp.protocol",
-                                                            "session/set_mode failed mid-turn: {reason}"
-                                                        );
-                                                        let _ = tx
-                                                            .send(Event::ModeSwitchFailed {
-                                                                mode_id,
-                                                                reason,
-                                                            })
-                                                            .await;
-                                                    }
-                                                }
-                                            });
                                         }
                                         Some(ClientCmd::DeleteSession {
                                             acp_session_id: target_id,
@@ -6967,45 +6954,15 @@ async fn run_connection_task<W, R>(
                             .send_notification(CancelNotification::new(acp_session_id.clone()));
                     }
                     Some(ClientCmd::SetMode(mode_id)) => {
-                        // Skip when the agent has not advertised this mode
-                        // (see the mode-tracking comments above).
-                        if !is_mode_advertised(
-                            &mode_id,
+                        dispatch_set_mode(
+                            &connection,
+                            &acp_session_id,
+                            mode_id,
                             &available_mode_ids,
-                            has_config_option_mode,
-                        ) {
-                            debug!(
-                                target: "acp.protocol",
-                                "skipping session/set_mode mode={mode_id}: not advertised"
-                            );
-                            continue;
-                        }
-                        info!(target: "acp.protocol", "sending session/set_mode mode={mode_id}");
-                        // Detached, same shape as the mid-turn path: don't
-                        // freeze the cmd_rx loop on the round-trip.
-                        let sent = connection.send_request(SetSessionModeRequest::new(
-                            acp_session_id.clone(),
-                            mode_id.clone(),
-                        ));
-                        let tx = event_tx_for_block.clone();
-                        tokio::spawn(async move {
-                            match sent.block_task().await {
-                                Ok(_) => {
-                                    let _ = tx
-                                        .send(Event::CurrentModeChanged {
-                                            current_mode_id: mode_id,
-                                        })
-                                        .await;
-                                }
-                                Err(e) => {
-                                    let reason = format!("{e}");
-                                    warn!(target: "acp.protocol", "session/set_mode failed: {reason}");
-                                    let _ = tx
-                                        .send(Event::ModeSwitchFailed { mode_id, reason })
-                                        .await;
-                                }
-                            }
-                        });
+                            mode_config_option_id.as_deref(),
+                            event_tx_for_block.clone(),
+                            false,
+                        );
                     }
                     Some(ClientCmd::DeleteSession {
                         acp_session_id: target_id,
@@ -10866,23 +10823,33 @@ mod tests {
     }
 
     #[test]
-    fn is_mode_advertised_matches_normalized_ids() {
+    fn resolve_mode_set_target_matches_normalized_session_mode_ids() {
         let ids = Some(vec!["acceptEdits".to_string(), "plan".to_string()]);
         // Underscore + case folding both sides.
-        assert!(is_mode_advertised("accept_edits", &ids, false));
-        assert!(is_mode_advertised("acceptEdits", &ids, false));
-        assert!(is_mode_advertised("PLAN", &ids, false));
+        assert_eq!(
+            resolve_mode_set_target("accept_edits", &ids, None),
+            Some(ModeSetTarget::SessionMode)
+        );
+        assert_eq!(
+            resolve_mode_set_target("acceptEdits", &ids, None),
+            Some(ModeSetTarget::SessionMode)
+        );
+        assert_eq!(
+            resolve_mode_set_target("PLAN", &ids, None),
+            Some(ModeSetTarget::SessionMode)
+        );
         // Not in the advertised set.
-        assert!(!is_mode_advertised("bypassPermissions", &ids, false));
+        assert_eq!(
+            resolve_mode_set_target("bypassPermissions", &ids, None),
+            None
+        );
     }
 
     #[test]
     fn profile_yolo_mode_ids_pass_the_advertised_guard() {
         use super::super::agent_profiles;
-        // The supervisor's post-spawn `set_mode(profile.yolo_mode_id)` is
-        // gated by this same `is_mode_advertised` guard. Pin each adapter's
-        // YOLO id against the modes that adapter actually advertises, so a
-        // mismatch (the #1142 codex bug, or the
+        // Pin each adapter's YOLO id against the modes that adapter actually
+        // advertises, so a mismatch (the #1142 codex bug, or the
         // @agentclientprotocol/codex-acp `agent-full-access` rename) can't
         // silently get dropped again.
         let claude_modes = Some(vec![
@@ -10899,27 +10866,48 @@ mod tests {
         ]);
 
         let claude_yolo = agent_profiles::resolve("claude").yolo_mode_id.unwrap();
-        assert!(is_mode_advertised(claude_yolo, &claude_modes, false));
+        assert_eq!(
+            resolve_mode_set_target(claude_yolo, &claude_modes, None),
+            Some(ModeSetTarget::SessionMode)
+        );
 
         let codex_yolo = agent_profiles::resolve("codex").yolo_mode_id.unwrap();
-        assert!(is_mode_advertised(codex_yolo, &codex_modes, false));
+        assert_eq!(
+            resolve_mode_set_target(codex_yolo, &codex_modes, None),
+            Some(ModeSetTarget::SessionMode)
+        );
         // The old hard-coded id would NOT survive the guard for codex.
-        assert!(!is_mode_advertised(
-            "bypassPermissions",
-            &codex_modes,
-            false
-        ));
+        assert_eq!(
+            resolve_mode_set_target("bypassPermissions", &codex_modes, None),
+            None
+        );
         // The old Zed adapter id is stale for @agentclientprotocol/codex-acp.
-        assert!(!is_mode_advertised("full-access", &codex_modes, false));
+        assert_eq!(
+            resolve_mode_set_target("full-access", &codex_modes, None),
+            None
+        );
     }
 
     #[test]
-    fn is_mode_advertised_without_mode_list_defers_to_config_option() {
-        // No SessionMode list: the agent steers mode through a config option,
-        // so set_mode must NOT be sent (returns false). Without a config-option
-        // mode either, fall back to allowing the legacy set_mode (true).
-        assert!(!is_mode_advertised("plan", &None, true));
-        assert!(is_mode_advertised("plan", &None, false));
+    fn config_option_mode_is_authoritative() {
+        let ids = Some(
+            vec!["agent", "agent-full-access"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        );
+        assert_eq!(
+            resolve_mode_set_target("agent-full-access", &ids, Some("mode")),
+            Some(ModeSetTarget::ConfigOption("mode"))
+        );
+        assert_eq!(
+            resolve_mode_set_target("agent-full-access", &None, Some("mode")),
+            Some(ModeSetTarget::ConfigOption("mode"))
+        );
+        assert_eq!(
+            resolve_mode_set_target("plan", &None, None),
+            Some(ModeSetTarget::SessionMode)
+        );
     }
 
     #[test]

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -40,10 +40,10 @@ pub struct AgentProfile {
     /// ACP session-mode id that means "bypass all permission prompts"
     /// (the wizard's "Auto-approve" / profile `yolo_mode_default`). Each
     /// adapter names this differently: claude-agent-acp advertises
-    /// `bypassPermissions`, codex-acp advertises `agent-full-access`, gemini-cli
-    /// advertises `yolo`. The supervisor sends this id via
-    /// `session/set_mode` immediately after spawn (see
-    /// `supervisor::spawn_inner`). `None` for adapters with no known
+    /// `bypassPermissions`, codex-acp advertises `agent-full-access`, and
+    /// gemini-cli advertises `yolo`. The supervisor applies this id through
+    /// the mode channel advertised at spawn (see `supervisor::spawn_inner`).
+    /// `None` for adapters with no known
     /// bypass mode: YOLO then stays a best-effort no-op and the session
     /// keeps the adapter's default mode rather than guessing an id the
     /// adapter would reject. See #1142.

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -262,7 +262,8 @@ mod tests {
     #[test]
     fn yolo_mode_id_is_adapter_specific() {
         // Each adapter names its bypass-all-permissions mode differently;
-        // the supervisor sends exactly this id via session/set_mode.
+        // the supervisor applies exactly this id through the advertised mode
+        // channel.
         assert_eq!(resolve("claude").yolo_mode_id, Some("bypassPermissions"));
         // Inherited from CLAUDE via `..CLAUDE`.
         assert_eq!(
@@ -273,8 +274,8 @@ mod tests {
         // Regression for #1142 and the @agentclientprotocol/codex-acp
         // migration: codex's bypass preset is `agent-full-access`, not
         // Claude's `bypassPermissions` or the old Zed adapter's `full-access`.
-        // A stale id is dropped by the not-advertised guard, leaving codex
-        // prompting for approvals despite yolo_mode_default.
+        // A stale id is rejected by Codex's advertised mode channel, leaving
+        // the session prompting for approvals despite yolo_mode_default.
         assert_eq!(resolve("codex").yolo_mode_id, Some("agent-full-access"));
         assert_eq!(resolve("gemini").yolo_mode_id, Some("yolo"));
         // Kimi's acp-adapter advertises the canonical default/plan/auto/yolo

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1568,14 +1568,10 @@ impl<S: BroadcastSink> Supervisor<S> {
         // by switching the ACP session to the adapter's bypass mode. The
         // tmux path achieves the same with `--dangerously-skip-permissions`
         // (see `apply_yolo_mode()` in `src/session/instance.rs`); structured view
-        // can't pass CLI flags through the ACP adapter, so we set the
-        // mode via `session/set_mode` instead. The mode id is adapter-specific
-        // (claude: `bypassPermissions`, codex: `agent-full-access`, gemini: `yolo`),
-        // so resolve it from the agent profile rather than hard-coding Claude's
-        // id; codex advertises `agent-full-access`, not `bypassPermissions`, so
-        // a hard-coded or stale id is silently dropped by the
-        // not-advertised guard and left codex sessions in their default
-        // (approval-prompting) preset. Best-effort: the call is
+        // can't pass CLI flags through the ACP adapter, so we apply the
+        // adapter-specific mode id through whichever ACP mode channel the
+        // adapter advertised (claude: `bypassPermissions`, codex:
+        // `agent-full-access`, gemini: `yolo`). Best-effort: the call is
         // fire-and-forget through cmd_tx, the connection loop warns on
         // failure, and adapters with no known bypass mode (`yolo_mode_id:
         // None`) stay in default. See #1142.

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2183,7 +2183,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         );
     }
 
-    /// Set the active session mode via ACP session/set_mode.
+    /// Set the active session mode through the adapter's advertised mode channel.
     pub async fn set_mode(&self, session_id: &str, mode_id: &str) -> Result<(), SupervisorError> {
         let client = self.ready_client(session_id).await?;
         client.set_mode(mode_id).await?;

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1986,18 +1986,17 @@ pub struct SetModeRequest {
     pub mode_id: String,
 }
 
-/// Whether a mode value selects plan mode. `"plan"` is the canonical plan value
-/// on both mode channels: the legacy `session/set_mode` `mode_id` and the
-/// config-option `value` (claude-agent-acp v0.37.0+, OpenCode). Routing both
-/// `acp_set_mode` and `acp_set_config_option` through this one check keeps the
-/// plan-mode telemetry tally from drifting between the two paths. See the web
-/// `modeChannel.ts`, where the plan choice id is `"plan"` regardless of channel.
+/// Whether a mode value selects plan mode. `"plan"` is the canonical value for
+/// both the mode endpoint's `mode_id` and the config-option endpoint's `value`.
+/// Routing both through this one check keeps the plan-mode telemetry tally from
+/// drifting between the two paths. See the web `modeChannel.ts`, where the plan
+/// choice id is `"plan"` regardless of channel.
 fn is_plan_mode_value(value: &str) -> bool {
     value == "plan"
 }
 
 /// Set the active session mode (Default / Plan / AcceptEdits /
-/// BypassPermissions). Sends an ACP `session/set_mode` request.
+/// BypassPermissions) through the adapter's advertised mode channel.
 pub async fn acp_set_mode(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -2098,11 +2097,11 @@ pub async fn acp_set_config_option(
         Ok(()) => {
             // Tally plan-mode adoption. claude-agent-acp v0.37.0+ (and OpenCode)
             // advertise the mode picker as a config option of category "mode" and
-            // switch through this path rather than the legacy `session/set_mode`
-            // handled by `acp_set_mode`, so the plan tally has to live here too or
-            // the modern fleet reports zero. No other config category (model,
+            // the web picker writes directly through this endpoint, so the plan
+            // tally has to live here too or the modern fleet reports zero. No other
+            // config category (model,
             // thought level) carries a "plan" value, so keying on the value alone
-            // is safe and stays in sync with the legacy path via the shared check.
+            // is safe and stays in sync with the mode endpoint via the shared check.
             if is_plan_mode_value(&req.value) {
                 state
                     .telemetry_structured
@@ -2417,7 +2416,7 @@ mod tests {
 
     #[test]
     fn plan_mode_value_matches_only_plan() {
-        // Both `acp_set_mode` (legacy `mode_id`) and `acp_set_config_option`
+        // Both `acp_set_mode` (`mode_id`) and `acp_set_config_option`
         // (config-option `value`) tally plan-mode adoption through this check, so
         // it must accept the canonical "plan" value and reject every other mode or
         // selector value (Default / AcceptEdits / model ids / thought levels).

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -826,7 +826,8 @@
       "components": [
         "web/src/components/session-wizard/SessionWizard.tsx",
         "web/src/components/session-wizard/steps/AgentStep.tsx",
-        "web/src/components/session-wizard/steps/AgentPickerEssentials.tsx"
+        "web/src/components/session-wizard/steps/AgentPickerEssentials.tsx",
+        "web/src/components/session-wizard/steps/AgentOptions.tsx"
       ]
     },
     {

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -468,13 +468,18 @@ function writeFakeAcpShim(
   for (const [key, value] of Object.entries(extraEnv ?? {})) {
     scriptLines.push(`export ${key}=${JSON.stringify(value)}`);
   }
-  for (const name of ["claude", "claude-agent-acp", "aoe-agent", "opencode"]) {
+  for (const name of ["claude", "claude-agent-acp", "aoe-agent", "opencode", "codex-acp"]) {
     // The agent_compat gate keys its version floor off the spawned binary
     // name. When the fake stands in for opencode it must report opencode's
     // handshake (name + a version at or above the opencode floor), or the
     // gate rejects it and the opencode live specs fail; FAKE_ACP_IMPERSONATE
     // tells fakeAcpAgent.mjs which identity to present.
-    const perName = name === "opencode" ? [...scriptLines, "export FAKE_ACP_IMPERSONATE=opencode"] : scriptLines;
+    const perName =
+      name === "opencode"
+        ? [...scriptLines, "export FAKE_ACP_IMPERSONATE=opencode"]
+        : name === "codex-acp"
+          ? [...scriptLines, "export FAKE_ACP_IMPERSONATE=codex"]
+          : scriptLines;
     const script = `#!/bin/bash\n${perName.join("\n")}\nexec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;
     const path = join(binDir, name);
     writeFileSync(path, script);

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -468,16 +468,23 @@ function writeFakeAcpShim(
   for (const [key, value] of Object.entries(extraEnv ?? {})) {
     scriptLines.push(`export ${key}=${JSON.stringify(value)}`);
   }
-  for (const name of ["claude", "claude-agent-acp", "aoe-agent", "opencode", "codex-acp"]) {
+  for (const name of ["claude", "claude-agent-acp", "aoe-agent", "opencode", "codex", "codex-acp"]) {
     // The agent_compat gate keys its version floor off the spawned binary
     // name. When the fake stands in for opencode it must report opencode's
     // handshake (name + a version at or above the opencode floor), or the
     // gate rejects it and the opencode live specs fail; FAKE_ACP_IMPERSONATE
     // tells fakeAcpAgent.mjs which identity to present.
+    //
+    // `codex` (the native CLI) is shimmed alongside `codex-acp` (the ACP
+    // adapter the supervisor actually spawns) because the wizard's agent
+    // picker only renders agents whose native binary is detected on PATH
+    // (`AvailableTools::detect` -> `DetectionMethod::Which("codex")`). Without
+    // a `codex` shim the picker button never appears and codex-selecting specs
+    // time out, even though the ACP spawn resolves `codex-acp`.
     const perName =
       name === "opencode"
         ? [...scriptLines, "export FAKE_ACP_IMPERSONATE=opencode"]
-        : name === "codex-acp"
+        : name === "codex-acp" || name === "codex"
           ? [...scriptLines, "export FAKE_ACP_IMPERSONATE=codex"]
           : scriptLines;
     const script = `#!/bin/bash\n${perName.join("\n")}\nexec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -14,8 +14,9 @@
 //                          `session/request_permission` JSON-RPC
 //                          REQUEST; the fake awaits the client's
 //                          response before continuing the turn.
-//   session/set_mode    -> emit current_mode_update (also accepts the
-//                          legacy camelCase `session/setMode`)
+//   session/set_mode    -> change mode; most fixtures also emit
+//                          current_mode_update (accepts the legacy
+//                          camelCase `session/setMode` too)
 //   session/cancel      -> notification (no response); sets a per-
 //                          session cancel flag that the in-flight
 //                          session/prompt loop polls so the prompt
@@ -664,6 +665,14 @@ async function handleRequest(msg) {
       }
       sendResult(id, {});
       if (sessionId && modeId) {
+        if (fixture?.includeSessionModes) {
+          // codex-acp changes its internal mode but returns no follow-up
+          // current_mode_update. Keep the config snapshot stale until the
+          // next config response, reproducing the dual-channel bug without
+          // pretending the legacy request itself failed.
+          modeBySession.set(sessionId, modeId);
+          return;
+        }
         // Emit the ACP-correct variant so the supervisor translates to
         // a server-side Event::CurrentModeChanged for the reducer.
         await emitSessionUpdates(sessionId, [{ sessionUpdate: "current_mode_update", currentModeId: modeId }]);

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -222,26 +222,60 @@ const DEFAULT_PERMISSION_OPTIONS = [
 // "cancelled" instead of running the rest of the scripted updates.
 const cancelFlags = new Map();
 
-// OpenCode-shaped mode advertisement (#1764). When
-// FAKE_ACP_MODE_VIA_CONFIG_OPTION is set, the fake advertises its modes
-// ONLY as a `category:"mode"` config option (no ACP SessionModeState
-// `modes` field) and rejects any mode value outside this list, exactly
-// like `opencode acp`. Lets a test prove the structured view picker reads the
-// config-option channel and never offers a phantom "default" mode.
+// Config-option mode fixtures. A truthy
+// FAKE_ACP_MODE_VIA_CONFIG_OPTION uses OpenCode's config-only channel;
+// the `codex` value advertises Codex's current modes through both mode
+// channels. This covers manual picker routing (#1764) and startup
+// auto-approve channel precedence.
 const OPENCODE_MODE_CHOICES = [
   { value: "build", name: "Build" },
   { value: "plan", name: "Plan" },
 ];
-const opencodeModeBySession = new Map();
+const CODEX_MODE_CHOICES = [
+  {
+    value: "read-only",
+    name: "Read-only",
+    description: "Requires approval to edit files and run commands.",
+  },
+  {
+    value: "agent",
+    name: "Agent",
+    description: "Read and edit files, and run commands.",
+  },
+  {
+    value: "agent-full-access",
+    name: "Agent (full access)",
+    description: "Edit outside the workspace and use network access.",
+  },
+];
+const modeBySession = new Map();
 
-function makeOpencodeModeOption(currentValue) {
+function modeFixture() {
+  if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION === "codex") {
+    return {
+      choices: CODEX_MODE_CHOICES,
+      defaultValue: "agent",
+      includeSessionModes: true,
+    };
+  }
+  if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION) {
+    return {
+      choices: OPENCODE_MODE_CHOICES,
+      defaultValue: "build",
+      includeSessionModes: false,
+    };
+  }
+  return null;
+}
+
+function makeModeOption(currentValue, fixture) {
   return {
     id: "mode",
     name: "Session Mode",
     category: "mode",
     type: "select",
     currentValue,
-    options: OPENCODE_MODE_CHOICES,
+    options: fixture.choices,
   };
 }
 
@@ -278,12 +312,28 @@ function buildSessionConfigOptions(sessionId) {
       ],
     },
   ];
-  if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION) {
-    const current = opencodeModeBySession.get(sessionId) ?? "build";
-    opencodeModeBySession.set(sessionId, current);
-    configOptions.push(makeOpencodeModeOption(current));
+  const fixture = modeFixture();
+  if (fixture) {
+    const current = modeBySession.get(sessionId) ?? fixture.defaultValue;
+    modeBySession.set(sessionId, current);
+    configOptions.push(makeModeOption(current, fixture));
   }
   return configOptions;
+}
+
+function buildSessionModes(sessionId) {
+  const fixture = modeFixture();
+  if (!fixture?.includeSessionModes) return undefined;
+  const current = modeBySession.get(sessionId) ?? fixture.defaultValue;
+  modeBySession.set(sessionId, current);
+  return {
+    availableModes: fixture.choices.map(({ value, name, description }) => ({
+      id: value,
+      name,
+      ...(description ? { description } : {}),
+    })),
+    currentModeId: current,
+  };
 }
 
 async function emitSessionUpdates(sessionId, updates) {
@@ -411,7 +461,7 @@ const INITIALIZE_RESULT = {
 };
 
 // The same fake is shimmed under several binary names (claude /
-// claude-agent-acp / aoe-agent / opencode). The agent_compat gate keys
+// claude-agent-acp / aoe-agent / opencode / codex-acp). The agent_compat gate keys
 // its policy off the binary the supervisor spawned, so when this process
 // stands in for opencode it must report opencode's own name and a version
 // at or above the opencode floor (OPENCODE_MIN_VERSION in
@@ -422,6 +472,9 @@ function resolveAgentInfo() {
   if (process.env.FAKE_ACP_IMPERSONATE === "opencode") {
     // Keep at (or above) the agent_compat opencode floor (>=1.16.0).
     return { name: "OpenCode", version: "1.16.0" };
+  }
+  if (process.env.FAKE_ACP_IMPERSONATE === "codex") {
+    return { name: "@agentclientprotocol/codex-acp", version: "1.1.4" };
   }
   return INITIALIZE_RESULT.agentInfo;
 }
@@ -532,6 +585,8 @@ async function handleRequest(msg) {
       const result = { sessionId };
       const configOptions = buildSessionConfigOptions(sessionId);
       if (configOptions) result.configOptions = configOptions;
+      const modes = buildSessionModes(sessionId);
+      if (modes) result.modes = modes;
       sendResult(id, result);
       // Test hook for the import flow (#2276): on session/load, replay a
       // deterministic transcript chunk the way claude-agent-acp re-emits
@@ -588,6 +643,8 @@ async function handleRequest(msg) {
       const result = { sessionId: forkedId };
       const configOptions = buildSessionConfigOptions(forkedId);
       if (configOptions) result.configOptions = configOptions;
+      const modes = buildSessionModes(forkedId);
+      if (modes) result.modes = modes;
       sendResult(id, result);
       return;
     }
@@ -599,9 +656,9 @@ async function handleRequest(msg) {
       // rename doesn't silently regress this fake.
       const sessionId = params?.sessionId;
       const modeId = params?.modeId;
-      if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION && !OPENCODE_MODE_CHOICES.some((m) => m.value === modeId)) {
-        // OpenCode rejects set_mode for any id outside its real mode
-        // list (this is the "mode not found" the trapped user hit).
+      const fixture = modeFixture();
+      if (fixture && !fixture.choices.some((m) => m.value === modeId)) {
+        // Reject values outside the active adapter fixture's real list.
         sendError(id, -32000, `mode not found: ${modeId}`);
         return;
       }
@@ -629,15 +686,15 @@ async function handleRequest(msg) {
         sendError(id, -32000, process.env.FAKE_ACP_REJECT_CONFIG_OPTION);
         return;
       }
-      if (process.env.FAKE_ACP_MODE_VIA_CONFIG_OPTION && configId === "mode") {
-        // OpenCode-shaped mode switch via the config-option channel.
-        if (!OPENCODE_MODE_CHOICES.some((m) => m.value === value)) {
+      const fixture = modeFixture();
+      if (fixture && configId === "mode") {
+        if (!fixture.choices.some((m) => m.value === value)) {
           sendError(id, -32000, `mode not found: ${value}`);
           return;
         }
         const sessionId = params?.sessionId;
-        if (sessionId) opencodeModeBySession.set(sessionId, value);
-        sendResult(id, { configOptions: [makeOpencodeModeOption(value)] });
+        if (sessionId) modeBySession.set(sessionId, value);
+        sendResult(id, { configOptions: [makeModeOption(value, fixture)] });
         return;
       }
       const configOptions =

--- a/web/tests/live/wizard-acp-create-session.spec.ts
+++ b/web/tests/live/wizard-acp-create-session.spec.ts
@@ -5,6 +5,7 @@
 
 import { test, expect } from "@playwright/test";
 import { listSessions, spawnAoeServe, waitForView } from "../helpers/aoeServe";
+import { waitForStructuredView } from "../helpers/acp";
 
 test("wizard with Use structured view on creates a structured_view session", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -48,6 +49,44 @@ test("wizard with Use structured view on creates a structured_view session", asy
     const sessions = await listSessions(serve.baseUrl);
     expect(sessions).toHaveLength(1);
     await waitForView(serve.baseUrl, sessions[0]!.id, "structured");
+  } finally {
+    await serve.stop();
+  }
+});
+
+test("wizard auto-approve starts Codex in full-access mode", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    extraEnv: { FAKE_ACP_MODE_VIA_CONFIG_OPTION: "codex" },
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+
+    const wizard = page.locator('[data-testid="session-wizard"]');
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+    await wizard.getByRole("switch", { name: "Skip project folder" }).click();
+    await wizard.getByRole("button", { name: "codex", exact: true }).click();
+    await wizard.getByRole("button", { name: "More options" }).click();
+
+    const autoApprove = wizard.getByRole("switch", {
+      name: "Auto-approve actions",
+    });
+    await autoApprove.click();
+    await expect(autoApprove).toBeChecked();
+    await wizard.getByRole("button", { name: /Launch session/ }).click();
+
+    await waitForStructuredView(page);
+    await expect(page.getByRole("button", { name: /Agent \(full access\)/ }).first()).toBeVisible({ timeout: 15_000 });
+
+    const sessions = await listSessions(serve.baseUrl);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.tool).toBe("codex");
+    expect(sessions[0]!.yolo_mode).toBe(true);
   } finally {
     await serve.stop();
   }


### PR DESCRIPTION
## Description

Structured Codex sessions created from the web wizard with **Auto-approve actions** enabled could still open in the default **Agent** mode instead of **Agent (full access)**.

### Root cause

Codex advertises mode state through both ACP channels:

- `SessionModeState`, changed with `session/set_mode`
- a `category: "mode"` config option, changed with `session/set_config_option`

The structured-view composer treats the config option as authoritative. Post-spawn auto-approve, however, always called the legacy `session/set_mode` path when a session-mode list was present. That left the authoritative config snapshot at `agent`, so the UI and effective session mode stayed on **Agent**.

### What changed

- Track the advertised mode config-option ID after new, load, and fork responses.
- Prefer `session/set_config_option` whenever a mode config option is available, while retaining `session/set_mode` for legacy adapters.
- Route both idle and in-flight mode changes through the same dispatch path.
- Preserve `CurrentModeChanged` and `ModeSwitchFailed` semantic events when the config channel is used, keeping the native structured TUI synchronized without duplicating web notices.
- Extend the fake ACP adapter with a Codex-shaped dual-channel fixture that mirrors Codex's lack of a follow-up notification on legacy `set_mode`.
- Add a live Playwright regression that launches Codex from the wizard with auto-approve and verifies **Agent (full access)** plus persisted `yolo_mode: true`.
- Update the web coverage matrix for the wizard options surface.

### User impact

New Codex structured sessions now honor **Auto-approve actions** immediately, and the mode shown in structured view matches the full-access mode actually requested.

No migration or compatibility break is involved. Adapters without config-option modes continue to use `session/set_mode`.

### Validation

Passed locally:

- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 build --features serve`
- Targeted ACP channel-precedence and semantic-event unit tests
- `cargo +1.95.0 clippy --features serve --all-targets -- -D warnings -A clippy::collapsible_match -A clippy::items_after_test_module`
- `npm run format:check`
- `npm run lint`
- `npx tsc -b`
- `node tests/validate-coverage-matrix.mjs`
- Live Playwright wizard spec, 2 tests passed

An earlier full Rust unit run completed with 5,462 passed, 7 unrelated environment-sensitive failures, and 2 ignored. The failures are confined to existing `file_watch` and `server::login` tests under the temporary worktree's `/tmp` permissions. The affected ACP tests were rerun successfully after the final review changes. Unmodified all-target Clippy under Rust 1.95 also reaches two pre-existing new-toolchain lints in `src/acp/event_store.rs` and `src/tui/home/mod.rs`; the scoped command above suppresses only those two baseline lints and is otherwise warning-clean. Rust 1.94 cannot compile current `main`'s `libsqlite3-sys` dependency, so validation used the already-installed Rust 1.95 toolchain without changing repository configuration.

### Independent final review

A separate strict maintainer-style review found one cross-surface issue before this PR was marked ready: mode changes routed through the config channel initially omitted the semantic events consumed by the native TUI. That issue and all documentation/fake-adapter fidelity nits were fixed, unit-covered, and re-reviewed. The final independent verdict was **Approve, no findings remain**.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The first item remains unchecked only because of the seven unrelated local-environment failures documented above. A screenshot is not included because this changes startup state rather than visual styling; the live browser regression exercises the complete user flow and asserts the resulting mode.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**

- [x] Added/updated Playwright coverage, or covered by an existing user-story test.
- [ ] Deferred; tracking issue: #
- [ ] N/A; non-user-facing change.

Coverage: `web/tests/live/wizard-acp-create-session.spec.ts` now creates a structured Codex session with auto-approve enabled and verifies that the composer reports **Agent (full access)** and the backend persists `yolo_mode: true`.

**TUI / CLI (e2e test)**

- [ ] Added/updated an e2e test under `tests/e2e/`.
- [ ] Deferred; tracking issue: #
- [x] N/A; not a TUI / CLI behavior change.

The requested user story is the web wizard. Native TUI compatibility for the shared mode-dispatch path is preserved and covered by the semantic-event unit test rather than a new full-binary user story.

## AI Usage

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR.

Model/tool: OpenAI Codex (GPT-5)

Additional details: Codex traced the ACP mode-routing behavior, implemented the focused patch and regression coverage, ran the validation listed above, and coordinated an independent final review. The author remains responsible for the final review and merge decision.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed Codex structured-session auto-approve handling by routing “mode” changes through the adapter’s configuration option when available, with a fallback to the older mode endpoint for legacy adapters.
- Consolidated the mode-switching flow so mode changes go through a single path, preserving the same success/failure semantics and keeping the native TUI and structured view in sync.
- Updated session-mode advertisement tracking so the system remembers whether a “mode” config option is actually supported for sessions created via fork/load/new.
- Expanded test support for Codex in the web test environment (including fake ACP shims for both `codex-acp` and `codex`) and added Playwright coverage for wizard-created Codex sessions with auto-approve enabled and persisted `yolo_mode: true`.
- Updated the web coverage matrix and added a `codex` CLI shim so CI can select/render Codex correctly in the wizard picker.

## Benefits

- Codex sessions now reliably retain and apply Auto-approve settings across wizard flows and structured-view sessions.
- Older adapters continue to work without behavioral regressions or migration changes.
- Broader automated coverage reduces the chance of future mode/auto-approve regressions.

## Technical details (optional)

- Added mode-targeting logic that prefers `session/set_config_option` (when advertised) over `session/set_mode`.
- Preserved/standardized mode change events (e.g., emitting mode-changed on success and mode-switch-failed on error) and synchronized structured-view state updates.
- Extended fake ACP agent behavior to support both config-option-only and Codex session-mode behaviors, including validating mode IDs and persisting `yolo_mode`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->