### PR TITLE
fix(tui): gate "Switch to structured" on the structured-view opt-in

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -378,11 +378,11 @@ fn default_show_spans() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize, SettingsSection)]
 #[setting_section(name = "acp", category = "Acp")]
 pub struct AcpConfig {
-    /// Show the "Structured view" toggle in the new-session dialog. The
-    /// structured view is still maturing, so it is hidden by default;
-    /// turn this on to opt into creating structured-view sessions from
-    /// the new-session flow. Switching an existing session's view and
-    /// opening already-structured sessions are unaffected.
+    /// Show the "Structured view" toggle in the new-session dialog, and
+    /// offer switching an existing terminal session into the structured
+    /// view. The structured view is still maturing, so both are hidden by
+    /// default; turn this on to opt in. Opening already-structured sessions,
+    /// and switching a structured session back to a terminal, are unaffected.
     #[serde(default)]
     #[setting(
         label = "Offer structured view when creating a session",

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -116,9 +116,10 @@ impl ContextMenuDialog {
     /// refusal and the web sidebar's `acp_can_fork` gating.
     ///
     /// `switch_view` is `None` when the row can't change views (non-ACP
-    /// tool, or a non-serve build with no structured view to switch into),
-    /// and `Some(is_structured)` when the entry should appear, with the
-    /// label naming the view the switch lands on.
+    /// tool, a non-serve build with no structured view to switch into, or a
+    /// terminal row while the structured-view opt-in is off), and
+    /// `Some(is_structured)` when the entry should appear, with the label
+    /// naming the view the switch lands on.
     pub fn for_session(
         anchor: (u16, u16),
         is_archived: bool,

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -387,8 +387,8 @@ fn handle_editable_list_key(
 fn compute_structured_capable(tool: &str, config: &crate::session::Config) -> bool {
     // Gated behind an opt-in setting: the structured view is still
     // maturing, so the new-session toggle is hidden unless the user
-    // turned it on. Switching an existing session's view is a separate
-    // path and stays available.
+    // turned it on. Switching a terminal session into the structured view
+    // is gated on the same setting (see `session_switch_view_target`).
     config.acp.offer_structured_in_new_session
         && crate::session::builder::structured::tool_acp_capable(tool, config)
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2919,7 +2919,9 @@ impl HomeView {
     /// it currently renders: `Some(is_structured)` when the context menu
     /// should offer a switch, `None` otherwise. A structured session can
     /// always go back to a terminal; a terminal session can go structured
-    /// only when its tool is ACP-capable. Serve builds only (the swap runs
+    /// only when its tool is ACP-capable and the `offer_structured_in_new_session`
+    /// opt-in is on (the structured view is still maturing, so switching into it
+    /// is gated the same way the new-session toggle is). Serve builds only (the swap runs
     /// through the daemon and the result needs a structured view to open).
     /// Archived / trashed / mid-lifecycle rows are excluded: their agent is
     /// deliberately stopped, and the swap would boot a worker or tmux pane
@@ -2941,8 +2943,14 @@ impl HomeView {
                 &inst.source_profile,
                 std::path::Path::new(&inst.project_path),
             );
-            crate::session::builder::structured::tool_acp_capable(&inst.tool, &config)
-                .then_some(false)
+            // Switching a terminal session INTO the structured view is gated on
+            // the same opt-in as the new-session toggle: the structured view is
+            // still maturing, so don't offer to switch into it unless the user
+            // turned it on. The reverse direction (already-structured -> terminal)
+            // stays available above regardless, so a session can always get out.
+            (config.acp.offer_structured_in_new_session
+                && crate::session::builder::structured::tool_acp_capable(&inst.tool, &config))
+            .then_some(false)
         }
         #[cfg(not(feature = "serve"))]
         {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -15528,12 +15528,18 @@ mod default_attach_mode {
 
     /// The switch-view context entry offers the opposite view: terminal for
     /// a structured row, structured for a terminal row whose tool is
-    /// ACP-capable, and nothing for rows mid-lifecycle.
+    /// ACP-capable (only when the structured-view opt-in is on), and nothing
+    /// for rows mid-lifecycle.
     #[cfg(feature = "serve")]
     #[test]
     #[serial]
     fn switch_view_target_gates_by_view_and_state() {
+        use crate::session::config::update_config;
         let (mut env, id) = structured_session_env();
+        update_config(|config| {
+            config.acp.offer_structured_in_new_session = true;
+        })
+        .unwrap();
         assert_eq!(env.view.session_switch_view_target(&id), Some(true));
         // Terminal row with an ACP-capable tool (claude): offer structured.
         env.view.mutate_instance(&id, |inst| {
@@ -15543,6 +15549,29 @@ mod default_attach_mode {
         // Mid-lifecycle rows are excluded.
         env.view.mutate_instance(&id, |inst| {
             inst.status = crate::session::Status::Creating;
+        });
+        assert_eq!(env.view.session_switch_view_target(&id), None);
+    }
+
+    /// Switching a terminal session INTO the structured view is gated on the
+    /// `offer_structured_in_new_session` opt-in, so with it off an ACP-capable
+    /// terminal row offers no switch. A structured row can always switch back
+    /// to terminal regardless, so a session is never stranded.
+    #[cfg(feature = "serve")]
+    #[test]
+    #[serial]
+    fn switch_view_target_gated_on_structured_opt_in() {
+        use crate::session::config::update_config;
+        let (mut env, id) = structured_session_env();
+        update_config(|config| {
+            config.acp.offer_structured_in_new_session = false;
+        })
+        .unwrap();
+        // Structured -> terminal is always available (escape hatch).
+        assert_eq!(env.view.session_switch_view_target(&id), Some(true));
+        // Terminal -> structured is suppressed while the opt-in is off.
+        env.view.mutate_instance(&id, |inst| {
+            inst.view = crate::session::View::Terminal;
         });
         assert_eq!(env.view.session_switch_view_target(&id), None);
     }


### PR DESCRIPTION
## Description

The per-session **Switch to structured** action (context-menu row, plus its keybind twin) let a user convert any ACP-capable terminal session into the structured view, even though the structured view is otherwise hidden behind the `acp.offer_structured_in_new_session` opt-in. That was an unintended back door into the still-maturing structured view for users who never opted in.

This gates the terminal to structured direction on the same setting the new-session toggle uses. The reverse direction (structured to terminal) stays ungated, so a session created while the opt-in was on is never stranded if the user later turns the setting off.

The change lives in `session_switch_view_target` (`src/tui/home/input.rs`), the single funnel feeding both the context-menu label and the toggle action, so both surfaces are covered by one edit. Doc comments on `session_switch_view_target` and `ContextMenuDialog::for_session` were updated to match.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

This is a native-TUI-only gate; the web sidebar switch path is unaffected.

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

Covered by unit tests on the funnel instead of a full-binary e2e: updated `switch_view_target_gates_by_view_and_state` to enable the opt-in, and added `switch_view_target_gated_on_structured_opt_in` asserting a terminal row offers no switch while the opt-in is off, and that a structured row can always switch back to terminal regardless.

Verified: `cargo test --features serve --lib switch_view_target`, `cargo fmt`, `cargo clippy --features serve` all clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude drafted the change and this description via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed the TUI “Switch to structured” action to only offer switching a terminal session into structured view when the `acp.offer_structured_in_new_session` opt-in is enabled.
- Confirmed the reverse direction—switching structured back to terminal—remains available regardless of that opt-in setting.
- Updated configuration/context documentation to clearly describe the new gating behavior.
- Updated and expanded unit tests to cover both cases (opt-in enabled vs disabled), ensuring the menu/keybind logic behaves correctly.

## Benefits

Prevents users from switching terminal sessions into structured view when the feature is not enabled, while still guaranteeing they can always switch back from structured to terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->