### PR TITLE
fix: refresh local TUI token after rotation

### DIFF
--- a/src/acp/client/discovery.rs
+++ b/src/acp/client/discovery.rs
@@ -14,6 +14,8 @@
 //! variant whose message tells the user how to start one.
 
 use std::env;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 
 use thiserror::Error;
 
@@ -28,18 +30,72 @@ pub struct DaemonEndpoint {
     /// Bare base URL (`http://127.0.0.1:8080`). No trailing slash, no
     /// query string.
     pub base_url: String,
-    /// Bearer token. `None` when the daemon was started with
-    /// `--no-auth`, or when `AOE_DAEMON_URL` is set without
-    /// `AOE_DAEMON_TOKEN`.
-    pub token: Option<String>,
+    /// Bearer token captured during discovery. Loopback clients re-read the
+    /// owner-only `serve.token` before each request because remote daemons
+    /// rotate it while a TUI can remain open.
+    ///
+    /// `None` when the daemon was started with `--no-auth`, or when
+    /// `AOE_DAEMON_URL` is set without `AOE_DAEMON_TOKEN`.
+    token: Arc<RwLock<Option<String>>>,
+    local_token_path: Option<PathBuf>,
     pub source: Source,
 }
 
 impl DaemonEndpoint {
+    pub(crate) fn new(base_url: String, token: Option<String>, source: Source) -> Self {
+        Self {
+            base_url,
+            token: Arc::new(RwLock::new(token)),
+            local_token_path: None,
+            source,
+        }
+    }
+
+    pub(crate) fn with_local_token_path(mut self, token_path: PathBuf) -> Self {
+        self.local_token_path = Some(token_path);
+        self
+    }
+
     /// Same base URL, scheme rewritten to `ws://` / `wss://` so a
     /// caller can hand it to `tokio_tungstenite::connect_async`.
     pub fn ws_base_url(&self) -> String {
         http_to_ws(&self.base_url)
+    }
+
+    /// Resolve the credential to send now rather than relying forever on the
+    /// discovery-time snapshot. Only loopback local-daemon discovery may
+    /// consult the app directory; explicit env and legacy public endpoints
+    /// must never receive a token read for some other local daemon.
+    pub(crate) fn resolved_token(&self) -> Option<String> {
+        let cached = self.cached_token();
+        if self.source != Source::LocalDaemon || !is_loopback(&self.base_url) {
+            return cached;
+        }
+        let Some(token_path) = self.local_token_path.as_deref() else {
+            return cached;
+        };
+        self.resolved_token_from_path(token_path)
+    }
+
+    fn resolved_token_from_path(&self, token_path: &Path) -> Option<String> {
+        let cached = self.cached_token();
+        cached.as_ref()?;
+        if self.source != Source::LocalDaemon || !is_loopback(&self.base_url) {
+            return cached;
+        }
+        let Some(current) = read_valid_token(token_path) else {
+            return cached;
+        };
+        *self.token.write().unwrap_or_else(|e| e.into_inner()) = Some(current.clone());
+        Some(current)
+    }
+
+    pub(crate) fn has_token(&self) -> bool {
+        self.cached_token().is_some()
+    }
+
+    pub(crate) fn cached_token(&self) -> Option<String> {
+        self.token.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
 }
 
@@ -81,11 +137,11 @@ pub fn discover_env() -> Option<DaemonEndpoint> {
         .ok()
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty());
-    Some(DaemonEndpoint {
-        base_url: trim_query(url).trim_end_matches('/').to_string(),
+    Some(DaemonEndpoint::new(
+        trim_query(url).trim_end_matches('/').to_string(),
         token,
-        source: Source::Env,
-    })
+        Source::Env,
+    ))
 }
 
 /// Local serve daemon discovery. Returns `Err(NoLocalDaemon)` when no
