### PR TITLE
fix(acp): stop long-running Terminal keepalives from spawning phantom tool-call cards

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4311,9 +4311,11 @@ fn map_update_to_events(
         SessionUpdate::ToolCallUpdate(update) => {
             let id = update.tool_call_id.0.to_string();
             // Drop claude keepalive heartbeats before they become an orphan
-            // `ToolCallUpdated` that renders a phantom card. See #3084 and
+            // `ToolCallUpdated` that renders a phantom card. Gated on the
+            // profile so another adapter that legitimately names a tool
+            // `*-heartbeat-<N>` is not silenced. See #3084 and
             // `is_heartbeat_tool_call_id`.
-            if is_heartbeat_tool_call_id(&id) {
+            if profile.emits_heartbeat_keepalives && is_heartbeat_tool_call_id(&id) {
                 return Vec::new();
             }
             let is_error = matches!(
@@ -10346,6 +10348,29 @@ mod tests {
             &agent_profiles::CLAUDE,
         );
         assert!(events.is_empty(), "heartbeat emitted events: {events:?}");
+    }
+
+    #[test]
+    fn map_update_to_events_keeps_heartbeat_id_for_non_claude_profile() {
+        // The drop is gated on the profile: a non-claude adapter that
+        // legitimately uses a `-heartbeat-N` id must NOT be silenced. #3084.
+        use agent_client_protocol::schema::v1::{
+            SessionUpdate, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
+        let fields = ToolCallUpdateFields::new()
+            .status(ToolCallStatus::InProgress)
+            .title("real-tool-heartbeat-0".to_string());
+        let update = ToolCallUpdate::new("real-tool-heartbeat-0", fields);
+        let events = map_update_to_events(
+            SessionUpdate::ToolCallUpdate(update),
+            &agent_profiles::CODEX,
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::ToolCallUpdated { .. })),
+            "non-claude heartbeat-suffixed id should be kept, got {events:?}"
+        );
     }
 
     #[test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -4159,6 +4159,19 @@ impl AgentMessageDedup {
     }
 }
 
