### PR TITLE
feat(plugins): installed-agent picker filter, ACP catalog probe, optional/multi project sessions

### DIFF
--- a/aoe-plugin-api/src/acp.rs
+++ b/aoe-plugin-api/src/acp.rs
@@ -3,9 +3,11 @@
 //!
 //! This is the stable wire contract a session-driving plugin (for example
 //! `plugin-cron`) pins its fixtures against. The host assembles it from the
-//! static agent registry plus the last option catalog each agent advertised;
-//! answering never launches an agent, so a never-run agent reports
-//! `CatalogStatus::Undiscovered` with empty model/mode lists. All lists are
+//! static agent registry plus the last option catalog each agent advertised.
+//! `acp.capabilities.get` never launches an agent, so a never-run agent reports
+//! `CatalogStatus::Undiscovered` with empty lists; `acp.capabilities.probe`
+//! (API v11, the `acp.capabilities.probe` grant) runs a handshake-only probe to
+//! populate the catalog first, then returns the same shape. All lists are
 //! sorted by id so serialized fixtures are deterministic. Fields are additive
 //! from here on; an incompatible reshape bumps the crate `API_VERSION`.
 
@@ -30,11 +32,24 @@ pub struct AcpAgentCapability {
     pub catalog_updated_at: Option<String>,
     pub models: Vec<AcpModelCapability>,
     pub modes: Vec<AcpModeCapability>,
+    /// Reasoning-effort / thought-level choices the agent advertised (for
+    /// example claude's `think`/`ultrathink`). Empty for agents that do not
+    /// expose one or whose catalog is undiscovered. Added in API v11; omitted
+    /// from the wire when empty so v10 fixtures stay byte-stable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub thinking: Vec<AcpThinkingCapability>,
 }
 
 /// A model choice the agent advertised.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AcpModelCapability {
+    pub id: String,
+    pub display_name: String,
+}
+
+/// A reasoning-effort / thought-level choice the agent advertised.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpThinkingCapability {
     pub id: String,
     pub display_name: String,
 }
@@ -103,6 +118,10 @@ mod tests {
                         approval_class: ApprovalClass::Guarded,
                     },
                 ],
+                thinking: vec![AcpThinkingCapability {
+                    id: "think".into(),
+                    display_name: "Think".into(),
+                }],
             }],
         };
         let json = serde_json::to_value(&response).expect("serialize");
@@ -118,7 +137,8 @@ mod tests {
                     "modes": [
                         {"id": "bypassPermissions", "display_name": "Bypass Permissions", "approval_class": "unattended"},
                         {"id": "plan", "display_name": "Plan", "approval_class": "guarded"}
-                    ]
+                    ],
+                    "thinking": [{"id": "think", "display_name": "Think"}]
                 }]
             })
         );
@@ -135,9 +155,12 @@ mod tests {
             catalog_updated_at: None,
             models: vec![],
             modes: vec![],
+            thinking: vec![],
         };
         let json = serde_json::to_value(&agent).expect("serialize");
         assert!(json.get("catalog_updated_at").is_none());
+        // Empty thinking is omitted so v10 fixtures stay byte-stable.
+        assert!(json.get("thinking").is_none());
         assert_eq!(json["catalog_status"], "undiscovered");
     }
 }