@@ -104,11 +160,16 @@ pub fn discover_local() -> Result<DaemonEndpoint, DiscoveryError> {
     if base_url.is_empty() {
         return Err(DiscoveryError::Malformed);
     }
-    Ok(DaemonEndpoint {
-        base_url,
-        token,
-        source: Source::LocalDaemon,
-    })
+    let endpoint = DaemonEndpoint::new(base_url, token, Source::LocalDaemon);
+    let endpoint = if is_loopback(&endpoint.base_url) {
+        match crate::session::get_app_dir() {
+            Ok(app_dir) => endpoint.with_local_token_path(app_dir.join("serve.token")),
+            Err(_) => endpoint,
+        }
+    } else {
+        endpoint
+    };
+    Ok(endpoint)
 }
 
 fn preferred_daemon_url(urls: &[ServeUrl]) -> Option<&ServeUrl> {
@@ -118,14 +179,20 @@ fn preferred_daemon_url(urls: &[ServeUrl]) -> Option<&ServeUrl> {
 }
 
 fn is_loopback(url: &str) -> bool {
-    let host = url
-        .split_once("://")
-        .map(|(_, rest)| rest)
-        .unwrap_or(url)
-        .split(['/', '?'])
-        .next()
-        .unwrap_or("");
-    host.starts_with("127.0.0.1") || host.starts_with("localhost") || host.starts_with("[::1]")
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let ip_host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.eq_ignore_ascii_case("localhost")
+        || ip_host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
 }
 
 fn trim_query(url: &str) -> &str {
@@ -145,6 +212,16 @@ fn extract_token(url: &str) -> Option<&str> {
     None
 }
 
+fn read_valid_token(path: &Path) -> Option<String> {
+    let token = std::fs::read_to_string(path).ok()?;
+    let token = token.trim();
+    let valid_len = token.len() == 64 || token.len() == 32;
+    let valid_chars = token
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() || c.is_ascii_lowercase());
+    (valid_len && valid_chars).then(|| token.to_string())
+}
+
 fn http_to_ws(http_url: &str) -> String {
     if let Some(rest) = http_url.strip_prefix("https://") {
         return format!("wss://{rest}");
@@ -158,6 +235,14 @@ fn http_to_ws(http_url: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn endpoint(token: Option<&str>, source: Source) -> DaemonEndpoint {
+        DaemonEndpoint::new(
+            "http://127.0.0.1:8080".into(),
+            token.map(str::to_string),
+            source,
+        )
+    }
 
     #[test]
     fn extract_token_simple() {
@@ -209,12 +294,88 @@ mod tests {
     }
 
     #[test]
+    fn local_endpoint_resolves_rotated_token_at_use_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        let old = "a".repeat(64);
+        let new = "b".repeat(64);
+        std::fs::write(&path, &new).unwrap();
+
+        let endpoint = endpoint(Some(&old), Source::LocalDaemon);
+        assert_eq!(endpoint.resolved_token_from_path(&path), Some(new));
+    }
+
+    #[test]
+    fn local_endpoint_falls_back_during_invalid_token_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        let old = "a".repeat(64);
+        std::fs::write(&path, "partial").unwrap();
+
+        let endpoint = endpoint(Some(&old), Source::LocalDaemon);
+        assert_eq!(endpoint.resolved_token_from_path(&path), Some(old));
+    }
+
+    #[test]
+    fn local_endpoint_caches_last_valid_rotated_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        let old = "a".repeat(64);
+        let new = "b".repeat(64);
+        let endpoint = endpoint(Some(&old), Source::LocalDaemon);
+
+        std::fs::write(&path, &new).unwrap();
+        assert_eq!(endpoint.resolved_token_from_path(&path), Some(new.clone()));
+        std::fs::write(&path, "partial").unwrap();
+        assert_eq!(endpoint.resolved_token_from_path(&path), Some(new));
+    }
+
+    #[test]
+    fn legacy_public_endpoint_never_receives_local_daemon_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        let captured = "a".repeat(64);
+        std::fs::write(&path, "b".repeat(64)).unwrap();
+        let endpoint = DaemonEndpoint::new(
+            "https://old-tunnel.example.com".into(),
+            Some(captured.clone()),
+            Source::LocalDaemon,
+        );
+
+        assert_eq!(endpoint.resolved_token_from_path(&path), Some(captured));
+    }
+
+    #[test]
+    fn env_endpoint_never_reads_local_daemon_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        let explicit = "a".repeat(64);
+        std::fs::write(&path, "b".repeat(64)).unwrap();
+
+        let endpoint = endpoint(Some(&explicit), Source::Env);
+        assert_eq!(endpoint.resolved_token_from_path(&path), Some(explicit));
+    }
+
+    #[test]
+    fn no_auth_endpoint_ignores_lingering_token_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        std::fs::write(&path, "b".repeat(64)).unwrap();
+
+        let endpoint = endpoint(None, Source::LocalDaemon);
+        assert_eq!(endpoint.resolved_token_from_path(&path), None);
+    }
+
+    #[test]
     fn is_loopback_matches_localhost_variants() {
         assert!(is_loopback("http://127.0.0.1:8080"));
         assert!(is_loopback("http://localhost:8081/"));
         assert!(is_loopback("http://[::1]:8080"));
+        assert!(is_loopback("http://127.2.3.4:8080"));
         assert!(!is_loopback("https://example.com"));
         assert!(!is_loopback("http://192.168.1.50:8080"));
+        assert!(!is_loopback("https://localhost.attacker.example"));
+        assert!(!is_loopback("http://127.0.0.1.evil.example"));
     }
 
     #[test]
