### PR TITLE
fix(mcp): honor disabled Codex native servers

### DIFF
--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -108,7 +108,10 @@ config read per agent:
 - **Gemini**: `~/.gemini/settings.json` (`mcpServers`; transport is chosen by
   which key the entry sets, `command` for stdio, `httpUrl` for http, `url` for
   sse).
-- **Codex**: `~/.codex/config.toml` (`[mcp_servers.<name>]` tables).
+- **Codex**: `~/.codex/config.toml` (`[mcp_servers.<name>]` tables). AoE honors
+  Codex's `enabled` flag: an omitted value or `enabled = true` includes the
+  server, while `enabled = false` keeps the native definition known for drift
+  bookkeeping but excludes it from the effective and forwarded sets.
 
 ## Precedence
 

--- a/src/session/mcp_model.rs
+++ b/src/session/mcp_model.rs
@@ -19,7 +19,7 @@
 //! [`ProjectMcpServer::redacted_summary`], so names reach a screen, a log, or
 //! CLI output and values never do.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::BufReader;
 use std::path::Path;
 
@@ -407,14 +407,17 @@ fn native_config_for(agent_key: &str) -> Option<NativeMcpConfig> {
     }
 }
 
-/// A native config read: the converted servers plus the names of any entries
-/// that were skipped because they failed to convert. The skipped list gates
-/// drift detection (#1996): a native file with a malformed entry must not make
-/// the drift detector report that entry as "removed" (it is still there, just
-/// unparseable), so callers pause drift for that agent when `skipped` is
-/// non-empty.
+/// A native config read: every converted definition, the names disabled by the
+/// native agent, and the names of entries skipped because they failed to
+/// convert. Disabled definitions remain in `servers` so drift reconciliation
+/// sees them as present; only the effective-set loader filters them out. The
+/// skipped list gates drift detection (#1996): a native file with a malformed
+/// entry must not make the drift detector report that entry as "removed" (it is
+/// still there, just unparseable), so callers pause drift for that agent when
+/// `skipped` is non-empty.
 pub struct NativeRead {
     pub servers: Vec<ProjectMcpServer>,
+    pub disabled_names: BTreeSet<String>,
     pub skipped: Vec<String>,
 }
 
@@ -422,6 +425,7 @@ impl NativeRead {
     fn empty() -> Self {
         NativeRead {
             servers: Vec::new(),
+            disabled_names: BTreeSet::new(),
             skipped: Vec::new(),
         }
     }
@@ -446,10 +450,15 @@ pub fn load_native_mcp_servers_checked(agent_key: &str, home: &Path) -> Result<N
     }
 }
 
-/// Like [`load_native_mcp_servers_checked`] but discards the skipped-entry list.
-/// Used by forwarding, which only needs the parseable servers.
+/// Like [`load_native_mcp_servers_checked`] but returns only definitions enabled
+/// by the native agent. Used by effective-set resolution and forwarding.
 pub fn load_native_mcp_servers(agent_key: &str, home: &Path) -> Result<Vec<ProjectMcpServer>> {
-    Ok(load_native_mcp_servers_checked(agent_key, home)?.servers)
+    let read = load_native_mcp_servers_checked(agent_key, home)?;
+    Ok(read
+        .servers
+        .into_iter()
+        .filter(|server| !read.disabled_names.contains(&server.name))
+        .collect())
 }
 
 /// Convenience wrapper that resolves the real home dir. Kept separate from
@@ -494,6 +503,7 @@ fn convert_tolerant<R>(
     }
     NativeRead {
         servers: out,
+        disabled_names: BTreeSet::new(),
         skipped,
     }
 }
