### PR TITLE
fix(sandbox): copy ~/.claude/hooks into the container (#3014)

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -70,7 +70,10 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         container_suffix: ".claude",
         skip_entries: &["sandbox", "projects"],
         seed_files: &[],
-        copy_dirs: &["plugins", "skills"],
+        // `hooks` carries user hook scripts referenced by settings.json. settings.json
+        // is copied as a top-level file, so without the scripts it points at, every
+        // referenced hook errors in-container ("No such file or directory"). See #3014.
+        copy_dirs: &["plugins", "skills", "hooks"],
         // On macOS, OAuth tokens live in the Keychain. Extract and write as .credentials.json
         // so the container can authenticate without re-login.
         keychain_credential: Some(("Claude Code-credentials", ".credentials.json")),
@@ -2814,6 +2817,42 @@ mod tests {
             .exists());
         // "subdir" is NOT in copy_dirs, so still skipped.
         assert!(!sandbox.join("subdir").exists());
+    }
+
+    // Regression for #3014: settings.json (a top-level file) referenced a hook
+    // script under ~/.claude/hooks/, but `hooks` was absent from Claude's
+    // copy_dirs, so the config was carried into the sandbox without the script
+    // it points at and every tool call errored ("No such file or directory").
+    #[test]
+    fn test_claude_mount_copies_hooks_alongside_settings() {
+        let claude_mount = AGENT_CONFIG_MOUNTS
+            .iter()
+            .find(|m| m.tool_name == "claude")
+            .expect("claude mount must exist");
+        assert!(
+            claude_mount.copy_dirs.contains(&"hooks"),
+            "claude copy_dirs must include 'hooks' so settings.json's referenced scripts land in-container"
+        );
+
+        let dir = TempDir::new().unwrap();
+        let host = dir.path().join("host");
+        fs::create_dir_all(&host).unwrap();
+        fs::write(
+            host.join("settings.json"),
+            r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"~/.claude/hooks/secret-guard.sh"}]}]}}"#,
+        )
+        .unwrap();
+        fs::create_dir_all(host.join("hooks")).unwrap();
+        fs::write(host.join("hooks").join("secret-guard.sh"), "#!/bin/sh\n").unwrap();
+
+        let sandbox = dir.path().join("sandbox");
+        sync_agent_config(&host, &sandbox, &[], &[], claude_mount.copy_dirs, &[]).unwrap();
+
+        assert!(sandbox.join("settings.json").exists());
+        assert!(
+            sandbox.join("hooks").join("secret-guard.sh").exists(),
+            "hook script referenced by settings.json must be copied into the sandbox"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #3014.

The Docker sandbox copies `~/.claude/settings.json` into the container as a top-level file, but Claude's `copy_dirs` was `&["plugins", "skills"]`, so `~/.claude/hooks/` was never copied. Any user hook wired into `settings.json` (for example a `PreToolUse` secret-guard) landed in-container pointing at a script that wasn't there, so every tool call emitted:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: bash: /root/.claude/hooks/secret-guard.sh: No such file or directory
```

It is non-blocking, so the agent keeps running, but the hook the user relies on silently never runs inside the sandbox.

The fix adds `"hooks"` to Claude's `copy_dirs`, mirroring the remedy in #1069 (pi agent's missing `agent/` config dir), which is the same class of bug in `sync_agent_config`. `std::fs::copy` preserves the executable bit, so copied hook scripts stay runnable.

### Scope and a known caveat

This is the minimal fix. Like `plugins` and `skills`, `hooks/` is subject to the existing `has_prior_data` first-launch freeze: it is copied on a sandbox's first run and not re-synced afterward. So a hook edited after that first launch will run a stale copy in-container until the staging dir is reset. That copy-once staleness gap is pre-existing (it already affects `plugins`/`skills`) and out of scope here; this PR restores hooks on fresh sandboxes, which is where the reported error originates.

This also only covers hooks under `~/.claude/hooks/`. A `settings.json` entry pointing at a script elsewhere (an absolute path, a different subdir) is not copied. Covering arbitrary referenced paths would mean parsing `settings.json` and resolving each command, which has real edge cases; the fixed-subdir approach matches the established convention and the #1069 precedent.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no docs affected)
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated a unit test: `test_claude_mount_copies_hooks_alongside_settings` in `src/session/container_config.rs` asserts the live Claude mount lists `"hooks"` and that a `settings.json` referencing `~/.claude/hooks/secret-guard.sh` gets both the settings file and the script copied into the sandbox. It fails on the old `copy_dirs`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root cause investigation and the patch were done with Claude Code under @njbrake's direction. Findings and the fix direction were reviewed against the #1069 precedent before committing.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Claude sandbox setup to copy `~/.claude/hooks/` alongside `settings.json`.
- Added regression coverage confirming referenced hook scripts are available in fresh containers.
- Preserved executable permissions and existing first-launch behavior.

## Benefits

- Prevents Claude hooks from failing because their scripts are missing in Docker sandboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->