### PR TITLE
fix(recovery): skip resume when the agent is alive on an orphaned tmux server (#2994)

### DIFF
--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -45,6 +45,30 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
+/// Return `true` if any live process has `needle` as a substring of its argv.
+/// Reads `/proc/<pid>/cmdline` (NUL-separated argv, rendered with spaces) for
+/// every numeric `/proc` entry; skips entries that vanish or are unreadable
+/// mid-scan. Best-effort: an unreadable `/proc` returns `false`.
+pub(super) fn any_process_cmdline_contains(needle: &str) -> bool {
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().parse::<u32>().is_err() {
+            continue;
+        }
+        let Ok(bytes) = fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        let cmdline = String::from_utf8_lossy(&bytes).replace('\0', " ");
+        if cmdline.contains(needle) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Get the foreground process group leader for a shell PID
 /// Walks the process tree to find the actual foreground process
 pub fn get_foreground_pid(shell_pid: u32) -> Option<u32> {

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -45,11 +45,13 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
-/// Return `true` if any live process has `needle` as a substring of its argv.
-/// Reads `/proc/<pid>/cmdline` (NUL-separated argv, rendered with spaces) for
-/// every numeric `/proc` entry; skips entries that vanish or are unreadable
-/// mid-scan. Best-effort: an unreadable `/proc` returns `false`.
-pub(super) fn any_process_cmdline_contains(needle: &str) -> bool {
+/// Return `true` if any live process has one of `needles` as a substring of
+/// its argv or environment. Reads `/proc/<pid>/cmdline` and `/proc/<pid>/environ`
+/// (both NUL-separated, rendered with spaces) for every numeric `/proc` entry;
+/// `environ` is owner-only, so only same-uid processes (which include our own
+/// agent children) contribute an environment match. Skips entries that vanish
+/// or are unreadable mid-scan. Best-effort: an unreadable `/proc` returns `false`.
+pub(super) fn any_process_cmdline_or_env_contains(needles: &[&str]) -> bool {
     let Ok(entries) = fs::read_dir("/proc") else {
         return false;
     };
@@ -58,11 +60,19 @@ pub(super) fn any_process_cmdline_contains(needle: &str) -> bool {
         if name.to_string_lossy().parse::<u32>().is_err() {
             continue;
         }
-        let Ok(bytes) = fs::read(entry.path().join("cmdline")) else {
-            continue;
+        let dir = entry.path();
+        let read_nul_joined = |file: &str| {
+            fs::read(dir.join(file))
+                .ok()
+                .map(|bytes| String::from_utf8_lossy(&bytes).replace('\0', " "))
+                .unwrap_or_default()
         };
-        let cmdline = String::from_utf8_lossy(&bytes).replace('\0', " ");
-        if cmdline.contains(needle) {
+        let cmdline = read_nul_joined("cmdline");
+        let environ = read_nul_joined("environ");
+        if needles
+            .iter()
+            .any(|n| !n.is_empty() && (cmdline.contains(n) || environ.contains(n)))
+        {
             return true;
         }
     }

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -45,38 +45,58 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
-/// Return `true` if any live process has one of `needles` as a substring of
-/// its argv or environment. Reads `/proc/<pid>/cmdline` and `/proc/<pid>/environ`
-/// (both NUL-separated, rendered with spaces) for every numeric `/proc` entry;
-/// `environ` is owner-only, so only same-uid processes (which include our own
-/// agent children) contribute an environment match. Skips entries that vanish
-/// or are unreadable mid-scan. Best-effort: an unreadable `/proc` returns `false`.
-pub(super) fn any_process_cmdline_or_env_contains(needles: &[&str]) -> bool {
+/// One `/proc` walk deciding, for each candidate `i`, whether a live process
+/// belongs to it: an `/proc/<pid>/environ` *entry* exactly equals
+/// `env_needles[i]` (NUL-delimited, so no prefix-collision), or
+/// `/proc/<pid>/cmdline` contains `cmdline_needles[i]`. `environ` is owner-only,
+/// so only same-uid processes (our agent children among them) contribute an
+/// environment match. Skips entries that vanish or are unreadable mid-scan;
+/// stops early once every candidate is matched. Best-effort: an unreadable
+/// `/proc` yields all `false`.
+pub(super) fn processes_matching(
+    env_needles: &[String],
+    cmdline_needles: &[Option<String>],
+) -> Vec<bool> {
+    let n = env_needles.len();
+    let mut found = vec![false; n];
+    let mut remaining = n;
     let Ok(entries) = fs::read_dir("/proc") else {
-        return false;
+        return found;
     };
     for entry in entries.flatten() {
+        if remaining == 0 {
+            break;
+        }
         let name = entry.file_name();
         if name.to_string_lossy().parse::<u32>().is_err() {
             continue;
         }
         let dir = entry.path();
-        let read_nul_joined = |file: &str| {
-            fs::read(dir.join(file))
-                .ok()
-                .map(|bytes| String::from_utf8_lossy(&bytes).replace('\0', " "))
-                .unwrap_or_default()
-        };
-        let cmdline = read_nul_joined("cmdline");
-        let environ = read_nul_joined("environ");
-        if needles
-            .iter()
-            .any(|n| !n.is_empty() && (cmdline.contains(n) || environ.contains(n)))
-        {
-            return true;
+
+        let environ_raw = fs::read(dir.join("environ")).unwrap_or_default();
+        let environ = String::from_utf8_lossy(&environ_raw);
+        let env_entries: std::collections::HashSet<&str> =
+            environ.split('\0').filter(|s| !s.is_empty()).collect();
+
+        let cmd_raw = fs::read(dir.join("cmdline")).unwrap_or_default();
+        let cmdline = String::from_utf8_lossy(&cmd_raw).replace('\0', " ");
+
+        for i in 0..n {
+            if found[i] {
+                continue;
+            }
+            let env_hit =
+                !env_needles[i].is_empty() && env_entries.contains(env_needles[i].as_str());
+            let cmd_hit = cmdline_needles[i]
+                .as_deref()
+                .is_some_and(|s| !s.is_empty() && cmdline.contains(s));
+            if env_hit || cmd_hit {
+                found[i] = true;
+                remaining -= 1;
+            }
         }
     }
-    false
+    found
 }
 
 /// Get the foreground process group leader for a shell PID

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -35,26 +35,45 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
-/// Return `true` if any live process has one of `needles` as a substring of
-/// its command line or environment. Parses `ps -A -ww -E -o command=`: `-ww`
-/// disables column truncation so a long argv/env carrying a needle is not cut
-/// off, and `-E` appends each (owner-owned) process's environment to the
-/// command column so an `AOE_INSTANCE_ID=<id>` env marker matches too. If a
-/// `ps` build rejects `-E`, the call fails closed to `false` and recovery
-/// falls back to today's behavior. Best-effort: a failed `ps` returns `false`.
-pub(super) fn any_process_cmdline_or_env_contains(needles: &[&str]) -> bool {
+/// One `ps -A -ww -E -o command=` fork deciding, for each candidate `i`,
+/// whether a live process belongs to it: a whitespace-delimited token exactly
+/// equals `env_needles[i]` (anchored, matching the `KEY=VAL` env tokens `-E`
+/// appends), or the line contains `cmdline_needles[i]`. `-ww` disables column
+/// truncation; `-E` appends each owner-owned process's environment. If a `ps`
+/// build rejects `-E`, the call fails closed to all `false` and recovery falls
+/// back to the ledger. Best-effort: a failed `ps` yields all `false`.
+pub(super) fn processes_matching(
+    env_needles: &[String],
+    cmdline_needles: &[Option<String>],
+) -> Vec<bool> {
+    let n = env_needles.len();
+    let mut found = vec![false; n];
     let Ok(output) = Command::new("ps")
         .args(["-A", "-ww", "-E", "-o", "command="])
         .output()
     else {
-        return false;
+        return found;
     };
     if !output.status.success() {
-        return false;
+        return found;
     }
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .any(|line| needles.iter().any(|n| !n.is_empty() && line.contains(n)))
+    let text = String::from_utf8_lossy(&output.stdout);
+    for line in text.lines() {
+        let tokens: std::collections::HashSet<&str> = line.split_whitespace().collect();
+        for i in 0..n {
+            if found[i] {
+                continue;
+            }
+            let env_hit = !env_needles[i].is_empty() && tokens.contains(env_needles[i].as_str());
+            let cmd_hit = cmdline_needles[i]
+                .as_deref()
+                .is_some_and(|s| !s.is_empty() && line.contains(s));
+            if env_hit || cmd_hit {
+                found[i] = true;
+            }
+        }
+    }
+    found
 }
 
 /// Get the foreground process group leader for a shell PID

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -35,6 +35,25 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
+/// Return `true` if any live process has `needle` as a substring of its
+/// command line. Parses `ps -A -ww -o command=` (the `-ww` disables column
+/// truncation so a long argv carrying the needle is not cut off). Best-effort:
+/// a failed `ps` returns `false`.
+pub(super) fn any_process_cmdline_contains(needle: &str) -> bool {
+    let Ok(output) = Command::new("ps")
+        .args(["-A", "-ww", "-o", "command="])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(|line| line.contains(needle))
+}
+
 /// Get the foreground process group leader for a shell PID
 pub fn get_foreground_pid(shell_pid: u32) -> Option<u32> {
     // Use ps to get the foreground process group

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -35,13 +35,16 @@ fn build_children_map() -> HashMap<u32, Vec<u32>> {
     children_map
 }
 
-/// Return `true` if any live process has `needle` as a substring of its
-/// command line. Parses `ps -A -ww -o command=` (the `-ww` disables column
-/// truncation so a long argv carrying the needle is not cut off). Best-effort:
-/// a failed `ps` returns `false`.
-pub(super) fn any_process_cmdline_contains(needle: &str) -> bool {
+/// Return `true` if any live process has one of `needles` as a substring of
+/// its command line or environment. Parses `ps -A -ww -E -o command=`: `-ww`
+/// disables column truncation so a long argv/env carrying a needle is not cut
+/// off, and `-E` appends each (owner-owned) process's environment to the
+/// command column so an `AOE_INSTANCE_ID=<id>` env marker matches too. If a
+/// `ps` build rejects `-E`, the call fails closed to `false` and recovery
+/// falls back to today's behavior. Best-effort: a failed `ps` returns `false`.
+pub(super) fn any_process_cmdline_or_env_contains(needles: &[&str]) -> bool {
     let Ok(output) = Command::new("ps")
-        .args(["-A", "-ww", "-o", "command="])
+        .args(["-A", "-ww", "-E", "-o", "command="])
         .output()
     else {
         return false;
@@ -51,7 +54,7 @@ pub(super) fn any_process_cmdline_contains(needle: &str) -> bool {
     }
     String::from_utf8_lossy(&output.stdout)
         .lines()
-        .any(|line| line.contains(needle))
+        .any(|line| needles.iter().any(|n| !n.is_empty() && line.contains(n)))
 }
 
 /// Get the foreground process group leader for a shell PID

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -202,27 +202,35 @@ pub fn get_pane_pid(session_name: &str) -> Option<u32> {
     pid
 }
 
-/// Return `true` if any live process on this host has `needle` as a substring
-/// of its command line (argv). Best-effort: an unreadable process table
-/// returns `false` (callers treat that as "no match found").
+/// Return `true` if any live process on this host has one of `needles` as a
+/// substring of its command line (argv) **or** its environment block. Empty
+/// needles are ignored; if none remain the scan is skipped. Best-effort: an
+/// unreadable process table returns `false` (callers treat that as "no match
+/// found").
 ///
 /// Startup recovery uses this to detect an agent session a *prior* recovery
 /// pass already resumed on a tmux server this process can no longer see, e.g.
 /// the socket's `/tmp` dir was wiped mid-crash and the old server was orphaned
-/// (#2994). The resumed agent child carries its `agent_session_id` verbatim in
-/// argv (see `build_resume_flags`), so a live match means "already resumed;
-/// do not duplicate."
-pub fn any_process_cmdline_contains(needle: &str) -> bool {
-    if needle.is_empty() {
+/// (#2994). Two identity signals are checked so the match survives an agent
+/// that rewrites its own argv/process-title:
+/// - `AOE_INSTANCE_ID=<id>` in the agent's environment (aoe-injected for
+///   hook-enabled agents; `/proc/<pid>/environ` is immune to argv rewrites),
+/// - the `agent_session_id` in the launch command line (universal fallback;
+///   every resume strategy embeds it verbatim, and the host `docker exec` argv
+///   carries it for sandboxed sessions).
+///
+/// A live match means "already resumed; do not duplicate."
+pub fn any_process_cmdline_or_env_contains(needles: &[&str]) -> bool {
+    if needles.iter().all(|n| n.is_empty()) {
         return false;
     }
     #[cfg(target_os = "linux")]
     {
-        linux::any_process_cmdline_contains(needle)
+        linux::any_process_cmdline_or_env_contains(needles)
     }
     #[cfg(target_os = "macos")]
     {
-        macos::any_process_cmdline_contains(needle)
+        macos::any_process_cmdline_or_env_contains(needles)
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
@@ -498,17 +506,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn any_process_cmdline_contains_rejects_empty_needle() {
-        assert!(!any_process_cmdline_contains(""));
+    fn any_process_cmdline_or_env_contains_rejects_empty_needles() {
+        assert!(!any_process_cmdline_or_env_contains(&[]));
+        assert!(!any_process_cmdline_or_env_contains(&["", ""]));
     }
 
     /// A live process carrying a unique marker in its argv is found; a marker
     /// no process carries is not. Backs the #2994 orphan guard: the resumed
-    /// agent child carries its session id in argv, so an off-socket orphan is
-    /// still detectable via the process table.
+    /// agent carries its session id in argv, so an off-socket orphan is still
+    /// detectable via the process table.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn any_process_cmdline_contains_detects_live_process_argv() {
+    fn any_process_cmdline_or_env_contains_detects_live_process_argv() {
         let marker = format!("aoe_orphan_scan_marker_{}", std::process::id());
         let absent = format!("aoe_absent_scan_marker_{}", std::process::id());
 
@@ -529,13 +538,13 @@ mod tests {
         // kernel necessarily populates cmdline).
         let mut found = false;
         for _ in 0..100 {
-            if any_process_cmdline_contains(&marker) {
+            if any_process_cmdline_or_env_contains(&[marker.as_str()]) {
                 found = true;
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
         }
-        let absent_result = any_process_cmdline_contains(&absent);
+        let absent_result = any_process_cmdline_or_env_contains(&[absent.as_str()]);
 
         let _ = child.kill();
         let _ = child.wait();
@@ -547,6 +556,47 @@ mod tests {
         assert!(
             !absent_result,
             "a marker no live process carries must not match"
+        );
+    }
+
+    /// The environment signal: a live process with `AOE_INSTANCE_ID=<marker>`
+    /// in its environment is detected even when the marker is absent from argv.
+    /// This is the argv-rewrite-proof identity signal the #2994 guard relies on
+    /// for hook-enabled agents. Linux-only: `/proc/<pid>/environ` is a stable
+    /// probe; macOS `ps -E` env visibility is exercised by the mac CI run of
+    /// the argv test above.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn any_process_cmdline_or_env_contains_detects_env_marker() {
+        let marker = format!("aoe_env_marker_{}", std::process::id());
+
+        // `sleep` keeps the process alive; the marker is only in the env, never
+        // in argv, so a match must come from the environ scan.
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .env("AOE_INSTANCE_ID", &marker)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn env-marker process");
+
+        let env_needle = format!("AOE_INSTANCE_ID={}", marker);
+        let mut found = false;
+        for _ in 0..100 {
+            if any_process_cmdline_or_env_contains(&[env_needle.as_str()]) {
+                found = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            found,
+            "a live process carrying AOE_INSTANCE_ID in its environment must be detected"
         );
     }
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -202,6 +202,34 @@ pub fn get_pane_pid(session_name: &str) -> Option<u32> {
     pid
 }
 
+/// Return `true` if any live process on this host has `needle` as a substring
+/// of its command line (argv). Best-effort: an unreadable process table
+/// returns `false` (callers treat that as "no match found").
+///
+/// Startup recovery uses this to detect an agent session a *prior* recovery
+/// pass already resumed on a tmux server this process can no longer see, e.g.
+/// the socket's `/tmp` dir was wiped mid-crash and the old server was orphaned
+/// (#2994). The resumed agent child carries its `agent_session_id` verbatim in
+/// argv (see `build_resume_flags`), so a live match means "already resumed;
+/// do not duplicate."
+pub fn any_process_cmdline_contains(needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::any_process_cmdline_contains(needle)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::any_process_cmdline_contains(needle)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        false
+    }
+}
+
 /// Get the foreground process group leader PID for a given shell PID
 /// This finds the actual process that has the terminal foreground
 pub fn get_foreground_pid(shell_pid: u32) -> Option<u32> {
@@ -468,6 +496,59 @@ fn signal_process_tree(pid: u32, signal: Signal) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn any_process_cmdline_contains_rejects_empty_needle() {
+        assert!(!any_process_cmdline_contains(""));
+    }
+
+    /// A live process carrying a unique marker in its argv is found; a marker
+    /// no process carries is not. Backs the #2994 orphan guard: the resumed
+    /// agent child carries its session id in argv, so an off-socket orphan is
+    /// still detectable via the process table.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn any_process_cmdline_contains_detects_live_process_argv() {
+        let marker = format!("aoe_orphan_scan_marker_{}", std::process::id());
+        let absent = format!("aoe_absent_scan_marker_{}", std::process::id());
+
+        // The marker rides as `$0` of a `sh` running a compound list, so sh
+        // does not exec-optimize away and stays alive (with the marker in
+        // argv) for the sleep.
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 30; true")
+            .arg(&marker)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn marker process");
+
+        // Poll until the child's argv is observable (spawn returns before the
+        // kernel necessarily populates cmdline).
+        let mut found = false;
+        for _ in 0..100 {
+            if any_process_cmdline_contains(&marker) {
+                found = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let absent_result = any_process_cmdline_contains(&absent);
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            found,
+            "a live process carrying the marker in argv must be detected"
+        );
+        assert!(
+            !absent_result,
+            "a marker no live process carries must not match"
+        );
+    }
 
     /// Restores the pre-test SIGINT/SIGQUIT disposition on drop. `#[serial]`
     /// only keeps these tests from racing each other; it does nothing to

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -202,39 +202,44 @@ pub fn get_pane_pid(session_name: &str) -> Option<u32> {
     pid
 }
 
-/// Return `true` if any live process on this host has one of `needles` as a
-/// substring of its command line (argv) **or** its environment block. Empty
-/// needles are ignored; if none remain the scan is skipped. Best-effort: an
-/// unreadable process table returns `false` (callers treat that as "no match
-/// found").
+/// For a single pass over the process table, decide for each candidate `i`
+/// whether a live process belongs to it. A process belongs to candidate `i`
+/// when an environment *entry* exactly equals `env_needles[i]` (anchored, so a
+/// longer id cannot prefix-collide) **or** the command line contains
+/// `cmdline_needles[i]` (when `Some`). The two slices must have equal length;
+/// the result has one `bool` per candidate. An empty env needle never matches.
+/// Best-effort: an unreadable process table yields all `false`.
 ///
 /// Startup recovery uses this to detect an agent session a *prior* recovery
 /// pass already resumed on a tmux server this process can no longer see, e.g.
 /// the socket's `/tmp` dir was wiped mid-crash and the old server was orphaned
 /// (#2994). Two identity signals are checked so the match survives an agent
-/// that rewrites its own argv/process-title:
+/// that rewrites its own argv or process title:
 /// - `AOE_INSTANCE_ID=<id>` in the agent's environment (aoe-injected for
 ///   hook-enabled agents; `/proc/<pid>/environ` is immune to argv rewrites),
-/// - the `agent_session_id` in the launch command line (universal fallback;
-///   every resume strategy embeds it verbatim, and the host `docker exec` argv
-///   carries it for sandboxed sessions).
+/// - the `agent_session_id` in the launch command line (fallback for non-hook
+///   agents; the host `docker exec` argv carries it for sandboxed sessions).
 ///
-/// A live match means "already resumed; do not duplicate."
-pub fn any_process_cmdline_or_env_contains(needles: &[&str]) -> bool {
-    if needles.iter().all(|n| n.is_empty()) {
-        return false;
+/// Batching keeps this to one `/proc` walk (or one `ps` fork) regardless of
+/// candidate count. Callers on an async runtime must wrap it in
+/// `tokio::task::spawn_blocking`.
+pub fn processes_matching(env_needles: &[String], cmdline_needles: &[Option<String>]) -> Vec<bool> {
+    debug_assert_eq!(env_needles.len(), cmdline_needles.len());
+    let n = env_needles.len().min(cmdline_needles.len());
+    if n == 0 {
+        return Vec::new();
     }
     #[cfg(target_os = "linux")]
     {
-        linux::any_process_cmdline_or_env_contains(needles)
+        linux::processes_matching(&env_needles[..n], &cmdline_needles[..n])
     }
     #[cfg(target_os = "macos")]
     {
-        macos::any_process_cmdline_or_env_contains(needles)
+        macos::processes_matching(&env_needles[..n], &cmdline_needles[..n])
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
-        false
+        vec![false; n]
     }
 }
 
@@ -506,18 +511,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn any_process_cmdline_or_env_contains_rejects_empty_needles() {
-        assert!(!any_process_cmdline_or_env_contains(&[]));
-        assert!(!any_process_cmdline_or_env_contains(&["", ""]));
+    fn processes_matching_empty_input_is_empty() {
+        assert!(processes_matching(&[], &[]).is_empty());
     }
 
-    /// A live process carrying a unique marker in its argv is found; a marker
-    /// no process carries is not. Backs the #2994 orphan guard: the resumed
-    /// agent carries its session id in argv, so an off-socket orphan is still
-    /// detectable via the process table.
+    /// A live process carrying a unique marker in its argv is matched by the
+    /// cmdline needle; a marker no process carries is not. Backs the #2994
+    /// orphan guard's fallback signal for non-hook agents.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn any_process_cmdline_or_env_contains_detects_live_process_argv() {
+    fn processes_matching_detects_live_process_by_cmdline() {
         let marker = format!("aoe_orphan_scan_marker_{}", std::process::id());
         let absent = format!("aoe_absent_scan_marker_{}", std::process::id());
 
@@ -534,58 +537,66 @@ mod tests {
             .spawn()
             .expect("spawn marker process");
 
+        // env slot empty, cmdline slot carries the needle. Two candidates: the
+        // live marker and an absent one, testing both outcomes in one pass.
+        let env = vec![String::new(), String::new()];
+        let cmd = vec![Some(marker.clone()), Some(absent.clone())];
+
         // Poll until the child's argv is observable (spawn returns before the
         // kernel necessarily populates cmdline).
-        let mut found = false;
+        let mut flags = vec![false, false];
         for _ in 0..100 {
-            if any_process_cmdline_or_env_contains(&[marker.as_str()]) {
-                found = true;
+            flags = processes_matching(&env, &cmd);
+            if flags[0] {
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
         }
-        let absent_result = any_process_cmdline_or_env_contains(&[absent.as_str()]);
 
         let _ = child.kill();
         let _ = child.wait();
 
         assert!(
-            found,
-            "a live process carrying the marker in argv must be detected"
+            flags[0],
+            "a live process carrying the marker in argv must match"
         );
-        assert!(
-            !absent_result,
-            "a marker no live process carries must not match"
-        );
+        assert!(!flags[1], "a marker no live process carries must not match");
     }
 
     /// The environment signal: a live process with `AOE_INSTANCE_ID=<marker>`
-    /// in its environment is detected even when the marker is absent from argv.
-    /// This is the argv-rewrite-proof identity signal the #2994 guard relies on
-    /// for hook-enabled agents. Linux-only: `/proc/<pid>/environ` is a stable
-    /// probe; macOS `ps -E` env visibility is exercised by the mac CI run of
-    /// the argv test above.
+    /// in its environment is matched by the anchored env needle even when the
+    /// marker is absent from argv. This is the argv-rewrite-proof identity
+    /// signal the #2994 guard relies on for hook-enabled agents. Linux-only:
+    /// `/proc/<pid>/environ` is a stable probe; macOS `ps -E` env visibility is
+    /// hardening-dependent and not asserted here.
     #[cfg(target_os = "linux")]
     #[test]
-    fn any_process_cmdline_or_env_contains_detects_env_marker() {
+    fn processes_matching_detects_live_process_by_env_entry() {
         let marker = format!("aoe_env_marker_{}", std::process::id());
 
         // `sleep` keeps the process alive; the marker is only in the env, never
         // in argv, so a match must come from the environ scan.
+        let key = crate::tmux::env::AOE_INSTANCE_ID_KEY;
         let mut child = Command::new("sleep")
             .arg("30")
-            .env("AOE_INSTANCE_ID", &marker)
+            .env(key, &marker)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .expect("spawn env-marker process");
 
-        let env_needle = format!("AOE_INSTANCE_ID={}", marker);
+        let env = vec![format!("{key}={marker}")];
+        // A prefix of the real value must NOT match (anchored entry, not prefix).
+        let env_prefix = vec![format!("{key}={}", &marker[..marker.len() - 1])];
+        let cmd = vec![None];
+
         let mut found = false;
+        let mut prefix_hit = true;
         for _ in 0..100 {
-            if any_process_cmdline_or_env_contains(&[env_needle.as_str()]) {
-                found = true;
+            found = processes_matching(&env, &cmd)[0];
+            prefix_hit = processes_matching(&env_prefix, &cmd)[0];
+            if found {
                 break;
             }
             std::thread::sleep(Duration::from_millis(20));
@@ -594,9 +605,10 @@ mod tests {
         let _ = child.kill();
         let _ = child.wait();
 
+        assert!(found, "AOE_INSTANCE_ID in the environment must be matched");
         assert!(
-            found,
-            "a live process carrying AOE_INSTANCE_ID in its environment must be detected"
+            !prefix_hit,
+            "a prefix of the env value must not match (anchored entry, not substring)"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4370,7 +4370,21 @@ async fn daemon_startup_recovery_mark(
                     .get(&session_name)
                     .map(|m| !m.pane_dead)
                     .unwrap_or(false);
-                !has_live_tmux && crate::session::recovery::is_recovery_candidate(i)
+                if has_live_tmux || !crate::session::recovery::is_recovery_candidate(i) {
+                    return false;
+                }
+                // #2994: skip a session already resumed on a tmux server this
+                // daemon can no longer see (orphaned socket), so recovery does
+                // not spawn a duplicate.
+                if crate::session::recovery::orphaned_resume_child_alive(i) {
+                    tracing::info!(
+                        target: "session.startup_recovery",
+                        id = %i.id,
+                        "skipping recovery: agent already resumed on an orphaned tmux server",
+                    );
+                    return false;
+                }
+                true
             })
             .cloned()
             .collect()
@@ -4467,7 +4481,12 @@ async fn daemon_startup_recovery_cascade(
                             .get(&session_name)
                             .map(|m| !m.pane_dead)
                             .unwrap_or(false);
-                        !has_live_tmux && crate::session::recovery::is_recovery_candidate(i)
+                        !has_live_tmux
+                            && crate::session::recovery::is_recovery_candidate(i)
+                            // #2994: re-check the orphan guard under the lock so
+                            // an agent still alive on an invisible tmux server
+                            // is not duplicated by the cascade.
+                            && !crate::session::recovery::orphaned_resume_child_alive(i)
                     })
                     .unwrap_or(false)
             };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4376,27 +4376,49 @@ async fn daemon_startup_recovery_mark(
             .collect()
     };
 
-    // #2994: skip sessions already resumed on a tmux server this daemon can no
-    // longer see (orphaned socket) so recovery does not spawn a duplicate. Done
-    // *after* dropping the `instances` read lock: the process-table scan is
-    // heavy synchronous I/O and must not stall the executor or block REST
-    // writers on the lock.
-    candidates.retain(|i| {
-        if crate::session::recovery::orphaned_agent_process_alive(i) {
-            tracing::info!(
-                target: "session.startup_recovery",
-                id = %i.id,
-                "skipping recovery: agent already alive on an orphaned tmux server",
-            );
-            false
-        } else {
-            true
-        }
-    });
+    // #2994 (deterministic): drop any session already attempted this boot. The
+    // boot-scoped ledger makes startup recovery idempotent per boot for every
+    // agent, so a prior pass that resumed (then whose owner exited) cannot be
+    // duplicated here regardless of whether the orphan is still identifiable.
+    let attempted = crate::session::recovery::recovery_attempted_this_boot();
+    candidates.retain(|i| !attempted.contains(&i.id));
+
+    // #2994 (defense-in-depth): also skip sessions whose agent is positively
+    // still alive on a tmux server this daemon can no longer see (orphaned
+    // socket). The batched process-table scan runs in `spawn_blocking` and only
+    // after the `instances` read lock is dropped, so its heavy synchronous I/O
+    // cannot stall the executor or block REST writers.
+    if !candidates.is_empty() {
+        let scan_input = candidates.clone();
+        let orphan_flags = tokio::task::spawn_blocking(move || {
+            crate::session::recovery::orphaned_agents_alive(&scan_input)
+        })
+        .await
+        .unwrap_or_else(|_| vec![false; candidates.len()]);
+        let mut idx = 0;
+        candidates.retain(|i| {
+            let alive = orphan_flags.get(idx).copied().unwrap_or(false);
+            idx += 1;
+            if alive {
+                tracing::info!(
+                    target: "session.startup_recovery",
+                    id = %i.id,
+                    "skipping recovery: agent already alive on an orphaned tmux server",
+                );
+            }
+            !alive
+        });
+    }
 
     if candidates.is_empty() {
         return None;
     }
+
+    // Record the attempt *before* any worker runs `tmux new-session`, so a
+    // mid-pass crash fails toward "already attempted" for the next pass.
+    crate::session::recovery::mark_recovery_attempted(
+        &candidates.iter().map(|i| i.id.clone()).collect::<Vec<_>>(),
+    );
 
     for inst in &candidates {
         crate::session::recovery::mark_recently_restarted(&state.recently_restarted, &inst.id);
@@ -4489,12 +4511,22 @@ async fn daemon_startup_recovery_cascade(
                     })
                     .cloned()
             };
-            // #2994: re-check the orphan guard *outside* the lock so an agent
-            // still alive on an invisible tmux server is not duplicated by the
-            // cascade, without the process-table scan stalling the executor or
-            // blocking REST writers on the `instances` lock.
-            let still_candidate = match &recheck_inst {
-                Some(inst) => !crate::session::recovery::orphaned_agent_process_alive(inst),
+            // #2994: re-check the orphan guard *outside* the lock and inside
+            // `spawn_blocking` so an agent still alive on an invisible tmux
+            // server is not duplicated by the cascade, without the process-table
+            // scan stalling the executor or blocking REST writers on the
+            // `instances` lock. The boot ledger is intentionally not re-checked
+            // here: Phase A already recorded this id, so re-reading it would
+            // self-skip every candidate.
+            let still_candidate = match recheck_inst {
+                Some(inst) => {
+                    let alive = tokio::task::spawn_blocking(move || {
+                        crate::session::recovery::orphaned_agent_process_alive(&inst)
+                    })
+                    .await
+                    .unwrap_or(false);
+                    !alive
+                }
                 None => false,
             };
             if !still_candidate {
@@ -5531,80 +5563,118 @@ mod tests {
         v.iter().map(|s| s.to_string()).collect()
     }
 
-    /// #2994 wiring test: `daemon_startup_recovery_mark` (Phase A) must EXCLUDE
-    /// a "missing" session from the recovery candidate set when a live process
-    /// already carries that instance's identity (an orphaned agent on a tmux
-    /// server this daemon cannot see), and INCLUDE it when no such process
-    /// exists. This proves the orphan guard is actually consulted in the real
-    /// daemon recovery path, not merely as a standalone predicate. The TUI path
-    /// (`maybe_start_startup_recovery`) gates on the same
-    /// `orphaned_agent_process_alive` call.
+    /// #2994 wiring test for `daemon_startup_recovery_mark` (Phase A). Proves
+    /// the two guards are consulted in the real daemon recovery path, not merely
+    /// as standalone predicates:
     ///
-    /// Deterministic without reproducing the `/tmp`-wipe: the orphan is
-    /// simulated by a live `sleep` carrying `AOE_INSTANCE_ID=<id>` in its
-    /// environment, exactly the marker aoe injects into a resumed agent.
+    /// - **ledger (deterministic):** an id already attempted this boot is
+    ///   excluded, so a second pass cannot duplicate it (the #2994 crash-then-
+    ///   re-run scenario). Covers every agent, needle or not.
+    /// - **process scan (defense-in-depth):** an id whose agent is positively
+    ///   still alive (a live `sleep` carrying `AOE_INSTANCE_ID=<id>`, the marker
+    ///   aoe injects into a resumed agent) is excluded.
+    ///
+    /// Deterministic without reproducing the `/tmp`-wipe. The ledger is isolated
+    /// to a tempdir via `AOE_RECOVERY_ATTEMPT_DIR`, so it never touches real
+    /// user state. The TUI path gates on the same two calls.
     #[tokio::test]
     #[serial_test::serial]
-    async fn daemon_recovery_skips_candidate_with_live_orphan_process() {
+    async fn daemon_recovery_ledger_and_scan_exclude_candidates() {
         if !crate::tmux::is_tmux_available() {
-            eprintln!("skipping daemon_recovery_skips_candidate_with_live_orphan_process: no tmux");
+            eprintln!("skipping daemon_recovery_ledger_and_scan_exclude_candidates: no tmux");
             return;
         }
 
-        // A resume-capable, unarchived session with a valid sid and no live
-        // tmux pane on the isolated test socket: normally a recovery candidate.
+        let ledger_dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var(
+            crate::session::recovery::RECOVERY_ATTEMPT_DIR_ENV,
+            ledger_dir.path(),
+        );
+
         let unique = format!("{:012}", std::process::id());
-        let mut inst = crate::session::Instance::new("orphan-wire", "/tmp/aoe-test-2994");
-        inst.id = format!("wire2994{unique}");
-        inst.agent_session_id = Some(format!("55555555-5555-4555-8555-{unique}"));
-        let inst_id = inst.id.clone();
+        let mut inst_a = crate::session::Instance::new("orphan-wire-a", "/tmp/aoe-test-2994");
+        inst_a.id = format!("wireA{unique}");
+        inst_a.agent_session_id = Some(format!("55555555-5555-4555-8555-{unique}"));
+        let id_a = inst_a.id.clone();
         assert!(
-            crate::session::recovery::is_recovery_candidate(&inst),
+            crate::session::recovery::is_recovery_candidate(&inst_a),
             "precondition: the fixture must be a recovery candidate",
         );
 
-        // Case 1: no orphan process, so the missing session is a candidate.
+        // Pass 1: no orphan, id_a unattempted -> included (and now marked).
         {
-            let state = test_support::build_test_app_state(vec![inst.clone()]);
+            let state = test_support::build_test_app_state(vec![inst_a.clone()]);
             let picked = daemon_startup_recovery_mark(state).await;
             let candidates = picked.map(|(_lock, c)| c).unwrap_or_default();
             assert!(
-                candidates.iter().any(|c| c.id == inst_id),
-                "with no orphan process, the missing session must be a recovery candidate",
+                candidates.iter().any(|c| c.id == id_a),
+                "an unattempted, non-orphaned missing session must be a candidate",
             );
-            // The RecoveryLock guard drops here, freeing it for Case 2.
         }
 
-        // Case 2: a live process carrying this instance's AOE_INSTANCE_ID stands
-        // in for the orphaned agent; the candidate must now be skipped.
-        let env_needle = format!("AOE_INSTANCE_ID={inst_id}");
-        let mut decoy = std::process::Command::new("sleep")
-            .arg("60")
-            .env("AOE_INSTANCE_ID", &inst_id)
+        // Ledger case: with id_a now recorded this boot, a second pass must
+        // exclude it deterministically (only assert when the ledger is active
+        // on this host, i.e. a boot id was resolvable).
+        let ledger_active =
+            crate::session::recovery::recovery_attempted_this_boot().contains(&id_a);
+        if ledger_active {
+            let state = test_support::build_test_app_state(vec![inst_a.clone()]);
+            let picked = daemon_startup_recovery_mark(state).await;
+            let candidates = picked.map(|(_lock, c)| c).unwrap_or_default();
+            assert!(
+                !candidates.iter().any(|c| c.id == id_a),
+                "an id attempted earlier this boot must be excluded (idempotent recovery)",
+            );
+        }
+
+        // Scan case: a distinct id_b (never attempted) whose agent is positively
+        // alive must be excluded by the process scan. Uses a non-hook agent
+        // (opencode) whose sid the decoy carries in argv, so detection goes
+        // through the cross-platform cmdline needle rather than `ps -E` env
+        // visibility, which a hardened macOS can hide (#3006 review).
+        let sid_b = format!("66666666-6666-4666-8666-{unique}");
+        let mut inst_b = crate::session::Instance::new("orphan-wire-b", "/tmp/aoe-test-2994");
+        inst_b.id = format!("wireB{unique}");
+        inst_b.tool = "opencode".to_string();
+        inst_b.agent_session_id = Some(sid_b.clone());
+        let id_b = inst_b.id.clone();
+        assert!(
+            crate::session::recovery::is_recovery_candidate(&inst_b),
+            "precondition: inst_b must be a recovery candidate",
+        );
+
+        // The sid rides as `$0` of a compound-list `sh` so it stays alive with
+        // the sid in argv (visible via plain `ps`, no `-E` needed).
+        let mut decoy = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("sleep 60; true")
+            .arg(&sid_b)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
             .expect("spawn orphan decoy");
 
-        // Wait until the decoy's environment is observable before running
-        // recovery (spawn returns before the kernel populates environ).
+        // Wait until the decoy's argv is observable before running recovery.
         for _ in 0..100 {
-            if crate::process::any_process_cmdline_or_env_contains(&[env_needle.as_str()]) {
+            let flags =
+                crate::process::processes_matching(&[String::new()], &[Some(sid_b.clone())]);
+            if flags.first().copied().unwrap_or(false) {
                 break;
             }
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
 
-        let state = test_support::build_test_app_state(vec![inst.clone()]);
+        let state = test_support::build_test_app_state(vec![inst_b.clone()]);
         let picked = daemon_startup_recovery_mark(state).await;
         let candidates = picked.map(|(_lock, c)| c).unwrap_or_default();
 
         let _ = decoy.kill();
         let _ = decoy.wait();
+        std::env::remove_var(crate::session::recovery::RECOVERY_ATTEMPT_DIR_ENV);
 
         assert!(
-            !candidates.iter().any(|c| c.id == inst_id),
+            !candidates.iter().any(|c| c.id == id_b),
             "a live orphan process must exclude the session from recovery candidates",
         );
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4360,7 +4360,7 @@ async fn daemon_startup_recovery_mark(
         }
     };
 
-    let candidates: Vec<crate::session::Instance> = {
+    let mut candidates: Vec<crate::session::Instance> = {
         let instances = state.instances.read().await;
         instances
             .iter()
@@ -4370,25 +4370,29 @@ async fn daemon_startup_recovery_mark(
                     .get(&session_name)
                     .map(|m| !m.pane_dead)
                     .unwrap_or(false);
-                if has_live_tmux || !crate::session::recovery::is_recovery_candidate(i) {
-                    return false;
-                }
-                // #2994: skip a session already resumed on a tmux server this
-                // daemon can no longer see (orphaned socket), so recovery does
-                // not spawn a duplicate.
-                if crate::session::recovery::orphaned_resume_child_alive(i) {
-                    tracing::info!(
-                        target: "session.startup_recovery",
-                        id = %i.id,
-                        "skipping recovery: agent already resumed on an orphaned tmux server",
-                    );
-                    return false;
-                }
-                true
+                !has_live_tmux && crate::session::recovery::is_recovery_candidate(i)
             })
             .cloned()
             .collect()
     };
+
+    // #2994: skip sessions already resumed on a tmux server this daemon can no
+    // longer see (orphaned socket) so recovery does not spawn a duplicate. Done
+    // *after* dropping the `instances` read lock: the process-table scan is
+    // heavy synchronous I/O and must not stall the executor or block REST
+    // writers on the lock.
+    candidates.retain(|i| {
+        if crate::session::recovery::orphaned_agent_process_alive(i) {
+            tracing::info!(
+                target: "session.startup_recovery",
+                id = %i.id,
+                "skipping recovery: agent already alive on an orphaned tmux server",
+            );
+            false
+        } else {
+            true
+        }
+    });
 
     if candidates.is_empty() {
         return None;
@@ -4470,25 +4474,28 @@ async fn daemon_startup_recovery_cascade(
                     return;
                 }
             };
-            let still_candidate = {
+            let recheck_inst: Option<crate::session::Instance> = {
                 let instances = inst_state.instances.read().await;
                 instances
                     .iter()
                     .find(|i| i.id == id)
-                    .map(|i| {
+                    .filter(|i| {
                         let session_name = crate::tmux::Session::generate_name(&i.id, &i.title);
                         let has_live_tmux = pane_meta
                             .get(&session_name)
                             .map(|m| !m.pane_dead)
                             .unwrap_or(false);
-                        !has_live_tmux
-                            && crate::session::recovery::is_recovery_candidate(i)
-                            // #2994: re-check the orphan guard under the lock so
-                            // an agent still alive on an invisible tmux server
-                            // is not duplicated by the cascade.
-                            && !crate::session::recovery::orphaned_resume_child_alive(i)
+                        !has_live_tmux && crate::session::recovery::is_recovery_candidate(i)
                     })
-                    .unwrap_or(false)
+                    .cloned()
+            };
+            // #2994: re-check the orphan guard *outside* the lock so an agent
+            // still alive on an invisible tmux server is not duplicated by the
+            // cascade, without the process-table scan stalling the executor or
+            // blocking REST writers on the `instances` lock.
+            let still_candidate = match &recheck_inst {
+                Some(inst) => !crate::session::recovery::orphaned_agent_process_alive(inst),
+                None => false,
             };
             if !still_candidate {
                 // Phase A pre-marked this id and seeded recovery_pending;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5531,6 +5531,84 @@ mod tests {
         v.iter().map(|s| s.to_string()).collect()
     }
 
+    /// #2994 wiring test: `daemon_startup_recovery_mark` (Phase A) must EXCLUDE
+    /// a "missing" session from the recovery candidate set when a live process
+    /// already carries that instance's identity (an orphaned agent on a tmux
+    /// server this daemon cannot see), and INCLUDE it when no such process
+    /// exists. This proves the orphan guard is actually consulted in the real
+    /// daemon recovery path, not merely as a standalone predicate. The TUI path
+    /// (`maybe_start_startup_recovery`) gates on the same
+    /// `orphaned_agent_process_alive` call.
+    ///
+    /// Deterministic without reproducing the `/tmp`-wipe: the orphan is
+    /// simulated by a live `sleep` carrying `AOE_INSTANCE_ID=<id>` in its
+    /// environment, exactly the marker aoe injects into a resumed agent.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn daemon_recovery_skips_candidate_with_live_orphan_process() {
+        if !crate::tmux::is_tmux_available() {
+            eprintln!("skipping daemon_recovery_skips_candidate_with_live_orphan_process: no tmux");
+            return;
+        }
+
+        // A resume-capable, unarchived session with a valid sid and no live
+        // tmux pane on the isolated test socket: normally a recovery candidate.
+        let unique = format!("{:012}", std::process::id());
+        let mut inst = crate::session::Instance::new("orphan-wire", "/tmp/aoe-test-2994");
+        inst.id = format!("wire2994{unique}");
+        inst.agent_session_id = Some(format!("55555555-5555-4555-8555-{unique}"));
+        let inst_id = inst.id.clone();
+        assert!(
+            crate::session::recovery::is_recovery_candidate(&inst),
+            "precondition: the fixture must be a recovery candidate",
+        );
+
+        // Case 1: no orphan process, so the missing session is a candidate.
+        {
+            let state = test_support::build_test_app_state(vec![inst.clone()]);
+            let picked = daemon_startup_recovery_mark(state).await;
+            let candidates = picked.map(|(_lock, c)| c).unwrap_or_default();
+            assert!(
+                candidates.iter().any(|c| c.id == inst_id),
+                "with no orphan process, the missing session must be a recovery candidate",
+            );
+            // The RecoveryLock guard drops here, freeing it for Case 2.
+        }
+
+        // Case 2: a live process carrying this instance's AOE_INSTANCE_ID stands
+        // in for the orphaned agent; the candidate must now be skipped.
+        let env_needle = format!("AOE_INSTANCE_ID={inst_id}");
+        let mut decoy = std::process::Command::new("sleep")
+            .arg("60")
+            .env("AOE_INSTANCE_ID", &inst_id)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn orphan decoy");
+
+        // Wait until the decoy's environment is observable before running
+        // recovery (spawn returns before the kernel populates environ).
+        for _ in 0..100 {
+            if crate::process::any_process_cmdline_or_env_contains(&[env_needle.as_str()]) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let state = test_support::build_test_app_state(vec![inst.clone()]);
+        let picked = daemon_startup_recovery_mark(state).await;
+        let candidates = picked.map(|(_lock, c)| c).unwrap_or_default();
+
+        let _ = decoy.kill();
+        let _ = decoy.wait();
+
+        assert!(
+            !candidates.iter().any(|c| c.id == inst_id),
+            "a live orphan process must exclude the session from recovery candidates",
+        );
+    }
+
     #[derive(Default)]
     struct MockInhibitState {
         acquires: u32,

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -134,6 +134,41 @@ pub fn is_recovery_candidate(inst: &Instance) -> bool {
         && should_attempt_resume(inst.agent_session_id.as_deref(), &inst.tool)
 }
 
+/// Minimum `agent_session_id` length before it is trusted as a process-argv
+/// needle. Real agent session ids are long (16 hex chars for claude, 36 for a
+/// UUID); a needle this short cannot collide with an unrelated command line by
+/// accident, and refusing shorter ids keeps a pathological 1-3 char id from
+/// matching half the process table.
+const ORPHAN_SCAN_MIN_SID_LEN: usize = 8;
+
+/// Guard against the sequential-recovery duplication in #2994.
+///
+/// A prior recovery pass may have resumed this instance on a tmux server that
+/// this process can no longer see: on a mid-crash `/tmp` wipe (WSL2) the
+/// server's socket file is unlinked, orphaning the still-running server, and a
+/// later pass resolving a fresh default socket observes the session as
+/// "missing" (`has_live_tmux_pane()` is false) and would recreate it,
+/// orphaning the first batch's `--resume` children.
+///
+/// Before recreating a "missing" session, this checks the OS process table for
+/// a live process already carrying the instance's `agent_session_id` in its
+/// argv (every resume strategy embeds the id verbatim; see
+/// `build_resume_flags`). A match means the agent is alive on a tmux server we
+/// cannot see, so recovery must skip it rather than duplicate it.
+///
+/// Returns `false` (allow recovery) when the instance has no id, the id is too
+/// short to trust as a needle, or no matching live process exists — including
+/// the genuine post-reboot case, where the agent processes are gone.
+pub fn orphaned_resume_child_alive(inst: &Instance) -> bool {
+    let Some(sid) = inst.agent_session_id.as_deref() else {
+        return false;
+    };
+    if sid.len() < ORPHAN_SCAN_MIN_SID_LEN || !super::capture::is_valid_session_id(sid) {
+        return false;
+    }
+    crate::process::any_process_cmdline_contains(sid)
+}
+
 /// Warm up the tmux server so that the first concurrent `new-session` from
 /// recovery workers does not race the server's cold start. On macOS post-reboot,
 /// tmux is not running until the first client connects; without this warm-up,
@@ -671,6 +706,81 @@ mod tests {
         assert!(
             is_recovery_candidate(&inst),
             "expired snooze must restore recovery eligibility"
+        );
+    }
+
+    /// #2994 orphan guard: cheap rejections that never touch the process
+    /// table. No session id, or an id too short to trust as a needle, must
+    /// return `false` so genuine recovery proceeds.
+    #[test]
+    fn orphaned_resume_child_alive_rejects_missing_or_short_sid() {
+        let mut inst = Instance::new("no-sid", "/tmp/test");
+        inst.agent_session_id = None;
+        assert!(
+            !orphaned_resume_child_alive(&inst),
+            "no session id must allow recovery",
+        );
+
+        inst.agent_session_id = Some("short".into());
+        assert!(
+            !orphaned_resume_child_alive(&inst),
+            "a sub-{ORPHAN_SCAN_MIN_SID_LEN}-char id must not be trusted as a needle",
+        );
+    }
+
+    /// A valid, long session id that no live process carries returns `false`
+    /// (the genuine post-reboot case: the agent processes are gone).
+    #[test]
+    fn orphaned_resume_child_alive_false_when_no_process_matches() {
+        let mut inst = Instance::new("absent", "/tmp/test");
+        inst.agent_session_id = Some(format!(
+            "11111111-1111-4111-8111-{:012}",
+            std::process::id()
+        ));
+        assert!(
+            !orphaned_resume_child_alive(&inst),
+            "no matching live process must allow recovery",
+        );
+    }
+
+    /// End-to-end #2994: an agent process still alive off-socket (its session
+    /// id present in a live process's argv) is detected, so recovery skips it
+    /// instead of spawning a duplicate.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn orphaned_resume_child_alive_detects_live_agent_by_sid() {
+        let sid = format!("22222222-2222-4222-8222-{:012}", std::process::id());
+        let mut inst = Instance::new("orphan", "/tmp/test");
+        inst.agent_session_id = Some(sid.clone());
+
+        // Stand in for the orphaned `<agent> --resume <sid>` child: the sid
+        // rides as `$0` of a compound-list `sh` so it stays alive with the id
+        // in argv.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("sleep 30; true")
+            .arg(&sid)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn orphan-agent stand-in");
+
+        let mut detected = false;
+        for _ in 0..100 {
+            if orphaned_resume_child_alive(&inst) {
+                detected = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            detected,
+            "a live agent process carrying the sid must be detected as an orphan",
         );
     }
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -135,13 +135,63 @@ pub fn is_recovery_candidate(inst: &Instance) -> bool {
 }
 
 /// Minimum `agent_session_id` length before it is trusted as a process-argv
-/// needle. Real agent session ids are long (16 hex chars for claude, 36 for a
-/// UUID); a needle this short cannot collide with an unrelated command line by
-/// accident, and refusing shorter ids keeps a pathological 1-3 char id from
-/// matching half the process table.
+/// needle. This fallback signal is used only for non-hook agents (hook agents
+/// match on the anchored `AOE_INSTANCE_ID` env entry instead). Real sids are
+/// long (16 hex for claude, 36 for a UUID); refusing shorter ids keeps a
+/// pathological 1-3 char id from matching an unrelated command line.
 const ORPHAN_SCAN_MIN_SID_LEN: usize = 8;
 
-/// Guard against the sequential-recovery duplication in #2994.
+/// True when aoe injects `AOE_INSTANCE_ID` into this agent's environment. Gated
+/// on the same hook presence as `status_hook_env_prefix`, so it tracks exactly
+/// the agents whose live process carries the anchored env marker.
+fn agent_injects_instance_id_env(tool: &str) -> bool {
+    crate::agents::get_agent(tool)
+        .is_some_and(|a| a.hook_config.is_some() || a.sidecar_hooks.is_some())
+}
+
+/// The identity needles used to detect a live agent process for `inst`: the
+/// anchored `AOE_INSTANCE_ID=<id>` env entry, and (only for non-hook agents)
+/// the `agent_session_id` as a command-line needle.
+///
+/// Hook agents deliberately do *not* use the sid needle: a live
+/// `claude --resume <parent_sid> --fork-session` child carries the *parent's*
+/// sid in its argv, so a bare-sid match could let a fork-child suppress the
+/// parent's recovery (#3006 review). The env marker names the exact instance,
+/// so it has no such collision.
+pub fn orphan_needles(inst: &Instance) -> (String, Option<String>) {
+    let env = if inst.id.is_empty() {
+        String::new()
+    } else {
+        format!("{}={}", crate::tmux::env::AOE_INSTANCE_ID_KEY, inst.id)
+    };
+    let cmdline = if agent_injects_instance_id_env(&inst.tool) {
+        None
+    } else {
+        inst.agent_session_id
+            .as_deref()
+            .filter(|sid| {
+                sid.len() >= ORPHAN_SCAN_MIN_SID_LEN && super::capture::is_valid_session_id(sid)
+            })
+            .map(str::to_string)
+    };
+    (env, cmdline)
+}
+
+/// Batched orphan check: one process-table walk deciding, for each instance,
+/// whether a live agent process belongs to it. See [`orphaned_agent_process_alive`]
+/// for the rationale; this is the form the recovery paths use so N candidates
+/// cost one `/proc` walk (or one `ps` fork), and the callers wrap it in
+/// `tokio::task::spawn_blocking`.
+pub fn orphaned_agents_alive(insts: &[Instance]) -> Vec<bool> {
+    if insts.is_empty() {
+        return Vec::new();
+    }
+    let (env, cmdline): (Vec<String>, Vec<Option<String>>) =
+        insts.iter().map(orphan_needles).unzip();
+    crate::process::processes_matching(&env, &cmdline)
+}
+
+/// Defense-in-depth guard against the sequential-recovery duplication in #2994.
 ///
 /// A prior recovery pass may have resumed this instance on a tmux server that
 /// this process can no longer see: on a mid-crash `/tmp` wipe (WSL2) the
@@ -153,41 +203,145 @@ const ORPHAN_SCAN_MIN_SID_LEN: usize = 8;
 /// and therefore any `tmux` query, is gone), and it is host-local, so unlike a
 /// persisted PID it is safe under a `sessions.json` synced across hosts.
 ///
-/// Before recreating a "missing" session, this checks the process table for a
-/// live agent process belonging to this instance, using two identity signals:
-///
-/// - `AOE_INSTANCE_ID=<id>` in the process environment. aoe injects this for
-///   hook-enabled agents (claude, codex, ...), and `/proc/<pid>/environ` is
-///   immune to an agent that rewrites its own argv/process-title, so it is the
-///   sturdier signal where available.
-/// - the `agent_session_id` in the launch command line. Universal fallback for
-///   agents without hooks; every resume strategy embeds the sid verbatim (see
-///   `build_resume_flags`), and the host `docker exec` argv carries it for
-///   sandboxed sessions.
-///
 /// A match means the agent is alive on a tmux server we cannot see, so recovery
 /// skips it rather than duplicate it. Returns `false` (allow recovery) when no
-/// live process matches — including the genuine post-reboot case, where the
-/// agent processes are gone.
+/// live process matches, including the genuine post-reboot case where the agent
+/// processes are gone. This positively identifies live orphans; the boot-scoped
+/// [`mark_recovery_attempted`] ledger is the deterministic backstop that also
+/// covers agents with no usable identity needle.
 ///
-/// Callers must invoke this *outside* any async lock: it walks the process
-/// table (a `/proc` scan on Linux, a `ps` fork on macOS) and would otherwise
-/// stall the executor and every task contending the lock.
+/// Callers on an async runtime must invoke this inside `spawn_blocking`: it
+/// walks the process table and would otherwise stall the executor.
 pub fn orphaned_agent_process_alive(inst: &Instance) -> bool {
-    if inst.id.is_empty() {
-        return false;
-    }
-    let env_needle = format!("{}={}", crate::tmux::env::AOE_INSTANCE_ID_KEY, inst.id);
-    let mut needles: Vec<&str> = vec![env_needle.as_str()];
+    orphaned_agents_alive(std::slice::from_ref(inst))
+        .first()
+        .copied()
+        .unwrap_or(false)
+}
 
-    let sid = inst.agent_session_id.as_deref().filter(|sid| {
-        sid.len() >= ORPHAN_SCAN_MIN_SID_LEN && super::capture::is_valid_session_id(sid)
-    });
-    if let Some(sid) = sid {
-        needles.push(sid);
-    }
+/// Env override for the recovery-attempt ledger directory, so tests isolate it
+/// from real user state. Honored in all builds, mirroring `AOE_TMUX_SOCKET`.
+pub const RECOVERY_ATTEMPT_DIR_ENV: &str = "AOE_RECOVERY_ATTEMPT_DIR";
 
-    crate::process::any_process_cmdline_or_env_contains(&needles)
+/// Directory holding the per-boot recovery-attempt ledgers, or `None` if the
+/// app dir cannot be resolved.
+fn recovery_attempt_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os(RECOVERY_ATTEMPT_DIR_ENV) {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    super::get_app_dir()
+        .ok()
+        .map(|d| d.join("recovery_attempts"))
+}
+
+/// Host boot identity, used to scope the recovery-attempt ledger to the current
+/// boot so a reboot (which genuinely kills every agent process) resets it and
+/// post-reboot recovery runs. Linux reads `/proc/sys/kernel/random/boot_id`;
+/// macOS uses `kern.boottime`. `None` disables the ledger (recovery falls back
+/// to the process-scan guard alone), which is safe: the scan still prevents
+/// duplication for identifiable agents.
+fn boot_id() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("sysctl")
+            .args(["-n", "kern.boottime"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+/// Path to the current boot's ledger file, or `None` if the app dir or boot id
+/// is unavailable. The boot id is reduced to a filesystem-safe filename.
+fn recovery_ledger_path() -> Option<PathBuf> {
+    let dir = recovery_attempt_dir()?;
+    let boot = boot_id()?;
+    let safe: String = boot
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    Some(dir.join(safe))
+}
+
+/// Instance ids for which a startup-recovery attempt has already been recorded
+/// this boot. Recovery filters these out so a session is attempted at most once
+/// per boot, which deterministically prevents the #2994 sequential duplication
+/// for *every* agent (including those with no usable process-scan needle).
+/// Empty when the ledger is unavailable or unreadable (fail open to the scan).
+pub fn recovery_attempted_this_boot() -> std::collections::HashSet<String> {
+    let mut set = std::collections::HashSet::new();
+    if let Some(path) = recovery_ledger_path() {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            for line in content.lines() {
+                let id = line.trim();
+                if !id.is_empty() {
+                    set.insert(id.to_string());
+                }
+            }
+        }
+    }
+    set
+}
+
+/// Record that a startup-recovery attempt is being made for each id in `ids`,
+/// this boot. Called *before* the cascade creates any tmux session, so a
+/// mid-pass crash fails toward "already attempted, do not duplicate" rather
+/// than "no record, recreate". Best-effort (an unwritable app dir is ignored);
+/// also GCs ledgers from prior boots so the directory stays bounded.
+pub fn mark_recovery_attempted(ids: &[String]) {
+    if ids.is_empty() {
+        return;
+    }
+    let Some(path) = recovery_ledger_path() else {
+        return;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+        gc_stale_boot_ledgers(dir, path.file_name());
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        use std::io::Write;
+        for id in ids {
+            let _ = writeln!(file, "{id}");
+        }
+    }
+}
+
+/// Remove ledger files for boots other than the current one. Best-effort.
+fn gc_stale_boot_ledgers(dir: &Path, keep: Option<&std::ffi::OsStr>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if Some(entry.file_name().as_os_str()) != keep {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// Warm up the tmux server so that the first concurrent `new-session` from
@@ -744,6 +898,8 @@ mod tests {
             "no matching live process (no sid) must allow recovery",
         );
 
+        // Non-hook agent so the sid needle is actually built and tested absent.
+        inst.tool = "opencode".to_string();
         inst.agent_session_id = Some(format!(
             "11111111-1111-4111-8111-{:012}",
             std::process::id()
@@ -755,11 +911,13 @@ mod tests {
     }
 
     /// A too-short session id is not trusted as a cmdline needle; with no live
-    /// process carrying the env id either, the guard returns `false`.
+    /// process carrying the env id either, the guard returns `false`. Uses a
+    /// non-hook agent so the sid path (not the env marker) is exercised.
     #[test]
     fn orphaned_agent_process_alive_ignores_short_sid() {
         let mut inst = Instance::new("short-sid", "/tmp/test");
         inst.id = format!("shortsid{:012}", std::process::id());
+        inst.tool = "opencode".to_string();
         inst.agent_session_id = Some("short".into());
         assert!(
             !orphaned_agent_process_alive(&inst),
@@ -767,14 +925,16 @@ mod tests {
         );
     }
 
-    /// End-to-end #2994: an agent still alive off-socket, detected by the
-    /// `agent_session_id` in a live process's argv, so recovery skips it.
+    /// End-to-end #2994: a *non-hook* agent still alive off-socket, detected by
+    /// the `agent_session_id` in a live process's argv (hook agents match on
+    /// the env marker instead; see the fork-collision rationale).
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn orphaned_agent_process_alive_detects_live_agent_by_sid() {
         let sid = format!("22222222-2222-4222-8222-{:012}", std::process::id());
         let mut inst = Instance::new("orphan-sid", "/tmp/test");
         inst.id = format!("orphansid{:012}", std::process::id());
+        inst.tool = "opencode".to_string();
         inst.agent_session_id = Some(sid.clone());
 
         // Stand in for the orphaned `<agent> --resume <sid>` child: the sid
@@ -821,7 +981,7 @@ mod tests {
 
         let mut child = std::process::Command::new("sleep")
             .arg("30")
-            .env("AOE_INSTANCE_ID", &inst.id)
+            .env(crate::tmux::env::AOE_INSTANCE_ID_KEY, &inst.id)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
@@ -844,6 +1004,41 @@ mod tests {
             detected,
             "a live agent carrying AOE_INSTANCE_ID in its env must be detected as an orphan",
         );
+    }
+
+    /// The boot-scoped ledger round-trips: a marked id is reported attempted,
+    /// an unmarked id is not. Isolated to a tempdir via the env override so it
+    /// never touches real user state. `#[serial]` because the override is a
+    /// process-global env var.
+    #[test]
+    #[serial_test::serial]
+    fn recovery_attempt_ledger_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var(RECOVERY_ATTEMPT_DIR_ENV, dir.path());
+        if boot_id().is_none() {
+            std::env::remove_var(RECOVERY_ATTEMPT_DIR_ENV);
+            return; // ledger disabled on this host; nothing to assert
+        }
+
+        let id = format!("ledger{:012}", std::process::id());
+        let other = format!("other{:012}", std::process::id());
+        assert!(
+            !recovery_attempted_this_boot().contains(&id),
+            "fresh ledger must not report an unmarked id",
+        );
+
+        mark_recovery_attempted(std::slice::from_ref(&id));
+        let attempted = recovery_attempted_this_boot();
+        assert!(
+            attempted.contains(&id),
+            "a marked id must be reported attempted"
+        );
+        assert!(
+            !attempted.contains(&other),
+            "an unmarked id must not appear"
+        );
+
+        std::env::remove_var(RECOVERY_ATTEMPT_DIR_ENV);
     }
 
     #[test]

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -148,25 +148,46 @@ const ORPHAN_SCAN_MIN_SID_LEN: usize = 8;
 /// server's socket file is unlinked, orphaning the still-running server, and a
 /// later pass resolving a fresh default socket observes the session as
 /// "missing" (`has_live_tmux_pane()` is false) and would recreate it,
-/// orphaning the first batch's `--resume` children.
+/// orphaning the first batch's agent processes. After a socket loss the OS
+/// process table is the *only* source of truth that survives (the socket file,
+/// and therefore any `tmux` query, is gone), and it is host-local, so unlike a
+/// persisted PID it is safe under a `sessions.json` synced across hosts.
 ///
-/// Before recreating a "missing" session, this checks the OS process table for
-/// a live process already carrying the instance's `agent_session_id` in its
-/// argv (every resume strategy embeds the id verbatim; see
-/// `build_resume_flags`). A match means the agent is alive on a tmux server we
-/// cannot see, so recovery must skip it rather than duplicate it.
+/// Before recreating a "missing" session, this checks the process table for a
+/// live agent process belonging to this instance, using two identity signals:
 ///
-/// Returns `false` (allow recovery) when the instance has no id, the id is too
-/// short to trust as a needle, or no matching live process exists — including
-/// the genuine post-reboot case, where the agent processes are gone.
-pub fn orphaned_resume_child_alive(inst: &Instance) -> bool {
-    let Some(sid) = inst.agent_session_id.as_deref() else {
-        return false;
-    };
-    if sid.len() < ORPHAN_SCAN_MIN_SID_LEN || !super::capture::is_valid_session_id(sid) {
+/// - `AOE_INSTANCE_ID=<id>` in the process environment. aoe injects this for
+///   hook-enabled agents (claude, codex, ...), and `/proc/<pid>/environ` is
+///   immune to an agent that rewrites its own argv/process-title, so it is the
+///   sturdier signal where available.
+/// - the `agent_session_id` in the launch command line. Universal fallback for
+///   agents without hooks; every resume strategy embeds the sid verbatim (see
+///   `build_resume_flags`), and the host `docker exec` argv carries it for
+///   sandboxed sessions.
+///
+/// A match means the agent is alive on a tmux server we cannot see, so recovery
+/// skips it rather than duplicate it. Returns `false` (allow recovery) when no
+/// live process matches — including the genuine post-reboot case, where the
+/// agent processes are gone.
+///
+/// Callers must invoke this *outside* any async lock: it walks the process
+/// table (a `/proc` scan on Linux, a `ps` fork on macOS) and would otherwise
+/// stall the executor and every task contending the lock.
+pub fn orphaned_agent_process_alive(inst: &Instance) -> bool {
+    if inst.id.is_empty() {
         return false;
     }
-    crate::process::any_process_cmdline_contains(sid)
+    let env_needle = format!("{}={}", crate::tmux::env::AOE_INSTANCE_ID_KEY, inst.id);
+    let mut needles: Vec<&str> = vec![env_needle.as_str()];
+
+    let sid = inst.agent_session_id.as_deref().filter(|sid| {
+        sid.len() >= ORPHAN_SCAN_MIN_SID_LEN && super::capture::is_valid_session_id(sid)
+    });
+    if let Some(sid) = sid {
+        needles.push(sid);
+    }
+
+    crate::process::any_process_cmdline_or_env_contains(&needles)
 }
 
 /// Warm up the tmux server so that the first concurrent `new-session` from
@@ -709,48 +730,51 @@ mod tests {
         );
     }
 
-    /// #2994 orphan guard: cheap rejections that never touch the process
-    /// table. No session id, or an id too short to trust as a needle, must
-    /// return `false` so genuine recovery proceeds.
+    /// A valid, long session id that no live process carries returns `false`
+    /// (the genuine post-reboot case: the agent processes are gone). Also
+    /// covers the no-sid path, where only the `AOE_INSTANCE_ID` env needle is
+    /// scanned and no live process carries this synthetic id.
     #[test]
-    fn orphaned_resume_child_alive_rejects_missing_or_short_sid() {
-        let mut inst = Instance::new("no-sid", "/tmp/test");
+    fn orphaned_agent_process_alive_false_when_no_process_matches() {
+        let mut inst = Instance::new("absent", "/tmp/test");
+        inst.id = format!("absent{:012}", std::process::id());
         inst.agent_session_id = None;
         assert!(
-            !orphaned_resume_child_alive(&inst),
-            "no session id must allow recovery",
+            !orphaned_agent_process_alive(&inst),
+            "no matching live process (no sid) must allow recovery",
         );
 
-        inst.agent_session_id = Some("short".into());
-        assert!(
-            !orphaned_resume_child_alive(&inst),
-            "a sub-{ORPHAN_SCAN_MIN_SID_LEN}-char id must not be trusted as a needle",
-        );
-    }
-
-    /// A valid, long session id that no live process carries returns `false`
-    /// (the genuine post-reboot case: the agent processes are gone).
-    #[test]
-    fn orphaned_resume_child_alive_false_when_no_process_matches() {
-        let mut inst = Instance::new("absent", "/tmp/test");
         inst.agent_session_id = Some(format!(
             "11111111-1111-4111-8111-{:012}",
             std::process::id()
         ));
         assert!(
-            !orphaned_resume_child_alive(&inst),
+            !orphaned_agent_process_alive(&inst),
             "no matching live process must allow recovery",
         );
     }
 
-    /// End-to-end #2994: an agent process still alive off-socket (its session
-    /// id present in a live process's argv) is detected, so recovery skips it
-    /// instead of spawning a duplicate.
+    /// A too-short session id is not trusted as a cmdline needle; with no live
+    /// process carrying the env id either, the guard returns `false`.
+    #[test]
+    fn orphaned_agent_process_alive_ignores_short_sid() {
+        let mut inst = Instance::new("short-sid", "/tmp/test");
+        inst.id = format!("shortsid{:012}", std::process::id());
+        inst.agent_session_id = Some("short".into());
+        assert!(
+            !orphaned_agent_process_alive(&inst),
+            "a sub-{ORPHAN_SCAN_MIN_SID_LEN}-char sid must not be trusted, and nothing else matches",
+        );
+    }
+
+    /// End-to-end #2994: an agent still alive off-socket, detected by the
+    /// `agent_session_id` in a live process's argv, so recovery skips it.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn orphaned_resume_child_alive_detects_live_agent_by_sid() {
+    fn orphaned_agent_process_alive_detects_live_agent_by_sid() {
         let sid = format!("22222222-2222-4222-8222-{:012}", std::process::id());
-        let mut inst = Instance::new("orphan", "/tmp/test");
+        let mut inst = Instance::new("orphan-sid", "/tmp/test");
+        inst.id = format!("orphansid{:012}", std::process::id());
         inst.agent_session_id = Some(sid.clone());
 
         // Stand in for the orphaned `<agent> --resume <sid>` child: the sid
@@ -768,7 +792,7 @@ mod tests {
 
         let mut detected = false;
         for _ in 0..100 {
-            if orphaned_resume_child_alive(&inst) {
+            if orphaned_agent_process_alive(&inst) {
                 detected = true;
                 break;
             }
@@ -780,7 +804,45 @@ mod tests {
 
         assert!(
             detected,
-            "a live agent process carrying the sid must be detected as an orphan",
+            "a live agent carrying the sid in argv must be detected as an orphan",
+        );
+    }
+
+    /// End-to-end #2994, argv-rewrite-proof path: an agent whose sid is absent
+    /// from argv is still detected via the `AOE_INSTANCE_ID` env marker aoe
+    /// injects for hook agents. Linux-only (stable `/proc/<pid>/environ`).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn orphaned_agent_process_alive_detects_live_agent_by_env_marker() {
+        let mut inst = Instance::new("orphan-env", "/tmp/test");
+        inst.id = format!("orphanenv{:012}", std::process::id());
+        // No sid at all: the only identity signal is the env marker.
+        inst.agent_session_id = None;
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .env("AOE_INSTANCE_ID", &inst.id)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn env-marker orphan stand-in");
+
+        let mut detected = false;
+        for _ in 0..100 {
+            if orphaned_agent_process_alive(&inst) {
+                detected = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            detected,
+            "a live agent carrying AOE_INSTANCE_ID in its env must be detected as an orphan",
         );
     }
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -212,6 +212,11 @@ pub fn orphaned_agents_alive(insts: &[Instance]) -> Vec<bool> {
 ///
 /// Callers on an async runtime must invoke this inside `spawn_blocking`: it
 /// walks the process table and would otherwise stall the executor.
+///
+/// The TUI path scans in a batch via [`orphaned_agents_alive`], so this
+/// single-instance convenience is compiled only where it is actually used: the
+/// serve-gated daemon Phase B re-check and the unit tests.
+#[cfg(any(feature = "serve", test))]
 pub fn orphaned_agent_process_alive(inst: &Instance) -> bool {
     orphaned_agents_alive(std::slice::from_ref(inst))
         .first()

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3680,11 +3680,13 @@ impl HomeView {
             // tmux server this process can no longer see (its socket dir was
             // wiped mid-crash). If the agent is still alive off-socket, skip
             // it rather than spawn a duplicate that orphans the first batch.
-            if crate::session::recovery::orphaned_resume_child_alive(inst) {
+            // This TUI path is synchronous (no async lock to stall), so the
+            // process-table scan runs inline.
+            if crate::session::recovery::orphaned_agent_process_alive(inst) {
                 tracing::info!(
                     target: "session.startup_recovery",
                     id = %inst.id,
-                    "skipping recovery: agent already resumed on an orphaned tmux server",
+                    "skipping recovery: agent already alive on an orphaned tmux server",
                 );
                 continue;
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3676,6 +3676,18 @@ impl HomeView {
             if !crate::session::recovery::is_recovery_candidate(inst) {
                 continue;
             }
+            // #2994: a prior recovery pass may have resumed this session on a
+            // tmux server this process can no longer see (its socket dir was
+            // wiped mid-crash). If the agent is still alive off-socket, skip
+            // it rather than spawn a duplicate that orphans the first batch.
+            if crate::session::recovery::orphaned_resume_child_alive(inst) {
+                tracing::info!(
+                    target: "session.startup_recovery",
+                    id = %inst.id,
+                    "skipping recovery: agent already resumed on an orphaned tmux server",
+                );
+                continue;
+            }
             // Set Status::Starting AND last_start_time: the existing 3s
             // grace at `update_status_with_metadata_inner` only fires on
             // the latter, and without it the TUI's StatusPoller (every

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3664,50 +3664,69 @@ impl HomeView {
                 return;
             }
         };
-        for inst in self.instances.values_mut() {
-            let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-            let has_live_tmux = pane_meta
-                .get(&session_name)
-                .map(|m| !m.pane_dead)
-                .unwrap_or(false);
-            if has_live_tmux {
-                continue;
-            }
-            if !crate::session::recovery::is_recovery_candidate(inst) {
-                continue;
-            }
-            // #2994: a prior recovery pass may have resumed this session on a
-            // tmux server this process can no longer see (its socket dir was
-            // wiped mid-crash). If the agent is still alive off-socket, skip
-            // it rather than spawn a duplicate that orphans the first batch.
-            // This TUI path is synchronous (no async lock to stall), so the
-            // process-table scan runs inline.
-            if crate::session::recovery::orphaned_agent_process_alive(inst) {
+        // Pass 1: eligible = missing tmux pane + recovery candidate + not
+        // already attempted this boot. The boot-scoped ledger (#2994) makes
+        // startup recovery idempotent per boot for every agent, so a session a
+        // prior pass already resumed (before its owner exited) is never
+        // recreated here.
+        let attempted = crate::session::recovery::recovery_attempted_this_boot();
+        let eligible: Vec<crate::session::Instance> = self
+            .instances
+            .values()
+            .filter(|inst| {
+                let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+                let has_live_tmux = pane_meta
+                    .get(&session_name)
+                    .map(|m| !m.pane_dead)
+                    .unwrap_or(false);
+                !has_live_tmux
+                    && crate::session::recovery::is_recovery_candidate(inst)
+                    && !attempted.contains(&inst.id)
+            })
+            .cloned()
+            .collect();
+
+        // #2994 (defense-in-depth): one batched process-table walk drops any
+        // session whose agent is positively still alive on a tmux server this
+        // process can no longer see (its socket dir was wiped mid-crash).
+        let orphan_flags = crate::session::recovery::orphaned_agents_alive(&eligible);
+
+        // Pass 2: commit the survivors.
+        for (idx, elig) in eligible.iter().enumerate() {
+            if orphan_flags.get(idx).copied().unwrap_or(false) {
                 tracing::info!(
                     target: "session.startup_recovery",
-                    id = %inst.id,
+                    id = %elig.id,
                     "skipping recovery: agent already alive on an orphaned tmux server",
                 );
                 continue;
             }
-            // Set Status::Starting AND last_start_time: the existing 3s
-            // grace at `update_status_with_metadata_inner` only fires on
-            // the latter, and without it the TUI's StatusPoller (every
-            // 500ms) would observe missing tmux + no last_start_time and
-            // immediately flip the status to `Error` before the worker
-            // has finished its cascade.
-            debug_assert!(inst.status != crate::session::Status::Creating);
-            inst.status = crate::session::Status::Starting;
-            inst.last_error = None;
-            inst.last_start_time = Some(std::time::Instant::now());
-            self.recovery_in_flight.insert(inst.id.clone());
-            candidates.push(inst.clone());
+            if let Some(inst) = self.instances.get_mut(&elig.id) {
+                // Set Status::Starting AND last_start_time: the existing 3s
+                // grace at `update_status_with_metadata_inner` only fires on
+                // the latter, and without it the TUI's StatusPoller (every
+                // 500ms) would observe missing tmux + no last_start_time and
+                // immediately flip the status to `Error` before the worker
+                // has finished its cascade.
+                debug_assert!(inst.status != crate::session::Status::Creating);
+                inst.status = crate::session::Status::Starting;
+                inst.last_error = None;
+                inst.last_start_time = Some(std::time::Instant::now());
+                self.recovery_in_flight.insert(inst.id.clone());
+                candidates.push(inst.clone());
+            }
         }
 
         if candidates.is_empty() {
             drop(lock);
             return;
         }
+
+        // Record the attempt before any worker runs `tmux new-session`, so a
+        // mid-pass crash fails toward "already attempted" for the next pass.
+        crate::session::recovery::mark_recovery_attempted(
+            &candidates.iter().map(|i| i.id.clone()).collect::<Vec<_>>(),
+        );
 
         crate::session::recovery::warm_tmux_server();
 


### PR DESCRIPTION
## Description

Fixes #2994.

Startup session recovery decided candidacy entirely from **live tmux state on the one socket this process resolves to**, with nothing durable recording that an instance had already been resumed. Release builds use tmux's default socket (`/tmp/tmux-<uid>/default`). When that socket directory is wiped mid-crash (observed on WSL2 during a host resource crunch), the prior recovery pass's tmux server is orphaned and invisible; a later, independent pass (TUI or daemon, minutes later, well outside any lock window) finds every session "missing" by its own bookkeeping and re-resumes them. That orphans the first batch's agent processes (4.52GB RSS in the report).

The recovery `flock` only serializes *concurrent* passes. It says nothing about whether a prior pass's work outlived its owner, which is the *sequential* case this bug is about.

### Fix

Two layers, following review on this PR:

**1. Deterministic backstop: a host-local, boot-scoped recovery-attempt ledger.** Before the cascade runs `tmux new-session`, recovery records each candidate id in a ledger keyed by the host boot id (`/proc/sys/kernel/random/boot_id` on Linux, `kern.boottime` on macOS), under the app dir. A later pass drops any id already attempted this boot, so startup recovery is idempotent per boot for **every** agent, regardless of whether its live process is identifiable. A reboot (which genuinely kills every agent) changes the boot id and re-enables recovery. This is the durable fix that closes the window even for agents with no usable process-scan needle.

**2. Defense-in-depth: a live-orphan process scan.** On top of the ledger, before recreating a "missing" session, one batched process-table walk checks whether the agent is positively still alive on a tmux server this process cannot see, using two identity signals:
- `AOE_INSTANCE_ID=<id>` matched as an anchored environment *entry* (aoe injects it for hook agents; `/proc/<pid>/environ` survives an agent rewriting its own argv).
- the `agent_session_id` in the command line, for non-hook agents (the host `docker exec` argv carries it for sandboxed sessions).

Hook agents match only on the env marker (not the bare sid), so a live `--fork-session` child carrying the parent's sid cannot suppress the parent's recovery.

Safe by construction:
- Genuine post-reboot recovery is unaffected: the boot id changes and the agent processes are gone.
- The scan is only consulted for sessions tmux already reports missing, so the happy path is untouched.
- The scan runs off the async executor (daemon Phase A/B wrap it in `spawn_blocking`), batched to one process-table walk regardless of candidate count.

Wired into all three recovery decision points: the TUI candidate loop, the daemon Phase A filter, and the daemon Phase B post-lock re-check. New primitive `process::processes_matching` (`/proc/<pid>/{cmdline,environ}` on Linux, `ps -A -ww -E -o command=` on macOS).

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed; internal recovery behavior)
- [ ] For UI changes: included screenshot or recording (no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a full-binary e2e, because: the trigger is an environmental tmux-socket loss (a `/tmp` wipe orphaning a server) that isn't reproducible deterministically in the e2e harness. Instead, wire-level and unit coverage exercise the real recovery path:
  - `server::tests::daemon_recovery_ledger_and_scan_exclude_candidates` drives the actual `daemon_startup_recovery_mark` (Phase A) and asserts both guards flip real candidate selection: an id already attempted this boot is excluded (ledger), and an id whose agent is a live decoy process is excluded (scan). Ledger isolated to a tempdir via `AOE_RECOVERY_ATTEMPT_DIR`.
  - `recovery::tests::recovery_attempt_ledger_roundtrips` covers the ledger round-trip.
  - `process::tests` cover cmdline detection, anchored env-entry detection (and prefix non-match), and empty input.
  - `recovery::tests` cover sid/env detection, short/absent sid rejection, and the no-match (post-reboot) case.

### Testing

- `cargo build` and `cargo build --features serve`: clean.
- `cargo fmt --check`, `cargo clippy --features serve --all-targets`: clean (2 pre-existing warnings unrelated to this diff).
- `cargo test --features serve --lib`: 5501 passed. The only 3 failures (`acp::supervisor::…load_errs_without_peer`, `acp::worker_registry::…load_err`, `tui::home::…resume_failed_after_async_restart`) reproduce identically on `main` without this diff; they are root-in-container environment artifacts (chmod-based unreadable-file fixtures that root bypasses), not caused by this change.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and implementation done via Claude Code, reviewed and directed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed startup recovery duplicating agent processes when tmux’s socket directory is removed and the old tmux server becomes orphaned.
- Made recovery idempotent per boot by adding a host-local “recovery attempt” ledger, so the same instance won’t be recovered twice during the same restart (with best-effort cleanup of stale ledgers).
- Added a cross-platform check to detect whether the “missing” agent is already running on the host, primarily by matching an exact `AOE_INSTANCE_ID` environment marker (with session-id / argv matching as a fallback).
- Applied the safeguards across the full recovery flow:
  - the TUI candidate selection step
  - daemon Phase A candidate filtering
  - daemon Phase B post-lock re-check (only proceeding when tmux is still missing, the candidate is valid, and no live orphan agent is detected).
- Improved reliability of live-process detection by scanning the OS process table in batches (Linux `/proc`, macOS `ps`) and running these scans outside the async executor and relevant locks.

## Benefits

This prevents “double-resume” cascades caused by orphaned tmux servers, while keeping recovery behavior unchanged when the live agent genuinely isn’t present.

## Potential further enhancement

Relying on string-based matching is inherently best-effort; integrating more direct tmux-provided identity/session tracking (e.g., PID/session mapping) would further reduce edge-case mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->