### PR TITLE
fix(session): persist engine swap from the restart dialog

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1649,6 +1649,15 @@ impl Instance {
         self.status = src.status;
         self.last_accessed_at = self.last_accessed_at.max(src.last_accessed_at);
         self.idle_entered_at = src.idle_entered_at;
+        // Launch-config fields are TUI-authoritative and only mutated after
+        // creation by the restart dialog (engine / command / args swap). They
+        // have no peer writer, so a plain copy is safe. Syncing them here is
+        // required: `reconcile_from_disk`'s `*self = disk` reload runs on every
+        // launch, so a swap that never reached disk is silently reverted and
+        // the session respawns with its original tool. See #switching-tools.
+        self.tool = src.tool.clone();
+        self.command = src.command.clone();
+        self.extra_args = src.extra_args.clone();
     }
 
     /// Apply a passively-detected status transition to a disk row. Touches
@@ -7404,6 +7413,30 @@ mod tests {
             stored.base_branch_override.as_deref(),
             Some("upstream/main")
         );
+    }
+
+    #[test]
+    fn test_merge_from_tui_syncs_launch_config_swap() {
+        // The restart dialog mutates tool/command/extra_args in the TUI's
+        // in-memory row. save() -> merge_from_tui must carry those onto disk,
+        // otherwise reconcile_from_disk reverts the swap on the next launch and
+        // the session respawns with its original tool.
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.tool = "claude".to_string();
+        stored.command = String::new();
+        stored.extra_args = String::new();
+
+        let mut src = Instance::new("session", "/tmp/test");
+        src.id = stored.id.clone();
+        src.tool = "codex".to_string();
+        src.command = "codex-wrapper".to_string();
+        src.extra_args = "--foo".to_string();
+
+        stored.merge_from_tui(&src);
+
+        assert_eq!(stored.tool, "codex");
+        assert_eq!(stored.command, "codex-wrapper");
+        assert_eq!(stored.extra_args, "--foo");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Switching the AI engine in the restart dialog (`e`) had no effect: the session always respawned with its original tool.

**Root cause.** The restart dialog's tool/command/args swap is applied in `restart_selected_session` to the TUI's in-memory `Instance` only. On launch, `Instance::start_with_size_opts` calls `reconcile_from_disk`, which does a wholesale `*self = disk` reload and reverts `tool`/`command`/`extra_args` to the on-disk values. Those disk values were never updated, because the TUI's `save()` syncs existing rows through `merge_from_tui`, which only copied `status` and the activity timestamps. Net effect: the swap was silently dropped.

**Fix.** `merge_from_tui` now also syncs `tool`, `command`, and `extra_args`. These are TUI-authoritative launch config, set at creation and mutated post-creation only by the restart dialog (no CLI/server writer), so a plain copy is race-safe. With disk carrying the swap, `reconcile_from_disk` reads the new engine instead of clobbering it.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [ ] For UI changes: included screenshot or recording (N/A, no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: `test_merge_from_tui_syncs_launch_config_swap` in `src/session/instance.rs` covers the persistence layer that was dropping the swap. Ran `cargo test --lib merge_from_tui` and the `restart_selected_session` suite; both green. `cargo fmt` clean.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed restart-dialog AI engine swaps so the selected tool, command, and arguments are saved and remain effective after a session restart.
- Added coverage to verify launch configuration changes are preserved during TUI-to-disk synchronization.

## Benefits

- Prevents user-selected restart settings from being silently reverted to stale values.
- Improves reliability of session restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->