### PR TITLE
fix(session): wire OMP session capture so --resume works

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -508,7 +508,31 @@ pub(crate) fn capture_pi_session_id(
     project_path: &str,
     exclusion: &HashSet<String>,
 ) -> Result<String> {
-    let pi_home = resolve_agent_home(Some("PI_CODING_AGENT_DIR"), ".pi/agent")?;
+    capture_pi_family_session_id(project_path, exclusion, ".pi/agent")
+}
+
+/// Capture an Oh My Pi (omp) session ID.
+///
+/// OMP is a pi fork that shares pi's on-disk session format and the
+/// `PI_CODING_AGENT_DIR` override, but defaults its data dir to `~/.omp/agent`
+/// on the host rather than `~/.pi/agent`. Only the host default differs, so
+/// this delegates to the shared pi scan with the omp default subdir.
+pub(crate) fn capture_omp_session_id(
+    project_path: &str,
+    exclusion: &HashSet<String>,
+) -> Result<String> {
+    capture_pi_family_session_id(project_path, exclusion, ".omp/agent")
+}
+
+/// Shared pi-family session scan. `default_subdir` is the host home directory
+/// used when `PI_CODING_AGENT_DIR` is unset (`.pi/agent` for pi, `.omp/agent`
+/// for omp).
+fn capture_pi_family_session_id(
+    project_path: &str,
+    exclusion: &HashSet<String>,
+    default_subdir: &str,
+) -> Result<String> {
+    let pi_home = resolve_agent_home(Some("PI_CODING_AGENT_DIR"), default_subdir)?;
     let sessions_dir = pi_home.join("sessions");
 
     if !sessions_dir.exists() {
@@ -647,6 +671,26 @@ pub(crate) fn pi_poll_fn(
         capture_pi_session_id(&project_path, &exclusion)
             .map_err(
                 |e| tracing::debug!(target: "session.capture", "Pi poll capture failed: {}", e),
+            )
+            .ok()
+            .and_then(validated_session_id)
+    }
+}
+
+/// Host polling closure for Oh My Pi (omp), mirroring [`pi_poll_fn`] against
+/// omp's `~/.omp/agent` default data dir. Sandboxed omp reuses
+/// [`pi_poll_fn_sandboxed`], since `PI_CODING_AGENT_DIR` is set in the omp
+/// container so the shared container scan already resolves the right dir.
+pub(crate) fn omp_poll_fn(
+    project_path: String,
+    instance_id: String,
+    extra_excludes: HashSet<String>,
+) -> impl Fn() -> Option<String> + Send + 'static {
+    move || {
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
+        capture_omp_session_id(&project_path, &exclusion)
+            .map_err(
+                |e| tracing::debug!(target: "session.capture", "OMP poll capture failed: {}", e),
             )
             .ok()
             .and_then(validated_session_id)
@@ -3225,6 +3269,88 @@ mod tests {
             Some(v) => std::env::set_var("PI_CODING_AGENT_DIR", v),
             None => std::env::remove_var("PI_CODING_AGENT_DIR"),
         }
+    }
+
+    /// omp shares pi's on-disk format: with `PI_CODING_AGENT_DIR` set, the omp
+    /// capture reads the same sessions dir the pi capture would.
+    #[test]
+    #[serial]
+    fn test_capture_omp_session_id_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        let project_encoded = encode_pi_project_path("/home/user/project");
+        let project_dir = sessions_dir.join(&project_encoded);
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let uuid = "019342ab-1234-7def-8901-abcdef012345";
+        std::fs::write(
+            project_dir.join(format!("2024-12-03T14-00-00-000Z_{uuid}.jsonl")),
+            format!(r#"{{"type":"session","id":"{uuid}","cwd":"/home/user/project"}}"#),
+        )
+        .unwrap();
+
+        let old_val = std::env::var("PI_CODING_AGENT_DIR").ok();
+        std::env::set_var("PI_CODING_AGENT_DIR", tmp.path());
+
+        let result = capture_omp_session_id("/home/user/project", &HashSet::new());
+
+        match old_val {
+            Some(v) => std::env::set_var("PI_CODING_AGENT_DIR", v),
+            None => std::env::remove_var("PI_CODING_AGENT_DIR"),
+        }
+
+        assert_eq!(result.unwrap(), uuid);
+    }
+
+    /// Path-adjustment regression (#3065 follow-up): with `PI_CODING_AGENT_DIR`
+    /// unset, omp must default its host data dir to `~/.omp/agent`, NOT pi's
+    /// `~/.pi/agent`. A session written under `~/.omp/agent` is found by the omp
+    /// capture but not by the pi capture. Without the remap, omp resume would
+    /// silently scan the wrong (empty) dir and never resume.
+    #[test]
+    #[serial]
+    fn test_capture_omp_defaults_to_omp_agent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_encoded = encode_pi_project_path("/home/user/project");
+        let omp_project_dir = tmp
+            .path()
+            .join(".omp/agent/sessions")
+            .join(&project_encoded);
+        std::fs::create_dir_all(&omp_project_dir).unwrap();
+
+        let uuid = "019342ab-1234-7def-8901-abcdef012345";
+        std::fs::write(
+            omp_project_dir.join(format!("2024-12-03T14-00-00-000Z_{uuid}.jsonl")),
+            format!(r#"{{"type":"session","id":"{uuid}","cwd":"/home/user/project"}}"#),
+        )
+        .unwrap();
+
+        let old_pi_dir = std::env::var("PI_CODING_AGENT_DIR").ok();
+        let old_home = std::env::var("HOME").ok();
+        std::env::remove_var("PI_CODING_AGENT_DIR");
+        std::env::set_var("HOME", tmp.path());
+
+        let omp_result = capture_omp_session_id("/home/user/project", &HashSet::new());
+        let pi_result = capture_pi_session_id("/home/user/project", &HashSet::new());
+
+        match old_pi_dir {
+            Some(v) => std::env::set_var("PI_CODING_AGENT_DIR", v),
+            None => std::env::remove_var("PI_CODING_AGENT_DIR"),
+        }
+        match old_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        assert_eq!(
+            omp_result.unwrap(),
+            uuid,
+            "omp capture should default to ~/.omp/agent"
+        );
+        assert!(
+            pi_result.is_err(),
+            "pi capture must NOT find omp's session under ~/.omp/agent"
+        );
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -20,16 +20,16 @@ use super::poller::SessionPoller;
 use crate::session::capture::{
     capture_claude_session_id, capture_claude_session_id_in_container, capture_codex_session_id,
     capture_copilot_session_id, capture_gemini_session_id, capture_hermes_session_id,
-    capture_kimi_session_id, capture_pi_session_id, capture_vibe_session_id, claude_poll_fn,
-    claude_poll_fn_sandboxed, codex_poll_fn, codex_poll_fn_sandboxed, copilot_poll_fn,
-    gemini_poll_fn, gemini_poll_fn_sandboxed, generate_claude_session_id, hermes_poll_fn,
-    hermes_poll_fn_sandboxed, is_valid_session_id, kimi_poll_fn, opencode_poll_fn,
-    opencode_poll_fn_sandboxed, pi_poll_fn, pi_poll_fn_sandboxed,
-    try_capture_codex_session_id_in_container, try_capture_gemini_session_id_in_container,
-    try_capture_hermes_session_id_in_container, try_capture_opencode_session_id,
-    try_capture_opencode_session_id_in_container, try_capture_pi_session_id_in_container,
-    try_capture_vibe_session_id_in_container, validated_session_id, vibe_poll_fn,
-    vibe_poll_fn_sandboxed,
+    capture_kimi_session_id, capture_omp_session_id, capture_pi_session_id,
+    capture_vibe_session_id, claude_poll_fn, claude_poll_fn_sandboxed, codex_poll_fn,
+    codex_poll_fn_sandboxed, copilot_poll_fn, gemini_poll_fn, gemini_poll_fn_sandboxed,
+    generate_claude_session_id, hermes_poll_fn, hermes_poll_fn_sandboxed, is_valid_session_id,
+    kimi_poll_fn, omp_poll_fn, opencode_poll_fn, opencode_poll_fn_sandboxed, pi_poll_fn,
+    pi_poll_fn_sandboxed, try_capture_codex_session_id_in_container,
+    try_capture_gemini_session_id_in_container, try_capture_hermes_session_id_in_container,
+    try_capture_opencode_session_id, try_capture_opencode_session_id_in_container,
+    try_capture_pi_session_id_in_container, try_capture_vibe_session_id_in_container,
+    validated_session_id, vibe_poll_fn, vibe_poll_fn_sandboxed,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2485,6 +2485,24 @@ impl Instance {
                     capture_pi_session_id(&self.project_path, &exclusion).ok()
                 }
             }
+            "omp" => {
+                // Oh My Pi is a pi fork: same on-disk session format, but the
+                // host data dir defaults to `~/.omp/agent`. The container scan
+                // is identical (the omp container sets `PI_CODING_AGENT_DIR`),
+                // so sandboxed omp reuses the shared pi container capture.
+                let exclusion = self.retroactive_capture_exclusion_set();
+                if self.is_sandboxed() {
+                    let container_name = self.sandbox_info.as_ref()?.container_name.clone();
+                    try_capture_pi_session_id_in_container(
+                        &container_name,
+                        &self.container_workdir(),
+                        &exclusion,
+                    )
+                    .ok()
+                } else {
+                    capture_omp_session_id(&self.project_path, &exclusion).ok()
+                }
+            }
             "codex" => {
                 let exclusion = self.retroactive_capture_exclusion_set();
                 if self.is_sandboxed() {
@@ -4139,6 +4157,29 @@ impl Instance {
                     ))
                 } else {
                     Box::new(pi_poll_fn(
+                        self.project_path.clone(),
+                        self.id.clone(),
+                        extra_excludes.clone(),
+                    ))
+                }
+            }
+            "omp" => {
+                // Sandboxed omp reuses pi's container poll (the omp container
+                // sets `PI_CODING_AGENT_DIR`); host omp uses omp_poll_fn, which
+                // scans `~/.omp/agent`.
+                if self.is_sandboxed() {
+                    let container_name = match self.sandbox_info.as_ref() {
+                        Some(s) => s.container_name.clone(),
+                        None => return,
+                    };
+                    Box::new(pi_poll_fn_sandboxed(
+                        container_name,
+                        self.container_workdir(),
+                        self.id.clone(),
+                        extra_excludes.clone(),
+                    ))
+                } else {
+                    Box::new(omp_poll_fn(
                         self.project_path.clone(),
                         self.id.clone(),
                         extra_excludes.clone(),


### PR DESCRIPTION
## Description

OMP (Oh My Pi) shipped in #3073 with `ResumeStrategy::Flag("--resume")` but no session-capture wiring, so `--resume` never had a session id to resume: every restart began a fresh conversation.

Session capture is dispatched by tool name in two places in `src/session/instance.rs`, the live poller and `try_retroactive_capture`. Neither had an `"omp"` arm, so omp fell through to the `_ => return` / `_ => None` defaults. With no id ever captured, `agent_session_id` stayed `None`, `build_resume_flags` was never fed a valid id, and the resume flag was effectively dead code.

OMP is a pi fork that shares pi's on-disk session format, but its host data dir defaults to `~/.omp/agent` rather than pi's `~/.pi/agent`. Routing omp straight through `capture_pi_session_id` would have scanned the wrong (empty) directory, so the fix also remaps the host default while still honoring `PI_CODING_AGENT_DIR`.

### Changes

- `src/session/capture.rs`: factor `capture_pi_session_id` into a shared `capture_pi_family_session_id` parameterized by host default subdir; add `capture_omp_session_id` (defaults `~/.omp/agent`, honors `PI_CODING_AGENT_DIR`) and `omp_poll_fn`. Sandboxed omp reuses pi's container scan, since the omp container already sets `PI_CODING_AGENT_DIR`, so no container-side change is needed.
- `src/session/instance.rs`: add `"omp"` arms to `try_retroactive_capture` and the live poller (host uses the omp-defaulted capture; sandbox reuses the pi container path).

This targets the tmux/terminal resume path. OMP's ACP structured-view resume goes through the ACP `EventStore` and was already wired in #3073.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none needed; behavior fix)
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit regression tests in `src/session/capture.rs`:
  - `test_capture_omp_defaults_to_omp_agent_dir`: with `PI_CODING_AGENT_DIR` unset, omp finds a session under `~/.omp/agent` while pi capture does not. Guards the path remap; fails without the default-subdir fix.
  - `test_capture_omp_session_id_basic`: omp reads the shared pi format when `PI_CODING_AGENT_DIR` is set.

Verification: `cargo build` clean, `cargo fmt --check` and `cargo clippy` clean, 130 `session::capture` tests plus 266 omp-matching tests pass.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and implementation done via Claude Code, reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed OMP session capture so `--resume` can reuse previous conversations.
- Shared session-capture logic between Pi and OMP while supporting each tool’s default data directory.
- Added OMP support to live polling and retroactive capture, including sandboxed environments.
- Added regression tests for OMP directory handling and shared session formats.

## Benefits

OMP sessions now reliably retain their IDs, improving conversation resumption across standard and sandboxed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->