### PR TITLE
fix(tui): eliminate residual live-entry blip and cross-process vt pipe fighting

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -29,6 +29,23 @@ pub struct Session {
 const SIZE_OWNER_OPT: &str = "@aoe_size_owner";
 const SIZE_OWNER_HB_OPT: &str = "@aoe_size_owner_hb";
 
+/// tmux user options holding the cross-process VT-pipe owner lock. `tmux
+/// pipe-pane` is exclusive per pane: a second process arming it silently
+/// kills the first process's forwarder, so two aoe processes previewing the
+/// same pane (a second TUI, the serve daemon's web live view) used to fight
+/// over the pipe on their re-arm throttles, each flipping the other back to
+/// the capture fallback every few seconds. The lock makes arming cooperative:
+/// only the holder pipes; everyone else stays on `capture-pane`, which every
+/// consumer already falls back to.
+const VT_OWNER_OPT: &str = "@aoe_vt_owner";
+const VT_OWNER_HB_OPT: &str = "@aoe_vt_owner_hb";
+
+/// How long a VT-pipe owner lock survives without a heartbeat before another
+/// process may arm over it. The holder refreshes from its sample loop (every
+/// viewer samples at least at idle cadence), so a live holder keeps the pipe
+/// and a crashed one frees it within this window.
+pub const VT_OWNER_TTL: Duration = Duration::from_secs(4);
+
 /// How long a size-owner lock survives without a heartbeat before another
 /// client may steal it. Shared by every surface that drives window size (the
 /// web PTY relay, the mobile live view, the native TUI) so they age the lock
@@ -815,11 +832,27 @@ impl Session {
     /// vacant lock and both write: the last write wins and only its author
     /// reads its own id back.
     pub fn claim_size_owner(&self, owner_id: &str, ttl: Duration) -> bool {
+        self.claim_owner_at(SIZE_OWNER_OPT, SIZE_OWNER_HB_OPT, owner_id, ttl)
+    }
+
+    /// Bump the heartbeat iff we still own the lock. Returns false when
+    /// ownership was lost (another client took over), so the caller can demote
+    /// itself. Cheap enough to call on each capture/render tick.
+    pub fn refresh_size_owner(&self, owner_id: &str) -> bool {
+        self.refresh_owner_at(SIZE_OWNER_OPT, SIZE_OWNER_HB_OPT, owner_id)
+    }
+
+    /// The shared claim protocol behind the size- and VT-owner locks:
+    /// claimable when vacant, already ours, or stale past `ttl`; the
+    /// confirm-read after the write resolves the race where two processes
+    /// both observe a vacant lock and both write (last write wins and only
+    /// its author reads its own id back).
+    fn claim_owner_at(&self, opt: &str, hb_opt: &str, owner_id: &str, ttl: Duration) -> bool {
         if !self.exists() {
             return false;
         }
         let now = now_ms();
-        let claimable = match self.size_owner() {
+        let claimable = match self.owner_at(opt, hb_opt) {
             None => true,
             Some((id, _)) if id == owner_id => true,
             Some((_, hb)) => now.saturating_sub(hb) > ttl.as_millis() as u64,
@@ -827,21 +860,49 @@ impl Session {
         if !claimable {
             return false;
         }
-        self.set_user_option(SIZE_OWNER_OPT, owner_id);
-        self.set_user_option(SIZE_OWNER_HB_OPT, &now.to_string());
-        matches!(self.size_owner(), Some((id, _)) if id == owner_id)
+        self.set_user_option(opt, owner_id);
+        self.set_user_option(hb_opt, &now.to_string());
+        matches!(self.owner_at(opt, hb_opt), Some((id, _)) if id == owner_id)
     }
 
-    /// Bump the heartbeat iff we still own the lock. Returns false when
-    /// ownership was lost (another client took over), so the caller can demote
-    /// itself. Cheap enough to call on each capture/render tick.
-    pub fn refresh_size_owner(&self, owner_id: &str) -> bool {
-        match self.size_owner() {
+    fn refresh_owner_at(&self, opt: &str, hb_opt: &str, owner_id: &str) -> bool {
+        match self.owner_at(opt, hb_opt) {
             Some((id, _)) if id == owner_id => {
-                self.set_user_option(SIZE_OWNER_HB_OPT, &now_ms().to_string());
+                self.set_user_option(hb_opt, &now_ms().to_string());
                 true
             }
             _ => false,
+        }
+    }
+
+    fn owner_at(&self, opt: &str, hb_opt: &str) -> Option<(String, u64)> {
+        let id = self.show_user_option(opt)?;
+        let hb = self
+            .show_user_option(hb_opt)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        Some((id, hb))
+    }
+
+    /// Try to become the pane's sole `pipe-pane` owner. Same protocol as
+    /// [`claim_size_owner`](Self::claim_size_owner) over a separate option
+    /// pair; see `VT_OWNER_OPT` for why the pipe needs an owner at all.
+    pub fn claim_vt_owner(&self, owner_id: &str, ttl: Duration) -> bool {
+        self.claim_owner_at(VT_OWNER_OPT, VT_OWNER_HB_OPT, owner_id, ttl)
+    }
+
+    /// Bump the VT-owner heartbeat iff we still hold the lock. Rate-limited
+    /// by the caller (the channel's sample loop), not here.
+    pub fn refresh_vt_owner(&self, owner_id: &str) -> bool {
+        self.refresh_owner_at(VT_OWNER_OPT, VT_OWNER_HB_OPT, owner_id)
+    }
+
+    /// Release the VT-owner lock iff we hold it, so another viewer can arm
+    /// immediately instead of waiting out the TTL.
+    pub fn release_vt_owner(&self, owner_id: &str) {
+        if matches!(self.owner_at(VT_OWNER_OPT, VT_OWNER_HB_OPT), Some((id, _)) if id == owner_id) {
+            self.unset_user_option(VT_OWNER_OPT);
+            self.unset_user_option(VT_OWNER_HB_OPT);
         }
     }
 
@@ -888,12 +949,7 @@ impl Session {
     /// Read the current size owner and its last heartbeat (unix millis), if a
     /// lock is held.
     pub fn size_owner(&self) -> Option<(String, u64)> {
-        let id = self.show_user_option(SIZE_OWNER_OPT)?;
-        let hb = self
-            .show_user_option(SIZE_OWNER_HB_OPT)
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-        Some((id, hb))
+        self.owner_at(SIZE_OWNER_OPT, SIZE_OWNER_HB_OPT)
     }
 
     /// Release the lock iff we own it. Restores `window-size latest` once the
@@ -1368,6 +1424,56 @@ mod tests {
         );
         session.release_size_owner("d");
         assert!(session.size_owner().is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vt_owner_lock_claims_rejects_and_releases_independently() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = TmuxTestSession::new("aoe_test_vt_owner");
+        let out = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                guard.name(),
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(out.status.success());
+        refresh_session_cache();
+        let session = Session::from_name(guard.name());
+
+        // Same claim protocol as the size owner: vacant -> first claimer
+        // wins, idempotent re-claim, fresh lock rejects others, stale lock
+        // steals through the normal claim path.
+        assert!(session.claim_vt_owner("pid-1", Duration::from_secs(10)));
+        assert!(session.claim_vt_owner("pid-1", Duration::from_secs(10)));
+        assert!(!session.claim_vt_owner("pid-2", Duration::from_secs(10)));
+        assert!(session.refresh_vt_owner("pid-1"));
+        assert!(!session.refresh_vt_owner("pid-2"));
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(session.claim_vt_owner("pid-3", Duration::from_millis(1)));
+
+        // The two locks are independent option pairs: holding the VT pipe
+        // must not block a size claim or vice versa.
+        assert!(session.claim_size_owner("sz", Duration::from_secs(10)));
+        assert!(session.refresh_vt_owner("pid-3"));
+
+        // Non-owner release is a no-op; owner release clears it.
+        session.release_vt_owner("pid-2");
+        assert!(session.refresh_vt_owner("pid-3"));
+        session.release_vt_owner("pid-3");
+        assert!(!session.refresh_vt_owner("pid-3"));
+        session.release_size_owner("sz");
     }
 
     #[test]

--- a/src/tmux/vt.rs
+++ b/src/tmux/vt.rs
@@ -251,6 +251,13 @@ fn chunk_now_ms() -> u64 {
     CHUNK_CLOCK.elapsed().as_millis() as u64
 }
 
+/// This process's identity in the cross-process VT-owner lock. Per-process
+/// (not per-channel): one process never fights itself (the registry dedups),
+/// so the lock only needs to distinguish processes.
+fn vt_owner_id() -> String {
+    format!("pid-{}", std::process::id())
+}
+
 /// A `(Mutex, Condvar)` pair an in-process poller parks on. Registered via
 /// [`VtChannel::set_change_wakeup`]; the reader thread pokes it after every
 /// grid change (and on death) so the poller samples the moment output lands
@@ -1087,6 +1094,10 @@ pub(crate) struct VtChannel {
     cols: AtomicU16,
     rows: AtomicU16,
     last_size_check: Mutex<Instant>,
+    /// When this process last refreshed the cross-process VT-owner heartbeat,
+    /// so `sample` refreshes at a fraction of `VT_OWNER_TTL` instead of
+    /// forking `set-option` every call.
+    last_owner_hb: Mutex<Instant>,
 }
 
 /// One cached [`VtChannel::sample`] assembly, valid while the grid
@@ -1180,6 +1191,25 @@ impl VtChannel {
         }
         let target = format!("{name}:^.0");
         let (cols, rows) = pane_size(&target)?;
+        // `pipe-pane` is exclusive per pane: arming replaces (and thereby
+        // kills) any other process's forwarder. Two aoe processes viewing the
+        // same pane (a second TUI, the serve daemon's web live view) used to
+        // fight over it on their re-arm throttles, flipping each other back
+        // to the capture fallback every few seconds. Claim the cross-process
+        // VT-owner lock first and defer if another live owner holds it; the
+        // caller's capture fallback is fully functional, and the arm throttle
+        // re-checks the lock so ownership transfers once the holder releases
+        // (or its heartbeat goes stale: crash, kill -9).
+        let session = crate::tmux::Session::from_name(name);
+        let owner = vt_owner_id();
+        if !session.claim_vt_owner(&owner, crate::tmux::session::VT_OWNER_TTL) {
+            tracing::info!(
+                %target,
+                pid = std::process::id(),
+                "vt: pipe owned by another process; using capture fallback"
+            );
+            return None;
+        }
         let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, SCROLLBACK_LINES)));
         let stop = Arc::new(AtomicBool::new(false));
         let seeded = Arc::new(AtomicBool::new(false));
@@ -1254,6 +1284,9 @@ impl VtChannel {
             let _ = UnixStream::connect(&sock_path);
             let _ = reader.join();
             let _ = std::fs::remove_dir_all(&sock_dir);
+            // Free the owner lock we claimed above so another process can arm
+            // right away instead of waiting out the TTL on our failed attempt.
+            session.release_vt_owner(&owner);
             return None;
         }
 
@@ -1274,6 +1307,7 @@ impl VtChannel {
                 let _ = UnixStream::connect(&sock_path);
                 let _ = reader.join();
                 let _ = std::fs::remove_dir_all(&sock_dir);
+                session.release_vt_owner(&owner);
                 return None;
             }
             std::thread::sleep(Duration::from_millis(2));
@@ -1284,7 +1318,13 @@ impl VtChannel {
         seed_parser(&target, &parser, &app_cursor, cols, rows);
         grid_gen.fetch_add(1, Ordering::Relaxed);
         seeded.store(true, Ordering::Relaxed);
-        tracing::info!(%target, cols, rows, "vt channel armed (pipe-pane -IO <-> vt100 grid)");
+        tracing::info!(
+            %target,
+            cols,
+            rows,
+            pid = std::process::id(),
+            "vt channel armed (pipe-pane -IO <-> vt100 grid)"
+        );
 
         Some(Self {
             name: name.to_string(),
@@ -1309,7 +1349,27 @@ impl VtChannel {
             cols: AtomicU16::new(cols),
             rows: AtomicU16::new(rows),
             last_size_check: Mutex::new(Instant::now()),
+            last_owner_hb: Mutex::new(Instant::now()),
         })
+    }
+
+    /// Keep the cross-process VT-owner heartbeat fresh while this channel is
+    /// held. Every viewer's capture loop samples at least at idle cadence, so
+    /// routing the refresh through `sample` keeps the lock alive exactly as
+    /// long as someone is actually viewing through the pipe; a crashed
+    /// process stops refreshing and the lock goes stale within
+    /// `VT_OWNER_TTL`. Rate-limited to a fraction of the TTL (one
+    /// `set-option` fork); a lost lock needs no demote here, because the new
+    /// owner's arm replaces our pipe and the reader's EOF death path already
+    /// flips every consumer to the capture fallback.
+    fn refresh_owner_heartbeat(&self) {
+        let mut guard = self.last_owner_hb.lock().unwrap();
+        if guard.elapsed() < Duration::from_millis(1500) {
+            return;
+        }
+        *guard = Instant::now();
+        drop(guard);
+        let _ = crate::tmux::Session::from_name(&self.name).refresh_vt_owner(&vt_owner_id());
     }
 
     /// Reconcile the parser size with the pane at most once a second (a
@@ -1372,6 +1432,7 @@ impl VtChannel {
     /// here, not just the visible screen.
     pub(crate) fn sample(&self, max_lines: usize) -> (String, Option<PaneCursor>) {
         self.reconcile_size();
+        self.refresh_owner_heartbeat();
         let cols = self.cols.load(Ordering::Relaxed);
         let rows = self.rows.load(Ordering::Relaxed);
         // Read the generation BEFORE assembling: a chunk that lands
@@ -1496,6 +1557,10 @@ impl Drop for VtChannel {
         }
         // Remove the whole per-channel 0700 dir (socket included).
         let _ = std::fs::remove_dir_all(&self.sock_dir);
+        // Free the cross-process VT-owner lock so another viewer (a second
+        // TUI, the serve daemon) can arm immediately instead of waiting out
+        // the TTL. Best-effort like the rest of this teardown.
+        crate::tmux::Session::from_name(&self.name).release_vt_owner(&vt_owner_id());
     }
 }
 
@@ -1792,6 +1857,7 @@ mod tests {
             cols: AtomicU16::new(20),
             rows: AtomicU16::new(4),
             last_size_check: Mutex::new(Instant::now()),
+            last_owner_hb: Mutex::new(Instant::now()),
         });
         (ch, alive)
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3331,12 +3331,24 @@ impl App {
                 // pull) or while the readiness loop waits for an agent
                 // splash to clear. The status poller will correct the row
                 // back to the real state after we return.
-                self.home
-                    .set_instance_status(&id, crate::session::Status::Starting);
-                self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
-                self.draw(terminal)?;
+                //
+                // Warm sessions skip the toast frame for the same reason
+                // EnterLiveSend does: its bottom bar row shifts the
+                // bottom-anchored preview paint up a row for the frame's
+                // lifetime, and a warm send is too fast for the toast to
+                // inform anyone.
+                let warm = self.home.agent_pane_is_warm(&id);
+                if !warm {
+                    self.home
+                        .set_instance_status(&id, crate::session::Status::Starting);
+                    self.update_status =
+                        Some(UpdateStatus::transient("Reviving session...".into()));
+                    self.draw(terminal)?;
+                }
                 self.home.execute_send_message(&id, &message);
-                self.update_status = None;
+                if !warm {
+                    self.update_status = None;
+                }
             }
             Action::EnterLiveSend(id) => {
                 // Same revive flow as SendMessage so cold-start (Docker,
@@ -3344,10 +3356,21 @@ impl App {
                 // After the pane is ready, install the live-send state on
                 // HomeView so the next key event routes through the live
                 // handler instead of the normal action dispatch.
-                self.home
-                    .set_instance_status(&id, crate::session::Status::Starting);
-                self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
-                self.draw(terminal)?;
+                //
+                // The toast frame is skipped entirely for a warm target:
+                // its bottom bar row shifts the bottom-anchored preview
+                // paint up a row for as long as the frame is on screen,
+                // which on a warm entry is the only visible effect the
+                // toast has (the entry itself is near-instant). See
+                // `live_entry_is_warm`.
+                let warm = self.home.live_entry_is_warm(&id);
+                if !warm {
+                    self.home
+                        .set_instance_status(&id, crate::session::Status::Starting);
+                    self.update_status =
+                        Some(UpdateStatus::transient("Reviving session...".into()));
+                    self.draw(terminal)?;
+                }
                 let outcome = self.home.prepare_live_send(&id);
                 // Settle the toast to its final state BEFORE the sync resize
                 // and redraw, so HomeView's cached `preview_pane_area`
@@ -3357,12 +3380,14 @@ impl App {
                 // row shorter than post-toast, the sync resize would target
                 // the smaller pane, and the first capture would render
                 // shifted up.
-                self.update_status = match &outcome {
-                    // On clean ready, drop the toast entirely. On Err the
-                    // info_dialog already carries the failure detail, so the
-                    // transient toast just gets in the way.
-                    Ok(()) | Err(()) => None,
-                };
+                if !warm {
+                    self.update_status = match &outcome {
+                        // On clean ready, drop the toast entirely. On Err the
+                        // info_dialog already carries the failure detail, so the
+                        // transient toast just gets in the way.
+                        Ok(()) | Err(()) => None,
+                    };
+                }
                 if outcome.is_ok() {
                     self.draw(terminal)?;
                     self.home.finalize_live_send_resize();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -5205,6 +5205,65 @@ mod permission_response_tokens_tests {
 }
 
 impl HomeView {
+    /// Whether the agent row is in a live status with its tmux pane up, so a
+    /// revive cascade (`ensure_pane_ready` / `prepare_live_send`) is expected
+    /// to be a fast no-op.
+    ///
+    /// The `EnterLiveSend` / `SendMessage` handlers use this to skip the
+    /// "Reviving session..." toast frame for warm sessions: the toast claims a
+    /// bottom bar row, and for the frame(s) it is on screen the bottom-anchored
+    /// preview paints its content one row up (68 cached rows into 67 visible),
+    /// then drops back when the toast clears. On a warm entry that hop is the
+    /// only thing the toast ever shows the user; how long it lingers depends on
+    /// how slow the readiness re-checks happen to be, which is why it reads as
+    /// an intermittent "cursor jiggle" on live-view entry. Cold paths (dead
+    /// pane, Docker start, agent splash) keep the toast: there the feedback is
+    /// real and the reflow unavoidable.
+    ///
+    /// `exists()` is cache-backed, so a stale cache can misclassify a
+    /// just-died pane as warm; the only cost is a missing toast over a
+    /// slower-than-expected revive, never a broken entry.
+    pub fn agent_pane_is_warm(&self, session_id: &str) -> bool {
+        let Some(inst) = self.get_instance(session_id) else {
+            return false;
+        };
+        if !matches!(
+            inst.status,
+            crate::session::Status::Running
+                | crate::session::Status::Waiting
+                | crate::session::Status::Idle
+        ) {
+            return false;
+        }
+        inst.tmux_session().is_ok_and(|s| s.exists())
+    }
+
+    /// [`agent_pane_is_warm`](Self::agent_pane_is_warm) for the pane the
+    /// pending live-send target actually drives. Terminal / tool targets check
+    /// their own pane's existence and ignore the agent's status (a stopped
+    /// agent can have a live paired terminal); the Agent target defers to the
+    /// full agent predicate.
+    pub fn live_entry_is_warm(&self, session_id: &str) -> bool {
+        let Some(inst) = self.get_instance(session_id) else {
+            return false;
+        };
+        let tmux_name = match &self.pending_live_send_target {
+            live_send::LiveSendTarget::Agent => return self.agent_pane_is_warm(session_id),
+            live_send::LiveSendTarget::Terminal => {
+                crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::ContainerTerminal => {
+                crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::Tool(name) => {
+                crate::tmux::ToolSession::new(&inst.id, &inst.title, name)
+                    .session_name()
+                    .to_string()
+            }
+        };
+        crate::tmux::Session::from_name(&tmux_name).exists()
+    }
+
     /// Size to boot a cold/dead agent pane at on live-send entry: the visible
     /// preview output rect when known, else the full terminal. `preview_pane_area`
     /// is the exact rect `finalize_live_send_resize` resizes to, so seeding the

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14535,6 +14535,56 @@ mod live_send_mode {
 
     #[test]
     #[serial]
+    fn warm_predicates_stay_cold_without_a_live_pane() {
+        // The EnterLiveSend / SendMessage handlers skip the "Reviving
+        // session..." toast only when the target pane is provably warm; every
+        // uncertain case must stay cold so a real revive keeps its feedback.
+        // The unit fixture has no tmux server, so even a live-status row must
+        // report cold (pane existence is the load-bearing half).
+        let mut env = create_test_env_with_sessions(1);
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has one session");
+
+        // Unknown session id: cold.
+        assert!(!env.view.agent_pane_is_warm("no-such-session"));
+        assert!(!env.view.live_entry_is_warm("no-such-session"));
+
+        // Live status but no tmux session behind it: cold.
+        env.view
+            .set_instance_status(&id, crate::session::Status::Idle);
+        assert!(!env.view.agent_pane_is_warm(&id));
+
+        // Non-live statuses are cold regardless of pane state.
+        for status in [
+            crate::session::Status::Stopped,
+            crate::session::Status::Starting,
+            crate::session::Status::Error,
+            crate::session::Status::Unknown,
+        ] {
+            env.view.set_instance_status(&id, status);
+            assert!(
+                !env.view.agent_pane_is_warm(&id),
+                "status {status:?} must not count as warm"
+            );
+        }
+
+        // Terminal-target warmth is keyed on the paired terminal pane, which
+        // the fixture also lacks: cold.
+        env.view
+            .set_instance_status(&id, crate::session::Status::Idle);
+        env.view.pending_live_send_target = crate::tui::home::live_send::LiveSendTarget::Terminal;
+        assert!(!env.view.live_entry_is_warm(&id));
+    }
+
+    #[test]
+    #[serial]
     fn passive_preview_sync_ignores_one_frame_toast_geometry() {
         // The EnterLiveSend / SendMessage handlers draw exactly one frame with
         // a transient toast up; its bottom bar makes the preview output rect


### PR DESCRIPTION
## Description

Follow-up to #3005, closing out the remaining live-view enter/exit glitches, both root-caused with an anchor/lifecycle trace on the affected machine.

**1. Warm entries skip the "Reviving session..." toast frame.** The `EnterLiveSend` / `SendMessage` handlers drew one frame with the toast before the readiness cascade. The toast claims a bottom bar row, so for that frame the bottom-anchored preview painted its content one row up (trace: `total_lines=68 visible_rows=67` on every entry), then dropped back, a visible blip whose duration tracked how slow the readiness re-checks happened to be. Warm targets (live status, pane exists; terminal/tool targets check their own pane) now skip the status flip, toast, and pre-draw entirely. Cold starts (dead pane, Docker, splash) keep the toast, where the feedback is real.

**2. Cross-process owner lock for the VT `pipe-pane` channel.** `pipe-pane` is exclusive per pane: arming replaces (and kills) any other process's forwarder. Two aoe processes previewing the same pane (a second TUI, the serve daemon's web live view) fought over it on their 3s re-arm throttles, flipping each other back to the capture fallback every few seconds (observed as an arm/death ping-pong in debug.log; reproduced with two TUIs on one namespace). Arming now claims a cross-process VT-owner lock first, reusing the size-owner protocol over a separate tmux user-option pair; losers stay on the fully-functional capture fallback and re-check on the existing throttle. The holder heartbeats from its sample loop and releases on teardown; a crashed holder goes stale within `VT_OWNER_TTL`, verified by SIGKILLing the owner and watching the second process arm ~4s later.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the toast blip is a single ~10ms frame that screen-capture e2e cannot sample deterministically, and the pipe fight needs two concurrent TUI processes, which the e2e harness serializes. Covered instead by unit tests: `warm_predicates_stay_cold_without_a_live_pane` (every uncertain case keeps the cold-path toast) and `vt_owner_lock_claims_rejects_and_releases_independently` (tmux-backed lock semantics incl. stale-steal and independence from the size lock), plus manual two-process verification (fight elimination, cooperative deferral, crash takeover) recorded in the PR discussion.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:**

Claude root-caused both issues via a temporary anchor/lifecycle trace branch run on the reporting machine, implemented the fixes, and verified them with headless two-process tmux repros. Reviewed and directed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved TUI live-send behavior by skipping unnecessary “Reviving session…” notifications and redraws for already-active sessions, preventing visual jumps while preserving the notification for cold starts.
- Added cross-process ownership coordination for tmux’s exclusive VT output channel, including heartbeats, cleanup, and stale-owner recovery.
- Refactored shared tmux ownership logic and added tests covering warm-session detection and VT lock behavior.

## Benefits

- Smoother, more stable live-view interactions.
- Prevents competing processes from fighting over tmux output.
- Allows ownership to recover automatically after a process becomes inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->