### PR TITLE
feat(acp): runner owns the ACP handshake and turn over v2 control channel (#2976)

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3280,7 +3280,7 @@ async fn attach_runner_control(
         let _write_half = write_half;
         loop {
             match control_protocol::read_frame(&mut read_half).await {
-                Ok(Some(ControlBody::PromptCompleted { stop_reason, .. })) => {
+                Ok(Some(ControlBody::PromptCompleted { outcome, .. })) => {
                     // Claim the one-shot terminal guard. Winning means the
                     // watchdogs stand down; losing means one already fired,
                     // so do not double-emit Stopped.
@@ -3288,7 +3288,7 @@ async fn attach_runner_control(
                         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                         .is_ok()
                     {
-                        let reason = control_stop_reason(stop_reason.as_deref());
+                        let reason = control_outcome_reason(&outcome);
                         let _ = event_tx.send(Event::Stopped { reason }).await;
                     }
                     // The adopted turn is resolved; the control channel's
@@ -3315,17 +3315,20 @@ async fn attach_runner_control(
 /// Map a runner-reported prompt outcome to an `Event::Stopped` reason. A
 /// completed turn renders as Idle regardless of stop reason, so the
 /// default is `prompt_complete`; the one reason with special downstream
-/// handling (`rate_limited`) is preserved when the agent reports it.
+/// handling (`rate_limited`) is preserved when the agent reports it. An
+/// agent error-envelope or an aborted turn also renders Idle, so they map
+/// to `prompt_complete` as well; the turn is over either way.
 ///
-/// Phase A deliberately collapses the other ACP stop reasons (`cancelled`,
-/// `max_tokens`, `refusal`, `max_turn_requests`) into `prompt_complete`,
-/// since they all render Idle today. Preserving their identity for the UI
-/// is tracked as a follow-up on the Phase C runner-terminator work (#2977),
-/// where the runner owns the protocol and can forward the typed stop reason
-/// natively.
-fn control_stop_reason(stop_reason: Option<&str>) -> String {
-    match stop_reason {
-        Some("rate_limited") | Some("rate_limit") => "rate_limited".to_string(),
+/// The other ACP stop reasons (`cancelled`, `max_tokens`, `refusal`,
+/// `max_turn_requests`) collapse into `prompt_complete`, since they all
+/// render Idle today. Preserving their identity for the UI is tracked as a
+/// follow-up on the Phase C runner-terminator work (#2977).
+fn control_outcome_reason(outcome: &crate::acp::control_protocol::PromptOutcome) -> String {
+    use crate::acp::control_protocol::PromptOutcome;
+    match outcome {
+        PromptOutcome::Completed {
+            stop_reason: Some(r),
+        } if r == "rate_limited" || r == "rate_limit" => "rate_limited".to_string(),
         _ => "prompt_complete".to_string(),
     }
 }

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3226,13 +3226,20 @@ impl DaemonControlClient {
     }
 
     /// Run the ACP `initialize` the runner owns; returns the raw result
-    /// value to deserialize into `InitializeResponse`.
-    async fn initialize(&self, request: serde_json::Value) -> Result<serde_json::Value, AcpError> {
-        self.send(ControlBody::Initialize { request }).await?;
+    /// value to deserialize into `InitializeResponse`. A `HandshakeFailed`
+    /// is surfaced as the reconstructed crate error so the caller propagates
+    /// the same `AgentStartupError` (with `data.details`) the relay path did.
+    async fn initialize(
+        &self,
+        request: serde_json::Value,
+    ) -> Result<serde_json::Value, agent_client_protocol::Error> {
+        self.send(ControlBody::Initialize { request })
+            .await
+            .map_err(|e| acp_internal_error(format!("control write failed: {e}")))?;
         match self.handshake_rx.lock().await.recv().await {
             Some(ControlBody::Initialized { result }) => Ok(result),
-            Some(ControlBody::HandshakeFailed { message }) => Err(AcpError::Spawn(message)),
-            _ => Err(AcpError::Spawn(
+            Some(ControlBody::HandshakeFailed { error }) => Err(acp_error_from_value(error)),
+            _ => Err(acp_internal_error(
                 "control channel closed during initialize".into(),
             )),
         }
@@ -3240,24 +3247,25 @@ impl DaemonControlClient {
 
     /// Run the session-creation request the runner owns; returns
     /// `(acp_session_id, raw result)` to deserialize into the matching
-    /// session response.
+    /// session response, or the reconstructed crate error on failure.
     async fn establish_session(
         &self,
         method: &str,
         request: serde_json::Value,
-    ) -> Result<(String, serde_json::Value), AcpError> {
+    ) -> Result<(String, serde_json::Value), agent_client_protocol::Error> {
         self.send(ControlBody::EstablishSession {
             method: method.to_string(),
             request,
         })
-        .await?;
+        .await
+        .map_err(|e| acp_internal_error(format!("control write failed: {e}")))?;
         match self.handshake_rx.lock().await.recv().await {
             Some(ControlBody::SessionReady {
                 acp_session_id,
                 result,
             }) => Ok((acp_session_id, result)),
-            Some(ControlBody::HandshakeFailed { message }) => Err(AcpError::Spawn(message)),
-            _ => Err(AcpError::Spawn(
+            Some(ControlBody::HandshakeFailed { error }) => Err(acp_error_from_value(error)),
+            _ => Err(acp_internal_error(
                 "control channel closed during session establishment".into(),
             )),
         }
@@ -3272,7 +3280,15 @@ impl DaemonControlClient {
     ) -> oneshot::Receiver<control_protocol::PromptOutcome> {
         let (tx, rx) = oneshot::channel();
         *self.completion.lock().expect("completion mutex poisoned") = Some(tx);
-        let _ = self.send(ControlBody::Prompt { request }).await;
+        if self.send(ControlBody::Prompt { request }).await.is_err() {
+            // Write failed: drop the parked sender so `rx` resolves to Err ->
+            // Aborted immediately instead of hanging until the cancel /
+            // orphan watchdog eventually unwedges the turn.
+            self.completion
+                .lock()
+                .expect("completion mutex poisoned")
+                .take();
+        }
         rx
     }
 
@@ -3426,10 +3442,21 @@ fn acp_internal_error(message: String) -> agent_client_protocol::Error {
     err
 }
 
+/// Reconstruct a crate `Error` from the raw JSON-RPC error object the
+/// runner forwarded in `HandshakeFailed`. Preserves `code` / `message` /
+/// `data` so the downstream `AgentStartupError` surfaces the same
+/// `data.details` remediation the byte-relay handshake did; falls back to a
+/// generic internal error if the object is malformed.
+fn acp_error_from_value(error: serde_json::Value) -> agent_client_protocol::Error {
+    serde_json::from_value(error.clone())
+        .unwrap_or_else(|_| acp_internal_error(format!("runner handshake failed: {error}")))
+}
+
 /// Drive a session-creation request over the v2 control channel and
 /// deserialize the runner's cached result into the crate response type,
 /// so each `session/new|load|fork` site's `Result<Resp, Error>` matches
-/// the crate `send_request` path it replaces.
+/// the crate `send_request` path it replaces (including the failure path:
+/// the runner-forwarded agent error propagates verbatim).
 async fn establish_session_v2<Resp: serde::de::DeserializeOwned>(
     control: &DaemonControlClient,
     method: &str,
@@ -3437,10 +3464,7 @@ async fn establish_session_v2<Resp: serde::de::DeserializeOwned>(
 ) -> Result<Resp, agent_client_protocol::Error> {
     let params = serde_json::to_value(request)
         .map_err(|e| acp_internal_error(format!("serialize {method} params: {e}")))?;
-    let (_id, result) = control
-        .establish_session(method, params)
-        .await
-        .map_err(|e| acp_internal_error(format!("runner {method}: {e}")))?;
+    let (_id, result) = control.establish_session(method, params).await?;
     serde_json::from_value(result)
         .map_err(|e| acp_internal_error(format!("deserialize {method} result: {e}")))
 }
@@ -5903,10 +5927,7 @@ async fn run_connection_task<W, R>(
             let init: InitializeResponse = if let Some(control) = control_client.as_ref() {
                 let params = serde_json::to_value(build_initialize_request())
                     .map_err(|e| acp_internal_error(format!("serialize initialize params: {e}")))?;
-                let result = control
-                    .initialize(params)
-                    .await
-                    .map_err(|e| acp_internal_error(format!("runner initialize: {e}")))?;
+                let result = control.initialize(params).await?;
                 serde_json::from_value(result)
                     .map_err(|e| acp_internal_error(format!("deserialize initialize result: {e}")))?
             } else {

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -23,9 +23,10 @@ use agent_client_protocol::schema::v1::{
     CreateElicitationRequest, CreateElicitationResponse, CreateTerminalRequest,
     CreateTerminalResponse, ElicitationAction, ElicitationCapabilities,
     ElicitationFormCapabilities, EmbeddedResource, EmbeddedResourceResource,
-    FileSystemCapabilities, ForkSessionRequest, ImageContent, Implementation, InitializeRequest,
-    KillTerminalRequest, KillTerminalResponse, LoadSessionRequest, McpServer, MessageId,
-    NewSessionRequest, PermissionOptionKind, PromptRequest, ReadTextFileRequest,
+    FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse, ImageContent, Implementation,
+    InitializeRequest, InitializeResponse, KillTerminalRequest, KillTerminalResponse,
+    LoadSessionRequest, LoadSessionResponse, McpServer, MessageId, NewSessionRequest,
+    NewSessionResponse, PermissionOptionKind, PromptRequest, PromptResponse, ReadTextFileRequest,
     ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
     RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
     SelectedPermissionOutcome, SessionConfigId, SessionConfigValueId, SessionId,
@@ -63,6 +64,7 @@ use super::state::{
     StartupErrorDetail, ToolCall, ToolOutputBlock, UsageCost,
 };
 use super::terminal_handler::TerminalManager;
+use crate::acp::control_protocol::{self, ControlBody};
 use crate::session::SandboxInfo;
 
 #[derive(Debug, Error)]
@@ -2159,7 +2161,9 @@ impl AcpClient {
                 default_mode,
                 mcp_servers,
                 // Direct stdio agents have no runner and thus no control
-                // channel; the task owns its own terminal guard.
+                // channel; the task owns its own terminal guard and speaks
+                // the full protocol over stdio.
+                None,
                 None,
             )
             .instrument(conn_span),
@@ -2245,34 +2249,24 @@ impl AcpClient {
         let pending_for_task = pending_responders.clone();
         let expected_agent = ExpectedAgent::from_command(&install_binary);
 
-        // #1054 Phase A: for a mid-flight resume, the agent's response to
-        // the orphaned `session/prompt` carries an id this client never
-        // issued and the crate transport drops it, which is what the 30s
-        // resume-idle watchdog exists to paper over. Dial the runner's
-        // sibling control socket; if it speaks the control protocol, its
-        // native `prompt_complete` claims the shared terminal guard and
-        // fires `Stopped` deterministically, and the watchdog stands down.
-        // A runner too old to bind the control socket falls back to the
-        // watchdog unchanged.
-        let external_terminal_guard = if matches!(
-            mode,
-            ConnectMode::Resume {
-                in_flight_turn: true,
-                ..
-            }
-        ) {
-            let guard = Arc::new(std::sync::atomic::AtomicBool::new(false));
-            attach_runner_control(
-                &socket_path,
-                event_tx.clone(),
-                session_label.clone(),
-                guard.clone(),
-            )
-            .await;
-            Some(guard)
-        } else {
-            None
-        };
+        // #2976 Phase B: dial the runner's sibling control socket. A v2
+        // runner returns a control client the connection task uses to drive
+        // the handshake and every turn (the runner owns the ACP client side
+        // now). The shared terminal guard lets the client's reader deliver
+        // an adopted turn's completion on a mid-flight resume, so the
+        // resume-idle / between-prompt watchdogs stand down. An absent or
+        // older (v1) runner returns None: the task falls back to the
+        // byte-relay handshake and, for a mid-flight resume, the resume-idle
+        // watchdog (guard left None so it still fires).
+        let guard = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let control_client = connect_runner_control_v2(
+            &socket_path,
+            event_tx.clone(),
+            session_label.clone(),
+            guard.clone(),
+        )
+        .await;
+        let external_terminal_guard = control_client.as_ref().map(|_| guard);
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
@@ -2300,6 +2294,7 @@ impl AcpClient {
                 default_mode,
                 mcp_servers,
                 external_terminal_guard,
+                control_client,
             )
             .instrument(conn_span),
         );
@@ -3205,37 +3200,110 @@ async fn wait_for_socket(
     }
 }
 
-/// Dial the runner's sibling control socket (#1054 Phase A) and, if it
-/// speaks the control protocol, spawn a reader that turns the runner's
-/// native `PromptCompleted` into `Event::Stopped { reason }`. The reader
-/// CAS-claims `terminal_guard` so the caller's resume-idle and
-/// between-prompt watchdogs stand down for the adopted turn. Best-effort:
-/// a connect failure or an unrecognized/absent control socket (a runner
-/// too old to bind it) leaves the guard unclaimed so the legacy watchdog
-/// still fires.
-async fn attach_runner_control(
+/// Bidirectional client for the runner's sibling control socket
+/// (#2976 Phase B). The runner owns the ACP handshake and the turn, so the
+/// daemon drives `initialize` / `session/*` / `session/prompt` /
+/// `session/cancel` over this channel and receives the typed results,
+/// rather than speaking those methods over the byte relay.
+///
+/// `initialize` / `session/*` responses arrive sequentially on
+/// `handshake_rx`; a turn's `PromptCompleted` is routed to the oneshot in
+/// `completion` when a prompt is awaiting, else (an adopted turn on a
+/// mid-flight resume, where this daemon never issued the prompt) the reader
+/// CAS-claims the terminal guard and fires `Stopped` so the UI clears.
+struct DaemonControlClient {
+    write: Mutex<tokio::net::unix::OwnedWriteHalf>,
+    handshake_rx: Mutex<mpsc::Receiver<ControlBody>>,
+    completion: Arc<std::sync::Mutex<Option<oneshot::Sender<control_protocol::PromptOutcome>>>>,
+}
+
+impl DaemonControlClient {
+    async fn send(&self, body: ControlBody) -> Result<(), AcpError> {
+        let mut w = self.write.lock().await;
+        control_protocol::write_frame(&mut *w, &body)
+            .await
+            .map_err(|e| AcpError::Spawn(format!("control write failed: {e}")))
+    }
+
+    /// Run the ACP `initialize` the runner owns; returns the raw result
+    /// value to deserialize into `InitializeResponse`.
+    async fn initialize(&self, request: serde_json::Value) -> Result<serde_json::Value, AcpError> {
+        self.send(ControlBody::Initialize { request }).await?;
+        match self.handshake_rx.lock().await.recv().await {
+            Some(ControlBody::Initialized { result }) => Ok(result),
+            Some(ControlBody::HandshakeFailed { message }) => Err(AcpError::Spawn(message)),
+            _ => Err(AcpError::Spawn(
+                "control channel closed during initialize".into(),
+            )),
+        }
+    }
+
+    /// Run the session-creation request the runner owns; returns
+    /// `(acp_session_id, raw result)` to deserialize into the matching
+    /// session response.
+    async fn establish_session(
+        &self,
+        method: &str,
+        request: serde_json::Value,
+    ) -> Result<(String, serde_json::Value), AcpError> {
+        self.send(ControlBody::EstablishSession {
+            method: method.to_string(),
+            request,
+        })
+        .await?;
+        match self.handshake_rx.lock().await.recv().await {
+            Some(ControlBody::SessionReady {
+                acp_session_id,
+                result,
+            }) => Ok((acp_session_id, result)),
+            Some(ControlBody::HandshakeFailed { message }) => Err(AcpError::Spawn(message)),
+            _ => Err(AcpError::Spawn(
+                "control channel closed during session establishment".into(),
+            )),
+        }
+    }
+
+    /// Issue a turn: register the completion oneshot, send the `Prompt`
+    /// frame, and return the receiver the prompt loop awaits. The runner
+    /// assigns the `session/prompt` id and reports `PromptCompleted`.
+    async fn prompt(
+        &self,
+        request: serde_json::Value,
+    ) -> oneshot::Receiver<control_protocol::PromptOutcome> {
+        let (tx, rx) = oneshot::channel();
+        *self.completion.lock().expect("completion mutex poisoned") = Some(tx);
+        let _ = self.send(ControlBody::Prompt { request }).await;
+        rx
+    }
+
+    async fn cancel(&self) {
+        let _ = self.send(ControlBody::Cancel).await;
+    }
+}
+
+/// Dial the runner's sibling control socket and, if it speaks control
+/// protocol v2 (#2976), return a [`DaemonControlClient`] and spawn its
+/// reader. Returns None for an absent or older (v1) runner, whose caller
+/// falls back to the byte-relay handshake plus the resume-idle watchdog.
+async fn connect_runner_control_v2(
     main_socket: &std::path::Path,
     event_tx: mpsc::Sender<Event>,
     session_label: String,
     terminal_guard: Arc<std::sync::atomic::AtomicBool>,
-) {
-    use crate::acp::control_protocol::{self, ControlBody};
+) -> Option<Arc<DaemonControlClient>> {
     use std::sync::atomic::Ordering;
 
     let control_path = crate::process::worker::control_socket_sibling(main_socket);
-
     // A single deadline covers connect plus the Hello read. The runner
     // binds the control socket before the main relay socket the caller
     // already waited for, so both steps are effectively immediate; the
     // bound only caps a wedged runner that bound the socket but never
-    // greets, so it cannot stall the whole resume path. An old socketless
-    // runner fails connect at once and falls back to the watchdog.
+    // greets. An old socketless runner fails connect at once and falls
+    // back to the byte-relay handshake.
     let bound = std::time::Duration::from_secs(2);
     let dial = async {
         let stream = tokio::net::UnixStream::connect(&control_path).await.ok()?;
         let (mut read_half, mut write_half) = stream.into_split();
-        // The runner greets with Hello on accept; require a matching
-        // version before trusting the channel.
         match control_protocol::read_frame(&mut read_half).await {
             Ok(Some(ControlBody::Hello {
                 control_protocol_version,
@@ -3243,13 +3311,14 @@ async fn attach_runner_control(
             })) if control_protocol_version == control_protocol::CONTROL_PROTOCOL_VERSION => {}
             _ => return None,
         }
-        let _ = control_protocol::write_frame(
+        control_protocol::write_frame(
             &mut write_half,
             &ControlBody::Attach {
                 control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
             },
         )
-        .await;
+        .await
+        .ok()?;
         Some((read_half, write_half))
     };
     let (mut read_half, write_half) = match tokio::time::timeout(bound, dial).await {
@@ -3258,51 +3327,60 @@ async fn attach_runner_control(
             debug!(
                 target: "acp.protocol",
                 session = %session_label,
-                "no usable runner control socket; using resume-idle watchdog"
+                "no usable v2 runner control socket; using byte-relay handshake + watchdog"
             );
-            return;
+            return None;
         }
     };
 
     info!(
         target: "acp.protocol",
         session = %session_label,
-        "runner control channel attached; native turn-complete active"
+        "runner control channel v2 attached; runner owns handshake + turn"
     );
 
+    let (hs_tx, hs_rx) = mpsc::channel::<ControlBody>(8);
+    let completion: Arc<
+        std::sync::Mutex<Option<oneshot::Sender<control_protocol::PromptOutcome>>>,
+    > = Arc::new(std::sync::Mutex::new(None));
+    let reader_completion = completion.clone();
+    let reader_session = session_label.clone();
     tokio::spawn(async move {
-        // Hold the write half open so the runner does not see EOF before
-        // it delivers the adopted turn's completion. Dropped when this
-        // task returns (below), which closes the socket so the runner
-        // clears its own control outbound. The runner also tears its side
-        // down one-shot after a single delivered completion, so it never
-        // writes to a stale socket regardless.
-        let _write_half = write_half;
         loop {
             match control_protocol::read_frame(&mut read_half).await {
+                Ok(Some(
+                    frame @ (ControlBody::Initialized { .. }
+                    | ControlBody::SessionReady { .. }
+                    | ControlBody::HandshakeFailed { .. }),
+                )) => {
+                    if hs_tx.send(frame).await.is_err() {
+                        return;
+                    }
+                }
                 Ok(Some(ControlBody::PromptCompleted { outcome, .. })) => {
-                    // Claim the one-shot terminal guard. Winning means the
-                    // watchdogs stand down; losing means one already fired,
-                    // so do not double-emit Stopped.
-                    if terminal_guard
+                    let waiter = reader_completion
+                        .lock()
+                        .expect("completion mutex poisoned")
+                        .take();
+                    if let Some(tx) = waiter {
+                        let _ = tx.send(outcome);
+                    } else if terminal_guard
                         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                         .is_ok()
                     {
+                        // Adopted turn on a mid-flight resume: this daemon
+                        // never issued the prompt, so surface the completion
+                        // as Stopped and stand the watchdogs down.
                         let reason = control_outcome_reason(&outcome);
                         let _ = event_tx.send(Event::Stopped { reason }).await;
                     }
-                    // The adopted turn is resolved; the control channel's
-                    // Phase A duty for this attach is done. Return so the
-                    // write half drops and the socket closes. Subsequent
-                    // turns complete through the crate's own prompt future.
-                    return;
                 }
                 Ok(Some(_)) => {}
                 Ok(None) => return,
                 Err(e) => {
                     debug!(
                         target: "acp.protocol",
-                        session = %session_label,
+                        session = %reader_session,
                         "runner control read ended: {e}"
                     );
                     return;
@@ -3310,6 +3388,12 @@ async fn attach_runner_control(
             }
         }
     });
+
+    Some(Arc::new(DaemonControlClient {
+        write: Mutex::new(write_half),
+        handshake_rx: Mutex::new(hs_rx),
+        completion,
+    }))
 }
 
 /// Map a runner-reported prompt outcome to an `Event::Stopped` reason. A
@@ -3330,6 +3414,75 @@ fn control_outcome_reason(outcome: &crate::acp::control_protocol::PromptOutcome)
             stop_reason: Some(r),
         } if r == "rate_limited" || r == "rate_limit" => "rate_limited".to_string(),
         _ => "prompt_complete".to_string(),
+    }
+}
+
+/// Build a crate `Error` carrying `message`, for the v2 control path where
+/// the daemon's handshake round-trip fails at the control channel rather
+/// than at a crate `send_request`.
+fn acp_internal_error(message: String) -> agent_client_protocol::Error {
+    let mut err = agent_client_protocol::Error::internal_error();
+    err.message = message;
+    err
+}
+
+/// Drive a session-creation request over the v2 control channel and
+/// deserialize the runner's cached result into the crate response type,
+/// so each `session/new|load|fork` site's `Result<Resp, Error>` matches
+/// the crate `send_request` path it replaces.
+async fn establish_session_v2<Resp: serde::de::DeserializeOwned>(
+    control: &DaemonControlClient,
+    method: &str,
+    request: &impl serde::Serialize,
+) -> Result<Resp, agent_client_protocol::Error> {
+    let params = serde_json::to_value(request)
+        .map_err(|e| acp_internal_error(format!("serialize {method} params: {e}")))?;
+    let (_id, result) = control
+        .establish_session(method, params)
+        .await
+        .map_err(|e| acp_internal_error(format!("runner {method}: {e}")))?;
+    serde_json::from_value(result)
+        .map_err(|e| acp_internal_error(format!("deserialize {method} result: {e}")))
+}
+
+/// Adapt a runner-reported [`PromptOutcome`](control_protocol::PromptOutcome)
+/// into the `Result<PromptResponse, Error>` the prompt loop already
+/// consumes, so the loop body is identical for the v2 control path and the
+/// legacy crate path. A completed turn maps to its `StopReason`; an agent
+/// error-envelope reconstructs a crate `Error` (preserving `data` so
+/// `classify_rate_limit_error` still recognizes a rate limit); an aborted
+/// turn (runner lost the agent) ends the turn cleanly as `EndTurn`.
+fn prompt_outcome_to_response(
+    outcome: control_protocol::PromptOutcome,
+) -> Result<PromptResponse, agent_client_protocol::Error> {
+    use control_protocol::PromptOutcome;
+    // `PromptResponse` is `#[non_exhaustive]`, so build it by deserializing
+    // the ACP `stopReason` string the runner forwarded verbatim (e.g.
+    // "cancelled" / "max_tokens" / "end_turn") rather than a struct literal.
+    let build = |stop: &str| {
+        serde_json::from_value::<PromptResponse>(serde_json::json!({ "stopReason": stop }))
+            .map_err(|e| acp_internal_error(format!("build prompt response: {e}")))
+    };
+    match outcome {
+        PromptOutcome::Completed { stop_reason } => {
+            build(stop_reason.as_deref().unwrap_or("end_turn"))
+        }
+        // The runner lost the agent before it answered; end the turn.
+        PromptOutcome::Aborted => build("end_turn"),
+        // Reconstruct the crate error, preserving `data` so
+        // `classify_rate_limit_error` still recognizes a rate limit. The
+        // numeric `code` is informational and dropped (the crate `code` is
+        // a typed `ErrorCode`); message + data carry the signal.
+        PromptOutcome::Error {
+            code: _,
+            message,
+            data,
+        } => {
+            let mut err = agent_client_protocol::Error::internal_error();
+            err.message = message;
+            err.data = data;
+            Err(err)
+        }
     }
 }
 
@@ -5199,6 +5352,13 @@ async fn run_connection_task<W, R>(
     // see it already fired and stand down. `None` on paths with no
     // control channel (direct stdio), where the task owns its own guard.
     external_terminal_guard: Option<Arc<std::sync::atomic::AtomicBool>>,
+    // #2976 Phase B: control client for a v2 runner. When Some, the task
+    // drives `initialize` / `session/*` / `session/prompt` / cancel over it
+    // instead of the crate connection (relay), which stays attached only
+    // for `session/update` notifications and server->client callbacks. None
+    // on the direct-stdio path and against an older (v1) runner, where the
+    // task speaks the full protocol over the relay as before.
+    control_client: Option<Arc<DaemonControlClient>>,
 ) where
     W: futures_util::AsyncWrite + Send + 'static,
     R: futures_util::AsyncRead + Send + 'static,
@@ -5732,14 +5892,29 @@ async fn run_connection_task<W, R>(
         )
         .connect_with(transport, |connection: ConnectionTo<Agent>| async move {
             info!(target: "acp.protocol", session = %session_label, "initializing ACP agent");
-            // `initialize` is sent in both Fresh and Resume modes.
-            // It's idempotent on every ACP agent we ship against
-            // (aoe-agent, claude-agent-acp); the response only carries
-            // capability metadata; so re-sending it on attach is safe.
-            let init = connection
-                .send_request(build_initialize_request())
-                .block_task()
-                .await?;
+            // #2976 Phase B: against a v2 runner the runner owns
+            // `initialize` (it runs it once and caches the result), so the
+            // daemon drives it over the control channel and deserializes the
+            // cached result. Against the direct-stdio path or an older (v1)
+            // runner, send it over the relay via the crate connection as
+            // before. `initialize` is idempotent on every ACP agent we ship
+            // against (aoe-agent, claude-agent-acp); the response only
+            // carries capability metadata.
+            let init: InitializeResponse = if let Some(control) = control_client.as_ref() {
+                let params = serde_json::to_value(build_initialize_request())
+                    .map_err(|e| acp_internal_error(format!("serialize initialize params: {e}")))?;
+                let result = control
+                    .initialize(params)
+                    .await
+                    .map_err(|e| acp_internal_error(format!("runner initialize: {e}")))?;
+                serde_json::from_value(result)
+                    .map_err(|e| acp_internal_error(format!("deserialize initialize result: {e}")))?
+            } else {
+                connection
+                    .send_request(build_initialize_request())
+                    .block_task()
+                    .await?
+            };
 
             // Per-adapter compatibility check (see src/acp/agent_compat.rs).
             // Currently only gates claude-agent-acp at >=0.37.0; other
@@ -5920,7 +6095,21 @@ async fn run_connection_task<W, R>(
                         );
                         let req = ForkSessionRequest::new(parent.clone(), agent_cwd.clone())
                             .mcp_servers(mcp_servers.clone());
-                        match connection.send_request(req).block_task().await {
+                        // #2976 Phase B: a v2 runner owns session creation;
+                        // drive session/fork over the control channel and
+                        // deserialize the cached result. Else send over the
+                        // relay via the crate connection.
+                        let fork_result = if let Some(control) = control_client.as_ref() {
+                            establish_session_v2::<ForkSessionResponse>(
+                                control,
+                                "session/fork",
+                                &req,
+                            )
+                            .await
+                        } else {
+                            connection.send_request(req).block_task().await
+                        };
+                        match fork_result {
                             Ok(resp) => {
                                 let new_id = resp.session_id.clone();
                                 info!(
@@ -6051,7 +6240,18 @@ async fn run_connection_task<W, R>(
                             }
                             let req = LoadSessionRequest::new(stored.clone(), agent_cwd.clone())
                                 .mcp_servers(mcp_servers.clone());
-                            match connection.send_request(req).block_task().await {
+                            // #2976 Phase B: v2 runner owns session/load.
+                            let load_result = if let Some(control) = control_client.as_ref() {
+                                establish_session_v2::<LoadSessionResponse>(
+                                    control,
+                                    "session/load",
+                                    &req,
+                                )
+                                .await
+                            } else {
+                                connection.send_request(req).block_task().await
+                            };
+                            match load_result {
                                 Ok(resp) => {
                                     info!(
                                         target: "acp.protocol",
@@ -6144,12 +6344,15 @@ async fn run_connection_task<W, R>(
                             session = %session_label,
                             "creating fresh session via session/new"
                         );
-                        let new_session = connection
-                            .send_request(
-                                NewSessionRequest::new(agent_cwd.clone()).mcp_servers(mcp_servers),
-                            )
-                            .block_task()
-                            .await?;
+                        let req =
+                            NewSessionRequest::new(agent_cwd.clone()).mcp_servers(mcp_servers);
+                        // #2976 Phase B: v2 runner owns session/new.
+                        let new_session = if let Some(control) = control_client.as_ref() {
+                            establish_session_v2::<NewSessionResponse>(control, "session/new", &req)
+                                .await?
+                        } else {
+                            connection.send_request(req).block_task().await?
+                        };
                         let id = new_session.session_id.clone();
                         info!(
                             target: "acp.protocol",
@@ -6314,6 +6517,24 @@ async fn run_connection_task<W, R>(
                     }
                 }
             };
+
+            // #2976 Phase B: send session/cancel over the v2 control channel
+            // when the runner owns the turn, else as a crate notification
+            // over the relay. A macro (not a helper fn) so it expands at each
+            // call site with that site's error-handling shape, and yields the
+            // same `Result<(), Error>` the relay send did. Defined after
+            // `acp_session_id` binds because macro_rules! resolves free
+            // identifiers at the definition site, not the call site.
+            macro_rules! send_session_cancel {
+                () => {{
+                    if let Some(control) = control_client.as_ref() {
+                        control.cancel().await;
+                        Ok::<(), agent_client_protocol::Error>(())
+                    } else {
+                        connection.send_notification(CancelNotification::new(acp_session_id.clone()))
+                    }
+                }};
+            }
 
             // Arm the resume-idle watchdog. The agent's response to the
             // orphaned in-flight `session/prompt` (from the previous
@@ -6602,10 +6823,52 @@ async fn run_connection_task<W, R>(
                         tokio::pin!(silent_orphan_check);
 
                         let prompt_started_at_ms = chrono::Utc::now().timestamp_millis();
-                        let prompt_fut = connection
-                            .send_request(PromptRequest::new(acp_session_id.clone(), blocks))
-                            .block_task();
-                        tokio::pin!(prompt_fut);
+                        // #2976 Phase B: against a v2 runner the turn is
+                        // issued over the control channel (the runner assigns
+                        // the session/prompt id and reports PromptCompleted,
+                        // which the control reader routes into this future);
+                        // otherwise it goes over the relay via the crate
+                        // connection. Both arms resolve to the same
+                        // `Result<PromptResponse, Error>` so the select body
+                        // below is identical. Boxed as a `Pin<Box<dyn
+                        // Future>>` (Unpin) so no `tokio::pin!` is needed.
+                        let mut prompt_fut: std::pin::Pin<
+                            Box<
+                                dyn std::future::Future<
+                                        Output = Result<PromptResponse, agent_client_protocol::Error>,
+                                    > + Send,
+                            >,
+                        > = if let Some(control) = control_client.as_ref() {
+                            match serde_json::to_value(PromptRequest::new(
+                                acp_session_id.clone(),
+                                blocks,
+                            )) {
+                                Ok(params) => {
+                                    let rx = control.prompt(params).await;
+                                    Box::pin(async move {
+                                        match rx.await {
+                                            Ok(outcome) => prompt_outcome_to_response(outcome),
+                                            // Control channel closed before
+                                            // completion: end the turn
+                                            // cleanly; the dying connection
+                                            // surfaces the underlying failure.
+                                            Err(_) => prompt_outcome_to_response(
+                                                control_protocol::PromptOutcome::Aborted,
+                                            ),
+                                        }
+                                    })
+                                }
+                                Err(e) => Box::pin(async move {
+                                    Err(acp_internal_error(format!("serialize prompt params: {e}")))
+                                }),
+                            }
+                        } else {
+                            Box::pin(
+                                connection
+                                    .send_request(PromptRequest::new(acp_session_id.clone(), blocks))
+                                    .block_task(),
+                            )
+                        };
 
                         // Debug-only fault injection: when this env var
                         // is set, the prompt_fut select arm is gated
@@ -6815,9 +7078,7 @@ async fn run_connection_task<W, R>(
                                         // the cancel_grace arm fires
                                         // and we synthesize Stopped
                                         // with reason "prompt_orphaned".
-                                        if let Err(err) = connection.send_notification(
-                                            CancelNotification::new(acp_session_id.clone()),
-                                        ) {
+                                        if let Err(err) = send_session_cancel!() {
                                             warn!(
                                                 target: "acp.protocol",
                                                 session = %session_label,
@@ -6861,9 +7122,7 @@ async fn run_connection_task<W, R>(
                                                 target: "acp.protocol",
                                                 "sending session/cancel during in-flight prompt"
                                             );
-                                            connection.send_notification(
-                                                CancelNotification::new(acp_session_id.clone()),
-                                            )?;
+                                            send_session_cancel!()?;
                                             // Arm the escalation watchdog on
                                             // the first cancel only; later
                                             // cancels just resend the
@@ -6902,9 +7161,7 @@ async fn run_connection_task<W, R>(
                                             // real lever is ending the turn so
                                             // the drain task kills the process
                                             // group and respawns. See #1727.
-                                            let _ = connection.send_notification(
-                                                CancelNotification::new(acp_session_id.clone()),
-                                            );
+                                            let _ = send_session_cancel!();
                                             force_stopped = true;
                                             shutdown = true;
                                             break;
@@ -7118,9 +7375,7 @@ async fn run_connection_task<W, R>(
                         // is exactly when the UI most needs the synthetic
                         // Stopped below to unstick. Propagating the error here
                         // would skip that emit and defeat the desync recovery.
-                        if let Err(e) = connection
-                            .send_notification(CancelNotification::new(acp_session_id.clone()))
-                        {
+                        if let Err(e) = send_session_cancel!() {
                             warn!(
                                 target: "acp.protocol",
                                 error = %e,
@@ -7164,8 +7419,7 @@ async fn run_connection_task<W, R>(
                         watchdog_fired.store(true, Ordering::Relaxed);
                         adopted_turn_active.store(false, Ordering::Relaxed);
                         between_prompt_active.store(false, Ordering::Relaxed);
-                        let _ = connection
-                            .send_notification(CancelNotification::new(acp_session_id.clone()));
+                        let _ = send_session_cancel!();
                     }
                     Some(ClientCmd::SetMode(mode_id)) => {
                         dispatch_set_mode(
@@ -11908,13 +12162,14 @@ mod tests {
         }
     }
 
-    /// Daemon-side control consumer (#1054 Phase A): a runner that greets
-    /// with a matching `Hello` and then reports `PromptCompleted` drives an
+    /// Daemon-side control consumer (#2976 Phase B): a v2 runner that greets
+    /// with a matching `Hello` and then reports `PromptCompleted` for an
+    /// adopted turn (no prompt awaiting on this daemon) drives an
     /// `Event::Stopped { reason: "prompt_complete" }` and claims the shared
     /// terminal guard so the resume-idle watchdog stands down.
     #[tokio::test]
     async fn runner_control_native_completion_fires_stopped() {
-        use crate::acp::control_protocol::{self, ControlBody};
+        use crate::acp::control_protocol::{self, ControlBody, PromptOutcome};
         use std::sync::atomic::{AtomicBool, Ordering};
         use tokio::net::UnixListener;
 
@@ -11941,7 +12196,9 @@ mod tests {
                 &mut w,
                 &ControlBody::PromptCompleted {
                     prompt_req_id: 5,
-                    stop_reason: Some("end_turn".into()),
+                    outcome: PromptOutcome::Completed {
+                        stop_reason: Some("end_turn".into()),
+                    },
                 },
             )
             .await
@@ -11952,7 +12209,9 @@ mod tests {
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
         let guard = Arc::new(AtomicBool::new(false));
-        attach_runner_control(&main_socket, event_tx, "s".into(), guard.clone()).await;
+        let client = connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone())
+            .await
+            .expect("v2 control client");
 
         let ev = tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv())
             .await
@@ -11963,6 +12222,7 @@ mod tests {
             guard.load(Ordering::Relaxed),
             "terminal guard must be claimed"
         );
+        drop(client);
         let _ = fake.await;
     }
 
@@ -11995,8 +12255,13 @@ mod tests {
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
         let guard = Arc::new(AtomicBool::new(false));
-        attach_runner_control(&main_socket, event_tx, "s".into(), guard.clone()).await;
+        let client =
+            connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone()).await;
 
+        assert!(
+            client.is_none(),
+            "unknown control version must not yield a v2 client"
+        );
         assert!(
             !guard.load(Ordering::Relaxed),
             "unknown control version must not claim the guard"
@@ -12021,8 +12286,13 @@ mod tests {
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(8);
         let guard = Arc::new(AtomicBool::new(false));
-        attach_runner_control(&main_socket, event_tx, "s".into(), guard.clone()).await;
+        let client =
+            connect_runner_control_v2(&main_socket, event_tx, "s".into(), guard.clone()).await;
 
+        assert!(
+            client.is_none(),
+            "absent control socket must fall back to the watchdog"
+        );
         assert!(
             !guard.load(Ordering::Relaxed),
             "absent control socket must fall back to the watchdog"

--- a/src/acp/control_protocol.rs
+++ b/src/acp/control_protocol.rs
@@ -79,10 +79,13 @@ pub enum ControlBody {
         result: serde_json::Value,
     },
     /// The runner-owned handshake failed (agent incompatible, `session/new`
-    /// error, transport failure). The daemon surfaces this as an
-    /// `AgentStartupError` instead of hanging on a handshake that will
-    /// never complete.
-    HandshakeFailed { message: String },
+    /// error, transport failure). Carries the raw JSON-RPC error object
+    /// (`{code, message, data?}`) so the daemon can reconstruct the crate
+    /// error verbatim and surface the same `AgentStartupError` (including
+    /// `data.details` remediation) it would have on the byte-relay path,
+    /// instead of hanging on a handshake that will never complete. A
+    /// transport failure with no agent error synthesizes a minimal object.
+    HandshakeFailed { error: serde_json::Value },
     /// The runner observed the agent's response to the `session/prompt`
     /// request it issued. `prompt_req_id` is the JSON-RPC id the runner
     /// assigned. `outcome` is the typed turn result.
@@ -251,7 +254,7 @@ mod tests {
                 result: serde_json::json!({"sessionId": "sess-1"}),
             },
             ControlBody::HandshakeFailed {
-                message: "incompatible".into(),
+                error: serde_json::json!({"code": -32603, "message": "incompatible"}),
             },
             ControlBody::Prompt {
                 request: serde_json::json!({"sessionId": "sess-1", "prompt": []}),

--- a/src/acp/control_protocol.rs
+++ b/src/acp/control_protocol.rs
@@ -125,8 +125,15 @@ pub enum PromptOutcome {
     /// Normal completion. `stop_reason` is the ACP `stopReason` from the
     /// response result when present.
     Completed { stop_reason: Option<String> },
-    /// The agent answered the prompt with a JSON-RPC error envelope.
-    Error { code: i64, message: String },
+    /// The agent answered the prompt with a JSON-RPC error envelope. The
+    /// `data` object is preserved so the daemon can still classify a
+    /// rate-limit error (which carries `errorKind` / `resets_at` there).
+    Error {
+        code: i64,
+        message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        data: Option<serde_json::Value>,
+    },
     /// The turn ended because the runner lost the agent (process exit,
     /// transport failure) before a response arrived.
     Aborted,
@@ -214,6 +221,7 @@ mod tests {
             PromptOutcome::Error {
                 code: -32000,
                 message: "boom".into(),
+                data: Some(serde_json::json!({"errorKind": "rate_limit"})),
             },
             PromptOutcome::Aborted,
         ] {

--- a/src/acp/control_protocol.rs
+++ b/src/acp/control_protocol.rs
@@ -7,8 +7,21 @@
 //! request and reports a native turn-complete signal over this channel,
 //! so the daemon fires `Stopped { reason: "prompt_complete" }`
 //! deterministically instead of guessing with the 30s resume-idle
-//! watchdog. Later phases move the ACP handshake and the agent's
-//! server-method callbacks onto this channel too.
+//! watchdog.
+//!
+//! Phase B (#2976): the runner now owns the ACP handshake and the turn
+//! request/response. The daemon drives the handshake inputs over this
+//! channel ([`ControlBody::Initialize`] then [`ControlBody::EstablishSession`]);
+//! the runner runs `initialize` + `session/new|load|fork` against the
+//! agent exactly once, caches the raw results, and returns them as
+//! [`ControlBody::Initialized`] / [`ControlBody::SessionReady`]. On every
+//! later attach it replays those from cache without touching the agent.
+//! Prompts and cancels move here too ([`ControlBody::Prompt`] /
+//! [`ControlBody::Cancel`]); the runner assigns the canonical
+//! `session/prompt` JSON-RPC id and reports the typed
+//! [`ControlBody::PromptCompleted`] outcome. Agent `session/update`
+//! notifications and server->client callbacks (permission / fs /
+//! terminal) still flow over the raw byte relay on `<id>.sock`.
 //!
 //! Wire format: each frame is a 4-byte big-endian length prefix followed
 //! by that many bytes of JSON (a serialized [`ControlBody`]). The byte
@@ -23,8 +36,12 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 /// Bumped when the frame set changes in a wire-incompatible way. The
 /// runner announces it in [`ControlBody::Hello`]; a daemon that does not
 /// recognize the version keeps the legacy resume-idle watchdog rather
-/// than trusting the channel.
-pub const CONTROL_PROTOCOL_VERSION: u32 = 1;
+/// than trusting the channel. v2 (#2976) adds the runner-owned handshake
+/// and typed prompt/cancel frames; the [`ControlBody::PromptCompleted`]
+/// shape changed, so v1 and v2 are wire-incompatible and the version gate
+/// is what keeps a mixed-version daemon/runner pair from misreading each
+/// other.
+pub const CONTROL_PROTOCOL_VERSION: u32 = 2;
 
 /// Hard cap on a single control frame. Phase A frames are tiny; reject
 /// anything larger as a framing error instead of allocating a huge
@@ -45,21 +62,74 @@ pub enum ControlBody {
         control_protocol_version: u32,
         session_id: String,
     },
-    /// The runner observed the agent's response to the tracked
-    /// `session/prompt` request. `prompt_req_id` is the JSON-RPC id the
-    /// daemon issued for that prompt. `stop_reason` is the ACP
-    /// `stopReason` from the response result when present (None for an
-    /// error-envelope response, which still ends the turn).
+    /// Runner's answer to [`ControlBody::Initialize`]: the raw ACP
+    /// `initialize` result (an `InitializeResponse` serialized to JSON).
+    /// Produced by running `initialize` against the agent on the first
+    /// attach and replayed verbatim from cache on every later attach. The
+    /// daemon deserializes it into the crate `InitializeResponse` to drive
+    /// its capability consumers.
+    Initialized { result: serde_json::Value },
+    /// Runner's answer to [`ControlBody::EstablishSession`]: the
+    /// established ACP session id plus the raw session response result
+    /// (a `NewSessionResponse` / `LoadSessionResponse` serialized to
+    /// JSON) so the daemon can extract modes / config options. Replayed
+    /// from cache on later attaches.
+    SessionReady {
+        acp_session_id: String,
+        result: serde_json::Value,
+    },
+    /// The runner-owned handshake failed (agent incompatible, `session/new`
+    /// error, transport failure). The daemon surfaces this as an
+    /// `AgentStartupError` instead of hanging on a handshake that will
+    /// never complete.
+    HandshakeFailed { message: String },
+    /// The runner observed the agent's response to the `session/prompt`
+    /// request it issued. `prompt_req_id` is the JSON-RPC id the runner
+    /// assigned. `outcome` is the typed turn result.
     PromptCompleted {
         prompt_req_id: i64,
-        stop_reason: Option<String>,
+        outcome: PromptOutcome,
     },
 
     // ---- daemon -> runner ----
     /// First frame the daemon sends after [`ControlBody::Hello`],
-    /// acknowledging the version it will speak. Phase A carries no other
-    /// daemon-to-runner traffic.
+    /// acknowledging the version it will speak.
     Attach { control_protocol_version: u32 },
+    /// The ACP `initialize` request params (an `InitializeRequest`
+    /// serialized to JSON). The runner injects the JSON-RPC envelope + id.
+    /// On a runner that already handshook, the params are ignored and the
+    /// cached [`ControlBody::Initialized`] is replayed.
+    Initialize { request: serde_json::Value },
+    /// The session-creation request the runner should issue: `method` is
+    /// `session/new`, `session/load`, or `session/fork`, and `request` is
+    /// the matching params. Ignored (cache replayed) once the runner has
+    /// an established session.
+    EstablishSession {
+        method: String,
+        request: serde_json::Value,
+    },
+    /// Run a turn. `request` is the ACP `session/prompt` params
+    /// (`PromptRequest`); the runner assigns the canonical JSON-RPC id and
+    /// tracks the response.
+    Prompt { request: serde_json::Value },
+    /// Cancel the in-flight turn (maps to a `session/cancel` notification).
+    Cancel,
+}
+
+/// Typed result of a runner-owned turn. Replaces Phase A's
+/// `stop_reason`-only form so an agent error-envelope response is
+/// surfaced as an error rather than collapsed into a silent stop.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum PromptOutcome {
+    /// Normal completion. `stop_reason` is the ACP `stopReason` from the
+    /// response result when present.
+    Completed { stop_reason: Option<String> },
+    /// The agent answered the prompt with a JSON-RPC error envelope.
+    Error { code: i64, message: String },
+    /// The turn ended because the runner lost the agent (process exit,
+    /// transport failure) before a response arrived.
+    Aborted,
 }
 
 /// Encode a frame: 4-byte big-endian length prefix, then the JSON body.
@@ -130,16 +200,65 @@ mod tests {
     fn prompt_completed_roundtrips() {
         let body = ControlBody::PromptCompleted {
             prompt_req_id: 42,
-            stop_reason: Some("end_turn".into()),
+            outcome: PromptOutcome::Completed {
+                stop_reason: Some("end_turn".into()),
+            },
         };
         assert_eq!(roundtrip(body.clone()), body);
+    }
+
+    #[test]
+    fn prompt_outcome_variants_roundtrip() {
+        for outcome in [
+            PromptOutcome::Completed { stop_reason: None },
+            PromptOutcome::Error {
+                code: -32000,
+                message: "boom".into(),
+            },
+            PromptOutcome::Aborted,
+        ] {
+            let body = ControlBody::PromptCompleted {
+                prompt_req_id: 1,
+                outcome: outcome.clone(),
+            };
+            assert_eq!(roundtrip(body.clone()), body);
+        }
+    }
+
+    #[test]
+    fn handshake_frames_roundtrip() {
+        for body in [
+            ControlBody::Initialize {
+                request: serde_json::json!({"protocolVersion": 1}),
+            },
+            ControlBody::Initialized {
+                result: serde_json::json!({"agentCapabilities": {}}),
+            },
+            ControlBody::EstablishSession {
+                method: "session/new".into(),
+                request: serde_json::json!({"cwd": "/tmp"}),
+            },
+            ControlBody::SessionReady {
+                acp_session_id: "sess-1".into(),
+                result: serde_json::json!({"sessionId": "sess-1"}),
+            },
+            ControlBody::HandshakeFailed {
+                message: "incompatible".into(),
+            },
+            ControlBody::Prompt {
+                request: serde_json::json!({"sessionId": "sess-1", "prompt": []}),
+            },
+            ControlBody::Cancel,
+        ] {
+            assert_eq!(roundtrip(body.clone()), body);
+        }
     }
 
     #[tokio::test]
     async fn write_then_read_frame() {
         let body = ControlBody::PromptCompleted {
             prompt_req_id: 7,
-            stop_reason: None,
+            outcome: PromptOutcome::Aborted,
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &body).await.expect("write");
@@ -151,12 +270,14 @@ mod tests {
     #[tokio::test]
     async fn multiple_frames_in_one_stream() {
         let a = ControlBody::Hello {
-            control_protocol_version: 1,
+            control_protocol_version: CONTROL_PROTOCOL_VERSION,
             session_id: "s".into(),
         };
         let b = ControlBody::PromptCompleted {
             prompt_req_id: 1,
-            stop_reason: Some("cancelled".into()),
+            outcome: PromptOutcome::Completed {
+                stop_reason: Some("cancelled".into()),
+            },
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &a).await.unwrap();

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -59,7 +59,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
 use super::worker_registry::{self, WorkerRecord};
-use crate::acp::control_protocol::{self, ControlBody};
+use crate::acp::control_protocol::{self, ControlBody, PromptOutcome};
 use crate::process::worker::RunnerRecordState;
 
 /// How often the abandonment watchdog inspects its own registry record.
@@ -808,11 +808,11 @@ impl RunnerShared {
         // of `note_daemon_response`). Independent of the byte-relay
         // outbound below, since the control channel is a separate socket.
         if !self.prompt_requests.lock().await.is_empty() {
-            if let Some((id, stop_reason)) = parse_response(line) {
+            if let Some((id, outcome)) = parse_response(line) {
                 if self.prompt_requests.lock().await.remove(&id) {
                     self.emit_control(ControlBody::PromptCompleted {
                         prompt_req_id: id,
-                        stop_reason,
+                        outcome,
                     })
                     .await;
                 }
@@ -1139,7 +1139,8 @@ async fn read_frame_bounded<R: AsyncBufRead + Unpin>(
 }
 
 /// Peek fields of a JSON-RPC response line for turn-complete detection:
-/// the `result.stopReason` when the response succeeded.
+/// the `result.stopReason` when the response succeeded, or the `error`
+/// envelope when it failed.
 #[derive(Deserialize)]
 struct JsonRpcResponsePeek {
     #[serde(default)]
@@ -1148,26 +1149,46 @@ struct JsonRpcResponsePeek {
     method: Option<String>,
     #[serde(default)]
     result: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<JsonRpcErrorPeek>,
 }
 
-/// Parse a JSON-RPC response line into `(id, stop_reason)`. Returns None
-/// for requests (a `method` is present), notifications (no `id`),
-/// non-numeric ids, and malformed lines. An error-envelope response (no
-/// `result`) still counts as a completion, with `stop_reason` None; the
-/// turn ended either way, so the UI should stop showing "thinking".
-fn parse_response(line: &[u8]) -> Option<(i64, Option<String>)> {
+/// The JSON-RPC `error` object on a failed response.
+#[derive(Deserialize)]
+struct JsonRpcErrorPeek {
+    #[serde(default)]
+    code: i64,
+    #[serde(default)]
+    message: String,
+}
+
+/// Parse a JSON-RPC response line into `(id, outcome)`. Returns None for
+/// requests (a `method` is present), notifications (no `id`), non-numeric
+/// ids, and malformed lines. An error-envelope response is surfaced as
+/// `PromptOutcome::Error` so the daemon can report it rather than
+/// collapse it into a silent stop; a success response carries the ACP
+/// `stopReason` when present.
+fn parse_response(line: &[u8]) -> Option<(i64, PromptOutcome)> {
     let peek: JsonRpcResponsePeek = serde_json::from_slice(line).ok()?;
     if peek.method.is_some() {
         return None;
     }
     let id = peek.id?.as_i64()?;
-    let stop_reason = peek
-        .result
-        .as_ref()
-        .and_then(|r| r.get("stopReason"))
-        .and_then(|s| s.as_str())
-        .map(|s| s.to_string());
-    Some((id, stop_reason))
+    let outcome = if let Some(err) = peek.error {
+        PromptOutcome::Error {
+            code: err.code,
+            message: err.message,
+        }
+    } else {
+        let stop_reason = peek
+            .result
+            .as_ref()
+            .and_then(|r| r.get("stopReason"))
+            .and_then(|s| s.as_str())
+            .map(|s| s.to_string());
+        PromptOutcome::Completed { stop_reason }
+    };
+    Some((id, outcome))
 }
 
 /// Read agent stdout line-by-line (ndjson) and either forward to the

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1418,6 +1418,8 @@ struct JsonRpcErrorPeek {
     code: i64,
     #[serde(default)]
     message: String,
+    #[serde(default)]
+    data: Option<serde_json::Value>,
 }
 
 /// Parse a JSON-RPC response line into `(id, outcome)`. Returns None for
@@ -1436,6 +1438,7 @@ fn parse_response(line: &[u8]) -> Option<(i64, PromptOutcome)> {
         PromptOutcome::Error {
             code: err.code,
             message: err.message,
+            data: err.data,
         }
     } else {
         let stop_reason = peek
@@ -1852,15 +1855,33 @@ mod tests {
     #[test]
     fn parse_response_extracts_stop_reason() {
         let line = br#"{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}"#;
-        assert_eq!(parse_response(line), Some((3, Some("end_turn".into()))));
+        assert_eq!(
+            parse_response(line),
+            Some((
+                3,
+                PromptOutcome::Completed {
+                    stop_reason: Some("end_turn".into())
+                }
+            ))
+        );
     }
 
     #[test]
-    fn parse_response_treats_error_envelope_as_completion() {
-        // An error response still ends the turn; detected as a completion
-        // with no stopReason.
-        let line = br#"{"jsonrpc":"2.0","id":4,"error":{"code":-32000,"message":"boom"}}"#;
-        assert_eq!(parse_response(line), Some((4, None)));
+    fn parse_response_surfaces_error_envelope() {
+        // An error response still ends the turn, now as a typed Error
+        // outcome (preserving data) rather than a silent completion.
+        let line = br#"{"jsonrpc":"2.0","id":4,"error":{"code":-32000,"message":"boom","data":{"errorKind":"rate_limit"}}}"#;
+        assert_eq!(
+            parse_response(line),
+            Some((
+                4,
+                PromptOutcome::Error {
+                    code: -32000,
+                    message: "boom".into(),
+                    data: Some(serde_json::json!({"errorKind": "rate_limit"})),
+                }
+            ))
+        );
     }
 
     #[test]
@@ -1906,7 +1927,9 @@ mod tests {
             shared.control.lock().await.pending,
             Some(ControlBody::PromptCompleted {
                 prompt_req_id: 5,
-                stop_reason: Some("end_turn".into()),
+                outcome: PromptOutcome::Completed {
+                    stop_reason: Some("end_turn".into()),
+                },
             })
         );
     }
@@ -1954,7 +1977,9 @@ mod tests {
 
         let body = ControlBody::PromptCompleted {
             prompt_req_id: 9,
-            stop_reason: Some("end_turn".into()),
+            outcome: PromptOutcome::Completed {
+                stop_reason: Some("end_turn".into()),
+            },
         };
         shared.emit_control(body.clone()).await;
 

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -700,12 +700,14 @@ struct RunnerShared {
     handshake: Mutex<RunnerHandshake>,
     /// Monotonic JSON-RPC id allocator for the requests the runner issues
     /// to the agent on its own (`initialize`, `session/*`, `session/prompt`)
-    /// now that it owns the client side of the protocol. Seeded from a high
-    /// base ([`RUNNER_REQUEST_ID_BASE`]) so it stays disjoint from the crate
-    /// connection's low, monotonic-from-1 ids: on the v2 path the daemon
-    /// still issues `set_mode` / `set_config_option` over the relay via the
-    /// crate connection, so overlapping id ranges would let the runner
-    /// mis-route (swallow) a crate response, or collide on the agent's wire.
+    /// now that it owns the client side of the protocol. On the v2 path the
+    /// daemon still issues `set_mode` / `set_config_option` / `delete_session`
+    /// over the relay to the same agent via the crate connection, but the
+    /// crate allocates UUID-string request ids (`RequestId::Str`), so they
+    /// can never match the runner's integer ids (`parse_response_id` reads
+    /// `as_i64`, which is `None` for a string) and the two id spaces cannot
+    /// overlap. The high [`RUNNER_REQUEST_ID_BASE`] seed is defense in depth
+    /// in case the crate ever switches to integer ids.
     next_req_id: AtomicI64,
     /// Responders for runner-issued request/response round-trips awaited
     /// inline (`initialize`, `session/*`). The stdout fanout routes a
@@ -770,13 +772,12 @@ const PERMISSION_METHOD: &str = "session/request_permission";
 /// the agent to daemon path. Phase A of #1054.
 const PROMPT_METHOD: &str = "session/prompt";
 
-/// Base for the runner's own agent-bound JSON-RPC ids (#2976 Phase B). The
-/// crate `ConnectionTo` on the daemon side allocates monotonic ids from a
-/// small start (~1) for the `set_mode` / `set_config_option` requests it
-/// still sends over the relay on the v2 path. Seeding the runner's ids far
-/// above that keeps the two id spaces disjoint, so an agent response routes
-/// to exactly one waiter and the wire never carries two live requests with
-/// the same id.
+/// Seed for the runner's own agent-bound JSON-RPC ids (#2976 Phase B). The
+/// crate `ConnectionTo` on the daemon side allocates UUID-string ids for
+/// the `set_mode` / `set_config_option` / `delete_session` requests it
+/// still sends over the relay on the v2 path, so those never collide with
+/// the runner's integer ids by construction. This high seed is only defense
+/// in depth against a future crate change to integer ids.
 const RUNNER_REQUEST_ID_BASE: i64 = 1 << 48;
 
 /// Deadline for a single control-channel frame write. `emit_control`

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -45,7 +45,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -343,13 +343,22 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
         args.session_id.clone(),
     ));
 
-    // Control-channel accept loop (#1054 Phase A). Serves the sibling
-    // `<id>.control.sock`, over which the runner reports native
-    // turn-complete signals. Independent of the main byte-relay accept
+    // Wrap agent stdin in a tokio Mutex so both accept loops can hand it
+    // to one connection at a time. Wrapping (not splitting) keeps stdin
+    // alive across reconnects; closing it would cause aoe-agent to
+    // `process.exit(0)`. The control loop needs it too now that the runner
+    // owns the handshake and issues `session/prompt` itself (#2976).
+    let agent_stdin = Arc::new(Mutex::new(agent_stdin));
+
+    // Control-channel accept loop. Serves the sibling `<id>.control.sock`,
+    // over which the runner drives the ACP handshake it owns and the turn
+    // request/response (#2976 Phase B), and reports native turn-complete
+    // signals (#1054 Phase A). Independent of the main byte-relay accept
     // loop; a daemon attaches to both. Detached like the stderr drainer:
     // the process teardown drops it.
     let control_shared = Arc::clone(&shared);
     let control_session = args.session_id.clone();
+    let control_stdin = Arc::clone(&agent_stdin);
     let control_accept_task = tokio::spawn(async move {
         loop {
             match control_listener.accept().await {
@@ -362,6 +371,7 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
                     handle_control_connection(
                         stream,
                         Arc::clone(&control_shared),
+                        Arc::clone(&control_stdin),
                         control_session.clone(),
                     )
                     .await;
@@ -378,12 +388,6 @@ pub async fn run(args: AcpRunnerArgs) -> Result<()> {
             }
         }
     });
-
-    // Wrap agent stdin in a tokio Mutex so the accept loop can hand it
-    // to one connection at a time. Wrapping (not splitting) keeps stdin
-    // alive across reconnects; closing it would cause aoe-agent to
-    // `process.exit(0)`.
-    let agent_stdin = Arc::new(Mutex::new(agent_stdin));
 
     // Signal handling: SIGTERM/SIGINT → kill agent, cleanup, exit.
     let shutdown_signal = wait_for_shutdown();
@@ -689,6 +693,33 @@ struct RunnerShared {
     /// gap (buffer it for the next control attach). Set/cleared alongside
     /// `active_outbound`.
     main_attached: std::sync::atomic::AtomicBool,
+    /// Runner-owned ACP handshake cache (#2976 Phase B). Populated the
+    /// first time a v2 daemon drives `initialize` / `session/new|load|fork`
+    /// through the control channel; replayed verbatim on every later
+    /// attach so the agent is handshaken exactly once.
+    handshake: Mutex<RunnerHandshake>,
+    /// Monotonic JSON-RPC id allocator for the requests the runner issues
+    /// to the agent on its own (`initialize`, `session/*`, `session/prompt`)
+    /// now that it owns the client side of the protocol. The daemon no
+    /// longer issues requests over the relay on the v2 path, so this is the
+    /// sole client-request id space and cannot collide.
+    next_req_id: AtomicI64,
+    /// Responders for runner-issued request/response round-trips awaited
+    /// inline (`initialize`, `session/*`). The stdout fanout routes a
+    /// matching response into the oneshot and swallows it instead of
+    /// forwarding it to the daemon. Prompt responses are NOT here; they use
+    /// the async `prompt_requests` path that fires `PromptCompleted`.
+    pending_client_responses: Mutex<HashMap<i64, tokio::sync::oneshot::Sender<serde_json::Value>>>,
+}
+
+/// Runner-owned ACP handshake state (#2976 Phase B).
+#[derive(Default)]
+struct RunnerHandshake {
+    /// Cached raw `initialize` result once the runner has run it.
+    initialized: Option<serde_json::Value>,
+    /// Cached `(acp_session_id, raw session response result)` once the
+    /// session is established.
+    session: Option<(String, serde_json::Value)>,
 }
 
 /// Control-channel state for the sibling `<id>.control.sock`. A single
@@ -703,6 +734,12 @@ struct ControlChannel {
     /// next control attach. ACP is serial per session, so at most one turn
     /// is ever legitimately pending; a newer completion supersedes.
     pending: Option<ControlBody>,
+    /// True while a v2 daemon (#2976 Phase B) holds the control channel.
+    /// The v2 channel is persistent: it carries the handshake and every
+    /// turn, so `emit_control` must retain the outbound after a
+    /// `PromptCompleted` write instead of the Phase A one-shot teardown
+    /// (which delivers a single adopted-turn completion and closes).
+    persistent: bool,
 }
 
 /// JSON-RPC peek for outstanding-request tracking. Pulls only the
@@ -774,12 +811,31 @@ impl RunnerShared {
             prompt_requests: Mutex::new(HashSet::new()),
             control: Mutex::new(ControlChannel::default()),
             main_attached: std::sync::atomic::AtomicBool::new(false),
+            handshake: Mutex::new(RunnerHandshake::default()),
+            next_req_id: AtomicI64::new(1),
+            pending_client_responses: Mutex::new(HashMap::new()),
         }
     }
 
     /// Forward a line to the daemon if attached; else buffer. Returns
-    /// whether forwarding happened (false → buffered).
+    /// whether forwarding happened (false → buffered/consumed).
     async fn deliver_line(&self, line: &[u8]) -> bool {
+        // #2976 Phase B: a response to a request the RUNNER issued
+        // (`initialize` / `session/*` during the runner-owned handshake) is
+        // consumed here and never forwarded to the daemon, which drives
+        // those over the control channel and would drop the stray response.
+        // Agent server->client requests (id + method) and notifications
+        // (no id) are not runner responses and fall through to the relay.
+        if let Some(id) = parse_response_id(line) {
+            let responder = self.pending_client_responses.lock().await.remove(&id);
+            if let Some(tx) = responder {
+                if let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) {
+                    let _ = tx.send(value);
+                }
+                return false;
+            }
+        }
+
         // Peek-parse outgoing agent → daemon traffic to track outstanding
         // requests. A line with both a numeric `id` and a `method` is a
         // request the agent is making to the daemon; record it so we can
@@ -1014,10 +1070,18 @@ impl RunnerShared {
         let mut ch = self.control.lock().await;
         if let Some(out) = ch.outbound.as_mut() {
             let ok = write_control_frame(out, &body).await;
-            ch.outbound = None;
+            // v2 (#2976): the control channel is persistent, so keep the
+            // outbound after a successful write to carry later turns. Phase
+            // A tears it down: it delivers one adopted-turn completion per
+            // attach and must never write to a socket the daemon stopped
+            // reading.
             if ok {
+                if !ch.persistent {
+                    ch.outbound = None;
+                }
                 return;
             }
+            ch.outbound = None;
             // Dead or stalled control socket. A control daemon had dialed
             // in (this is the resume/adopted-turn path), so this completion
             // is real and was not received: buffer it unconditionally for
@@ -1041,37 +1105,231 @@ impl RunnerShared {
         ch.pending = Some(body);
     }
 
-    /// Install a control-channel write half: greet with `Hello`, then under
-    /// the same lock either hand off the one buffered completion (and leave
-    /// the outbound unset, since that is the adopted turn's single frame)
-    /// or store the write half to deliver the completion live later.
-    async fn install_control_outbound(
+    async fn clear_control_outbound(&self) {
+        let mut ch = self.control.lock().await;
+        ch.outbound = None;
+        ch.persistent = false;
+    }
+
+    /// Install the v2 (#2976) control write half: greet with `Hello`, then
+    /// under the control lock mark the channel persistent, drain any
+    /// completion buffered across a no-daemon gap, and retain the outbound
+    /// so the handshake and every turn's `PromptCompleted` can be written
+    /// to it. Returns false if the initial `Hello` write failed.
+    async fn install_v2_control(
         &self,
-        mut out: tokio::net::unix::OwnedWriteHalf,
+        out: &mut Option<tokio::net::unix::OwnedWriteHalf>,
         session_id: &str,
-    ) {
+    ) -> bool {
         let hello = ControlBody::Hello {
             control_protocol_version: control_protocol::CONTROL_PROTOCOL_VERSION,
             session_id: session_id.to_string(),
         };
-        if !write_control_frame(&mut out, &hello).await {
-            return;
+        let mut w = out.take().expect("write half present");
+        if !write_control_frame(&mut w, &hello).await {
+            return false;
         }
-        let mut ch = self.control.lock().await;
-        if let Some(body) = ch.pending.take() {
-            if !write_control_frame(&mut out, &body).await {
-                ch.pending = Some(body);
+        let pending = {
+            let mut ch = self.control.lock().await;
+            ch.persistent = true;
+            ch.pending.take()
+        };
+        if let Some(body) = pending {
+            if !write_control_frame(&mut w, &body).await {
+                self.control.lock().await.pending = Some(body);
+                return false;
             }
-            // Delivered (or failed on a dead/stalled socket); one completion
-            // per attach, so do not retain the outbound.
-            return;
         }
-        ch.outbound = Some(out);
+        self.control.lock().await.outbound = Some(w);
+        true
     }
 
-    async fn clear_control_outbound(&self) {
-        self.control.lock().await.outbound = None;
+    /// Serialize a JSON value as one ndjson line to the agent's stdin.
+    /// Returns false if serialization or the write failed.
+    async fn write_agent_line(
+        &self,
+        agent_stdin: &Mutex<tokio::process::ChildStdin>,
+        value: &serde_json::Value,
+    ) -> bool {
+        let mut bytes = match serde_json::to_vec(value) {
+            Ok(b) => b,
+            Err(_) => return false,
+        };
+        bytes.push(b'\n');
+        let mut stdin = agent_stdin.lock().await;
+        stdin.write_all(&bytes).await.is_ok() && stdin.flush().await.is_ok()
     }
+
+    /// Issue a runner-owned JSON-RPC request to the agent and await the
+    /// full response line as JSON. Used for the handshake requests the
+    /// runner now owns (`initialize`, `session/new|load|fork`). Returns
+    /// None if the write failed or the agent closed before answering.
+    async fn agent_request(
+        &self,
+        agent_stdin: &Mutex<tokio::process::ChildStdin>,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        let id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.pending_client_responses.lock().await.insert(id, tx);
+        let req = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        if !self.write_agent_line(agent_stdin, &req).await {
+            self.pending_client_responses.lock().await.remove(&id);
+            return None;
+        }
+        rx.await.ok()
+    }
+
+    /// Issue a runner-owned `session/prompt` to the agent. The response is
+    /// detected asynchronously by the stdout fanout (via `prompt_requests`),
+    /// which fires `PromptCompleted`. Returns the assigned request id, or
+    /// None if the write failed.
+    async fn agent_prompt(
+        &self,
+        agent_stdin: &Mutex<tokio::process::ChildStdin>,
+        params: serde_json::Value,
+    ) -> Option<i64> {
+        let id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
+        self.prompt_requests.lock().await.insert(id);
+        let req = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": PROMPT_METHOD,
+            "params": params,
+        });
+        if !self.write_agent_line(agent_stdin, &req).await {
+            self.prompt_requests.lock().await.remove(&id);
+            return None;
+        }
+        Some(id)
+    }
+
+    /// Issue a `session/cancel` notification for the established session.
+    async fn agent_cancel(
+        &self,
+        agent_stdin: &Mutex<tokio::process::ChildStdin>,
+        acp_session_id: &str,
+    ) {
+        let note = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": { "sessionId": acp_session_id },
+        });
+        let _ = self.write_agent_line(agent_stdin, &note).await;
+    }
+
+    /// Run (once) or replay (from cache) the ACP `initialize` the runner
+    /// now owns. On first call it sends `initialize` to the agent and
+    /// caches the raw result; later calls return the cache without touching
+    /// the agent. `Ok` carries the result to hand back as
+    /// `ControlBody::Initialized`; `Err` is a message for
+    /// `ControlBody::HandshakeFailed`.
+    async fn run_or_replay_initialize(
+        &self,
+        agent_stdin: &Mutex<tokio::process::ChildStdin>,
+        request: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        if let Some(cached) = self.handshake.lock().await.initialized.clone() {
+            return Ok(cached);
+        }
+        let response = self
+            .agent_request(agent_stdin, "initialize", request)
+            .await
+            .ok_or_else(|| "agent closed before answering initialize".to_string())?;
+        let result = handshake_result(&response).map_err(|e| format!("initialize {e}"))?;
+        self.handshake.lock().await.initialized = Some(result.clone());
+        Ok(result)
+    }
+
+    /// Run (once) or replay (from cache) the session-creation request the
+    /// runner now owns. `method` is `session/new|load|fork`. Caches
+    /// `(acp_session_id, raw result)`; later calls replay the cache. `Ok`
+    /// carries `(acp_session_id, result)`; `Err` is a HandshakeFailed
+    /// message.
+    async fn run_or_replay_session(
+        &self,
+        agent_stdin: &Mutex<tokio::process::ChildStdin>,
+        method: &str,
+        request: serde_json::Value,
+    ) -> Result<(String, serde_json::Value), String> {
+        if let Some(cached) = self.handshake.lock().await.session.clone() {
+            return Ok(cached);
+        }
+        let response = self
+            .agent_request(agent_stdin, method, request)
+            .await
+            .ok_or_else(|| format!("agent closed before answering {method}"))?;
+        let result = handshake_result(&response).map_err(|e| format!("{method} {e}"))?;
+        let acp_session_id = result
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| format!("{method} response missing sessionId"))?
+            .to_string();
+        let cached = (acp_session_id, result);
+        self.handshake.lock().await.session = Some(cached.clone());
+        Ok(cached)
+    }
+
+    /// The ACP session id the runner established, if any.
+    async fn acp_session_id(&self) -> Option<String> {
+        self.handshake
+            .lock()
+            .await
+            .session
+            .as_ref()
+            .map(|(id, _)| id.clone())
+    }
+
+    /// If a daemon re-sends a handshake request over the relay after the
+    /// runner already owns the session, answer it from cache instead of
+    /// forwarding a duplicate `initialize` / `session/*` to the
+    /// already-initialized agent. This guards the downgrade case where a v1
+    /// daemon (which drives the handshake over the relay) reattaches to a
+    /// runner a v2 daemon already handshook. Returns the synthesized
+    /// response line to send back to the daemon, or None to forward the
+    /// line to the agent unchanged.
+    async fn intercept_handshake(&self, line: &[u8]) -> Option<Vec<u8>> {
+        let (id, method) = parse_request(line)?;
+        let result = {
+            let hs = self.handshake.lock().await;
+            match method.as_str() {
+                "initialize" => hs.initialized.clone()?,
+                "session/new" | "session/load" | "session/fork" => {
+                    hs.session.as_ref().map(|(_, r)| r.clone())?
+                }
+                _ => return None,
+            }
+        };
+        let resp = serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result });
+        let mut bytes = serde_json::to_vec(&resp).ok()?;
+        bytes.push(b'\n');
+        Some(bytes)
+    }
+}
+
+/// Extract the `result` object from a runner-issued request's JSON-RPC
+/// response, mapping an `error` envelope or a missing result to an `Err`
+/// message. Used by the handshake path, where the runner needs the typed
+/// body rather than the fire-and-forget prompt path.
+fn handshake_result(response: &serde_json::Value) -> Result<serde_json::Value, String> {
+    if let Some(err) = response.get("error") {
+        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+        let message = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error");
+        return Err(format!("failed: {message} (code {code})"));
+    }
+    response
+        .get("result")
+        .cloned()
+        .ok_or_else(|| "response had neither result nor error".to_string())
 }
 
 /// Extract `(id, method)` from a JSON-RPC request line. Returns None
@@ -1246,6 +1504,13 @@ async fn handle_connection(
         match read_frame_bounded(&mut reader, &mut line).await {
             Ok(0) => break, // EOF: daemon closed the connection.
             Ok(_) => {
+                // #2976: once the runner owns the session, answer a relay
+                // handshake re-send from cache rather than double-initialize
+                // the agent (v1-daemon downgrade reattach).
+                if let Some(synth) = shared.intercept_handshake(&line).await {
+                    shared.deliver_line(&synth).await;
+                    continue;
+                }
                 shared.note_daemon_response(&line).await;
                 shared.note_prompt_request(&line).await;
                 let mut stdin = agent_stdin.lock().await;
@@ -1275,24 +1540,39 @@ async fn handle_connection(
     shared.clear_outbound().await;
 }
 
-/// Handle one control-channel connection: install its write half
-/// (greeting with `Hello` and draining buffered completion events), then
-/// read daemon to runner frames until EOF so a disconnect is detected.
-/// Phase A of #1054 has no daemon to runner frames that require action
-/// (the daemon's `Attach` just confirms the version), so the read loop
-/// exists only to observe the socket closing.
+/// Handle one control-channel connection (#2976 Phase B). Greets with
+/// `Hello`, installs the persistent write half (draining any completion
+/// buffered across a no-daemon gap), then drives the runner-owned protocol:
+///
+/// - `Initialize` / `EstablishSession` run (or replay from cache) the ACP
+///   handshake against the agent and answer with `Initialized` /
+///   `SessionReady` (or `HandshakeFailed`).
+/// - `Prompt` / `Cancel` issue a runner-owned `session/prompt` /
+///   `session/cancel`; the turn's `PromptCompleted` is fired
+///   asynchronously by the stdout fanout, so this loop does not block on it.
+///
+/// A v1 daemon never dials the control channel (it sees `Hello`'s v2
+/// version and falls back to the relay + resume-idle watchdog), so this
+/// loop only ever serves a v2 daemon; the read simply ends at EOF when the
+/// daemon detaches.
 async fn handle_control_connection(
     stream: UnixStream,
     shared: Arc<RunnerShared>,
+    agent_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
     session_id: String,
 ) {
     let (mut read_half, write_half) = stream.into_split();
-    shared
-        .install_control_outbound(write_half, &session_id)
-        .await;
+    let mut write_half = Some(write_half);
+    if !shared
+        .install_v2_control(&mut write_half, &session_id)
+        .await
+    {
+        shared.clear_control_outbound().await;
+        return;
+    }
     loop {
-        match control_protocol::read_frame(&mut read_half).await {
-            Ok(Some(_body)) => {}
+        let body = match control_protocol::read_frame(&mut read_half).await {
+            Ok(Some(body)) => body,
             Ok(None) => break, // clean EOF: daemon closed the control socket.
             Err(e) => {
                 warn!(
@@ -1302,6 +1582,51 @@ async fn handle_control_connection(
                 );
                 break;
             }
+        };
+        match body {
+            ControlBody::Attach { .. } => {}
+            ControlBody::Initialize { request } => {
+                let frame = match shared.run_or_replay_initialize(&agent_stdin, request).await {
+                    Ok(result) => ControlBody::Initialized { result },
+                    Err(message) => {
+                        warn!(target: "acp.runner", session = %session_id, "initialize failed: {message}");
+                        ControlBody::HandshakeFailed { message }
+                    }
+                };
+                shared.emit_control(frame).await;
+            }
+            ControlBody::EstablishSession { method, request } => {
+                let frame = match shared
+                    .run_or_replay_session(&agent_stdin, &method, request)
+                    .await
+                {
+                    Ok((acp_session_id, result)) => ControlBody::SessionReady {
+                        acp_session_id,
+                        result,
+                    },
+                    Err(message) => {
+                        warn!(target: "acp.runner", session = %session_id, "{method} failed: {message}");
+                        ControlBody::HandshakeFailed { message }
+                    }
+                };
+                shared.emit_control(frame).await;
+            }
+            ControlBody::Prompt { request } => {
+                if shared.agent_prompt(&agent_stdin, request).await.is_none() {
+                    warn!(
+                        target: "acp.runner",
+                        session = %session_id,
+                        "prompt write to agent failed; likely exited"
+                    );
+                }
+            }
+            ControlBody::Cancel => {
+                if let Some(acp_session_id) = shared.acp_session_id().await {
+                    shared.agent_cancel(&agent_stdin, &acp_session_id).await;
+                }
+            }
+            // Runner -> daemon frames should never arrive here; ignore.
+            _ => {}
         }
     }
     shared.clear_control_outbound().await;

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -700,9 +700,12 @@ struct RunnerShared {
     handshake: Mutex<RunnerHandshake>,
     /// Monotonic JSON-RPC id allocator for the requests the runner issues
     /// to the agent on its own (`initialize`, `session/*`, `session/prompt`)
-    /// now that it owns the client side of the protocol. The daemon no
-    /// longer issues requests over the relay on the v2 path, so this is the
-    /// sole client-request id space and cannot collide.
+    /// now that it owns the client side of the protocol. Seeded from a high
+    /// base ([`RUNNER_REQUEST_ID_BASE`]) so it stays disjoint from the crate
+    /// connection's low, monotonic-from-1 ids: on the v2 path the daemon
+    /// still issues `set_mode` / `set_config_option` over the relay via the
+    /// crate connection, so overlapping id ranges would let the runner
+    /// mis-route (swallow) a crate response, or collide on the agent's wire.
     next_req_id: AtomicI64,
     /// Responders for runner-issued request/response round-trips awaited
     /// inline (`initialize`, `session/*`). The stdout fanout routes a
@@ -767,6 +770,15 @@ const PERMISSION_METHOD: &str = "session/request_permission";
 /// the agent to daemon path. Phase A of #1054.
 const PROMPT_METHOD: &str = "session/prompt";
 
+/// Base for the runner's own agent-bound JSON-RPC ids (#2976 Phase B). The
+/// crate `ConnectionTo` on the daemon side allocates monotonic ids from a
+/// small start (~1) for the `set_mode` / `set_config_option` requests it
+/// still sends over the relay on the v2 path. Seeding the runner's ids far
+/// above that keeps the two id spaces disjoint, so an agent response routes
+/// to exactly one waiter and the wire never carries two live requests with
+/// the same id.
+const RUNNER_REQUEST_ID_BASE: i64 = 1 << 48;
+
 /// Deadline for a single control-channel frame write. `emit_control`
 /// holds the `control` mutex across the write and runs on the sole
 /// stdout-relay task, so an unbounded write to a stalled control peer (a
@@ -812,7 +824,7 @@ impl RunnerShared {
             control: Mutex::new(ControlChannel::default()),
             main_attached: std::sync::atomic::AtomicBool::new(false),
             handshake: Mutex::new(RunnerHandshake::default()),
-            next_req_id: AtomicI64::new(1),
+            next_req_id: AtomicI64::new(RUNNER_REQUEST_ID_BASE),
             pending_client_responses: Mutex::new(HashMap::new()),
         }
     }
@@ -1228,21 +1240,21 @@ impl RunnerShared {
     /// now owns. On first call it sends `initialize` to the agent and
     /// caches the raw result; later calls return the cache without touching
     /// the agent. `Ok` carries the result to hand back as
-    /// `ControlBody::Initialized`; `Err` is a message for
-    /// `ControlBody::HandshakeFailed`.
+    /// `ControlBody::Initialized`; `Err` is the raw JSON-RPC error object
+    /// for `ControlBody::HandshakeFailed`.
     async fn run_or_replay_initialize(
         &self,
         agent_stdin: &Mutex<tokio::process::ChildStdin>,
         request: serde_json::Value,
-    ) -> Result<serde_json::Value, String> {
+    ) -> Result<serde_json::Value, serde_json::Value> {
         if let Some(cached) = self.handshake.lock().await.initialized.clone() {
             return Ok(cached);
         }
         let response = self
             .agent_request(agent_stdin, "initialize", request)
             .await
-            .ok_or_else(|| "agent closed before answering initialize".to_string())?;
-        let result = handshake_result(&response).map_err(|e| format!("initialize {e}"))?;
+            .ok_or_else(|| transport_error("agent closed before answering initialize"))?;
+        let result = handshake_result(&response)?;
         self.handshake.lock().await.initialized = Some(result.clone());
         Ok(result)
     }
@@ -1250,26 +1262,26 @@ impl RunnerShared {
     /// Run (once) or replay (from cache) the session-creation request the
     /// runner now owns. `method` is `session/new|load|fork`. Caches
     /// `(acp_session_id, raw result)`; later calls replay the cache. `Ok`
-    /// carries `(acp_session_id, result)`; `Err` is a HandshakeFailed
-    /// message.
+    /// carries `(acp_session_id, result)`; `Err` is the raw JSON-RPC error
+    /// object for `ControlBody::HandshakeFailed`.
     async fn run_or_replay_session(
         &self,
         agent_stdin: &Mutex<tokio::process::ChildStdin>,
         method: &str,
         request: serde_json::Value,
-    ) -> Result<(String, serde_json::Value), String> {
+    ) -> Result<(String, serde_json::Value), serde_json::Value> {
         if let Some(cached) = self.handshake.lock().await.session.clone() {
             return Ok(cached);
         }
         let response = self
             .agent_request(agent_stdin, method, request)
             .await
-            .ok_or_else(|| format!("agent closed before answering {method}"))?;
-        let result = handshake_result(&response).map_err(|e| format!("{method} {e}"))?;
+            .ok_or_else(|| transport_error(&format!("agent closed before answering {method}")))?;
+        let result = handshake_result(&response)?;
         let acp_session_id = result
             .get("sessionId")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| format!("{method} response missing sessionId"))?
+            .ok_or_else(|| transport_error(&format!("{method} response missing sessionId")))?
             .to_string();
         let cached = (acp_session_id, result);
         self.handshake.lock().await.session = Some(cached.clone());
@@ -1314,22 +1326,24 @@ impl RunnerShared {
 }
 
 /// Extract the `result` object from a runner-issued request's JSON-RPC
-/// response, mapping an `error` envelope or a missing result to an `Err`
-/// message. Used by the handshake path, where the runner needs the typed
-/// body rather than the fire-and-forget prompt path.
-fn handshake_result(response: &serde_json::Value) -> Result<serde_json::Value, String> {
+/// response. On an `error` envelope, returns the raw error object so the
+/// daemon can reconstruct the crate error verbatim (preserving `data`); a
+/// response with neither result nor error synthesizes a minimal error.
+fn handshake_result(response: &serde_json::Value) -> Result<serde_json::Value, serde_json::Value> {
     if let Some(err) = response.get("error") {
-        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
-        let message = err
-            .get("message")
-            .and_then(|m| m.as_str())
-            .unwrap_or("unknown error");
-        return Err(format!("failed: {message} (code {code})"));
+        return Err(err.clone());
     }
     response
         .get("result")
         .cloned()
-        .ok_or_else(|| "response had neither result nor error".to_string())
+        .ok_or_else(|| transport_error("response had neither result nor error"))
+}
+
+/// A synthetic JSON-RPC error object for a runner-side transport failure
+/// (agent closed, malformed response), shaped like an agent error so the
+/// daemon reconstructs it as a crate error uniformly.
+fn transport_error(message: &str) -> serde_json::Value {
+    serde_json::json!({ "code": -32603, "message": message })
 }
 
 /// Extract `(id, method)` from a JSON-RPC request line. Returns None
@@ -1591,9 +1605,9 @@ async fn handle_control_connection(
             ControlBody::Initialize { request } => {
                 let frame = match shared.run_or_replay_initialize(&agent_stdin, request).await {
                     Ok(result) => ControlBody::Initialized { result },
-                    Err(message) => {
-                        warn!(target: "acp.runner", session = %session_id, "initialize failed: {message}");
-                        ControlBody::HandshakeFailed { message }
+                    Err(error) => {
+                        warn!(target: "acp.runner", session = %session_id, "initialize failed: {error}");
+                        ControlBody::HandshakeFailed { error }
                     }
                 };
                 shared.emit_control(frame).await;
@@ -1607,9 +1621,9 @@ async fn handle_control_connection(
                         acp_session_id,
                         result,
                     },
-                    Err(message) => {
-                        warn!(target: "acp.runner", session = %session_id, "{method} failed: {message}");
-                        ControlBody::HandshakeFailed { message }
+                    Err(error) => {
+                        warn!(target: "acp.runner", session = %session_id, "{method} failed: {error}");
+                        ControlBody::HandshakeFailed { error }
                     }
                 };
                 shared.emit_control(frame).await;

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -55,6 +55,18 @@ impl Drop for Scratch {
     }
 }
 
+/// Kill+reap the spawned runner on drop so an assertion failure mid-test
+/// doesn't leave a runner (and its agent tree) behind. Pairs with
+/// `Scratch`, which removes the scratch dir on drop.
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
 fn wait_for(path: &Path, what: &str) {
     let deadline = Instant::now() + Duration::from_secs(10);
     while !path.exists() {
@@ -254,27 +266,29 @@ for line in sys.stdin:
     let record = workers.join(format!("{session_id}.json"));
 
     let bin = env!("CARGO_BIN_EXE_aoe");
-    let mut child: Child = Command::new(bin)
-        .args([
-            "__acp-runner",
-            "--socket",
-            socket.to_str().unwrap(),
-            "--session-id",
-            session_id,
-            "--agent-name",
-            "fake-agent",
-            "--cwd",
-            home.to_str().unwrap(),
-            "--",
-            python3.to_str().unwrap(),
-            agent_py.to_str().unwrap(),
-        ])
-        .env("HOME", &home)
-        .env("XDG_CONFIG_HOME", &xdg)
-        .env("AOE_FAKE_AGENT_LOG", &agent_log)
-        .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
-        .spawn()
-        .expect("spawn acp runner");
+    let _child = KillOnDrop(
+        Command::new(bin)
+            .args([
+                "__acp-runner",
+                "--socket",
+                socket.to_str().unwrap(),
+                "--session-id",
+                session_id,
+                "--agent-name",
+                "fake-agent",
+                "--cwd",
+                home.to_str().unwrap(),
+                "--",
+                python3.to_str().unwrap(),
+                agent_py.to_str().unwrap(),
+            ])
+            .env("HOME", &home)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("AOE_FAKE_AGENT_LOG", &agent_log)
+            .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+            .spawn()
+            .expect("spawn acp runner"),
+    );
 
     wait_for(&record, "registry record");
     wait_for(&control, "control socket");
@@ -345,9 +359,6 @@ for line in sys.stdin:
         assert_eq!(ready["kind"], "session_ready");
         assert_eq!(ready["acp_session_id"], "sess-fake-1");
     }
-
-    let _ = child.kill();
-    let _ = child.wait();
 
     // The agent saw the handshake exactly once despite two attaches; the
     // second attach was served entirely from the runner's cache.
@@ -428,26 +439,28 @@ for line in sys.stdin:
     let record = workers.join(format!("{session_id}.json"));
 
     let bin = env!("CARGO_BIN_EXE_aoe");
-    let mut child: Child = Command::new(bin)
-        .args([
-            "__acp-runner",
-            "--socket",
-            socket.to_str().unwrap(),
-            "--session-id",
-            session_id,
-            "--agent-name",
-            "fake-agent",
-            "--cwd",
-            home.to_str().unwrap(),
-            "--",
-            python3.to_str().unwrap(),
-            agent_py.to_str().unwrap(),
-        ])
-        .env("HOME", &home)
-        .env("XDG_CONFIG_HOME", &xdg)
-        .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
-        .spawn()
-        .expect("spawn acp runner");
+    let _child = KillOnDrop(
+        Command::new(bin)
+            .args([
+                "__acp-runner",
+                "--socket",
+                socket.to_str().unwrap(),
+                "--session-id",
+                session_id,
+                "--agent-name",
+                "fake-agent",
+                "--cwd",
+                home.to_str().unwrap(),
+                "--",
+                python3.to_str().unwrap(),
+                agent_py.to_str().unwrap(),
+            ])
+            .env("HOME", &home)
+            .env("XDG_CONFIG_HOME", &xdg)
+            .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+            .spawn()
+            .expect("spawn acp runner"),
+    );
 
     wait_for(&record, "registry record");
     wait_for(&control, "control socket");
@@ -480,7 +493,4 @@ for line in sys.stdin:
         "native binary failed to launch"
     );
     assert_eq!(failed["error"]["code"], -32603);
-
-    let _ = child.kill();
-    let _ = child.wait();
 }

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -156,7 +156,8 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
     let completed = read_frame(&mut ctl);
     assert_eq!(completed["kind"], "prompt_completed");
     assert_eq!(completed["prompt_req_id"], 5);
-    assert_eq!(completed["stop_reason"], "end_turn");
+    assert_eq!(completed["outcome"]["status"], "completed");
+    assert_eq!(completed["outcome"]["stop_reason"], "end_turn");
 
     let _ = child.kill();
     let _ = child.wait();

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -369,3 +369,118 @@ for line in sys.stdin:
         "session/prompt sent to agent once: {methods:?}"
     );
 }
+
+/// #2976 Phase B regression: when the agent answers `session/new` with a
+/// JSON-RPC error, the runner forwards the FULL error object (including
+/// `data`) in `HandshakeFailed`, so the daemon can reconstruct the crate
+/// error and surface the same `data.details` remediation banner the
+/// byte-relay path did. Guards the startup-error-banner live test at the
+/// runner layer.
+#[test]
+fn runner_forwards_session_error_data_in_handshake_failed() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    let Some(python3) = find_python3() else {
+        eprintln!("skipping: python3 not found for fake ACP agent");
+        return;
+    };
+
+    let scratch = Scratch::new("hserr");
+    let home = scratch.0.join("home");
+    let xdg = scratch.0.join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    let agent_py = scratch.0.join("fail_agent.py");
+    std::fs::write(
+        &agent_py,
+        r#"
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    method = msg.get("method")
+    mid = msg.get("id")
+    if method is None or mid is None:
+        continue
+    if method == "initialize":
+        resp = {"jsonrpc": "2.0", "id": mid, "result": {"protocolVersion": 1, "agentCapabilities": {"loadSession": False, "promptCapabilities": {}}}}
+    elif method == "session/new":
+        resp = {"jsonrpc": "2.0", "id": mid, "error": {"code": -32603, "message": "Internal error", "data": {"details": "native binary failed to launch"}}}
+    else:
+        resp = {"jsonrpc": "2.0", "id": mid, "result": {}}
+    sys.stdout.write(json.dumps(resp) + "\n")
+    sys.stdout.flush()
+"#,
+    )
+    .unwrap();
+
+    let session_id = "shserr01";
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let socket = workers.join(format!("{session_id}.sock"));
+    let control = workers.join(format!("{session_id}.control.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let mut child: Child = Command::new(bin)
+        .args([
+            "__acp-runner",
+            "--socket",
+            socket.to_str().unwrap(),
+            "--session-id",
+            session_id,
+            "--agent-name",
+            "fake-agent",
+            "--cwd",
+            home.to_str().unwrap(),
+            "--",
+            python3.to_str().unwrap(),
+            agent_py.to_str().unwrap(),
+        ])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+        .spawn()
+        .expect("spawn acp runner");
+
+    wait_for(&record, "registry record");
+    wait_for(&control, "control socket");
+
+    let mut ctl = UnixStream::connect(&control).expect("connect control socket");
+    ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    let hello = read_frame(&mut ctl);
+    assert_eq!(hello["kind"], "hello");
+
+    write_frame(
+        &mut ctl,
+        &serde_json::json!({"kind": "attach", "control_protocol_version": 2}),
+    );
+    write_frame(
+        &mut ctl,
+        &serde_json::json!({"kind": "initialize", "request": {"protocolVersion": 1}}),
+    );
+    let initialized = read_frame(&mut ctl);
+    assert_eq!(initialized["kind"], "initialized");
+
+    write_frame(
+        &mut ctl,
+        &serde_json::json!({"kind": "establish_session", "method": "session/new", "request": {}}),
+    );
+    let failed = read_frame(&mut ctl);
+    assert_eq!(failed["kind"], "handshake_failed");
+    // The remediation detail survives the control channel intact.
+    assert_eq!(
+        failed["error"]["data"]["details"],
+        "native binary failed to launch"
+    );
+    assert_eq!(failed["error"]["code"], -32603);
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/tests/acp_runner_control.rs
+++ b/tests/acp_runner_control.rs
@@ -162,3 +162,210 @@ fn runner_reports_native_prompt_complete_over_control_socket() {
     let _ = child.kill();
     let _ = child.wait();
 }
+
+/// Write a length-prefixed control frame (4-byte big-endian length, then
+/// the JSON body).
+fn write_frame(stream: &mut UnixStream, body: &serde_json::Value) {
+    let json = serde_json::to_vec(body).expect("serialize frame");
+    let len = (json.len() as u32).to_be_bytes();
+    stream.write_all(&len).expect("write frame length");
+    stream.write_all(&json).expect("write frame body");
+    stream.flush().expect("flush frame");
+}
+
+/// Resolve a python3 interpreter for the fake ACP agent, or None to skip.
+fn find_python3() -> Option<PathBuf> {
+    for cand in [
+        "/usr/bin/python3",
+        "/opt/homebrew/bin/python3",
+        "/usr/local/bin/python3",
+    ] {
+        let p = PathBuf::from(cand);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// #2976 Phase B: the runner owns the ACP handshake. Drive it as a v2
+/// daemon over the control channel across two attaches and assert the
+/// agent is handshaken (initialize + session/new) exactly once, that the
+/// second attach replays the cache without touching the agent, and that a
+/// prompt completes natively.
+#[test]
+fn runner_owns_handshake_and_caches_across_attaches() {
+    if cfg!(not(unix)) {
+        return;
+    }
+    let Some(python3) = find_python3() else {
+        eprintln!("skipping: python3 not found for fake ACP agent");
+        return;
+    };
+
+    let scratch = Scratch::new("hs");
+    let home = scratch.0.join("home");
+    let xdg = scratch.0.join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    // A minimal ACP agent: responds to the runner-issued handshake and
+    // prompt requests and appends each received method to a log so the test
+    // can assert the agent saw each exactly once.
+    let agent_log = scratch.0.join("agent-methods.log");
+    let agent_py = scratch.0.join("fake_agent.py");
+    std::fs::write(
+        &agent_py,
+        r#"
+import sys, json, os
+log = os.environ["AOE_FAKE_AGENT_LOG"]
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    method = msg.get("method")
+    mid = msg.get("id")
+    if method is None or mid is None:
+        continue
+    with open(log, "a") as f:
+        f.write(method + "\n")
+    if method == "initialize":
+        result = {"protocolVersion": 1, "agentCapabilities": {"loadSession": False, "promptCapabilities": {}}}
+    elif method == "session/new":
+        result = {"sessionId": "sess-fake-1"}
+    elif method == "session/prompt":
+        result = {"stopReason": "end_turn"}
+    else:
+        result = {}
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": mid, "result": result}) + "\n")
+    sys.stdout.flush()
+"#,
+    )
+    .unwrap();
+
+    let session_id = "shs00001";
+    let workers = app_dir(&home, &xdg).join("acp-workers");
+    let socket = workers.join(format!("{session_id}.sock"));
+    let control = workers.join(format!("{session_id}.control.sock"));
+    let record = workers.join(format!("{session_id}.json"));
+
+    let bin = env!("CARGO_BIN_EXE_aoe");
+    let mut child: Child = Command::new(bin)
+        .args([
+            "__acp-runner",
+            "--socket",
+            socket.to_str().unwrap(),
+            "--session-id",
+            session_id,
+            "--agent-name",
+            "fake-agent",
+            "--cwd",
+            home.to_str().unwrap(),
+            "--",
+            python3.to_str().unwrap(),
+            agent_py.to_str().unwrap(),
+        ])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("AOE_FAKE_AGENT_LOG", &agent_log)
+        .env("AOE_ACP_WATCHDOG_POLL_MS", "150")
+        .spawn()
+        .expect("spawn acp runner");
+
+    wait_for(&record, "registry record");
+    wait_for(&control, "control socket");
+
+    let v2 = serde_json::json!(2);
+
+    // --- First attach: the runner runs the handshake against the agent. ---
+    {
+        let mut ctl = UnixStream::connect(&control).expect("connect control socket");
+        ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        let hello = read_frame(&mut ctl);
+        assert_eq!(hello["kind"], "hello");
+        assert_eq!(hello["control_protocol_version"], v2);
+
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "attach", "control_protocol_version": 2}),
+        );
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "initialize", "request": {"protocolVersion": 1}}),
+        );
+        let initialized = read_frame(&mut ctl);
+        assert_eq!(initialized["kind"], "initialized");
+        assert!(initialized["result"].is_object());
+
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "establish_session", "method": "session/new", "request": {"cwd": home.to_str().unwrap()}}),
+        );
+        let ready = read_frame(&mut ctl);
+        assert_eq!(ready["kind"], "session_ready");
+        assert_eq!(ready["acp_session_id"], "sess-fake-1");
+
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "prompt", "request": {"sessionId": "sess-fake-1", "prompt": []}}),
+        );
+        let completed = read_frame(&mut ctl);
+        assert_eq!(completed["kind"], "prompt_completed");
+        assert_eq!(completed["outcome"]["status"], "completed");
+        assert_eq!(completed["outcome"]["stop_reason"], "end_turn");
+    }
+
+    // --- Second attach: the runner replays the cache, no agent contact. ---
+    {
+        let mut ctl = UnixStream::connect(&control).expect("reconnect control socket");
+        ctl.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        let hello = read_frame(&mut ctl);
+        assert_eq!(hello["kind"], "hello");
+
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "attach", "control_protocol_version": 2}),
+        );
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "initialize", "request": {"protocolVersion": 1}}),
+        );
+        let initialized = read_frame(&mut ctl);
+        assert_eq!(initialized["kind"], "initialized");
+
+        write_frame(
+            &mut ctl,
+            &serde_json::json!({"kind": "establish_session", "method": "session/new", "request": {}}),
+        );
+        let ready = read_frame(&mut ctl);
+        assert_eq!(ready["kind"], "session_ready");
+        assert_eq!(ready["acp_session_id"], "sess-fake-1");
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // The agent saw the handshake exactly once despite two attaches; the
+    // second attach was served entirely from the runner's cache.
+    let methods = std::fs::read_to_string(&agent_log).unwrap_or_default();
+    let count = |m: &str| methods.lines().filter(|l| *l == m).count();
+    assert_eq!(
+        count("initialize"),
+        1,
+        "initialize sent to agent once: {methods:?}"
+    );
+    assert_eq!(
+        count("session/new"),
+        1,
+        "session/new sent to agent once: {methods:?}"
+    );
+    assert_eq!(
+        count("session/prompt"),
+        1,
+        "session/prompt sent to agent once: {methods:?}"
+    );
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Phase B of runner-side ACP protocol termination (#1054), following PR #2975 (Phase A). The `aoe __acp-runner` shim now terminates the ACP client side of the protocol: it owns the handshake and the turn, and the daemon speaks a small typed control protocol to it instead of running `initialize` / `session/*` / `session/prompt` / `session/cancel` over the byte relay itself.

What changes:

- **Control protocol v2** (`control_protocol.rs`): `CONTROL_PROTOCOL_VERSION` bumped 1 to 2. New handshake frames (`Initialize`/`Initialized`, `EstablishSession`/`SessionReady`, `HandshakeFailed`) and turn frames (`Prompt`/`Cancel`). Phase A's `stop_reason`-only `PromptCompleted` becomes a typed `PromptOutcome` (`Completed` / `Error` / `Aborted`) so an agent error envelope is surfaced (with its `data`, preserving rate-limit classification) rather than collapsed into a silent stop.
- **Runner** (`runner.rs`): on the first v2 attach the runner runs `initialize` + `session/new|load|fork` against the agent exactly once, caches the raw results, and answers `Initialized` / `SessionReady`. Every later attach replays the cache without touching the agent. Prompts arrive as typed `Prompt` frames; the runner assigns the canonical `session/prompt` id and reports the typed `PromptCompleted`. A cached handshake also lets the runner answer a relay handshake re-send from cache, so a downgrade v1-daemon reattach never double-initializes the agent. The control channel is now persistent (carries the handshake and every turn) rather than the Phase A one-shot adopted-turn delivery.
- **Daemon** (`acp_client.rs`): on the runner path the daemon dials the control socket and, when the runner greets v2, drives the handshake and each turn over a `DaemonControlClient`, deserializing the cached results into the existing crate response types. The crate connection stays attached to the relay only for `session/update` notifications and the server-to-client callbacks (permission / fs / terminal). The watchdog-dense prompt loop body is left intact: the prompt future is adapted so a runner `PromptCompleted` maps back to `Result<PromptResponse, Error>`. An absent or older (v1) runner yields no control client, so the daemon falls back to the exact byte-relay handshake plus resume-idle watchdog behavior; the direct-stdio path is untouched.

Backward compatibility is purely via the `control_protocol_version` handshake, with no runner-version migration (that stays in Phase C, #2977): a v2 daemon on a v1 runner falls back to Phase A; a v1 daemon on a v2 runner drives the handshake over the relay and the runner intercepts it from cache. This removes the redundant per-reconnect `initialize` against the agent.

**Scope note:** this lands the full Phase B (handshake + prompt + cancel over control) in one PR, per the decision on the issue, rather than splitting handshake and turn migration. The `ConnectMode::Resume` skip-new/load trick is retained for the v2 path (it stays correct because the runner keeps the session alive, and its result equals the runner's cache), rather than routing Resume through `EstablishSession`.

Deferred (called out for the follow-ups): relay watermark ordering between `PromptCompleted` and buffered `session/update` (a pre-existing property from Phase A), long-detach ring durability, and `<id>.sock` retirement + `RUNNER_VERSION` migration (Phase C/D, #2977/#2978).

Relates to #1054
Closes #2976

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view ACP session, send a normal prompt, confirm it completes exactly once (goes Idle) with no duplicate stop.
- [ ] Reconnect the dashboard / restart nothing across several turns; confirm the agent is not re-initialized each turn (the session keeps working; no new `initialize` churn in `debug.log`).
- [ ] Mid-turn `aoe serve --stop` then `aoe serve`; confirm the session clears "thinking" promptly when the agent's response lands (native completion), not after the ~30s resume-idle pause.
- [ ] Cancel / force-stop an in-flight turn; confirm the turn ends and the spinner clears.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

<!-- Coverage detail: extended `tests/acp_runner_control.rs` with an integration test that drives a real `aoe __acp-runner` as a v2 daemon over the control socket against a minimal fake ACP agent, asserting the runner runs the handshake once, a prompt completes natively, and a second attach replays the cache without touching the agent (each handshake method reaches the agent exactly once). Plus control-protocol v2 codec tests, runner unit tests (typed prompt outcome, error-envelope surfacing), and daemon control-client unit tests. The v1 fallback path stays covered by `tests/integration/acp_midturn_resume.rs`. A full daemon-restart-mid-turn structured-view e2e remains deferred as in Phase A. -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, a two-model design debate on the protocol seams, the plan, and the implementation were drafted by Claude under my direction. I made the scope and design calls (full Phase B in one PR, adapter-future to keep the prompt loop intact, retaining the Resume skip trick), reviewed each commit, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved the ACP handshake and session establishment into the `aoe __acp-runner` shim (Phase B), so it runs `initialize` and `session/new|load|fork` once, caches the results, and replays them on later attaches.
- Upgraded the runner/daemon control channel to protocol v2, where the daemon drives the turn using typed `Prompt` and `Cancel` messages (instead of re-running initialization on reconnects).
- Added structured, typed prompt completion outcomes (normal stop, agent JSON-RPC error envelopes including attached data, and runner aborts) to make failures easier to interpret and propagate.
- Preserved Phase A fallback behavior by reverting to the older byte-relay approach when a v1/incompatible or unavailable runner is detected.
- Improved robustness around failures by keeping detailed handshake error information, using runner-side request IDs, and aborting promptly when prompt transmission fails.
- Expanded and adjusted test coverage for v2 handshake behavior, cached replay across reconnects, error forwarding fidelity, protocol-version mismatch, and control-socket fallback.

## Benefits

- Avoids repeated initialization/session work on daemon reconnects by shifting responsibility and caching to the runner.
- Makes prompted/resumed interactions more reliable by letting the runner own the handshake/session lifecycle and turn lifecycle.
- Provides clearer, more structured error reporting for agent failures (including any extra error data) while staying compatible with older runners.

## Potential follow-up

- Add more cross-platform integration coverage (beyond current Unix-focused runner control tests) to further validate v2 control compatibility and reconnect replay across varied runner/ACP-agent implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->