### PR TITLE
chore(plugins): pin agent-of-empires.cron 1.0.0

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -33,3 +33,7 @@ source = "gh:agent-of-empires/plugin-github"
 # reserved-namespace install gate blocks it outright. Fixed in 1.2.0, which
 # builds under `.aoe-build/`.
 versions = {"0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c28276df435ced940fc", "1.0.0" = "sha256:b2f293d77244b03ddd98deb4426e96a09184a9454e2424bdd00a8e9d93ff4388", "1.2.0" = "sha256:e5fe509a3e7d39030350d7ee7efcd94623e9ec8ce7707a121804ec95212aba8a", "1.3.0" = "sha256:112fc40480a0dff2abacaa38062f619653a8153ac61bfeab9f14721090ee8e28", "1.4.0" = "sha256:f2d231e8d0877a8092c75efaa06016359be8da30c2c4a9ffe88ee7c7f3dfac18", "1.5.0" = "sha256:c61ae57dd94baf895869279a0ebe63a4bf478c3356a26077a6f269ee16eb5685", "1.6.0" = "sha256:353e30d21a5ceee9c7522cec0ab49f2e66a234c6f6a318a40ec24bd9436de903", "1.6.1" = "sha256:b3067c0483b4fc12d32d5084809190216fe53a1c1e471dabfe8748bf37592511", "1.7.0" = "sha256:98e8c88e133de38df499433ec0a8dc0b1831066a4fc4d37a3bf275dcc6f21606", "1.7.1" = "sha256:7a843bbb4c9ef37d5a367b2305aff62902c7d7111fd25e2c80058c7de255aaca", "1.7.2" = "sha256:dc15857292f26768b17a60689ac24c88486e1c8c3260df625fd6de7a6b8b7ba6", "1.8.0" = "sha256:5f8d13ed463beb1127b4fa207804b6f91b80a94fedcf6e07f3e9e08cbf2fec09"}
+
+[plugins."agent-of-empires.cron"]
+source = "gh:agent-of-empires/plugin-cron"
+versions = {"1.0.0" = "sha256:b98ab9304a9906bd33acdcc5b4c1f5e9d6eb44db442d7409f82dcd8b0eeac2ac"}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

Pins `agent-of-empires.cron` `1.0.0` in `plugins/featured.toml`, the compiled trust root that lets the reserved-namespace plugin install.

- Version: `1.0.0`
- Tree hash: `sha256:b98ab9304a9906bd33acdcc5b4c1f5e9d6eb44db442d7409f82dcd8b0eeac2ac`
- Hash algorithm: `aoe-plugin-tree-hash-v1` (verified identical on aoe 1.13.0 and the v11 dev build)
- Source: `gh:agent-of-empires/plugin-cron` @ [v1.0.0](https://github.com/agent-of-empires/plugin-cron/releases/tag/v1.0.0)

Manual featured pin (the plugin-cron release pipeline's `AOE_FEATURED_PR_TOKEN` is not configured, so the automated `featured-pr` job self-skipped). The plugin declares `api_version = 11` / `aoe_version >= 1.14.0`, so it installs on the upcoming aoe 1.14 release and is cleanly rejected by the api_version gate on older hosts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `agent-of-empires.cron` as a featured plugin.
- Pinned its verified `v1.0.0` release for secure, reproducible installations.
- Enables installation on aoe 1.14 while older hosts are blocked when unsupported.

## Benefits

- Improves plugin discoverability and installation integrity.
- Supports the latest aoe version with compatibility safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->