### PR TITLE
fix(serve): drop stored ACP session id on /clear so restart starts fresh

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5266,6 +5266,24 @@ fn apply_acp_session_change(
                 inst.import_pending = None;
             }
         }
+        AcpSessionChange::Cleared => {
+            tracing::info!(
+                target: "acp.event_listener",
+                session = %session_id,
+                "clearing stored ACP session id after a user /clear"
+            );
+            // AoE never learns the adapter's post-clear conversation id
+            // (upstream claude-agent-acp #906), so the only way to stop a
+            // restart from resurrecting the pre-clear conversation via
+            // session/load is to drop the stored id now and force a fresh
+            // session/new. Clear the paired fork/import markers
+            // unconditionally too: a /clear issued before a pending
+            // fork/import resolves must still restart clean, not
+            // re-session/fork the parent. See #3080.
+            inst.acp_session_id = None;
+            inst.fork_pending = None;
+            inst.import_pending = None;
+        }
     }
     Some(inst.source_profile.clone())
 }
@@ -5278,6 +5296,10 @@ fn apply_acp_session_change(
 enum AcpSessionChange {
     Assigned(String),
     Reset(String),
+    /// A user `/clear`: drop the stored resume id so the next worker
+    /// restart starts a fresh `session/new` instead of resurrecting the
+    /// pre-clear conversation via `session/load`. See #3080.
+    Cleared,
 }
 
 #[cfg(feature = "serve")]
@@ -5288,6 +5310,7 @@ fn derive_acp_session_change(event: &crate::acp::Event) -> Option<AcpSessionChan
             Some(AcpSessionChange::Assigned(acp_session_id.clone()))
         }
         Event::SessionContextReset { reason } => Some(AcpSessionChange::Reset(reason.clone())),
+        Event::SessionCleared => Some(AcpSessionChange::Cleared),
         _ => None,
     }
 }
@@ -7115,6 +7138,70 @@ mod tests {
         assert!(
             persist.is_none(),
             "unchanged id with no stale marker is a no-op"
+        );
+    }
+
+    // #3080: a user /clear emits Event::SessionCleared. Before the fix this
+    // derived no session change, so the stale ACP id survived on disk and the
+    // next worker restart replayed the pre-clear conversation via session/load.
+    // It must now derive a Cleared change so the stored id is dropped.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn session_cleared_derives_cleared_change() {
+        assert_eq!(
+            derive_acp_session_change(&crate::acp::Event::SessionCleared),
+            Some(AcpSessionChange::Cleared),
+            "a /clear must invalidate the persisted ACP resume id"
+        );
+    }
+
+    // Applying Cleared must null the stored id and force a clean restart by
+    // dropping the paired fork/import markers too: a /clear issued before a
+    // pending fork/import resolves must still restart as session/new, not
+    // re-session/fork the parent. See #3080.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn cleared_nulls_stored_id_and_pending_markers() {
+        let mut inst = Instance::new("seed", "/tmp/seed");
+        inst.view = crate::session::View::Structured;
+        inst.acp_session_id = Some("pre-clear-id".into());
+        inst.fork_pending = Some("parent-acp-id".into());
+        inst.import_pending = Some(true);
+
+        let profile =
+            apply_acp_session_change(&mut inst, "sess-1", Some(&AcpSessionChange::Cleared));
+
+        assert_eq!(inst.acp_session_id, None, "clear drops the stored id");
+        assert_eq!(
+            inst.fork_pending, None,
+            "clear drops fork_pending so restart does not re-fork the parent"
+        );
+        assert_eq!(
+            inst.import_pending, None,
+            "clear drops import_pending so restart is a clean session/new"
+        );
+        assert!(profile.is_some(), "the clear must persist");
+    }
+
+    // Regression for the event-ordering the listener sees: an id assigned at
+    // connect followed by a later /clear must end with no stored id. See #3080.
+    #[cfg(feature = "serve")]
+    #[test]
+    fn assign_then_clear_leaves_no_stored_id() {
+        let mut inst = Instance::new("seed", "/tmp/seed");
+        inst.view = crate::session::View::Structured;
+
+        apply_acp_session_change(
+            &mut inst,
+            "sess-1",
+            Some(&AcpSessionChange::Assigned("old-id".into())),
+        );
+        assert_eq!(inst.acp_session_id, Some("old-id".into()));
+
+        apply_acp_session_change(&mut inst, "sess-1", Some(&AcpSessionChange::Cleared));
+        assert_eq!(
+            inst.acp_session_id, None,
+            "a /clear after an assignment must not leave the old id on disk"
         );
     }
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

After a user runs `/clear` in a structured-view ACP session, the pre-clear conversation reappeared on the next worker restart. `/clear` looked correct while the worker stayed alive, but a restart resurrected the old context.

Root cause: `/clear` emits `Event::SessionCleared`, which was consumed only for UI and in-memory session-state resets. The persisted `Instance.acp_session_id` was mutated only by `AcpSessionAssigned` and `SessionContextReset`, so the stale resume id survived on disk. On restart the reconciler threads that id into the spawn's `stored_acp_session_id`, and the ACP client reissues `session/load <stale id>`, replaying the pre-clear conversation.

The adapter never tells AoE the post-clear conversation id (`conversation_reset` / `new_conversation_id` do not exist anywhere in the tree; that is the upstream `claude-agent-acp` bug, filed as agentclientprotocol/claude-agent-acp#906). So the only implementable defensive fix is to invalidate the stale resume id at the moment AoE observes the `/clear`.

`derive_acp_session_change` now maps `Event::SessionCleared` to a dedicated `AcpSessionChange::Cleared`. Applying it nulls `acp_session_id` and, unconditionally, the paired `fork_pending` / `import_pending` markers, so the next worker restart starts a clean `session/new` instead of `session/load` or `session/fork`. The new empty conversation is the accepted degradation: better a fresh session than resurrecting context the user explicitly cleared.

A dedicated variant (rather than reusing the existing `Reset(String)`) keeps user-initiated clearing distinct from error-recovery resets: the log line differs and the marker-clearing policy differs (a `/clear` before a pending fork/import resolves must still restart clean).

Closes #3080

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start `aoe serve`, open a structured-view session, and have a short conversation with the agent.
- [ ] Run `/clear` in that session; confirm the transcript folds and the conversation reads as cleared.
- [ ] Restart the worker (or restart `aoe serve`) so the session reattaches from disk.
- [ ] Send a new prompt (e.g. `continue`) and confirm the agent does NOT reference any pre-clear context.
- [ ] Optionally tail `debug.log` and confirm the restarted session issues `session/new`, not `session/load <pre-clear id>`.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the defect is server-side persistence logic in `derive_acp_session_change` / `apply_acp_session_change`. A red-then-green unit test on the exact path proves it deterministically (pre-fix the stored id survives a `SessionCleared`; post-fix it is nulled), verified against the pre-fix tree in a detached worktree. A full restart e2e would require extending the fake ACP agent to model `/clear` plus a fresh post-clear conversation id, disproportionate for a one-arm defensive fix.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a two-model design debate), and implementation were drafted by Claude under my direction. I made the design calls, reviewed each commit, and own the review responses.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed stale ACP conversation context returning after `/clear` and worker restarts.
- Added session-cleared handling that removes the saved session ID and pending fork/import state.
- Added tests covering clearing behavior and event ordering.

## Benefits
- Ensures restarts create a fresh ACP session instead of restoring pre-clear conversation history.
- Prevents unintended session forks or imports after a conversation is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->