### PR TITLE
fix(tui): debounce passive preview resize so toast frames stop jolting the agent pane

### DIFF
--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -637,6 +637,16 @@ pub struct HomeView {
     /// under us and the next render must re-assert the preview geometry. See
     /// `refresh_preview_cache_if_needed`.
     pub(super) preview_pane_synced: Option<(String, u16, u16)>,
+    /// `(session_id, cols, rows)` the NON-live preview sync wants but has only
+    /// seen for one refresh so far. The sync fires a resize only once the same
+    /// geometry is wanted on two consecutive refreshes: the `EnterLiveSend` /
+    /// `SendMessage` handlers each draw exactly one frame with a transient
+    /// "Reviving session..." toast up, that frame's output rect is one row
+    /// shorter (the toast claims a bottom bar row), and chasing it resized the
+    /// agent's pane down and back up within ~30ms. The double SIGWINCH made
+    /// agents with a bottom-anchored input box (claude) visibly jump right as
+    /// live mode opened. See `passive_resize_step`.
+    pub(super) preview_pane_pending: Option<(String, u16, u16)>,
     /// Pasted text captured at the home view that we couldn't immediately
     /// route (no session selected, cursor on a group header, etc.). Drained
     /// into the next compose dialog the user opens, so voice/dictation never
@@ -2178,6 +2188,7 @@ impl HomeView {
             footer_buttons: Vec::new(),
             footer_hover: None,
             preview_pane_synced: None,
+            preview_pane_pending: None,
             pending_paste: None,
             pending_attach_after_warning: None,
             pending_stop_session: None,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1993,7 +1993,18 @@ impl HomeView {
                     self.preview_pane_pending.as_ref(),
                 ) {
                     PassiveResizeStep::InSync => self.preview_pane_pending = None,
-                    PassiveResizeStep::Arm => self.preview_pane_pending = Some(want),
+                    PassiveResizeStep::Arm => {
+                        self.preview_pane_pending = Some(want);
+                        // Nudge the event loop so the confirming refresh isn't
+                        // left to the next natural wake: outside live-send an
+                        // idle home view can go up to the disk-heartbeat
+                        // interval (~5s) between draws, and the debounce would
+                        // hold a real resize hostage for that long. On the
+                        // nudged frame a genuine change Fires immediately,
+                        // while a one-frame toast transient lands back InSync,
+                        // still without touching tmux.
+                        self.preview_wake.notify_one();
+                    }
                     PassiveResizeStep::Fire => {
                         // Only record the dedup once the pane actually exists and was
                         // resized. If a Stopped session we're viewing is started later

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -160,6 +160,48 @@ fn scroll_exceeds_cache(cache_captured_lines: usize, height: u16, scroll_offset:
     needed > cache_captured_lines
 }
 
+/// What the passive (non-live) preview sync should do this refresh for the
+/// wanted `(session_id, cols, rows)` geometry.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum PassiveResizeStep {
+    /// The pane already matches; nothing to do (and any armed pending
+    /// geometry was transient noise, so the caller drops it).
+    InSync,
+    /// First sighting of this geometry; remember it and wait one refresh
+    /// before resizing.
+    Arm,
+    /// Same geometry wanted on two consecutive refreshes; resize now.
+    Fire,
+}
+
+/// Debounce for the passive preview sync: resize only once the same geometry
+/// has been wanted on two consecutive refreshes.
+///
+/// The `EnterLiveSend` / `SendMessage` handlers each draw exactly one frame
+/// with a transient "Reviving session..." toast before doing the slow work.
+/// That toast claims a one-row bottom bar, so the frame's preview output rect
+/// is one row shorter than both the frame before and the frame after. Chasing
+/// it resized the agent's detached pane down and straight back up (43 -> 42 ->
+/// 43 rows ~30ms apart in the repro), and the double SIGWINCH made
+/// bottom-anchored agent UIs visibly jump, worst right as live mode opened.
+/// Requiring two consecutive sightings means one-frame transients never reach
+/// tmux, while real geometry changes (terminal resize, info-header toggle,
+/// persistent update banner) land one refresh later, within the normal poll
+/// cadence.
+fn passive_resize_step(
+    want: &(String, u16, u16),
+    synced: Option<&(String, u16, u16)>,
+    pending: Option<&(String, u16, u16)>,
+) -> PassiveResizeStep {
+    if synced == Some(want) {
+        PassiveResizeStep::InSync
+    } else if pending == Some(want) {
+        PassiveResizeStep::Fire
+    } else {
+        PassiveResizeStep::Arm
+    }
+}
+
 /// Clamp the user's preview scroll offset to what the freshly captured pane
 /// can actually render. Prevents the offset from drifting into "phantom"
 /// territory (M3 from the multi-AI review) when tmux history is shorter than
@@ -1945,29 +1987,38 @@ impl HomeView {
         if !in_live && width > 0 && height > 0 {
             if let Some(id) = self.selected_session.clone() {
                 let want = (id, width, height);
-                if self.preview_pane_synced.as_ref() != Some(&want) {
-                    // Only record the dedup once the pane actually exists and was
-                    // resized. If a Stopped session we're viewing is started later
-                    // without an attach in this instance to clear the dedup (e.g.
-                    // a peer or the web structured view launches it), marking it synced now
-                    // would pin the preview to the pre-start size and keep clipping
-                    // until the next geometry change. Leaving it unset retries on
-                    // the next refresh; `exists()` is cache-backed, so the retry is
-                    // cheap.
-                    if let Some(session) = self
-                        .get_instance(&want.0)
-                        .and_then(|inst| inst.tmux_session().ok())
-                        .filter(|s| s.exists())
-                    {
-                        // Defer to an active size owner (a phone/desktop live
-                        // client, or this TUI's own live-send below). The
-                        // detached preview is a passive display, so it only
-                        // sizes a session nobody else is driving and never
-                        // claims the lock itself; leaving the dedup unset
-                        // retries once the owner disconnects.
-                        if !session.has_active_size_owner() {
-                            session.resize_window(width, height);
-                            self.preview_pane_synced = Some(want);
+                match passive_resize_step(
+                    &want,
+                    self.preview_pane_synced.as_ref(),
+                    self.preview_pane_pending.as_ref(),
+                ) {
+                    PassiveResizeStep::InSync => self.preview_pane_pending = None,
+                    PassiveResizeStep::Arm => self.preview_pane_pending = Some(want),
+                    PassiveResizeStep::Fire => {
+                        // Only record the dedup once the pane actually exists and was
+                        // resized. If a Stopped session we're viewing is started later
+                        // without an attach in this instance to clear the dedup (e.g.
+                        // a peer or the web structured view launches it), marking it synced now
+                        // would pin the preview to the pre-start size and keep clipping
+                        // until the next geometry change. Leaving it unset (and the
+                        // pending slot armed) retries on the next refresh; `exists()`
+                        // is cache-backed, so the retry is cheap.
+                        if let Some(session) = self
+                            .get_instance(&want.0)
+                            .and_then(|inst| inst.tmux_session().ok())
+                            .filter(|s| s.exists())
+                        {
+                            // Defer to an active size owner (a phone/desktop live
+                            // client, or this TUI's own live-send below). The
+                            // detached preview is a passive display, so it only
+                            // sizes a session nobody else is driving and never
+                            // claims the lock itself; leaving the dedup unset
+                            // retries once the owner disconnects.
+                            if !session.has_active_size_owner() {
+                                session.resize_window(width, height);
+                                self.preview_pane_synced = Some(want);
+                                self.preview_pane_pending = None;
+                            }
                         }
                     }
                 }
@@ -3770,6 +3821,70 @@ mod tests {
             mouse_all: false,
             position_reliable: true,
         }
+    }
+
+    fn geo(id: &str, cols: u16, rows: u16) -> (String, u16, u16) {
+        (id.to_string(), cols, rows)
+    }
+
+    #[test]
+    fn passive_resize_arms_before_firing() {
+        // A geometry change resizes only on its second consecutive sighting.
+        let synced = geo("a", 141, 43);
+        let want = geo("a", 141, 40);
+        assert_eq!(
+            passive_resize_step(&want, Some(&synced), None),
+            PassiveResizeStep::Arm,
+        );
+        assert_eq!(
+            passive_resize_step(&want, Some(&synced), Some(&want)),
+            PassiveResizeStep::Fire,
+        );
+    }
+
+    #[test]
+    fn passive_resize_ignores_one_frame_toast_geometry() {
+        // The EnterLiveSend / SendMessage toast frame: output rect drops one
+        // row for a single refresh, then returns. Neither the shrink nor the
+        // bounce-back may reach tmux; the double SIGWINCH is the cursor
+        // jiggle users saw on live-send entry.
+        let steady = geo("a", 141, 43);
+        let toast = geo("a", 141, 42);
+        // Toast frame: shrink is armed, not fired.
+        assert_eq!(
+            passive_resize_step(&toast, Some(&steady), None),
+            PassiveResizeStep::Arm,
+        );
+        // Post-toast frame: back in sync, and the caller drops the armed
+        // geometry so a later real change still needs two sightings.
+        assert_eq!(
+            passive_resize_step(&steady, Some(&steady), Some(&toast)),
+            PassiveResizeStep::InSync,
+        );
+    }
+
+    #[test]
+    fn passive_resize_refires_while_unsynced() {
+        // A Fire whose tmux-side resize couldn't happen (session not started
+        // yet, or an active size owner) leaves synced empty and pending
+        // armed, so the next refresh fires again instead of re-arming.
+        let want = geo("a", 141, 43);
+        assert_eq!(
+            passive_resize_step(&want, None, Some(&want)),
+            PassiveResizeStep::Fire,
+        );
+    }
+
+    #[test]
+    fn passive_resize_session_switch_rearms() {
+        // Selecting a different session is a new geometry key: it must go
+        // through Arm again rather than firing against the stale pending.
+        let pending = geo("a", 141, 43);
+        let want = geo("b", 141, 43);
+        assert_eq!(
+            passive_resize_step(&want, None, Some(&pending)),
+            PassiveResizeStep::Arm,
+        );
     }
 
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14535,6 +14535,42 @@ mod live_send_mode {
 
     #[test]
     #[serial]
+    fn passive_preview_sync_ignores_one_frame_toast_geometry() {
+        // The EnterLiveSend / SendMessage handlers draw exactly one frame with
+        // a transient toast up; its bottom bar makes the preview output rect
+        // one row shorter for that frame only. The passive sync must not chase
+        // it: pre-debounce it resized the agent's pane down and back up ~30ms
+        // apart, and the double SIGWINCH made claude's bottom-anchored input
+        // box (and cursor) visibly jump right as live mode opened.
+        let mut env = create_test_env_with_sessions(1);
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has one session");
+        env.view.selected_session = Some(id.clone());
+        // Steady state: pane already synced to the toast-free geometry.
+        env.view.preview_pane_synced = Some((id.clone(), 141, 43));
+
+        // Toast frame: one row shorter. Armed only; the synced geometry (and
+        // with it the real pane) must stay untouched.
+        env.view.refresh_preview_cache_if_needed(141, 42);
+        assert_eq!(env.view.preview_pane_pending, Some((id.clone(), 141, 42)));
+        assert_eq!(env.view.preview_pane_synced, Some((id.clone(), 141, 43)));
+
+        // Post-toast frame: back in sync; the transient arm is dropped so a
+        // later real change still needs two consecutive sightings.
+        env.view.refresh_preview_cache_if_needed(141, 43);
+        assert_eq!(env.view.preview_pane_pending, None);
+        assert_eq!(env.view.preview_pane_synced, Some((id, 141, 43)));
+    }
+
+    #[test]
+    #[serial]
     fn refresh_terminal_cache_overwrites_on_empty_capture() {
         // Counterpart to `refresh_preserves_cache_when_live_capture_fails`:
         // the agent cache and the host-terminal cache now share


### PR DESCRIPTION
## Description

Entering live view in the TUI made the agent's cursor block visibly shift right as the view attached. Root cause: the `EnterLiveSend` handler (and the `SendMessage` handler, same pattern) draws one frame with the transient "Reviving session..." toast before doing the slow prepare work. The toast claims a one-row bottom bar, so that single frame's preview output rect is one row shorter, and the passive detached-pane sync chased it: the agent's tmux pane was resized down and straight back up (measured 141x43 to 141x42 to 141x43, ~30ms apart). The double SIGWINCH made claude's bottom-anchored input box re-lay out twice, which is the visible jump. The #2742/#2766 prepare/finalize split fixed the target of the final resize but missed that the toast frame itself fires a passive resize.

Fix: the passive preview sync now fires only once the same geometry has been wanted on two consecutive refreshes (`passive_resize_step`: Arm, then Fire; a matching frame drops the armed value). One-frame transients never reach tmux; real geometry changes (terminal resize, info-header toggle, persistent banners) land one refresh later, within the existing poll cadence. Terminal/container/tool previews only use the live resize path, so the agent preview sync was the whole affected surface.

Verified with a headless repro (isolated HOME, fake claude with a bottom-anchored input box, 25ms tmux geometry poll): before the fix both live entry and send-message dip one row and bounce back; after the fix the pane holds steady through both flows, and a real outer-terminal resize still propagates.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the transient dip is a ~30ms tmux-side geometry bounce that an e2e screen capture cannot sample reliably; covered instead by 4 unit tests on the pure `passive_resize_step` decision and a HomeView-level regression test (`passive_preview_sync_ignores_one_frame_toast_geometry`) pinning that a one-frame toast rect never disturbs the synced pane geometry.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:**

Claude reproduced the bug headlessly (tmux geometry polling at 25ms while driving the TUI), isolated the toast frame as the cause via the send-message differential, and implemented the debounce plus tests. Reviewed and directed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed a TUI pane “bounce” caused by transient “Reviving session…” toast geometry briefly triggering a tmux resize and then undoing it.
- Implemented a safer passive preview resize synchronization that waits for matching geometry on two consecutive refreshes before applying a resize, filtering out one-frame toast changes.
- Updated the preview resize flow to “wake” the event loop when a stable resize is being armed, so real geometry changes aren’t delayed during idle periods.
- Added internal tracking for pending (to-be-applied) preview pane geometry and expanded test coverage:
  - Unit tests for the passive resize debounce/state behavior (`passive_resize_step`)
  - A HomeView regression test ensuring one-frame toast geometry doesn’t reach/affect tmux

## Benefits

- Removes visible cursor/input shifts during session revival and message sending.
- Ensures genuine terminal/layout changes (like real resizes and persistent UI elements) still propagate reliably to tmux.

## Potential follow-up

- Add coverage for other transient UI geometry events (e.g., additional banner/toast variants) to further confirm the two-refresh stability filter holds across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->