@@ -646,9 +656,14 @@ struct CodexRawServer {
     url: Option<String>,
     #[serde(default)]
     headers: BTreeMap<String, String>,
+    enabled: Option<toml::Value>,
 }
 
 fn convert_codex(name: String, raw: CodexRawServer) -> Result<ProjectMcpServer> {
+    match &raw.enabled {
+        None | Some(toml::Value::Boolean(_)) => {}
+        Some(_) => bail!("MCP server \"{name}\" has non-boolean \"enabled\""),
+    }
     let transport = match (raw.command, raw.url) {
         (Some(command), None) => ProjectMcpTransport::Stdio {
             command,
@@ -678,7 +693,15 @@ fn read_codex_toml(path: &Path) -> Result<NativeRead> {
     };
     let parsed: CodexConfigFile = toml::from_str(&text)
         .with_context(|| format!("parsing native MCP config at {}", path.display()))?;
-    Ok(convert_tolerant(parsed.mcp_servers, path, convert_codex))
+    let disabled_names = parsed
+        .mcp_servers
+        .iter()
+        .filter(|(_, raw)| matches!(raw.enabled, Some(toml::Value::Boolean(false))))
+        .map(|(name, _)| name.clone())
+        .collect();
+    let mut read = convert_tolerant(parsed.mcp_servers, path, convert_codex);
+    read.disabled_names = disabled_names;
+    Ok(read)
 }
 
 #[cfg(test)]
@@ -1158,6 +1181,111 @@ url = "https://e/mcp"
         ));
         // Secret env value never appears in the redacted summary.
         assert!(!servers[0].redacted_summary().contains("secret"));
