### PR TITLE
feat(plugins): sandbox flag on sessions.create and multiline settings fields

### DIFF
--- a/aoe-plugin-api/src/manifest.rs
+++ b/aoe-plugin-api/src/manifest.rs
@@ -176,6 +176,10 @@ pub struct SettingContribution {
     /// Group under an "Advanced" fold on the settings surfaces.
     #[serde(default)]
     pub advanced: bool,
+    /// Render a `string` field as a multi-line textarea instead of a single
+    /// line. Ignored for non-string types. API v11.
+    #[serde(default)]
+    pub multiline: bool,
     /// Host option source for a `dynamic_select` (API v9). Ignored for other
     /// types; the host resolves the choices, so the plugin never ships them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -233,6 +237,9 @@ pub struct ObjectFieldContribution {
     /// Whether the item must carry a non-empty value for this field.
     #[serde(default)]
     pub required: bool,
+    /// Render a `string` field as a multi-line textarea. Ignored otherwise. v11.
+    #[serde(default)]
+    pub multiline: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub options: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/aoe-plugin-api/src/session.rs
+++ b/aoe-plugin-api/src/session.rs
@@ -29,6 +29,13 @@ pub struct SessionsCreateRequest {
     /// with a scratch session is refused. API v11.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_project_paths: Vec<String>,
+    /// Run the session inside the host's sandbox (a container). The host uses
+    /// its configured sandbox image; a plugin cannot pick an image. Sandboxing
+    /// only narrows what the agent can reach, so it needs no extra grant beyond
+    /// `session.create`. Fails the create if no container runtime is available.
+    /// API v11.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub sandbox: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
     /// Approval mode id. Omitted means the adapter default (interactive).
@@ -84,6 +91,7 @@ mod tests {
             agent_id: "claude".into(),
             project_path: Some("/home/user/project".into()),
             extra_project_paths: Vec::new(),
+            sandbox: false,
             model_id: Some("sonnet".into()),
             mode_id: Some("plan".into()),
             title: Some("nightly maintenance".into()),
@@ -131,6 +139,7 @@ mod tests {
             agent_id: "claude".into(),
             project_path: None,
             extra_project_paths: Vec::new(),
+            sandbox: false,
             model_id: None,
             mode_id: None,
             title: None,
@@ -146,11 +155,38 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_flag_serializes_only_when_set() {
+        let mut request = SessionsCreateRequest {
+            agent_id: "claude".into(),
+            project_path: Some("/p".into()),
+            extra_project_paths: Vec::new(),
+            sandbox: false,
+            model_id: None,
+            mode_id: None,
+            title: None,
+            group: None,
+            initial_turn: None,
+            idempotency_key: None,
+        };
+        // Default (false) is omitted so it never bloats a fixture.
+        assert!(serde_json::to_value(&request)
+            .expect("serialize")
+            .get("sandbox")
+            .is_none());
+        request.sandbox = true;
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(json["sandbox"], serde_json::json!(true));
+        let round: SessionsCreateRequest = serde_json::from_value(json).expect("deserialize");
+        assert!(round.sandbox);
+    }
+
+    #[test]
     fn multi_repo_request_carries_extra_paths() {
         let request = SessionsCreateRequest {
             agent_id: "claude".into(),
             project_path: Some("/repos/app".into()),
             extra_project_paths: vec!["/repos/lib".into(), "/repos/proto".into()],
+            sandbox: false,
             model_id: None,
             mode_id: None,
             title: None,

--- a/aoe-plugin-api/src/session.rs
+++ b/aoe-plugin-api/src/session.rs
@@ -32,7 +32,10 @@ pub struct SessionsCreateRequest {
     /// Run the session inside the host's sandbox (a container). The host uses
     /// its configured sandbox image; a plugin cannot pick an image. Sandboxing
     /// only narrows what the agent can reach, so it needs no extra grant beyond
-    /// `session.create`. Fails the create if no container runtime is available.
+    /// `session.create`. The create fails synchronously when no container
+    /// runtime is installed or running; when a runtime is present the container
+    /// is started asynchronously after the create returns, so image-pull or
+    /// startup failures surface on the session later, not as a create error.
     /// API v11.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub sandbox: bool,

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -22,7 +22,7 @@ A manifest carries two independent version axes.
 | `api_version` | The manifest *schema* version. The current schema is `11`. The host rejects a manifest whose `api_version` is newer than it supports. Bump it as you adopt newer sections (see below). |
 | `aoe_version` | A semver requirement on the *host app* version, e.g. `">=1.11.0, <2.0.0"`. The host refuses to install, and skips loading, a plugin whose requirement excludes the running version. Optional; requires `api_version >= 4`. |
 
-Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot, `11` added the `acp.capabilities.probe` RPC + capability, a `thinking` (thought-level) list on the capability response, the `dynamic_multi_select` object-list field widget, and an optional `project_path` (empty = scratch session) plus `extra_project_paths` on `sessions.create`.
+Schema additions by `api_version`: `2` added contributions (commands, keybinds, settings, ui), `3` added the `pane` UI slot, `4` added `status` and `aoe_version`, `5` added `screenshots`, `6` added a command `action`, `7` added identity icons, `8` added the `composer-action` UI slot, `9` added session-driving worker RPCs (see [Session-driving RPCs](#session-driving-rpcs)), plugin-private storage, and the `dynamic_select` / `object_list` / `cron` settings widgets, `10` added the `tool-card-badge` UI slot, `11` added the `acp.capabilities.probe` RPC + capability, a `thinking` (thought-level) list on the capability response, the `dynamic_multi_select` object-list field widget, and an optional `project_path` (empty = scratch session), `extra_project_paths`, and a `sandbox` flag on `sessions.create`, plus a `multiline` attribute for `string` settings fields.
 
 ## Top-level fields
 
@@ -160,6 +160,7 @@ advanced = true
 | `min` / `max` | integer | no | Inclusive bounds for `integer`; ignored otherwise. |
 | `default` | any | no | Declared default. Must match `type`. Absent means the type's zero value. |
 | `advanced` | bool | no | Group under the Advanced fold. Defaults to `false`. |
+| `multiline` | bool | no | Render a `string` field as a multi-line textarea; ignored for other types (`api_version >= 11`). |
 | `option_source` | string | no | Host source for a `dynamic_select` (`api_version >= 9`). |
 | `depends_on` | array of string | no | Sibling keys whose values parameterize a `dynamic_select` (`api_version >= 9`). |
 | `fields` | array | no | Item fields of an `object_list` (`api_version >= 9`). |
@@ -271,7 +272,13 @@ working directory with no repository, hence no trust anchor. When present, the
 `project_path` is the trust-checked primary repo and each `extra_project_paths`
 entry is an additional repo of a multi-repo session; combining extras with a
 scratch session (no `project_path`) is refused. Every path is canonicalized and
-existence-checked host-side, fail-closed.
+existence-checked host-side, fail-closed (capped per call).
+
+**Sandbox (`api_version >= 11`).** Set `sandbox: true` to run the session inside
+the host's container sandbox. The host uses its own configured sandbox image; a
+plugin cannot pick an image. Sandboxing only *narrows* what the agent can reach,
+so it needs no grant beyond `session.create`. If no container runtime is
+available the create fails with a clear error.
 
 **Approval-mode classification.** The plugin proposes a `mode_id`; the **host**
 decides its security class, never the plugin. A mode is *interactive* (omitted /

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -243,8 +243,9 @@ required = true
 ```
 
 Each item field takes the same `key` / `label` / `description` / `type` /
-`options` / `min` / `max` / `default` / `option_source` / `depends_on` keys as a
-top-level setting, plus `required` (the item must carry a non-empty value). An
+`options` / `min` / `max` / `default` / `multiline` / `option_source` /
+`depends_on` keys as a top-level setting, plus `required` (the item must carry a
+non-empty value). An
 item field's `type` cannot be `object_list`. An item field may be a
 `dynamic_multi_select` (`api_version >= 11`): like `dynamic_select` it names an
 `option_source` and may `depends_on` siblings, but its stored value is an array
@@ -277,8 +278,10 @@ existence-checked host-side, fail-closed (capped per call).
 **Sandbox (`api_version >= 11`).** Set `sandbox: true` to run the session inside
 the host's container sandbox. The host uses its own configured sandbox image; a
 plugin cannot pick an image. Sandboxing only *narrows* what the agent can reach,
-so it needs no grant beyond `session.create`. If no container runtime is
-available the create fails with a clear error.
+so it needs no grant beyond `session.create`. The create fails synchronously
+when no container runtime is installed or running; when one is present the
+container starts asynchronously after the create returns, so image-pull or
+startup problems surface on the session later, not as a create error.
 
 **Approval-mode classification.** The plugin proposes a `mode_id`; the **host**
 decides its security class, never the plugin. A mode is *interactive* (omitted /

--- a/src/plugin/session_api.rs
+++ b/src/plugin/session_api.rs
@@ -432,7 +432,10 @@ async fn admit_and_create(
         worktree_branch: None,
         create_new_branch: false,
         base_branch: None,
-        sandbox: false,
+        // The plugin opts into sandboxing; the host resolves the image from its
+        // own config (a plugin cannot pick an image). Sandboxing only contains
+        // the agent, so it rides on session.create.
+        sandbox: req.sandbox,
         sandbox_image: None,
         yolo_mode: false,
         extra_env: Vec::new(),

--- a/src/session/settings_schema/plugin.rs
+++ b/src/session/settings_schema/plugin.rs
@@ -136,7 +136,7 @@ fn widget_and_validation(s: &SettingContribution) -> (WidgetKind, ValidationKind
         SettingType::Bool => (WidgetKind::Toggle, ValidationKind::None),
         SettingType::String => (
             WidgetKind::Text {
-                multiline: false,
+                multiline: s.multiline,
                 mono: false,
             },
             ValidationKind::None,
@@ -216,7 +216,7 @@ fn object_field_descriptor(f: &aoe_plugin_api::ObjectFieldContribution) -> Objec
         T::Bool => (ObjectFieldWidget::Toggle, ValidationKind::BoolValue),
         T::String => (
             ObjectFieldWidget::Text {
-                multiline: false,
+                multiline: f.multiline,
                 mono: false,
             },
             if f.required {
@@ -314,6 +314,7 @@ mod tests {
             max: None,
             default: None,
             advanced: false,
+            multiline: false,
             option_source: None,
             depends_on: Vec::new(),
             fields: Vec::new(),


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to #3021, extending the session plugin API (still `api_version` 11) with two additions plugins asked for:

1. **Sandbox on `sessions.create`.** New optional `sandbox: bool`. When set, the host runs the session in its container sandbox using its **own configured image** (a plugin cannot pass an image, avoiding arbitrary-image pulls). Sandboxing only *narrows* what the agent can reach, so it rides on `session.create` with no new capability. The builder already fails a sandbox spawn with a clear error when no container runtime is present, so a create just surfaces that.
2. **`multiline` settings attribute.** A `string` settings field (top-level or object-list item) can set `multiline = true` to render a textarea instead of a single-line input. The web renderer already honors `widget.multiline`, so this is a pure manifest + schema-mapping change.

Both verified live in a dev workspace: `sessions.create` accepts `sandbox`, and the plugin schema resolves `prompt -> {kind: text, multiline: true}` and a `sandbox` toggle.

Companion plugin PR: agent-of-empires/plugin-cron#8 (adds a per-job Sandbox toggle and makes the cron Prompt multi-line).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording <!-- no UI code change: the existing multiline TextField path is reused; verified via the live schema -->

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow <!-- Rust-only diff; the web renderer already supported multiline text fields -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 (via Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Extended `sessions.create` (API v11) with an optional `sandbox` flag to run sessions inside the host’s configured container sandbox. Plugins still can’t choose container images; the host determines the sandboxing behavior.
- Added a `multiline` option for string settings fields (including `object_list` item fields) so they can be rendered as multi-line textareas.
- Updated API/schema definitions, runtime schema mappings, documentation, and test fixtures to support both new options and clarify creation-vs-start failure timing for sandboxing.

## Benefits

- Improves session isolation while keeping plugin control constrained and safe (host-managed sandboxing only).
- Makes longer string inputs easier to view and edit via textarea rendering.
- Maintains backward compatibility by defaulting both `sandbox` and `multiline` to disabled behavior.

## Potential Enhancement

- Add/strengthen end-to-end coverage for sandbox behavior—especially the distinction between synchronous `create` failures when no container runtime exists vs. asynchronous failures during session startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->