### PR TITLE
feat: pin favorites to the top in every sort order

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -367,7 +367,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `set-base` — Set or clear the per-session diff base branch. The diff view compares the worktree against this ref instead of the auto-detected default. Useful when the PR target differs from the project default (stacked PRs, hotfix off `release/*`, renamed default branch). See #970
 * `snooze` — Snooze a session for a duration (temporary archive, auto wakes)
 * `unsnooze` — Wake a snoozed session immediately
-* `favorite` — Mark a session as a favorite. With `session.favorites_first` on (the default), favorited rows pin to the top of their sibling scope in every sort order; with it off, they pin within their status tier in the Attention sort only. Either way the row renders with a leading `* ` glyph plus bold + underline wherever the pin applies. Snoozing a favorite suspends the pin until it wakes
+* `favorite` — Mark a session as a favorite. With `session.favorites_first` on (the default), favorited rows pin to the top of their sibling scope in every sort order; with it off, they pin within their status tier in the Attention sort only. Either way the row renders with a leading `*` marker plus bold and underline wherever the pin applies. Snoozing a favorite suspends the pin until it wakes
 * `unfavorite` — Clear the favorite flag on a session
 * `color` — Set (or clear) a per-session color label, rendered as a colored dot in the web sidebar for at-a-glance status signaling. Intended for a running agent to flag its own state, e.g. `aoe session color $(aoe session current -q) red`. Colors: `red` (needs attention), `amber` (working), `green` (done); `none` clears it
 * `archive` — Archive a session: sink it in the Attention sort and tear down its tmux sessions. Worktree, branch, container preserved. `--no-kill` skips tmux teardown. See #1868
@@ -578,7 +578,7 @@ Wake a snoozed session immediately
 
 ## `aoe session favorite`
 
-Mark a session as a favorite. With `session.favorites_first` on (the default), favorited rows pin to the top of their sibling scope in every sort order; with it off, they pin within their status tier in the Attention sort only. Either way the row renders with a leading `* ` glyph plus bold + underline wherever the pin applies. Snoozing a favorite suspends the pin until it wakes
+Mark a session as a favorite. With `session.favorites_first` on (the default), favorited rows pin to the top of their sibling scope in every sort order; with it off, they pin within their status tier in the Attention sort only. Either way the row renders with a leading `*` marker plus bold and underline wherever the pin applies. Snoozing a favorite suspends the pin until it wakes
 
 **Usage:** `aoe session favorite <IDENTIFIER>`
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -367,7 +367,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `set-base` — Set or clear the per-session diff base branch. The diff view compares the worktree against this ref instead of the auto-detected default. Useful when the PR target differs from the project default (stacked PRs, hotfix off `release/*`, renamed default branch). See #970
 * `snooze` — Snooze a session for a duration (temporary archive, auto wakes)
 * `unsnooze` — Wake a snoozed session immediately
-* `favorite` — Mark a session as a favorite. Favorited rows pin to the top of their status tier in the Attention sort and render with a leading `* ` glyph plus bold + underline
+* `favorite` — Mark a session as a favorite. With `session.favorites_first` on (the default), favorited rows pin to the top of their sibling scope in every sort order; with it off, they pin within their status tier in the Attention sort only. Either way the row renders with a leading `* ` glyph plus bold + underline wherever the pin applies. Snoozing a favorite suspends the pin until it wakes
 * `unfavorite` — Clear the favorite flag on a session
 * `color` — Set (or clear) a per-session color label, rendered as a colored dot in the web sidebar for at-a-glance status signaling. Intended for a running agent to flag its own state, e.g. `aoe session color $(aoe session current -q) red`. Colors: `red` (needs attention), `amber` (working), `green` (done); `none` clears it
 * `archive` — Archive a session: sink it in the Attention sort and tear down its tmux sessions. Worktree, branch, container preserved. `--no-kill` skips tmux teardown. See #1868
@@ -578,7 +578,7 @@ Wake a snoozed session immediately
 
 ## `aoe session favorite`
 
-Mark a session as a favorite. Favorited rows pin to the top of their status tier in the Attention sort and render with a leading `* ` glyph plus bold + underline
+Mark a session as a favorite. With `session.favorites_first` on (the default), favorited rows pin to the top of their sibling scope in every sort order; with it off, they pin within their status tier in the Attention sort only. Either way the row renders with a leading `* ` glyph plus bold + underline wherever the pin applies. Snoozing a favorite suspends the pin until it wakes
 
 **Usage:** `aoe session favorite <IDENTIFIER>`
 

--- a/docs/guides/web/dashboard.md
+++ b/docs/guides/web/dashboard.md
@@ -70,7 +70,7 @@ The choice is per-browser (localStorage). Collapse state is tracked separately p
 
 The right-click (long-press on touch) context menu on any session row exposes three triage primitives:
 
-- **Pin**: floats the workspace to the top in every sort mode. Pin is web-only and distinct from the favorite mark (a within-tier Attention signal on both surfaces). Renders as a pushpin glyph.
+- **Pin**: floats the workspace to the top in every sort mode. Pin is web-only and distinct from the favorite mark. On the web, favorite stays a within-tier Attention signal; in the TUI it pins to the top of its sibling scope in every sort order while `session.favorites_first` is on (the default). Renders as a pushpin glyph.
 - **Archive**: tears down every tmux session the workspace owns (agent, web terminal, container terminal, and tool sub-sessions; pass `kill_pane: false` in the API body, or `--no-kill` on the CLI, to skip the tmux teardown) and shuts down the structured-view worker for ACP sessions, then sinks the row into the collapsible "Snoozed & archived" footer. Sending a message wakes it back into the live list. Daemon restarts skip archived sessions. See #1868.
 - **Snooze**: sinks the row for a chosen duration (presets: 1h, 2h, 3h, 4h, 5h, 6h, 1d, 1w). Wakes when the timer expires; sending a message wakes it early.
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -55,9 +55,12 @@ pub enum SessionCommands {
     /// Wake a snoozed session immediately
     Unsnooze(SessionIdArgs),
 
-    /// Mark a session as a favorite. Favorited rows pin to the top of
-    /// their status tier in the Attention sort and render with a leading
-    /// `* ` glyph plus bold + underline.
+    /// Mark a session as a favorite. With `session.favorites_first` on (the
+    /// default), favorited rows pin to the top of their sibling scope in every
+    /// sort order; with it off, they pin within their status tier in the
+    /// Attention sort only. Either way the row renders with a leading `* `
+    /// glyph plus bold + underline wherever the pin applies. Snoozing a
+    /// favorite suspends the pin until it wakes.
     Favorite(SessionIdArgs),
 
     /// Clear the favorite flag on a session.

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -58,8 +58,8 @@ pub enum SessionCommands {
     /// Mark a session as a favorite. With `session.favorites_first` on (the
     /// default), favorited rows pin to the top of their sibling scope in every
     /// sort order; with it off, they pin within their status tier in the
-    /// Attention sort only. Either way the row renders with a leading `* `
-    /// glyph plus bold + underline wherever the pin applies. Snoozing a
+    /// Attention sort only. Either way the row renders with a leading `*`
+    /// marker plus bold and underline wherever the pin applies. Snoozing a
     /// favorite suspends the pin until it wakes.
     Favorite(SessionIdArgs),
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -728,6 +728,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // `push_enabled`, this is read once at startup; a config change needs a
     // restart to take effect. The TUI process maintains its own copy.
     crate::session::set_unread_enabled(config.session.unread_indicator);
+    crate::session::set_favorites_first(config.session.favorites_first);
 
     // Login sessions persist across daemon restarts by default (#1235) so
     // signed-in devices are not re-prompted for the passphrase on every

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1218,6 +1218,26 @@ pub struct SessionConfig {
     )]
     pub unread_indicator: bool,
 
+    /// Pin favorited sessions to the top of their sibling scope in every sort
+    /// order, not just Attention. A group holding a favorited session is
+    /// pinned the same way. When on (default), favoriting is a general "keep
+    /// this where I can find it" marker; when off, the star only biases the
+    /// Attention sort (its tier-local tiebreak) and the favorite key is inert
+    /// everywhere else, which is the pre-1.14 behavior.
+    ///
+    /// `global_only`: read through a single process-wide flag
+    /// (`crate::session::favorites_first`) on the sort hot path, so a
+    /// per-profile override could not be honored. Same reasoning as
+    /// `unread_indicator`.
+    #[serde(default = "default_true")]
+    #[setting(
+        label = "Favorites First",
+        widget = "toggle",
+        category = "Interaction",
+        global_only
+    )]
+    pub favorites_first: bool,
+
     /// Show occasional discovery tips: the `💡` badge in the footer, the
     /// browsable tips overlay, and the one-time earned pop. Turn this off to
     /// hide the badge and stop tips from popping; seen/earned state still lives
