### PR TITLE
fix(web): add missing subagentToolNames to OMP agent profile

### DIFF
--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -223,6 +223,7 @@ const PI: AgentProfile = {
 // indentation stay disabled. `/new` starts a fresh conversation.
 const OMP: AgentProfile = {
   key: "omp",
+  subagentToolNames: [],
   capabilities: {
     todos: false,
     skills: false,


### PR DESCRIPTION
## Description

main's web build is currently failing `tsc` and taking down every serve-featured CI job (macOS test, serve-e2e, Playwright build):

```
src/lib/agentProfiles.ts(224,7): error TS2741: Property 'subagentToolNames' is
missing in type '{ ... }' but required in type 'AgentProfile'.
```

The `OMP` agent profile was added in #3073 (Oh My Pi support), authored before `subagentToolNames` became a required field on `AgentProfile` in #3074 (render opencode subagent as a subagent card). The two PRs landed back-to-back with no rebase between them, so the OMP profile literal never picked up the new required field.

This adds the empty `subagentToolNames: []` to the OMP profile, matching every other non-subagent profile (gemini, vibe, pi, kimi).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Verified locally: `cd web && npm run build` (`tsc -b && vite build`), `npm run format:check`, and `npm run lint` all pass.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Skipped a test, because: this is a type-completeness fix restoring a broken build; there is no new user-facing behavior. The existing `tsc -b` gate (which was failing on main) is what catches this class of regression.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Claude diagnosed the failing CI run, identified the missing field from the merge gap between #3073 and #3074, and applied the one-line fix. Reasoning and decisions are @njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added the required `subagentToolNames` field to the OMP agent profile.
- Keeps subagent classification disabled while restoring compatibility with the agent profile definition.
- Resolves the TypeScript build error affecting web builds and CI checks.

## Validation
- Local build, formatting, and lint checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->