### PR TITLE
fix(tui): stop committed search from shadowing Shift+N (new session)

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -83,7 +83,7 @@ fn shortcuts(strict: bool, live_on_enter: bool) -> Vec<(&'static str, Vec<(Strin
 
     // Non-action rows with no single registry binding.
     views.push(("< >".to_string(), "Resize list panel".to_string()));
-    other.push(("n/N".to_string(), "Next/prev match".to_string()));
+    other.push(("n".to_string(), "Next match (after search)".to_string()));
     other.push((
         "Ctrl+x".to_string(),
         "Dismiss update bar (this session)".to_string(),

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -762,10 +762,6 @@ mod tests {
             "search-cycle; only meaningful while a search is active",
         ),
         (
-            ActionId::SearchPrev,
-            "search-cycle; only meaningful while a search is active",
-        ),
-        (
             ActionId::ToggleProjectPin,
             "only valid on a project header in project view; reached via the header context menu and `p`",
         ),

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -35,7 +35,6 @@ pub enum ActionId {
     ToolPicker,
     SearchStart,
     SearchNext,
-    SearchPrev,
     NewSession,
     NewFromSelection,
     NewFromProject,
@@ -357,18 +356,13 @@ fn format_chord(c: &Chord) -> String {
 // one (search-cycle vs new, etc.) come first so they win when their guard holds.
 pub static BINDINGS: &[Binding] = &[
     // --- search cycle (only while matches are active; both modes) ---
+    // Only bare `n` cycles (forward, wrapping). `N`/Shift+N stays a new-session
+    // key in every state so a committed search never shadows it (#3038); the
+    // forward wrap keeps every match reachable, so there is no reverse binding.
     Binding {
         id: ActionId::SearchNext,
         non_strict: &[k('n')],
         strict: &[k('n')],
-        context: Context::SearchActive,
-        help: None,
-        palette: None,
-    },
-    Binding {
-        id: ActionId::SearchPrev,
-        non_strict: &[k('N')],
-        strict: &[k('N')],
         context: Context::SearchActive,
         help: None,
         palette: None,
@@ -957,7 +951,6 @@ pub fn palette_id(id: ActionId) -> &'static str {
         ActionId::ToolPicker => "tool-picker",
         ActionId::SearchStart => "search",
         ActionId::SearchNext => "search-next",
-        ActionId::SearchPrev => "search-prev",
         ActionId::Update => "update",
         ActionId::ToggleContainer => "toggle-container",
         ActionId::ToggleProjectPin => "toggle-project-pin",
@@ -1174,18 +1167,37 @@ mod tests {
         }
     }
 
+    // #3038: a committed search must never shadow Shift+N. Only bare `n` cycles
+    // (forward); every `N`/Shift+N chord stays a new-session action whether or
+    // not a search is committed.
     #[test]
-    fn search_cycle_overrides_new_session_when_active() {
+    fn committed_search_cycles_n_but_never_shadows_shift_new_session() {
         let mut c = ctx();
         c.has_search = true;
-        for strict in [false, true] {
-            assert_eq!(resolve(&key('n'), strict, &c), Some(ActionId::SearchNext));
-            assert_eq!(resolve(&key('N'), strict, &c), Some(ActionId::SearchPrev));
-        }
-        // Without an active search, the same keys are new-session actions.
+        // Bare `n` cycles forward through matches in both modes.
+        assert_eq!(resolve(&key('n'), false, &c), Some(ActionId::SearchNext));
+        assert_eq!(resolve(&key('n'), true, &c), Some(ActionId::SearchNext));
+        // Shift+N stays a new-session action even while a search is live:
+        // NewFromSelection in non-strict, NewSession in strict.
+        assert_eq!(
+            resolve(&key('N'), false, &c),
+            Some(ActionId::NewFromSelection)
+        );
+        assert_eq!(resolve(&key('N'), true, &c), Some(ActionId::NewSession));
+
+        // Without a committed search, the same keys keep their new-session
+        // meaning; `n` is only borrowed for cycling while matches exist.
         c.has_search = false;
         assert_eq!(resolve(&key('n'), false, &c), Some(ActionId::NewSession));
+        assert_eq!(
+            resolve(&key('N'), false, &c),
+            Some(ActionId::NewFromSelection)
+        );
         assert_eq!(resolve(&key('N'), true, &c), Some(ActionId::NewSession));
+        assert_eq!(
+            resolve(&ctrl_key('n'), true, &c),
+            Some(ActionId::NewFromSelection)
+        );
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2728,18 +2728,6 @@ impl HomeView {
                 self.cursor = self.search_matches[self.search_match_index];
                 self.update_selected();
             }
-            ActionId::SearchPrev => {
-                if self.search_matches.is_empty() {
-                    return None;
-                }
-                self.search_match_index = if self.search_match_index == 0 {
-                    self.search_matches.len() - 1
-                } else {
-                    self.search_match_index - 1
-                };
-                self.cursor = self.search_matches[self.search_match_index];
-                self.update_selected();
-            }
             ActionId::NewSession => self.open_new_session_dialog(),
             ActionId::NewFromSelection => self.open_new_from_selection(),
             ActionId::NewFromProject => self.open_project_session_picker(),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -3547,6 +3547,12 @@ impl HomeView {
         let sep_style = Style::default().fg(theme.border);
         let strict = self.strict_hotkeys;
 
+        // A committed search (Enter pressed, search box closed, matches kept)
+        // silently borrows bare `n` for match cycling — the search bar and its
+        // `[i/N]` counter are gone, so the mode is otherwise invisible and `n`
+        // changing meaning surprises users (#3038). Surface it in the footer.
+        let committed_search = !self.search_active && !self.search_matches.is_empty();
+
         // Priority-tagged shortcut groups. Lower priority = kept longer when
         // the footer can't fit everything (iPhone Mosh landscape is ~80 cols,
         // where the full label set used to truncate Help/Quit). Essentials
@@ -3708,10 +3714,15 @@ impl HomeView {
             }
         }
 
+        // New session. In non-strict mode bare `n` is the usual chord, but while
+        // a committed search borrows `n` for cycling, advertise Shift+N (which
+        // still creates, #3038) so the footer never claims `n` makes a session
+        // when it actually cycles. Strict already uses `N`, so it needs no swap.
+        let new_uses_shift = committed_search && !strict;
         groups.push((
             2,
-            kc(if strict { 'N' } else { 'n' }),
-            mk(if strict { "N" } else { "n" }, "New"),
+            kc(if strict || new_uses_shift { 'N' } else { 'n' }),
+            mk(if strict || new_uses_shift { "N" } else { "n" }, "New"),
         ));
 
         // Priority 1: user's core daily workflow (message / del).
@@ -3757,6 +3768,28 @@ impl HomeView {
                     mk(if strict { "H" } else { "h" }, "Snooze"),
                 ));
             }
+        }
+
+        // Committed-search cue: restores the `[i/N]` counter the search box
+        // carried before Enter and spells out that `n` cycles matches and `Esc`
+        // clears (#3038). Priority 0 so it survives the greedy pack; clicking it
+        // cycles to the next match.
+        if committed_search {
+            let hint = vec![
+                Span::styled(
+                    format!(
+                        "[{}/{}] ",
+                        self.search_match_index + 1,
+                        self.search_matches.len()
+                    ),
+                    Style::default().fg(theme.accent).bold(),
+                ),
+                Span::styled("n", key_style),
+                Span::styled(" next ", desc_style),
+                Span::styled("Esc", key_style),
+                Span::styled(" clear", desc_style),
+            ];
+            groups.push((0, kc('n'), hint));
         }
 
         groups.push((4, kc('/'), mk_key("/")));

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1773,7 +1773,7 @@ fn test_reload_after_enter_preserves_search_state() {
     // Regression guard for #2676: `refresh_search_matches` wipes matches
     // whenever the query is empty. If Enter cleared search_query, the very
     // next storage/config reload would destroy the matches Enter promised
-    // to keep, silently breaking n/N cycling.
+    // to keep, silently breaking `n` match cycling.
     let mut env = create_test_env_with_sessions(5);
     env.view.handle_key(key(KeyCode::Char('/')), None);
     env.view.handle_key(key(KeyCode::Char('s')), None);
@@ -1874,15 +1874,18 @@ fn test_search_mode_enter_keeps_matches_for_cycling() {
     env.view.handle_key(key(KeyCode::Char('n')), None);
     assert_eq!(env.view.search_match_index, 0, "n wraps to first");
 
+    // #3038: Shift+N never cycles. Even with a committed search live, it opens
+    // the new-from-selection dialog and leaves the match index untouched.
+    assert!(env.view.new_dialog.is_none());
     env.view.handle_key(key(KeyCode::Char('N')), None);
-    assert_eq!(
-        env.view.search_match_index,
-        n_matches - 1,
-        "N wraps to last"
+    assert!(
+        env.view.new_dialog.is_some(),
+        "Shift+N opens new-from-selection even during a committed search"
     );
-
-    env.view.handle_key(key(KeyCode::Char('N')), None);
-    assert_eq!(env.view.search_match_index, n_matches - 2);
+    assert_eq!(
+        env.view.search_match_index, 0,
+        "Shift+N must not cycle the search"
+    );
 }
 
 #[test]
@@ -2054,16 +2057,26 @@ fn test_search_n_wraps_around() {
 
 #[test]
 #[serial]
-fn test_search_shift_n_cycles_backward() {
+fn test_search_shift_n_opens_new_from_selection_not_cycle() {
+    // #3038 regression guard: after a committed search, Shift+N must create a
+    // new session (new-from-selection), not jump to the previous match. Before
+    // #3038 the committed search shadowed Shift+N with a reverse-cycle.
     let mut env = create_test_env_with_sessions(5);
     env.view.search_query = Input::new("session".to_string());
     env.view.update_search();
-    let match_count = env.view.search_matches.len();
-    assert!(match_count > 1);
+    assert!(env.view.search_matches.len() > 1);
+    assert_eq!(env.view.search_match_index, 0);
 
-    // N from index 0 should wrap to last
+    assert!(env.view.new_dialog.is_none());
     env.view.handle_key(key(KeyCode::Char('N')), None);
-    assert_eq!(env.view.search_match_index, match_count - 1);
+    assert!(
+        env.view.new_dialog.is_some(),
+        "Shift+N opens new-from-selection during a committed search"
+    );
+    assert_eq!(
+        env.view.search_match_index, 0,
+        "Shift+N must not cycle the search backward"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Fixes #3038.

After committing a non-empty search on the home view (`/query` then `Enter`), `Shift+N` jumped to the previous search match instead of creating a new session in the selected directory. Reported by a user (Ally P.).

**Root cause.** The `n`/`N` search-cycle bindings are guarded on `Context::SearchActive`, defined as "committed matches exist" (`!search_matches.is_empty()`), and they sit first in the binding table, so they shadow the unguarded new-session bindings for as long as matches persist. That state only became reachable after #2688 (which kept matches on `Enter` so `n`/`N` cycle vim-style, closing #2676). Before #2688, `Enter` cleared the matches, so `has_search` went false and `Shift+N` fell through to new-session. The `n`/`N` overload was only ever safe because committing a search used to reset `has_search`.

**Fix.** Give `Shift+N` back to new-session in every state and keep only bare `n` as the forward, wrapping match cycle. The forward wrap keeps every match reachable, so #2676's cycling still works; `SearchPrev` had no other home, so it is removed rather than left dead. Reverse-cycle-via-`N` is dropped by design.

A committed search is otherwise an invisible mode: the search bar and its `[i/N]` counter vanish on `Enter`, so `n` silently changes meaning. This surfaces it in the footer status bar while a search is committed: it restores the `[i/N]` counter, shows `n next / Esc clear`, and relabels the "New" footer chord to `Shift+N` so it never claims `n` makes a session while `n` is cycling.

Behavior after this change, while a search is committed:
- `n` cycles forward through matches (wraps).
- `Shift+N` always creates a new session (new-from-selection in non-strict, new-session in strict).
- `Esc` clears the search.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

The UI change is a TUI footer status line (text only). Before this change, a committed search showed nothing in the footer and `n New` was misleading; after it, the footer shows `[i/N] n next Esc clear` and the New chord reads `N New`. Happy to add a `needs-recording` label if a recording is preferred over the text description.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is deterministic at the keybinding-resolution and dialog-open layers, which are covered by new regression tests without an e2e run. Added `committed_search_cycles_n_but_never_shadows_shift_new_session` (bindings unit test) and `test_search_shift_n_opens_new_from_selection_not_cycle` (home integration test), and reworked `test_search_mode_enter_keeps_matches_for_cycling` to assert `Shift+N` opens the new-session dialog during a committed search. All fail without the fix.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code.

**Any Additional AI Details you'd like to share:**

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The diagnosis, the decision to make Shift+N always win (forward-only cycle), and the footer-hint direction are his; the prose and implementation are Claude's._

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Resolved the TUI search and new-session keybinding conflict.
- `Shift+N` now consistently opens a new session or new session from selection.
- Lowercase `n` continues cycling forward through search matches, including wrapping; reverse cycling with `N` was removed.
- Updated the footer and help overlay to show committed-search status and relevant shortcuts.
- Added regression tests covering key resolution and opening the new-session dialog during committed searches.

## Benefits

- Prevents accidental search navigation when creating a session.
- Makes active search controls clearer and more discoverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->