### PR TITLE
fix(acp): retire leftover cockpit terminology (#3018)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -139,7 +139,7 @@ It watches `src/**`, `Cargo.toml`, and `Cargo.lock`; on a change it runs
 failed build leaves the running backend in place and prints the error. The Vite
 dev server is never restarted, so frontend HMR keeps working and the browser
 reconnects through the proxy once the backend is back. Note that the backend
-restart drops all live terminal and cockpit WebSocket connections.
+restart drops all live terminal and structured-view WebSocket connections.
 
 ### Dev namespace
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4259,7 +4259,7 @@ fn background_agent_launched_from_value(v: &serde_json::Value) -> Option<Event> 
 
 /// Build a `ConfigOptionsUpdated` event from a session response's
 /// `config_options`, or `None` when the response carried none (so the
-/// cockpit's cached selectors persist). A present-but-empty list is a
+/// structured view's cached selectors persist). A present-but-empty list is a
 /// real full replacement and must propagate, otherwise stale selectors
 /// never clear when an adapter intentionally drops them (see #1403).
 ///
@@ -4335,7 +4335,7 @@ fn dispatch_set_config_option(
     event_tx: mpsc::Sender<Event>,
 ) {
     info!(
-        target: "cockpit.acp",
+        target: "acp.protocol",
         "sending session/set_config_option {config_id}={value}"
     );
     let sent = connection.send_request(SetSessionConfigOptionRequest::new(
@@ -4353,7 +4353,7 @@ fn dispatch_set_config_option(
             Err(e) => {
                 let reason = format!("{e}");
                 warn!(
-                    target: "cockpit.acp",
+                    target: "acp.protocol",
                     "session/set_config_option failed: {reason}"
                 );
                 let event = config_option_failure_event(config_id, value, reason, purpose);
@@ -4634,12 +4634,12 @@ fn extract_tool_content_text(
 /// ~3 MiB of bytes, comfortably above a typical screenshot.
 const MAX_INLINE_MEDIA_B64: usize = 4 * 1024 * 1024;
 
-/// Bridge an ACP `ToolCallContent` array into the cockpit's renderable
+/// Bridge an ACP `ToolCallContent` array into the structured view's renderable
 /// `ToolOutputBlock` list, preserving non-text completion payloads (images,
 /// audio, resource links/contents) that `extract_tool_content_text` drops.
 /// Diff blocks are bridged separately (`extract_diffs_from_content`) and are
 /// skipped here; an embedded terminal surfaces as a text placeholder since
-/// cockpit does not own ACP terminals. Returns an EMPTY vec when every block
+/// the structured view does not own ACP terminals. Returns an EMPTY vec when every block
 /// is plain text (or diff): the existing `content` text path renders those,
 /// so the structured list only carries weight when real media is present.
 /// See #1818.
@@ -7710,7 +7710,7 @@ async fn handle_elicitation_request(
             // answer) would misrepresent it; Cancel tells the agent the
             // request could not be presented. Either way the turn does not
             // hang on a card we'll never show.
-            warn!(target: "cockpit.acp", "unsupported elicitation, cancelling: {e}");
+            warn!(target: "acp.protocol", "unsupported elicitation, cancelling: {e}");
             return responder.respond(CreateElicitationResponse::new(ElicitationAction::Cancel));
         }
     };

--- a/src/acp/client/http.rs
+++ b/src/acp/client/http.rs
@@ -609,7 +609,7 @@ mod tests {
         assert!(matches!(
             classify_resolve_error(
                 StatusCode::NOT_FOUND,
-                "session has no running cockpit",
+                "session has no running structured view",
                 "abc-123",
                 "s-1"
             ),

--- a/src/acp/state.rs
+++ b/src/acp/state.rs
@@ -120,7 +120,7 @@ pub struct DiffPreview {
 
 /// One renderable block of a tool call's completion payload, bridged from
 /// an ACP `ToolCallContent` block. Carries the structured shape (image,
-/// audio, resource) so the cockpit can render media on completion instead
+/// audio, resource) so the structured view can render media on completion instead
 /// of collapsing everything to text. The web card renders these richly;
 /// the native TUI shows a textual placeholder for the non-text variants.
 /// See #1818.

--- a/src/cli/killall.rs
+++ b/src/cli/killall.rs
@@ -1,5 +1,5 @@
 //! `aoe killall`: a panic button that stops then force-kills everything aoe is
-//! running, in one command. Tears down the serve daemon, every ACP cockpit
+//! running, in one command. Tears down the serve daemon, every ACP
 //! worker, and every aoe tmux session (agent, terminal, container terminal,
 //! tool). Each surface is attempted independently; one failing surface never
 //! aborts the others, and the exit code is non-zero only if something failed.


### PR DESCRIPTION
## Description

Fixes #3025.

Follow-up to `v012_acp_rename`: a few post-migration "cockpit" strings lingered in user-facing copy, docs, and internal comments/tracing targets. This replaces them with the current **ACP worker** / **structured view** terminology.

**What changed:**
- `aoe killall` module doc: "every ACP cockpit worker" → "every ACP worker"
- `classify_resolve_error` unit-test fixture: `"session has no running cockpit"` → `"session has no running structured view"` (matches the live server body in `src/server/api/acp.rs`)
- `docs/development.md`: "cockpit WebSocket connections" → "structured-view WebSocket connections"
- `src/acp/acp_client.rs`: `cockpit.acp` tracing targets → `acp.protocol`; related doc comments updated
- `src/acp/state.rs`: comment "cockpit can render" → "structured view can render"

**Out of scope:** migration files (`v005`/`v006`/`v012`), `CHANGELOG.md` history, and the intentional historical `[cockpit]` references in `docs/development/internals/structured-view.md`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Cursor (Grok)

**Any Additional AI Details you'd like to share:** Terminology cleanup only; no behavior changes.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed remaining “cockpit” terminology from documentation, logs, comments, and test fixtures.
- Standardized wording around “ACP worker,” “structured view,” and `acp.protocol`.
- Preserved historical references and made no functional or behavioral changes.

## Benefits

Improves terminology consistency following the ACP rename and makes user-facing and internal documentation clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
