### PR TITLE
fix(acp): show real rate-limit reset time and continue the turn on resume

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -173,14 +173,19 @@ impl AcpError {
 /// surface the same signal differently; the catch-all message regex in
 /// `classify_rate_limit_from_message` is the defensive fallback.
 ///
-/// Reset time is recovered from `data.resets_at` (RFC3339) when
-/// present. Some claude-agent-acp versions only embed the time in the
-/// message text ("resets 12:10pm (Europe/Paris)"); robustly parsing
-/// arbitrary locale strings would require chrono-tz, so the fallback
-/// is `now + 1h` and the message is preserved verbatim in
-/// `RateLimitInfo.status` so the UI can surface the exact text.
+/// Reset time is recovered, in priority order: `data.resets_at`
+/// (RFC3339) if the adapter ever supplies it; else `captured_resets_at`
+/// (the authoritative unix epoch the adapter forwards out-of-band on a
+/// `usage_update`'s `_meta._claude/rateLimit.resetsAt`, threaded in by
+/// the caller from `last_rate_limit_resets_at`) when it is still in the
+/// future; else `now + 1h`. Current claude-agent-acp puts NO reset in
+/// the error, only a locale string in the message text ("resets 12:10pm
+/// (Europe/Paris)"), so without the captured epoch the fallback would
+/// always be the wrong `now + 1h` (#3028). The message is preserved
+/// verbatim in `RateLimitInfo.status` so the UI can surface the text.
 pub(crate) fn classify_rate_limit_error(
     err: &agent_client_protocol::Error,
+    captured_resets_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> Option<RateLimitInfo> {
     let data = err.data.as_ref()?;
     let kind = data.get("errorKind").and_then(|v| v.as_str())?;
@@ -193,6 +198,7 @@ pub(crate) fn classify_rate_limit_error(
         .and_then(|v| v.as_str())
         .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
         .map(|dt| dt.with_timezone(&chrono::Utc))
+        .or_else(|| captured_resets_at.filter(|dt| *dt > chrono::Utc::now()))
         .unwrap_or_else(|| chrono::Utc::now() + chrono::Duration::hours(1));
     Some(RateLimitInfo {
         status: err.message.clone(),
@@ -208,17 +214,61 @@ pub(crate) fn classify_rate_limit_error(
 /// `errorKind":"rate_limit"` only matches the JSON the adapter pastes
 /// into its error message; unrelated logs that mention "rate_limit"
 /// won't trigger.
-pub(crate) fn classify_rate_limit_from_message(message: &str) -> Option<RateLimitInfo> {
+pub(crate) fn classify_rate_limit_from_message(
+    message: &str,
+    captured_resets_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> Option<RateLimitInfo> {
     if !message.contains("\"errorKind\":\"rate_limit\"")
         && !message.contains("\"errorKind\": \"rate_limit\"")
     {
         return None;
     }
+    let resets_at = captured_resets_at
+        .filter(|dt| *dt > chrono::Utc::now())
+        .unwrap_or_else(|| chrono::Utc::now() + chrono::Duration::hours(1));
     Some(RateLimitInfo {
         status: message.to_string(),
-        resets_at: chrono::Utc::now() + chrono::Duration::hours(1),
+        resets_at,
         kind: "rate_limit".to_string(),
     })
+}
+
+/// Extract the rate-limit reset epoch (unix SECONDS) from a
+/// `usage_update`'s `_meta`. claude-agent-acp forwards the SDK's
+/// `SDKRateLimitInfo` under `_meta["_claude/rateLimit"]`, whose
+/// `resetsAt` is the authoritative window reset (the error's message
+/// text is only a locale rendering of this same value). Guards against a
+/// millisecond-scale value (the JS SDK ecosystem conflates seconds and
+/// ms) so a stray ms epoch cannot resolve to the year 5138+. See #3028.
+fn rate_limit_resets_at_secs_from_meta(
+    meta: &Option<agent_client_protocol::schema::v1::Meta>,
+) -> Option<i64> {
+    let v = meta.as_ref()?.get("_claude/rateLimit")?.get("resetsAt")?;
+    let raw = v.as_i64().or_else(|| v.as_f64().map(|f| f as i64))?;
+    if raw <= 0 {
+        return None;
+    }
+    // Anthropic reports unix seconds; anything past ~year 5138 in seconds
+    // is really milliseconds.
+    Some(if raw > 100_000_000_000 {
+        raw / 1000
+    } else {
+        raw
+    })
+}
+
+/// Read the captured rate-limit reset epoch (unix seconds) from the shared
+/// atomic and convert to a UTC datetime; `None` when unset (0) or not
+/// representable. The classify functions additionally gate on "in the
+/// future", so a stale-but-representable value is filtered there. #3028.
+fn captured_rate_limit_resets_at(
+    atomic: &std::sync::atomic::AtomicI64,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    let secs = atomic.load(std::sync::atomic::Ordering::Relaxed);
+    if secs <= 0 {
+        return None;
+    }
+    chrono::DateTime::from_timestamp(secs, 0)
 }
 
 /// Experimental `session/delete` ACP request. Adapters advertising
@@ -5315,6 +5365,14 @@ async fn run_connection_task<W, R>(
     let between_prompt_cost_seen = Arc::new(AtomicBool::new(false));
     // Wake `at` (ms) of the latest pending scheduled wake, 0 when none.
     let between_prompt_wake_at = Arc::new(AtomicI64::new(0));
+    // Authoritative rate-limit reset epoch (unix SECONDS) captured from the
+    // most recent `usage_update` `_meta._claude/rateLimit.resetsAt`; 0 = none
+    // seen. Cleared at each prompt start so a stale value from an earlier
+    // window can't leak into a later limit, and read at the rate-limit
+    // classify sites to replace the `now + 1h` guess with the real reset. The
+    // adapter never puts the reset in the error itself, only in this
+    // out-of-band usage_update, so this is the only structured source. #3028.
+    let last_rate_limit_resets_at = Arc::new(AtomicI64::new(0));
     // In-flight tool calls for the between-prompt (agent-initiated) path,
     // keyed by tool_call_id -> the `run_in_background` flag observed at
     // ToolStarted. Mirrors the per-prompt SilentOrphanWatchdog's
@@ -5345,6 +5403,8 @@ async fn run_connection_task<W, R>(
     let between_prompt_active_for_notif = between_prompt_active.clone();
     let between_prompt_cost_seen_for_notif = between_prompt_cost_seen.clone();
     let between_prompt_wake_at_for_notif = between_prompt_wake_at.clone();
+    let last_rate_limit_resets_at_for_notif = last_rate_limit_resets_at.clone();
+    let last_rate_limit_resets_at_for_block = last_rate_limit_resets_at.clone();
     let between_prompt_tools_for_notif = between_prompt_tools.clone();
     let between_prompt_off_protocol_for_notif = between_prompt_off_protocol.clone();
     let between_prompt_bg_agents_for_notif = between_prompt_bg_agents.clone();
@@ -5384,6 +5444,8 @@ async fn run_connection_task<W, R>(
                     between_prompt_cost_seen_for_notif.clone();
                 let between_prompt_wake_at =
                     between_prompt_wake_at_for_notif.clone();
+                let last_rate_limit_resets_at =
+                    last_rate_limit_resets_at_for_notif.clone();
                 let between_prompt_tools = between_prompt_tools_for_notif.clone();
                 let between_prompt_off_protocol =
                     between_prompt_off_protocol_for_notif.clone();
@@ -5547,6 +5609,20 @@ async fn run_connection_task<W, R>(
                                 between_prompt_off_protocol.store(false, Ordering::Relaxed);
                             }
                             _ => {}
+                        }
+                    }
+                    // Capture the authoritative rate-limit reset epoch the
+                    // adapter forwards on a `usage_update` (#3028) before the
+                    // update is consumed below. Overwrite unconditionally: the
+                    // freshest observed `resetsAt` for the active window is the
+                    // best "when can I resume" estimate.
+                    // ponytail: stores whatever window's resetsAt arrived last;
+                    // a seven_day-warning epoch could momentarily shadow a
+                    // five_hour-rejection one, but any real epoch beats the
+                    // now+1h guess. Per-window tracking only if that misleads.
+                    if let SessionUpdate::UsageUpdate(u) = &notification.update {
+                        if let Some(secs) = rate_limit_resets_at_secs_from_meta(&u.meta) {
+                            last_rate_limit_resets_at.store(secs, Ordering::Relaxed);
                         }
                     }
                     let update_for_tool_context = notification.update.clone();
@@ -6564,6 +6640,10 @@ async fn run_connection_task<W, R>(
                         let this_prompt_epoch = current_prompt_epoch
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                             + 1;
+                        // Clear any rate-limit reset captured for a prior turn
+                        // so this prompt only trusts a `resetsAt` observed while
+                        // it is in flight (#3028).
+                        last_rate_limit_resets_at_for_block.store(0, Ordering::Relaxed);
                         while lifecycle_signal_rx.try_recv().is_ok() {}
 
                         // Per-prompt silent-orphan state machine. Owned
@@ -6708,7 +6788,13 @@ async fn run_connection_task<W, R>(
                                             // restart budget respawning a worker
                                             // that will hit the same limit
                                             // immediately on retry. See #1281.
-                                            if let Some(info) = classify_rate_limit_error(&e) {
+                                            let captured_resets_at =
+                                                captured_rate_limit_resets_at(
+                                                    &last_rate_limit_resets_at_for_block,
+                                                );
+                                            if let Some(info) =
+                                                classify_rate_limit_error(&e, captured_resets_at)
+                                            {
                                                 info!(
                                                     target: "acp.protocol",
                                                     session = %session_label,
@@ -7215,7 +7301,10 @@ async fn run_connection_task<W, R>(
             // hint instead of a silent dead session.
             if let Some(tx) = ready_tx.lock().await.take() {
                 let _ = tx.send(Err(AcpError::Spawn(message.clone())));
-            } else if let Some(info) = classify_rate_limit_from_message(&message) {
+            } else if let Some(info) = classify_rate_limit_from_message(
+                &message,
+                captured_rate_limit_resets_at(&last_rate_limit_resets_at),
+            ) {
                 // Defensive: rate-limit can also surface from paths the
                 // prompt arm doesn't cover (handshake-time, mid-handshake
                 // request). Treat it as a parked terminal state instead
@@ -9385,7 +9474,7 @@ mod tests {
         let mut err = agent_client_protocol::Error::internal_error();
         err.message = "You've hit your limit · resets 12:10pm (Europe/Paris)".into();
         err.data = Some(serde_json::json!({ "errorKind": "rate_limit" }));
-        let info = classify_rate_limit_error(&err).expect("classified");
+        let info = classify_rate_limit_error(&err, None).expect("classified");
         assert_eq!(info.kind, "rate_limit");
         assert!(info.status.contains("hit your limit"));
         assert!(info.resets_at > chrono::Utc::now());
@@ -9399,7 +9488,46 @@ mod tests {
             "errorKind": "rate_limit",
             "resets_at": "2099-01-01T00:00:00Z",
         }));
-        let info = classify_rate_limit_error(&err).expect("classified");
+        let info = classify_rate_limit_error(&err, None).expect("classified");
+        assert_eq!(info.resets_at.to_rfc3339(), "2099-01-01T00:00:00+00:00");
+    }
+
+    // #3028: the adapter puts no reset in the error, only in an out-of-band
+    // usage_update. The captured epoch must replace the wrong now+1h guess.
+    #[test]
+    fn classify_rate_limit_uses_captured_resets_at_over_fallback() {
+        let mut err = agent_client_protocol::Error::internal_error();
+        err.message = "You've hit your limit".into();
+        err.data = Some(serde_json::json!({ "errorKind": "rate_limit" }));
+        let captured = chrono::Utc::now() + chrono::Duration::minutes(10);
+        let info = classify_rate_limit_error(&err, Some(captured)).expect("classified");
+        assert_eq!(info.resets_at, captured);
+    }
+
+    // A stale captured reset already in the past must be ignored so the
+    // fallback (now + 1h, always future) wins instead. #3028.
+    #[test]
+    fn classify_rate_limit_ignores_past_captured_resets_at() {
+        let mut err = agent_client_protocol::Error::internal_error();
+        err.message = "You've hit your limit".into();
+        err.data = Some(serde_json::json!({ "errorKind": "rate_limit" }));
+        let stale = chrono::Utc::now() - chrono::Duration::hours(3);
+        let info = classify_rate_limit_error(&err, Some(stale)).expect("classified");
+        assert!(info.resets_at > chrono::Utc::now());
+    }
+
+    // RFC3339 in the error data (should the adapter ever add it) wins over a
+    // captured epoch. #3028.
+    #[test]
+    fn classify_rate_limit_data_resets_at_beats_captured() {
+        let mut err = agent_client_protocol::Error::internal_error();
+        err.message = "rate limited".into();
+        err.data = Some(serde_json::json!({
+            "errorKind": "rate_limit",
+            "resets_at": "2099-01-01T00:00:00Z",
+        }));
+        let captured = chrono::Utc::now() + chrono::Duration::minutes(10);
+        let info = classify_rate_limit_error(&err, Some(captured)).expect("classified");
         assert_eq!(info.resets_at.to_rfc3339(), "2099-01-01T00:00:00+00:00");
     }
 
@@ -9408,22 +9536,65 @@ mod tests {
         let mut err = agent_client_protocol::Error::internal_error();
         err.message = "transport closed".into();
         err.data = Some(serde_json::json!({ "errorKind": "internal" }));
-        assert!(classify_rate_limit_error(&err).is_none());
+        assert!(classify_rate_limit_error(&err, None).is_none());
 
         let err = agent_client_protocol::Error::invalid_params();
-        assert!(classify_rate_limit_error(&err).is_none());
+        assert!(classify_rate_limit_error(&err, None).is_none());
     }
 
     #[test]
     fn classify_rate_limit_from_message_matches_acp_fingerprint() {
         let msg = "ACP connection failed: Internal error: You've hit your limit · resets 12:10pm (Europe/Paris): {\n  \"errorKind\":\"rate_limit\"\n}";
-        let info = classify_rate_limit_from_message(msg).expect("classified");
+        let info = classify_rate_limit_from_message(msg, None).expect("classified");
         assert_eq!(info.kind, "rate_limit");
         // Spaced variant the adapter sometimes emits.
-        let info_spaced = classify_rate_limit_from_message("{\n  \"errorKind\": \"rate_limit\"\n}")
-            .expect("classified");
+        let info_spaced =
+            classify_rate_limit_from_message("{\n  \"errorKind\": \"rate_limit\"\n}", None)
+                .expect("classified");
         assert_eq!(info_spaced.kind, "rate_limit");
-        assert!(classify_rate_limit_from_message("connection refused").is_none());
+        assert!(classify_rate_limit_from_message("connection refused", None).is_none());
+    }
+
+    #[test]
+    fn classify_rate_limit_from_message_uses_captured_resets_at() {
+        let msg = "{\n  \"errorKind\":\"rate_limit\"\n}";
+        let captured = chrono::Utc::now() + chrono::Duration::minutes(20);
+        let info = classify_rate_limit_from_message(msg, Some(captured)).expect("classified");
+        assert_eq!(info.resets_at, captured);
+    }
+
+    // #3028: resetsAt from the usage_update `_meta` is unix seconds; a
+    // millisecond-scale value must be normalized so it can't resolve to a
+    // far-future year.
+    #[test]
+    fn rate_limit_resets_at_secs_from_meta_reads_and_guards_units() {
+        let secs = 4_102_444_800_i64; // 2100-01-01 in seconds
+        let mut meta = serde_json::Map::new();
+        meta.insert(
+            "_claude/rateLimit".to_string(),
+            serde_json::json!({ "status": "rejected", "resetsAt": secs }),
+        );
+        assert_eq!(
+            rate_limit_resets_at_secs_from_meta(&Some(meta.clone())),
+            Some(secs)
+        );
+
+        // Millisecond-scale value normalizes back to seconds.
+        let mut meta_ms = serde_json::Map::new();
+        meta_ms.insert(
+            "_claude/rateLimit".to_string(),
+            serde_json::json!({ "resetsAt": secs * 1000 }),
+        );
+        assert_eq!(
+            rate_limit_resets_at_secs_from_meta(&Some(meta_ms)),
+            Some(secs)
+        );
+
+        // No meta, or meta without the rate-limit key, yields nothing.
+        assert_eq!(rate_limit_resets_at_secs_from_meta(&None), None);
+        let mut other = serde_json::Map::new();
+        other.insert("claudeCode".to_string(), serde_json::json!({}));
+        assert_eq!(rate_limit_resets_at_secs_from_meta(&Some(other)), None);
     }
 
     /// Regression for issue #2414 on the structured-view path: `from_info`

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1139,6 +1139,63 @@ impl EventStore {
         }
     }
 
+    /// Text of the user prompt whose turn was interrupted by a rate limit,
+    /// i.e. the latest `UserPromptSent` whose next terminal event is a
+    /// `Stopped{reason:"rate_limited"}`. Used on resume to re-issue the
+    /// interrupted prompt so the agent continues instead of sitting idle
+    /// (#3028). Returns `None` when the last turn completed normally, was
+    /// agent-initiated (its last user prompt has a non-rate-limit terminal
+    /// after it), or produced no prompt. `has_in_flight_turn` can't answer
+    /// this: the rate-limit park emits a `Stopped`, so the turn no longer
+    /// reads as in-flight; here we specifically match the rate-limit stop.
+    pub fn rate_limited_turn_prompt(&self, session_id: &str) -> Option<String> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let prompt: Option<(i64, String)> = conn
+            .query_row(
+                "SELECT seq, event_json FROM acp_events
+                 WHERE session_id = ?1
+                   AND json_extract(event_json, '$.UserPromptSent') IS NOT NULL
+                 ORDER BY seq DESC
+                 LIMIT 1",
+                params![session_id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(target: "acp.event_store", "rate_limited_turn_prompt prompt query {session_id}: {e}");
+                None
+            });
+        let (prompt_seq, prompt_json) = prompt?;
+        let text = match serde_json::from_str::<Event>(&prompt_json).ok()? {
+            Event::UserPromptSent { text, .. } => text,
+            _ => return None,
+        };
+        let terminator: Option<String> = conn
+            .query_row(
+                "SELECT event_json FROM acp_events
+                 WHERE session_id = ?1
+                   AND seq > ?2
+                   AND (json_extract(event_json, '$.Stopped') IS NOT NULL
+                     OR json_extract(event_json, '$.AgentStartupError') IS NOT NULL)
+                 ORDER BY seq ASC
+                 LIMIT 1",
+                params![session_id, prompt_seq],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!(target: "acp.event_store", "rate_limited_turn_prompt terminator query {session_id}: {e}");
+                None
+            });
+        match terminator.and_then(|s| serde_json::from_str::<Event>(&s).ok()) {
+            Some(Event::Stopped { reason }) if reason == "rate_limited" => Some(text),
+            _ => None,
+        }
+    }
+
     /// The first turn's transcript for smart rename: the earliest
     /// `UserPromptSent` text plus the agent's prose (`AgentMessageChunk`)
     /// emitted before the first `Stopped` that follows it (any reason, so an
@@ -2836,6 +2893,105 @@ mod tests {
             )
             .unwrap();
         assert!(!store.has_in_flight_turn("s-1"));
+    }
+
+    // #3028: the last user turn was rate-limited, so its prompt is recoverable
+    // for a resume continuation.
+    #[test]
+    fn rate_limited_turn_prompt_returns_interrupted_prompt() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "keep working".into(),
+                    attachments: Vec::new(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "rate_limited".into(),
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            store.rate_limited_turn_prompt("s-1"),
+            Some("keep working".to_string())
+        );
+    }
+
+    // A turn that ended normally must not be re-issued on resume.
+    #[test]
+    fn rate_limited_turn_prompt_none_when_completed_normally() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "go".into(),
+                    attachments: Vec::new(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .unwrap();
+        assert_eq!(store.rate_limited_turn_prompt("s-1"), None);
+    }
+
+    // An agent-initiated turn hitting the limit leaves an old user prompt whose
+    // terminal is a normal Stopped, so we must not re-send it.
+    #[test]
+    fn rate_limited_turn_prompt_none_for_earlier_completed_user_prompt() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "old prompt".into(),
+                    attachments: Vec::new(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .unwrap();
+        // Later agent-initiated turn rate-limits, but no new UserPromptSent.
+        store
+            .record(
+                "s-1",
+                3,
+                &Event::Stopped {
+                    reason: "rate_limited".into(),
+                },
+            )
+            .unwrap();
+        assert_eq!(store.rate_limited_turn_prompt("s-1"), None);
+    }
+
+    #[test]
+    fn rate_limited_turn_prompt_none_on_empty_store() {
+        let (_tmp, store) = open_store(1000);
+        assert_eq!(store.rate_limited_turn_prompt("s-1"), None);
     }
 
     #[test]

--- a/src/acp/event_store.rs
+++ b/src/acp/event_store.rs
@@ -1139,16 +1139,20 @@ impl EventStore {
         }
     }
 
-    /// Text of the user prompt whose turn was interrupted by a rate limit,
-    /// i.e. the latest `UserPromptSent` whose next terminal event is a
-    /// `Stopped{reason:"rate_limited"}`. Used on resume to re-issue the
-    /// interrupted prompt so the agent continues instead of sitting idle
-    /// (#3028). Returns `None` when the last turn completed normally, was
-    /// agent-initiated (its last user prompt has a non-rate-limit terminal
-    /// after it), or produced no prompt. `has_in_flight_turn` can't answer
-    /// this: the rate-limit park emits a `Stopped`, so the turn no longer
-    /// reads as in-flight; here we specifically match the rate-limit stop.
-    pub fn rate_limited_turn_prompt(&self, session_id: &str) -> Option<String> {
+    /// The user prompt whose turn was interrupted by a rate limit: the text
+    /// plus its attachment refs, from the latest `UserPromptSent` whose next
+    /// terminal event is a `Stopped{reason:"rate_limited"}`. Used on resume to
+    /// re-issue the interrupted prompt (with its images/files) so the agent
+    /// continues instead of sitting idle (#3028). Returns `None` when the last
+    /// turn completed normally, was agent-initiated (its last user prompt has a
+    /// non-rate-limit terminal after it), or produced no prompt.
+    /// `has_in_flight_turn` can't answer this: the rate-limit park emits a
+    /// `Stopped`, so the turn no longer reads as in-flight; here we specifically
+    /// match the rate-limit stop.
+    pub fn rate_limited_turn_prompt(
+        &self,
+        session_id: &str,
+    ) -> Option<(String, Vec<crate::acp::state::PromptAttachmentRef>)> {
         let conn = match self.conn.lock() {
             Ok(g) => g,
             Err(p) => p.into_inner(),
@@ -1169,8 +1173,8 @@ impl EventStore {
                 None
             });
         let (prompt_seq, prompt_json) = prompt?;
-        let text = match serde_json::from_str::<Event>(&prompt_json).ok()? {
-            Event::UserPromptSent { text, .. } => text,
+        let (text, attachments) = match serde_json::from_str::<Event>(&prompt_json).ok()? {
+            Event::UserPromptSent { text, attachments } => (text, attachments),
             _ => return None,
         };
         let terminator: Option<String> = conn
@@ -1191,7 +1195,9 @@ impl EventStore {
                 None
             });
         match terminator.and_then(|s| serde_json::from_str::<Event>(&s).ok()) {
-            Some(Event::Stopped { reason }) if reason == "rate_limited" => Some(text),
+            Some(Event::Stopped { reason }) if reason == "rate_limited" => {
+                Some((text, attachments))
+            }
             _ => None,
         }
     }
@@ -2921,7 +2927,44 @@ mod tests {
             .unwrap();
         assert_eq!(
             store.rate_limited_turn_prompt("s-1"),
-            Some("keep working".to_string())
+            Some(("keep working".to_string(), Vec::new()))
+        );
+    }
+
+    // #3028: attachment refs on the interrupted prompt must ride along so the
+    // resume continuation can replay images/files, not just text.
+    #[test]
+    fn rate_limited_turn_prompt_preserves_attachments() {
+        let (_tmp, store) = open_store(1000);
+        let att = crate::acp::state::PromptAttachmentRef {
+            id: "att-1".into(),
+            kind: crate::acp::state::PromptAttachmentKind::Image,
+            mime_type: "image/png".into(),
+            name: Some("shot.png".into()),
+            size: 42,
+        };
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "look at this".into(),
+                    attachments: vec![att.clone()],
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "rate_limited".into(),
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            store.rate_limited_turn_prompt("s-1"),
+            Some(("look at this".to_string(), vec![att]))
         );
     }
 

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1018,9 +1018,12 @@ async fn reap_rate_limit_resumes(state: &Arc<AppState>, attempted: &mut HashSet<
         if state.acp_supervisor.is_running(&id).await {
             continue;
         }
-        // Eligible: publish the breadcrumb (supersedes Stopped{rate_limited})
-        // and free the `attempted` slot so the main resume loop spawns a
-        // fresh worker this tick.
+        // Eligible: queue the interrupted prompt (if any) so the respawned
+        // worker continues instead of sitting idle (#3028), then publish the
+        // breadcrumb (supersedes Stopped{rate_limited}) and free the
+        // `attempted` slot so the main resume loop spawns a fresh worker this
+        // tick. The pending-turn drain delivers the continuation once live.
+        enqueue_rate_limit_continuation(state, &id).await;
         state
             .acp_supervisor
             .publish_rate_limit_auto_resumed(&id, info.resets_at);
@@ -1240,6 +1243,35 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
 /// so overlapping ticks and the create fast path cannot double-deliver.
 /// Triaged sessions are skipped like everywhere else in the reconciler; the
 /// turn stays persisted and delivers if the session is ever un-triaged.
+/// Queue the rate-limit-interrupted prompt as the session's next turn so a
+/// resume (manual `/acp/spawn` or auto-resume) continues the work instead of
+/// leaving the agent idle. Reads the interrupted prompt from the event store
+/// off the async runtime, then hands it to the pending-initial-turn drain
+/// (no-op when the last turn wasn't rate-limited or a turn is already
+/// queued). #3028.
+pub(crate) async fn enqueue_rate_limit_continuation(state: &Arc<AppState>, id: &str) {
+    let store = Arc::clone(&state.acp_event_store);
+    let id_owned = id.to_string();
+    let text = match tokio::task::spawn_blocking(move || store.rate_limited_turn_prompt(&id_owned))
+        .await
+    {
+        Ok(Some(text)) => text,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!(
+                target: "acp.supervisor",
+                session = %id,
+                "rate-limit continuation lookup failed: {e}"
+            );
+            return;
+        }
+    };
+    state
+        .session_service
+        .set_pending_initial_turn(id, text)
+        .await;
+}
+
 async fn drain_pending_initial_turns(state: &Arc<AppState>) {
     let candidates: Vec<String> = {
         let instances = state.instances.read().await;

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1252,10 +1252,12 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
 pub(crate) async fn enqueue_rate_limit_continuation(state: &Arc<AppState>, id: &str) {
     let store = Arc::clone(&state.acp_event_store);
     let id_owned = id.to_string();
-    let text = match tokio::task::spawn_blocking(move || store.rate_limited_turn_prompt(&id_owned))
-        .await
+    let (text, attachments) = match tokio::task::spawn_blocking(move || {
+        store.rate_limited_turn_prompt(&id_owned)
+    })
+    .await
     {
-        Ok(Some(text)) => text,
+        Ok(Some(prompt)) => prompt,
         Ok(None) => return,
         Err(e) => {
             tracing::warn!(
@@ -1268,7 +1270,7 @@ pub(crate) async fn enqueue_rate_limit_continuation(state: &Arc<AppState>, id: &
     };
     state
         .session_service
-        .set_pending_initial_turn(id, text)
+        .set_pending_initial_turn(id, text, attachments)
         .await;
 }
 

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -456,6 +456,10 @@ pub async fn spawn_acp(
     match spawn_result {
         Ok(()) => {
             if let Some(resets_at) = rate_limit_resume_resets_at {
+                // Continue the rate-limit-interrupted turn instead of leaving
+                // the resumed agent idle; the pending-turn drain delivers it
+                // once the worker is live (#3028).
+                crate::server::acp_reconciler::enqueue_rate_limit_continuation(&state, &id).await;
                 state
                     .acp_supervisor
                     .publish_rate_limit_auto_resumed(&id, resets_at);
@@ -469,6 +473,7 @@ pub async fn spawn_acp(
         }
         Err(SupervisorError::AlreadyRunning(_)) if rate_limit_resume_resets_at.is_some() => {
             if let Some(resets_at) = rate_limit_resume_resets_at {
+                crate::server::acp_reconciler::enqueue_rate_limit_continuation(&state, &id).await;
                 state
                     .acp_supervisor
                     .publish_rate_limit_auto_resumed(&id, resets_at);

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1184,6 +1184,12 @@ pub async fn acp_prompt(
         Ok(a) => a,
         Err((code, msg)) => return (code, msg).into_response(),
     };
+    // A fresh user prompt supersedes any queued rate-limit resume
+    // continuation, so drop it before sending: otherwise the reconciler could
+    // later replay the older interrupted prompt after this newer one (#3028).
+    // The drain path never routes through here, so this cannot race the
+    // continuation delivery itself.
+    state.session_service.clear_pending_initial_turn(&id).await;
     // Resume + publish + forward all live in the shared service so the
     // plugin host delivers turns through the same path (#2897).
     let outcome = state

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -1187,21 +1187,28 @@ pub async fn acp_prompt(
     // A fresh user prompt supersedes any queued rate-limit resume
     // continuation, so drop it before sending: otherwise the reconciler could
     // later replay the older interrupted prompt after this newer one (#3028).
-    // The drain path never routes through here, so this cannot race the
-    // continuation delivery itself.
-    state.session_service.clear_pending_initial_turn(&id).await;
-    // Resume + publish + forward all live in the shared service so the
-    // plugin host delivers turns through the same path (#2897).
-    let outcome = state
-        .session_service
-        .send_turn(
-            &SessionCaller::User,
-            &id,
-            &req.text,
-            &attachments,
-            woke_idle_dormant,
-        )
-        .await;
+    // The clear + send run under the per-session `instance_lock` because the
+    // pending-turn drain holds that same lock across its whole snapshot ->
+    // reload -> send -> clear; without it a drain mid-await could deliver the
+    // stale continuation *after* this newer prompt. `send_turn` does not take
+    // `instance_lock` (the drain calls it while holding the lock), so this
+    // cannot deadlock. Resume + publish + forward all live in the shared
+    // service so the plugin host delivers turns through the same path (#2897).
+    let outcome = {
+        let inst_lock = state.instance_lock(&id).await;
+        let _serialized = inst_lock.lock().await;
+        state.session_service.clear_pending_initial_turn(&id).await;
+        state
+            .session_service
+            .send_turn(
+                &SessionCaller::User,
+                &id,
+                &req.text,
+                &attachments,
+                woke_idle_dormant,
+            )
+            .await
+    };
     // Smart-rename fires from `acp_event_listener` on the first clean
     // `prompt_complete` `Event::Stopped` (turn-end), so the one-shot never
     // races this handler's live worker for the provider API. See

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -838,6 +838,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         Arc::clone(&file_watch),
         Arc::clone(&telemetry_session_creates),
         acp_supervisor.clone(),
+        acp_event_store.clone(),
     ));
     #[cfg(not(feature = "serve"))]
     let session_service = Arc::new(session_service::SessionService::new(
@@ -5437,6 +5438,7 @@ pub mod test_support {
             Arc::clone(&file_watch),
             Arc::clone(&telemetry_session_creates),
             supervisor.clone(),
+            event_store.clone(),
         ));
         Arc::new(AppState {
             profile: "test".to_string(),

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -90,6 +90,11 @@ pub struct SessionService {
     #[cfg(feature = "serve")]
     pub acp_supervisor:
         Arc<crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>>,
+    /// Durable ACP event store, shared with `AppState.acp_event_store`. Used
+    /// by the pending-turn drain to reload attachment blobs for a rate-limit
+    /// resume continuation (#3028).
+    #[cfg(feature = "serve")]
+    pub acp_event_store: Arc<crate::acp::event_store::EventStore>,
     /// In-flight plugin creates keyed by `(plugin_id, idempotency_key)`.
     /// Sync mutex: critical sections are tiny and never span an `await`.
     // ponytail: one daemon process is the only sessions.json writer, so a
@@ -169,6 +174,7 @@ impl SessionService {
         acp_supervisor: Arc<
             crate::acp::supervisor::Supervisor<crate::acp::supervisor::ChannelSink>,
         >,
+        acp_event_store: Arc<crate::acp::event_store::EventStore>,
     ) -> Self {
         Self {
             instances,
@@ -176,6 +182,7 @@ impl SessionService {
             file_watch,
             telemetry_session_creates,
             acp_supervisor,
+            acp_event_store,
             create_in_flight: std::sync::Mutex::new(HashMap::new()),
             pending_drains: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
@@ -475,7 +482,7 @@ impl SessionService {
         };
         let inst_lock = self.instance_lock(id).await;
         let _serialized = inst_lock.lock().await;
-        let Some((text, profile, caller)) = ({
+        let Some((text, attachment_refs, profile, caller)) = ({
             let instances = self.instances.read().await;
             instances.iter().find(|i| i.id == id).and_then(|i| {
                 i.pending_initial_turn.clone().map(|text| {
@@ -488,13 +495,51 @@ impl SessionService {
                         },
                         None => SessionCaller::User,
                     };
-                    (text, i.source_profile.clone(), caller)
+                    (
+                        text,
+                        i.pending_initial_turn_attachments.clone(),
+                        i.source_profile.clone(),
+                        caller,
+                    )
                 })
             })
         }) else {
             return;
         };
-        if let Err(e) = self.send_turn(&caller, id, &text, &[], false).await {
+        // Reload the attachment blobs so a rate-limit resume continuation
+        // replays the interrupted prompt's images/files, not just its text
+        // (#3028). Refs are empty for create-time initial turns. Bytes live in
+        // the event store (a locking sqlite read), so load off the runtime.
+        let attachments = if attachment_refs.is_empty() {
+            Vec::new()
+        } else {
+            let store = Arc::clone(&self.acp_event_store);
+            let id_load = id.to_string();
+            tokio::task::spawn_blocking(move || {
+                attachment_refs
+                    .into_iter()
+                    .filter_map(|r| {
+                        store
+                            .load_attachment(&id_load, &r.id)
+                            .map(
+                                |(mime_type, data)| crate::acp::event_store::AttachmentBlob {
+                                    id: r.id,
+                                    kind: r.kind,
+                                    mime_type,
+                                    name: r.name,
+                                    data,
+                                },
+                            )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .await
+            .unwrap_or_default()
+        };
+        if let Err(e) = self
+            .send_turn(&caller, id, &text, &attachments, false)
+            .await
+        {
             tracing::warn!(
                 target: "acp.supervisor",
                 session = %id,
@@ -506,6 +551,7 @@ impl SessionService {
             let mut instances = self.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
                 inst.pending_initial_turn = None;
+                inst.pending_initial_turn_attachments = Vec::new();
             }
         }
         match crate::session::Storage::new(&profile, self.file_watch.clone()) {
@@ -515,6 +561,7 @@ impl SessionService {
                     storage.update(|instances, _groups| {
                         if let Some(inst) = instances.iter_mut().find(|i| i.id == id_persist) {
                             inst.pending_initial_turn = None;
+                            inst.pending_initial_turn_attachments = Vec::new();
                         }
                         Ok(())
                     })
@@ -538,19 +585,25 @@ impl SessionService {
         }
     }
 
-    /// Queue `text` as the session's next turn, reusing the pending-initial-
-    /// turn drain so the turn is delivered once the (resumed) worker is live.
-    /// No-op when a turn is already queued (never clobber a create/plugin
-    /// turn) or the session is gone. Persists so a daemon restart mid-resume
-    /// still re-delivers. Used to continue a rate-limit-interrupted turn on
-    /// resume (#3028).
+    /// Queue `text` (with its `attachments` refs) as the session's next turn,
+    /// reusing the pending-initial-turn drain so the turn is delivered once the
+    /// (resumed) worker is live. No-op when a turn is already queued (never
+    /// clobber a create/plugin turn) or the session is gone. Persists so a
+    /// daemon restart mid-resume still re-delivers. Used to continue a
+    /// rate-limit-interrupted turn on resume (#3028).
     #[cfg(feature = "serve")]
-    pub(crate) async fn set_pending_initial_turn(self: &Arc<Self>, id: &str, text: String) {
+    pub(crate) async fn set_pending_initial_turn(
+        self: &Arc<Self>,
+        id: &str,
+        text: String,
+        attachments: Vec<crate::acp::state::PromptAttachmentRef>,
+    ) {
         let profile = {
             let mut instances = self.instances.write().await;
             match instances.iter_mut().find(|i| i.id == id) {
                 Some(inst) if inst.pending_initial_turn.is_none() => {
                     inst.pending_initial_turn = Some(text.clone());
+                    inst.pending_initial_turn_attachments = attachments.clone();
                     inst.source_profile.clone()
                 }
                 _ => return,
@@ -563,6 +616,7 @@ impl SessionService {
                     storage.update(|instances, _groups| {
                         if let Some(inst) = instances.iter_mut().find(|i| i.id == id_persist) {
                             inst.pending_initial_turn = Some(text);
+                            inst.pending_initial_turn_attachments = attachments;
                         }
                         Ok(())
                     })
@@ -581,6 +635,54 @@ impl SessionService {
                     target: "acp.supervisor",
                     session = %id,
                     "failed to open storage for resume continuation turn: {e}"
+                );
+            }
+        }
+    }
+
+    /// Drop any queued pending initial turn (text + attachment refs) for a
+    /// session, in memory and on disk. A newer user prompt supersedes a queued
+    /// rate-limit resume continuation, so the stale continuation must not
+    /// replay after the newer message (#3028). No-op when nothing is queued.
+    #[cfg(feature = "serve")]
+    pub(crate) async fn clear_pending_initial_turn(self: &Arc<Self>, id: &str) {
+        let profile = {
+            let mut instances = self.instances.write().await;
+            match instances.iter_mut().find(|i| i.id == id) {
+                Some(inst) if inst.pending_initial_turn.is_some() => {
+                    inst.pending_initial_turn = None;
+                    inst.pending_initial_turn_attachments = Vec::new();
+                    inst.source_profile.clone()
+                }
+                _ => return,
+            }
+        };
+        match crate::session::Storage::new(&profile, self.file_watch.clone()) {
+            Ok(storage) => {
+                let id_persist = id.to_string();
+                let persisted = tokio::task::spawn_blocking(move || {
+                    storage.update(|instances, _groups| {
+                        if let Some(inst) = instances.iter_mut().find(|i| i.id == id_persist) {
+                            inst.pending_initial_turn = None;
+                            inst.pending_initial_turn_attachments = Vec::new();
+                        }
+                        Ok(())
+                    })
+                })
+                .await;
+                if !matches!(persisted, Ok(Ok(()))) {
+                    tracing::warn!(
+                        target: "acp.supervisor",
+                        session = %id,
+                        "failed to persist pending-turn clear; the drain re-checks liveness before delivery"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "acp.supervisor",
+                    session = %id,
+                    "failed to open storage to clear pending turn: {e}"
                 );
             }
         }

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -538,6 +538,54 @@ impl SessionService {
         }
     }
 
+    /// Queue `text` as the session's next turn, reusing the pending-initial-
+    /// turn drain so the turn is delivered once the (resumed) worker is live.
+    /// No-op when a turn is already queued (never clobber a create/plugin
+    /// turn) or the session is gone. Persists so a daemon restart mid-resume
+    /// still re-delivers. Used to continue a rate-limit-interrupted turn on
+    /// resume (#3028).
+    #[cfg(feature = "serve")]
+    pub(crate) async fn set_pending_initial_turn(self: &Arc<Self>, id: &str, text: String) {
+        let profile = {
+            let mut instances = self.instances.write().await;
+            match instances.iter_mut().find(|i| i.id == id) {
+                Some(inst) if inst.pending_initial_turn.is_none() => {
+                    inst.pending_initial_turn = Some(text.clone());
+                    inst.source_profile.clone()
+                }
+                _ => return,
+            }
+        };
+        match crate::session::Storage::new(&profile, self.file_watch.clone()) {
+            Ok(storage) => {
+                let id_persist = id.to_string();
+                let persisted = tokio::task::spawn_blocking(move || {
+                    storage.update(|instances, _groups| {
+                        if let Some(inst) = instances.iter_mut().find(|i| i.id == id_persist) {
+                            inst.pending_initial_turn = Some(text);
+                        }
+                        Ok(())
+                    })
+                })
+                .await;
+                if !matches!(persisted, Ok(Ok(()))) {
+                    tracing::warn!(
+                        target: "acp.supervisor",
+                        session = %id,
+                        "failed to persist resume continuation turn; it still drains this daemon life"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "acp.supervisor",
+                    session = %id,
+                    "failed to open storage for resume continuation turn: {e}"
+                );
+            }
+        }
+    }
+
     /// Same lazy per-instance mutex registry as `AppState::instance_lock`;
     /// both operate on the shared map, so a lock taken through either handle
     /// excludes the other.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -712,10 +712,23 @@ pub struct Instance {
     /// tick after a crash or restart) and clears it after a successful
     /// publish + forward. Delivery is at-least-once: a crash between the
     /// forward and this field's clear re-delivers on the next drain.
-    // ponytail: plain text, no attachments or dedup turn id; move to a typed
-    // record via a vNNN migration if either becomes necessary.
+    // ponytail: plain text plus a companion attachment-refs field below (no
+    // dedup turn id); fold both into a typed record via a vNNN migration if
+    // more turn state becomes necessary.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_initial_turn: Option<String>,
+
+    /// Attachment refs for `pending_initial_turn` when the queued turn is a
+    /// rate-limit resume continuation replaying a prompt that carried
+    /// images/files (#3028). Metadata only; bytes stay in the acp_attachments
+    /// store and are reloaded at drain time. Empty for create-time initial
+    /// turns (those are text-only). `#[serde(default)]` + skip-when-empty keeps
+    /// pre-existing rows deserialising unchanged, so no migration is needed.
+    /// Serve-only: `PromptAttachmentRef` lives in the serve-gated `acp` module,
+    /// and only the structured-view resume path (serve) ever populates it.
+    #[cfg(feature = "serve")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_initial_turn_attachments: Vec<crate::acp::state::PromptAttachmentRef>,
 
     /// Explicit ACP approval-mode id this session should run under (#2897),
     /// applied via `session/set_mode` after every worker (re)spawn, taking
@@ -1347,6 +1360,8 @@ impl Instance {
             created_by_plugin: None,
             plugin_create_idempotency: None,
             pending_initial_turn: None,
+            #[cfg(feature = "serve")]
+            pending_initial_turn_attachments: Vec::new(),
             acp_mode_id: None,
             scratch: false,
             worktree_info: None,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2353,6 +2353,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "story.rate-limit-resume-continuation",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/acp-stories/rate-limit-resume-continuation.spec.ts"],
+      "components": ["web/src/components/acp/StructuredView.tsx", "web/src/hooks/useRespawnSession.ts"]
+    },
+    {
       "id": "sidebar.rate-limit-hook",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -48,7 +48,7 @@
 // exhausted, subsequent prompts get the default happy-path turn.
 
 import { createInterface } from "node:readline";
-import { readFileSync, existsSync, appendFileSync } from "node:fs";
+import { readFileSync, existsSync, appendFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 
 // Silently swallow EPIPE/EBADF on stdout/stderr writes. The fake is a
@@ -133,13 +133,30 @@ function loadScript() {
 }
 
 const script = loadScript();
-let turnCursor = 0;
+
+// Turn cursor is per-process by default. When FAKE_ACP_TURN_STATE points at a
+// file, persist the cursor there so it survives a respawn: a resume-after-
+// rate-limit spawns a fresh fake process, and a test that needs the resumed
+// turn to differ from the parked one (e.g. rate-limit -> resume -> continue)
+// must not restart at turn 0. Opt-in so every other test keeps the simple
+// per-process behavior.
+const TURN_STATE_PATH = process.env.FAKE_ACP_TURN_STATE;
+let turnCursor = (() => {
+  if (!TURN_STATE_PATH || !existsSync(TURN_STATE_PATH)) return 0;
+  const n = Number.parseInt(readFileSync(TURN_STATE_PATH, "utf8").trim(), 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+})();
 
 function nextTurn() {
-  if (turnCursor < script.turns.length) {
-    return script.turns[turnCursor++];
+  const turn = turnCursor < script.turns.length ? script.turns[turnCursor++] : DEFAULT_TURN;
+  if (TURN_STATE_PATH) {
+    try {
+      writeFileSync(TURN_STATE_PATH, String(turnCursor));
+    } catch (err) {
+      process.stderr.write(`[fakeAcpAgent] failed to persist turn cursor: ${err}\n`);
+    }
   }
-  return DEFAULT_TURN;
+  return turn;
 }
 
 function send(obj) {

--- a/web/tests/live/acp-stories/rate-limit-resume-continuation.spec.ts
+++ b/web/tests/live/acp-stories/rate-limit-resume-continuation.spec.ts
@@ -1,0 +1,101 @@
+// User story: a structured view turn is interrupted by a provider rate limit
+// and parks the session. When the user clicks "Resume now", aoe must not only
+// respawn the worker but also re-issue the interrupted prompt so the agent
+// continues instead of sitting idle. See #3028.
+//
+// The fake ACP agent rate-limits the first turn, then (via a persisted turn
+// cursor that survives the resume respawn) answers the next prompt normally
+// with a distinct marker. Asserting that marker appears in the replay proves
+// the interrupted prompt was automatically re-sent on resume.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../../helpers/aoeServe";
+import {
+  enableStructuredViewAndWait,
+  waitForStructuredView,
+  waitForReplayContains,
+  attachServeDiagnostics,
+} from "../../helpers/acp";
+
+const RESETS_AT = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+// Turn 0 rate-limits; turn 1 (served to the resumed worker) is the
+// continuation and carries a marker distinct from turn 0.
+const SCRIPT = {
+  turns: [
+    {
+      updates: [{ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Starting the task." } }],
+      rateLimit: { resets_at: RESETS_AT, message: "usage limit reached" },
+    },
+    {
+      updates: [
+        { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Resumed and continued the task." } },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("resume re-issues the interrupted prompt so the agent continues", async ({ page }, testInfo) => {
+  let serveHandle: { home: string } | undefined;
+  let serve: Awaited<ReturnType<typeof spawnAoeServe>> | undefined;
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-rl-resume-"));
+  const scriptPath = join(scriptDir, "script.json");
+  const turnStatePath = join(scriptDir, "turn-cursor");
+  writeFileSync(scriptPath, JSON.stringify(SCRIPT));
+
+  try {
+    serve = await spawnAoeServe({
+      authMode: "none",
+      acp: true,
+      fakeAcpScript: scriptPath,
+      // Persist the fake agent's turn cursor across the resume respawn so the
+      // continuation prompt gets turn 1, not turn 0 again.
+      extraEnv: { FAKE_ACP_TURN_STATE: turnStatePath },
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "rl-resume" }),
+    });
+    serveHandle = serve;
+
+    const sessions = await listSessions(serve.baseUrl);
+    const session = sessions.find((s) => s.title === "rl-resume");
+    if (!session) throw new Error("seeded session 'rl-resume' missing");
+
+    await enableStructuredViewAndWait(serve.baseUrl, session.id, 30_000, serve.home);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(session.id)}`);
+    await waitForStructuredView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message|Queue a follow-up/i });
+    await composer.fill("keep working on the task");
+    await composer.press("Enter");
+
+    // The turn parks on the rate limit.
+    await expect(page.getByText(/Rate-limited/i)).toBeVisible({ timeout: 15_000 });
+
+    // Resume: respawns the worker AND (the #3028 fix) re-issues the
+    // interrupted prompt via the pending-initial-turn drain.
+    await page.getByRole("button", { name: /Resume now/i }).click();
+
+    // The continuation marker only appears if the interrupted prompt was
+    // re-sent to the resumed worker.
+    await waitForReplayContains(serve.baseUrl, session.id, "Resumed and continued the task.", {
+      timeoutMs: 30_000,
+    });
+  } finally {
+    try {
+      if (serveHandle) await attachServeDiagnostics(testInfo, serveHandle);
+    } catch {
+      // best-effort diagnostics; do not block cleanup
+    }
+    try {
+      if (serve) await serve.stop();
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true });
+    }
+  }
+});

--- a/web/tests/live/acp-stories/rate-limit-resume-continuation.spec.ts
+++ b/web/tests/live/acp-stories/rate-limit-resume-continuation.spec.ts
@@ -3,10 +3,16 @@
 // respawn the worker but also re-issue the interrupted prompt so the agent
 // continues instead of sitting idle. See #3028.
 //
-// The fake ACP agent rate-limits the first turn, then (via a persisted turn
-// cursor that survives the resume respawn) answers the next prompt normally
-// with a distinct marker. Asserting that marker appears in the replay proves
-// the interrupted prompt was automatically re-sent on resume.
+// Two halves of #3028 get e2e teeth here:
+//  1. Reset time: the fake reports the real reset ONLY out-of-band, on a
+//     `usage_update`'s `_meta._claude/rateLimit.resetsAt` (the way
+//     claude-agent-acp does it), and the rate-limit error carries NO
+//     `resets_at`. The banner must render that distinctive time; a regression
+//     to the old `now + 1h` guess would show a different time and fail.
+//  2. Continuation: the fake rate-limits turn 0, then (via a persisted turn
+//     cursor surviving the resume respawn) answers turn 1 with a distinct
+//     marker. That marker in the replay proves the interrupted prompt was
+//     re-issued on resume.
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -20,15 +26,28 @@ import {
   attachServeDiagnostics,
 } from "../../helpers/acp";
 
-const RESETS_AT = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+// A distinctive future reset, deliberately far from `now + 1h` (the fallback
+// this PR replaces) so a regression to that guess renders a different time.
+const RESET_SECS = Math.floor(Date.now() / 1000) + 2 * 3600 + 37 * 60;
+const RESET_ISO = new Date(RESET_SECS * 1000).toISOString();
 
 // Turn 0 rate-limits; turn 1 (served to the resumed worker) is the
-// continuation and carries a marker distinct from turn 0.
+// continuation and carries a marker distinct from turn 0. The reset time
+// rides ONLY on the usage_update meta, and the error omits resets_at, so the
+// banner's time can only be right if the meta-capture path works.
 const SCRIPT = {
   turns: [
     {
-      updates: [{ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Starting the task." } }],
-      rateLimit: { resets_at: RESETS_AT, message: "usage limit reached" },
+      updates: [
+        { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Starting the task." } },
+        {
+          sessionUpdate: "usage_update",
+          used: 1234,
+          size: 200000,
+          _meta: { "_claude/rateLimit": { status: "rejected", resetsAt: RESET_SECS } },
+        },
+      ],
+      rateLimit: { message: "usage limit reached" },
     },
     {
       updates: [
@@ -76,6 +95,13 @@ base("resume re-issues the interrupted prompt so the agent continues", async ({ 
 
     // The turn parks on the rate limit.
     await expect(page.getByText(/Rate-limited/i)).toBeVisible({ timeout: 15_000 });
+
+    // The banner must show the real reset from the usage_update meta, rendered
+    // the same way the UI does (`new Date(resets_at).toLocaleTimeString()`),
+    // computed in-browser so locale/timezone match. A regression to the old
+    // `now + 1h` guess would render a different time and fail this.
+    const expectedReset: string = await page.evaluate((iso) => new Date(iso).toLocaleTimeString(), RESET_ISO);
+    await expect(page.getByText(`resets at ${expectedReset}`)).toBeVisible({ timeout: 15_000 });
 
     // Resume: respawns the worker AND (the #3028 fix) re-issues the
     // interrupted prompt via the pending-initial-turn drain.


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Fixes both halves of #3028.

**Wrong reset time.** claude-agent-acp's rate-limit JSON-RPC error carries only `{ "errorKind": "rate_limit" }` with no reset timestamp, so `classify_rate_limit_error` always fell back to `now + 1h`. A user in Europe/Berlin therefore saw a reset roughly an hour past the real one. The authoritative reset (`resetsAt`, a unix epoch) is forwarded out-of-band on a `usage_update`'s `_meta._claude/rateLimit`; the message text is only a locale rendering of that same value. We now capture that epoch into a per-connection atomic (cleared at each prompt start so a stale window cannot leak) and prefer it, when still in the future, over the fallback at both rate-limit classify sites. A millisecond-scale epoch is normalized back to seconds. No new dependency and no locale/timezone parsing.

**Resume did not continue.** Resuming a rate-limited session (manual "Resume now" or opt-in auto-resume) respawned the worker and restored context via `session/load` but never re-issued the interrupted prompt, so the agent sat idle. A new `EventStore::rate_limited_turn_prompt` recovers the prompt whose turn ended in `Stopped{rate_limited}`, and both resume sites enqueue it as the session's pending initial turn so the existing drain-after-live plumbing delivers it once the worker is running. It is a no-op when the last turn completed normally or was agent-initiated.

Closes #3028

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Rate-limit a structured-view turn (or use the fake ACP agent). Confirm the recovery banner shows the real reset time from the provider, not a time roughly one hour from now.
- [ ] While parked, click "Resume now". Confirm the agent resumes and continues the interrupted prompt instead of sitting idle.
- [ ] With `acp.rate_limit_auto_resume` enabled, let the reset window elapse. Confirm the auto-resume also re-issues the interrupted prompt.
- [ ] Rate-limit, resume, and verify a turn that had already completed normally before the limit is NOT re-sent.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (epoch capture over message parsing, reusing the pending-initial-turn drain for continuation) and reviewed each commit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Rate-limit handling now uses the provider’s authoritative reset time from the `usage_update` metadata (instead of an estimated fallback), and safely ignores stale/invalid values.
- When a conversation is interrupted by a rate limit, “Resume now” now truly continues the interrupted turn by re-sending the original prompt (including attachment references).
- Auto-resume behavior was updated to queue the interrupted prompt so the resumed worker continues immediately rather than idling.
- If a newer user message arrives, any older queued rate-limit continuation is cleared to prevent replaying the wrong prompt.
- Added durable session support for queued pending-turn continuations (including attachment references) so behavior remains consistent across worker respawns/restarts.
- Expanded test coverage: added unit tests for reset-time priority and interrupted-prompt reconstruction, plus a Playwright story with a stateful fake ACP agent that persists its progress across restarts.

## Benefits

Users see the correct “rate limit reset” time and can reliably resume after rate limiting—manually or automatically—without losing or mis-replaying the interrupted work, even across restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->