@@ -271,7 +432,7 @@ mod tests {
         // ENV override strips the query string defensively even though
         // tokens should travel via AOE_DAEMON_TOKEN, not the URL.
         assert_eq!(endpoint.base_url, "https://remote.example.com:9000");
-        assert_eq!(endpoint.token.as_deref(), Some("real-token"));
+        assert_eq!(endpoint.cached_token().as_deref(), Some("real-token"));
         assert_eq!(endpoint.source, Source::Env);
         unsafe {
             std::env::remove_var("AOE_DAEMON_URL");

--- a/src/acp/client/discovery.rs
+++ b/src/acp/client/discovery.rs
@@ -218,7 +218,7 @@ fn read_valid_token(path: &Path) -> Option<String> {
     let valid_len = token.len() == 64 || token.len() == 32;
     let valid_chars = token
         .chars()
-        .all(|c| c.is_ascii_hexdigit() || c.is_ascii_lowercase());
+        .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c));
     (valid_len && valid_chars).then(|| token.to_string())
 }
 
@@ -314,6 +314,19 @@ mod tests {
 
         let endpoint = endpoint(Some(&old), Source::LocalDaemon);
         assert_eq!(endpoint.resolved_token_from_path(&path), Some(old));
+    }
+
+    #[test]
+    fn local_endpoint_rejects_non_lowercase_hex_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("serve.token");
+        let old = "a".repeat(64);
+        let endpoint = endpoint(Some(&old), Source::LocalDaemon);
+
+        for invalid in ["A".repeat(64), "g".repeat(64)] {
+            std::fs::write(&path, invalid).unwrap();
+            assert_eq!(endpoint.resolved_token_from_path(&path), Some(old.clone()));
+        }
     }
 
     #[test]

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -604,7 +604,11 @@ mod tests {
     #[test]
     fn auth_skips_bearer_when_no_token() {
         let client = HttpClient::new(endpoint("http://127.0.0.1:8080", None)).unwrap();
-        assert!(client.endpoint.cached_token().is_none());
+        let request = client
+            .auth(client.http.get("http://127.0.0.1:8080/api/sessions"))
+            .build()
+            .unwrap();
+        assert!(request.headers().get(header::AUTHORIZATION).is_none());
     }
 
     // Regression test for #1525. The startup toast on a 401 from the

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -471,7 +471,7 @@ impl HttpClient {
     }
 
     fn auth(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match &self.endpoint.token {
+        match self.endpoint.resolved_token() {
             Some(token) => builder.header(header::AUTHORIZATION, format!("Bearer {token}")),
             None => builder,
         }
@@ -555,26 +555,56 @@ mod tests {
     use crate::acp::client::discovery::Source;
 
     fn endpoint(base: &str, token: Option<&str>) -> DaemonEndpoint {
-        DaemonEndpoint {
-            base_url: base.to_string(),
-            token: token.map(str::to_string),
-            source: Source::Env,
-        }
+        DaemonEndpoint::new(base.to_string(), token.map(str::to_string), Source::Env)
     }
 
     #[test]
     fn auth_sets_bearer_when_token_present() {
         let client = HttpClient::new(endpoint("http://127.0.0.1:8080", Some("tok"))).unwrap();
-        // Smoke-check by reading endpoint back; full header inspection
-        // requires a live request and lives in the integration tests
-        // alongside the axum mock.
-        assert_eq!(client.endpoint.token.as_deref(), Some("tok"));
+        let request = client
+            .auth(client.http.get("http://127.0.0.1:8080/api/sessions"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request.headers().get(header::AUTHORIZATION).unwrap(),
+            "Bearer tok"
+        );
+    }
+
+    #[test]
+    fn auth_uses_rotated_token_for_local_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("serve.token");
+        let rotated = "b".repeat(64);
+        std::fs::write(&token_path, &rotated).unwrap();
+        let endpoint = DaemonEndpoint::new(
+            "http://127.0.0.1:8080".into(),
+            Some("a".repeat(64)),
+            Source::LocalDaemon,
+        )
+        .with_local_token_path(token_path);
+        let client = HttpClient::new(endpoint).unwrap();
+
+        let request = client
+            .auth(client.http.get("http://127.0.0.1:8080/api/sessions"))
+            .build()
+            .unwrap();
+        let expected = format!("Bearer {rotated}");
+        assert_eq!(
+            request
+                .headers()
+                .get(header::AUTHORIZATION)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn auth_skips_bearer_when_no_token() {
         let client = HttpClient::new(endpoint("http://127.0.0.1:8080", None)).unwrap();
-        assert!(client.endpoint.token.is_none());
+        assert!(client.endpoint.cached_token().is_none());
     }
 
     // Regression test for #1525. The startup toast on a 401 from the

--- a/src/acp/client/ws.rs
+++ b/src/acp/client/ws.rs
@@ -213,7 +213,7 @@ fn ws_url(endpoint: &DaemonEndpoint, session_id: &str, since: u64) -> String {
     if since > 0 {
         params.push(format!("since={since}"));
     }
-    if let Some(token) = &endpoint.token {
+    if let Some(token) = endpoint.resolved_token() {
         params.push(format!("token={token}"));
     }
     if params.is_empty() {
@@ -244,11 +244,7 @@ mod tests {
     use crate::acp::state::Event;
 
     fn endpoint(base: &str, token: Option<&str>) -> DaemonEndpoint {
-        DaemonEndpoint {
-            base_url: base.to_string(),
-            token: token.map(str::to_string),
-            source: Source::Env,
-        }
+        DaemonEndpoint::new(base.to_string(), token.map(str::to_string), Source::Env)
     }
 
     #[test]
@@ -258,6 +254,25 @@ mod tests {
         assert_eq!(
             url,
             "ws://127.0.0.1:8080/sessions/s-1/acp/ws?since=42&token=abc"
+        );
+    }
+
+    #[test]
+    fn ws_url_uses_rotated_token_for_local_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("serve.token");
+        let rotated = "b".repeat(64);
+        std::fs::write(&token_path, &rotated).unwrap();
+        let endpoint = DaemonEndpoint::new(
+            "http://127.0.0.1:8080".into(),
+            Some("a".repeat(64)),
+            Source::LocalDaemon,
+        )
+        .with_local_token_path(token_path);
+
+        assert_eq!(
+            ws_url(&endpoint, "s-1", 0),
+            format!("ws://127.0.0.1:8080/sessions/s-1/acp/ws?token={rotated}")
         );
     }
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1251,11 +1251,7 @@ async fn print_status() -> Result<()> {
                 println!("URL:    {}", endpoint.base_url);
                 println!(
                     "Token:  {}",
-                    if endpoint.token.is_some() {
-                        "set"
-                    } else {
-                        "unset"
-                    }
+                    if endpoint.has_token() { "set" } else { "unset" }
                 );
                 Ok(())
             }

--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -330,6 +330,17 @@ async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSe
                 ticker.tick().await;
                 let snapshot = match http.plugin_ui_state().await {
                     Ok(snapshot) => snapshot,
+                    // A fixed env credential cannot recover inside this view.
+                    // Stop instead of turning its 3-second poll into repeated
+                    // IP-wide lockouts. Local credentials refresh from disk,
+                    // so rotation does not reach this branch.
+                    Err(e) if !should_retry_plugin_ui_poll(&e) => {
+                        tracing::warn!(
+                            target: "acp.tui",
+                            "plugin ui-state poll stopped after authentication failure: {e}"
+                        );
+                        break;
+                    }
                     // Transient or older-daemon-without-the-endpoint: keep the
                     // last good snapshot and retry on the next tick rather than
                     // toasting repeatedly.
@@ -365,6 +376,10 @@ async fn setup_view(endpoint: DaemonEndpoint, session_id: &str) -> Result<ViewSe
         plugin_rx,
         path_roots_rx,
     })
+}
+
+fn should_retry_plugin_ui_poll(error: &HttpError) -> bool {
+    !matches!(error, HttpError::Unauthorized)
 }
 
 pub async fn run_for_endpoint(
@@ -1586,17 +1601,22 @@ mod tests {
     use crate::acp::client::discovery::Source;
 
     fn test_state() -> StructuredViewState {
-        let endpoint = DaemonEndpoint {
-            base_url: "http://127.0.0.1:8080".into(),
-            token: None,
-            source: Source::Env,
-        };
+        let endpoint = DaemonEndpoint::new("http://127.0.0.1:8080".into(), None, Source::Env);
         let http = HttpClient::new(endpoint.clone()).unwrap();
         StructuredViewState::new("s-1".into(), endpoint, http, None)
     }
 
     fn composer_text(state: &StructuredViewState) -> String {
         state.composer.lines().join("\n")
+    }
+
+    #[test]
+    fn plugin_poll_stops_only_for_unauthorized() {
+        assert!(!should_retry_plugin_ui_poll(&HttpError::Unauthorized));
+        assert!(should_retry_plugin_ui_poll(&HttpError::Server {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            body: "locked".into(),
+        }));
     }
 
     #[test]

--- a/src/tui/structured_view/render.rs
+++ b/src/tui/structured_view/render.rs
@@ -1480,11 +1480,7 @@ mod tests {
     use crate::acp::client::{DaemonEndpoint, HttpClient};
 
     fn test_state() -> StructuredViewState {
-        let endpoint = DaemonEndpoint {
-            base_url: "http://127.0.0.1:8080".into(),
-            token: None,
-            source: Source::Env,
-        };
+        let endpoint = DaemonEndpoint::new("http://127.0.0.1:8080".into(), None, Source::Env);
         let http = HttpClient::new(endpoint.clone()).unwrap();
         StructuredViewState::new("s-1".into(), endpoint, http, None)
     }
@@ -1753,11 +1749,11 @@ mod tests {
 
     #[test]
     fn render_shows_slash_picker_overlay() {
-        let endpoint = DaemonEndpoint {
-            base_url: "http://127.0.0.1:8080".to_string(),
-            token: None,
-            source: Source::LocalDaemon,
-        };
+        let endpoint = DaemonEndpoint::new(
+            "http://127.0.0.1:8080".to_string(),
+            None,
+            Source::LocalDaemon,
+        );
         let http = HttpClient::new(endpoint.clone()).expect("http client");
         let mut state = StructuredViewState::new("sess".to_string(), endpoint, http, None);
         state.focus = Focus::Composer;
@@ -1789,11 +1785,11 @@ mod tests {
         // bottom selection painted above the fold and vanished. Render a
         // 9-row terminal with many commands, select the last, and assert
         // the selected label + marker actually paint.
-        let endpoint = DaemonEndpoint {
-            base_url: "http://127.0.0.1:8080".to_string(),
-            token: None,
-            source: Source::LocalDaemon,
-        };
+        let endpoint = DaemonEndpoint::new(
+            "http://127.0.0.1:8080".to_string(),
+            None,
+            Source::LocalDaemon,
+        );
         let http = HttpClient::new(endpoint.clone()).expect("http client");
         let mut state = StructuredViewState::new("sess".to_string(), endpoint, http, None);
         state.focus = Focus::Composer;

--- a/src/tui/structured_view/state.rs
+++ b/src/tui/structured_view/state.rs
@@ -559,11 +559,7 @@ mod tests {
     use crate::acp::client::Source;
 
     fn test_state(ws: Option<WsHandle>) -> StructuredViewState {
-        let endpoint = DaemonEndpoint {
-            base_url: "http://127.0.0.1:8080".into(),
-            token: None,
-            source: Source::Env,
-        };
+        let endpoint = DaemonEndpoint::new("http://127.0.0.1:8080".into(), None, Source::Env);
         let http = HttpClient::new(endpoint.clone()).unwrap();
         StructuredViewState::new("s-1".into(), endpoint, http, ws)
     }
@@ -722,11 +718,11 @@ mod tests {
     }
 
     fn state_with_commands(names: &[&str]) -> StructuredViewState {
-        let endpoint = DaemonEndpoint {
-            base_url: "http://127.0.0.1:8080".to_string(),
-            token: None,
-            source: Source::LocalDaemon,
-        };
+        let endpoint = DaemonEndpoint::new(
+            "http://127.0.0.1:8080".to_string(),
+            None,
+            Source::LocalDaemon,
+        );
         let http = HttpClient::new(endpoint.clone()).expect("build test http client");
         let mut state = StructuredViewState::new("test-session".to_string(), endpoint, http, None);
         state.transcript.available_commands = names.iter().map(|n| cmd(n)).collect();


### PR DESCRIPTION
## Description

The native structured-view TUI snapshots the daemon bearer token during discovery, but a running remote daemon rotates that token every four hours. A TUI left open across a rotation keeps sending the expired credential for HTTP polling and WebSocket reconnects. Repeated plugin UI-state polls can then exhaust the shared per-IP authentication failure budget, causing otherwise valid clients to receive `429 Too Many Requests`.

This change:

- resolves the current owner-only `serve.token` before each local loopback HTTP request and WebSocket handshake
- shares the last valid token across endpoint clones so a partial file write never falls back to an older discovery-time credential
- restricts disk token refresh to parsed loopback endpoints discovered from the local daemon, preventing token substitution into explicit environment or legacy public URLs
- stops the three-second plugin UI-state poll after an unrecoverable `401`, while continuing to retry transient errors and an existing `429` lockout
- adds regression coverage for token rotation, HTTP headers, WebSocket URLs, partial writes, hostile lookalike hostnames, endpoint isolation, and polling policy

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (not applicable; no rendering changes)

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this changes native TUI daemon authentication, not a browser dashboard flow; the transport behavior is covered directly in Rust.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: production rotation is a four-hour timing boundary; deterministic unit tests cover discovery, rotated credentials on both transports, invalid-write fallback, endpoint isolation, and poll termination.

## Validation

- `cargo +1.95.0 fmt --all -- --check`
- `git diff --check upstream/main...HEAD`
- focused discovery, HTTP, WebSocket, and plugin-poll tests: 18, 7, 7, and 1 passed respectively
- `cargo +1.95.0 clippy -- -D warnings`
- `cargo +1.95.0 clippy --features serve --all-targets -- -A clippy::collapsible-match -A clippy::items-after-test-module -D warnings`
  - both allowances cover existing Rust 1.95 warnings in files untouched by this PR
- `umask 077; TMPDIR=<owner-only temp dir> CARGO_BUILD_JOBS=1 cargo +1.95.0 test --features serve`
  - library: 5,650 passed, 2 ignored
  - integration main: 159 passed, 5 ignored
  - all remaining test binaries passed; aggregate: 5,903 passed, 7 ignored, 0 failed; doc tests: 0 passed, 1 ignored

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

GPT-5 Codex

**Any Additional AI Details you'd like to share:**

Used for root-cause analysis, implementation, regression tests, security-focused patch review, rebase conflict resolution, and validation. The resulting diff and validation output were reviewed before publishing.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed local TUI authentication after the daemon rotates its bearer token by refreshing/using the latest token right before HTTP requests and WebSocket handshakes.
- Updated daemon endpoint token storage to be safely shareable across endpoint clones, so all parts of the client use the same up-to-date credentials.
- Limited on-disk token refresh to validated loopback/local-daemon endpoints, and added extra checks to avoid using partially written or malformed token files.
- Prevented the plugin UI polling loop from continuing indefinitely after unrecoverable `401` authentication failures, while keeping retries for transient errors (including existing rate-limit handling).
- Strengthened loopback/hostname detection logic and expanded regression tests for token rotation, isolation between endpoint types, and polling behavior.

## Benefits

Local TUI sessions stay authenticated reliably across daemon token rotations, avoid falling back to stale/unsafe credentials from broken token files, and reduce wasted work by stopping polling when authentication can’t recover.

Validation passed: formatting, Clippy, focused tests, and the full suite (5,902 passed, 7 ignored).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->