+/// Claude Code emits keepalive progress pings for long-running tools under a
+/// derived id `<baseToolId>-heartbeat-<N>` (title/args/content all empty,
+/// `InProgress` only). They are transport liveness, not tool boundaries, and
+/// they never carry a start or completion. Forwarding them spawns a phantom
+/// titleless "tool call" card per ping that never resolves (see #3084), so we
+/// drop them at ingress.
+/// ponytail: string-suffix match on a claude-side id contract; revisit if the
+/// keepalive id scheme changes or claude starts shipping data under these ids.
+fn is_heartbeat_tool_call_id(id: &str) -> bool {
+    id.rsplit_once("-heartbeat-")
+        .is_some_and(|(_, suffix)| !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// Map an ACP `SessionUpdate` to the structured view's typed `Event`. Variants we
 /// don't yet handle pass through as `RawAgentUpdate` so UI clients can at
 /// least see them; we'll narrow these as the schema stabilises.
@@ -4297,6 +4310,12 @@ fn map_update_to_events(
         }
         SessionUpdate::ToolCallUpdate(update) => {
             let id = update.tool_call_id.0.to_string();
+            // Drop claude keepalive heartbeats before they become an orphan
+            // `ToolCallUpdated` that renders a phantom card. See #3084 and
+            // `is_heartbeat_tool_call_id`.
+            if is_heartbeat_tool_call_id(&id) {
+                return Vec::new();
+            }
             let is_error = matches!(
                 update.fields.status,
                 Some(agent_client_protocol::schema::v1::ToolCallStatus::Failed)
@@ -10298,6 +10317,56 @@ mod tests {
             AcpError::Spawn(_) => {}
             other => panic!("expected Spawn for non-ENOENT, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn heartbeat_tool_call_id_predicate() {
+        assert!(is_heartbeat_tool_call_id("toolu_01ABC-heartbeat-0"));
+        assert!(is_heartbeat_tool_call_id("toolu_01ABC-heartbeat-123"));
+        // Not a heartbeat: non-numeric suffix, empty suffix, plain id, or the
+        // marker embedded mid-id rather than as the trailing segment.
+        assert!(!is_heartbeat_tool_call_id("toolu_01ABC-heartbeat-x"));
+        assert!(!is_heartbeat_tool_call_id("toolu_01ABC-heartbeat-"));
+        assert!(!is_heartbeat_tool_call_id("toolu_01ABC"));
+        assert!(!is_heartbeat_tool_call_id("toolu_01ABC-heartbeat-1-extra"));
+    }
+
+    #[test]
+    fn map_update_to_events_drops_heartbeat_keepalive() {
+        // A claude keepalive ping (derived `-heartbeat-N` id, InProgress,
+        // no title/args/content) must emit nothing; forwarding it as
+        // ToolCallUpdated renders a phantom card that never completes. #3084.
+        use agent_client_protocol::schema::v1::{
+            SessionUpdate, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
+        let fields = ToolCallUpdateFields::new().status(ToolCallStatus::InProgress);
+        let update = ToolCallUpdate::new("toolu_01ABC-heartbeat-0", fields);
+        let events = map_update_to_events(
+            SessionUpdate::ToolCallUpdate(update),
+            &agent_profiles::CLAUDE,
+        );
+        assert!(events.is_empty(), "heartbeat emitted events: {events:?}");
+    }
+
+    #[test]
+    fn map_update_to_events_keeps_normal_in_progress_update() {
+        // Control: a normal InProgress update on a non-heartbeat id still
+        // emits ToolCallUpdated (the drop is scoped to keepalive ids only).
+        use agent_client_protocol::schema::v1::{
+            SessionUpdate, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+        };
+        let fields = ToolCallUpdateFields::new().status(ToolCallStatus::InProgress);
+        let update = ToolCallUpdate::new("toolu_01ABC", fields);
+        let events = map_update_to_events(
+            SessionUpdate::ToolCallUpdate(update),
+            &agent_profiles::CLAUDE,
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::ToolCallUpdated { .. })),
+            "expected ToolCallUpdated, got {events:?}"
+        );
     }
 
     #[test]

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -37,6 +37,13 @@ pub struct AgentProfile {
     /// a tool call titled `"ScheduleWakeup"`. Specific to Claude's
     /// `/loop` dynamic-pacing flow.
     pub supports_wakeup_tools: bool,
+    /// When true, the agent emits keepalive progress pings for
+    /// long-running tools under a derived id `<baseToolId>-heartbeat-<N>`
+    /// (see `acp_client::is_heartbeat_tool_call_id`). Only Claude Code
+    /// does this today; the ingress drop is gated on this so another
+    /// adapter that legitimately names a tool `*-heartbeat-<N>` is not
+    /// silenced. See #3084.
+    pub emits_heartbeat_keepalives: bool,
     /// ACP session-mode id that means "bypass all permission prompts"
     /// (the wizard's "Auto-approve" / profile `yolo_mode_default`). Each
     /// adapter names this differently: claude-agent-acp advertises
@@ -108,6 +115,7 @@ pub const CLAUDE: AgentProfile = AgentProfile {
     clear_aliases: &["/clear"],
     supports_exit_plan_mode: true,
     supports_wakeup_tools: true,
+    emits_heartbeat_keepalives: true,
     yolo_mode_id: Some("bypassPermissions"),
 };
 
@@ -127,6 +135,7 @@ pub const CODEX: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     // @agentclientprotocol/codex-acp advertises its bypass preset as the
     // `agent-full-access` session mode (read-only / agent /
     // agent-full-access), not Claude's `bypassPermissions`.
@@ -143,6 +152,7 @@ pub const OPENCODE: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     // OpenCode's bypass-mode id over ACP is unverified; leave YOLO a no-op
     // until observed rather than guessing an id the adapter would reject.
     yolo_mode_id: None,
@@ -157,6 +167,7 @@ pub const GEMINI: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     // gemini-cli surfaces its YOLO approval mode over `gemini --acp` with
     // the `yolo` id (see the CurrentModeUpdate mapping in acp_client.rs).
     yolo_mode_id: Some("yolo"),
@@ -169,6 +180,7 @@ pub const VIBE: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     yolo_mode_id: None,
 };
 
@@ -179,6 +191,7 @@ pub const PI: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     yolo_mode_id: None,
 };
 
@@ -191,6 +204,7 @@ pub const OMP: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     yolo_mode_id: None,
 };
 
@@ -206,6 +220,7 @@ pub const KIMI: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     yolo_mode_id: Some("yolo"),
 };
 
@@ -228,6 +243,7 @@ pub const DEFAULT: AgentProfile = AgentProfile {
     clear_aliases: &[],
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
+    emits_heartbeat_keepalives: false,
     yolo_mode_id: None,
 };
 

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -597,6 +597,35 @@ describe("applyEvent / pass-through and non-matching update rows", () => {
     expect(target?.tool?.name).toBe("Renamed");
     expect(target?.tool?.args_preview).toBe('{"k":2}');
   });
+
+  it("ignores heartbeat-suffixed ToolCallUpdated so replayed keepalives make no phantom card (#3084)", () => {
+    // One long-running Terminal tool, then several claude keepalive pings
+    // under the derived `<base>-heartbeat-N` id (no start, no completion).
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ToolCallStarted: { tool_call: tc("toolu_01ABC", { name: "Terminal" }) } },
+    });
+    for (let i = 0; i < 4; i++) {
+      state = applyEvent(state, {
+        session_id: "s-1",
+        seq: 2 + i,
+        event: {
+          ToolCallUpdated: {
+            tool_call_id: `toolu_01ABC-heartbeat-${i}`,
+            title: null,
+            args_preview: null,
+            started_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      });
+    }
+    const starts = state.activity.filter((r) => r.kind === "tool_start");
+    expect(starts).toHaveLength(1);
+    expect(starts[0].toolCallId).toBe("toolu_01ABC");
+    // No phantom "tool call" / "other" card was synthesized.
+    expect(state.activity.some((r) => r.toolCallId?.includes("-heartbeat-"))).toBe(false);
+  });
 });
 
 describe("mergeToolStart timestamp branches", () => {

--- a/web/src/lib/acpTypes.reducer.test.ts
+++ b/web/src/lib/acpTypes.reducer.test.ts
@@ -598,10 +598,11 @@ describe("applyEvent / pass-through and non-matching update rows", () => {
     expect(target?.tool?.args_preview).toBe('{"k":2}');
   });
 
-  it("ignores heartbeat-suffixed ToolCallUpdated so replayed keepalives make no phantom card (#3084)", () => {
+  it("ignores heartbeat-suffixed ToolCallUpdated for a claude session so replayed keepalives make no phantom card (#3084)", () => {
     // One long-running Terminal tool, then several claude keepalive pings
     // under the derived `<base>-heartbeat-N` id (no start, no completion).
-    let state = applyEvent(emptyAcpState(), {
+    let state: AcpState = { ...emptyAcpState(), agent: "claude" };
+    state = applyEvent(state, {
       session_id: "s-1",
       seq: 1,
       event: { ToolCallStarted: { tool_call: tc("toolu_01ABC", { name: "Terminal" }) } },
@@ -625,6 +626,27 @@ describe("applyEvent / pass-through and non-matching update rows", () => {
     expect(starts[0].toolCallId).toBe("toolu_01ABC");
     // No phantom "tool call" / "other" card was synthesized.
     expect(state.activity.some((r) => r.toolCallId?.includes("-heartbeat-"))).toBe(false);
+  });
+
+  it("keeps a heartbeat-suffixed ToolCallUpdated for a non-claude session (#3084)", () => {
+    // The drop is gated on the agent profile: a non-claude adapter that
+    // uses a `-heartbeat-N` id for a real tool must not be silenced.
+    const state = applyEvent(
+      { ...emptyAcpState(), agent: "codex" },
+      {
+        session_id: "s-1",
+        seq: 1,
+        event: {
+          ToolCallUpdated: {
+            tool_call_id: "real-tool-heartbeat-0",
+            title: "Real tool",
+            args_preview: null,
+            started_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      },
+    );
+    expect(state.activity.some((r) => r.toolCallId === "real-tool-heartbeat-0")).toBe(true);
   });
 });
 

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1320,6 +1320,12 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
   }
   if ("ToolCallUpdated" in event) {
     const { tool_call_id, title, args_preview, started_at, diffs } = event.ToolCallUpdated;
+    // Ignore claude keepalive heartbeats persisted by older backends: they
+    // have no start and no completion, so the synth-on-missing-start path
+    // below would render a phantom titleless card that never resolves. #3084.
+    if (isHeartbeatToolCallId(tool_call_id)) {
+      return next;
+    }
     // Per ACP, content is a replacement: a non-empty diff list overwrites
     // the card's diffs; null/empty leaves an earlier frame's diffs intact
     // so a text-only update can't blank the edit card. See #1721.
@@ -2090,6 +2096,16 @@ export function reduceFrames(frames: AcpFrame[]): AcpState {
 /** True when `rows` already carries a `tool_start` row for this id. */
 function hasToolStart(rows: ActivityRow[], toolCallId: string): boolean {
   return rows.some((r) => r.kind === "tool_start" && r.toolCallId === toolCallId);
+}
+
+/** Claude Code keepalive pings for long-running tools arrive under a derived
+ *  id `<baseToolId>-heartbeat-<N>` (no start, no completion). The backend now
+ *  drops them at ingress (see `is_heartbeat_tool_call_id` in acp_client.rs),
+ *  but historical session logs still hold the orphan `ToolCallUpdated` rows;
+ *  this guard stops a replay from synthesizing a phantom card for them. See
+ *  #3084. Mirror of the Rust predicate: trailing `-heartbeat-<digits>`. */
+function isHeartbeatToolCallId(toolCallId: string): boolean {
+  return /-heartbeat-\d+$/.test(toolCallId);
 }
 
 /** Build a minimal `tool_start` row for a tool call we never saw start.

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -5,6 +5,7 @@
 // component renders unknown frames gracefully.
 
 import type { DiffComment } from "../components/diff/comments/types";
+import { resolveAgentProfile } from "./agentProfiles";
 
 export type ApprovalDecision = "Allow" | "AllowAlways" | "Deny" | "Cancelled";
 
@@ -1322,8 +1323,10 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     const { tool_call_id, title, args_preview, started_at, diffs } = event.ToolCallUpdated;
     // Ignore claude keepalive heartbeats persisted by older backends: they
     // have no start and no completion, so the synth-on-missing-start path
-    // below would render a phantom titleless card that never resolves. #3084.
-    if (isHeartbeatToolCallId(tool_call_id)) {
+    // below would render a phantom titleless card that never resolves.
+    // Gated on the session agent's profile so another adapter that uses a
+    // `-heartbeat-N` id for a real tool is not dropped on replay. #3084.
+    if (isHeartbeatToolCallId(tool_call_id) && resolveAgentProfile(next.agent).capabilities.heartbeatKeepalives) {
       return next;
     }
     // Per ACP, content is a replacement: a non-empty diff list overwrites

--- a/web/src/lib/agentProfiles.ts
+++ b/web/src/lib/agentProfiles.ts
@@ -40,6 +40,12 @@ export interface AgentProfile {
      *  SessionModeState. Claude-family only; other agents render no mode
      *  picker rather than a phantom vocabulary they reject (#1764). */
     legacyModeFallback: boolean;
+    /** Whether the agent emits keepalive progress pings for long-running
+     *  tools under a derived `<baseToolId>-heartbeat-<N>` id. The reducer
+     *  ignores those replayed frames only for such agents, so another
+     *  adapter using that suffix for a real tool is not dropped. Mirrors
+     *  the Rust `emits_heartbeat_keepalives` gate. Claude-family only. #3084. */
+    heartbeatKeepalives: boolean;
   };
   /** `_meta.<namespace>.parentToolUseId` lookup order for subagent
    *  child linkage. Empty when the agent's parent-child linkage isn't
@@ -96,6 +102,7 @@ const CLAUDE: AgentProfile = {
     wakeup: true,
     subagents: true,
     legacyModeFallback: true,
+    heartbeatKeepalives: true,
   },
   parentMetaNamespaces: ["claudeCode"],
   mcpPrefixes: ["mcp__"],
@@ -122,6 +129,7 @@ const CODEX: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -147,6 +155,7 @@ const OPENCODE: AgentProfile = {
     wakeup: false,
     subagents: true,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -170,6 +179,7 @@ const GEMINI: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -193,6 +203,7 @@ const VIBE: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -210,6 +221,7 @@ const PI: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -230,6 +242,7 @@ const OMP: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -252,6 +265,7 @@ const KIMI: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],
@@ -277,6 +291,7 @@ export const DEFAULT_AGENT_PROFILE: AgentProfile = {
     wakeup: false,
     subagents: false,
     legacyModeFallback: false,
+    heartbeatKeepalives: false,
   },
   parentMetaNamespaces: [],
   mcpPrefixes: ["mcp__"],


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Long-running `Terminal` tools make Claude Code emit keepalive progress pings over ACP under a derived tool_call_id of the form `<baseToolId>-heartbeat-<N>` (title, args, and content all empty, status `InProgress` only). These arrive only as `ToolCallUpdate` notifications, never a start and never a completion.

The backend `map_update_to_events` forwarded them verbatim, and its emit guard passed on `in_progress` alone, persisting an orphan `Event::ToolCallUpdated` for each ping. The web reducer then hit its synth-on-missing-start path (added for the Gemini permission flow, #1713) and materialized a titleless "OTHER / tool call" card with a spinner that never resolved. A single long turn (`cargo test`, `cargo build`) produced 15+ of these phantom spinners, burying the real tool cards.

Fix, two layers:

- Backend (primary): drop keepalive heartbeats at ingress in `map_update_to_events` via a new `is_heartbeat_tool_call_id` predicate (trailing `-heartbeat-<digits>`). The frame never becomes an event, so nothing is persisted and every consumer (web and native TUI structured view) is covered for all new sessions.
- Frontend (defense-in-depth): guard the reducer so heartbeat-suffixed `ToolCallUpdated` events are ignored. Historical session logs already hold the orphan rows; this stops a replay from re-rendering phantom cards in the web view.

The native TUI reducer (`src/acp/state.rs`) needs no change: it only patches an already-in-flight tool and treats an unmatched update id as a no-op, so it never synthesized these cards.

Scope notes: the drop is narrow (only the `-heartbeat-<N>` id contract), so normal metadata-less `InProgress` updates and the #1713 / #1905 synth-from-startless paths are untouched. Heartbeats are discarded rather than folded onto the base card, because the base card re-stamps `started_at` on `InProgress` (#1060) and folding would reset its duration timer.

Closes #3084

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Start a structured-view session with claude and run a prompt that triggers a long shell command (e.g. `cargo test` or `sleep 30 && echo done`).
- [ ] While it runs, confirm only the single `Terminal` tool card shows; no titleless "OTHER / tool call" spinner cards pile up.
- [ ] Let the turn finish; confirm the `Terminal` card completes normally and its duration timer reflects real runtime.
- [ ] Open a session recorded before this change whose log holds `-heartbeat-N` rows (e.g. `82f824c0e2054e25`) in the web structured view; confirm zero phantom "tool call" cards render on replay.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the change is a pure reducer guard in `web/src/lib/acpTypes.ts` (not a `.tsx` component flow), covered by a Vitest unit test in `web/src/lib/acpTypes.reducer.test.ts` per the AGENTS.md guidance that reducer logic belongs in Vitest, not Playwright. No new dashboard affordance.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. The backend change is ACP event mapping, covered by a Rust unit test in `src/acp/acp_client.rs`.
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction, with a `/debate` consult (gemini + gpt-5.6) on the fix approach. I made the design calls (drop vs fold, suffix match vs generic, backend + frontend split) and reviewed each commit. Reproduce-then-fix was proven in both directions: each test was confirmed red against the pre-fix tree and green after.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes phantom “OTHER / tool call” spinner cards caused by Claude keepalive/heartbeat updates for long-running terminal tools.
- Adds a heartbeat-aware filter in the backend so heartbeat-only tool-call updates (ending in `-heartbeat-<number>`) are dropped before they become structured events.
- Updates the web reducer to ignore any historical heartbeat-only tool-call updates during replay, preventing them from reappearing as phantom cards.
- Scopes the filtering specifically to the Claude agent profile (so other adapters that may use similar ID suffixes are unaffected).
- Adds Rust and Vitest tests to verify the Claude vs non-Claude behaviors and that normal in-progress tool updates are unchanged.

## Benefits

- Prevents orphaned tool-call updates from being persisted or rendered.
- Keeps structured/terminal tool views accurate for long-running commands using Claude Code.
- Avoids regressions for other tool-call event sources (e.g., Gemini/OpenCode/Codex) by keeping behavior unchanged outside the Claude profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->