### PR TITLE
fix(tmux): forward desktop/session env (DISPLAY, XDG_*) into sessions

### DIFF
--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -185,6 +185,14 @@ pub(crate) fn forwarded_desktop_env() -> Vec<(String, String)> {
 /// without mutating the process environment. Keeps a var when it is on the
 /// explicit allowlist or has an `XDG_` prefix, drops empty values, and sorts
 /// the result so the emitted `-e` args are deterministic.
+///
+/// Empty values are dropped on purpose. `new-session -e KEY=` overrides the
+/// tmux server's frozen base environment with an empty string, and that base
+/// env is frequently the *good* one (the server was first started from the
+/// user's graphical login while the current daemon is the impoverished side).
+/// Forwarding `DISPLAY=` there would blank out a working display, so we only
+/// add values aoe positively has and never clobber an inherited one with empty
+/// (an empty desktop var is useless to a browser anyway).
 fn forwarded_desktop_env_from<I>(vars: I) -> Vec<(String, String)>
 where
     I: IntoIterator<Item = (String, String)>,

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -151,6 +151,55 @@ pub(crate) fn user_shell() -> String {
         .unwrap_or_else(|| "bash".to_string())
 }
 
+/// Desktop and session environment variables a user's graphical login sets but
+/// that tmux does not reliably carry into a `new-session`. tmux's
+/// `update-environment` only refreshes DISPLAY/SSH_*/XAUTHORITY/WINDOWID/
+/// KRB5CCNAME (and removes any not present in the creating process); everything
+/// else survives only if it was in the tmux server's frozen global environment.
+/// In structured view the sessions are created by the `aoe serve` daemon, so
+/// without explicit forwarding a browser launched from an agent (e.g. an OIDC
+/// login) has no DISPLAY/XDG_RUNTIME_DIR/DBUS to reach the user's desktop
+/// (#3075). Any `XDG_*` var is forwarded on top of this explicit list.
+const FORWARDED_DESKTOP_VARS: &[&str] = &[
+    "DISPLAY",
+    "WAYLAND_DISPLAY",
+    "XAUTHORITY",
+    "DBUS_SESSION_BUS_ADDRESS",
+    "SSH_AUTH_SOCK",
+];
+
+/// The desktop/session `(KEY, VALUE)` pairs present in aoe's own environment,
+/// for forwarding into a tmux session via `new-session -e` so the agent, any
+/// browser it spawns, and user-opened panes inherit them. Sourced from the
+/// running process (the daemon in structured view), so a session inherits
+/// whatever aoe itself has; a truly headless daemon has nothing to forward.
+/// Arbitrary user vars are intentionally not forwarded wholesale, the profile
+/// host-environment list ([`host_environment_prefix`]) covers those.
+pub(crate) fn forwarded_desktop_env() -> Vec<(String, String)> {
+    let vars = std::env::vars_os()
+        .filter_map(|(k, v)| Some((k.into_string().ok()?, v.into_string().ok()?)));
+    forwarded_desktop_env_from(vars)
+}
+
+/// Pure core of [`forwarded_desktop_env`], split out so it can be unit-tested
+/// without mutating the process environment. Keeps a var when it is on the
+/// explicit allowlist or has an `XDG_` prefix, drops empty values, and sorts
+/// the result so the emitted `-e` args are deterministic.
+fn forwarded_desktop_env_from<I>(vars: I) -> Vec<(String, String)>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut pairs: Vec<(String, String)> = vars
+        .into_iter()
+        .filter(|(key, value)| {
+            !value.is_empty()
+                && (key.starts_with("XDG_") || FORWARDED_DESKTOP_VARS.contains(&key.as_str()))
+        })
+        .collect();
+    pairs.sort();
+    pairs
+}
+
 /// Shells whose quoting rules are incompatible with POSIX `'\''` escaping.
 const NON_POSIX_SHELLS: &[&str] = &["fish", "nu", "nushell", "pwsh", "powershell"];
 
