### PR TITLE
feat: add Oh My Pi (OMP) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A session manager for AI coding agents on Linux and macOS, driven from the termi
 
 ## Features
 
-- **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code
+- **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code
 - **TUI dashboard**: visual interface to create, monitor, and manage sessions
 - **Web dashboard**: create, monitor, and control your agents from any browser, installable as a PWA
 - **Structured view** (web dashboard default): mobile-first native rendering of agent state via the Agent Client Protocol, with plan panels, tool-call cards, and swipe-to-approve. Flip a session to the terminal view for raw tmux rendering
@@ -136,7 +136,7 @@ Nothing. Sessions are tmux sessions running in the background. Open and close `a
 
 ### Which AI tools are supported?
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code. AoE auto-detects which are installed on your system.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code. AoE auto-detects which are installed on your system.
 
 ### Can I use AoE over SSH?
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # aoe-sandbox: Docker image for Agent of Empires sandbox sessions
-# This image provides Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code in an isolated environment
+# This image provides Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, OMP, Kiro CLI, and Qwen Code in an isolated environment
 
 FROM ubuntu:26.04
 
@@ -29,6 +29,11 @@ WORKDIR /root
 # Install Claude Code CLI (official installer)
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.local/bin:${PATH}"
+
+# Install Bun and Oh My Pi (OMP)
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+RUN bun install -g @oh-my-pi/pi-coding-agent
 
 # Install OpenCode
 RUN curl -fsSL https://opencode.ai/install | bash
@@ -103,6 +108,7 @@ RUN mkdir -p /root/.claude \
     /root/.cursor \
     /root/.copilot \
     /root/.pi \
+    /root/.omp \
     /root/.factory \
     /root/.kiro \
     /root/.qwen \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,10 +30,8 @@ WORKDIR /root
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.local/bin:${PATH}"
 
-# Install Bun and Oh My Pi (OMP)
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
-RUN bun install -g @oh-my-pi/pi-coding-agent
+# Install Oh My Pi (OMP) using its official prebuilt-binary installer
+RUN curl -fsSL https://omp.sh/install | sh
 
 # Install OpenCode
 RUN curl -fsSL https://opencode.ai/install | bash

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 # aoe-dev-sandbox: Extended sandbox with development tools
 # Includes: Rust, uv (Python), nvm + Node.js, pnpm, bun, gh (GitHub CLI)
 # Note: Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI,
-# Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, and Kimi Code are inherited from the base image
+# Antigravity CLI, Cursor CLI, Copilot CLI, Pi, OMP, Kiro CLI, Qwen Code, and Kimi Code are inherited from the base image
 
 ARG BASE_IMAGE=ghcr.io/agent-of-empires/aoe-sandbox:latest
 FROM ${BASE_IMAGE}

--- a/docs/features.md
+++ b/docs/features.md
@@ -44,7 +44,7 @@ Press `R` in the TUI to expose the web dashboard over HTTPS with QR + passphrase
 
 ### Multi-agent support
 
-AoE drives Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code, auto-detecting which are installed and listing them in the new-session picker.
+AoE drives Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi.dev, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, and Qwen Code, auto-detecting which are installed and listing them in the new-session picker.
 
 For per-agent structured-view support (which agents render plan panels, which tools are recognized), see the [Structured view feature matrix](structured-view.md#feature-matrix).
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, Kimi Code) inside isolated Docker containers while maintaining access to your project files and credentials.
+Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Kiro CLI, Qwen Code, Kimi Code) inside isolated Docker containers while maintaining access to your project files and credentials.
 
 > **Linux users:** AoE also supports [Podman](podman.md) as a daemonless, rootless-friendly alternative to Docker.
 >
@@ -150,7 +150,7 @@ AOE provides two official sandbox images:
 
 | Image | Description |
 |-------|-------------|
-| `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, Kimi Code, git, ripgrep, fzf |
+| `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Kiro CLI, Qwen Code, Kimi Code, git, ripgrep, fzf |
 | `ghcr.io/agent-of-empires/aoe-dev-sandbox:latest` | Extended image with additional dev tools |
 
 ### Dev Sandbox Tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Running several AI coding agents in parallel across tasks or branches means jugg
 
 ## Supported Agents
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code. AoE auto-detects which are installed.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Oh My Pi (OMP), Factory Droid, Hermes, Kiro CLI, Qwen Code, and Kimi Code. AoE auto-detects which are installed.
 
 <div class="cta-box">
 <p><strong>Ready to get started?</strong></p>

--- a/docs/structured-view.md
+++ b/docs/structured-view.md
@@ -26,6 +26,7 @@ aoe ships an ACP registry entry for each tool whose ACP server we've verified. F
 | `gemini` | `gemini --acp` (native) | `npm install -g @google/gemini-cli` | `GEMINI_API_KEY`, OAuth, or Vertex |
 | `vibe` | `vibe-acp` (native) | see [mistral-vibe](https://github.com/mistralai/mistral-vibe) | Mistral API key |
 | `pi` | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) | `pi-acp --terminal-login`, or provider env |
+| `omp` | `omp acp` (native) | `curl -fsSL https://omp.sh/install \| sh` | provider environment or OMP login |
 | `kimi` | `kimi acp` (native) | `curl -fsSL https://code.kimi.com/kimi-code/install.sh \| bash` | `kimi login`, or provider env |
 | `aoe-agent` | bundled (Vercel AI SDK 6) | ships with `aoe` | provider env vars |
 