@@ -1428,6 +1448,7 @@ impl Default for SessionConfig {
             click_action: ClickAction::default(),
             confirm_before_quit: true,
             unread_indicator: true,
+            favorites_first: true,
             show_tips: true,
             tie_workdir_to_name: true,
         }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1219,11 +1219,14 @@ pub struct SessionConfig {
     pub unread_indicator: bool,
 
     /// Pin favorited sessions to the top of their sibling scope in every sort
-    /// order, not just Attention. A group holding a favorited session is
-    /// pinned the same way. When on (default), favoriting is a general "keep
-    /// this where I can find it" marker; when off, the star only biases the
-    /// Attention sort (its tier-local tiebreak) and the favorite key is inert
-    /// everywhere else, which is the pre-1.14 behavior.
+    /// order of the TUI session list, not just Attention. A group holding a
+    /// favorited session is pinned the same way. When on (default), favoriting
+    /// is a general "keep this where I can find it" marker; when off, the star
+    /// only biases the Attention sort (its tier-local tiebreak) and the
+    /// favorite key is inert everywhere else, which is the pre-1.14 behavior.
+    ///
+    /// Governs the TUI list only. The web dashboard keeps favorite as a
+    /// within-tier Attention signal and has its own pin control.
     ///
     /// `global_only`: read through a single process-wide flag
     /// (`crate::session::favorites_first`) on the sort hot path, so a

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -447,6 +447,24 @@ fn group_members<'a>(
     })
 }
 
+/// True for a favorited session that is not currently snoozed.
+///
+/// `Instance::snooze` deliberately leaves `favorited_at` intact (only
+/// `archive` clears it), so a snoozed row can still be a favorite. Snooze
+/// means "hide this from me for now", which outranks the favorite pin: the
+/// Attention sort encodes the same precedence by sinking snoozed rows to
+/// tier 99 before favorite is ever consulted.
+fn is_live_favorite(inst: &Instance) -> bool {
+    !inst.is_snoozed() && inst.is_favorited()
+}
+
+/// True when the group at `path` (including nested sub-groups) has at least
+/// one live favorited member. `group_members` already filters archived and
+/// trashed rows; [`is_live_favorite`] adds the snooze guard.
+fn has_live_favorite(path: &str, instances: &[Instance]) -> bool {
+    group_members(path, instances).any(is_live_favorite)
+}
+
 /// Get the most recent created_at among all sessions (direct and nested) in a group.
 /// Returns DateTime::MIN_UTC if the group has no sessions.
 fn max_created_at_in_group(path: &str, instances: &[Instance]) -> DateTime<Utc> {
@@ -684,10 +702,7 @@ fn attention_group_key(
     // Group-level favorite bias: within its min_tier bucket, a group with
     // any live favorited member pins above peers. Mirrors the session key's
     // tier-primary shape so favorite never promotes a group across tiers.
-    let favorite_bias = min_tier != 99
-        && members
-            .iter()
-            .any(|i| !i.is_archived() && !i.is_snoozed() && !i.is_trashed() && i.is_favorited());
+    let favorite_bias = min_tier != 99 && has_live_favorite(path, instances);
 
     if min_tier == 99 {
         // All members archived: sort archived block by latest archived_at.
@@ -2175,6 +2190,51 @@ mod tests {
             plain_key < fav_key,
             "plain+Waiting (tier 0) must sort above fav+Idle (tier 2): plain={plain_key:?} fav={fav_key:?}"
         );
+    }
+
+    #[test]
+    fn test_has_live_favorite_matches_inline_predicate() {
+        // A live favorited member => true.
+        let mut fav = Instance::new("fav", "/tmp/fav");
+        fav.group_path = "work".to_string();
+        fav.favorite();
+        assert!(has_live_favorite("work", std::slice::from_ref(&fav)));
+
+        // Not favorited => false.
+        let mut plain = Instance::new("plain", "/tmp/plain");
+        plain.group_path = "work".to_string();
+        assert!(!has_live_favorite("work", std::slice::from_ref(&plain)));
+
+        // A member of a nested sub-group counts for the parent group.
+        let mut nested = Instance::new("nested", "/tmp/nested");
+        nested.group_path = "work/frontend".to_string();
+        nested.favorite();
+        assert!(has_live_favorite("work", std::slice::from_ref(&nested)));
+
+        // A favorite in a different group has no effect here.
+        assert!(!has_live_favorite(
+            "personal",
+            std::slice::from_ref(&nested)
+        ));
+
+        // A snoozed favorite is not "live". `snooze` leaves `favorited_at`
+        // set, so the `!is_snoozed()` guard is what actually excludes it.
+        let mut snoozed = Instance::new("snoozed", "/tmp/snoozed");
+        snoozed.group_path = "work".to_string();
+        snoozed.favorite();
+        snoozed.snooze(60);
+        assert!(snoozed.is_favorited(), "snooze must not clear the star");
+        assert!(!has_live_favorite("work", std::slice::from_ref(&snoozed)));
+    }
+
+    #[test]
+    fn test_is_live_favorite_excludes_snoozed() {
+        let mut fav = Instance::new("fav", "/tmp/fav");
+        fav.favorite();
+        assert!(is_live_favorite(&fav));
+
+        fav.snooze(60);
+        assert!(!is_live_favorite(&fav), "snoozed favorite is not live");
     }
 
     #[test]

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -498,20 +498,25 @@ fn group_members<'a>(
     })
 }
 
-/// True for a favorited session that is not currently snoozed.
+/// True for a favorited session that is actively pinnable: not archived, not
+/// trashed, and not snoozed.
 ///
-/// `Instance::snooze` deliberately leaves `favorited_at` intact (only
-/// `archive` clears it), so a snoozed row can still be a favorite. Snooze
-/// means "hide this from me for now", which outranks the favorite pin: the
-/// Attention sort encodes the same precedence by sinking snoozed rows to
-/// tier 99 before favorite is ever consulted.
+/// `favorite()` and `archive()` are mutually exclusive today, so a favorited
+/// row is normally never archived. The archive/trash guards defend the direct
+/// callers (the sort pass and the row renderer's `ViewMode::Tool` arm, which
+/// does not pre-filter those states) against a legacy or hand-edited record
+/// that carries both. Snooze is different: `snooze()` deliberately leaves
+/// `favorited_at` intact, so "snoozed favorite" is a normal reachable state,
+/// and snooze outranks the pin, the Attention sort encodes the same precedence
+/// by sinking snoozed rows to tier 99 before favorite is ever consulted.
 pub(crate) fn is_live_favorite(inst: &Instance) -> bool {
-    !inst.is_snoozed() && inst.is_favorited()
+    !inst.is_archived() && !inst.is_trashed() && !inst.is_snoozed() && inst.is_favorited()
 }
 
 /// True when the group at `path` (including nested sub-groups) has at least
 /// one live favorited member. `group_members` already filters archived and
