### PR TITLE
feat(web): add per-panel auto-open toggles for cockpit panes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -472,10 +472,16 @@ function AppContent({
   }, [pluginPanes]);
 
   // Auto-add newly available plugin panes as tabs in their default dock; the
-  // layout suppresses any the user explicitly closed.
+  // layout suppresses any the user explicitly closed. When the user disabled
+  // plugin auto-open (#3035) pass an empty list rather than skipping the
+  // effect: syncPlugins still materializes the session's seeded layout on
+  // mount (pinning the diff/terminal defaults), it just adds no plugin panes.
+  // Manual activity-bar opens and already-open panes are unaffected.
   useEffect(() => {
-    syncPlugins(pluginPanes.map((p) => ({ id: p.id, defaultDock: p.defaultDock })));
-  }, [pluginPanes, syncPlugins]);
+    syncPlugins(
+      webSettings.autoOpenPluginPanes ? pluginPanes.map((p) => ({ id: p.id, defaultDock: p.defaultDock })) : [],
+    );
+  }, [pluginPanes, syncPlugins, webSettings.autoOpenPluginPanes]);
 
   // One-shot lookup from plugin id to its manifest identity (icon name +
   // icon_asset URL), so a pane gets a real identity glyph, up to the plugin's

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -522,7 +522,8 @@ export function SettingsView({
       activeTab !== "structured-view" &&
       activeTab !== "mcp" &&
       activeTab !== "plugins" &&
-      activeTab !== "telemetry"
+      activeTab !== "telemetry" &&
+      activeTab !== "panels"
     ) {
       return <div className="text-sm text-text-dim">Loading settings...</div>;
     }

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -20,6 +20,7 @@ import type { ProfileInfo, SettingsFieldDescriptor } from "../lib/types";
 import { SchemaSection } from "./settings/SchemaSection";
 import { SelectField } from "./settings/FormFields";
 import { DiffSettings } from "./settings/DiffSettings";
+import { PanelsSettings } from "./settings/PanelsSettings";
 import { TelemetrySettings } from "./settings/TelemetrySettings";
 import { PluginsSettings } from "./settings/PluginsSettings";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
@@ -40,6 +41,7 @@ export type TabId =
   | "updates"
   | "telemetry"
   | "notifications"
+  | "panels"
   | "terminal"
   | "security"
   | "devices"
@@ -164,6 +166,7 @@ export function buildSidebar(pluginPages: PluginPageNav[] = []): SidebarItem[] {
     { kind: "tab", id: "sound", label: "Sound" },
     { kind: "tab", id: "notifications", label: "Notifications" },
     { kind: "divider", label: "Web Dashboard" },
+    { kind: "tab", id: "panels", label: "Panels" },
     { kind: "tab", id: "terminal", label: "Terminal" },
     { kind: "tab", id: "security", label: "Security" },
     { kind: "tab", id: "devices", label: "Devices" },
@@ -210,6 +213,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "updates",
   "telemetry",
   "notifications",
+  "panels",
   "terminal",
   "security",
   "devices",
@@ -629,6 +633,8 @@ export function SettingsView({
         );
       case "diff":
         return <DiffSettings />;
+      case "panels":
+        return <PanelsSettings />;
       case "sound":
         return (
           <SchemaSection

--- a/web/src/components/__tests__/SettingsView.test.tsx
+++ b/web/src/components/__tests__/SettingsView.test.tsx
@@ -40,6 +40,7 @@ describe("buildSidebar", () => {
       { kind: "tab", id: "sound", label: "Sound" },
       { kind: "tab", id: "notifications", label: "Notifications" },
       { kind: "divider", label: "Web Dashboard" },
+      { kind: "tab", id: "panels", label: "Panels" },
       { kind: "tab", id: "terminal", label: "Terminal" },
       { kind: "tab", id: "security", label: "Security" },
       { kind: "tab", id: "devices", label: "Devices" },

--- a/web/src/components/settings/PanelsSettings.tsx
+++ b/web/src/components/settings/PanelsSettings.tsx
@@ -1,6 +1,6 @@
 import { useWebSettings } from "../../hooks/useWebSettings";
 
-/// Client-side defaults for which cockpit panes auto-open (#3035). Stored per
+/// Client-side defaults for which panes auto-open (#3035). Stored per
 /// browser in `localStorage` (like the Diff and Terminal sections), not backend
 /// config, so they need no server round-trip. The diff/terminal toggles only
 /// shape sessions opened after the change; already-open sessions keep their

--- a/web/src/components/settings/PanelsSettings.tsx
+++ b/web/src/components/settings/PanelsSettings.tsx
@@ -1,0 +1,69 @@
+import { useWebSettings } from "../../hooks/useWebSettings";
+
+/// Client-side defaults for which cockpit panes auto-open (#3035). Stored per
+/// browser in `localStorage` (like the Diff and Terminal sections), not backend
+/// config, so they need no server round-trip. The diff/terminal toggles only
+/// shape sessions opened after the change; already-open sessions keep their
+/// layout, and every pane stays openable on demand from the activity bar.
+export function PanelsSettings() {
+  const { settings, update } = useWebSettings();
+
+  return (
+    <div>
+      <div className="space-y-4">
+        <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">Open the diff panel in new sessions</div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Show the diff pane automatically when a session first opens. Turn off to start with it closed; open it
+                any time from the activity bar.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.autoOpenDiffPane}
+              onChange={(e) => update({ autoOpenDiffPane: e.target.checked })}
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
+
+        <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">Open a terminal panel in new sessions</div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Show a terminal pane automatically when a session first opens. Turn off to start with it closed.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.autoOpenTerminalPane}
+              onChange={(e) => update({ autoOpenTerminalPane: e.target.checked })}
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
+
+        <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">Open plugin panels automatically</div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Auto-open panes contributed by installed plugins, such as the GitHub pull-request pane. Turn off to keep
+                them closed until you open one from the activity bar.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.autoOpenPluginPanes}
+              onChange={(e) => update({ autoOpenPluginPanes: e.target.checked })}
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/__tests__/PanelsSettings.test.tsx
+++ b/web/src/components/settings/__tests__/PanelsSettings.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+//
+// Contract test for the PanelsSettings panel (#3035). Like DiffSettings, this
+// persists through useWebSettings + localStorage (key `aoe-web-settings`), not
+// PATCH /api/settings. The contract is the JSON shape written to that key: the
+// three auto-open-pane booleans default true and flip independently.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { PanelsSettings } from "../PanelsSettings";
+
+const KEY = "aoe-web-settings";
+
+function readStored(): Record<string, unknown> {
+  const raw = window.localStorage.getItem(KEY);
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("PanelsSettings localStorage contract", () => {
+  it("all three toggles default on", () => {
+    const { container } = render(<PanelsSettings />);
+    const boxes = container.querySelectorAll("input[type=checkbox]");
+    expect(boxes).toHaveLength(3);
+    for (const box of boxes) expect((box as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("each toggle writes its own key independently", () => {
+    const { container } = render(<PanelsSettings />);
+    const [diff, terminal, plugins] = Array.from(
+      container.querySelectorAll("input[type=checkbox]"),
+    ) as HTMLInputElement[];
+
+    fireEvent.click(diff!);
+    expect(readStored().autoOpenDiffPane).toBe(false);
+    expect(readStored().autoOpenTerminalPane).not.toBe(false);
+    expect(readStored().autoOpenPluginPanes).not.toBe(false);
+
+    fireEvent.click(terminal!);
+    expect(readStored().autoOpenTerminalPane).toBe(false);
+
+    fireEvent.click(plugins!);
+    expect(readStored().autoOpenPluginPanes).toBe(false);
+
+    // Flipping back restores true.
+    fireEvent.click(diff!);
+    expect(readStored().autoOpenDiffPane).toBe(true);
+  });
+});

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -18,6 +18,15 @@ export interface WebSettings {
   /** Which edge the session sidebar slides in from on mobile. Client-local;
    *  desktop layout (md:static) is unaffected. See #2244. */
   sidebarSide: "left" | "right";
+  /** Auto-open the diff pane in newly opened sessions (#3035). Off keeps it
+   *  closed by default; the activity-bar toggle still opens it on demand. */
+  autoOpenDiffPane: boolean;
+  /** Auto-open a terminal pane in newly opened sessions (#3035). */
+  autoOpenTerminalPane: boolean;
+  /** Auto-open plugin panes (e.g. the GitHub PR pane) when available (#3035).
+   *  Unlike the diff/terminal flags this is an ongoing policy: turning it back
+   *  on can add newly available plugin panes to existing sessions too. */
+  autoOpenPluginPanes: boolean;
 }
 
 function getDefaults(): WebSettings {
@@ -32,7 +41,14 @@ function getDefaults(): WebSettings {
     diffViewLayout: "unified",
     collapsedDiffDirs: [],
     sidebarSide: "left",
+    autoOpenDiffPane: true,
+    autoOpenTerminalPane: true,
+    autoOpenPluginPanes: true,
   };
+}
+
+function normalizeBool(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
 }
 
 function normalizeSnapshot(settings: WebSettings): WebSettings {
@@ -42,6 +58,11 @@ function normalizeSnapshot(settings: WebSettings): WebSettings {
     persistentTerminals:
       typeof settings.persistentTerminals === "boolean" ? settings.persistentTerminals : defaults.persistentTerminals,
     maxPersistentTerminals: normalizePersistentTerminalLimit(settings.maxPersistentTerminals),
+    // localStorage is user-editable: a corrupted stringy "false" must not read
+    // truthy and silently auto-open panes the user disabled.
+    autoOpenDiffPane: normalizeBool(settings.autoOpenDiffPane, defaults.autoOpenDiffPane),
+    autoOpenTerminalPane: normalizeBool(settings.autoOpenTerminalPane, defaults.autoOpenTerminalPane),
+    autoOpenPluginPanes: normalizeBool(settings.autoOpenPluginPanes, defaults.autoOpenPluginPanes),
   };
 }
 
@@ -55,6 +76,13 @@ function getSnapshot(): WebSettings {
     }
   }
   return getDefaults();
+}
+
+/** Fresh, normalized settings read outside React. Used by non-reactive code
+ *  paths (e.g. the pane-layout `setStore` updater) that must read the latest
+ *  prefs synchronously without subscribing, avoiding a stale closure. */
+export function getWebSettingsSnapshot(): WebSettings {
+  return getSnapshot();
 }
 
 // Subscribers for useSyncExternalStore

--- a/web/src/lib/__tests__/paneLayout.test.ts
+++ b/web/src/lib/__tests__/paneLayout.test.ts
@@ -13,6 +13,7 @@ import {
   placeTab,
   removeAllTerminals,
   removeTab,
+  seedLayout,
   setActive,
   setDockCollapsed,
   syncPluginTabs,
@@ -352,5 +353,47 @@ describe("usePaneLayout migration + persistence", () => {
     expect(dockTabs(result.current.layout, "right")).toEqual(["terminal:0"]);
     act(() => result.current.toggleKind("terminal", "right"));
     expect(dockTabs(result.current.layout, "right")).toEqual([]);
+  });
+});
+
+describe("seedLayout (auto-open pane prefs, #3035)", () => {
+  // Mirrors defaultTemplate(): diff + terminal:0 added via addTab (not the
+  // monotonic addTerminal allocator, which would start at terminal:1).
+  function template(): DockLayout {
+    let l = addTab(emptyLayout(), "right", "diff");
+    l = addTab(l, "right", "terminal:0");
+    return l;
+  }
+
+  it("keeps the full template when both prefs are on", () => {
+    const seeded = seedLayout(template(), { diff: true, terminal: true });
+    expect(dockTabs(seeded, "right")).toEqual(["diff", "terminal:0"]);
+  });
+
+  it("drops the diff tab when diff is off", () => {
+    const seeded = seedLayout(template(), { diff: false, terminal: true });
+    expect(dockTabs(seeded, "right")).toEqual(["terminal:0"]);
+  });
+
+  it("drops every terminal when terminal is off", () => {
+    const t = addTab(template(), "right", "terminal:1"); // a second terminal
+    const seeded = seedLayout(t, { diff: true, terminal: false });
+    expect(dockTabs(seeded, "right")).toEqual(["diff"]);
+  });
+
+  it("drops both when both are off, leaving an empty dock", () => {
+    const seeded = seedLayout(template(), { diff: false, terminal: false });
+    expect(dockTabs(seeded, "right")).toEqual([]);
+  });
+
+  it("is a no-op on an already-empty template (mobile)", () => {
+    const seeded = seedLayout(emptyLayout(), { diff: false, terminal: false });
+    expect(dockTabs(seeded, "right")).toEqual([]);
+    expect(dockTabs(seeded, "bottom")).toEqual([]);
+  });
+
+  it("does not mark the removed diff tab as an explicitly closed plugin", () => {
+    const seeded = seedLayout(template(), { diff: false, terminal: false });
+    expect(seeded.closedPlugins).toEqual([]);
   });
 });

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { getWebSettingsSnapshot, useWebSettings } from "../hooks/useWebSettings";
 import { safeGetItem, safeSetItem } from "./safeStorage";
 import { BUILTIN_PANES, isTerminalTabId, terminalTabId, type DockLocation } from "./panes";
 
@@ -438,15 +439,45 @@ function terminalTabs(layout: DockLayout): { id: TabId; dock: DockLocation }[] {
   );
 }
 
+/** Which built-in panes may auto-open in a new session (#3035). Kept minimal
+ *  and decoupled from the full `WebSettings` shape so the layout module owns
+ *  only what it filters on. */
+export interface AutoOpenPanePrefs {
+  diff: boolean;
+  terminal: boolean;
+}
+
+/** The layout an unseen session inherits: the persisted template with the diff
+ *  tab and/or terminals stripped out per the user's auto-open prefs. Filtering
+ *  happens here, at seed time, rather than in `defaultTemplate()`, so the
+ *  toggles take effect for existing users (whose template was persisted with
+ *  panes open) and only shape sessions opened after the toggle changed. Purely
+ *  subtractive: a pref back on restores only what the template still holds, it
+ *  cannot conjure a pane the template never had (e.g. a mobile-first template).
+ *  Plugin panes are not in the template; their auto-open is gated separately in
+ *  the App shell. */
+export function seedLayout(template: DockLayout, prefs: AutoOpenPanePrefs): DockLayout {
+  let l = template;
+  if (!prefs.diff) l = removeTab(l, "diff");
+  if (!prefs.terminal) l = removeAllTerminals(l);
+  return l;
+}
+
 export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
   const [store, setStore] = useState(loadStore);
+  const { settings } = useWebSettings();
+  const { autoOpenDiffPane, autoOpenTerminalPane } = settings;
   useEffect(() => {
     safeSetItem(LAYOUT_KEY, JSON.stringify(store));
   }, [store]);
 
   const layout = useMemo(
-    () => (sessionId ? (store.sessions[sessionId] ?? store.template) : emptyDockLayout()),
-    [store, sessionId],
+    () =>
+      sessionId
+        ? (store.sessions[sessionId] ??
+          seedLayout(store.template, { diff: autoOpenDiffPane, terminal: autoOpenTerminalPane }))
+        : emptyDockLayout(),
+    [store, sessionId, autoOpenDiffPane, autoOpenTerminalPane],
   );
 
   // Apply a pure transform to the active session's layout, seeding it from the
@@ -455,7 +486,14 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     (fn: (l: DockLayout) => DockLayout) => {
       if (!sessionId) return;
       setStore((s) => {
-        const current = s.sessions[sessionId] ?? s.template;
+        // Read prefs synchronously here, not from the hook closure: putting
+        // `settings` in this callback's deps would rebuild the whole pane API
+        // (and re-render every consumer) on any unrelated web-setting change,
+        // and omitting it would stale-seed. See #3035.
+        const prefs = getWebSettingsSnapshot();
+        const current =
+          s.sessions[sessionId] ??
+          seedLayout(s.template, { diff: prefs.autoOpenDiffPane, terminal: prefs.autoOpenTerminalPane });
         const updated = fn(current);
         if (updated === current && sessionId in s.sessions) return s;
         return { ...s, sessions: { ...s.sessions, [sessionId]: updated } };

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1554,6 +1554,17 @@
       "components": ["web/src/components/settings/DiffSettings.tsx", "web/src/components/SettingsView.tsx"]
     },
     {
+      "id": "settings.panels-section",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/settings/__tests__/PanelsSettings.test.tsx", "src/lib/__tests__/paneLayout.test.ts"],
+      "components": [
+        "web/src/components/settings/PanelsSettings.tsx",
+        "web/src/components/SettingsView.tsx",
+        "web/src/lib/paneLayout.ts"
+      ]
+    },
+    {
       "id": "devices",
       "kind": "live-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

When a new session opens in the web dashboard, the diff and terminal panes (and any available plugin pane, such as the GitHub PR pane) auto-open in the right dock. There was no way to turn this off, so anyone who prefers a clean start had to close the panels on every new session.

This adds three per-panel client-local toggles under a new **Settings > Panels** tab: "Open the diff panel in new sessions", "Open a terminal panel in new sessions", and "Open plugin panels automatically". All default ON, so existing behavior is unchanged unless you opt out.

Implementation notes:
- The toggles are client-local (localStorage `aoe-web-settings`), matching the existing Diff and Terminal sections, so there is no backend config, settings-schema, or migration.
- The diff/terminal filtering happens at *seed* time (`seedLayout` in `paneLayout.ts`), not by rewriting the default template, so the toggle takes effect even for existing users whose pane template was already persisted with panels open. It only shapes sessions opened after the change; already-open sessions keep their layout.
- `mutate` reads the prefs synchronously (`getWebSettingsSnapshot`) rather than closing over the settings object, which would otherwise rebuild the whole pane API on any unrelated web-setting change.
- The plugin toggle gates the `syncPlugins` auto-add (an empty list is still passed so the session's seeded layout is materialized on mount); a panel disabled this way is still openable on demand from the activity bar.

Closes #3035

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the dashboard, launch a new session on desktop: diff + terminal panes open by default (unchanged).
- [ ] Go to Settings > Panels, turn off "Open the diff panel in new sessions", launch another new session: the diff pane is not open, the terminal pane still is.
- [ ] Confirm a session you already had open before the toggle change keeps its existing panels.
- [ ] With the diff toggle off, click the diff icon in the activity bar: the pane still opens manually.
- [ ] Repeat for the terminal and plugin toggles (plugin requires an installed pane-contributing plugin, e.g. GitHub).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated tests and updated `web/tests/coverage-matrix.json`
  - Client-local settings are covered with Vitest + RTL rather than Playwright, per AGENTS.md (the DiffSettings / SoundSettings precedent): `PanelsSettings.test.tsx` asserts the localStorage contract, `paneLayout.test.ts` asserts `seedLayout` filtering, and `SettingsView.test.tsx` covers the new tab in the sidebar order.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult (Gemini + GPT) used to pressure-test the seed-time-filtering design. I made the design calls and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new **Settings > Panels** section with three checkbox toggles to control whether new web dashboard sessions automatically open:
  - the **Diff** pane
  - the **Terminal** pane
  - **Installed plugin** panes
- Implemented client-local preference storage (in `localStorage` under `aoe-web-settings`) with all toggles defaulting to **enabled**, preserving existing behavior.
- Updated **layout seeding** so the first-time session layout is filtered according to the new diff/terminal toggles (so persisted pane templates are also respected).
- Updated **plugin pane synchronization** so plugin panes respect the **auto-open plugins** toggle: when disabled, they aren’t auto-added, while the layout seeding/mounting flow still materializes the remaining structure.
- Ensured the **Panels** settings tab renders independently (not blocked by the usual settings/profile loading flow).
- Added/extended unit tests to cover localStorage persistence, settings navigation, pane/layout filtering behavior, and added coverage-matrix metadata.

## Benefits

Users can prevent specific panes (diff, terminal, installed plugins) from auto-opening in new sessions while still keeping them available to open manually. Existing sessions keep their current layouts, and the change works entirely on the client with no backend configuration or migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->