### PR TITLE
fix(tui): freeze the live preview while reading scrollback or selecting

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -251,19 +251,15 @@ impl Preview {
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
         } else if let Some(output_text) = parsed_output {
-            let paragraph_scroll = compute_scroll(line_count, visible_height, scroll_offset);
-
-            // ratatui's `Paragraph::new` takes ownership of the
-            // `Text`, so we clone the cached parse here. The clone
-            // walks the parsed `Vec<Line<'static>>` (one allocation
-            // per Span's `Cow`) but is still much cheaper than
-            // re-running `ansi-to-tui` on the raw pane bytes, which
-            // is what this whole caching dance avoids.
-            let paragraph = Paragraph::new(output_text.clone())
-                .style(Style::default().fg(theme.text))
-                .scroll((paragraph_scroll, 0));
-
-            frame.render_widget(paragraph, inner);
+            render_scrolled_output(
+                frame,
+                inner,
+                output_text,
+                line_count,
+                visible_height,
+                scroll_offset,
+                Style::default().fg(theme.text),
+            );
         } else {
             let hint = Paragraph::new("No output available")
                 .style(Style::default().fg(theme.dimmed))
@@ -471,22 +467,15 @@ impl Preview {
         }
 
         if let Some(output_text) = parsed_output {
-            let paragraph_scroll = compute_scroll(line_count, visible_height, scroll_offset);
-
-            // ratatui's `Paragraph::new` takes ownership of the
-            // `Text`, so we clone the cached parse here. The clone
-            // walks the parsed `Vec<Line<'static>>` (one allocation
-            // per Span's Cow), which is a few-millisecond operation
-            // but well under the cost of re-running `ansi-to-tui` on
-            // the raw bytes; the latter is what this whole caching
-            // dance avoids. If a cheaper "render Paragraph by
-            // reference" path appears in a future ratatui release,
-            // we can revisit.
-            let paragraph = Paragraph::new(output_text.clone())
-                .style(Style::default().fg(theme.text))
-                .scroll((paragraph_scroll, 0));
-
-            frame.render_widget(paragraph, inner);
+            render_scrolled_output(
+                frame,
+                inner,
+                output_text,
+                line_count,
+                visible_height,
+                scroll_offset,
+                Style::default().fg(theme.text),
+            );
         } else {
             let hint = Paragraph::new("No output available")
                 .style(Style::default().fg(theme.dimmed))
@@ -524,6 +513,43 @@ pub(crate) fn compute_scroll(line_count: usize, visible_height: usize, user_offs
     }
     let bottom = (line_count - visible_height) as u16;
     bottom.saturating_sub(user_offset)
+}
+
+/// The half-open range of line indices `[top, end)` that a `visible_height`
+/// viewport shows at `scroll_offset` into a `line_count`-line snapshot. Pure so
+/// the slice math is unit-tested without a `Frame`.
+pub(crate) fn visible_line_range(
+    line_count: usize,
+    visible_height: usize,
+    scroll_offset: u16,
+) -> (usize, usize) {
+    let top = (compute_scroll(line_count, visible_height, scroll_offset) as usize).min(line_count);
+    let end = top.saturating_add(visible_height).min(line_count);
+    (top, end)
+}
+
+/// Render only the visible window of `text` into `area`.
+///
+/// `Paragraph::new(text).scroll((n, 0))` clones and lays out the WHOLE parsed
+/// `Text` every frame, so a deep frozen snapshot (the reading capture can run to
+/// thousands of lines) made a fast wheel flick stutter: each frame paid an
+/// O(total-lines) clone plus layout, and at a high event rate the renders
+/// couldn't keep up. Slicing to just the `visible_height` rows at the current
+/// offset first keeps every frame O(visible), so scroll cost is flat no matter
+/// how much scrollback is held. Rendered at scroll 0 because the slice already
+/// starts at the top visible row.
+fn render_scrolled_output(
+    frame: &mut Frame,
+    area: Rect,
+    text: &Text<'static>,
+    line_count: usize,
+    visible_height: usize,
+    scroll_offset: u16,
+    style: Style,
+) {
+    let (top, end) = visible_line_range(line_count, visible_height, scroll_offset);
+    let visible: Vec<Line<'static>> = text.lines[top..end].to_vec();
+    frame.render_widget(Paragraph::new(Text::from(visible)).style(style), area);
 }
 
 /// Render a tmux-style ` [offset/max] ` indicator when the user has scrolled
@@ -724,6 +750,18 @@ mod tests {
     #[test]
     fn compute_scroll_saturates_at_top() {
         assert_eq!(compute_scroll(100, 20, 500), 0);
+    }
+
+    #[test]
+    fn visible_line_range_slices_only_the_viewport() {
+        // Content fits: the whole snapshot is the window.
+        assert_eq!(visible_line_range(5, 10, 0), (0, 5));
+        // Live edge (offset 0): the last `visible_height` lines.
+        assert_eq!(visible_line_range(100, 20, 0), (80, 100));
+        // Walked back 15: window slides up by 15, still 20 rows tall.
+        assert_eq!(visible_line_range(100, 20, 15), (65, 85));
+        // Saturated past the top: pinned to the first 20 rows, never negative.
+        assert_eq!(visible_line_range(100, 20, 500), (0, 20));
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -4061,6 +4061,14 @@ impl HomeView {
             }
             if self.selected_session != prev_session {
                 self.preview_scroll_offset = 0;
+                // A finalized preview selection pins to the previous pane's
+                // cells; carried into a different session it would paint a
+                // stale highlight and, because the preview holds its snapshot
+                // while a selection is live, stop the new session's preview
+                // from following output. Keystroke and click navigation already
+                // drop it upstream; clearing here also covers programmatic
+                // reselects (e.g. a poller) that never ran those paths.
+                self.clear_preview_selection();
                 // Moving off a hand-flagged row ends its manual-unread hold, so
                 // returning to it later dwell-clears like any other unread. Done
                 // here at the cursor->selection sync (every navigation path runs

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -102,6 +102,13 @@ impl PaneLayout {
 /// requested scroll.
 const CAPTURE_BUFFER: u16 = 20;
 
+/// Window captured while the user is off the live edge (reading scrollback):
+/// the full scrollback in one shot, rather than a window that tracks the offset
+/// and re-anchors to the advancing live edge on every capture. Matches tmux's
+/// default `history-limit` and the VT grid's `SCROLLBACK_LINES`, so the frozen
+/// snapshot spans the whole history a live pane could have accumulated.
+const READING_CAPTURE_LINES: u16 = 2000;
+
 /// Map a tmux pane cursor onto the preview's output rect for live-send.
 ///
 /// `output` is the rect the captured pane text paints into; `visible_rows` is
@@ -145,9 +152,32 @@ fn map_live_preview_cursor(
 /// scrollback offset. A small buffer is added so moderate scrolls don't force a
 /// fresh capture on every wheel tick.
 fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
-    height
-        .saturating_add(scroll_offset)
-        .saturating_add(CAPTURE_BUFFER) as usize
+    // Off the live edge (reading scrollback): capture the whole scrollback once
+    // so the snapshot stays put. A window that grew by the scroll step each
+    // notch was re-anchored to the advancing live edge on every capture, so on a
+    // live pane the text under the reader was yanked toward the tail as output
+    // streamed. `scroll_exceeds_cache` still fires the single grow when reading
+    // begins; after that this wide window keeps covering the offset, so the
+    // cache is captured once and then held (the render path stops refreshing it
+    // while `preview_is_frozen`).
+    if scroll_offset > 0 {
+        return height
+            .saturating_add(READING_CAPTURE_LINES)
+            .saturating_add(CAPTURE_BUFFER) as usize;
+    }
+    height.saturating_add(CAPTURE_BUFFER) as usize
+}
+
+/// Whether the preview holds its captured snapshot instead of following live
+/// output. True when the user is reading scrollback (scrolled off the live
+/// edge, `scroll_offset > 0`) or has a text selection in flight (an active drag
+/// or a finalized highlight, `has_selection`). In both cases applying the
+/// worker's bottom-anchored live frames would shift the content out from under
+/// the user: the read position gets yanked toward the tail as output streams,
+/// or the drag anchors slide off their text. Frozen, wheel-scroll stays smooth
+/// and a drag-select tracks exactly the cells under the pointer.
+fn preview_frozen(scroll_offset: u16, has_selection: bool) -> bool {
+    scroll_offset > 0 || has_selection
 }
 
 /// Decide whether the cached capture window still covers the requested scroll.
@@ -1793,13 +1823,18 @@ impl HomeView {
             return;
         };
         let scroll_offset = self.preview_scroll_offset;
+        let frozen = self.preview_is_frozen();
 
         let cache = select(self);
         let needs_refresh = force
             || cache.session_id.as_ref() != Some(&id)
             || cache.dimensions != (width, height)
             || scroll_exceeds_cache(cache.captured_lines, height, scroll_offset)
-            || cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS;
+            // While frozen (reading scrollback or holding a selection) the idle
+            // poll must not re-capture: a fresh bottom-anchored snapshot would
+            // shift the held content out from under the reader or the drag.
+            // Session change, resize, and the reading grow still refresh.
+            || (!frozen && cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS);
         if !needs_refresh {
             return;
         }
@@ -1906,6 +1941,13 @@ impl HomeView {
     /// to populate the cache once via the fork gate. Steady state across
     /// every view goes through here, so `tmux capture-pane` stays off the
     /// render thread.
+    /// Whether the preview holds its captured snapshot instead of following
+    /// live output. Decision lives in the pure [`preview_frozen`] helper so it
+    /// is unit-tested away from a live `HomeView`.
+    fn preview_is_frozen(&self) -> bool {
+        preview_frozen(self.preview_scroll_offset, self.preview_selection.is_some())
+    }
+
     fn apply_worker_capture(
         &mut self,
         width: u16,
@@ -1915,6 +1957,13 @@ impl HomeView {
         let Some(id) = self.selected_session.clone() else {
             return false;
         };
+        // Frozen (reading scrollback, or a selection is in flight): don't apply
+        // the worker's live frames. Falling through leaves the held snapshot in
+        // place; `refresh_preview_cache_core` won't re-capture it either (its
+        // idle poll is gated on `!frozen`), so nothing shifts under the user.
+        if self.preview_is_frozen() {
+            return false;
+        }
         let scroll_offset = self.preview_scroll_offset;
         let capture_lines = capture_lines_for(height, scroll_offset);
         let Some(worker) = self.preview_capture_worker.as_ref() else {
@@ -4196,8 +4245,26 @@ mod tests {
     }
 
     #[test]
-    fn capture_lines_for_extends_by_scroll_offset() {
-        assert_eq!(capture_lines_for(30, 200), 250);
+    fn capture_lines_for_captures_full_scrollback_while_reading() {
+        // Any non-zero offset switches to the wide reading window so the
+        // snapshot spans the whole scrollback and is captured once, instead of
+        // a window that tracks (and re-anchors to) the live edge each notch.
+        let want = 30 + READING_CAPTURE_LINES as usize + CAPTURE_BUFFER as usize;
+        assert_eq!(capture_lines_for(30, 1), want);
+        assert_eq!(capture_lines_for(30, 200), want);
+    }
+
+    #[test]
+    fn preview_frozen_while_reading_or_selecting() {
+        // Live edge, no selection: follow live output.
+        assert!(!preview_frozen(0, false));
+        // Scrolled off the live edge: hold the snapshot so streaming output
+        // can't yank the read position.
+        assert!(preview_frozen(1, false));
+        // Selection in flight at the live edge: hold so the drag anchors
+        // (or a finalized highlight) don't slide off their text.
+        assert!(preview_frozen(0, true));
+        assert!(preview_frozen(5, true));
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -160,12 +160,18 @@ fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
     // begins; after that this wide window keeps covering the offset, so the
     // cache is captured once and then held (the render path stops refreshing it
     // while `preview_is_frozen`).
+    //
+    // Depth is at least `READING_CAPTURE_LINES` so a normal read is one capture,
+    // but grows with the offset past that: a pane whose tmux `history-limit`
+    // exceeds the baseline must still be readable to its top, not clamped at
+    // 2000 lines.
     if scroll_offset > 0 {
-        return height
-            .saturating_add(READING_CAPTURE_LINES)
-            .saturating_add(CAPTURE_BUFFER) as usize;
+        let depth = (scroll_offset as usize).max(READING_CAPTURE_LINES as usize);
+        return (height as usize)
+            .saturating_add(depth)
+            .saturating_add(CAPTURE_BUFFER as usize);
     }
-    height.saturating_add(CAPTURE_BUFFER) as usize
+    (height as usize).saturating_add(CAPTURE_BUFFER as usize)
 }
 
 /// Whether the preview holds its captured snapshot instead of following live
@@ -188,6 +194,32 @@ fn scroll_exceeds_cache(cache_captured_lines: usize, height: u16, scroll_offset:
         .saturating_add(scroll_offset as usize)
         .saturating_add(CAPTURE_BUFFER as usize);
     needed > cache_captured_lines
+}
+
+/// Whether the cache must be re-captured this frame.
+///
+/// Live-follow (`!frozen`) keeps `scroll_exceeds_cache`'s `CAPTURE_BUFFER`
+/// headroom so a few notches of scroll pre-fetch instead of re-capturing each
+/// tick. While frozen we already hold a full-scrollback snapshot, so the
+/// headroom is dropped and the test is exact: only a viewport that genuinely
+/// runs past the captured content (`visible_rows + offset`) forces a refresh.
+/// Keeping the headroom while frozen re-forks `capture-pane` every frame at the
+/// physical top of history, where the offset is clamped to
+/// `captured_lines - visible_rows` and the extra buffer lines can never exist.
+/// `visible_rows` (the rendered body height) is what the offset is clamped
+/// against, so it, not the raw pane `height`, is the correct coverage bound.
+fn capture_window_stale(
+    frozen: bool,
+    cache_captured_lines: usize,
+    height: u16,
+    visible_rows: usize,
+    scroll_offset: u16,
+) -> bool {
+    if frozen {
+        visible_rows.saturating_add(scroll_offset as usize) > cache_captured_lines
+    } else {
+        scroll_exceeds_cache(cache_captured_lines, height, scroll_offset)
+    }
 }
 
 /// What the passive (non-live) preview sync should do this refresh for the
@@ -1824,12 +1856,13 @@ impl HomeView {
         };
         let scroll_offset = self.preview_scroll_offset;
         let frozen = self.preview_is_frozen();
+        let visible_rows = self.preview_visible_rows;
 
         let cache = select(self);
         let needs_refresh = force
             || cache.session_id.as_ref() != Some(&id)
             || cache.dimensions != (width, height)
-            || scroll_exceeds_cache(cache.captured_lines, height, scroll_offset)
+            || capture_window_stale(frozen, cache.captured_lines, height, visible_rows, scroll_offset)
             // While frozen (reading scrollback or holding a selection) the idle
             // poll must not re-capture: a fresh bottom-anchored snapshot would
             // shift the held content out from under the reader or the drag.
@@ -4246,12 +4279,21 @@ mod tests {
 
     #[test]
     fn capture_lines_for_captures_full_scrollback_while_reading() {
-        // Any non-zero offset switches to the wide reading window so the
-        // snapshot spans the whole scrollback and is captured once, instead of
-        // a window that tracks (and re-anchors to) the live edge each notch.
-        let want = 30 + READING_CAPTURE_LINES as usize + CAPTURE_BUFFER as usize;
-        assert_eq!(capture_lines_for(30, 1), want);
-        assert_eq!(capture_lines_for(30, 200), want);
+        // A non-zero offset within the baseline switches to the wide reading
+        // window so the snapshot spans the whole scrollback and is captured
+        // once, instead of a window that tracks (and re-anchors to) the live
+        // edge each notch.
+        let baseline = 30 + READING_CAPTURE_LINES as usize + CAPTURE_BUFFER as usize;
+        assert_eq!(capture_lines_for(30, 1), baseline);
+        assert_eq!(capture_lines_for(30, 200), baseline);
+        // Past the baseline the window grows with the offset so a pane whose
+        // tmux history-limit exceeds READING_CAPTURE_LINES stays readable to its
+        // top instead of clamping at 2000 lines.
+        let deep = READING_CAPTURE_LINES as usize + 3000;
+        assert_eq!(
+            capture_lines_for(30, deep as u16),
+            30 + deep + CAPTURE_BUFFER as usize
+        );
     }
 
     #[test]
@@ -4268,8 +4310,28 @@ mod tests {
     }
 
     #[test]
-    fn capture_lines_for_saturates_instead_of_overflowing() {
-        assert_eq!(capture_lines_for(u16::MAX, u16::MAX), u16::MAX as usize);
+    fn capture_lines_for_grows_without_overflow() {
+        // usize arithmetic: an extreme offset extends the window past u16
+        // without wrapping (u16::MAX height + u16::MAX depth + buffer).
+        assert_eq!(
+            capture_lines_for(u16::MAX, u16::MAX),
+            u16::MAX as usize * 2 + CAPTURE_BUFFER as usize
+        );
+    }
+
+    #[test]
+    fn capture_window_stale_breaks_the_fork_loop_at_history_top() {
+        // Frozen: exact coverage test, no CAPTURE_BUFFER headroom. At the top
+        // the offset is clamped to captured - visible_rows, so the viewport is
+        // exactly covered and no re-capture fires (the per-frame capture-pane
+        // fork loop). Uses visible_rows, not the raw pane height.
+        assert!(!capture_window_stale(true, 100, /*height*/ 999, 20, 80));
+        // A viewport that genuinely runs past the captured content still
+        // refreshes so a deeper read can grow the window.
+        assert!(capture_window_stale(true, 100, 999, 20, 90));
+        // Not frozen: keeps scroll_exceeds_cache's buffered pre-fetch semantics.
+        assert!(!capture_window_stale(false, 60, 30, 20, 3));
+        assert!(capture_window_stale(false, 40, 30, 20, 3));
     }
 
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6,7 +6,7 @@ use serial_test::serial;
 use tempfile::TempDir;
 use tui_input::Input;
 
-use super::{ConfigRefreshOrigin, ConfigWatchKey, HomeView, ViewMode};
+use super::{ConfigRefreshOrigin, ConfigWatchKey, HomeView, PreviewSelection, ViewMode};
 use crate::session::{GroupTree, Instance, Item, Storage};
 use crate::tmux::AvailableTools;
 use crate::tui::app::Action;
@@ -13151,6 +13151,49 @@ mod click_to_select {
             env.view.hovered_index(),
             None,
             "keyboard nav must clear hover so only the selected row paints"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn changing_session_clears_preview_selection() {
+        // A finalized preview selection pins to the previous pane's cells, and
+        // the preview freezes while a selection is held. Carried into a
+        // different session it would both paint a stale highlight and stop the
+        // new session's preview from following output, so selecting another
+        // session must drop it.
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        let sessions: Vec<usize> = env
+            .view
+            .flat_items
+            .iter()
+            .enumerate()
+            .filter(|(_, it)| matches!(it, Item::Session { .. }))
+            .map(|(i, _)| i)
+            .collect();
+        assert!(sessions.len() >= 2, "test needs two session rows");
+
+        env.view.cursor = sessions[0];
+        env.view.update_selected();
+        let first = env.view.selected_session.clone();
+        assert!(first.is_some(), "precondition: a session is selected");
+        env.view.preview_selection = Some(PreviewSelection {
+            anchor: (0, 0),
+            extent: (4, 2),
+            finalized: true,
+        });
+
+        env.view.cursor = sessions[1];
+        env.view.update_selected();
+        assert_ne!(
+            env.view.selected_session, first,
+            "precondition: cursor moved to a different session"
+        );
+        assert!(
+            env.view.preview_selection.is_none(),
+            "changing sessions must clear the stale selection so the new preview isn't frozen"
         );
     }
 


### PR DESCRIPTION
## Description

> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning, the fix, and the decisions are his; the prose is Claude's._

Wheel-scrolling the live preview pane was herky-jerky, worst while an agent was actively streaming output. Two things combined, both amplified once `[tmux] vt_live` went default-on (#2910):

1. **Live-edge yank.** The preview scroll offset is anchored to the live edge, so streaming output pulled the read position toward the tail on every frame. Scrolling up to read history kept getting dragged back down.
2. **Source alternation.** The capture window grew by the scroll step on each wheel notch, so it re-anchored to the advancing live edge and flip-flopped its content source between the in-process VT grid and the synchronous `capture-pane` scroll catch-up. Frame-to-frame that reads as bouncing.

### The fix

**Freeze the preview snapshot while off the live edge or mid-selection** (`src/tui/home/render.rs`). When `preview_scroll_offset > 0` or a text selection is in flight, the preview captures the full scrollback once, stops applying the worker's bottom-anchored live frames, and drops the idle re-poll. Reading history and drag-select now hold still. The pane resumes following the tail when you scroll back to the bottom or clear the selection (copy-mode style). A follow-up request to also freeze during drag-select is included.

**Render only the visible slice** (`src/tui/components/preview.rs`). The deep frozen snapshot exposed a latent per-frame cost: `Paragraph::new(text).scroll((n, 0))` clones and lays out the entire parsed `Text` every frame (ratatui composes from line 0 even without wrap). Fine for a ~50-line window, but a fast wheel flick over a 2000-line snapshot stuttered because each frame paid O(total-lines). `visible_line_range` + `render_scrolled_output` now clone only the ~visible rows and render at scroll 0, so each frame is O(visible) no matter how much scrollback is held. Both preview render paths (terminal and structured/agent) go through it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed; behavior fix, no user-facing docs)
- [ ] For UI changes: included screenshot or recording

TUI change; a recording was not captured in the sandbox (needs a live streaming agent + `asciinema`/`agg`). Verified interactively by @njbrake: fast wheel flicks over a streaming pane are smooth, reading history no longer gets yanked toward the tail, and drag-select holds still while output streams. Happy to add the `needs-recording` label so CI captures one.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the decision logic is covered by new unit tests for the pure helpers (`preview_frozen`, `visible_line_range`, and the reworked `capture_lines_for`). A full e2e that asserts wheel-scroll "smoothness" over a live streaming pane is timing-dependent and not deterministic, so it would be flaky rather than protective.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code.

**Any Additional AI Details you'd like to share:** Root-cause investigation and implementation done in a Claude Code session with @njbrake, who ran the interactive smoke tests and directed the approach.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed jerky live-preview scrolling by freezing the preview output when you scroll away from the newest content or when text selection is active.
- Stopped both live-frame updates and periodic “idle” refreshes while frozen, then automatically resumes live-follow once you return to the bottom or clear the selection.
- Improved performance by rendering only the currently visible slice of the cached preview, instead of re-rendering the entire cached output each time.
- Expanded the scrollback capture window for frozen/off-live-edge reading so the frozen preview matches what the user is viewing.
- Ensured finalized preview selections don’t carry over when switching sessions by clearing selection on session changes.
- Added/updated unit tests covering preview freezing decisions, the visible line-range math, and capture/cutoff logic.

## Potential follow-up

- Continue validating perceived smoothness and correctness with very large outputs and longer tmux scrollback histories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->