-/// trashed rows; [`is_live_favorite`] adds the snooze guard.
+/// trashed rows; [`is_live_favorite`] re-checks them so it is also sound for
+/// its direct callers.
 fn has_live_favorite(path: &str, instances: &[Instance]) -> bool {
     group_members(path, instances).any(is_live_favorite)
 }
@@ -2533,6 +2538,33 @@ mod tests {
 
         fav.snooze(60);
         assert!(!is_live_favorite(&fav), "snoozed favorite is not live");
+    }
+
+    /// `favorite()` and `archive()` clear each other, so an archived-or-trashed
+    /// favorite is only reachable via a legacy or hand-edited record. Build
+    /// those states directly: the helper must still reject them, since its
+    /// direct callers (the sort pass, the Tool-view renderer) do not pre-filter.
+    #[test]
+    fn test_is_live_favorite_excludes_archived_and_trashed() {
+        let now = chrono::Utc::now();
+
+        let mut archived = Instance::new("archived", "/tmp/a");
+        archived.favorited_at = Some(now);
+        archived.archived_at = Some(now);
+        assert!(archived.is_favorited() && archived.is_archived());
+        assert!(
+            !is_live_favorite(&archived),
+            "an archived favorite is not live"
+        );
+
+        let mut trashed = Instance::new("trashed", "/tmp/t");
+        trashed.favorited_at = Some(now);
+        trashed.trashed_at = Some(now);
+        assert!(trashed.is_favorited() && trashed.is_trashed());
+        assert!(
+            !is_live_favorite(&trashed),
+            "a trashed favorite is not live"
+        );
     }
 
     #[test]

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -438,6 +438,32 @@ fn sort_groups<T, N, P, A>(
     P: Fn(&T) -> &str,
     A: Fn(&T) -> Option<DateTime<Utc>>,
 {
+    sort_groups_inner(
+        items,
+        sort_order,
+        instances,
+        name,
+        path,
+        archived,
+        crate::session::favorites_first(),
+    );
+}
+
+/// Pure core of [`sort_groups`]. See [`sort_sessions_inner`] for why the
+/// favorites bias is a second stable pass and why the flag is a parameter.
+fn sort_groups_inner<T, N, P, A>(
+    items: &mut [T],
+    sort_order: SortOrder,
+    instances: &[Instance],
+    name: N,
+    path: P,
+    archived: A,
+    favorites_first: bool,
+) where
+    N: Fn(&T) -> &str,
+    P: Fn(&T) -> &str,
+    A: Fn(&T) -> Option<DateTime<Utc>>,
+{
     match sort_order {
         SortOrder::Oldest => {
             items.sort_by_key(|g| min_created_at_in_group(path(g), instances));
@@ -450,8 +476,12 @@ fn sort_groups<T, N, P, A>(
         }
         SortOrder::Attention => {
             items.sort_by_key(|g| attention_group_key(path(g), archived(g), instances));
+            return;
         }
         SortOrder::AZ | SortOrder::ZA => sort_by_name(items, sort_order, name),
+    }
+    if favorites_first {
+        items.sort_by_key(|g| !has_live_favorite(path(g), instances));
     }
 }
 
@@ -2326,6 +2356,82 @@ mod tests {
         assert_eq!(
             refs[0].title, "new_plain",
             "snoozed favorite must not pin: snooze outranks the star"
+        );
+    }
+
+    /// A group holding a favorited member outranks its sibling groups.
+    #[test]
+    fn test_favorites_first_pins_groups() {
+        // "old" holds an old favorite; "new" holds a recent non-favorite.
+        let mut old_fav = Instance::new("old_fav", "/tmp/of");
+        old_fav.group_path = "old".to_string();
+        old_fav.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        old_fav.favorite();
+
+        let mut new_plain = Instance::new("new_plain", "/tmp/np");
+        new_plain.group_path = "new".to_string();
+        new_plain.created_at = chrono::Utc::now();
+
+        let instances = vec![old_fav, new_plain];
+        let groups = vec![Group::new("old", "old"), Group::new("new", "new")];
+
+        // Feature off: Newest ordering puts "new" on top.
+        let mut items = groups.clone();
+        sort_groups_inner(
+            &mut items,
+            SortOrder::Newest,
+            &instances,
+            |g: &Group| g.name.as_str(),
+            |g: &Group| g.path.as_str(),
+            |_: &Group| None,
+            false,
+        );
+        assert_eq!(items[0].path, "new");
+
+        // Feature on: "old" wins because it holds a favorite.
+        let mut items = groups.clone();
+        sort_groups_inner(
+            &mut items,
+            SortOrder::Newest,
+            &instances,
+            |g: &Group| g.name.as_str(),
+            |g: &Group| g.path.as_str(),
+            |_: &Group| None,
+            true,
+        );
+        assert_eq!(items[0].path, "old");
+    }
+
+    /// A group whose only favorite is archived must not be promoted.
+    /// (`favorite()` clears `archived_at`, and `has_live_favorite` filters
+    /// archived rows, so neither path may pin the group.)
+    #[test]
+    fn test_favorites_first_ignores_archived_members() {
+        let mut archived_fav = Instance::new("archived_fav", "/tmp/af");
+        archived_fav.group_path = "old".to_string();
+        archived_fav.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        archived_fav.favorite();
+        archived_fav.archive();
+
+        let mut new_plain = Instance::new("new_plain", "/tmp/np");
+        new_plain.group_path = "new".to_string();
+        new_plain.created_at = chrono::Utc::now();
+
+        let instances = vec![archived_fav, new_plain];
+        let mut items = vec![Group::new("old", "old"), Group::new("new", "new")];
+
+        sort_groups_inner(
+            &mut items,
+            SortOrder::Newest,
+            &instances,
+            |g: &Group| g.name.as_str(),
+            |g: &Group| g.path.as_str(),
+            |_: &Group| None,
+            true,
+        );
+        assert_eq!(
+            items[0].path, "new",
+            "archived favorite must not pin its group"
         );
     }
 

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -390,14 +390,35 @@ where
     }
 }
 
-/// Sort a slice of session references by `sort_order`.
+/// Sort a slice of session references by `sort_order`, reading the
+/// favorites-first preference from config.
 fn sort_sessions(sessions: &mut [&Instance], sort_order: SortOrder) {
+    sort_sessions_inner(sessions, sort_order, crate::session::favorites_first());
+}
+
+/// Pure core of [`sort_sessions`]: takes the favorites-first flag explicitly so
+/// tests do not have to mutate the process-global atomic, which would race with
+/// tests running in parallel. Mirrors `attention_rank`'s shape.
+///
+/// Favorites are applied as a second stable pass rather than being folded into
+/// each mode's key tuple: `sort_by_key` is stable, so re-sorting by
+/// `!is_live_favorite` moves favorites to the front while preserving the mode's
+/// own ordering inside each partition. Attention opts out: favorite is already a
+/// within-tier tiebreak there, and promoting it would let a favorited Running
+/// row leap above a plain Waiting one.
+fn sort_sessions_inner(sessions: &mut [&Instance], sort_order: SortOrder, favorites_first: bool) {
     match sort_order {
         SortOrder::Oldest => sessions.sort_by_key(|i| i.created_at),
         SortOrder::Newest => sessions.sort_by_key(|i| Reverse(i.created_at)),
         SortOrder::LastActivity => sessions.sort_by_key(|i| last_activity_session_key(i)),
-        SortOrder::Attention => sessions.sort_by_key(|i| attention_session_key(i)),
+        SortOrder::Attention => {
+            sessions.sort_by_key(|i| attention_session_key(i));
+            return;
+        }
         SortOrder::AZ | SortOrder::ZA => sort_by_name(sessions, sort_order, |i| &i.title),
+    }
+    if favorites_first {
+        sessions.sort_by_key(|i| !is_live_favorite(i));
     }
 }
 
