### PR TITLE
fix(tui): make PluginPoll pub(crate) to silence private_interfaces warning

### DIFF
--- a/src/tui/structured_view/mod.rs
+++ b/src/tui/structured_view/mod.rs
@@ -231,7 +231,7 @@ async fn offer_daemon_start(
 /// One plugin poll tick from the daemon: the UI-state snapshot plus, when the
 /// fetch succeeded, the active command list. `commands` is `None` on a transient
 /// command-fetch failure so the last-good set is kept rather than wiped.
-struct PluginPoll {
+pub(crate) struct PluginPoll {
     snapshot: UiSnapshot,
     commands: Option<Vec<PluginCommandView>>,
 }


### PR DESCRIPTION
## Description

`PluginPoll` in `src/tui/structured_view/mod.rs` was a module-private (`pub(self)`) struct, but it's used as the payload of the `pub enum EmbeddedEvent`'s `Plugin(PluginPoll)` variant in `embedded.rs`. Because `EmbeddedEvent` is reachable at `pub(crate)`, that field leaked a less-visible type, tripping the `private_interfaces` lint under `--features serve`:

```
warning: type `PluginPoll` is more private than the item `EmbeddedEvent::Plugin::0`
```

This bumps `PluginPoll` to `pub(crate)` so its visibility matches the surface that exposes it. One-line change.

### Why CI didn't catch it

The warning falls in a blind spot between the gate that denies warnings and the jobs that see the warning:

- The only warnings-as-errors gate is the clippy job (`cargo clippy -- -D warnings`), and it runs **without** `--features serve`. The affected module is `#[cfg(feature = "serve")]`-gated (`src/tui/mod.rs`), so clippy never compiles it and `-D warnings` never fires.
- The jobs that do compile with `--features serve` (`tests.yml` serve legs) run `cargo test`, which prints warnings but does not fail on them.

A follow-up worth considering: run the clippy gate across the feature matrix (`serve`, default, `--no-default-features`) so this class of warning is caught at PR time. Not included here to keep this PR to the fix.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A: no UI change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

This is a visibility-only change to an internal type; there is no behavior change to test. Confirmed clean with `cargo build --features serve --profile dev-release` (no warnings).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Diagnosis and one-line fix drafted by Claude via back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Made `PluginPoll` visible across the crate to align with the plugin event interface.
- Removed the `private_interfaces` warning without changing behavior or data.

## Benefits
- Enables valid internal references to `PluginPoll`.
- Builds cleanly with the `serve` feature enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->