### PR TITLE
feat(web): clarify background-agents pane scope (async-only + inline hint)

### DIFF
--- a/web/src/components/acp/BackgroundAgentsPanel.tsx
+++ b/web/src/components/acp/BackgroundAgentsPanel.tsx
@@ -40,9 +40,15 @@ export function BackgroundAgentsPanel({ sessionId }: { sessionId: string | null 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
       <div className="flex items-center gap-2 border-b border-surface-700 px-3 py-1.5">
-        <span className="flex-1 text-[11px] uppercase tracking-wider text-text-dim">Sub agents · {agents.length}</span>
+        <span className="flex-1 text-[11px] uppercase tracking-wider text-text-dim">
+          Background agents · {agents.length}
+        </span>
         {anyRunning && sessionId && <StopButton sessionId={sessionId} />}
       </div>
+      <p className="border-b border-surface-800 px-3 py-1 text-[11px] leading-snug text-text-dim">
+        Only async (background) <span className="font-mono">Task</span> sub-agents show here. Synchronous sub-agents run
+        inline in the transcript.
+      </p>
       <div className="flex flex-col">
         {sorted.map((a) => (
           <AgentRow key={a.agentId} agent={a} />

--- a/web/src/components/acp/__tests__/BackgroundAgentsPanel.test.tsx
+++ b/web/src/components/acp/__tests__/BackgroundAgentsPanel.test.tsx
@@ -43,7 +43,10 @@ describe("BackgroundAgentsPanel", () => {
   it("lists a running agent with description, tool count, and last activity", () => {
     agentsMock.mockReturnValue([agent()]);
     const { container } = render(<BackgroundAgentsPanel sessionId="s-1" />);
-    expect(container.textContent).toContain("Sub agents · 1");
+    expect(container.textContent).toContain("Background agents · 1");
+    // Persistent hint: async-only scope + where the sync ones live.
+    expect(container.textContent).toContain("Only async");
+    expect(container.textContent).toContain("Synchronous sub-agents run inline in the transcript");
     expect(container.textContent).toContain("Map backend lifecycle");
     expect(container.textContent).toContain("running");
     expect(container.textContent).toContain("3 tools");


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured-view "Sub agents" pane lists only async background sub-agents (Claude `Task` launched with `run_in_background`), but its header read the generic "Sub agents". A session running both synchronous and async sub-agents therefore showed a partial, seemingly random list, with no in-pane explanation of where the rest were. Synchronous sub-agents render inline in the transcript as sub-agent cards and never reach this pane.

This is scope A of the issue: make the async-only scope unambiguous without changing what the pane tracks.

- Rename the pane header from "Sub agents" to "Background agents", matching the file's own comment, the backend module (`background_agent.rs`), and the async-only reality.
- Add a persistent one-line hint under the header (shown whenever agents are listed): only async background `Task` sub-agents appear here, and synchronous sub-agents run inline in the transcript.

Scope B (listing synchronous sub-agents in the pane too) is a follow-on and intentionally not in this PR.

Closes #3019

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session in the web dashboard and dispatch an async `Task` (a background sub-agent); open the Sub agents dock pane.
- [ ] Confirm the header reads "Background agents · N", not "Sub agents · N".
- [ ] Confirm a persistent hint under the header states the pane is async-only and that synchronous sub-agents run inline in the transcript, and that it stays visible while agents are listed.
- [ ] Run a session with a synchronous sub-agent (a normal `Task`); confirm it renders inline in the transcript and does not appear in the pane, which the hint now explains.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: copy/label change; covered by the updated Vitest on `BackgroundAgentsPanel` (asserts the new header text and the persistent hint), and `web/tests/coverage-matrix.json` already maps the component via `acp.background-agents`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (header wording, persistent hint) and reviewed the commit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Renamed the pane to **“Background agents”**.
- Added a persistent hint explaining that only asynchronous agents appear there, while synchronous agents run inline in the transcript.
- Updated tests to verify the new label and guidance.

This clarifies the pane’s behavior and avoids making the partial agent list seem inconsistent. Supporting synchronous agents in the pane remains future scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->