@@ -2225,6 +2246,110 @@ mod tests {
         snoozed.snooze(60);
         assert!(snoozed.is_favorited(), "snooze must not clear the star");
         assert!(!has_live_favorite("work", std::slice::from_ref(&snoozed)));
+    }
+
+    /// In the Newest sort, an old favorite outranks a newer non-favorite.
+    #[test]
+    fn test_favorites_first_pins_in_newest_sort() {
+        let mut old_fav = Instance::new("old_fav", "/tmp/of");
+        old_fav.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        old_fav.favorite();
+        let mut new_plain = Instance::new("new_plain", "/tmp/np");
+        new_plain.created_at = chrono::Utc::now();
+
+        let instances = vec![old_fav, new_plain];
+
+        // Feature off: plain newest-first, unchanged behavior.
+        let mut refs: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut refs, SortOrder::Newest, false);
+        assert_eq!(refs[0].title, "new_plain");
+
+        // Feature on: the favorite floats to the top.
+        let mut refs: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut refs, SortOrder::Newest, true);
+        assert_eq!(refs[0].title, "old_fav");
+        assert_eq!(refs[1].title, "new_plain");
+    }
+
+    /// Favorites keep the mode's own ordering among themselves (stable sort).
+    #[test]
+    fn test_favorites_first_preserves_order_within_favorites() {
+        let mut fav_old = Instance::new("fav_old", "/tmp/fo");
+        fav_old.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        fav_old.favorite();
+        let mut fav_new = Instance::new("fav_new", "/tmp/fnew");
+        fav_new.created_at = chrono::Utc::now();
+        fav_new.favorite();
+        let plain = Instance::new("plain", "/tmp/p");
+
+        let instances = vec![fav_old, fav_new, plain];
+        let mut refs: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut refs, SortOrder::Newest, true);
+
+        assert_eq!(refs[0].title, "fav_new");
+        assert_eq!(refs[1].title, "fav_old");
+        assert_eq!(refs[2].title, "plain");
+    }
+
+    /// The same holds for the AZ sort.
+    #[test]
+    fn test_favorites_first_pins_in_az_sort() {
+        let mut z_fav = Instance::new("zebra", "/tmp/z");
+        z_fav.favorite();
+        let a_plain = Instance::new("apple", "/tmp/a");
+
+        let instances = vec![z_fav, a_plain];
+
+        let mut refs: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut refs, SortOrder::AZ, true);
+        assert_eq!(refs[0].title, "zebra");
+
+        let mut refs: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut refs, SortOrder::AZ, false);
+        assert_eq!(refs[0].title, "apple");
+    }
+
+    /// A snoozed favorite must not be pinned to the top.
+    #[test]
+    fn test_favorites_first_ignores_snoozed_favorite() {
+        let mut snoozed_fav = Instance::new("snoozed_fav", "/tmp/sf");
+        snoozed_fav.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        snoozed_fav.favorite();
+        snoozed_fav.snooze(60);
+        let mut new_plain = Instance::new("new_plain", "/tmp/np");
+        new_plain.created_at = chrono::Utc::now();
+
+        let instances = vec![snoozed_fav, new_plain];
+        let mut refs: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut refs, SortOrder::Newest, true);
+
+        assert_eq!(
+            refs[0].title, "new_plain",
+            "snoozed favorite must not pin: snooze outranks the star"
+        );
+    }
+
+    /// The Attention sort produces the same order regardless of the flag.
+    #[test]
+    fn test_favorites_first_does_not_change_attention_sort() {
+        let mut fav_idle = Instance::new("fav_idle", "/tmp/fi");
+        fav_idle.status = crate::session::Status::Idle;
+        fav_idle.favorite();
+        let mut plain_waiting = Instance::new("plain_waiting", "/tmp/pw");
+        plain_waiting.status = crate::session::Status::Waiting;
+
+        let instances = vec![fav_idle, plain_waiting];
+
+        let mut on: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut on, SortOrder::Attention, true);
+        let mut off: Vec<&Instance> = instances.iter().collect();
+        sort_sessions_inner(&mut off, SortOrder::Attention, false);
+
+        let on_titles: Vec<&str> = on.iter().map(|i| i.title.as_str()).collect();
+        let off_titles: Vec<&str> = off.iter().map(|i| i.title.as_str()).collect();
+        assert_eq!(on_titles, off_titles, "Attention sort must ignore the flag");
+        // Tier stays primary, so Waiting is still on top.
+        assert_eq!(on_titles[0], "plain_waiting");
     }
 
     #[test]

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -861,6 +861,14 @@ pub fn flatten_tree_all_profiles(
             sort_by_name(&mut all_roots, sort_order, |(_, g, _)| &*g.name)
         }
     }