+    }
+
+    #[test]
+    fn native_codex_honors_enabled_flag() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".codex/config.toml",
+            r#"
+[mcp_servers.omitted]
+command = "omitted"
+
+[mcp_servers.explicit_true]
+command = "true"
+enabled = true
+
+[mcp_servers.explicit_false]
+command = "false"
+enabled = false
+"#,
+        );
+
+        let effective = load_native_mcp_servers("codex", home.path()).unwrap();
+        assert_eq!(names(&effective), vec!["explicit_true", "omitted"]);
+
+        let checked = load_native_mcp_servers_checked("codex", home.path()).unwrap();
+        assert_eq!(
+            names(&checked.servers),
+            vec!["explicit_false", "explicit_true", "omitted"],
+            "disabled definitions remain present for drift bookkeeping"
+        );
+        assert_eq!(
+            checked.disabled_names,
+            BTreeSet::from(["explicit_false".to_string()])
+        );
+    }
+
+    #[test]
+    fn native_codex_invalid_enabled_is_skipped_with_valid_siblings() {
+        let home = tempfile::tempdir().unwrap();
+        write(
+            home.path(),
+            ".codex/config.toml",
+            r#"
+[mcp_servers.bad]
+command = "bad"
+enabled = "sometimes"
+
+[mcp_servers.good]
+command = "good"
+"#,
+        );
+
+        let read = load_native_mcp_servers_checked("codex", home.path()).unwrap();
+        assert_eq!(names(&read.servers), vec!["good"]);
+        assert_eq!(read.skipped, vec!["bad"]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn codex_enabled_toggle_preserves_drift_and_restores_effective_server() {
+        let home = set_tmp_home();
+        let cwd = home.path().join("repo");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        let write_toggle = |enabled: bool| {
+            write(
+                home.path(),
+                ".codex/config.toml",
+                &format!(
+                    r#"
+[mcp_servers.toggle]
+command = "toggle"
+enabled = {enabled}
+"#
+                ),
+            );
+        };
+
+        write_toggle(true);
+        let enabled = resolve_surface("codex", None, &cwd);
+        assert_eq!(resolved_names(&enabled.effective), vec!["toggle"]);
+        assert!(enabled.kept_on_removal.is_empty());
+        assert!(enabled.conflicts.is_empty());
+        assert!(!enabled.drift_paused);
+
+        write_toggle(false);
+        let disabled = resolve_surface("codex", None, &cwd);
+        assert!(disabled.effective.is_empty());
+        assert!(
+            disabled.kept_on_removal.is_empty(),
+            "disabling a native server is not a removal"
+        );
+        assert!(disabled.conflicts.is_empty());
+        assert!(!disabled.drift_paused);
+
+        write_toggle(true);
+        let re_enabled = resolve_surface("codex", None, &cwd);
+        assert_eq!(resolved_names(&re_enabled.effective), vec!["toggle"]);
+        assert!(re_enabled.kept_on_removal.is_empty());
+        assert!(
+            re_enabled.conflicts.is_empty(),
+            "re-enabling the same definition must not create a stale conflict"
+        );
+        assert!(!re_enabled.drift_paused);
     }
 
     #[test]

--- a/src/session/mcp_state.rs
+++ b/src/session/mcp_state.rs
@@ -123,7 +123,9 @@ fn mcp_state_path() -> Result<PathBuf> {
 /// and removed servers KEEP their old snapshot value (the AoE side), pending an
 /// explicit user resolution, so the same drift surfaces on every open until the
 /// user acts. If the native read skipped a malformed entry, drift detection is
-/// paused and the snapshot is left completely untouched.
+/// paused and the snapshot is left completely untouched. Native definitions
+/// disabled by their agent remain in `read.servers`, so toggling enabled state
+/// alone is neither a removal nor a definition conflict.
 ///
 /// The whole read-modify-write runs under an exclusive lock so concurrent
 /// surface opens (e.g. web and TUI) cannot clobber each other's snapshot.
@@ -337,6 +339,7 @@ mod tests {
     fn read(json: &str) -> NativeRead {
         NativeRead {
             servers: parse_standard_mcp_servers(json).unwrap(),
+            disabled_names: Default::default(),
             skipped: Vec::new(),
         }
     }
@@ -547,6 +550,7 @@ mod tests {
         // A read with a skipped (malformed) entry must not report "fs" removed.
         let poisoned = NativeRead {
             servers: Vec::new(),
+            disabled_names: Default::default(),
             skipped: vec!["fs".to_string()],
         };
         let r = reconcile_agent("claude", &poisoned).unwrap();

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -139,6 +139,51 @@ fn test_cli_mcp_list_provenance_and_redaction() {
     assert_eq!(native_only["envNames"], serde_json::json!(["TOKEN"]));
 }
 
+/// Native Codex entries with `enabled = false` remain known to drift tracking
+/// but do not appear in the effective set printed by `aoe mcp list`.
+#[test]
+#[serial]
+fn test_cli_mcp_list_honors_codex_enabled_flag() {
+    let h = TuiTestHarness::new("cli_mcp_codex_enabled");
+    let home = h.home_path();
+    let codex_dir = home.join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("create .codex dir");
+    std::fs::write(
+        codex_dir.join("config.toml"),
+        r#"
+[mcp_servers.omitted]
+command = "omitted"
+
+[mcp_servers.explicit_true]
+command = "true"
+enabled = true
+
+[mcp_servers.explicit_false]
+command = "false"
+enabled = false
+"#,
+    )
+    .expect("write Codex config");
+
+    let out = h.run_cli(&["mcp", "list", "--agent", "codex", "--json"]);
+    assert!(
+        out.status.success(),
+        "aoe mcp list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let val: serde_json::Value = serde_json::from_str(&stdout).expect("output is JSON");
+    let effective = val["effective"].as_array().expect("effective array");
+    let names = effective
+        .iter()
+        .map(|server| server["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["explicit_true", "omitted"]);
+    assert_eq!(val["keptOnRemoval"], serde_json::json!([]));
+    assert_eq!(val["conflicts"], serde_json::json!([]));
+    assert_eq!(val["driftPaused"], false);
+}
+
 /// #1909: `aoe add --interactive` must fail loudly when stdin is not a
 /// terminal instead of hanging on the name prompt. `run_cli` runs the
 /// binary as a plain subprocess with no controlling TTY, which is the

--- a/tests/integration/acp_mcp.rs
+++ b/tests/integration/acp_mcp.rs
@@ -187,6 +187,55 @@ async fn native_and_global_merge_reaches_new_session() {
 }
 
 #[tokio::test]
+async fn disabled_codex_server_does_not_reach_new_session() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+
+    let home = tempfile::tempdir().unwrap();
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        codex_dir.join("config.toml"),
+        r#"
+[mcp_servers.omitted]
+command = "omitted"
+
+[mcp_servers.explicit_true]
+command = "true"
+enabled = true
+
+[mcp_servers.explicit_false]
+command = "false"
+enabled = false
+"#,
+    )
+    .unwrap();
+    let native = mcp_model::load_native_mcp_servers("codex", home.path()).unwrap();
+
+    let record_dir = tempfile::tempdir().unwrap();
+    let record_path = record_dir.path().join("record.json");
+    let mut config = base_config(std::env::temp_dir(), &record_path);
+    config.agent_key = "codex".into();
+    config.mcp_servers = mcp_config::project_servers_to_acp(native);
+
+    let client = AcpClient::spawn(config, AcpSessionId("mcp-codex-disabled".into()))
+        .await
+        .expect("spawn shim agent");
+
+    let body = read_record(&record_path);
+    let _ = client.shutdown().await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("record is JSON");
+    let arr = parsed.as_array().expect("mcp_servers is an array");
+    let names = arr
+        .iter()
+        .map(|server| server["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["explicit_true", "omitted"], "got {body}");
+}
+
+#[tokio::test]
 async fn no_config_forwards_empty_list() {
     if let Err(reason) = shim_ready() {
         eprintln!("skipping: {reason}");

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -42,7 +42,7 @@
       "id": "settings.mcp-servers",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/mcp-servers.spec.ts"],
+      "specs": ["tests/live/mcp-servers.spec.ts", "tests/live/mcp-codex-disabled.spec.ts"],
       "components": ["web/src/components/McpServers.tsx"]
     },
     {

--- a/web/tests/live/mcp-codex-disabled.spec.ts
+++ b/web/tests/live/mcp-codex-disabled.spec.ts
@@ -1,0 +1,58 @@
+// Live: native Codex MCP entries with `enabled = false` stay out of the
+// effective set rendered by the dashboard's MCP settings panel.
+
+import { test as base, expect } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { appDirFor, resolveAoeBinary, spawnAoeServe } from "../helpers/aoeServe";
+
+base("MCP panel excludes disabled native Codex servers", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, xdg }) => {
+      const codexDir = join(home, ".codex");
+      mkdirSync(codexDir, { recursive: true });
+      writeFileSync(
+        join(codexDir, "config.toml"),
+        `
+[mcp_servers.omitted]
+command = "mcp-omitted"
+
+[mcp_servers.explicit_true]
+command = "mcp-true"
+enabled = true
+
+[mcp_servers.explicit_false]
+command = "mcp-false"
+enabled = false
+`,
+      );
+
+      const appDir = appDirFor(home, xdg, resolveAoeBinary());
+      mkdirSync(appDir, { recursive: true });
+      writeFileSync(
+        join(appDir, "config.toml"),
+        `
+[session]
+default_tool = "codex"
+`,
+      );
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings/mcp`);
+
+    const panel = page.getByTestId("mcp-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Effective set forwarded to codex");
+    await expect(panel.getByText("omitted", { exact: true })).toBeVisible();
+    await expect(panel.getByText("explicit_true", { exact: true })).toBeVisible();
+    await expect(panel.getByText("explicit_false", { exact: true })).toHaveCount(0);
+    await expect(panel.getByText("agent-native:codex").first()).toBeVisible();
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
## Description

Honor Codex's native `[mcp_servers.<name>] enabled` metadata when AoE builds the effective MCP server set.

Disabled definitions remain present during drift reconciliation, so disabling a server is not mistaken for removal and re-enabling it does not create a stale conflict. They are filtered only from effective CLI output and ACP forwarding. Missing or `true` values remain enabled, while malformed values keep the existing per-entry skip-and-warn behavior.

Testing performed:

- `cargo fmt --check`
- `cargo clippy --features serve --all-targets`
- `cargo test --lib codex_`
- CLI MCP list e2e regression
- ACP forwarding integration regression
- Live Playwright MCP dashboard regression
- Web formatting, linting, typechecking, and coverage-matrix validation

The full local `cargo test --features serve` run reached 5,636 passing tests with 11 environment-sensitive shell-launch failures in an unrelated module. That complete 53-test module passes in isolation with the system shell.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

OpenAI Codex

**Any Additional AI Details you'd like to share:**

Codex implemented and verified the fix with user review of the resulting behavior and diff.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed Codex MCP server handling to honor the native `enabled` flag when building the effective set.
- If `enabled` is omitted or set to `true`, the server is included for effective use and forwarding.
- If `enabled = false`, the server is kept for drift/change bookkeeping, but excluded from the effective set shown in CLI output and forwarded via ACP.
- Malformed `enabled` values keep the existing behavior: the entry is skipped with a warning, without breaking other valid entries.
- Added/updated coverage across parsing, drift reconciliation, CLI (`aoe mcp list`), ACP forwarding, the dashboard UI, docs, plus e2e and integration tests (including Playwright tests).

## Benefits

Ensures explicitly disabled Codex MCP servers aren’t treated as removed during reconciliation, preventing stale conflicts when re-enabled, and keeps what the user sees/what gets forwarded aligned with the intended effective configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->