### PR TITLE
fix(tui): route paste to dialogs opened over live-send instead of the pane

### DIFF
--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -76,6 +76,11 @@ impl RenameDialog {
         self.mode
     }
 
+    #[cfg(test)]
+    pub fn title_value(&self) -> &str {
+        self.new_title.value()
+    }
+
     pub fn new(
         current_title: &str,
         current_group: &str,

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5661,26 +5661,35 @@ impl HomeView {
 
     /// Route a bracketed paste event to the active text input dialog.
     ///
-    /// Live-send mode wins above every dialog: a paste while the user is
-    /// "attached" should stream straight to the agent's pane, not buffer
-    /// in a dialog the user isn't even looking at. Text-input dialogs
-    /// (rename / send_message / new) come next so multi-line dictation
-    /// lands in whichever dialog the user is actively typing into. The
-    /// settings view is checked last; its paste handler strips newlines,
-    /// which would destroy multi-line dictation if we checked it first.
+    /// Live-send mode wins over every dialog as long as no overlay is
+    /// stacked on top of it: a paste while the user is "attached" should
+    /// stream straight to the agent's pane, not buffer in a dialog the
+    /// user isn't even looking at. But once an overlay HAS been opened
+    /// on top of live-send (via a right-click context menu, the
+    /// empty-sidebar click, or any future click-to-open path), the paste
+    /// must go to that overlay, exactly like the key path in
+    /// `handle_key` — otherwise the user sees a focused input field
+    /// while their clipboard silently lands in the pane behind it.
+    /// Text-input dialogs (rename / send_message / new) come next so
+    /// multi-line dictation lands in whichever dialog the user is
+    /// actively typing into. The settings view is checked last; its
+    /// paste handler strips newlines, which would destroy multi-line
+    /// dictation if we checked it first.
     pub fn handle_paste(&mut self, text: &str) {
-        if let Some(state) = self.live_send.clone() {
-            // Mirror the live-send key path: any interaction dismisses
-            // the finalized highlight so it doesn't follow agent output
-            // through subsequent renders.
-            self.clear_preview_selection();
-            if let Some(worker) = &self.live_send_worker {
-                for key in split_paste_for_live_send(text) {
-                    worker.send(key);
+        if !self.has_non_live_send_overlay() {
+            if let Some(state) = self.live_send.clone() {
+                // Mirror the live-send key path: any interaction dismisses
+                // the finalized highlight so it doesn't follow agent output
+                // through subsequent renders.
+                self.clear_preview_selection();
+                if let Some(worker) = &self.live_send_worker {
+                    for key in split_paste_for_live_send(text) {
+                        worker.send(key);
+                    }
                 }
+                self.stamp_last_accessed(&state.session_id);
+                return;
             }
-            self.stamp_last_accessed(&state.session_id);
-            return;
         }
         if let Some(ref mut dialog) = self.rename_dialog {
             dialog.handle_paste(text);

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5676,12 +5676,18 @@ impl HomeView {
     /// paste handler strips newlines, which would destroy multi-line
     /// dictation if we checked it first.
     pub fn handle_paste(&mut self, text: &str) {
+        // Any paste drops a finalized preview-pane selection, exactly like
+        // `handle_key` clears it up front: the highlight pins to cell
+        // coords, so once the user pastes anywhere (the live-send pane, a
+        // dialog opened on top of live-send via the mouse, or the home
+        // view) the cells underneath can change and the highlight would
+        // point at unrelated content. Doing it here rather than only in
+        // the live-send branch keeps a mouse-driven drag-select ->
+        // right-click -> paste-into-dialog sequence from stranding the
+        // highlight, since that path never goes through `handle_key`.
+        self.clear_preview_selection();
         if !self.has_non_live_send_overlay() {
             if let Some(state) = self.live_send.clone() {
-                // Mirror the live-send key path: any interaction dismisses
-                // the finalized highlight so it doesn't follow agent output
-                // through subsequent renders.
-                self.clear_preview_selection();
                 if let Some(worker) = &self.live_send_worker {
                     for key in split_paste_for_live_send(text) {
                         worker.send(key);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14767,6 +14767,42 @@ mod live_send_mode {
         assert!(env.view.pending_paste.is_none());
     }
 
+    /// A finalized preview highlight (installed via a mouse drag, which
+    /// never runs through `handle_key`) must be dropped when the user
+    /// pastes into a dialog opened over live-send. Before the clear was
+    /// hoisted to the top of `handle_paste`, only the pane-streaming
+    /// branch cleared it, so the highlight survived a dialog-routed paste
+    /// and kept repainting over stale cells after the dialog closed.
+    #[test]
+    #[serial]
+    fn paste_into_dialog_over_live_send_clears_preview_selection() {
+        let mut env = create_test_env_with_sessions(1);
+        env.view.update_selected();
+        install_live_for_first_session(&mut env);
+        env.view.preview_selection = Some(PreviewSelection {
+            anchor: (0, 0),
+            extent: (4, 2),
+            finalized: true,
+        });
+        env.view.open_rename_for_selected();
+        assert!(env.view.rename_dialog.is_some());
+        assert!(
+            env.view.preview_selection.is_some(),
+            "precondition: opening the dialog must not clear the selection"
+        );
+
+        env.view.handle_paste("pasted-title");
+
+        assert!(
+            env.view.preview_selection.is_none(),
+            "a dialog-routed paste must still drop the finalized highlight"
+        );
+        assert_eq!(
+            env.view.rename_dialog.as_ref().unwrap().title_value(),
+            "pasted-title"
+        );
+    }
+
     #[test]
     #[serial]
     fn refresh_preserves_cache_when_live_capture_fails() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14720,6 +14720,53 @@ mod live_send_mode {
         assert!(env.view.has_non_live_send_overlay());
     }
 
+    /// Regression for the preview-mode paste misroute: a rename dialog
+    /// opened on top of live-send (reachable via the right-click context
+    /// menu, which stays clickable while "attached") must receive pastes.
+    /// Before the fix, `handle_paste` gave live-send absolute priority,
+    /// so the clipboard streamed into the agent's pane while the user was
+    /// staring at a focused dialog input; the key path had already been
+    /// taught to route to overlays, but paste hadn't.
+    #[test]
+    #[serial]
+    fn paste_routes_to_rename_dialog_opened_over_live_send() {
+        let mut env = create_test_env_with_sessions(1);
+        env.view.update_selected();
+        install_live_for_first_session(&mut env);
+        env.view.open_rename_for_selected();
+        assert!(env.view.rename_dialog.is_some());
+        assert!(
+            env.view.live_send.is_some(),
+            "live-send must stay active underneath the dialog"
+        );
+
+        env.view.handle_paste("pasted-title");
+
+        assert_eq!(
+            env.view.rename_dialog.as_ref().unwrap().title_value(),
+            "pasted-title",
+            "paste must land in the dialog's focused input, not the pane behind it"
+        );
+    }
+
+    /// Companion pin: with live-send active and NO overlay on top, paste
+    /// keeps streaming to the pane. The unit fixture has no worker
+    /// attached, so the observable contract is that the live-send branch
+    /// consumes the paste: nothing buffers into a compose dialog or
+    /// pending_paste.
+    #[test]
+    #[serial]
+    fn paste_in_pure_live_mode_is_consumed_by_live_send() {
+        let mut env = create_test_env_with_sessions(1);
+        env.view.update_selected();
+        install_live_for_first_session(&mut env);
+
+        env.view.handle_paste("streamed to pane");
+
+        assert!(env.view.send_message_dialog.is_none());
+        assert!(env.view.pending_paste.is_none());
+    }
+
     #[test]
     #[serial]
     fn refresh_preserves_cache_when_live_capture_fails() {


### PR DESCRIPTION
## Description

Closes #3059

While attached to a session in live-send (preview) mode, the sidebar still accepts right-clicks, so the context menu can open a Rename / New Session dialog on top of live-send. The dialog looked focused and accepted typed keys, but a clipboard paste streamed into the agent's tmux pane behind it.

`handle_key` already suspends live-send capture when a non-live-send overlay is open (`self.live_send.is_some() && !self.has_non_live_send_overlay()`), but `handle_paste` kept the older unconditional "live-send wins above every dialog" rule, written before any click-to-open overlay path existed. This PR gates the live-send branch of `handle_paste` on the same `has_non_live_send_overlay()` check, so keys and pastes route identically: to the overlay when one is open, straight to the pane otherwise.

Also adds a `#[cfg(test)] title_value()` accessor on `RenameDialog` (mirroring `NewSessionDialog::path_value()`) and two regression tests:
- a rename dialog opened over live-send receives the paste,
- with no overlay, a paste in pure live mode is still consumed by the live-send branch (priority pin).

The mosh paste-burst fallback needs no change: `wants_paste_burst()` already returns true for both live-send and the text-input dialogs, and the accumulated burst funnels through the fixed `handle_paste`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt --check`, `cargo test --lib tui::home::tests::live_send_mode` (35 passed), and `cargo clippy --all-targets` (no new warnings; the one `items_after_test_module` warning is pre-existing on main in `src/tui/home/mod.rs`) were run in a `rust:latest` container.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the routing decision is pure view-state logic with no tmux round-trip; it's pinned by two in-module regression tests in `src/tui/home/tests.rs` (dialog-over-live-send and pure-live-mode priority), which exercise the exact `handle_paste` entry point the terminal event loop calls.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:**
Diagnosis, fix, tests, and this PR were produced with Claude Code under human direction and review.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed how clipboard pastes are routed during live-send: when a Rename or New Session dialog is open over the live-send view, the pasted text now goes into the focused dialog field instead of the underlying tmux pane.
- Updated live-send paste behavior to follow the same “only capture when no overlay is open” rule used for keyboard input, so pastes match what users expect when popups/overlays are on screen.
- Cleared finalized preview selection highlights at the start of paste handling to prevent stale highlight artifacts after a paste redirects.
- Added a test-only `RenameDialog::title_value()` accessor to support assertions about dialog input.
- Added regression tests covering dialog routing under live-send, priority/behavior when no overlay is open, and highlight clearing after paste.

## Benefits

Pastes now behave consistently and predictably—clipboard input lands in the dialog the user is interacting with (not the background live-send target), and UI highlight state stays correct after routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->