@@ -704,6 +753,53 @@ pub(crate) fn build_docker_env_args(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn owned(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_forwarded_desktop_env_keeps_allowlist_and_xdg() {
+        let result = forwarded_desktop_env_from(owned(&[
+            ("DISPLAY", ":0"),
+            ("XDG_RUNTIME_DIR", "/run/user/1000"),
+            ("XDG_SESSION_TYPE", "wayland"),
+            ("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/1000/bus"),
+            ("PATH", "/usr/bin"),
+            ("HOME", "/home/me"),
+            ("SECRET_TOKEN", "abc"),
+        ]));
+        assert_eq!(
+            result,
+            owned(&[
+                ("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/1000/bus"),
+                ("DISPLAY", ":0"),
+                ("XDG_RUNTIME_DIR", "/run/user/1000"),
+                ("XDG_SESSION_TYPE", "wayland"),
+            ]),
+            "only allowlisted + XDG_ vars are forwarded, sorted, and unrelated \
+             vars (PATH/HOME/custom) are dropped"
+        );
+    }
+
+    #[test]
+    fn test_forwarded_desktop_env_drops_empty_values() {
+        let result = forwarded_desktop_env_from(owned(&[
+            ("DISPLAY", ""),
+            ("XDG_RUNTIME_DIR", ""),
+            ("WAYLAND_DISPLAY", "wayland-0"),
+        ]));
+        assert_eq!(result, owned(&[("WAYLAND_DISPLAY", "wayland-0")]));
+    }
+
+    #[test]
+    fn test_forwarded_desktop_env_empty_when_nothing_matches() {
+        let result = forwarded_desktop_env_from(owned(&[("PATH", "/bin"), ("TERM", "xterm")]));
+        assert!(result.is_empty());
+    }
 
     #[test]
     fn test_login_shell_command_adds_login_flag_for_known_shells() {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -261,7 +261,17 @@ impl Session {
             return Ok(());
         }
 
-        let mut args = build_create_args(&self.name, working_dir, &[], command, size);
+        // Forward the daemon's desktop/session env (DISPLAY, XDG_*, DBUS, ...)
+        // so an agent (and any browser it launches, e.g. for OIDC) can reach
+        // the user's desktop. tmux otherwise carries only its narrow
+        // `update-environment` set plus the server's frozen base env (#3075).
+        let desktop_env = crate::session::environment::forwarded_desktop_env();
+        let env_refs: Vec<(&str, &str)> = desktop_env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        let mut args = build_create_args(&self.name, working_dir, &env_refs, command, size);
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -1746,6 +1746,44 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn test_create_forwards_desktop_env_to_session() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        // A var only this test reads, caught by the `XDG_` forwarding rule, so
+        // it never collides with real config or another test's assertions.
+        let key = "XDG_AOE_ENV_TEST_3075";
+        let original = std::env::var(key).ok();
+        std::env::set_var(key, "sentinel-value");
+
+        let guard = TmuxTestSession::new("aoe_test_env_fwd");
+        let session = super::Session::from_name(guard.name());
+        let created = session.create_with_size("/tmp", Some("sleep 5"), Some((80, 24)));
+
+        let shown = crate::tmux::tmux_command()
+            .args(["show-environment", "-t", guard.name(), key])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string());
+
+        match original {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+
+        created.expect("create session");
+        assert_eq!(
+            shown.as_deref(),
+            Some("XDG_AOE_ENV_TEST_3075=sentinel-value"),
+            "a created agent session must carry the forwarded desktop/session env (#3075)"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_is_pane_dead_on_running_session() {
         if !tmux_available() {
             eprintln!("Skipping test: tmux not available");

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -620,4 +620,95 @@ mod tests {
             "Terminal session pane should be alive while command running"
         );
     }
+
+    /// Drive the real `create_with_size` for a host terminal and assert the
+    /// desktop/session env is forwarded, so a revert of the host-terminal
+    /// `forwarded_desktop_env()` extend is caught (#3075). Uses an `XDG_`
+    /// sentinel so the forwarding rule matches it without colliding with real
+    /// config or another test's assertions.
+    #[test]
+    #[serial_test::serial]
+    fn test_host_terminal_forwards_desktop_env() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let key = "XDG_AOE_TERM_ENV_TEST_3075";
+        let original = std::env::var(key).ok();
+        std::env::set_var(key, "host-sentinel");
+
+        let guard = TmuxTestSession::new("aoe_test_term_host_fwd");
+        let session = PairedTerminal {
+            name: guard.name().to_string(),
+            kind: TerminalKind::Host,
+        };
+        let created = session.create_with_size("/tmp", Some("sleep 5"), Some((80, 24)));
+
+        let shown = crate::tmux::tmux_command()
+            .args(["show-environment", "-t", guard.name(), key])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string());
+
+        match original {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+
+        created.expect("create host terminal");
+        assert_eq!(
+            shown.as_deref(),
+            Some("XDG_AOE_TERM_ENV_TEST_3075=host-sentinel"),
+            "a host terminal must carry the forwarded desktop/session env (#3075)"
+        );
+    }
+
+    /// Container terminals keep the container's own env; the host desktop env
+    /// (DISPLAY, XDG_*, SSH_AUTH_SOCK, ...) must NOT leak into them. Drive the
+    /// real `create_with_size` for a container terminal (a plain command, no
+    /// Docker) and assert the sentinel is absent, locking the `matches!(Host)`
+    /// exclusion so dropping the guard is caught (#3075).
+    #[test]
+    #[serial_test::serial]
+    fn test_container_terminal_excludes_desktop_env() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let key = "XDG_AOE_TERM_ENV_TEST_3075_CTR";
+        let original = std::env::var(key).ok();
+        std::env::set_var(key, "must-not-leak");
+
+        let guard = TmuxTestSession::new("aoe_test_term_ctr_excl");
+        let session = PairedTerminal {
+            name: guard.name().to_string(),
+            kind: TerminalKind::Container,
+        };
+        let created = session.create_with_size("/tmp", Some("sleep 5"), Some((80, 24)));
+
+        // `show-environment` exits non-zero and prints nothing to stdout for an
+        // unknown variable, so a forwarded var yields the `KEY=VALUE` line and
+        // an excluded one yields an empty string.
+        let shown = crate::tmux::tmux_command()
+            .args(["show-environment", "-t", guard.name(), key])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string());
+
+        match original {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+
+        created.expect("create container terminal");
+        assert_eq!(
+            shown.as_deref(),
+            Some(""),
+            "a container terminal must NOT inherit the host desktop/session env (#3075)"
+        );
+    }
 }

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -127,8 +127,14 @@ impl PairedTerminal {
         let host_shell = matches!(self.kind, TerminalKind::Host).then(user_shell);
         let home = std::env::var("HOME").unwrap_or_default();
         let path = std::env::var("PATH").unwrap_or_default();
-        let (env_pairs, effective_cmd) =
+        let (mut env_pairs, effective_cmd) =
             host_pane_inputs(host_shell.as_deref(), command, &home, &path);
+        // Host terminals also forward the desktop/session env (DISPLAY, XDG_*,
+        // DBUS, ...) so a browser opened from the pane reaches the user's
+        // desktop; container terminals keep the container's own env (#3075).
+        if matches!(self.kind, TerminalKind::Host) {
+            env_pairs.extend(crate::session::environment::forwarded_desktop_env());
+        }
         let env_refs: Vec<(&str, &str)> = env_pairs
             .iter()
             .map(|(k, v)| (k.as_str(), v.as_str()))


### PR DESCRIPTION
## Description

Fixes #3075. In structured view, the `aoe serve` daemon creates the tmux sessions, and aoe forwarded no desktop/session environment into them. Agent sessions passed `-e []`; host terminals forwarded only HOME/PATH/SHELL (#2617). Everything else reached a session only through tmux's narrow `update-environment` set (DISPLAY/SSH_*/XAUTHORITY/WINDOWID/KRB5CCNAME) plus the tmux server's frozen global environment, which the daemon freezes from its own launch context. So `DISPLAY`, all `XDG_*`, `DBUS_SESSION_BUS_ADDRESS`, and similar vars went missing, and a browser launched by an agent (e.g. an OIDC login) had nothing to reach the user's desktop with.

This forwards a curated desktop allowlist from aoe's own process environment via `new-session -e`:

- `DISPLAY`, `WAYLAND_DISPLAY`, `XAUTHORITY`, `DBUS_SESSION_BUS_ADDRESS`, `SSH_AUTH_SOCK`, and any `XDG_*` var.
- Applied to agent sessions (`src/tmux/session.rs`) and host terminals (`src/tmux/terminal_session.rs`). Container terminals are excluded; they keep the container's own env.
- New `forwarded_desktop_env()` helper in `src/session/environment.rs`, with a pure, unit-tested core.

Verified against a live tmux server started without `DISPLAY` (simulating a headless daemon that froze an impoverished base env): the `-e` value lands in the pane process's `/proc/<pid>/environ`, so `-e` overrides the server's frozen base env and is not stripped by `update-environment`.

### Known limitation

The vars are sourced from aoe's own environment, so a daemon launched with a genuinely empty desktop env (e.g. a systemd unit without `import-environment`, or a bare reboot) still has nothing to forward. Fully closing that requires capturing the user's environment where it is rich (persist it at interactive `aoe serve` launch, or have the TUI hand its env to the daemon), which is a larger change left as follow-up. Arbitrary custom vars beyond the desktop allowlist remain opt-in via the profile host-environment list.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (behavior is internal; no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow (backend tmux session env only; no dashboard UI or request-payload change)

**TUI / CLI (e2e test)**
- [x] Added or updated a test: unit tests for the env allowlist logic in `src/session/environment.rs` (`test_forwarded_desktop_env_keeps_allowlist_and_xdg` and two more). The tmux `-e` wiring is a thin pass-through covered by existing `build_create_args` tests plus manual verification against a live tmux server; a full daemon-launch-a-browser e2e is impractical to make deterministic here.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-cause investigation and the fix were done with Claude Code via back-and-forth with @njbrake. The diagnosis, the decision to forward a curated allowlist rather than the full env, and the scoping of the follow-up were his.

- [x] I am an AI Agent filling out this form (check box if true)

---

@cwrau this should restore `DISPLAY` / `XDG_*` / `DBUS` in your structured-view sessions so browser and OIDC launches work again. Since you run from git, could you build this branch (`fix/forward-desktop-env-to-sessions`) and confirm it fixes it for you? One thing worth checking given the known limitation above: how do you start `aoe serve` (interactive terminal, systemd unit, on reboot)? If the daemon itself lacks those vars at launch, they still will not be there to forward, and that would point us at the follow-up work.

_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- tmux sessions (created for the `aoe serve` structured view) now explicitly receive key desktop/session environment variables via `new-session -e KEY=VALUE`, ensuring GUI-dependent processes (like browsers and OIDC flows) can see the user’s real desktop context.
- Desktop/session forwarding is applied to agent sessions and host (non-container) terminal sessions; container terminals continue to use the container environment only.
- Added a unit-tested `forwarded_desktop_env()` helper that builds a deterministic set of forwarded variables from the daemon’s current environment, keeping only an allowlist plus any `XDG_*` variables, dropping empty values, and producing stable output for consistent tmux arguments.
- Added regression tests verifying that host terminals receive the forwarded desktop variables while container terminals do not.

## Benefits

This makes browser launches and OIDC-related flows inside tmux reliably able to access the user’s display/auth/session-related settings (e.g., DISPLAY/Wayland, X authority, DBus session bus, SSH agent socket, and relevant XDG config).

## Potential further enhancement

If the `aoe` daemon starts in an environment that lacks these desktop variables, the system can only forward what it already has at runtime; capturing a richer user environment at daemon startup is left for later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->