### PR TITLE
feat(cli): add substrate-agnostic `aoe ps` runtime view

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -242,7 +242,7 @@ Show a substrate-agnostic runtime view of in-flight sessions (tmux agent panes a
 
 * `--json` — Output as JSON
 * `--tmux` — Show only tmux-backed sessions
-* `--cockpit` — Show only ACP (structured-view) workers
+* `--acp` — Show only ACP (structured-view) workers
 * `--dead` — Include dead sessions and orphaned substrate entries (hidden by default)
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -9,6 +9,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe agents`↴](#aoe-agents)
 * [`aoe init`↴](#aoe-init)
 * [`aoe list`↴](#aoe-list)
+* [`aoe ps`↴](#aoe-ps)
 * [`aoe logs`↴](#aoe-logs)
 * [`aoe log-level`↴](#aoe-log-level)
 * [`aoe remove`↴](#aoe-remove)
@@ -124,6 +125,7 @@ Run without arguments to launch the TUI dashboard.
 * `agents` — List supported agents and their install status
 * `init` — Initialize .agent-of-empires/config.toml in a repository
 * `list` — List all sessions
+* `ps` — Show a substrate-agnostic runtime view of in-flight sessions (tmux agent panes and ACP structured-view workers), one row each
 * `logs` — View the configured AoE log file with a pretty viewer
 * `log-level` — Get or set the running daemon's log filter at runtime. Pass a bare level (debug/info/...) for the safe expansion, or `--filter <expr>` for raw EnvFilter syntax. `--get` prints the current filter. Changes are ephemeral and lost on daemon restart
 * `remove` — Remove a session
@@ -227,6 +229,21 @@ List all sessions
 
 * `--json` — Output as JSON
 * `--all` — List sessions from all profiles
+
+
+
+## `aoe ps`
+
+Show a substrate-agnostic runtime view of in-flight sessions (tmux agent panes and ACP structured-view workers), one row each
+
+**Usage:** `aoe ps [OPTIONS]`
+
+###### **Options:**
+
+* `--json` — Output as JSON
+* `--tmux` — Show only tmux-backed sessions
+* `--cockpit` — Show only ACP (structured-view) workers
+* `--dead` — Include dead sessions and orphaned substrate entries (hidden by default)
 
 
 

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -21,6 +21,7 @@ use super::mcp::McpCommands;
 use super::plugin::PluginCommands;
 use super::profile::ProfileCommands;
 use super::project::ProjectCommands;
+use super::ps::PsArgs;
 use super::remove::RemoveArgs;
 use super::send::SendArgs;
 #[cfg(feature = "serve")]
@@ -80,6 +81,10 @@ pub enum Commands {
     /// List all sessions
     #[command(alias = "ls")]
     List(ListArgs),
+
+    /// Show a substrate-agnostic runtime view of in-flight sessions
+    /// (tmux agent panes and ACP structured-view workers), one row each.
+    Ps(PsArgs),
 
     /// View the configured AoE log file with a pretty viewer
     Logs(LogsArgs),
@@ -244,6 +249,7 @@ pub const CLI_COMMAND_NAMES: &[&str] = &[
     "agents",
     "init",
     "list",
+    "ps",
     "logs",
     "log_level",
     "remove",
@@ -286,6 +292,7 @@ pub fn command_name(command: &Commands) -> Option<&'static str> {
         Commands::Agents => "agents",
         Commands::Init(_) => "init",
         Commands::List(_) => "list",
+        Commands::Ps(_) => "ps",
         Commands::Logs(_) => "logs",
         #[cfg(feature = "serve")]
         Commands::LogLevel(_) => "log_level",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,6 +19,7 @@ pub mod output;
 pub mod plugin;
 pub mod profile;
 pub mod project;
+pub mod ps;
 pub mod remove;
 pub mod send;
 #[cfg(feature = "serve")]

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -1,0 +1,685 @@
+//! `aoe ps` -- a substrate-agnostic runtime view of in-flight sessions.
+//!
+//! One row per running session across two substrates: `tmux` (agent panes
+//! tracked through the tmux session cache and pane metadata) and `acp` (the
+//! structured-view workers in the on-disk worker registry). It is additive and
+//! read-only: it never mutates session storage or the worker registry, and
+//! every substrate probe is fail-soft, so a dead tmux server or an unreadable
+//! registry degrades to fewer rows rather than a non-zero exit.
+//!
+//! The pure layer (`merge_rows`, `normalize_*`, `format_age`, `filter_rows`,
+//! `render_*`) takes only in-memory structs and is unit-tested without any
+//! tmux, disk, or network access. The impure `run` shell gathers the substrate
+//! snapshots and feeds them to the pure layer.
+
+use anyhow::Result;
+use clap::Args;
+use serde::Serialize;
+
+use crate::session::{Instance, Status, Storage};
+
+const COL_SESSION: usize = 30;
+const COL_SUBSTRATE: usize = 9;
+const COL_STATE: usize = 9;
+const COL_PID: usize = 8;
+const COL_AGE: usize = 6;
+const TITLE_BUDGET: usize = 20;
+
+#[derive(Args)]
+pub struct PsArgs {
+    /// Output as JSON
+    #[arg(long)]
+    json: bool,
+
+    /// Show only tmux-backed sessions
+    #[arg(long)]
+    tmux: bool,
+
+    /// Show only ACP (structured-view) workers
+    #[arg(long, conflicts_with = "tmux")]
+    cockpit: bool,
+
+    /// Include dead sessions and orphaned substrate entries (hidden by default)
+    #[arg(long)]
+    dead: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Substrate {
+    Tmux,
+    Acp,
+}
+
+impl Substrate {
+    fn as_str(self) -> &'static str {
+        match self {
+            Substrate::Tmux => "tmux",
+            Substrate::Acp => "acp",
+        }
+    }
+
+    fn order(self) -> u8 {
+        match self {
+            Substrate::Tmux => 0,
+            Substrate::Acp => 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubstrateFilter {
+    All,
+    Tmux,
+    Acp,
+}
+
+/// Canonical session identity from storage: the join key for both substrates.
+struct InstanceRow {
+    id: String,
+    title: String,
+}
+
+/// A tmux substrate probe. `session_name` is the full tmux name, which embeds
+/// only the 8-char truncated id suffix (`{PREFIX}{title}_{id8}`), so the merge
+/// joins it back to an `InstanceRow` by that suffix, not the full id.
+struct TmuxState {
+    session_name: String,
+    status: Status,
+    pid: Option<u32>,
+    activity_epoch: Option<i64>,
+    agent: String,
+}
+
+/// An acp substrate probe. `state` is pre-normalized by `normalize_acp_state`
+/// (serve-gated) so this struct carries no serve-only types and the merge stays
+/// feature-independent. `session_id` is the full id (`== Instance.id`).
+struct AcpState {
+    session_id: String,
+    pid: u32,
+    agent: String,
+    state: &'static str,
+    started_at: u64,
+}
+
+struct Row {
+    id: String,
+    title: String,
+    substrate: Substrate,
+    state: &'static str,
+    pid: Option<u32>,
+    age_secs: Option<u64>,
+    agent: String,
+    is_orphan: bool,
+}
+
+/// Map a tmux-derived [`Status`] to the substrate-agnostic output vocabulary.
+fn normalize_tmux_state(status: Status) -> &'static str {
+    match status {
+        Status::Running => "running",
+        Status::Waiting => "waiting",
+        Status::Idle | Status::Unknown | Status::Starting | Status::Creating => "idle",
+        Status::Stopped | Status::Error | Status::Deleting => "dead",
+    }
+}
+
+/// The acp state ladder, reused verbatim from `aoe acp ps`: dead when the
+/// runner is not live; detached when it has detached and has not re-attached
+/// since; attached otherwise.
+#[cfg(feature = "serve")]
+fn normalize_acp_state(
+    rec: &crate::process::worker_registry::WorkerRecord,
+    live: bool,
+) -> &'static str {
+    if !live {
+        "dead"
+    } else if rec.detached_at.is_some()
+        && rec.last_attached_at.unwrap_or(0) <= rec.detached_at.unwrap_or(0)
+    {
+        "detached"
+    } else {
+        "attached"
+    }
+}
+
+fn format_age(age_secs: Option<u64>) -> String {
+    match age_secs {
+        None => "-".to_string(),
+        Some(s) if s < 60 => format!("{s}s"),
+        Some(s) if s < 3600 => format!("{}m", s / 60),
+        Some(s) if s < 86400 => format!("{}h", s / 3600),
+        Some(s) => format!("{}d", s / 86400),
+    }
+}
+
+/// The 8-char truncated id a tmux session name ends with, i.e. the segment
+/// after the final `_` in `{PREFIX}{sanitized_title}_{truncate_id(id, 8)}`.
+fn tmux_id_suffix(session_name: &str) -> Option<&str> {
+    session_name.rsplit_once('_').map(|(_, suffix)| suffix)
+}
+
+/// Join both substrate snapshots against the canonical instances and produce
+/// the filtered, sorted rows. tmux matches by 8-char id suffix (the name only
+/// carries the truncated id); acp matches by full session id. A substrate entry
+/// with no matching instance is an orphan, shown only when `include_dead`.
+fn merge_rows(
+    instances: &[InstanceRow],
+    tmux_states: &[TmuxState],
+    acp_states: &[AcpState],
+    now: u64,
+    filter: SubstrateFilter,
+    include_dead: bool,
+) -> Vec<Row> {
+    let mut rows = Vec::with_capacity(tmux_states.len() + acp_states.len());
+
+    for st in tmux_states {
+        let suffix = tmux_id_suffix(&st.session_name);
+        let matched =
+            suffix.and_then(|s| instances.iter().find(|i| super::truncate_id(&i.id, 8) == s));
+        let (id, title, is_orphan) = match matched {
+            Some(i) => (i.id.clone(), i.title.clone(), false),
+            None => (
+                suffix.unwrap_or(&st.session_name).to_string(),
+                String::new(),
+                true,
+            ),
+        };
+        let age_secs = st
+            .activity_epoch
+            .map(|epoch| now.saturating_sub(epoch.max(0) as u64));
+        rows.push(Row {
+            id,
+            title,
+            substrate: Substrate::Tmux,
+            state: normalize_tmux_state(st.status),
+            pid: st.pid,
+            age_secs,
+            agent: st.agent.clone(),
+            is_orphan,
+        });
+    }
+
+    for st in acp_states {
+        let matched = instances.iter().find(|i| i.id == st.session_id);
+        let (id, title, is_orphan) = match matched {
+            Some(i) => (i.id.clone(), i.title.clone(), false),
+            None => (st.session_id.clone(), String::new(), true),
+        };
+        rows.push(Row {
+            id,
+            title,
+            substrate: Substrate::Acp,
+            state: st.state,
+            pid: Some(st.pid),
+            age_secs: Some(now.saturating_sub(st.started_at)),
+            agent: st.agent.clone(),
+            is_orphan,
+        });
+    }
+
+    filter_rows(rows, filter, include_dead)
+}
+
+/// Apply the substrate filter and the dead/orphan gate, then sort for a stable
+/// output (tmux before acp, then title, then id).
+fn filter_rows(rows: Vec<Row>, filter: SubstrateFilter, include_dead: bool) -> Vec<Row> {
+    let mut out: Vec<Row> = rows
+        .into_iter()
+        .filter(|r| match filter {
+            SubstrateFilter::All => true,
+            SubstrateFilter::Tmux => r.substrate == Substrate::Tmux,
+            SubstrateFilter::Acp => r.substrate == Substrate::Acp,
+        })
+        .filter(|r| include_dead || (!r.is_orphan && r.state != "dead"))
+        .collect();
+    out.sort_by(|a, b| {
+        a.substrate
+            .order()
+            .cmp(&b.substrate.order())
+            .then_with(|| a.title.cmp(&b.title))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    out
+}
+
+#[derive(Serialize)]
+struct RowJson {
+    session: String,
+    substrate: &'static str,
+    state: &'static str,
+    pid: Option<u32>,
+    age_secs: Option<u64>,
+    agent: String,
+}
+
+fn render_json(rows: &[Row]) -> Result<String> {
+    let out: Vec<RowJson> = rows
+        .iter()
+        .map(|r| RowJson {
+            session: r.id.clone(),
+            substrate: r.substrate.as_str(),
+            state: r.state,
+            pid: r.pid,
+            age_secs: r.age_secs,
+            agent: r.agent.clone(),
+        })
+        .collect();
+    Ok(serde_json::to_string_pretty(&out)?)
+}
+
+/// The SESSION cell: short id plus a truncated title (id only for orphans).
+fn session_cell(row: &Row) -> String {
+    let short = super::truncate_id(&row.id, 8);
+    if row.title.is_empty() {
+        short.to_string()
+    } else {
+        format!("{} {}", short, super::truncate(&row.title, TITLE_BUDGET))
+    }
+}
+
+fn render_table(rows: &[Row]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<cs$} {:<csub$} {:<cst$} {:<cp$} {:<ca$} AGENT",
+        "SESSION",
+        "SUBSTRATE",
+        "STATE",
+        "PID",
+        "AGE",
+        cs = COL_SESSION,
+        csub = COL_SUBSTRATE,
+        cst = COL_STATE,
+        cp = COL_PID,
+        ca = COL_AGE,
+    );
+    for r in rows {
+        let pid = r
+            .pid
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(
+            out,
+            "{:<cs$} {:<csub$} {:<cst$} {:<cp$} {:<ca$} {}",
+            super::truncate(&session_cell(r), COL_SESSION),
+            r.substrate.as_str(),
+            r.state,
+            pid,
+            format_age(r.age_secs),
+            r.agent,
+            cs = COL_SESSION,
+            csub = COL_SUBSTRATE,
+            cst = COL_STATE,
+            cp = COL_PID,
+            ca = COL_AGE,
+        );
+    }
+    out
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn load_instances(profile: &str, profile_explicit: bool) -> Vec<Instance> {
+    let mut out = Vec::new();
+    let profiles = if profile_explicit {
+        vec![profile.to_string()]
+    } else {
+        crate::session::list_profiles().unwrap_or_default()
+    };
+    for name in &profiles {
+        if let Ok(storage) = Storage::open_unwatched(name) {
+            if let Ok((instances, _)) = storage.load_with_groups() {
+                out.extend(instances);
+            }
+        }
+    }
+    out
+}
+
+/// Restrict orphan detection to agent sessions. Terminal, tool, and container
+/// terminal sessions share the `aoe_` root prefix but are auxiliary panes, not
+/// agent sessions, so they must not surface as `aoe ps` rows.
+fn is_agent_session_name(name: &str) -> bool {
+    name.starts_with(crate::tmux::SESSION_PREFIX)
+        && !name.starts_with(crate::tmux::TERMINAL_PREFIX)
+        && !name.starts_with(crate::tmux::CONTAINER_TERMINAL_PREFIX)
+        && !name.starts_with(crate::tmux::TOOL_PREFIX)
+}
+
+fn collect_tmux_states(instances: &mut [Instance]) -> Vec<TmuxState> {
+    use std::collections::HashSet;
+
+    crate::tmux::refresh_session_cache();
+    let meta = crate::tmux::batch_pane_metadata().unwrap_or_default();
+
+    let mut states = Vec::new();
+    let mut known: HashSet<String> = HashSet::new();
+
+    for inst in instances.iter_mut() {
+        if inst.is_structured() {
+            continue;
+        }
+        let name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        inst.update_status_with_metadata(meta.get(&name));
+        let agent = if inst.tool.is_empty() {
+            meta.get(&name)
+                .and_then(|m| m.pane_current_command.clone())
+                .unwrap_or_default()
+        } else {
+            inst.tool.clone()
+        };
+        states.push(TmuxState {
+            session_name: name.clone(),
+            status: inst.status,
+            pid: crate::process::get_pane_pid(&name),
+            activity_epoch: crate::tmux::session_activity(&name),
+            agent,
+        });
+        known.insert(name);
+    }
+
+    for (name, m) in &meta {
+        if known.contains(name) || !is_agent_session_name(name) {
+            continue;
+        }
+        states.push(TmuxState {
+            session_name: name.clone(),
+            status: if m.pane_dead {
+                Status::Stopped
+            } else {
+                Status::Idle
+            },
+            pid: crate::process::get_pane_pid(name),
+            activity_epoch: crate::tmux::session_activity(name),
+            agent: m.pane_current_command.clone().unwrap_or_default(),
+        });
+    }
+
+    states
+}
+
+#[cfg(feature = "serve")]
+fn collect_acp_states() -> Vec<AcpState> {
+    use crate::process::worker_registry;
+    worker_registry::list()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|rec| {
+            let live = worker_registry::is_record_live(&rec);
+            AcpState {
+                state: normalize_acp_state(&rec, live),
+                session_id: rec.session_id,
+                pid: rec.pid,
+                agent: rec.agent_name,
+                started_at: rec.started_at,
+            }
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "serve"))]
+fn collect_acp_states() -> Vec<AcpState> {
+    Vec::new()
+}
+
+#[tracing::instrument(target = "cli.ps", skip_all, fields(profile = %profile))]
+pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<()> {
+    #[cfg(not(feature = "serve"))]
+    if args.cockpit {
+        anyhow::bail!("--cockpit requires a build with the serve feature");
+    }
+
+    let filter = if args.tmux {
+        SubstrateFilter::Tmux
+    } else if args.cockpit {
+        SubstrateFilter::Acp
+    } else {
+        SubstrateFilter::All
+    };
+
+    let mut instances = load_instances(profile, profile_explicit);
+    let now = now_secs();
+
+    let tmux_states = collect_tmux_states(&mut instances);
+    let acp_states = collect_acp_states();
+
+    let instance_rows: Vec<InstanceRow> = instances
+        .iter()
+        .map(|i| InstanceRow {
+            id: i.id.clone(),
+            title: i.title.clone(),
+        })
+        .collect();
+
+    let rows = merge_rows(
+        &instance_rows,
+        &tmux_states,
+        &acp_states,
+        now,
+        filter,
+        args.dead,
+    );
+
+    if args.json {
+        println!("{}", render_json(&rows)?);
+    } else if rows.is_empty() {
+        println!("No running sessions.");
+    } else {
+        print!("{}", render_table(&rows));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inst(id: &str, title: &str) -> InstanceRow {
+        InstanceRow {
+            id: id.to_string(),
+            title: title.to_string(),
+        }
+    }
+
+    fn tmux_state(name: &str, status: Status) -> TmuxState {
+        TmuxState {
+            session_name: name.to_string(),
+            status,
+            pid: Some(42),
+            activity_epoch: Some(1000),
+            agent: "claude".to_string(),
+        }
+    }
+
+    #[test]
+    fn normalize_tmux_state_maps_every_status() {
+        assert_eq!(normalize_tmux_state(Status::Running), "running");
+        assert_eq!(normalize_tmux_state(Status::Waiting), "waiting");
+        assert_eq!(normalize_tmux_state(Status::Idle), "idle");
+        assert_eq!(normalize_tmux_state(Status::Unknown), "idle");
+        assert_eq!(normalize_tmux_state(Status::Starting), "idle");
+        assert_eq!(normalize_tmux_state(Status::Creating), "idle");
+        assert_eq!(normalize_tmux_state(Status::Stopped), "dead");
+        assert_eq!(normalize_tmux_state(Status::Error), "dead");
+        assert_eq!(normalize_tmux_state(Status::Deleting), "dead");
+    }
+
+    #[test]
+    fn format_age_scales_units() {
+        assert_eq!(format_age(None), "-");
+        assert_eq!(format_age(Some(5)), "5s");
+        assert_eq!(format_age(Some(59)), "59s");
+        assert_eq!(format_age(Some(60)), "1m");
+        assert_eq!(format_age(Some(3599)), "59m");
+        assert_eq!(format_age(Some(3600)), "1h");
+        assert_eq!(format_age(Some(86399)), "23h");
+        assert_eq!(format_age(Some(86400)), "1d");
+    }
+
+    #[test]
+    fn tmux_id_suffix_extracts_trailing_id() {
+        assert_eq!(tmux_id_suffix("aoe_My_Session_abcd1234"), Some("abcd1234"));
+        assert_eq!(tmux_id_suffix("aoe__abcd1234"), Some("abcd1234"));
+        assert_eq!(tmux_id_suffix("nounderscore"), None);
+    }
+
+    #[test]
+    fn merge_matches_tmux_by_truncated_id_suffix() {
+        let instances = vec![inst("abcd1234ef567890", "My Session")];
+        let tmux = vec![tmux_state("aoe_My_Session_abcd1234", Status::Running)];
+        let rows = merge_rows(&instances, &tmux, &[], 2000, SubstrateFilter::All, false);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "abcd1234ef567890");
+        assert_eq!(rows[0].title, "My Session");
+        assert!(!rows[0].is_orphan);
+        assert_eq!(rows[0].state, "running");
+        assert_eq!(rows[0].age_secs, Some(1000));
+    }
+
+    #[test]
+    fn merge_flags_tmux_session_without_instance_as_orphan() {
+        let tmux = vec![tmux_state("aoe_Ghost_99999999", Status::Running)];
+        let hidden = merge_rows(&[], &tmux, &[], 2000, SubstrateFilter::All, false);
+        assert!(hidden.is_empty(), "orphan is hidden without --dead");
+        let shown = merge_rows(&[], &tmux, &[], 2000, SubstrateFilter::All, true);
+        assert_eq!(shown.len(), 1);
+        assert!(shown[0].is_orphan);
+        assert_eq!(shown[0].id, "99999999");
+    }
+
+    #[test]
+    fn merge_matches_acp_by_full_session_id() {
+        let instances = vec![inst("full-session-id-1234", "Structured")];
+        let acp = vec![AcpState {
+            session_id: "full-session-id-1234".to_string(),
+            pid: 7,
+            agent: "claude-agent-acp".to_string(),
+            state: "attached",
+            started_at: 500,
+        }];
+        let rows = merge_rows(&instances, &[], &acp, 900, SubstrateFilter::All, false);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].substrate, Substrate::Acp);
+        assert_eq!(rows[0].title, "Structured");
+        assert!(!rows[0].is_orphan);
+        assert_eq!(rows[0].pid, Some(7));
+        assert_eq!(rows[0].age_secs, Some(400));
+    }
+
+    #[test]
+    fn merge_flags_acp_record_without_instance_as_orphan() {
+        let acp = vec![AcpState {
+            session_id: "gone".to_string(),
+            pid: 7,
+            agent: "a".to_string(),
+            state: "attached",
+            started_at: 0,
+        }];
+        assert!(merge_rows(&[], &[], &acp, 1, SubstrateFilter::All, false).is_empty());
+        let shown = merge_rows(&[], &[], &acp, 1, SubstrateFilter::All, true);
+        assert_eq!(shown.len(), 1);
+        assert!(shown[0].is_orphan);
+    }
+
+    #[test]
+    fn filter_hides_dead_by_default_and_reveals_with_flag() {
+        let instances = vec![inst("abcd1234ef567890", "Dead One")];
+        let tmux = vec![tmux_state("aoe_Dead_One_abcd1234", Status::Error)];
+        let hidden = merge_rows(&instances, &tmux, &[], 0, SubstrateFilter::All, false);
+        assert!(hidden.is_empty(), "dead is hidden by default");
+        let shown = merge_rows(&instances, &tmux, &[], 0, SubstrateFilter::All, true);
+        assert_eq!(shown.len(), 1);
+        assert_eq!(shown[0].state, "dead");
+        assert!(!shown[0].is_orphan);
+    }
+
+    #[test]
+    fn filter_by_substrate_selects_one_side() {
+        let instances = vec![inst("abcd1234ef567890", "T"), inst("acp-id-1", "A")];
+        let tmux = vec![tmux_state("aoe_T_abcd1234", Status::Running)];
+        let acp = vec![AcpState {
+            session_id: "acp-id-1".to_string(),
+            pid: 1,
+            agent: "x".to_string(),
+            state: "attached",
+            started_at: 0,
+        }];
+        let only_tmux = merge_rows(&instances, &tmux, &acp, 0, SubstrateFilter::Tmux, false);
+        assert_eq!(only_tmux.len(), 1);
+        assert_eq!(only_tmux[0].substrate, Substrate::Tmux);
+        let only_acp = merge_rows(&instances, &tmux, &acp, 0, SubstrateFilter::Acp, false);
+        assert_eq!(only_acp.len(), 1);
+        assert_eq!(only_acp[0].substrate, Substrate::Acp);
+    }
+
+    #[test]
+    fn render_json_emits_stable_schema() {
+        let instances = vec![inst("abcd1234ef567890", "My Session")];
+        let tmux = vec![tmux_state("aoe_My_Session_abcd1234", Status::Running)];
+        let rows = merge_rows(&instances, &tmux, &[], 2000, SubstrateFilter::All, false);
+        let json = render_json(&rows).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let row = &arr[0];
+        assert_eq!(row["session"], "abcd1234ef567890");
+        assert_eq!(row["substrate"], "tmux");
+        assert_eq!(row["state"], "running");
+        assert_eq!(row["pid"], 42);
+        assert_eq!(row["age_secs"], 1000);
+        assert_eq!(row["agent"], "claude");
+    }
+
+    #[test]
+    fn render_json_empty_is_array() {
+        assert_eq!(render_json(&[]).unwrap(), "[]");
+    }
+
+    #[test]
+    fn render_table_has_header_and_row() {
+        let instances = vec![inst("abcd1234ef567890", "My Session")];
+        let tmux = vec![tmux_state("aoe_My_Session_abcd1234", Status::Running)];
+        let rows = merge_rows(&instances, &tmux, &[], 2000, SubstrateFilter::All, false);
+        let table = render_table(&rows);
+        assert!(table.contains("SESSION"));
+        assert!(table.contains("SUBSTRATE"));
+        assert!(table.contains("abcd1234"));
+        assert!(table.contains("tmux"));
+        assert!(table.contains("running"));
+        assert!(table.contains("claude"));
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn normalize_acp_state_ladder() {
+        use crate::process::worker_registry::WorkerRecord;
+        use std::path::PathBuf;
+
+        let mut rec = WorkerRecord::new(
+            "s".into(),
+            1,
+            PathBuf::from("/tmp/s.sock"),
+            "claude-agent-acp".into(),
+            "claude".into(),
+            PathBuf::from("/repo"),
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        assert_eq!(normalize_acp_state(&rec, false), "dead");
+        assert_eq!(normalize_acp_state(&rec, true), "attached");
+        rec.detached_at = Some(100);
+        rec.last_attached_at = Some(50);
+        assert_eq!(normalize_acp_state(&rec, true), "detached");
+        rec.last_attached_at = Some(150);
+        assert_eq!(normalize_acp_state(&rec, true), "attached");
+    }
+}

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -23,6 +23,7 @@ const COL_SUBSTRATE: usize = 9;
 const COL_STATE: usize = 9;
 const COL_PID: usize = 8;
 const COL_AGE: usize = 6;
+const COL_AGENT: usize = 14;
 const TITLE_BUDGET: usize = 20;
 
 #[derive(Args)]
@@ -37,7 +38,7 @@ pub struct PsArgs {
 
     /// Show only ACP (structured-view) workers
     #[arg(long, conflicts_with = "tmux")]
-    cockpit: bool,
+    acp: bool,
 
     /// Include dead sessions and orphaned substrate entries (hidden by default)
     #[arg(long)]
@@ -74,14 +75,19 @@ enum SubstrateFilter {
 }
 
 /// Canonical session identity from storage: the join key for both substrates.
+/// `created_at_epoch` (Unix seconds) is the single uniform AGE source, so a
+/// matched row's AGE means the same thing (session age) regardless of substrate.
 struct InstanceRow {
     id: String,
     title: String,
+    created_at_epoch: u64,
 }
 
 /// A tmux substrate probe. `session_name` is the full tmux name, which embeds
 /// only the 8-char truncated id suffix (`{PREFIX}{title}_{id8}`), so the merge
 /// joins it back to an `InstanceRow` by that suffix, not the full id.
+/// `activity_epoch` is only the AGE fallback for orphans (a matched row's AGE
+/// comes from the instance's `created_at`).
 struct TmuxState {
     session_name: String,
     status: Status,
@@ -93,6 +99,7 @@ struct TmuxState {
 /// An acp substrate probe. `state` is pre-normalized by `normalize_acp_state`
 /// (serve-gated) so this struct carries no serve-only types and the merge stays
 /// feature-independent. `session_id` is the full id (`== Instance.id`).
+/// `started_at` is only the AGE fallback for orphans (see `TmuxState`).
 struct AcpState {
     session_id: String,
     pid: u32,
@@ -101,6 +108,9 @@ struct AcpState {
     started_at: u64,
 }
 
+/// One output row. `id` is the full session id for a matched row; for an orphan
+/// it is the best identity available (the tmux 8-char id suffix, or the
+/// registry `session_id`), since no matching instance exists.
 struct Row {
     id: String,
     title: String,
@@ -122,9 +132,12 @@ fn normalize_tmux_state(status: Status) -> &'static str {
     }
 }
 
-/// The acp state ladder, reused verbatim from `aoe acp ps`: dead when the
-/// runner is not live; detached when it has detached and has not re-attached
-/// since; attached otherwise.
+/// The acp state ladder: dead when the runner is not live; detached when it has
+/// detached and has not re-attached since; attached otherwise. This mirrors the
+/// inline ladder in `aoe acp ps` (src/cli/acp.rs). The two are intentionally not
+/// yet factored into one helper: its natural home is `worker_registry`, which is
+/// off-limits here (under active churn), so dedup is deferred to the `aoe acp ps`
+/// unification follow-up that will touch acp.rs anyway. Keep them in sync.
 #[cfg(feature = "serve")]
 fn normalize_acp_state(
     rec: &crate::process::worker_registry::WorkerRecord,
@@ -175,17 +188,21 @@ fn merge_rows(
         let suffix = tmux_id_suffix(&st.session_name);
         let matched =
             suffix.and_then(|s| instances.iter().find(|i| super::truncate_id(&i.id, 8) == s));
-        let (id, title, is_orphan) = match matched {
-            Some(i) => (i.id.clone(), i.title.clone(), false),
+        let (id, title, is_orphan, age_secs) = match matched {
+            Some(i) => (
+                i.id.clone(),
+                i.title.clone(),
+                false,
+                Some(now.saturating_sub(i.created_at_epoch)),
+            ),
             None => (
                 suffix.unwrap_or(&st.session_name).to_string(),
                 String::new(),
                 true,
+                st.activity_epoch
+                    .map(|epoch| now.saturating_sub(epoch.max(0) as u64)),
             ),
         };
-        let age_secs = st
-            .activity_epoch
-            .map(|epoch| now.saturating_sub(epoch.max(0) as u64));
         rows.push(Row {
             id,
             title,
@@ -200,9 +217,19 @@ fn merge_rows(
 
     for st in acp_states {
         let matched = instances.iter().find(|i| i.id == st.session_id);
-        let (id, title, is_orphan) = match matched {
-            Some(i) => (i.id.clone(), i.title.clone(), false),
-            None => (st.session_id.clone(), String::new(), true),
+        let (id, title, is_orphan, age_secs) = match matched {
+            Some(i) => (
+                i.id.clone(),
+                i.title.clone(),
+                false,
+                now.saturating_sub(i.created_at_epoch),
+            ),
+            None => (
+                st.session_id.clone(),
+                String::new(),
+                true,
+                now.saturating_sub(st.started_at),
+            ),
         };
         rows.push(Row {
             id,
@@ -210,7 +237,7 @@ fn merge_rows(
             substrate: Substrate::Acp,
             state: st.state,
             pid: Some(st.pid),
-            age_secs: Some(now.saturating_sub(st.started_at)),
+            age_secs: Some(age_secs),
             agent: st.agent.clone(),
             is_orphan,
         });
@@ -241,6 +268,8 @@ fn filter_rows(rows: Vec<Row>, filter: SubstrateFilter, include_dead: bool) -> V
     out
 }
 
+/// Stable JSON schema for one row. `session` is the full id for a matched row,
+/// else the orphan's best-available identity (see [`Row`]).
 #[derive(Serialize)]
 struct RowJson {
     session: String,
@@ -251,9 +280,11 @@ struct RowJson {
     agent: String,
 }
 
-fn render_json(rows: &[Row]) -> Result<String> {
-    let out: Vec<RowJson> = rows
-        .iter()
+/// Project rows into the serializable schema. Kept separate from the print so
+/// the schema is unit-testable and `run` can route through the shared
+/// `output::print_json` helper.
+fn rows_json(rows: &[Row]) -> Vec<RowJson> {
+    rows.iter()
         .map(|r| RowJson {
             session: r.id.clone(),
             substrate: r.substrate.as_str(),
@@ -262,8 +293,7 @@ fn render_json(rows: &[Row]) -> Result<String> {
             age_secs: r.age_secs,
             agent: r.agent.clone(),
         })
-        .collect();
-    Ok(serde_json::to_string_pretty(&out)?)
+        .collect()
 }
 
 /// The SESSION cell: short id plus a truncated title (id only for orphans).
@@ -292,6 +322,11 @@ fn render_table(rows: &[Row]) -> String {
         cst = COL_STATE,
         cp = COL_PID,
         ca = COL_AGE,
+    );
+    let _ = writeln!(
+        out,
+        "{}",
+        "-".repeat(COL_SESSION + COL_SUBSTRATE + COL_STATE + COL_PID + COL_AGE + COL_AGENT + 5)
     );
     for r in rows {
         let pid = r
@@ -430,18 +465,22 @@ fn collect_acp_states() -> Vec<AcpState> {
 #[tracing::instrument(target = "cli.ps", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<()> {
     #[cfg(not(feature = "serve"))]
-    if args.cockpit {
-        anyhow::bail!("--cockpit requires a build with the serve feature");
+    if args.acp {
+        anyhow::bail!("--acp requires a build with the serve feature");
     }
 
     let filter = if args.tmux {
         SubstrateFilter::Tmux
-    } else if args.cockpit {
+    } else if args.acp {
         SubstrateFilter::Acp
     } else {
         SubstrateFilter::All
     };
 
+    // `--profile` scopes only the instance load: an explicit profile lists that
+    // one, otherwise every profile. The worker registry is global (no profile
+    // field), so acp workers whose session belongs to an unlisted profile fail
+    // the id-join and surface as orphans, hidden unless `--dead`.
     let mut instances = load_instances(profile, profile_explicit);
     let now = now_secs();
 
@@ -453,6 +492,7 @@ pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<
         .map(|i| InstanceRow {
             id: i.id.clone(),
             title: i.title.clone(),
+            created_at_epoch: i.created_at.timestamp().max(0) as u64,
         })
         .collect();
 
@@ -466,7 +506,7 @@ pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<
     );
 
     if args.json {
-        println!("{}", render_json(&rows)?);
+        super::output::print_json(&rows_json(&rows))?;
     } else if rows.is_empty() {
         println!("No running sessions.");
     } else {
@@ -480,10 +520,17 @@ pub async fn run(profile: &str, profile_explicit: bool, args: PsArgs) -> Result<
 mod tests {
     use super::*;
 
+    // A fixed session creation epoch so AGE assertions are deterministic; kept
+    // distinct from the tmux activity epoch below to prove matched rows take
+    // their AGE from `created_at`, not the substrate-native fallback.
+    const CREATED_AT: u64 = 1000;
+    const ACTIVITY: i64 = 1500;
+
     fn inst(id: &str, title: &str) -> InstanceRow {
         InstanceRow {
             id: id.to_string(),
             title: title.to_string(),
+            created_at_epoch: CREATED_AT,
         }
     }
 
@@ -492,8 +539,18 @@ mod tests {
             session_name: name.to_string(),
             status,
             pid: Some(42),
-            activity_epoch: Some(1000),
+            activity_epoch: Some(ACTIVITY),
             agent: "claude".to_string(),
+        }
+    }
+
+    fn acp_state(session_id: &str, state: &'static str, started_at: u64) -> AcpState {
+        AcpState {
+            session_id: session_id.to_string(),
+            pid: 7,
+            agent: "claude-agent-acp".to_string(),
+            state,
+            started_at,
         }
     }
 
@@ -539,6 +596,7 @@ mod tests {
         assert_eq!(rows[0].title, "My Session");
         assert!(!rows[0].is_orphan);
         assert_eq!(rows[0].state, "running");
+        // AGE is now - created_at (1000), NOT now - activity (1500).
         assert_eq!(rows[0].age_secs, Some(1000));
     }
 
@@ -551,40 +609,33 @@ mod tests {
         assert_eq!(shown.len(), 1);
         assert!(shown[0].is_orphan);
         assert_eq!(shown[0].id, "99999999");
+        // Orphans have no instance, so AGE falls back to tmux activity (1500).
+        assert_eq!(shown[0].age_secs, Some(500));
     }
 
     #[test]
     fn merge_matches_acp_by_full_session_id() {
         let instances = vec![inst("full-session-id-1234", "Structured")];
-        let acp = vec![AcpState {
-            session_id: "full-session-id-1234".to_string(),
-            pid: 7,
-            agent: "claude-agent-acp".to_string(),
-            state: "attached",
-            started_at: 500,
-        }];
-        let rows = merge_rows(&instances, &[], &acp, 900, SubstrateFilter::All, false);
+        let acp = vec![acp_state("full-session-id-1234", "attached", 500)];
+        let rows = merge_rows(&instances, &[], &acp, 2000, SubstrateFilter::All, false);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].substrate, Substrate::Acp);
         assert_eq!(rows[0].title, "Structured");
         assert!(!rows[0].is_orphan);
         assert_eq!(rows[0].pid, Some(7));
-        assert_eq!(rows[0].age_secs, Some(400));
+        // AGE is now - created_at (1000), NOT now - started_at (1500).
+        assert_eq!(rows[0].age_secs, Some(1000));
     }
 
     #[test]
     fn merge_flags_acp_record_without_instance_as_orphan() {
-        let acp = vec![AcpState {
-            session_id: "gone".to_string(),
-            pid: 7,
-            agent: "a".to_string(),
-            state: "attached",
-            started_at: 0,
-        }];
+        let acp = vec![acp_state("gone", "attached", 500)];
         assert!(merge_rows(&[], &[], &acp, 1, SubstrateFilter::All, false).is_empty());
-        let shown = merge_rows(&[], &[], &acp, 1, SubstrateFilter::All, true);
+        let shown = merge_rows(&[], &[], &acp, 2000, SubstrateFilter::All, true);
         assert_eq!(shown.len(), 1);
         assert!(shown[0].is_orphan);
+        // Orphans fall back to the worker's started_at (500).
+        assert_eq!(shown[0].age_secs, Some(1500));
     }
 
     #[test]
@@ -603,13 +654,7 @@ mod tests {
     fn filter_by_substrate_selects_one_side() {
         let instances = vec![inst("abcd1234ef567890", "T"), inst("acp-id-1", "A")];
         let tmux = vec![tmux_state("aoe_T_abcd1234", Status::Running)];
-        let acp = vec![AcpState {
-            session_id: "acp-id-1".to_string(),
-            pid: 1,
-            agent: "x".to_string(),
-            state: "attached",
-            started_at: 0,
-        }];
+        let acp = vec![acp_state("acp-id-1", "attached", 0)];
         let only_tmux = merge_rows(&instances, &tmux, &acp, 0, SubstrateFilter::Tmux, false);
         assert_eq!(only_tmux.len(), 1);
         assert_eq!(only_tmux[0].substrate, Substrate::Tmux);
@@ -619,12 +664,37 @@ mod tests {
     }
 
     #[test]
-    fn render_json_emits_stable_schema() {
+    fn acp_filter_with_dead_reveals_dead_acp_orphan() {
+        let acp = vec![acp_state("gone", "dead", 0)];
+        assert!(
+            merge_rows(&[], &[], &acp, 0, SubstrateFilter::Acp, false).is_empty(),
+            "a dead acp orphan is hidden under --acp without --dead"
+        );
+        let shown = merge_rows(&[], &[], &acp, 0, SubstrateFilter::Acp, true);
+        assert_eq!(shown.len(), 1);
+        assert_eq!(shown[0].substrate, Substrate::Acp);
+        assert_eq!(shown[0].state, "dead");
+    }
+
+    #[test]
+    fn merge_sorts_tmux_before_acp() {
+        let instances = vec![inst("abcd1234ef567890", "Zeta"), inst("acp-id-1", "Alpha")];
+        let tmux = vec![tmux_state("aoe_Zeta_abcd1234", Status::Running)];
+        let acp = vec![acp_state("acp-id-1", "attached", 0)];
+        let rows = merge_rows(&instances, &tmux, &acp, 0, SubstrateFilter::All, false);
+        assert_eq!(rows.len(), 2);
+        // tmux sorts ahead of acp even though its title ("Zeta") sorts after
+        // the acp row's title ("Alpha"): substrate is the primary sort key.
+        assert_eq!(rows[0].substrate, Substrate::Tmux);
+        assert_eq!(rows[1].substrate, Substrate::Acp);
+    }
+
+    #[test]
+    fn render_json_projects_stable_schema() {
         let instances = vec![inst("abcd1234ef567890", "My Session")];
         let tmux = vec![tmux_state("aoe_My_Session_abcd1234", Status::Running)];
         let rows = merge_rows(&instances, &tmux, &[], 2000, SubstrateFilter::All, false);
-        let json = render_json(&rows).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let v = serde_json::to_value(rows_json(&rows)).unwrap();
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         let row = &arr[0];
@@ -634,25 +704,68 @@ mod tests {
         assert_eq!(row["pid"], 42);
         assert_eq!(row["age_secs"], 1000);
         assert_eq!(row["agent"], "claude");
+        // Exactly the six documented keys, no more.
+        assert_eq!(row.as_object().unwrap().len(), 6);
     }
 
     #[test]
     fn render_json_empty_is_array() {
-        assert_eq!(render_json(&[]).unwrap(), "[]");
+        assert!(rows_json(&[]).is_empty());
+        assert_eq!(serde_json::to_string(&rows_json(&[])).unwrap(), "[]");
     }
 
     #[test]
-    fn render_table_has_header_and_row() {
+    fn render_table_has_header_underline_and_row() {
         let instances = vec![inst("abcd1234ef567890", "My Session")];
         let tmux = vec![tmux_state("aoe_My_Session_abcd1234", Status::Running)];
         let rows = merge_rows(&instances, &tmux, &[], 2000, SubstrateFilter::All, false);
         let table = render_table(&rows);
         assert!(table.contains("SESSION"));
         assert!(table.contains("SUBSTRATE"));
+        assert!(table.contains("----"), "header underline present");
         assert!(table.contains("abcd1234"));
         assert!(table.contains("tmux"));
         assert!(table.contains("running"));
         assert!(table.contains("claude"));
+    }
+
+    #[test]
+    fn session_cell_truncates_long_title() {
+        let row = Row {
+            id: "abcd1234ef567890".to_string(),
+            title: "A very long session title that exceeds the budget".to_string(),
+            substrate: Substrate::Tmux,
+            state: "running",
+            pid: None,
+            age_secs: None,
+            agent: String::new(),
+            is_orphan: false,
+        };
+        let cell = session_cell(&row);
+        assert!(cell.starts_with("abcd1234 "));
+        assert!(
+            cell.contains("..."),
+            "long title is truncated with an ellipsis"
+        );
+        assert!(
+            !cell.contains("exceeds the budget"),
+            "the tail of an over-budget title is dropped"
+        );
+    }
+
+    #[test]
+    fn session_cell_omits_title_for_orphan() {
+        let row = Row {
+            id: "99999999".to_string(),
+            title: String::new(),
+            substrate: Substrate::Tmux,
+            state: "running",
+            pid: None,
+            age_secs: None,
+            agent: String::new(),
+            is_orphan: true,
+        };
+        assert_eq!(session_cell(&row), "99999999");
     }
 
     #[cfg(feature = "serve")]

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -1,4 +1,4 @@
-//! `aoe ps` -- a substrate-agnostic runtime view of in-flight sessions.
+//! `aoe ps`: a substrate-agnostic runtime view of in-flight sessions.
 //!
 //! One row per running session across two substrates: `tmux` (agent panes
 //! tracked through the tmux session cache and pane metadata) and `acp` (the
@@ -687,6 +687,27 @@ mod tests {
         // the acp row's title ("Alpha"): substrate is the primary sort key.
         assert_eq!(rows[0].substrate, Substrate::Tmux);
         assert_eq!(rows[1].substrate, Substrate::Acp);
+    }
+
+    #[test]
+    fn merge_sort_tiebreaks_by_title_then_id() {
+        // Same substrate: title is the secondary key, id the tertiary. Two rows
+        // share the title "Same" to force the id tiebreak.
+        let instances = vec![
+            inst("2222aaaabbbbcccc", "Same"),
+            inst("1111aaaabbbbcccc", "Same"),
+            inst("3333ffff00001111", "Alpha"),
+        ];
+        let tmux = vec![
+            tmux_state("aoe_Same_2222aaaa", Status::Running),
+            tmux_state("aoe_Same_1111aaaa", Status::Running),
+            tmux_state("aoe_Alpha_3333ffff", Status::Running),
+        ];
+        let rows = merge_rows(&instances, &tmux, &[], 0, SubstrateFilter::All, false);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].title, "Alpha");
+        assert_eq!(rows[1].id, "1111aaaabbbbcccc");
+        assert_eq!(rows[2].id, "2222aaaabbbbcccc");
     }
 
     #[test]

--- a/src/cli/ps.rs
+++ b/src/cli/ps.rs
@@ -186,6 +186,8 @@ fn merge_rows(
 
     for st in tmux_states {
         let suffix = tmux_id_suffix(&st.session_name);
+        // On an 8-char id collision `find` takes the first match; the tmux name
+        // only carries id8, so nothing more precise is available anyway.
         let matched =
             suffix.and_then(|s| instances.iter().find(|i| super::truncate_id(&i.id, 8) == s));
         let (id, title, is_orphan, age_secs) = match matched {

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,6 +344,7 @@ async fn main() -> Result<()> {
     let result = match cli.command {
         Some(Commands::Add(args)) => cli::add::run(&profile, *args).await,
         Some(Commands::List(args)) => cli::list::run(&profile, args).await,
+        Some(Commands::Ps(args)) => cli::ps::run(&profile, profile_explicit, args).await,
         Some(Commands::Remove(args)) => cli::remove::run(&profile, args).await,
         Some(Commands::Send(args)) => cli::send::run(&profile, args).await,
         Some(Commands::Status(args)) => cli::status::run(&profile, args).await,

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -575,7 +575,7 @@ pub fn session_exists_from_cache(name: &str) -> Option<bool> {
 }
 
 /// Cached tmux `#{session_activity}` epoch (seconds) for `name`, else `None`.
-/// Read-only view over [`SESSION_CACHE`]; caller refreshes first if needed.
+/// Read-only view over the private `SESSION_CACHE`; caller refreshes first if needed.
 /// Ignores the snapshot TTL on purpose: this is a best-effort AGE hint for
 /// `aoe ps`, not a liveness decision.
 pub fn session_activity(name: &str) -> Option<i64> {

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -574,6 +574,15 @@ pub fn session_exists_from_cache(name: &str) -> Option<bool> {
     cache.data.as_ref().map(|m| m.contains_key(name))
 }
 
+/// Cached tmux `#{session_activity}` epoch (seconds) for `name`, else `None`.
+/// Read-only view over [`SESSION_CACHE`]; caller refreshes first if needed.
+/// Ignores the snapshot TTL on purpose: this is a best-effort AGE hint for
+/// `aoe ps`, not a liveness decision.
+pub fn session_activity(name: &str) -> Option<i64> {
+    let cache = SESSION_CACHE.read().ok()?;
+    cache.data.as_ref()?.get(name).copied()
+}
+
 /// Tri-state result of probing whether an aoe tmux session exists, per
 /// [`probe_session_existence`]. Unlike a plain `bool`, this keeps "the tmux
 /// server itself was unreachable" distinct from "the server answered and the

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1620,6 +1620,30 @@ fn test_cli_add_scratch_conflicts_with_worktree_flag() {
     );
 }
 
+/// #1051: `aoe ps --json` is substrate-agnostic and fail-soft. On an empty
+/// profile with no tmux server it must emit an empty JSON array and exit 0,
+/// never abort because a substrate probe failed.
+#[test]
+#[serial]
+fn test_cli_ps_empty_json() {
+    let h = TuiTestHarness::new("cli_ps_empty_json");
+
+    let output = h.run_cli(&["ps", "--json"]);
+    assert!(
+        output.status.success(),
+        "aoe ps --json should succeed on an empty profile: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("aoe ps --json must emit valid JSON");
+    assert!(
+        value.as_array().map(|a| a.is_empty()).unwrap_or(false),
+        "expected an empty JSON array, got:\n{stdout}"
+    );
+}
+
 /// `aoe stop` (with or without args) is a hidden trap, not a real command: it
 /// must exit non-zero and redirect the user to the scoped stop verbs and
 /// `killall` rather than silently doing nothing or triggering a teardown.


### PR DESCRIPTION
## Description

Closes #1051.

`aoe list` shows static config and `aoe acp ps` is ACP-only, so there is no single CLI view of what is actually running. This adds `aoe ps`: one row per in-flight session across the `tmux` and `acp` substrates.

- **Columns:** `SESSION` (short id + truncated title) · `SUBSTRATE` (`tmux`|`acp`) · `STATE` · `PID` · `AGE` · `AGENT`
- **Flags:** `--json`, `--tmux`, `--acp` (filters `acp`; conflicts with `--tmux`), `--dead` (dead/orphans hidden by default), and the global `--profile` (all profiles by default).
- **STATE reuse, not reinvention:** tmux STATE goes through `Instance::update_status_with_metadata` (the tested path behind `aoe status`), mapped to `running/waiting/idle/dead`; acp STATE reuses the `aoe acp ps` ladder (`dead/detached/attached`).
- **AGE is one coherent quantity:** matched rows report `now - created_at` (session age) on both substrates, so the column means the same thing on every row and stays comparable/sortable (like `docker ps` STATUS / `ps -o etime`). Orphans, which have no instance, fall back to their only available timestamp (tmux last-activity / acp worker start).
- **Asymmetric merge:** acp joins by full `session_id`; tmux joins by the 8-char id suffix embedded in the session name (`{PREFIX}{title}_{id8}`). A substrate entry with no matching session is an orphan, shown only under `--dead`.
- **Fail-soft:** every probe (tmux server, pane metadata, worker registry) degrades to fewer rows, never a non-zero exit.
- **Feature gating:** all ACP/registry access sits behind `#[cfg(feature = "serve")]` with an empty stub, so a TUI-only `cargo build` compiles and shows tmux rows; `--acp` without `serve` bails cleanly.
- **Additive & read-only:** it is a read-only consumer of the worker registry and does **not** touch `aoe acp ps`.

The pure merge/normalize/format/render layer takes only in-memory structs and is unit-tested without tmux/disk/network; the impure `run` shell gathers the snapshots.

> **Follow-ups (tracked as issues, deliberately out of this additive PR):**
> - #3023: unify `aoe acp ps` into `aoe ps --acp` (needs a deprecation decision) and dedup the shared ACP state ladder.
> - #3024: `aoe ps` enhancements (`--watch`, `aoe ps <id>`, daemon `/api/sessions` source, merge scaling).
> - Review-surfaced tech-debt: #3025 (residual "cockpit" terminology cleanup), #3026 (consolidate duplicated `now_secs()` / duration helpers).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy` and `cargo clippy --features serve` (both `-D warnings` clean), `cargo test` and `cargo test --features serve` all pass. `docs/cli/reference.md` regenerated via `cargo xtask gen-docs`.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Pure logic (asymmetric id-suffix vs full-id merge, orphan detection, tmux/acp state normalization, AGE from `created_at` vs orphan fallback, sort order incl. title/id tiebreak, age formatting, substrate/dead filters, table + JSON rendering, acp state ladder) is covered by unit tests in `src/cli/ps.rs`; a cheap e2e (`tests/e2e/cli.rs::test_cli_ps_empty_json`) asserts `aoe ps --json` on an empty profile emits `[]` and exits 0.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (Opus) via an agentic coding assistant.

**Any Additional AI Details you'd like to share:** Used for grounding against the current code, implementation, and test authoring. The design (command name, asymmetric merge, reuse of the existing status/acp-state paths, uniform `created_at` AGE, fail-soft gating) and all review responses are the author's own.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new `aoe ps` CLI command that shows an aggregated, substrate-agnostic view of in-flight sessions across both `tmux` and ACP.
- Introduced new CLI wiring and documentation for the command, including telemetry allowlisting and regenerated CLI reference docs.
- Implemented a read-only runtime “ps” pipeline that:
  - normalizes substrate-specific session states,
  - merges matching runtime entries with a canonical session identity,
  - computes comparable session age,
  - renders either a table or `--json` output with consistent fields (`SESSION`, `SUBSTRATE`, `STATE`, `PID`, `AGE`, `AGENT`),
  - includes dead/orphaned entries only when `--dead` is set, and sorts output stably.
- Made runtime probing fail-soft (missing/unreadable tmux/acp runtime data degrades output rather than failing); ACP probing is feature-gated behind `serve` (using `--acp` without it errors).
- Added supporting tmux functionality for session activity lookup, and ensured deterministic behavior when tmux session-id suffix collisions occur.
- Added unit and end-to-end tests, including an e2e test confirming `aoe ps --json` returns valid empty JSON (empty array) without requiring a tmux server.

## Benefits

- Provides a unified “what’s running right now” command instead of relying on static config (`aoe list`) or substrate-specific runtime tooling.
- Produces consistent, comparable session reporting (including JSON) by normalizing states and using shared age logic.
- Improves reliability in real environments by not failing when runtime metadata is unavailable.

## Potential follow-up

- Watch mode / live updates and deeper per-session drilldowns (explicitly out of scope for this change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->