@@ -80,7 +81,7 @@ aoe acp doctor          # reports Node + each configured agent's reachability
 aoe acp doctor --fix    # npm-install the npm-distributed adapters (claude / codex / pi)
 ```
 
-It exits 1 if Node is missing, 2 if some agents are unreachable, else 0. Pass `--json` for machine-readable output. Install the native CLIs (opencode / gemini / vibe) through their own channels.
+It exits 1 if Node is missing, 2 if some agents are unreachable, else 0. Pass `--json` for machine-readable output. Install the native CLIs (opencode / gemini / vibe / omp) through their own channels.
 
 ## Choosing the view per session
 
@@ -96,7 +97,7 @@ Non-ACP tools always run in the terminal view, with no toggle.
 
 `aoe add` does not prompt for a name by default: it uses `--title`, else the worktree branch name, else a generated name. Pass `-i`/`--interactive` for the same name prompt the TUI and wizard show. Set per-agent defaults for web-created sessions under `[acp.acp_defaults.<agent>]`:
 
-When a structured view session keeps its generated civilization name (no `--title`, no branch name), AoE auto-renames it from its first turn using the session's own agent in one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`). This is on by default and controlled by `session.smart_rename`. It renames the title only, never the worktree directory (the running agent holds it), and never touches a session you named yourself. Sandboxed sessions, agents with no one-shot mode, and command-overridden agents keep the generated name. See [Configuration: Session](guides/configuration.md#session).
+When a structured view session keeps its generated civilization name (no `--title`, no branch name), AoE auto-renames it from its first turn using the session's own agent in one-shot mode (`claude -p`, `codex exec`, `opencode run`, `gemini -p`, `omp -p`). This is on by default and controlled by `session.smart_rename`. It renames the title only, never the worktree directory (the running agent holds it), and never touches a session you named yourself. Sandboxed sessions, agents with no one-shot mode, and command-overridden agents keep the generated name. See [Configuration: Session](guides/configuration.md#session).
 
 The rename waits for the first turn to finish and titles from the whole transcript, your prompt and the agent's response, so the title reflects what the turn did (and the one-shot never races the live agent for the provider API).
 

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -182,6 +182,18 @@ pub const PI: AgentProfile = AgentProfile {
     yolo_mode_id: None,
 };
 
+/// Oh My Pi via native `omp acp`. OMP advertises Default and Plan modes, but
+/// approval policy is separate from that mode channel, so AoE must not invent a
+/// YOLO mode id. Parent linkage metadata is unobserved and stays disabled.
+pub const OMP: AgentProfile = AgentProfile {
+    key: "omp",
+    parent_meta_namespaces: &[],
+    clear_aliases: &["/new"],
+    supports_exit_plan_mode: false,
+    supports_wakeup_tools: false,
+    yolo_mode_id: None,
+};
+
 /// Kimi Code (Moonshot AI) via native `kimi acp`. Verified against the
 /// binary's `acp-adapter/src/modes.ts`: it advertises the canonical
 /// four-mode taxonomy (`default`, `plan`, `auto`, `yolo`), so `yolo` is
@@ -230,6 +242,7 @@ pub fn resolve(key: &str) -> &'static AgentProfile {
         "gemini" => &GEMINI,
         "vibe" => &VIBE,
         "pi" => &PI,
+        "omp" => &OMP,
         "kimi" => &KIMI,
         "aoe-agent" => &AOE_AGENT,
         _ => &DEFAULT,
@@ -265,6 +278,7 @@ mod tests {
         assert_eq!(resolve("gemini").key, "gemini");
         assert_eq!(resolve("vibe").key, "vibe");
         assert_eq!(resolve("pi").key, "pi");
+        assert_eq!(resolve("omp").key, "omp");
         assert_eq!(resolve("kimi").key, "kimi");
         assert_eq!(resolve("aoe-agent").key, "aoe-agent");
     }
@@ -290,7 +304,7 @@ mod tests {
         }
         // Adapters whose default/mode approval behavior is unverified fail
         // closed to unattended, and unknown keys never count as reviewed.
-        for key in ["opencode", "vibe", "pi", "unknown-agent", ""] {
+        for key in ["opencode", "vibe", "pi", "omp", "unknown-agent", ""] {
             assert!(!is_reviewed(key), "{key} should not be reviewed");
         }
     }
@@ -321,6 +335,7 @@ mod tests {
         assert_eq!(resolve("opencode").yolo_mode_id, None);
         assert_eq!(resolve("vibe").yolo_mode_id, None);
         assert_eq!(resolve("pi").yolo_mode_id, None);
+        assert_eq!(resolve("omp").yolo_mode_id, None);
         assert_eq!(resolve("unknown-agent").yolo_mode_id, None);
     }
 
@@ -341,6 +356,8 @@ mod tests {
         assert!(!GEMINI.is_clear_command("/clear"));
         assert!(!GEMINI.is_clear_command("/new"));
         assert!(!GEMINI.is_clear_command("/restore"));
+        assert!(OMP.is_clear_command("/new"));
+        assert!(!OMP.is_clear_command("/clear"));
     }
 
     #[test]

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -424,7 +424,9 @@ mod tests {
             assert!(profile.supports_exit_plan_mode);
             assert!(profile.supports_wakeup_tools);
         }
-        for profile in [&CODEX, &OPENCODE, &GEMINI, &VIBE, &PI, &KIMI, &DEFAULT] {
+        for profile in [
+            &CODEX, &OPENCODE, &GEMINI, &VIBE, &PI, &OMP, &KIMI, &DEFAULT,
+        ] {
             assert!(!profile.supports_exit_plan_mode, "{}", profile.key);
             assert!(!profile.supports_wakeup_tools, "{}", profile.key);
         }

--- a/src/acp/agent_registry.rs
+++ b/src/acp/agent_registry.rs
@@ -57,8 +57,8 @@ impl AgentRegistry {
     /// a published ACP server, plus our own `aoe-agent` as a generic
     /// multi-provider fallback. Each entry is keyed on the same name
     /// the tmux view uses (claude / opencode / gemini / codex /
-    /// vibe / pi) so the spawn path can map `instance.tool` directly
-    /// to a registry key.
+    /// vibe / pi / omp) so the spawn path can map `instance.tool`
+    /// directly to a registry key.
     ///
     /// Sources verified against
     /// <https://agentclientprotocol.com/get-started/agents.md>
@@ -70,6 +70,7 @@ impl AgentRegistry {
     ///   codex    → codex-acp            (ACP adapter, OpenAI Codex CLI)
     ///   vibe     → vibe-acp             (native, Mistral)
     ///   pi       → pi-acp               (adapter, Pi coding agent)
+    ///   omp      → `omp acp`            (native, Oh My Pi)
     ///
     /// We deliberately don't use `npx -y` for these. First-run
     /// downloads can hang for tens of seconds with no output, which
@@ -151,6 +152,15 @@ impl AgentRegistry {
             },
         );
         reg.agents.insert(
+            "omp".into(),
+            AgentSpec {
+                command: "omp".into(),
+                args: vec!["acp".into()],
+                description: "Oh My Pi coding agent, native ACP via `omp acp`".into(),
+                env_allowlist: None,
+            },
+        );
+        reg.agents.insert(
             "kimi".into(),
             AgentSpec {
                 command: "kimi".into(),
@@ -199,6 +209,7 @@ mod tests {
         let reg = AgentRegistry::with_defaults();
         assert!(reg.get("claude-code").is_some());
         assert!(reg.get("aoe-agent").is_some());
+        assert!(reg.get("omp").is_some());
     }
 
     #[test]

--- a/src/acp/install_hints.rs
+++ b/src/acp/install_hints.rs
@@ -19,6 +19,7 @@ pub fn install_hint_for(binary: &str) -> Option<&'static str> {
             "follow https://github.com/mistralai/mistral-vibe (ships the `vibe-acp` binary)"
         }
         "kimi" => "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash  (then `kimi acp`)",
+        "omp" => "curl -fsSL https://omp.sh/install | sh",
         _ => return None,
     })
 }
@@ -57,6 +58,7 @@ mod tests {
         assert_eq!(npm_package_for("opencode"), None);
         assert_eq!(npm_package_for("vibe-acp"), None);
         assert_eq!(npm_package_for("pi-acp"), None);
+        assert_eq!(npm_package_for("omp"), None);
         assert_eq!(npm_package_for("nonexistent"), None);
     }
 
@@ -70,6 +72,7 @@ mod tests {
             "vibe-acp",
             "pi-acp",
             "kimi",
+            "omp",
         ] {
             assert!(
                 install_hint_for(binary).is_some(),

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1157,6 +1157,27 @@ pub const AGENTS: &[AgentDef] = &[
         install_hint: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
         permission_response: None,
     },
+    AgentDef {
+        name: "omp",
+        oneshot_flag: Some("-p"),
+        binary: "omp",
+        launch_subcommand: None,
+        aliases: &[],
+        detection: DetectionMethod::Which("omp"),
+        yolo: Some(YoloMode::CliFlag("--auto-approve")),
+        instruction_flag: Some("--append-system-prompt {}"),
+        set_default_command: false,
+        detect_status: status_detection::detect_omp_status,
+        container_env: &[("PI_CODING_AGENT_DIR", "/root/.omp/agent")],
+        hook_config: None,
+        sidecar_hooks: None,
+        resume_strategy: ResumeStrategy::Flag("--resume"),
+        fork_strategy: ForkStrategy::Unsupported,
+        host_only: false,
+        send_keys_enter_delay_ms: 0,
+        install_hint: "curl -fsSL https://omp.sh/install | sh",
+        permission_response: None,
+    },
 ];
 
 /// Look up an agent by canonical name.
@@ -1201,7 +1222,7 @@ impl AgentDef {
     /// ignored rather than mis-injected (fail-closed).
     pub fn oneshot_model_flag(&self) -> Option<&'static str> {
         match self.name {
-            "claude" | "copilot" => Some("--model"),
+            "claude" | "copilot" | "omp" => Some("--model"),
             "codex" | "gemini" | "opencode" | "kimi" => Some("-m"),
             _ => None,
         }
@@ -1232,8 +1253,8 @@ impl AgentDef {
     /// `-p`/`--prompt` value-binding flags (copilot, gemini, kimi) consume the
     /// next token as the prompt, so model args must follow the prompt (in the
     /// trailing region); placing them before it would make the flag swallow the
-    /// model selector. Positional-prompt one-shots (claude's boolean `-p`,
-    /// codex `exec`, opencode `run`) take the model args before the prompt.
+    /// model selector. Positional-prompt one-shots (claude and omp's boolean
+    /// `-p`, codex `exec`, opencode `run`) take the model args before the prompt.
     ///
     /// Verified 2026-07-21 against each CLI: gemini `-p` is yargs
     /// `type: string, nargs: 1`; kimi `-p` is a `typer.Option(str)`; copilot
@@ -1637,7 +1658,7 @@ mod tests {
         // flag to emit it.
         for agent in AGENTS {
             let expected = match agent.name {
-                "claude" | "copilot" => Some("--model"),
+                "claude" | "copilot" | "omp" => Some("--model"),
                 "codex" | "gemini" | "opencode" | "kimi" => Some("-m"),
                 _ => None,
             };
@@ -1708,11 +1729,9 @@ mod tests {
                 );
             }
             // Semi-independent oracle (not a copy of the impl's name list): the
-            // `-p`/`--prompt` one-shot flag is value-binding for every agent
-            // except claude, whose `-p` is a boolean `--print`. So any non-claude
-            // agent whose one-shot flag is `-p` must be classified value-binding;
-            // this trips if a new `-p` agent is added and left positional.
-            if agent.oneshot_flag == Some("-p") && agent.name != "claude" {
+            // `-p` is value-binding except for claude and omp, where it is the
+            // boolean `--print` flag.
+            if agent.oneshot_flag == Some("-p") && !matches!(agent.name, "claude" | "omp") {
                 assert!(
                     agent.oneshot_flag_binds_prompt(),
                     "agent '{}' has a `-p` one-shot flag but is not classified value-binding",
@@ -1739,6 +1758,24 @@ mod tests {
         assert_eq!(get_agent("qwen").unwrap().binary, "qwen");
         assert_eq!(get_agent("antigravity").unwrap().binary, "agy");
         assert_eq!(get_agent("kimi").unwrap().binary, "kimi");
+        assert_eq!(get_agent("omp").unwrap().binary, "omp");
+    }
+
+    #[test]
+    fn test_omp_agent_definition() {
+        let omp = get_agent("omp").unwrap();
+        assert!(matches!(&omp.detection, DetectionMethod::Which("omp")));
+        assert!(matches!(
+            &omp.yolo,
+            Some(YoloMode::CliFlag("--auto-approve"))
+        ));
+        assert!(matches!(
+            &omp.resume_strategy,
+            ResumeStrategy::Flag("--resume")
+        ));
+        assert_eq!(omp.oneshot_flag, Some("-p"));
+        assert_eq!(omp.oneshot_model_flag(), Some("--model"));
+        assert!(!omp.oneshot_flag_binds_prompt());
     }
 
     #[test]
@@ -1885,7 +1922,8 @@ mod tests {
                 "kiro",
                 "qwen",
                 "antigravity",
-                "kimi"
+                "kimi",
+                "omp"
             ]
         );
     }
@@ -1914,6 +1952,7 @@ mod tests {
         assert_eq!(resolve_tool_name("agy"), Some("antigravity"));
         assert_eq!(resolve_tool_name("kimi"), Some("kimi"));
         assert_eq!(resolve_tool_name("kimi-code"), Some("kimi"));
+        assert_eq!(resolve_tool_name("omp"), Some("omp"));
         assert_eq!(resolve_tool_name(""), Some("claude"));
         assert_eq!(resolve_tool_name("agent"), Some("cursor"));
         assert_eq!(resolve_tool_name("unknown-tool"), None);
@@ -1934,6 +1973,7 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("qwen")), 13);
         assert_eq!(settings_index_from_name(Some("antigravity")), 14);
         assert_eq!(settings_index_from_name(Some("kimi")), 15);
+        assert_eq!(settings_index_from_name(Some("omp")), 16);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -1948,6 +1988,7 @@ mod tests {
         assert_eq!(name_from_settings_index(13), Some("qwen"));
         assert_eq!(name_from_settings_index(14), Some("antigravity"));
         assert_eq!(name_from_settings_index(15), Some("kimi"));
+        assert_eq!(name_from_settings_index(16), Some("omp"));
         assert_eq!(name_from_settings_index(99), None);
     }
 
@@ -2173,6 +2214,10 @@ mod tests {
         assert_eq!(
             install_hint("kimi"),
             Some("curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash")
+        );
+        assert_eq!(
+            install_hint("omp"),
+            Some("curl -fsSL https://omp.sh/install | sh")
         );
         assert!(install_hint("unknown").is_none());
     }

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -202,6 +202,18 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         clean_files: &[],
     },
     AgentConfigMount {
+        tool_name: "omp",
+        host_rel: ".omp",
+        container_suffix: ".omp",
+        skip_entries: &["sandbox"],
+        seed_files: &[],
+        copy_dirs: &["agent"],
+        keychain_credential: None,
+        home_seed_files: &[],
+        preserve_files: &[],
+        clean_files: &[],
+    },
+    AgentConfigMount {
         tool_name: "hermes",
         host_rel: ".hermes",
         container_suffix: ".hermes",

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1506,21 +1506,6 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         .lines()
         .filter(|line| !line.trim().is_empty())
         .collect();
-    let recent: Vec<&str> = non_empty_lines
-        .iter()
-        .rev()
-        .take(12)
-        .rev()
-        .copied()
-        .collect();
-    let recent_lower = recent.join("\n").to_lowercase();
-
-    if contains_approval_prompt(
-        &recent_lower,
-        &["allow once", "always allow", "deny", "approval required"],
-    ) {
-        return Status::Waiting;
-    }
 
     let footer: Vec<&str> = non_empty_lines
         .iter()
@@ -1534,6 +1519,22 @@ pub fn detect_omp_status(raw_content: &str) -> Status {
         && (footer_lower.contains("working") || footer_lower.contains("⟦esc⟧"))
     {
         return Status::Running;
+    }
+
+    let approval_footer: String = non_empty_lines
+        .iter()
+        .rev()
+        .take(8)
+        .rev()
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_lowercase();
+    if approval_footer.contains("allow tool:")
+        && approval_footer.contains("approve")
+        && approval_footer.contains("deny")
+    {
+        return Status::Waiting;
     }
 
     let has_header = footer
@@ -4026,13 +4027,24 @@ run this command? (y/n)
     }
 
     #[test]
+    fn test_detect_omp_status_running_over_stale_approval() {
+        let pane = "Allow tool: bash\n\
+                    Approve\n\
+                    Deny\n\
+                    ⠋ Working… ⟦esc⟧\n\
+                    ╭── π  > GPT-5.6 Sol ─╮\n\
+                    ╰─                   ─╯";
+        assert_eq!(detect_omp_status(pane), Status::Running);
+    }
+
+    #[test]
     fn test_detect_omp_status_waiting() {
         let pane = "OK\n\
                     ╭── π  > GPT-5.6 Sol ─╮\n\
                     ╰─                   ─╯";
         assert_eq!(detect_omp_status(pane), Status::Waiting);
         assert_eq!(
-            detect_omp_status("Approval required: allow once or deny?"),
+            detect_omp_status("Allow tool: bash\nApprove\nDeny"),
             Status::Waiting
         );
     }

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1493,6 +1493,62 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
     Status::Idle
 }
 
+/// Oh My Pi status detection via its live footer.
+///
+/// OMP keeps a bordered prompt visible both while running and while idle. The
+/// active loader is the distinguishing signal: `Working… ⟦esc⟧` with a spinner
+/// sits immediately above the prompt. Restrict spinner matching to the final
+/// three non-empty lines so a completed turn's loader in scrollback cannot pin
+/// the session on Running.
+pub fn detect_omp_status(raw_content: &str) -> Status {
+    let clean = strip_ansi(raw_content);
+    let non_empty_lines: Vec<&str> = clean
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    let recent: Vec<&str> = non_empty_lines
+        .iter()
+        .rev()
+        .take(12)
+        .rev()
+        .copied()
+        .collect();
+    let recent_lower = recent.join("\n").to_lowercase();
+
+    if contains_approval_prompt(
+        &recent_lower,
+        &["allow once", "always allow", "deny", "approval required"],
+    ) {
+        return Status::Waiting;
+    }
+
+    let footer: Vec<&str> = non_empty_lines
+        .iter()
+        .rev()
+        .take(3)
+        .rev()
+        .copied()
+        .collect();
+    let footer_lower = footer.join("\n").to_lowercase();
+    if has_any_spinner(&footer)
+        && (footer_lower.contains("working") || footer_lower.contains("⟦esc⟧"))
+    {
+        return Status::Running;
+    }
+
+    let has_header = footer
+        .iter()
+        .any(|line| line.trim_start().starts_with("╭── π"));
+    let has_input = footer
+        .iter()
+        .any(|line| line.trim_start().starts_with("╰─"));
+    if has_header && has_input {
+        return Status::Waiting;
+    }
+
+    Status::Idle
+}
+
 /// Factory Droid CLI status detection via tmux pane parsing.
 /// Droid uses an interactive REPL similar to other coding agents. It shows
 /// activity indicators while processing and prompts for input when idle.
@@ -3958,6 +4014,43 @@ run this command? (y/n)
     fn test_detect_pi_status_idle() {
         assert_eq!(detect_pi_status("file saved"), Status::Idle);
         assert_eq!(detect_pi_status("random output text"), Status::Idle);
+    }
+
+    #[test]
+    fn test_detect_omp_status_running() {
+        let pane = "Reply with OK only.\n\
+                    ⠋ Working… ⟦esc⟧\n\
+                    ╭── π  > GPT-5.6 Sol ─╮\n\
+                    ╰─                   ─╯";
+        assert_eq!(detect_omp_status(pane), Status::Running);
+    }
+
+    #[test]
+    fn test_detect_omp_status_waiting() {
+        let pane = "OK\n\
+                    ╭── π  > GPT-5.6 Sol ─╮\n\
+                    ╰─                   ─╯";
+        assert_eq!(detect_omp_status(pane), Status::Waiting);
+        assert_eq!(
+            detect_omp_status("Approval required: allow once or deny?"),
+            Status::Waiting
+        );
+    }
+
+    #[test]
+    fn test_detect_omp_status_ignores_stale_loader() {
+        let pane = "⠋ Working… ⟦esc⟧\n\
+                    Completed response.\n\
+                    Additional output.\n\
+                    OK\n\
+                    ╭── π  > GPT-5.6 Sol ─╮\n\
+                    ╰─                   ─╯";
+        assert_eq!(detect_omp_status(pane), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_omp_status_idle_without_prompt() {
+        assert_eq!(detect_omp_status("plain command output"), Status::Idle);
     }
 
     #[test]

--- a/web/src/lib/acpCapableTools.ts
+++ b/web/src/lib/acpCapableTools.ts
@@ -7,7 +7,15 @@
 // ACP adapter to that registry, also add it here; otherwise the web
 // wizard will silently fall back to tmux for it. (Long-term we should
 // expose this list via /api/about and drop the JS-side copy.)
-export const ACP_CAPABLE_TOOLS: ReadonlySet<string> = new Set(["claude", "opencode", "gemini", "codex", "vibe", "pi"]);
+export const ACP_CAPABLE_TOOLS: ReadonlySet<string> = new Set([
+  "claude",
+  "opencode",
+  "gemini",
+  "codex",
+  "vibe",
+  "pi",
+  "omp",
+]);
 
 /** Authoritative acp-capability check. The server now reports
  *  `acp_capable` per agent (built-ins and custom agents with an

--- a/web/src/lib/agentProfiles.test.ts
+++ b/web/src/lib/agentProfiles.test.ts
@@ -10,6 +10,7 @@ describe("resolveAgentProfile", () => {
     expect(resolveAgentProfile("gemini").key).toBe("gemini");
     expect(resolveAgentProfile("vibe").key).toBe("vibe");
     expect(resolveAgentProfile("pi").key).toBe("pi");
+    expect(resolveAgentProfile("omp").key).toBe("omp");
     expect(resolveAgentProfile("kimi").key).toBe("kimi");
     expect(resolveAgentProfile("aoe-agent").key).toBe("aoe-agent");
   });
@@ -47,6 +48,15 @@ describe("resolveAgentProfile", () => {
     expect(p.parentMetaNamespaces).toEqual([]);
   });
 
+  it("omp uses its native ACP clear boundary without guessed capabilities", () => {
+    const p = resolveAgentProfile("omp");
+    expect(p.clearAliases).toEqual(["/new"]);
+    expect(p.capabilities.todos).toBe(false);
+    expect(p.capabilities.skills).toBe(false);
+    expect(p.capabilities.subagents).toBe(false);
+    expect(p.parentMetaNamespaces).toEqual([]);
+  });
+
   it("codex aliases route shell / apply_patch / view_file to canonical cards", () => {
     const p = resolveAgentProfile("codex");
     expect(p.aliases.execute).toEqual(["shell", "bash"]);
@@ -77,6 +87,7 @@ describe("resolveAgentProfile", () => {
     expect(resolveAgentProfile("opencode").clearAliases).toEqual(["/new"]);
     expect(resolveAgentProfile("gemini").clearAliases).toEqual([]);
     expect(resolveAgentProfile("kimi").clearAliases).toEqual(["/new"]);
+    expect(resolveAgentProfile("omp").clearAliases).toEqual(["/new"]);
   });
 });
 

--- a/web/src/lib/agentProfiles.test.ts
+++ b/web/src/lib/agentProfiles.test.ts
@@ -53,7 +53,9 @@ describe("resolveAgentProfile", () => {
     expect(p.clearAliases).toEqual(["/new"]);
     expect(p.capabilities.todos).toBe(false);
     expect(p.capabilities.skills).toBe(false);
+    expect(p.capabilities.wakeup).toBe(false);
     expect(p.capabilities.subagents).toBe(false);
+    expect(p.capabilities.legacyModeFallback).toBe(false);
     expect(p.parentMetaNamespaces).toEqual([]);
   });
 

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -198,6 +198,25 @@ const PI: AgentProfile = {
   specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
 };
 
+// Oh My Pi uses native ACP and emits standard ToolKind values for its tools.
+// Its parent linkage metadata is unobserved, so specialised cards and
+// indentation stay disabled. `/new` starts a fresh conversation.
+const OMP: AgentProfile = {
+  key: "omp",
+  capabilities: {
+    todos: false,
+    skills: false,
+    wakeup: false,
+    subagents: false,
+    legacyModeFallback: false,
+  },
+  parentMetaNamespaces: [],
+  mcpPrefixes: ["mcp__"],
+  clearAliases: ["/new"],
+  aliases: {},
+  specialTitles: { skillNames: [], scheduleNames: [], harnessNames: [] },
+};
+
 // Kimi Code (Moonshot AI) via native `kimi acp`. Kimi is Claude-influenced
 // (skills, plan mode, `mcp__` MCP naming), but its ACP tool-title surface
 // hasn't been verified hands-on, so specialised cards stay off and tools
@@ -251,6 +270,7 @@ const PROFILES: Record<string, AgentProfile> = {
   gemini: GEMINI,
   vibe: VIBE,
   pi: PI,
+  omp: OMP,
   kimi: KIMI,
   "aoe-agent": AOE_AGENT,
 };

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2104,6 +2104,13 @@
       ]
     },
     {
+      "id": "acp.omp-profile",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/agentProfiles.test.ts"],
+      "components": ["web/src/lib/agentProfiles.ts"]
+    },
+    {
       "id": "acp.context-primer-banner",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
## Description

- Register Oh My Pi (`omp`) as a built-in AoE agent with command detection, YOLO, instruction, one-shot, resume, and terminal status metadata.
- Add native structured-view support through `omp acp`, including conservative server/web profiles and install hints.
- Add sandbox config mounting, base-image installation, documentation, and regression coverage.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no visual layout change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: no browser-specific behavior changed. The structured-profile contract is covered by `src/lib/agentProfiles.test.ts` (Vitest), and `web/tests/coverage-matrix.json` now contains `acp.omp-profile`.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: registry, flag, install-hint, and captured-pane status behavior are covered by deterministic Rust unit tests; the built binary was also smoke-tested with `aoe agents` and `aoe acp doctor` against an installed `omp`.

## Verification

- `cargo clippy --features serve -- -D warnings`
- `env -u GIT_TERMINAL_PROMPT LANG=C LC_ALL=C cargo test --features serve` (5,898 passed)
- `npx vitest run src/lib/agentProfiles.test.ts` (16 passed)
- `node tests/validate-coverage-matrix.mjs`
- `npm run format:check`
- `npm run lint`
- `npx tsc -b`
- Installed-binary smoke: `aoe agents`, `aoe acp agents`, `aoe acp doctor`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Oh My Pi with `openai/gpt-5.6-sol`

**Any Additional AI Details you'd like to share:** The agent researched AoE's documented add-agent contract, implemented the integration, added tests, and ran the verification commands listed above.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added end-to-end built-in **Oh My Pi (`omp`)** agent support: automatic detection, launch/session handling (including **one-shot** and **resume** behavior), and **terminal status** parsing.
- Enabled **native structured-view** for `omp` via **`omp acp`**, with conservative capability settings and clearer install/login guidance.
- Updated backend + frontend wiring for `omp`:
  - New `omp` agent profile and registry entries (including `/new` clear-alias behavior and conservative feature gating).
  - Frontend profile resolution updates plus parity tests for the `omp` profile.
- Improved runtime/packaging and UX defaults:
  - Docker images now install OMP during build, set up required directories (including `/root/.omp`), and mount OMP sandbox configuration.
  - Added `omp` to dev/base Docker tool inheritance lists.
  - Added `omp` install-hint support so the correct installer command is suggested.
  - Expanded the web ACP-capable fallback set to include `omp` (avoids temporary fallback to tmux before capability data loads).
- Documentation + regression coverage:
  - Updated docs to list `omp` as a supported agent (features, sandbox, structured-view, supported agents).
  - Adjusted multi-agent documentation (removed **Factory Droid** from the enumerated list).
  - Added regression tests and coverage-matrix entries for the new `omp` profile/status logic.

## Benefits
AoE can reliably recognize and run **Oh My Pi (`omp`)** flows (including structured-view) with safer default capabilities, clearer setup instructions, and targeted automated tests to reduce the risk of regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->