--- a/aoe-plugin-api/src/capability.rs
+++ b/aoe-plugin-api/src/capability.rs
@@ -95,6 +95,13 @@ pub const KNOWN_CAPABILITIES: &[&str] = &[
     // advertised structured-session models/modes. Read-only discovery; the host
     // never launches an agent to answer it.
     "acp.capabilities.read",
+    // Triggering a handshake-only catalog probe: the host spawns the agent
+    // adapter, runs initialize + session/new (no prompt turn, so no tokens),
+    // records the advertised models/modes/thought-levels, and tears the process
+    // down. Distinct from the read grant because it makes the host spawn a real
+    // process (CPU, startup latency, possibly network auth), a different risk
+    // axis than reading a cached catalog.
+    "acp.capabilities.probe",
     // Creating a host-owned structured-view session (the host validates agent,
     // model, mode, and repository trust; the plugin cannot bypass those).
     "session.create",

--- a/aoe-plugin-api/src/lib.rs
+++ b/aoe-plugin-api/src/lib.rs
@@ -41,5 +41,7 @@ pub use manifest::{
 /// session creation / prompt delivery (with the `session.unattended` grant),
 /// plugin-private storage, and structured settings widgets (`object_list`,
 /// `dynamic_select`); 10 when the `settings-page` full-page slot and the
-/// `tool-card-badge` slot were added.
-pub const API_VERSION: u32 = 10;
+/// `tool-card-badge` slot were added; 11 when `acp.capabilities.probe` let a
+/// plugin trigger a handshake-only catalog probe and the capability response
+/// grew a `thinking` (thought-level) list.
+pub const API_VERSION: u32 = 11;

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -260,6 +260,10 @@ pub enum ObjectFieldType {
     Integer,
     Select,
     DynamicSelect,
+    /// A host-resolved multi-select: the stored value is an array of the chosen
+    /// option values (order preserved). Like `DynamicSelect` it names an
+    /// `option_source` and may `depends_on` siblings. API v11.
+    DynamicMultiSelect,
     Cron,
 }
 
@@ -371,16 +375,20 @@ fn validate_object_list_settings(
                     f.value_type != ObjectFieldType::Select || !f.options.is_empty(),
                     format!("settings[{i}].fields[{j}] is a select but declares no options"),
                 );
+                let is_dynamic = matches!(
+                    f.value_type,
+                    ObjectFieldType::DynamicSelect | ObjectFieldType::DynamicMultiSelect
+                );
                 check(
-                    (f.value_type == ObjectFieldType::DynamicSelect) == f.option_source.is_some(),
+                    is_dynamic == f.option_source.is_some(),
                     format!(
-                        "settings[{i}].fields[{j}]: option_source is required for and exclusive to dynamic_select"
+                        "settings[{i}].fields[{j}]: option_source is required for and exclusive to dynamic_select / dynamic_multi_select"
                     ),
                 );
                 check(
-                    f.value_type == ObjectFieldType::DynamicSelect || f.depends_on.is_empty(),
+                    is_dynamic || f.depends_on.is_empty(),
                     format!(
-                        "settings[{i}].fields[{j}]: depends_on is only valid on a dynamic_select"
+                        "settings[{i}].fields[{j}]: depends_on is only valid on a dynamic_select / dynamic_multi_select"
                     ),
                 );
                 // Every depends_on entry must name a distinct sibling field
@@ -486,6 +494,9 @@ fn validate_object_list_default(
                         | ObjectFieldType::Cron => v.is_str(),
                         ObjectFieldType::Bool => v.as_bool().is_some(),
                         ObjectFieldType::Integer => v.as_integer().is_some(),
+                        ObjectFieldType::DynamicMultiSelect => {
+                            v.as_array().is_some_and(|a| a.iter().all(|e| e.is_str()))
+                        }
                     };
                     check(
                         type_ok,
@@ -1272,6 +1283,18 @@ impl PluginManifest {
                 "tool-card-badge UI slots require api_version >= 10".into(),
             );
         }
+        // `dynamic_multi_select` object-list fields are api_version 11; same
+        // reasoning as the gates above.
+        if self.api_version < 11 {
+            check(
+                self.settings.iter().all(|s| {
+                    s.fields
+                        .iter()
+                        .all(|f| f.value_type != ObjectFieldType::DynamicMultiSelect)
+                }),
+                "dynamic_multi_select settings fields require api_version >= 11".into(),
+            );
+        }
         for key in self.setting_defaults.keys() {
             check(
                 key.contains('.') && !key.starts_with('.') && !key.ends_with('.'),
@@ -1335,6 +1358,41 @@ mod tests {
     fn dynamic_select_requires_option_source() {
         let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 9\n\n\
              [[settings]]\nkey = \"agent\"\ntype = \"dynamic_select\"\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("option_source"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_multi_select_field_requires_v11() {
+        let toml = |api_version: u32| {
+            format!(
+                "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = {api_version}\n\n\
+                 [[settings]]\nkey = \"jobs\"\ntype = \"object_list\"\nitem_id_key = \"id\"\n\n\
+                 [[settings.fields]]\nkey = \"projects\"\ntype = \"dynamic_multi_select\"\noption_source = \"projects\"\n"
+            )
+        };
+        // v11 accepts the new field type and maps its source.
+        let m = PluginManifest::from_toml_str(&toml(11)).expect("v11 manifest parses");
+        assert_eq!(
+            m.settings[0].fields[0].value_type,
+            ObjectFieldType::DynamicMultiSelect
+        );
+        assert_eq!(
+            m.settings[0].fields[0].option_source,
+            Some(OptionSource::Projects)
+        );
+        // A v10 manifest using it is rejected with a version-gate message.
+        let err = PluginManifest::from_toml_str(&toml(10))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("api_version >= 11"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_multi_select_requires_option_source() {
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 11\n\n\
+             [[settings]]\nkey = \"jobs\"\ntype = \"object_list\"\nitem_id_key = \"id\"\n\n\
+             [[settings.fields]]\nkey = \"projects\"\ntype = \"dynamic_multi_select\"\n";
         let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
         assert!(err.contains("option_source"), "{err}");
     }

--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -505,7 +505,17 @@ fn validate_object_list_default(
                             f.key, f.value_type
                         ),
                     );
-                    if f.required && v.as_str().map(|s| s.trim().is_empty()).unwrap_or(false) {
+                    // `required` means "carries a non-empty value". A string is
+                    // empty when blank; a dynamic_multi_select value is empty
+                    // when the array has no entries (`as_str` is always None for
+                    // an array, so it needs its own check).
+                    let empty_required = match f.value_type {
+                        ObjectFieldType::DynamicMultiSelect => {
+                            v.as_array().is_none_or(|a| a.is_empty())
+                        }
+                        _ => v.as_str().map(|s| s.trim().is_empty()).unwrap_or(false),
+                    };
+                    if f.required && empty_required {
                         check(
                             false,
                             format!("settings[{i}].default[{k}].{} is required but empty", f.key),
@@ -1395,6 +1405,18 @@ mod tests {
              [[settings.fields]]\nkey = \"projects\"\ntype = \"dynamic_multi_select\"\n";
         let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
         assert!(err.contains("option_source"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_multi_select_required_rejects_empty_array_default() {
+        // A default item whose required multi-select is an empty array must be
+        // rejected: `required` means "carries a non-empty value", and the array
+        // check is distinct from the string one.
+        let toml = "id = \"a.b\"\nname = \"B\"\nversion = \"1.0.0\"\napi_version = 11\n\n\
+             [[settings]]\nkey = \"jobs\"\ntype = \"object_list\"\nitem_id_key = \"id\"\ndefault = [ { id = \"x\", projects = [] } ]\n\n\
+             [[settings.fields]]\nkey = \"projects\"\ntype = \"dynamic_multi_select\"\noption_source = \"projects\"\nrequired = true\n";
+        let err = PluginManifest::from_toml_str(toml).unwrap_err().to_string();
+        assert!(err.contains("is required but empty"), "{err}");
     }
 
     #[test]

--- a/aoe-plugin-api/src/session.rs
+++ b/aoe-plugin-api/src/session.rs
@@ -17,8 +17,18 @@ pub struct SessionsCreateRequest {
     /// Agent to run, an id from `acp.capabilities.get`.
     pub agent_id: String,
     /// Project directory the session runs in. Canonicalized and checked
-    /// against repository trust by the host, fail-closed.
-    pub project_path: String,
+    /// against repository trust by the host, fail-closed. Absent or empty
+    /// means *no project*: the host provisions a throwaway scratch session
+    /// (no repo, so no trust anchor). Optional since API v11; a present value
+    /// keeps the v9/v10 behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    /// Additional repository paths for a multi-repo session, each canonicalized
+    /// and existence-checked by the host. Only valid alongside a
+    /// `project_path` (the first repo is the trust anchor); combining extras
+    /// with a scratch session is refused. API v11.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_project_paths: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
     /// Approval mode id. Omitted means the adapter default (interactive).
@@ -72,7 +82,8 @@ mod tests {
     fn create_request_wire_fixture_is_stable() {
         let request = SessionsCreateRequest {
             agent_id: "claude".into(),
-            project_path: "/home/user/project".into(),
+            project_path: Some("/home/user/project".into()),
+            extra_project_paths: Vec::new(),
             model_id: Some("sonnet".into()),
             mode_id: Some("plan".into()),
             title: Some("nightly maintenance".into()),
@@ -110,5 +121,49 @@ mod tests {
         }))
         .expect_err("unknown fields must be rejected");
         assert!(err.to_string().contains("allow_untrusted"));
+    }
+
+    #[test]
+    fn scratch_request_omits_project_path() {
+        // No project selected: project_path is absent on the wire (scratch),
+        // and an omitted project_path round-trips to None.
+        let request = SessionsCreateRequest {
+            agent_id: "claude".into(),
+            project_path: None,
+            extra_project_paths: Vec::new(),
+            model_id: None,
+            mode_id: None,
+            title: None,
+            group: None,
+            initial_turn: None,
+            idempotency_key: None,
+        };
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert!(json.get("project_path").is_none());
+        assert!(json.get("extra_project_paths").is_none());
+        let round: SessionsCreateRequest = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(round, request);
+    }
+
+    #[test]
+    fn multi_repo_request_carries_extra_paths() {
+        let request = SessionsCreateRequest {
+            agent_id: "claude".into(),
+            project_path: Some("/repos/app".into()),
+            extra_project_paths: vec!["/repos/lib".into(), "/repos/proto".into()],
+            model_id: None,
+            mode_id: None,
+            title: None,
+            group: None,
+            initial_turn: None,
+            idempotency_key: None,
+        };
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(
+            json["extra_project_paths"],
+            serde_json::json!(["/repos/lib", "/repos/proto"])
+        );
+        let round: SessionsCreateRequest = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(round, request);
     }
 }

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -19,10 +19,10 @@ A manifest carries two independent version axes.
 
 | Key | Meaning |
 |---|---|
-| `api_version` | The manifest *schema* version. The current schema is `10`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
+| `api_version` | The manifest *schema* version. The current schema is `11`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot, `11` added the `acp.capabilities.probe` RPC + capability, a `thinking` (thought-level) list on the capability response, the `dynamic_multi_select` object-list field widget, and an optional `project_path` (empty = scratch session) plus `extra_project_paths` on `sessions.create`.
 
 ## Top-level fields
 
@@ -41,7 +41,7 @@ capabilities = ["runtime.worker"]
 | `id` | string | yes | Plugin id (see [Plugin id](#plugin-id)). Namespaces config, events, and action names. |
 | `name` | string | yes | Human-readable display name. |
 | `version` | string | yes | Semantic version of the plugin. |
-| `api_version` | integer | yes | Manifest schema version, `1` to `10`. |
+| `api_version` | integer | yes | Manifest schema version, `1` to `11`. |
 | `description` | string | no | Shown in plugin listings. Defaults to empty. |
 | `aoe_version` | string | no | Host-app semver requirement. Requires `api_version >= 4`. |
 | `capabilities` | array of string | no | Runtime grants the worker needs (see [Capabilities](#capabilities)). Static contributions need none. |
@@ -81,6 +81,7 @@ themes, ui, status) need no capability.
 | `composer.read` | Reading a click-scoped snapshot of the active ACP composer draft from a `composer-action`. |
 | `composer.write` | Publishing a host-validated draft edit from a `composer-action` UI-state payload. |
 | `acp.capabilities.read` | Discovering available agents and their advertised models/modes via `acp.capabilities.get` (`api_version >= 9`). |
+| `acp.capabilities.probe` | Triggering a handshake-only catalog probe via `acp.capabilities.probe`: the host spawns the agent adapter, runs initialize + `session/new` (no prompt turn, so no tokens), records the advertised models/modes/thought-levels, and tears it down. Distinct from `acp.capabilities.read` because it spawns a real process (`api_version >= 11`). |
 | `session.create` | Creating a host-owned structured session via `sessions.create` (`api_version >= 9`). |
 | `session.prompt` | Delivering a turn to a session the plugin created via `sessions.turn.send`, and the initial turn on `sessions.create` (`api_version >= 9`). |
 | `session.unattended` | Creating a session in a host-classified *unattended* approval mode. A distinct, high-severity grant, never implied by `session.create` or `session.prompt` (`api_version >= 9`). See [Session-driving RPCs](#session-driving-rpcs). |
@@ -174,6 +175,7 @@ Setting types:
 | `integer` | Number input, bounded by `min` / `max`. |
 | `select` | Dropdown over a non-empty `options` array. |
 | `dynamic_select` | Dropdown whose choices the host resolves from `option_source` (`api_version >= 9`). |
+| `dynamic_multi_select` | Multi-select (checkbox list) whose choices the host resolves from `option_source`; the stored value is an array of chosen values. Object-list item fields only (`api_version >= 11`). |
 | `cron` | Validated 5-field cron expression text field (`api_version >= 9`). |
 | `object_list` | A repeatable list of structured items described by `fields` (`api_version >= 9`). |
 
@@ -185,17 +187,21 @@ the host's real agents, models, or projects. Set `option_source` to one of:
 
 | `option_source` | Choices |
 |---|---|
-| `acp.agents` | ACP-capable agents the host knows. |
+| `acp.agents` | ACP-capable agents the host knows *and whose adapter is installed on this host*. Uninstalled harnesses are not offered. |
 | `acp.models` | Models the selected agent advertised. Needs the agent via `depends_on`. |
 | `acp.modes` | Approval modes the selected agent advertised. Needs the agent via `depends_on`. |
 | `projects` | Registered projects (value is the project path). |
 | `groups` | Existing session group paths. |
 
 `depends_on` names sibling keys whose current values parameterize the source;
-`acp.models` and `acp.modes` require the selected agent. Saved ids are
-advisory: the host revalidates them when a session is actually created, so a
-model that later disappears from the catalog surfaces as an error at creation,
-not silently at save.
+`acp.models` and `acp.modes` require the selected agent. When the selected
+agent's option catalog has never been discovered, resolving `acp.models` /
+`acp.modes` runs a one-shot handshake probe (see `acp.capabilities.probe`) to
+populate it, so the picker self-fills on first open instead of staying empty
+until the agent has run a live session. Saved ids are advisory: the host
+revalidates them when a session is actually created, so a model that later
+disappears from the catalog surfaces as an error at creation, not silently at
+save.
 
 ### Object lists (`api_version >= 9`)
 
@@ -238,7 +244,10 @@ required = true
 Each item field takes the same `key` / `label` / `description` / `type` /
 `options` / `min` / `max` / `default` / `option_source` / `depends_on` keys as a
 top-level setting, plus `required` (the item must carry a non-empty value). An
-item field's `type` cannot be `object_list`.
+item field's `type` cannot be `object_list`. An item field may be a
+`dynamic_multi_select` (`api_version >= 11`): like `dynamic_select` it names an
+`option_source` and may `depends_on` siblings, but its stored value is an array
+of the chosen option values.
 
 ## Session-driving RPCs
 
@@ -249,10 +258,20 @@ enforces a strict security model around them.
 
 | Method | Capability | Purpose |
 |---|---|---|
-| `acp.capabilities.get` | `acp.capabilities.read` | List agents and their advertised models / modes (never launches an agent). |
+| `acp.capabilities.get` | `acp.capabilities.read` | List agents and their advertised models / modes / thought-levels (never launches an agent; a never-run agent reports `catalog_status: undiscovered` with empty lists). |
+| `acp.capabilities.probe` | `acp.capabilities.probe` | Populate the catalog for one agent (optional `agent_id`; otherwise every undiscovered registry agent) via a handshake-only probe, then return the same shape as `acp.capabilities.get`. Spawns the adapter and runs initialize + `session/new` with **no prompt turn** (no tokens); each probe degrades to a no-op on failure. `api_version >= 11`. |
 | `sessions.create` | `session.create` (+ `session.prompt` for an initial turn, + `session.unattended` for an unattended mode) | Create a structured session, optionally with an initial turn and a plugin-scoped idempotency key. |
 | `sessions.turn.send` | `session.prompt` | Deliver a turn to a session **this plugin created**. |
 | `plugin.storage.get` / `set` / `cas` / `remove` | `runtime.worker` | Plugin-private durable key/value storage (see [Plugin storage](#plugin-storage)). |
+
+**Project selection (`api_version >= 11`).** `sessions.create` takes an optional
+`project_path` and an optional `extra_project_paths` array. Omitting
+`project_path` (or sending it empty) creates a **scratch** session: a throwaway
+working directory with no repository, hence no trust anchor. When present, the
+`project_path` is the trust-checked primary repo and each `extra_project_paths`
+entry is an additional repo of a multi-repo session; combining extras with a
+scratch session (no `project_path`) is refused. Every path is canonicalized and
+existence-checked host-side, fail-closed.
 
 **Approval-mode classification.** The plugin proposes a `mode_id`; the **host**
 decides its security class, never the plugin. A mode is *interactive* (omitted /

--- a/src/acp/capability_probe.rs
+++ b/src/acp/capability_probe.rs
@@ -1,0 +1,151 @@
+//! Handshake-only ACP catalog probe (plugin-picker model-discovery fix).
+//!
+//! The structured-session model / mode / thought-level pickers are fed by the
+//! `config_options` an agent advertises. Those are cached per-agent in
+//! [`crate::acp::option_catalog`], but only ever written as a side effect of a
+//! *live* session (`src/server/mod.rs` on `ConfigOptionsUpdated`). So an agent
+//! that has never run shows an empty picker, which reads as a bug.
+//!
+//! ACP puts the option set in the `session/new` response itself
+//! (`NewSessionResponse.config_options`; claude-agent-acp emits models + modes +
+//! thought-levels there, see #1403), so we can populate the catalog without a
+//! conversation: spawn the adapter, run initialize + `session/new` against a
+//! throwaway cwd, record the first advertised snapshot, and tear the process
+//! down. No prompt turn is sent, so no tokens are spent. The probe reuses
+//! [`AcpClient::spawn`] on the in-process stdio transport (`socket_path: None`),
+//! so it leaves no detached runner or worker-registry entry behind.
+//!
+//! Everything here degrades to "undiscovered" rather than failing: an unknown
+//! agent, an absent adapter, a handshake that needs credentials the daemon does
+//! not have, or an adapter that never advertises options all return
+//! `Ok(false)`.
+
+use std::time::Duration;
+
+use crate::acp::acp_client::{AcpClient, SpawnConfig};
+use crate::acp::state::{AcpSessionId, Event};
+use crate::acp::AgentRegistry;
+
+/// Whole-spawn bound: initialize + `session/new` must complete within this or
+/// the adapter is treated as undiscovered.
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long to wait for the first `ConfigOptionsUpdated` after `session/new`.
+/// claude queues it in the `session/new` response so it is usually immediate;
+/// this only bounds adapters that push it as a follow-up notification.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Probe `agent`'s advertised option catalog via a handshake-only ACP session
+/// and record it into [`crate::acp::option_catalog`]. Returns `Ok(true)` when a
+/// non-empty snapshot was recorded, `Ok(false)` when the agent is unknown, its
+/// adapter is not installed, the handshake failed, or no options arrived in
+/// time. Never sends a prompt turn.
+pub async fn probe_agent(agent: &str) -> anyhow::Result<bool> {
+    // Registry agents only. The picker is populated from the static registry,
+    // and a custom agent's `agent_acp_cmd` can carry hostnames or secrets we
+    // should not blind-spawn from a settings GET.
+    let registry = AgentRegistry::with_defaults();
+    let Some(mut spec) = registry.get(agent).cloned() else {
+        return Ok(false);
+    };
+    // Absent adapter would just ENOENT at exec; skip the spawn entirely.
+    if !crate::cli::acp::command_present(&spec.command) {
+        return Ok(false);
+    }
+    if spec.command.contains("${aoe_data_dir}") {
+        if let Ok(data_dir) = crate::session::get_app_dir() {
+            spec.command = spec
+                .command
+                .replace("${aoe_data_dir}", &data_dir.to_string_lossy());
+        }
+    }
+
+    // Throwaway absolute cwd: `session/new` requires an existing absolute
+    // directory, but a handshake writes nothing to it. Dropped on return.
+    let tmp = tempfile::tempdir()?;
+
+    let config = SpawnConfig {
+        agent_key: agent.to_string(),
+        spec,
+        cwd: tmp.path().to_path_buf(),
+        additional_dirs: Vec::new(),
+        // Same as the reconciler/session-spawn paths: auth comes from the
+        // daemon's inherited environment, not this field.
+        provider_env: Vec::new(),
+        default_effort: None,
+        default_mode: None,
+        // In-process stdio: no detached runner, no persistent worker entry.
+        socket_path: None,
+        stored_acp_session_id: None,
+        fork_from: None,
+        sandbox_info: None,
+        source_profile: None,
+        mcp_servers: Vec::new(),
+        seed_history_replay: false,
+        artifact_dir: None,
+    };
+
+    // Probe-scoped id so it never collides with a real structured-view worker.
+    let session_id = AcpSessionId(format!("__probe__{agent}"));
+
+    let mut client =
+        match tokio::time::timeout(SPAWN_TIMEOUT, AcpClient::spawn(config, session_id.clone()))
+            .await
+        {
+            Ok(Ok(client)) => client,
+            Ok(Err(e)) => {
+                tracing::debug!(target: "acp.probe", agent, error = %e, "probe handshake failed");
+                return Ok(false);
+            }
+            // ponytail: a wedged handshake leaks the child (no kill_on_drop on the
+            // spawn), reaped at daemon exit. Acceptable on the settings probe path;
+            // add kill_on_drop to spawn_subprocess if this ever bites.
+            Err(_) => {
+                tracing::debug!(target: "acp.probe", agent, "probe handshake timed out");
+                return Ok(false);
+            }
+        };
+
+    let recorded = tokio::time::timeout(DRAIN_TIMEOUT, drain_first_snapshot(&mut client, agent))
+        .await
+        .unwrap_or(false);
+
+    // Best-effort teardown; both calls are internally bounded.
+    let _ = client.delete_session(session_id.0.clone()).await;
+    let _ = client.shutdown().await;
+    Ok(recorded)
+}
+
+/// Drain events until the first non-empty `ConfigOptionsUpdated`, record it, and
+/// return `true`. Returns `false` if the stream ends first.
+async fn drain_first_snapshot(client: &mut AcpClient, agent: &str) -> bool {
+    while let Some(event) = client.next_event().await {
+        if let Event::ConfigOptionsUpdated { options } = event {
+            if options.is_empty() {
+                continue;
+            }
+            let agent = agent.to_string();
+            let now = chrono::Utc::now().to_rfc3339();
+            let _ = tokio::task::spawn_blocking(move || {
+                crate::acp::option_catalog::record(&agent, &options, now)
+            })
+            .await;
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An agent that is not in the registry never spawns a process; the probe
+    /// degrades to `Ok(false)` immediately. Keeps the happy path (which spawns a
+    /// real adapter) out of the hermetic unit suite.
+    #[tokio::test]
+    async fn unknown_agent_never_spawns() {
+        assert!(!probe_agent("definitely-not-an-agent-xyz")
+            .await
+            .expect("unknown agent is a clean no-op"));
+    }
+}

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -19,6 +19,7 @@ pub mod agent_profiles;
 pub mod agent_registry;
 pub mod approvals;
 pub mod background_agent;
+pub mod capability_probe;
 pub mod client;
 pub mod context_primer;
 pub mod elicitations;

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use aoe_plugin_api::acp::{
     AcpAgentCapability, AcpCapabilitiesResponse, AcpModeCapability, AcpModelCapability,
-    ApprovalClass, CatalogStatus,
+    AcpThinkingCapability, ApprovalClass, CatalogStatus,
 };
 use aoe_plugin_api::session::{SessionsCreateRequest, SessionsCreateResponse, TurnSendRequest};
 
@@ -30,6 +30,7 @@ use crate::server::session_service::{
 use crate::server::session_spawn::StructuredSessionSpec;
 
 const CAP_ACP_CAPABILITIES_READ: &str = "acp.capabilities.read";
+const CAP_ACP_CAPABILITIES_PROBE: &str = "acp.capabilities.probe";
 const CAP_SESSION_CREATE: &str = "session.create";
 const CAP_SESSION_PROMPT: &str = "session.prompt";
 const CAP_SESSION_UNATTENDED: &str = "session.unattended";
@@ -47,7 +48,10 @@ pub struct SessionRpcDeps {
 pub(crate) fn handles(method: &str) -> bool {
     matches!(
         method,
-        "acp.capabilities.get" | "sessions.create" | "sessions.turn.send"
+        "acp.capabilities.get"
+            | "acp.capabilities.probe"
+            | "sessions.create"
+            | "sessions.turn.send"
     )
 }
 
@@ -57,6 +61,7 @@ pub(crate) fn handles(method: &str) -> bool {
 pub(crate) fn required_capability(method: &str) -> Option<&'static str> {
     match method {
         "acp.capabilities.get" => Some(CAP_ACP_CAPABILITIES_READ),
+        "acp.capabilities.probe" => Some(CAP_ACP_CAPABILITIES_PROBE),
         "sessions.create" => Some(CAP_SESSION_CREATE),
         "sessions.turn.send" => Some(CAP_SESSION_PROMPT),
         _ => None,
@@ -73,6 +78,10 @@ pub(crate) async fn dispatch(
         "acp.capabilities.get" => {
             ctx.require(CAP_ACP_CAPABILITIES_READ)?;
             capabilities_get().await
+        }
+        "acp.capabilities.probe" => {
+            ctx.require(CAP_ACP_CAPABILITIES_PROBE)?;
+            capabilities_probe(params).await
         }
         "sessions.create" => {
             ctx.require(CAP_SESSION_CREATE)?;
@@ -140,6 +149,17 @@ async fn capabilities_get() -> Result<Value, DispatchError> {
                 })
                 .unwrap_or_default();
             modes.sort_by(|a, b| a.id.cmp(&b.id));
+            let mut thinking: Vec<AcpThinkingCapability> = entry
+                .map(|e| {
+                    choices(e, ConfigOptionCategory::ThoughtLevel)
+                        .map(|choice| AcpThinkingCapability {
+                            id: choice.value.clone(),
+                            display_name: choice.name.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            thinking.sort_by(|a, b| a.id.cmp(&b.id));
             AcpAgentCapability {
                 // The registry has no display metadata; the id doubles as
                 // the display name until it grows one.
@@ -149,12 +169,56 @@ async fn capabilities_get() -> Result<Value, DispatchError> {
                 catalog_updated_at,
                 models,
                 modes,
+                thinking,
             }
         })
         .collect();
 
     serde_json::to_value(AcpCapabilitiesResponse { agents })
         .map_err(|e| DispatchError::internal(format!("serialize capabilities: {e}")))
+}
+
+/// `acp.capabilities.probe`: populate the option catalog for one agent (or every
+/// currently-undiscovered registry agent when no `agent_id` is given) via a
+/// handshake-only ACP probe, then return the same shape as
+/// `acp.capabilities.get`. Each probe degrades to a no-op on failure, so a
+/// missing adapter or an agent that needs credentials the daemon lacks simply
+/// stays `Undiscovered` instead of erroring the whole call.
+async fn capabilities_probe(params: &Value) -> Result<Value, DispatchError> {
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct ProbeParams {
+        #[serde(default)]
+        agent_id: Option<String>,
+    }
+
+    let req: ProbeParams = if params.is_null() {
+        ProbeParams { agent_id: None }
+    } else {
+        serde_json::from_value(params.clone())
+            .map_err(|e| DispatchError::invalid_params(format!("invalid probe params: {e}")))?
+    };
+
+    let targets: Vec<String> = match req.agent_id {
+        Some(id) if !id.trim().is_empty() => vec![id],
+        _ => {
+            let catalog = load_catalog().await;
+            crate::acp::AgentRegistry::with_defaults()
+                .list()
+                .into_iter()
+                .map(|(name, _)| name.clone())
+                .filter(|name| !catalog.agents.contains_key(name))
+                .collect()
+        }
+    };
+
+    for agent in &targets {
+        if let Err(e) = crate::acp::capability_probe::probe_agent(agent).await {
+            tracing::warn!(target: "acp.probe", agent = %agent, error = %e, "capability probe errored");
+        }
+    }
+
+    capabilities_get().await
 }
 
 fn choices(
@@ -293,15 +357,45 @@ async fn admit_and_create(
         ctx.require(CAP_SESSION_PROMPT)?;
     }
 
-    // Canonicalize immediately before the trust-checked spawn; a dangling
-    // path is the caller's error. Repo trust itself is enforced inside the
-    // service, fail-closed for plugin callers.
-    let project_path = std::fs::canonicalize(&req.project_path)
-        .map_err(|e| {
-            DispatchError::invalid_params(format!("project_path {:?}: {e}", req.project_path))
-        })?
-        .to_string_lossy()
-        .into_owned();
+    // Resolve the project selection into (path, extra_repo_paths, scratch).
+    // No project -> a scratch session (no repo, hence no trust anchor). One or
+    // more projects -> the first is the trust-checked primary repo and the rest
+    // are extra repos. Canonicalize immediately before the trust-checked spawn;
+    // a dangling path is the caller's error. Repo trust itself is enforced
+    // inside the service, fail-closed for plugin callers.
+    let primary = req
+        .project_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+    let (project_path, extra_repo_paths, scratch) = match primary {
+        None => {
+            // A scratch session has no repo, so extra repos are meaningless and
+            // the builder refuses the combination; reject early and clearly.
+            if req.extra_project_paths.iter().any(|p| !p.trim().is_empty()) {
+                return Err(DispatchError::invalid_params(
+                    "extra_project_paths requires a project_path; a scratch session takes no extra repos",
+                ));
+            }
+            (String::new(), Vec::new(), true)
+        }
+        Some(primary) => {
+            let canon = |p: &str| -> Result<String, DispatchError> {
+                std::fs::canonicalize(p)
+                    .map_err(|e| DispatchError::invalid_params(format!("project_path {p:?}: {e}")))
+                    .map(|c| c.to_string_lossy().into_owned())
+            };
+            let path = canon(primary)?;
+            let extras = req
+                .extra_project_paths
+                .iter()
+                .map(|p| p.trim())
+                .filter(|p| !p.is_empty())
+                .map(canon)
+                .collect::<Result<Vec<_>, _>>()?;
+            (path, extras, false)
+        }
+    };
 
     let spec = StructuredSessionSpec {
         title: req.title,
@@ -318,8 +412,8 @@ async fn admit_and_create(
         extra_env: Vec::new(),
         extra_args: String::new(),
         command_override: String::new(),
-        extra_repo_paths: Vec::new(),
-        scratch: false,
+        extra_repo_paths,
+        scratch,
         // The service forces this to Some(false) for plugin callers; set
         // explicitly anyway so the intent is local.
         trust_hooks: Some(false),
@@ -535,6 +629,7 @@ mod tests {
         let none = ctx_with(&[]);
         for method in [
             "acp.capabilities.get",
+            "acp.capabilities.probe",
             "sessions.create",
             "sessions.turn.send",
         ] {
@@ -590,6 +685,62 @@ mod tests {
         .await
         .expect_err("unknown fields must be rejected");
         assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    /// The probe RPC decodes params strictly: an unknown field is a client
+    /// error, refused before any spawn work.
+    #[tokio::test]
+    async fn probe_rejects_unknown_params() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let ctx = ctx_with(&["acp.capabilities.probe"]);
+        let err = dispatch(
+            &deps,
+            &ctx,
+            "acp.capabilities.probe",
+            &serde_json::json!({ "bogus": 1 }),
+        )
+        .await
+        .expect_err("unknown probe param must be rejected");
+        assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    /// A scratch create (no project_path) may not carry extra repos: the
+    /// session builder refuses that combination, so the RPC rejects it up front
+    /// with a clear invalid-params error, before any spawn.
+    #[tokio::test]
+    async fn scratch_with_extra_repos_is_rejected() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let ctx = ctx_with(&["session.create"]);
+        let err = dispatch(
+            &deps,
+            &ctx,
+            "sessions.create",
+            &serde_json::json!({
+                "agent_id": "claude",
+                "extra_project_paths": ["/tmp"],
+            }),
+        )
+        .await
+        .expect_err("scratch + extra repos must be refused");
+        assert_eq!(err.code, codes::INVALID_PARAMS);
+    }
+
+    /// A registry-unknown `agent_id` never spawns anything (the probe bails on
+    /// an unknown agent), so this stays hermetic while still exercising the RPC
+    /// end to end and confirming it returns the capability catalog shape.
+    #[tokio::test]
+    async fn probe_unknown_agent_is_noop_and_returns_catalog() {
+        let (deps, _dir) = test_deps(Vec::new());
+        let ctx = ctx_with(&["acp.capabilities.probe"]);
+        let out = dispatch(
+            &deps,
+            &ctx,
+            "acp.capabilities.probe",
+            &serde_json::json!({ "agent_id": "definitely-not-an-agent-xyz" }),
+        )
+        .await
+        .expect("probe returns the capability catalog");
+        assert!(out.get("agents").is_some());
     }
 
     /// A brand-new create at the active-session limit is denied with the stable

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -29,6 +29,10 @@ use crate::server::session_service::{
 };
 use crate::server::session_spawn::StructuredSessionSpec;
 
+/// Upper bound on `extra_project_paths` per create, so one plugin call cannot
+/// trigger an unbounded chain of blocking `canonicalize` calls.
+const MAX_EXTRA_PROJECT_PATHS: usize = 16;
+
 const CAP_ACP_CAPABILITIES_READ: &str = "acp.capabilities.read";
 const CAP_ACP_CAPABILITIES_PROBE: &str = "acp.capabilities.probe";
 const CAP_SESSION_CREATE: &str = "session.create";
@@ -380,20 +384,42 @@ async fn admit_and_create(
             (String::new(), Vec::new(), true)
         }
         Some(primary) => {
-            let canon = |p: &str| -> Result<String, DispatchError> {
-                std::fs::canonicalize(p)
-                    .map_err(|e| DispatchError::invalid_params(format!("project_path {p:?}: {e}")))
-                    .map(|c| c.to_string_lossy().into_owned())
-            };
-            let path = canon(primary)?;
-            let extras = req
+            // Cap the extras before any blocking work so one call cannot tie up
+            // a runtime worker with a long canonicalization chain.
+            let extras_in: Vec<String> = req
                 .extra_project_paths
                 .iter()
-                .map(|p| p.trim())
+                .map(|p| p.trim().to_string())
                 .filter(|p| !p.is_empty())
-                .map(canon)
-                .collect::<Result<Vec<_>, _>>()?;
-            (path, extras, false)
+                .collect();
+            if extras_in.len() > MAX_EXTRA_PROJECT_PATHS {
+                return Err(DispatchError::invalid_params(format!(
+                    "too many extra_project_paths ({}); max {MAX_EXTRA_PROJECT_PATHS}",
+                    extras_in.len()
+                )));
+            }
+            let primary = primary.to_string();
+            // Filesystem canonicalization is blocking; run it off the async
+            // runtime rather than stalling a worker thread.
+            tokio::task::spawn_blocking(move || {
+                let canon = |p: &str| -> Result<String, DispatchError> {
+                    std::fs::canonicalize(p)
+                        .map_err(|e| {
+                            DispatchError::invalid_params(format!("project_path {p:?}: {e}"))
+                        })
+                        .map(|c| c.to_string_lossy().into_owned())
+                };
+                let path = canon(&primary)?;
+                let extras = extras_in
+                    .iter()
+                    .map(|p| canon(p))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok::<_, DispatchError>((path, extras, false))
+            })
+            .await
+            .map_err(|e| {
+                DispatchError::internal(format!("path canonicalization task failed: {e}"))
+            })??
         }
     };
 

--- a/src/server/api/plugin_settings.rs
+++ b/src/server/api/plugin_settings.rs
@@ -69,23 +69,42 @@ pub async fn resolve_option_source(
 ) -> anyhow::Result<Vec<SelectOption>> {
     match source {
         OptionSource::AcpAgents => Ok(acp_agent_options(&state.profile).await),
-        OptionSource::AcpModels => Ok(catalog_options(depends.first(), CatalogCategory::Model)),
-        OptionSource::AcpModes => Ok(catalog_options(depends.first(), CatalogCategory::Mode)),
+        OptionSource::AcpModels => {
+            Ok(catalog_options_probing(depends.first(), CatalogCategory::Model).await)
+        }
+        OptionSource::AcpModes => {
+            Ok(catalog_options_probing(depends.first(), CatalogCategory::Mode).await)
+        }
         OptionSource::Projects => project_options(&state.profile).await,
         OptionSource::Groups => Ok(group_options(state).await),
     }
 }
 
-/// ACP-capable agents from the static registry plus any custom ACP agents the
-/// resolved profile config declares via a valid `agent_acp_cmd`. Sorted, deduped
-/// by id (a custom entry shadowing a built-in is dropped by the dedup).
+/// Registry agents whose ACP adapter is filtered by `present`, mapped to
+/// `{value,label}`. Split out so the install filter is unit-testable without
+/// depending on which adapters happen to be on the test host's PATH.
+fn installed_agent_options<'a>(
+    entries: impl IntoIterator<Item = (&'a String, &'a crate::acp::AgentSpec)>,
+    present: impl Fn(&str) -> bool,
+) -> Vec<SelectOption> {
+    entries
+        .into_iter()
+        .filter(|(_, spec)| present(&spec.command))
+        .map(|(name, _)| SelectOption::new(name, name))
+        .collect()
+}
+
+/// ACP-capable agents from the static registry whose adapter binary actually
+/// resolves on this host, plus any custom ACP agents the resolved profile
+/// config declares via a valid `agent_acp_cmd`. Sorted, deduped by id (a custom
+/// entry shadowing a built-in is dropped by the dedup).
+///
+/// The registry filter mirrors `list_agents` (`acp_installed`): an agent is
+/// only offered as a choice when the host could actually launch it, so the
+/// picker never lists uninstalled harnesses (#3-plugin-cron picker fix).
 async fn acp_agent_options(profile: &str) -> Vec<SelectOption> {
     let registry = crate::acp::AgentRegistry::with_defaults();
-    let mut opts: Vec<SelectOption> = registry
-        .list()
-        .into_iter()
-        .map(|(name, _)| SelectOption::new(name, name))
-        .collect();
+    let mut opts = installed_agent_options(registry.list(), crate::cli::acp::command_present);
 
     // Custom ACP agents live in the per-profile config; resolve the profile
     // (global -> profile, no repo) and keep entries whose command parses as a
@@ -113,9 +132,50 @@ async fn acp_agent_options(profile: &str) -> Vec<SelectOption> {
     opts
 }
 
+#[derive(Clone, Copy)]
 enum CatalogCategory {
     Model,
     Mode,
+}
+
+/// Like [`catalog_options`], but when the selected agent's catalog has never
+/// been discovered, run a one-shot handshake probe to populate it first, so a
+/// model/mode picker self-fills on first open instead of showing empty until
+/// the agent has run a live session. The probe records into the shared option
+/// catalog, so it is effectively one spawn per agent; the cache then suppresses
+/// repeats.
+async fn catalog_options_probing(
+    agent: Option<&String>,
+    category: CatalogCategory,
+) -> Vec<SelectOption> {
+    let first = catalog_options(agent, category);
+    if !first.is_empty() {
+        return first;
+    }
+    let Some(agent) = agent.filter(|a| !a.is_empty()) else {
+        return first;
+    };
+    // Already discovered (this category is just genuinely empty): don't respawn.
+    if crate::acp::option_catalog::load()
+        .agents
+        .contains_key(agent)
+    {
+        return first;
+    }
+    // Only registry agents are blind-probed; a custom agent's command can carry
+    // secrets, so it stays populated only by real runs.
+    if crate::acp::AgentRegistry::with_defaults()
+        .get(agent)
+        .is_none()
+    {
+        return first;
+    }
+    // ponytail: one handshake spawn per undiscovered agent; an agent that
+    // advertises no options at all re-probes on each open (rare, cheap).
+    match crate::acp::capability_probe::probe_agent(agent).await {
+        Ok(true) => catalog_options(Some(agent), category),
+        _ => first,
+    }
 }
 
 /// Model or mode choices the given agent last advertised. Empty when no agent
@@ -179,22 +239,28 @@ mod tests {
         b.group_path = "work/backend".to_string();
         let state = crate::server::test_support::build_test_app_state(vec![a, b]);
 
-        // Agents: the static ACP registry always has entries.
+        // Agents: filtered to adapters present on this host, so the exact set
+        // is environment-dependent; just assert the resolver succeeds and only
+        // ever returns known registry ids (no custom agents in this profile).
         let agents = resolve_option_source(&state, OptionSource::AcpAgents, &[])
             .await
             .expect("agents");
-        assert!(agents.iter().any(|o| o.value == "claude-code"));
+        let registry = crate::acp::AgentRegistry::with_defaults();
+        assert!(agents.iter().all(|o| registry.get(&o.value).is_some()));
 
         // Models with no selected agent: empty (nothing to resolve yet).
         let models = resolve_option_source(&state, OptionSource::AcpModels, &[])
             .await
             .expect("models");
         assert!(models.is_empty());
-        // Models for an agent with no discovered catalog: still empty, never errors.
+        // Models for a registry-unknown agent: empty and hermetic. A *known*
+        // undiscovered agent would trigger a live handshake probe (see
+        // `catalog_options_probing`), which is not something a unit test should
+        // spawn, so we assert the empty path via an id the probe declines.
         let models = resolve_option_source(
             &state,
             OptionSource::AcpModels,
-            &["claude-code".to_string()],
+            &["definitely-not-an-agent-xyz".to_string()],
         )
         .await
         .expect("models");
@@ -208,5 +274,27 @@ mod tests {
             groups.iter().map(|o| o.value.as_str()).collect::<Vec<_>>(),
             vec!["work/backend"]
         );
+    }
+
+    #[test]
+    fn agent_filter_keeps_only_present_adapters() {
+        let registry = crate::acp::AgentRegistry::with_defaults();
+        let total = registry.list().len();
+        assert!(total > 0, "registry should have default agents");
+
+        // No adapter present -> empty picker (the uninstalled-harness fix).
+        assert!(installed_agent_options(registry.list(), |_| false).is_empty());
+
+        // All present -> every registry entry, one option each.
+        assert_eq!(
+            installed_agent_options(registry.list(), |_| true).len(),
+            total
+        );
+
+        // A predicate that matches a single command keeps only that agent.
+        let (name, spec) = registry.list().into_iter().next().expect("one agent");
+        let want_cmd = spec.command.clone();
+        let picked = installed_agent_options(registry.list(), |cmd| cmd == want_cmd);
+        assert!(picked.iter().any(|o| &o.value == name));
     }
 }

--- a/src/session/settings_schema/mod.rs
+++ b/src/session/settings_schema/mod.rs
@@ -169,6 +169,13 @@ pub enum ObjectFieldWidget {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         depends_on: Vec<String>,
     },
+    /// A host-resolved multi-select; the stored value is an array of chosen
+    /// option values (API v11). Choices resolve like `DynamicSelect`.
+    DynamicMultiSelect {
+        source: OptionSource,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+    },
     Cron,
 }
 
@@ -223,6 +230,12 @@ pub enum ValidationKind {
     /// number or object cannot be smuggled in (API v9, #2897).
     #[serde(rename = "str")]
     StringValue,
+    /// Value must be a JSON array whose entries are all strings (any content,
+    /// empty allowed). Used for host-resolved `dynamic_multi_select` values
+    /// (revalidated at `sessions.create`): enforces the array-of-strings type
+    /// without constraining membership (API v11).
+    #[serde(rename = "str_list")]
+    StringListValue,
     /// Value must be a JSON boolean (API v9, #2897).
     #[serde(rename = "bool")]
     BoolValue,

--- a/src/session/settings_schema/plugin.rs
+++ b/src/session/settings_schema/plugin.rs
@@ -267,6 +267,18 @@ fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> Objec
                 ValidationKind::StringValue
             },
         ),
+        T::DynamicMultiSelect => (
+            ObjectFieldWidget::DynamicMultiSelect {
+                source: f
+                    .option_source
+                    .map(SchemaOptionSource::from)
+                    .unwrap_or(SchemaOptionSource::Projects),
+                depends_on: f.depends_on.clone(),
+            },
+            // Host-resolved list, revalidated at sessions.create; enforce only
+            // the array-of-strings shape here.
+            ValidationKind::StringListValue,
+        ),
         T::Cron => (ObjectFieldWidget::Cron, ValidationKind::Cron),
     };
     ObjectFieldDescriptor {

--- a/src/session/settings_schema/validate.rs
+++ b/src/session/settings_schema/validate.rs
@@ -64,6 +64,16 @@ pub fn validate_value(kind: &ValidationKind, value: &Value) -> Result<(), Valida
                 .ok_or_else(|| ValidationError::new("expected a string"))?;
             Ok(())
         }
+        ValidationKind::StringListValue => {
+            let arr = value
+                .as_array()
+                .ok_or_else(|| ValidationError::new("expected a list of strings"))?;
+            if arr.iter().all(Value::is_string) {
+                Ok(())
+            } else {
+                Err(ValidationError::new("every entry must be a string"))
+            }
+        }
         ValidationKind::BoolValue => {
             value
                 .as_bool()

--- a/web/src/components/settings/StructuredWidgets.tsx
+++ b/web/src/components/settings/StructuredWidgets.tsx
@@ -92,7 +92,10 @@ function PluginOptionMultiSelect({
   onChange: (v: string[]) => void;
 }) {
   const [options, setOptions] = useState<{ value: string; label: string }[]>([]);
-  const depsKey = depends.join("");
+  // Unit separator, not "" or " ": dependency values (e.g. project paths) can
+  // contain spaces, so a naive join would let distinct dep sets collide and
+  // skip a needed refetch.
+  const depsKey = depends.join("");
   const reqId = useRef(0);
 
   useEffect(() => {

--- a/web/src/components/settings/StructuredWidgets.tsx
+++ b/web/src/components/settings/StructuredWidgets.tsx
@@ -70,6 +70,64 @@ function PluginOptionSelect({
   );
 }
 
+/** A host-resolved multi-select for a `dynamic_multi_select` field: a checkbox
+ *  list whose options the host resolves, storing the chosen values as an
+ *  array. Reloads on dependency change and preserves a stored value no longer
+ *  offered (shown as "(unavailable)") since sessions.create is authoritative. */
+function PluginOptionMultiSelect({
+  label,
+  description,
+  section,
+  source,
+  depends,
+  values,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  section: string;
+  source: SettingsOptionSource;
+  depends: string[];
+  values: string[];
+  onChange: (v: string[]) => void;
+}) {
+  const [options, setOptions] = useState<{ value: string; label: string }[]>([]);
+  const depsKey = depends.join("");
+  const reqId = useRef(0);
+
+  useEffect(() => {
+    const id = ++reqId.current;
+    resolvePluginOptions(pluginIdOf(section), source, depends).then((opts) => {
+      if (id === reqId.current) setOptions(opts);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [section, source, depsKey]);
+
+  const known = new Set(options.map((o) => o.value));
+  const extras = values.filter((v) => !known.has(v)).map((v) => ({ value: v, label: `${v} (unavailable)` }));
+  const shown = [...options, ...extras];
+
+  const toggle = (val: string) => {
+    onChange(values.includes(val) ? values.filter((v) => v !== val) : [...values, val]);
+  };
+
+  return (
+    <div>
+      <div className="text-sm text-text-bright">{label}</div>
+      {description && <div className="text-xs text-text-dim">{description}</div>}
+      <div className="mt-1 space-y-1">
+        {shown.length === 0 && <div className="text-xs text-text-dim">No options available.</div>}
+        {shown.map((o) => (
+          <label key={o.value} className="flex items-center gap-2 text-sm text-text-primary">
+            <input type="checkbox" checked={values.includes(o.value)} onChange={() => toggle(o.value)} />
+            {o.label}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /** A cron text field with live client-side validation feedback. The server is
  *  authoritative; this is a UX nicety mirroring the same 5-field grammar. */
 export function CronField({
@@ -205,6 +263,22 @@ function renderItemField(
             return typeof v === "string" ? v : "";
           })}
           value={typeof raw === "string" ? raw : ""}
+          onChange={(v) => setField(field.field, v)}
+        />
+      );
+    case "dynamic_multi_select":
+      return (
+        <PluginOptionMultiSelect
+          key={field.field}
+          label={field.label}
+          description={field.description}
+          section={section}
+          source={widget.source}
+          depends={(widget.depends_on ?? []).map((k) => {
+            const v = item[k];
+            return typeof v === "string" ? v : "";
+          })}
+          values={Array.isArray(raw) ? raw.filter((x): x is string => typeof x === "string") : []}
           onChange={(v) => setField(field.field, v)}
         />
       );

--- a/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
@@ -279,6 +279,106 @@ describe("structured plugin settings widgets", () => {
     expect((value as { projects: string[] }[])[0]!.projects).toEqual(["claude-code"]);
   });
 
+  it("multi-select shows an unavailable stored value and toggling off removes it", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const schema: SettingsFieldDescriptor[] = [
+      {
+        section: "plugin:acme.cron",
+        field: "jobs",
+        category: "Plugins",
+        label: "Jobs",
+        description: "",
+        web_write: ALLOW,
+        profile_overridable: false,
+        validation: NONE,
+        advanced: false,
+        widget: {
+          kind: "object_list",
+          id_field: "id",
+          fields: [
+            {
+              field: "projects",
+              label: "Projects",
+              required: false,
+              widget: { kind: "dynamic_multi_select", source: "projects" },
+              validation: { rule: "str_list" },
+            },
+          ],
+        },
+      },
+    ];
+    // "ghost" is not among the host-resolved options, so it renders as
+    // unavailable but is preserved; "claude-code" is selected and gets removed.
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={schema}
+        values={{ jobs: [{ id: "j1", projects: ["claude-code", "ghost"] }] }}
+        onSaveField={onSave}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("ghost (unavailable)")).toBeTruthy());
+    fireEvent.click(screen.getByLabelText("Claude Code"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const [, , value] = onSave.mock.calls.at(-1)!;
+    expect((value as { projects: string[] }[])[0]!.projects).toEqual(["ghost"]);
+  });
+
+  it("multi-select resolves depends_on sibling values from the item", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const schema: SettingsFieldDescriptor[] = [
+      {
+        section: "plugin:acme.cron",
+        field: "jobs",
+        category: "Plugins",
+        label: "Jobs",
+        description: "",
+        web_write: ALLOW,
+        profile_overridable: false,
+        validation: NONE,
+        advanced: false,
+        widget: {
+          kind: "object_list",
+          id_field: "id",
+          fields: [
+            {
+              field: "agent",
+              label: "Agent",
+              required: false,
+              widget: { kind: "dynamic_select", source: "acp_agents" },
+              validation: { rule: "str" },
+            },
+            {
+              field: "models",
+              label: "Models",
+              required: false,
+              widget: { kind: "dynamic_multi_select", source: "acp_models", depends_on: ["agent"] },
+              validation: { rule: "str_list" },
+            },
+          ],
+        },
+      },
+    ];
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={schema}
+        values={{ jobs: [{ id: "j1", agent: "opencode", models: [] }] }}
+        onSaveField={onSave}
+      />,
+    );
+    // The multi-select resolved its options using the sibling `agent` value.
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/plugins/acme.cron/settings/options/resolve",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    expect(screen.getByText("Models")).toBeTruthy();
+  });
+
   it("re-syncs its working copy when the persisted items change externally", async () => {
     const onSave = vi.fn().mockResolvedValue(true);
     const { rerender } = render(

--- a/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
+++ b/web/src/components/settings/__tests__/StructuredWidgets.test.tsx
@@ -232,6 +232,53 @@ describe("structured plugin settings widgets", () => {
     await waitFor(() => expect(screen.getByText("Claude Code")).toBeTruthy());
   });
 
+  it("toggles a dynamic_multi_select item field and persists the chosen values as an array", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const schema: SettingsFieldDescriptor[] = [
+      {
+        section: "plugin:acme.cron",
+        field: "jobs",
+        category: "Plugins",
+        label: "Jobs",
+        description: "",
+        web_write: ALLOW,
+        profile_overridable: false,
+        validation: NONE,
+        advanced: false,
+        widget: {
+          kind: "object_list",
+          id_field: "id",
+          fields: [
+            {
+              field: "projects",
+              label: "Projects",
+              required: false,
+              widget: { kind: "dynamic_multi_select", source: "projects" },
+              validation: { rule: "str_list" },
+            },
+          ],
+        },
+      },
+    ];
+    render(
+      <SchemaSection
+        section="plugin:acme.cron"
+        schema={schema}
+        values={{ jobs: [{ id: "j1", projects: [] }] }}
+        onSaveField={onSave}
+      />,
+    );
+
+    // Options resolve from the host; toggling one persists it into the array.
+    await waitFor(() => expect(screen.getByText("Claude Code")).toBeTruthy());
+    fireEvent.click(screen.getByLabelText("Claude Code"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const [, field, value] = onSave.mock.calls.at(-1)!;
+    expect(field).toBe("jobs");
+    expect((value as { projects: string[] }[])[0]!.projects).toEqual(["claude-code"]);
+  });
+
   it("re-syncs its working copy when the persisted items change externally", async () => {
     const onSave = vi.fn().mockResolvedValue(true);
     const { rerender } = render(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -602,6 +602,9 @@ export type SettingsObjectFieldWidget =
   | { kind: "number"; min?: number; max?: number }
   | { kind: "select"; options: SettingsSelectOption[] }
   | { kind: "dynamic_select"; source: SettingsOptionSource; depends_on?: string[] }
+  /** A host-resolved multi-select; the value is an array of chosen option
+   *  values (API v11). */
+  | { kind: "dynamic_multi_select"; source: SettingsOptionSource; depends_on?: string[] }
   | { kind: "cron" };
 
 /** One nested field of an `object_list` item (API v9). */
@@ -628,6 +631,7 @@ export type SettingsValidation =
   | { rule: "none" }
   | { rule: "bool" }
   | { rule: "str" }
+  | { rule: "str_list" }
   | { rule: "range_u64"; min: number; max?: number }
   | { rule: "range_i64"; min?: number; max?: number }
   | { rule: "one_of"; options: string[] }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Three plugin picker / session-contract improvements found while testing the cron plugin's job form, gated behind a single `api_version` bump (10 → 11). All additive.

1. **Installed-agent filter (bug).** The `acp.agents` option source listed the entire static registry; it now filters to ACP adapters actually resolvable on the host (mirroring `list_agents`' `acp_installed`), so a plugin's agent picker never offers an uninstalled harness. Verified live: the picker returns only the 7 present adapters and drops `kimi` / `vibe`.

2. **ACP catalog probe (feature).** Model/mode pickers were empty for any agent that had never run a live session (the catalog is only populated as a side effect of a live `ConfigOptionsUpdated`). New `src/acp/capability_probe.rs` runs a **handshake-only** ACP probe (initialize + `session/new` against a throwaway cwd, drained to the first `ConfigOptionsUpdated`, then torn down) — **no prompt turn, so zero tokens**. It reuses `AcpClient::spawn` on the in-process stdio transport (no detached runner/worker) and degrades to a no-op on timeout/missing-adapter/missing-credentials. Surfaced two ways: a new `acp.capabilities.probe` RPC + capability for plugins, and a lazy trigger in the settings resolver so the dashboard model/mode pickers self-populate on first open (cached per agent). The capability response gains a `thinking` (thought-level) list. Verified live: opencode **and** codex (which has no models-list CLI) both self-populate.

3. **Optional / multi project sessions (feature).** `sessions.create` `project_path` is now optional — absent/empty provisions a **scratch** session (no repo, hence no trust anchor) — and a new `extra_project_paths` array creates a multi-repo session (first path is the trust-checked primary, the rest are extra repos; extras with no primary are refused, matching the builder). A new `dynamic_multi_select` object-list settings widget lets a plugin offer a multi-project picker. Verified live: a project-less scheduled job fired a real scratch session.

Companion plugin PR: agent-of-empires/plugin-cron#7 (adopts the multi-select project field + scratch jobs).

**Note for CI:** `cargo clippy --all-targets` trips a pre-existing `items_after_test_module` lint at `src/tui/home/mod.rs:5213` (unrelated to this PR; `git diff origin/main` on that file is empty). Lib/bin clippy is clean.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- multi-select widget covered by Vitest; happy to add a screenshot on request -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json` <!-- Vitest, not Playwright: the `settings.structured-widgets` matrix surface is `kind: vitest`. Added a `dynamic_multi_select` case to StructuredWidgets.test.tsx; the surface already lists StructuredWidgets.tsx. -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (via Claude Code)

**Any Additional AI Details you'd like to share:** Implementation and prose via back-and-forth; design decisions and verification are mine.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Upgraded the plugin API to version 11.
- Improved ACP discovery by only surfacing agent options when their adapter can actually run on the current host.
- Added a handshake-only “capability probe” flow to discover available catalogs (models/modes and new “thinking levels”) without sending prompts.
- Expanded ACP capability responses to include per-agent “thinking level” options (so hosts can present more accurate choices).
- Improved session creation:
  - `project_path` is optional for scratch sessions.
  - Added `extra_project_paths` to support multi-repository sessions, including validation/limits.
- Added `dynamic_multi_select` support for structured plugin settings, with correct server-side validation:
  - Required fields reject empty-array defaults.
  - The UI preserves stored selections that are no longer available, marking them as unavailable.
- Updated documentation and significantly expanded Vitest/frontend test coverage around the new widget behavior and validation edge cases.

## Benefits

- Safer and more reliable plugin configuration (users only see agent choices that can run on their machine).
- Faster, out-of-band capability discovery (no prompt/token turns during probing).
- Better UX and fewer configuration errors for multi-project and multi-select structured settings—especially for required multi-select defaults.

## Potential follow-ups

- Add deeper end-to-end coverage ensuring “thinking levels” render correctly and stay consistent across the probe→catalog→UI path, and expand multi-repo session edge-case tests (ordering/canonicalization/limit boundaries) across both API and frontend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->