+    // Favorites-first second pass, matching `sort_groups_inner`. This path
+    // cannot call that helper because each root carries its own per-profile
+    // instances rather than sharing one slice. Attention is excluded there and
+    // here alike: `attention_group_key` already folds the favorite bias in at
+    // its tier-local position.
+    if sort_order != SortOrder::Attention && crate::session::favorites_first() {
+        all_roots.sort_by_key(|(_, g, insts)| !has_live_favorite(&g.path, insts));
+    }
 
     for (profile_name, root, profile_instances) in &all_roots {
         flatten_group(
@@ -2400,6 +2408,65 @@ mod tests {
             true,
         );
         assert_eq!(items[0].path, "old");
+    }
+
+    /// The all-profiles view orders its root groups with its own inline pass
+    /// (each root carries per-profile instances), so the favorites bias needs
+    /// coverage here too. Serial: this path reads the process-wide flag.
+    #[test]
+    #[serial_test::serial]
+    fn test_favorites_first_pins_root_groups_across_profiles() {
+        let original = crate::session::favorites_first();
+
+        let mut old_fav = Instance::new("old_fav", "/tmp/of");
+        old_fav.source_profile = "p1".to_string();
+        old_fav.group_path = "old".to_string();
+        old_fav.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        old_fav.favorite();
+
+        let mut new_plain = Instance::new("new_plain", "/tmp/np");
+        new_plain.source_profile = "p2".to_string();
+        new_plain.group_path = "new".to_string();
+        new_plain.created_at = chrono::Utc::now();
+
+        let mut trees = std::collections::HashMap::new();
+        trees.insert(
+            "p1".to_string(),
+            GroupTree::new_with_groups(std::slice::from_ref(&old_fav), &[]),
+        );
+        trees.insert(
+            "p2".to_string(),
+            GroupTree::new_with_groups(std::slice::from_ref(&new_plain), &[]),
+        );
+        let instances = vec![old_fav, new_plain];
+
+        let first_group = |items: &[Item]| {
+            items
+                .iter()
+                .find_map(|i| match i {
+                    Item::Group { path, .. } => Some(path.clone()),
+                    _ => None,
+                })
+                .expect("a group item is present")
+        };
+
+        crate::session::set_favorites_first(false);
+        let items = flatten_tree_all_profiles(&instances, &trees, SortOrder::Newest);
+        assert_eq!(
+            first_group(&items),
+            "new",
+            "flag off: plain Newest puts the recent group first"
+        );
+
+        crate::session::set_favorites_first(true);
+        let items = flatten_tree_all_profiles(&instances, &trees, SortOrder::Newest);
+        assert_eq!(
+            first_group(&items),
+            "old",
+            "flag on: the group holding the favorite pins to the top"
+        );
+
+        crate::session::set_favorites_first(original);
     }
 
     /// A group whose only favorite is archived must not be promoted.

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -505,7 +505,7 @@ fn group_members<'a>(
 /// means "hide this from me for now", which outranks the favorite pin: the
 /// Attention sort encodes the same precedence by sinking snoozed rows to
 /// tier 99 before favorite is ever consulted.
-fn is_live_favorite(inst: &Instance) -> bool {
+pub(crate) fn is_live_favorite(inst: &Instance) -> bool {
     !inst.is_snoozed() && inst.is_favorited()
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -94,6 +94,23 @@ pub fn set_unread_enabled(on: bool) {
     UNREAD_ENABLED.store(on, Ordering::Relaxed);
 }
 
+/// Process-wide cache of the `session.favorites_first` toggle (default on).
+/// Refreshed alongside [`set_unread_enabled`] whenever config is applied.
+/// Read on every sort pass, so it is an atomic load rather than a parameter
+/// threaded through the sort helpers.
+static FAVORITES_FIRST: AtomicBool = AtomicBool::new(true);
+
+/// Whether favorited rows pin to the top of their sibling scope outside the
+/// Attention sort.
+pub fn favorites_first() -> bool {
+    FAVORITES_FIRST.load(Ordering::Relaxed)
+}
+
+/// Update the cached favorites-first flag from resolved config.
+pub fn set_favorites_first(on: bool) {
+    FAVORITES_FIRST.store(on, Ordering::Relaxed);
+}
+
 pub use profile_config::{
     load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,
     save_profile_config, validate_check_interval, validate_env_format, validate_memory_limit,
@@ -750,6 +767,28 @@ pub fn is_tui_active(threshold: Duration) -> bool {
 mod tests {
     use super::test_support::isolate_app_dir;
     use super::*;
+
+    /// Serial because the flag is process-wide: any test that applies config
+    /// writes it too, so a parallel run would see a foreign value.
+    #[test]
+    #[serial_test::serial]
+    fn favorites_first_flag_round_trips() {
+        let original = favorites_first();
+
+        set_favorites_first(false);
+        assert!(!favorites_first());
+        set_favorites_first(true);
+        assert!(favorites_first());
+
+        set_favorites_first(original);
+    }
+
+    /// The shipped default is on; the atomic's initial value only matters
+    /// before the first config apply, so assert the config default itself.
+    #[test]
+    fn favorites_first_defaults_on() {
+        assert!(config::SessionConfig::default().favorites_first);
+    }
 
     fn app_dir(root: impl AsRef<Path>) -> PathBuf {
         let root = root.as_ref();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -57,6 +57,9 @@ pub use config::{
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};
 pub use fork::{ForkDenied, ForkSeed};
+/// Shared by the sorter and the row renderer so a row is decorated as a
+/// favorite exactly when it is pinned as one.
+pub(crate) use groups::is_live_favorite;
 pub use groups::{
     append_archived_section, append_archived_section_by_project, append_trash_section,
     archived_project_sub_path, flatten_sessions_by_attention, flatten_tree,

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -209,8 +209,8 @@ static CATALOG: &[Tip] = &[
         id: "tui-triage",
         title: "Triage from the keyboard",
         body: "Cycle the sort with {sort} and grouping with {group}, and archive a session \
-               with {archive}. In Attention sort, snooze with {snooze} or favorite with \
-               {favorite}.",
+               with {archive}. Favorite with {favorite} to pin a session to the top of its \
+               group. In Attention sort, snooze with {snooze}.",
         trigger: TipTrigger::Rotation,
         surfaces: &[TipSurface::Tui],
     },

--- a/src/tips.rs
+++ b/src/tips.rs
@@ -209,8 +209,8 @@ static CATALOG: &[Tip] = &[
         id: "tui-triage",
         title: "Triage from the keyboard",
         body: "Cycle the sort with {sort} and grouping with {group}, and archive a session \
-               with {archive}. Favorite with {favorite} to pin a session to the top of its \
-               group. In Attention sort, snooze with {snooze}.",
+               with {archive}. Favorite with {favorite} to keep a session within reach; in \
+               Attention sort, snooze with {snooze}.",
         trigger: TipTrigger::Rotation,
         surfaces: &[TipSurface::Tui],
     },

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -128,7 +128,10 @@ fn shortcuts(strict: bool, live_on_enter: bool) -> Vec<(&'static str, Vec<(Strin
     vec![
         ("Navigation", navigation),
         (actions_title, actions_rows),
-        ("Attention (Attention sort only, except Archive)", attention),
+        (
+            "Attention (Attention sort only, except Archive and Favorite)",
+            attention,
+        ),
         ("Views", views),
         ("Other", other),
     ]

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -125,13 +125,18 @@ fn shortcuts(strict: bool, live_on_enter: bool) -> Vec<(&'static str, Vec<(Strin
     } else {
         "Actions"
     };
+    // Favorite is an Attention-section shortcut, but it also works outside the
+    // Attention sort while `favorites_first` is on, so the heading lists it as
+    // an exception only then. Archive is always an exception.
+    let attention_title = if crate::session::favorites_first() {
+        "Attention (Attention sort only, except Archive and Favorite)"
+    } else {
+        "Attention (Attention sort only, except Archive)"
+    };
     vec![
         ("Navigation", navigation),
         (actions_title, actions_rows),
-        (
-            "Attention (Attention sort only, except Archive and Favorite)",
-            attention,
-        ),
+        (attention_title, attention),
         ("Views", views),
         ("Other", other),
     ]

--- a/src/tui/home/bindings.rs
+++ b/src/tui/home/bindings.rs
@@ -117,6 +117,11 @@ pub enum Context {
     Always,
     TerminalView,
     AttentionSort,
+    /// Favorites are actionable: either the Attention sort is active, where
+    /// favorite is a within-tier tiebreak, or `session.favorites_first` is on,
+    /// where it pins in every sort order. With neither, toggling a favorite
+    /// would have no visible effect, so the key stays inert.
+    FavoritesUsable,
     SearchActive,
     /// The cursor is on a real (non-synthetic) project header in project view.
     ProjectGroupSelected,
@@ -180,6 +185,9 @@ fn context_holds(context: Context, ctx: &Ctx) -> bool {
         Context::Always => true,
         Context::TerminalView => ctx.view_mode == ViewMode::Terminal,
         Context::AttentionSort => ctx.sort_order == SortOrder::Attention,
+        Context::FavoritesUsable => {
+            ctx.sort_order == SortOrder::Attention || crate::session::favorites_first()
+        }
         Context::SearchActive => ctx.has_search,
         Context::ProjectGroupSelected => ctx.project_group_selected,
         Context::UnreadEnabled => crate::session::unread_enabled(),
@@ -372,10 +380,10 @@ pub static BINDINGS: &[Binding] = &[
         id: ActionId::ToggleFavorite,
         non_strict: &[k('f')],
         strict: &[k('F')],
-        context: Context::AttentionSort,
+        context: Context::FavoritesUsable,
         help: Some(HelpMeta {
             section: HelpSection::Attention,
-            desc: "Toggle favorite (Attention sort)",
+            desc: "Toggle favorite (pin to top)",
         }),
         palette: Some(PaletteMeta {
             title: "Toggle favorite",
@@ -981,6 +989,52 @@ mod tests {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
     }
 
+    /// Serial: the favorites-first gate is a process-wide flag, so a parallel
+    /// test that applies config would race with these.
+    #[test]
+    #[serial_test::serial]
+    fn favorite_key_follows_favorites_first_outside_attention() {
+        let original = crate::session::favorites_first();
+        let c = ctx();
+        assert_eq!(
+            c.sort_order,
+            SortOrder::Newest,
+            "precondition: not Attention"
+        );
+
+        crate::session::set_favorites_first(true);
+        assert_eq!(
+            resolve(&key('f'), false, &c),
+            Some(ActionId::ToggleFavorite),
+            "favorites-first on: 'f' must work outside the Attention sort"
+        );
+
+        crate::session::set_favorites_first(false);
+        assert_ne!(
+            resolve(&key('f'), false, &c),
+            Some(ActionId::ToggleFavorite),
+            "favorites-first off: 'f' stays inert outside the Attention sort"
+        );
+
+        crate::session::set_favorites_first(original);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn favorite_key_resolves_in_attention_sort_even_with_flag_off() {
+        let original = crate::session::favorites_first();
+        crate::session::set_favorites_first(false);
+
+        let mut c = ctx();
+        c.sort_order = SortOrder::Attention;
+        assert_eq!(
+            resolve(&key('f'), false, &c),
+            Some(ActionId::ToggleFavorite)
+        );
+
+        crate::session::set_favorites_first(original);
+    }
+
     #[test]
     fn parse_chord_handles_modifiers_and_keys() {
         assert_eq!(
@@ -1201,16 +1255,27 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn context_guards_gate_attention_and_terminal_actions() {
-        // Favorite/snooze only resolve in Attention sort.
+        // Snooze only resolves in the Attention sort. Favorite resolves there
+        // too, but it has a second opening (`session.favorites_first`), so pin
+        // that off to isolate the Attention-only half of its guard; the flag
+        // itself is covered by
+        // `favorite_key_follows_favorites_first_outside_attention`.
+        let original = crate::session::favorites_first();
+        crate::session::set_favorites_first(false);
+
         let mut c = ctx();
         assert_eq!(resolve(&key('f'), false, &c), None);
+        assert_eq!(resolve(&key('h'), false, &c), None);
         c.sort_order = SortOrder::Attention;
         assert_eq!(
             resolve(&key('f'), false, &c),
             Some(ActionId::ToggleFavorite)
         );
         assert_eq!(resolve(&key('h'), false, &c), Some(ActionId::ToggleSnooze));
+
+        crate::session::set_favorites_first(original);
 
         // Container toggle only resolves in Terminal view.
         let mut c = ctx();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2056,6 +2056,7 @@ impl HomeView {
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
         crate::session::set_unread_enabled(resolved.session.unread_indicator);
+        crate::session::set_favorites_first(resolved.session.favorites_first);
         let user_config = load_config().ok().flatten();
         let sort_order = user_config
             .as_ref()
@@ -6715,6 +6716,7 @@ impl HomeView {
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
         crate::session::set_unread_enabled(config.session.unread_indicator);
+        crate::session::set_favorites_first(config.session.favorites_first);
         self.tips_unseen = tips_unseen_count(&config);
         self.tool_configs = config.tools;
         self.tool_hotkey_cache = input::build_tool_hotkey_cache(&self.tool_configs);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1371,6 +1371,11 @@ impl HomeView {
         // the dedicated bottom-pinned "Archived" section regardless of
         // sort mode.
         let in_attention = self.sort_order == SortOrder::Attention;
+        // Favorite is a pin in every sort order once favorites-first is on, so
+        // its decoration follows the same predicate as the keybinding
+        // (`Context::FavoritesUsable`). Snooze and urgent stay Attention-only:
+        // both are tied to the tier model, which only exists there.
+        let show_favorite = in_attention || crate::session::favorites_first();
 
         use std::borrow::Cow;
 
@@ -1562,26 +1567,26 @@ impl HomeView {
                                     .fg(theme.error)
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::RAPID_BLINK);
-                            } else if in_attention && inst.is_favorited() {
-                                // Favorite decoration is Attention-only,
-                                // since favorites are within-tier pins.
+                            } else if show_favorite && crate::session::is_live_favorite(inst) {
                                 style = style
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::UNDERLINED);
                             }
                             // Prefix priority: archive (no prefix) wins
                             // over snooze (`z `) wins over urgent (`! `)
-                            // wins over favorite (`* `). All three
-                            // prefixes are Attention-mode-only so users
-                            // in Newest / AZ / etc. don't see decoration
-                            // for state they didn't opt into managing.
+                            // wins over favorite (`* `). Snooze and urgent
+                            // are Attention-mode-only so users in Newest /
+                            // AZ / etc. don't see decoration for state they
+                            // didn't opt into managing; the favorite star
+                            // also shows elsewhere, because favorites-first
+                            // pins the row there too.
                             let title_text = if inst.is_archived() || inst.is_trashed() {
                                 Cow::Owned(inst.title.clone())
                             } else if in_attention && inst.is_snoozed() {
                                 Cow::Owned(format!("z {}", inst.title))
                             } else if in_attention && inst.is_urgent() {
                                 Cow::Owned(format!("! {}", inst.title))
-                            } else if in_attention && inst.is_favorited() {
+                            } else if show_favorite && crate::session::is_live_favorite(inst) {
                                 Cow::Owned(format!("* {}", inst.title))
                             } else {
                                 Cow::Owned(inst.title.clone())
@@ -1634,7 +1639,7 @@ impl HomeView {
                                     .fg(theme.error)
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::RAPID_BLINK);
-                            } else if in_attention && inst.is_favorited() {
+                            } else if show_favorite && crate::session::is_live_favorite(inst) {
                                 style = style
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::UNDERLINED);
@@ -1645,7 +1650,7 @@ impl HomeView {
                                 Cow::Owned(format!("z {}", inst.title))
                             } else if in_attention && inst.is_urgent() {
                                 Cow::Owned(format!("! {}", inst.title))
-                            } else if in_attention && inst.is_favorited() {
+                            } else if show_favorite && crate::session::is_live_favorite(inst) {
                                 Cow::Owned(format!("* {}", inst.title))
                             } else {
                                 Cow::Owned(inst.title.clone())

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1667,8 +1667,17 @@ impl HomeView {
                             } else {
                                 (ICON_IDLE, theme.dimmed)
                             };
-                            let style = Style::default().fg(color);
-                            (icon, Cow::Owned(inst.title.clone()), style)
+                            let mut style = Style::default().fg(color);
+                            let title_text =
+                                if show_favorite && crate::session::is_live_favorite(inst) {
+                                    style = style
+                                        .add_modifier(ratatui::style::Modifier::BOLD)
+                                        .add_modifier(ratatui::style::Modifier::UNDERLINED);
+                                    Cow::Owned(format!("* {}", inst.title))
+                                } else {
+                                    Cow::Owned(inst.title.clone())
+                                };
+                            (icon, title_text, style)
                         }
                     }
                 } else {
@@ -3761,11 +3770,11 @@ impl HomeView {
                 mk(if strict { "D" } else { "d" }, "Del"),
             ));
         }
-        // Attention-workflow shortcuts (Archive / Fav / Snooze) only render
-        // when the user is in Attention sort. They are only useful for
-        // shaping the Attention queue; in Newest / Created / Last Accessed
-        // they just take footer space without changing what the user sees.
-        if self.sort_order == SortOrder::Attention {
+        // Archive / Snooze only render in Attention sort: they shape the
+        // Attention queue and do nothing visible in Newest / Created / Last
+        // Accessed, so they would just take footer space there.
+        let in_attention = self.sort_order == SortOrder::Attention;
+        if in_attention {
             if !self.flat_items.is_empty() {
                 groups.push((
                     1,
@@ -3776,15 +3785,20 @@ impl HomeView {
             if self.selected_session.is_some() {
                 groups.push((
                     1,
-                    kc(if strict { 'F' } else { 'f' }),
-                    mk(if strict { "F" } else { "f" }, "Fav"),
-                ));
-                groups.push((
-                    1,
                     kc(if strict { 'H' } else { 'h' }),
                     mk(if strict { "H" } else { "h" }, "Snooze"),
                 ));
             }
+        }
+        // Fav follows the key's own gate (`Context::FavoritesUsable`): usable in
+        // Attention, or in any sort order while `favorites_first` is on, so the
+        // footer advertises it wherever `f` actually does something.
+        if self.selected_session.is_some() && (in_attention || crate::session::favorites_first()) {
+            groups.push((
+                1,
+                kc(if strict { 'F' } else { 'f' }),
+                mk(if strict { "F" } else { "f" }, "Fav"),
+            ));
         }
 
         // Committed-search cue: spell out that `n` cycles matches and `Esc`

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7866,7 +7866,7 @@ fn footer_hides_attention_workflow_hints_outside_attention_sort() {
     };
 
     // Newest sort with favorites-first OFF: no attention-workflow shortcuts,
-    // Fav included, because `f` is inert here.
+    // Fav excluded, because `f` is inert here.
     crate::session::set_favorites_first(false);
     env.view.sort_order = SortOrder::Newest;
     let newest_off = render_footer(&mut env);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7827,10 +7827,12 @@ fn pollable_instances_recovers_after_inflight_clear() {
     assert_eq!(env.view.pollable_instances().len(), 1);
 }
 
-/// Footer hides Archive/Fav/Snooze hints unless `sort_order` is Attention.
-/// The underlying keybinds still work in any mode; only the discoverability
-/// hints in `render_status_bar` adapt so the footer doesn't waste width on
-/// shortcuts that don't visibly reorder the list in Newest/Created/LastAccessed.
+/// Footer discoverability hints track where each key actually does something.
+/// Archive/Snooze are Attention-only. Fav follows its keybind's own gate
+/// (`Context::FavoritesUsable`): usable in Attention, or in any sort order
+/// while `favorites_first` is on. The underlying keybinds are unchanged; only
+/// the footer adapts so it doesn't waste width on a shortcut that would not
+/// visibly do anything.
 #[test]
 #[serial]
 fn footer_hides_attention_workflow_hints_outside_attention_sort() {
@@ -7840,6 +7842,7 @@ fn footer_hides_attention_workflow_hints_outside_attention_sort() {
     use ratatui::Terminal;
 
     let mut env = create_test_env_with_sessions(1);
+    let original = crate::session::favorites_first();
     let theme = load_theme("empire");
 
     let render_footer = |env: &mut TestEnv| -> String {
@@ -7862,37 +7865,44 @@ fn footer_hides_attention_workflow_hints_outside_attention_sort() {
         out
     };
 
-    // Newest sort: footer should NOT advertise attention-workflow shortcuts.
+    // Newest sort with favorites-first OFF: no attention-workflow shortcuts,
+    // Fav included, because `f` is inert here.
+    crate::session::set_favorites_first(false);
     env.view.sort_order = SortOrder::Newest;
-    let newest_out = render_footer(&mut env);
-    assert!(
-        !newest_out.contains("Snooze"),
-        "Snooze hint should be hidden in Newest sort.\n{newest_out}"
-    );
-    assert!(
-        !newest_out.contains("Fav"),
-        "Fav hint should be hidden in Newest sort.\n{newest_out}"
-    );
-    assert!(
-        !newest_out.contains("Archive"),
-        "Archive hint should be hidden in Newest sort.\n{newest_out}"
-    );
+    let newest_off = render_footer(&mut env);
+    for hint in ["Snooze", "Fav", "Archive"] {
+        assert!(
+            !newest_off.contains(hint),
+            "{hint} hint should be hidden in Newest sort with favorites-first off.\n{newest_off}"
+        );
+    }
 
-    // Attention sort: footer should advertise them.
+    // Newest sort with favorites-first ON: Fav is advertised because `f` pins
+    // here, but Archive/Snooze stay Attention-only.
+    crate::session::set_favorites_first(true);
+    let newest_on = render_footer(&mut env);
+    assert!(
+        newest_on.contains("Fav"),
+        "Fav hint should appear in Newest sort with favorites-first on.\n{newest_on}"
+    );
+    for hint in ["Snooze", "Archive"] {
+        assert!(
+            !newest_on.contains(hint),
+            "{hint} hint should stay hidden outside Attention sort.\n{newest_on}"
+        );
+    }
+
+    // Attention sort: footer advertises all three regardless of the flag.
     env.view.sort_order = SortOrder::Attention;
     let attention_out = render_footer(&mut env);
-    assert!(
-        attention_out.contains("Snooze"),
-        "Snooze hint should appear in Attention sort.\n{attention_out}"
-    );
-    assert!(
-        attention_out.contains("Fav"),
-        "Fav hint should appear in Attention sort.\n{attention_out}"
-    );
-    assert!(
-        attention_out.contains("Archive"),
-        "Archive hint should appear in Attention sort.\n{attention_out}"
-    );
+    for hint in ["Snooze", "Fav", "Archive"] {
+        assert!(
+            attention_out.contains(hint),
+            "{hint} hint should appear in Attention sort.\n{attention_out}"
+        );
+    }
+
+    crate::session::set_favorites_first(original);
 }
 
 /// `toggle_favorite_at_cursor` flips the cursor's instance favorited state

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -10692,19 +10692,27 @@ fn prune_empty_group_survives_save_and_reload() {
 }
 
 /// Favorite, snooze, and urgent decorations only render in Attention sort.
-/// In Newest (or any other sort), the row paints with its plain title and
-/// status-driven color even when the flags are set, so users who don't
-/// triage in Attention don't see decoration for state they didn't opt into
-/// managing.
+/// With `session.favorites_first` off, the star is Attention-only: in Newest
+/// (or any other sort) the row paints with its plain title and status-driven
+/// color even when the flag is set, so users who don't triage in Attention
+/// don't see decoration for state they didn't opt into managing.
+///
+/// The flag-on case is `favorite_decoration_shows_outside_attention_when_favorites_first`.
 #[test]
 #[serial]
 fn favorite_decoration_gated_to_attention_sort() {
     use crate::session::config::SortOrder;
 
+    let original = crate::session::favorites_first();
+
     let mut env = create_test_env_with_sessions(1);
     let id = env.view.instance_at(0).id.clone();
     let title = env.view.instance_at(0).title.clone();
     env.view.mutate_instance(&id, |inst| inst.favorite());
+
+    // After the env is built: constructing it applies config, which resets the
+    // process-wide flag to the shipped default (on).
+    crate::session::set_favorites_first(false);
 
     // In Newest: row should NOT have the `* ` prefix or the bold/
     // underlined favorite styling.
@@ -10745,6 +10753,65 @@ fn favorite_decoration_gated_to_attention_sort() {
         "favorite prefix must surface in Attention sort; got: {:?}",
         text_attention
     );
+
+    crate::session::set_favorites_first(original);
+}
+
+/// With favorites-first on (the default), the star follows the pin: a
+/// favorited row shows it in Newest too, because it is pinned there.
+/// A snoozed favorite is not pinned, so it must not be decorated either.
+#[test]
+#[serial]
+fn favorite_decoration_shows_outside_attention_when_favorites_first() {
+    use crate::session::config::SortOrder;
+
+    let original = crate::session::favorites_first();
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instance_at(0).id.clone();
+    let title = env.view.instance_at(0).title.clone();
+    env.view.mutate_instance(&id, |inst| inst.favorite());
+
+    // Set after the env is built: constructing it applies config, which would
+    // overwrite the flag.
+    crate::session::set_favorites_first(true);
+
+    env.view.sort_order = SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
+    let row = |view: &HomeView, id: &str| {
+        let item = view
+            .flat_items
+            .iter()
+            .find(|i| matches!(i, Item::Session { id: sid, .. } if sid == id))
+            .cloned()
+            .expect("session item present");
+        rendered_row_text(view, &item)
+    };
+
+    let text = row(&env.view, &id);
+    assert!(
+        text.contains("* "),
+        "favorite prefix must show in Newest when favorites-first is on; got: {:?}",
+        text
+    );
+    assert!(
+        text.contains(&title),
+        "row title must still render; got: {:?}",
+        text
+    );
+
+    // Snooze outranks the star: the row is no longer pinned, so it must not
+    // be decorated as a favorite either.
+    env.view.mutate_instance(&id, |inst| inst.snooze(30));
+    env.view.flat_items = env.view.build_flat_items();
+    let text_snoozed = row(&env.view, &id);
+    assert!(
+        !text_snoozed.contains("* "),
+        "a snoozed favorite is not pinned, so it must not show the star; got: {:?}",
+        text_snoozed
+    );
+
+    crate::session::set_favorites_first(original);
 }
 
 /// Snoozed rows: prefix and remaining-time column only appear in Attention


### PR DESCRIPTION
## Description

Favorites already exist, but the star only does anything in the `Attention` sort: it biases
`attention_session_key` / `attention_group_key` within a status tier, the `f` binding is gated on
`Context::AttentionSort`, and the `* ` prefix is gated on `in_attention`. In every other sort order
the flag persists silently, the key is inert, and nothing renders.

That leaves no way to keep a session where you can find it in the sort orders people actually leave
the list in. Attention is a triage view whose order moves on its own as statuses change, and
favorite sits third in its key (behind urgent and the status tier), so it does not pin to the top
there either.

This makes a favorited session, and a group holding one, pin to the top of its sibling scope in
every sort order, behind a new `session.favorites_first` toggle that defaults to on.

No new persisted state: this reuses `favorited_at`, so there is no format change and no migration.
The mechanism is a second stable pass. `sort_by_key` is stable, so each mode sorts exactly as before
and then a `!is_live_favorite` pass partitions favorites to the front, preserving the mode's own
ordering inside both partitions. That is equivalent to prepending the bool to each mode's key tuple,
without touching five key types.

**`Attention` is deliberately untouched.** Both sort helpers return from the Attention arm before the
favorites pass, and `attention_session_key` is unmodified, so a favorited `Running` row still never
leaps above a plain `Waiting` one. A test asserts the flag makes no difference there.

**Snooze outranks the star.** `snooze()` leaves `favorited_at` set (only `archive()` clears it), so
"snoozed favorite" is a reachable state. Sorting, the key gate, and the decoration all go through one
`is_live_favorite` predicate, so a snoozed favorite is not pinned and does not render a star. Without
that shared predicate the row would have worn a star while sorting like an ordinary row.

Commits are split so each is reviewable on its own: a pure refactor, the config field, session
sorting, group sorting, the keybinding, the decoration, then a fix plus copy refresh.

### Decisions worth a reviewer's opinion

- **Default on.** A user who has never favorited anything sees zero change (every row's bool is
  equal, so the pass is a no-op), and a user who has favorited something has already expressed the
  intent. Happy to flip it to opt-in if you would rather ship it dark.
- **TUI only.** The web sidebar keeps favorite as a within-tier Attention signal and has its own Pin
  control, so this does not touch web ordering. The setting is still web-writable, matching
  `strict_hotkeys` / `click_action` / `confirm_before_quit` which are also TUI-only in effect; its
  description says it governs the TUI list so the dashboard toggle is not silently inert.
- **Groups pin without a marker.** A group can float up because a nested member is favorited, with no
  glyph on the group row explaining why. Decoration stayed scoped to sessions; say the word if you
  want a marker on the header too.
- **Perf shape.** The new group pass uses `sort_by_key`, which re-runs the key on every comparison,
  and `has_live_favorite` allocates a `format!("{}/")` and walks the instance slice. That matches the
  existing `max_created_at_in_group` keys around it rather than introducing a new pattern, but it does
  add one more such pass. `sort_by_cached_key` would be a strict improvement for all of them if you
  want that cleaned up here.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

On the last box: I verified the TUI by driving it under tmux and capturing the pane rather than
recording, so I have transcripts instead of a gif. Screens below if useful.

`cargo test --lib`: 4248 passed, up from 4233 on `main`. The 2 failures in my run
(`git::worktree::tests::delete_branch_reaps_lingering_locked_worktree`,
`session::trash::tests::purge_recovers_when_project_path_diverged_and_locked_entry_survives`) also
fail on unmodified `main` here, so they look environmental to my box rather than caused by this
branch. `cargo clippy -- -D warnings` and `cargo fmt -- --check` are clean.

Documentation: `src/cli/session.rs` help for `session favorite` was stale (it still said
Attention-only), so `docs/cli/reference.md` is regenerated via `cargo xtask gen-docs`. The
`tui-triage` tip in `src/tips.rs` and the Pin bullet in `docs/guides/web/dashboard.md` said the same
stale thing and are updated.

Manual TUI check, isolated `HOME`, debug build:

| Step | Result |
|---|---|
| Newest sort, `f` on a session in group `old` | row became `* alpha` and jumped to the top |
| same | its group `old` pinned above sibling group `new` |
| switch to Attention | favorite pins within its Idle tier, order otherwise unchanged |
| `favorites_first = false` written to config | pin and star dropped at runtime, no restart; `f` went inert |
| snooze the favorite | `z alpha 59m`, sunk in Attention; back in Newest: no star, no pin |
| restart | star and pin persisted |

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

The only web-visible effect is a new schema-derived toggle rendered by the existing generic
`SchemaSection`. No new component, no changed dashboard flow, and web ordering is unchanged, so
`coverage-matrix.json` has nothing new to point at. Tell me if you would rather have an entry anyway.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the behavior is covered by 15 unit tests at the layer where it lives,
  and I verified the integrated path by hand under tmux (table above) rather than encoding it. The
  six manual steps map cleanly onto a `TuiTestHarness` spec, so I am happy to add one if you want it
  in this PR rather than as follow-up.

New tests: pinning in Newest and A-Z; order preserved among favorites; snoozed favorite not pinned;
Attention output identical with the flag on and off; group pinning; archived member not pinning its
group; root-group pinning in the all-profiles view; the key gate on and off the flag; the flag's
round trip; and the decoration on both sides of the flag. Two existing tests pinned the old
"favorite is Attention-only" contract: each was re-scoped to the flag-off case where that contract
still holds, with the flag-on case moved to a new test, and the bindings one additionally gained an
assertion that snooze stays gated.

One thing worth calling out because it is easy to miss when reviewing: `flatten_tree_all_profiles`
orders root groups with its own inline `match` instead of calling the shared helper, because each
root carries per-profile instances rather than sharing one slice. My first pass missed it, so the
feature silently did nothing there and behavior depended on how many profiles you had. That path had
no ordering test at all; there is one now.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Claude Opus 4.8 via Claude Code.

**Any Additional AI Details you'd like to share:**

The implementation, tests, and this description were written by the agent, working from a design doc
and a task plan reviewed by me before any code was written. Every commit was verified against the
suite, and a separate reviewer pass caught the `flatten_tree_all_profiles` gap plus three stale
strings before this was opened.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new default-on `session.favorites_first` toggle to prioritize “live-favorited” sessions by pinning them to the top across standard TUI session sort orders (Newest, Oldest, Last Activity, and alphabetical), and to pin groups that contain live favorites (including all-profile root groups).
- Defined “live favorites” so snoozed, archived, and trashed favorites are not pinned and do not show the star/pin decoration; snoozing temporarily removes the pin/star until it wakes.
- Kept existing Attention sorting behavior intact, while aligning the pin/star/keybinding behavior with the new toggle: when `favorites_first` is off, favorites are only prioritized within the Attention tier; when on, they’re prioritized across other sorts too.
- Made the behavior runtime-configurable by introducing a process-wide gate that is refreshed on startup and config reload, so UI ordering, decoration, and keybinding/help text update immediately.
- Updated UX copy across the CLI, TUI help/shortcuts, dashboard wording, and tips so “favorite” behavior always matches the setting (including conditional “Attention” labeling).
- Added unit tests covering session/group ordering, live-favorite rules (including nested groups), config/runtime gating, keybinding and decoration eligibility, snoozed favorites, Attention interactions, and all-profile root group handling.
- Reused existing favorite timestamps (`favorited_at`) instead of adding migrations.

## Benefits

- Users get consistent, predictable visibility for favorites (“favorites first”) across most views and sort modes without changing the meaning of Attention results.
- The star/pin visuals and the keybinding hints stay accurate because they’re gated by the same runtime setting and live-favorite rules.

## Potential areas for further enhancement

- Add broader end-to-end/UI tests to confirm pin/star/keybinding consistency across all affected views when toggling `favorites_first` at runtime (not just unit-level coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->