### PR TITLE
fix(smart-rename): stop titling terminal sessions after the CLI startup banner

### DIFF
--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -676,12 +676,16 @@ fn capture_terminal_context(tmux: &crate::tmux::Session, tool: &str) -> Option<S
 /// substantive, so it can never make the capture worse. The `INSTRUCTION` prose
 /// is the backstop for banners this misses or for other agents.
 fn strip_agent_banner(text: &str, tool: &str) -> String {
-    // Only Claude Code has a verified banner signature to key on. Other agents
-    // rely on the instruction prose; add a case here per agent as needed.
+    // Only Claude Code has a verified banner shape to key on. Other agents rely
+    // on the instruction prose; add a case here per agent as needed.
     if !tool.eq_ignore_ascii_case("claude") {
         return text.to_string();
     }
-    if !text.to_lowercase().contains("welcome to claude code") {
+    // Gate loosely: the startup box names the tool ("Claude Code v2.1.216" in
+    // its top border). A false positive is harmless because the line filter
+    // below only strips an actual leading run of box chrome, so a task that
+    // merely mentions Claude Code (with no leading box) loses nothing.
+    if !text.to_lowercase().contains("claude code") {
         return text.to_string();
     }
     let mut in_banner = true;
@@ -703,37 +707,48 @@ fn strip_agent_banner(text: &str, tool: &str) -> String {
     stripped
 }
 
-/// Whether a line belongs to the Claude Code startup banner: the welcome box
-/// (box-drawing borders / body), the known welcome + tips phrases, numbered tip
-/// items, or the `※ Tip:` callout. Blank lines inside the leading block count so
-/// the run isn't cut short by the gaps between the box and the tips.
+/// Whether a line belongs to the Claude Code startup banner. The banner is a
+/// box: its borders are box-drawing glyphs, every body row opens with a vertical
+/// box edge, and its logo uses block-element glyphs, so a structural test
+/// captures the whole box regardless of the (version-dependent) wording inside.
+/// The `MARKERS` cover the notices printed just under the box (MCP-auth warning,
+/// tips, "what's new") before the REPL settles. Blank lines inside the leading
+/// block count so the run isn't cut short by the gaps between sections.
+///
+/// Verified against Claude Code v2.1.216, whose banner is a two-column box
+/// titled `Claude Code v<ver>` with "Welcome back <name>!", an ASCII logo, and a
+/// tips / what's-new column, followed by a `⚠ N MCP servers ...` notice.
 fn is_claude_banner_line(line: &str) -> bool {
     let t = line.trim();
     if t.is_empty() {
         return true;
     }
-    let is_box = |c: char| ('\u{2500}'..='\u{257F}').contains(&c);
-    // A pure box-drawing border, or a boxed body line (opens with a vertical
-    // edge), is chrome.
-    if t.chars().all(|c| is_box(c) || c.is_whitespace()) {
+    // Box-drawing (U+2500..=U+257F) borders/edges and block-element (U+2580..=
+    // U+259F) logo glyphs.
+    let is_chrome = |c: char| ('\u{2500}'..='\u{259F}').contains(&c);
+    if t.chars().all(|c| is_chrome(c) || c.is_whitespace()) {
         return true;
     }
-    if t.starts_with(|c: char| is_box(c) || c == '|') {
+    if t.starts_with(|c: char| is_chrome(c) || c == '|') {
         return true;
     }
     let lc = t.to_lowercase();
     const MARKERS: &[&str] = &[
+        "claude code v",
         "welcome to claude code",
+        "welcome back",
         "tips for getting started",
+        "what's new",
+        "/release-notes",
+        "run /mcp",
+        "need authentication",
         "/help for help",
-        "for your current setup",
-        "cwd:",
-        "run /init",
     ];
     if MARKERS.iter().any(|m| lc.contains(m)) {
         return true;
     }
-    if t.starts_with('\u{203B}') || lc.starts_with("tip:") {
+    // Startup notice / tip callouts: ⚠ (U+26A0) and ※ (U+203B).
+    if t.starts_with('\u{26A0}') || t.starts_with('\u{203B}') || lc.starts_with("tip:") {
         return true;
     }
     // Numbered tip: "1. ..." or "2) ...".
@@ -1783,22 +1798,23 @@ mod tests {
         ));
     }
 
+    // Reproduces the real Claude Code v2.1.216 startup banner shape: a
+    // two-column box titled `Claude Code v<ver>` (identity + logo on the left,
+    // tips / what's-new on the right), then a `⚠ ... MCP servers ...` notice,
+    // then the actual conversation. Captured from a live `claude` launch.
     const CLAUDE_BANNER_TRANSCRIPT: &str = "\
-╭─────────────────────────────────────────────╮
-│ ✻ Welcome to Claude Code!                     │
-│                                               │
-│   /help for help, /status for your setup      │
-│                                               │
-│   cwd: /home/user/project                     │
-╰─────────────────────────────────────────────╯
+╭─── Claude Code v2.1.216 ──────────────────────────────────────────────────╮
+│                                    │ Tips for getting started             │
+│         Welcome back Nathan!       │ Ask Claude to create a new app or     │
+│                                    │ ───────────────────────────────────  │
+│              ▐▛███▜▌               │ What's new                            │
+│             ▝▜█████▛▘              │ Added sandbox.filesystem.disabled     │
+│               ▘▘ ▝▝                │ Fixed a slowdown in long sessions     │
+│   Opus 4.8 (1M context) · Max ·    │ /release-notes for more               │
+│   nathan@mozilla.ai's Org          │                                       │
+╰────────────────────────────────────────────────────────────────────────────╯
 
- Tips for getting started:
-
- 1. Run /init to create a CLAUDE.md file with instructions for Claude
- 2. Use Claude to help with file analysis, editing, bash commands and git
- 3. Be as specific as you would with another engineer for the best results
-
- ※ Tip: Start with small features or bug fixes
+ ⚠ 3 MCP servers need authentication · run /mcp
 
 > fix the flaky login redirect test
 
@@ -1806,13 +1822,15 @@ I'll look at the auth redirect logic now.
 Patched the race in auth.rs and added a regression test.";
 
     #[test]
-    fn strip_agent_banner_drops_claude_welcome_and_tips() {
+    fn strip_agent_banner_drops_claude_startup_box() {
         let stripped = strip_agent_banner(CLAUDE_BANNER_TRANSCRIPT, "claude");
-        // The banner + tips are gone.
-        assert!(!stripped.contains("Welcome to Claude Code"));
+        // The box, its wording, the logo, and the MCP notice are gone.
+        assert!(!stripped.contains("Claude Code v"));
+        assert!(!stripped.contains("Welcome back"));
         assert!(!stripped.contains("Tips for getting started"));
-        assert!(!stripped.contains("Run /init"));
-        assert!(!stripped.contains('╭') && !stripped.contains('│'));
+        assert!(!stripped.contains("What's new"));
+        assert!(!stripped.contains("MCP servers"));
+        assert!(!stripped.contains('╭') && !stripped.contains('│') && !stripped.contains('█'));
         // The real conversation survives.
         assert!(stripped.contains("fix the flaky login redirect test"));
         assert!(stripped.contains("Patched the race in auth.rs"));
@@ -1828,10 +1846,20 @@ Patched the race in auth.rs and added a regression test.";
     }
 
     #[test]
-    fn strip_agent_banner_is_noop_without_welcome_marker() {
-        // Real transcript with no banner marker is untouched, even for claude.
+    fn strip_agent_banner_is_noop_without_claude_code_mention() {
+        // Real transcript that never names the tool is untouched, even for claude.
         let plain = "> refactor the payment retry loop\n\nDone: added a backoff and a test.";
         assert_eq!(strip_agent_banner(plain, "claude"), plain);
+    }
+
+    #[test]
+    fn strip_agent_banner_keeps_content_merely_mentioning_claude_code() {
+        // The gate matches "claude code", but a task ABOUT Claude Code with no
+        // leading banner box must be preserved: the line filter only strips an
+        // actual leading run of chrome, so `in_banner` flips off on line 1.
+        let about = "> make the Claude Code onboarding docs clearer\n\n\
+Rewrote the getting-started section and fixed two broken links.";
+        assert_eq!(strip_agent_banner(about, "claude"), about);
     }
 
     #[test]
@@ -1840,12 +1868,12 @@ Patched the race in auth.rs and added a regression test.";
         // the original so the caller still has something (and the instruction
         // prose can do its job) rather than skipping on an empty capture.
         let banner_only = "\
-╭──────────────────────────────╮
-│ ✻ Welcome to Claude Code!    │
-╰──────────────────────────────╯
+╭─── Claude Code v2.1.216 ──────────╮
+│         Welcome back Nathan!      │
+│              ▐▛███▜▌              │
+╰────────────────────────────────────╯
 
- Tips for getting started:
- 1. Run /init to create a CLAUDE.md file";
+ ⚠ 3 MCP servers need authentication · run /mcp";
         assert_eq!(strip_agent_banner(banner_only, "claude"), banner_only);
     }
 

--- a/src/session/smart_rename.rs
+++ b/src/session/smart_rename.rs
@@ -234,6 +234,9 @@ const MAX_TITLE_WORDS: usize = 8;
 /// has the least possible work to do; anything off-format is rejected, never
 /// salvaged.
 const INSTRUCTION: &str = "Generate a concise 3 to 5 word title summarizing the following task. \
+The transcript may begin with the CLI tool's startup banner, welcome message, tips, or help \
+text; ignore that boilerplate and title the user's actual request and the work done, never the \
+tool's own introduction. \
 Output the title and nothing else: no quotes, no markdown, no code fences, no labels, \
 no preamble, no explanation, no trailing punctuation. The entire response must be just \
 the title on a single line. Do not refuse: if the task is unclear, still produce your \
@@ -653,14 +656,89 @@ fn try_global_slot() -> Option<std::fs::File> {
 /// middle-elided head+tail block, or `None` when the capture is empty or looks
 /// like garbage (so the caller keeps the civ name without paying for a
 /// one-shot).
-fn capture_terminal_context(tmux: &crate::tmux::Session) -> Option<String> {
+fn capture_terminal_context(tmux: &crate::tmux::Session, tool: &str) -> Option<String> {
     let raw = tmux.capture_pane_full().ok()?;
     let cleaned = strip_ansi(&raw);
-    let trimmed = cleaned.trim();
+    let stripped = strip_agent_banner(&cleaned, tool);
+    let trimmed = stripped.trim();
     if !context_looks_usable(trimmed) {
         return None;
     }
     Some(head_tail(trimmed, CONTEXT_HEAD_BYTES, CONTEXT_TAIL_BYTES))
+}
+
+/// CLI agents print a startup banner (a welcome box plus "getting started"
+/// tips) on launch. It dominates the pane head, so a first-turn capture ends up
+/// summarizing the banner instead of the task (Claude Code -> "claude code
+/// getting started"). Best-effort: for agents we recognize, drop the leading
+/// run of banner lines. It only acts when the banner's signature marker is
+/// present, and falls back to the original text if stripping would leave nothing
+/// substantive, so it can never make the capture worse. The `INSTRUCTION` prose
+/// is the backstop for banners this misses or for other agents.
+fn strip_agent_banner(text: &str, tool: &str) -> String {
+    // Only Claude Code has a verified banner signature to key on. Other agents
+    // rely on the instruction prose; add a case here per agent as needed.
+    if !tool.eq_ignore_ascii_case("claude") {
+        return text.to_string();
+    }
+    if !text.to_lowercase().contains("welcome to claude code") {
+        return text.to_string();
+    }
+    let mut in_banner = true;
+    let mut kept: Vec<&str> = Vec::new();
+    for line in text.lines() {
+        if in_banner && is_claude_banner_line(line) {
+            continue;
+        }
+        in_banner = false;
+        kept.push(line);
+    }
+    let stripped = kept.join("\n");
+    // Guard against eating the whole transcript (a pane that was nothing but
+    // banner, or a future banner shape that trips the heuristic): keep the
+    // original when stripping leaves too little to title.
+    if stripped.chars().filter(|c| c.is_alphabetic()).count() < 12 {
+        return text.to_string();
+    }
+    stripped
+}
+
+/// Whether a line belongs to the Claude Code startup banner: the welcome box
+/// (box-drawing borders / body), the known welcome + tips phrases, numbered tip
+/// items, or the `※ Tip:` callout. Blank lines inside the leading block count so
+/// the run isn't cut short by the gaps between the box and the tips.
+fn is_claude_banner_line(line: &str) -> bool {
+    let t = line.trim();
+    if t.is_empty() {
+        return true;
+    }
+    let is_box = |c: char| ('\u{2500}'..='\u{257F}').contains(&c);
+    // A pure box-drawing border, or a boxed body line (opens with a vertical
+    // edge), is chrome.
+    if t.chars().all(|c| is_box(c) || c.is_whitespace()) {
+        return true;
+    }
+    if t.starts_with(|c: char| is_box(c) || c == '|') {
+        return true;
+    }
+    let lc = t.to_lowercase();
+    const MARKERS: &[&str] = &[
+        "welcome to claude code",
+        "tips for getting started",
+        "/help for help",
+        "for your current setup",
+        "cwd:",
+        "run /init",
+    ];
+    if MARKERS.iter().any(|m| lc.contains(m)) {
+        return true;
+    }
+    if t.starts_with('\u{203B}') || lc.starts_with("tip:") {
+        return true;
+    }
+    // Numbered tip: "1. ..." or "2) ...".
+    let mut chars = t.chars();
+    matches!((chars.next(), chars.next()), (Some(d), Some(p)) if d.is_ascii_digit() && (p == '.' || p == ')'))
 }
 
 /// Reject a pane capture that is empty, has no letters, or is dominated by
@@ -840,7 +918,7 @@ pub async fn run_terminal_rename(profile: &str, session_id: &str) -> anyhow::Res
         }
     }
 
-    let Some(context) = capture_terminal_context(&tmux) else {
+    let Some(context) = capture_terminal_context(&tmux, detect_tool) else {
         tracing::debug!(target: "smart_rename", session = %session_id, "terminal skip: unusable pane capture");
         return Ok(());
     };
@@ -1703,6 +1781,79 @@ mod tests {
             ),
             Err(SkipReason::NoOneshot)
         ));
+    }
+
+    const CLAUDE_BANNER_TRANSCRIPT: &str = "\
+╭─────────────────────────────────────────────╮
+│ ✻ Welcome to Claude Code!                     │
+│                                               │
+│   /help for help, /status for your setup      │
+│                                               │
+│   cwd: /home/user/project                     │
+╰─────────────────────────────────────────────╯
+
+ Tips for getting started:
+
+ 1. Run /init to create a CLAUDE.md file with instructions for Claude
+ 2. Use Claude to help with file analysis, editing, bash commands and git
+ 3. Be as specific as you would with another engineer for the best results
+
+ ※ Tip: Start with small features or bug fixes
+
+> fix the flaky login redirect test
+
+I'll look at the auth redirect logic now.
+Patched the race in auth.rs and added a regression test.";
+
+    #[test]
+    fn strip_agent_banner_drops_claude_welcome_and_tips() {
+        let stripped = strip_agent_banner(CLAUDE_BANNER_TRANSCRIPT, "claude");
+        // The banner + tips are gone.
+        assert!(!stripped.contains("Welcome to Claude Code"));
+        assert!(!stripped.contains("Tips for getting started"));
+        assert!(!stripped.contains("Run /init"));
+        assert!(!stripped.contains('╭') && !stripped.contains('│'));
+        // The real conversation survives.
+        assert!(stripped.contains("fix the flaky login redirect test"));
+        assert!(stripped.contains("Patched the race in auth.rs"));
+    }
+
+    #[test]
+    fn strip_agent_banner_is_noop_for_other_agents() {
+        // A non-claude agent keeps the text verbatim (no verified signature).
+        assert_eq!(
+            strip_agent_banner(CLAUDE_BANNER_TRANSCRIPT, "codex"),
+            CLAUDE_BANNER_TRANSCRIPT
+        );
+    }
+
+    #[test]
+    fn strip_agent_banner_is_noop_without_welcome_marker() {
+        // Real transcript with no banner marker is untouched, even for claude.
+        let plain = "> refactor the payment retry loop\n\nDone: added a backoff and a test.";
+        assert_eq!(strip_agent_banner(plain, "claude"), plain);
+    }
+
+    #[test]
+    fn strip_agent_banner_falls_back_when_only_banner() {
+        // A pane that is nothing but banner must not strip down to empty; keep
+        // the original so the caller still has something (and the instruction
+        // prose can do its job) rather than skipping on an empty capture.
+        let banner_only = "\
+╭──────────────────────────────╮
+│ ✻ Welcome to Claude Code!    │
+╰──────────────────────────────╯
+
+ Tips for getting started:
+ 1. Run /init to create a CLAUDE.md file";
+        assert_eq!(strip_agent_banner(banner_only, "claude"), banner_only);
+    }
+
+    #[test]
+    fn instruction_tells_model_to_ignore_startup_banner() {
+        let lc = INSTRUCTION.to_lowercase();
+        assert!(lc.contains("startup banner"));
+        assert!(lc.contains("ignore"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Terminal smart-rename fed the LLM the head of the raw tmux pane. For CLIs that print a launch banner (Claude Code's welcome box + "getting started" tips), that head *is* the banner, so a first-turn capture summarized the banner instead of the task, e.g. a session renamed to "claude code getting started". Two compounding factors: when the banner exceeded the 3072-byte head budget the user's actual prompt was elided in the middle, and `extract_echo_baseline` took a banner line as the "user prompt" baseline, so the parrot-check in `sanitize_title` could not reject the banner-derived title.

ACP sessions do not hit this: they have structured turn data and build a clean `User:`/`Agent:` frame via `render_first_turn`. The terminal path only has raw pane text.

Two-part fix:

- **Harden the one-shot `INSTRUCTION`** to tell the model the transcript may begin with the CLI's startup banner/tips/help and to ignore that boilerplate, titling the user's request and the work done. Helps every agent, including ones with no banner signature.
- **Add `strip_agent_banner`**, threaded into `capture_terminal_context` via the session's detect tool. For Claude Code it drops the leading welcome box + tips block (box-drawing lines, known phrases, numbered tips, the `※ Tip` callout). It only acts when the `welcome to claude code` marker is present and falls back to the original text if stripping leaves too little to title, so it can never make the capture worse; the instruction prose is the backstop for banners it misses or other agents.

**Known limitation (by design):** the stripper is CC-version-fragile. If Claude Code changes its banner wording, stripping quietly stops and the instruction prose carries it. Other agents (codex, gemini) rely on the instruction alone until their signature is added to `strip_agent_banner`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No UI change; this is title-generation logic.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the fix is a pure text transform (`strip_agent_banner`) plus a prompt-string change, both deterministic and unit-tested without a live agent. Added: strips a realistic CC banner while keeping the conversation, no-op for other agents, no-op without the welcome marker, falls back on a banner-only pane, and asserts the instruction carries the ignore-banner guidance. A full e2e would require a real Claude Code session and a live one-shot model call, which is non-deterministic; the input-shaping is what this PR controls and what the tests pin.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code.

**Any Additional AI Details you'd like to share:**

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The diagnosis, and the decision to do both instruction hardening and a surgical banner stripper (accepting the CC-version fragility), are his; the prose and implementation are Claude's._

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the smart-rename one-shot prompt so the renaming agent ignores any terminal startup banner, tips, or help text and instead uses only the user’s real work.
- Improved terminal context capture by making it tool-aware, including a Claude Code-specific banner “stripper” that removes the leading startup banner chrome/notices using a structure-based matcher (not version-specific wording).
- Added safety behavior: if stripping would leave too little usable content, the rename falls back to the original pane text.
- Ensured tasks that merely mention “Claude Code” (but do not start with the banner) are preserved.
- Threaded the detected tool through the terminal context capture path, and added unit tests + a real Claude Code banner fixture covering realistic banners, unsupported tools, missing banners, banner-only panes, preserved task text, and instruction guidance.

## Benefits

Smart-rename titles now more reliably reflect the user’s actual task/work, avoiding renames that were previously driven by terminal startup output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->