### PR TITLE
feat: add Atlas Cloud model routing to aoe-agent

### DIFF
--- a/acp-worker/aoe-agent/src/index.ts
+++ b/acp-worker/aoe-agent/src/index.ts
@@ -17,10 +17,8 @@
 import * as acp from "@agentclientprotocol/sdk";
 import { Readable, Writable } from "node:stream";
 import { streamText, tool, stepCountIs, type ModelMessage } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { openai } from "@ai-sdk/openai";
-import { google } from "@ai-sdk/google";
 import { z } from "zod";
+import { pickModel } from "./models.ts";
 import { appendTurn, loadTranscript } from "./transcript.ts";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
@@ -286,19 +284,6 @@ function serialiseToolOutput(output: unknown): Record<string, unknown> {
     return output as Record<string, unknown>;
   }
   return { value: output };
-}
-
-function pickModel(modelId: string) {
-  if (modelId.startsWith("claude-") || modelId.startsWith("anthropic:")) {
-    return anthropic(modelId.replace(/^anthropic:/, ""));
-  }
-  if (modelId.startsWith("gpt-") || modelId.startsWith("openai:")) {
-    return openai(modelId.replace(/^openai:/, ""));
-  }
-  if (modelId.startsWith("gemini-") || modelId.startsWith("google:")) {
-    return google(modelId.replace(/^google:/, ""));
-  }
-  return anthropic(modelId);
 }
 
 function randomHexId(): string {

--- a/acp-worker/aoe-agent/src/models.ts
+++ b/acp-worker/aoe-agent/src/models.ts
@@ -1,0 +1,59 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+export const ATLASCLOUD_DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1";
+export const ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash";
+
+const ATLASCLOUD_ALIASES = ["atlascloud", "atlas-cloud", "atlas"] as const;
+
+type Env = Record<string, string | undefined>;
+
+export function atlasCloudApiKey(env: Env = process.env): string | undefined {
+  return env.ATLASCLOUD_API_KEY || env.ATLAS_CLOUD_API_KEY;
+}
+
+export function atlasCloudBaseURL(env: Env = process.env): string {
+  return (
+    env.ATLASCLOUD_BASE_URL ||
+    env.ATLAS_CLOUD_BASE_URL ||
+    ATLASCLOUD_DEFAULT_BASE_URL
+  );
+}
+
+export function atlasCloudModelId(modelId: string): string | null {
+  const trimmed = modelId.trim();
+  for (const alias of ATLASCLOUD_ALIASES) {
+    if (trimmed === alias) {
+      return ATLASCLOUD_DEFAULT_MODEL;
+    }
+    const prefix = `${alias}:`;
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length).trim() || ATLASCLOUD_DEFAULT_MODEL;
+    }
+  }
+  return null;
+}
+
+export function pickModel(modelId: string) {
+  const atlasModelId = atlasCloudModelId(modelId);
+  if (atlasModelId) {
+    const atlasCloud = createOpenAICompatible({
+      name: "atlascloud",
+      apiKey: atlasCloudApiKey(),
+      baseURL: atlasCloudBaseURL(),
+    });
+    return atlasCloud(atlasModelId);
+  }
+  if (modelId.startsWith("claude-") || modelId.startsWith("anthropic:")) {
+    return anthropic(modelId.replace(/^anthropic:/, ""));
+  }
+  if (modelId.startsWith("gpt-") || modelId.startsWith("openai:")) {
+    return openai(modelId.replace(/^openai:/, ""));
+  }
+  if (modelId.startsWith("gemini-") || modelId.startsWith("google:")) {
+    return google(modelId.replace(/^google:/, ""));
+  }
+  return anthropic(modelId);
+}

--- a/acp-worker/aoe-agent/test/models.test.ts
+++ b/acp-worker/aoe-agent/test/models.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ATLASCLOUD_DEFAULT_BASE_URL,
+  ATLASCLOUD_DEFAULT_MODEL,
+  atlasCloudApiKey,
+  atlasCloudBaseURL,
+  atlasCloudModelId,
+} from "../src/models.ts";
+
+test("resolves Atlas Cloud model aliases", () => {
+  assert.equal(atlasCloudModelId("atlascloud"), ATLASCLOUD_DEFAULT_MODEL);
+  assert.equal(atlasCloudModelId("atlas-cloud"), ATLASCLOUD_DEFAULT_MODEL);
+  assert.equal(atlasCloudModelId("atlas"), ATLASCLOUD_DEFAULT_MODEL);
+  assert.equal(
+    atlasCloudModelId("atlascloud:deepseek-ai/deepseek-v4-pro"),
+    "deepseek-ai/deepseek-v4-pro",
+  );
+  assert.equal(
+    atlasCloudModelId("atlas-cloud:qwen/qwen3.5-flash"),
+    "qwen/qwen3.5-flash",
+  );
+});
+
+test("keeps existing provider model routes outside Atlas Cloud", () => {
+  assert.equal(atlasCloudModelId("claude-opus-4-7"), null);
+  assert.equal(atlasCloudModelId("openai:gpt-5"), null);
+  assert.equal(atlasCloudModelId("google:gemini-2.5-pro"), null);
+});
+
+test("reads Atlas Cloud credential aliases", () => {
+  assert.equal(
+    atlasCloudApiKey({
+      ATLASCLOUD_API_KEY: "primary",
+      ATLAS_CLOUD_API_KEY: "secondary",
+    }),
+    "primary",
+  );
+  assert.equal(
+    atlasCloudApiKey({ ATLAS_CLOUD_API_KEY: "secondary" }),
+    "secondary",
+  );
+});
+
+test("reads Atlas Cloud base URL aliases", () => {
+  assert.equal(atlasCloudBaseURL({}), ATLASCLOUD_DEFAULT_BASE_URL);
+  assert.equal(
+    atlasCloudBaseURL({
+      ATLASCLOUD_BASE_URL: "https://example.test/v1",
+      ATLAS_CLOUD_BASE_URL: "https://fallback.test/v1",
+    }),
+    "https://example.test/v1",
+  );
+  assert.equal(
+    atlasCloudBaseURL({ ATLAS_CLOUD_BASE_URL: "https://fallback.test/v1" }),
+    "https://fallback.test/v1",
+  );
+});

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -3189,6 +3189,10 @@ const ALWAYS_FORWARD_ENV: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "ATLASCLOUD_API_KEY",
+    "ATLAS_CLOUD_API_KEY",
+    "ATLASCLOUD_BASE_URL",
+    "ATLAS_CLOUD_BASE_URL",
     "CLAUDE_CONFIG_DIR",
 ];
 
@@ -12300,6 +12304,8 @@ mod tests {
         assert!(provider_env_denyreason("ANTHROPIC_API_KEY").is_none());
         assert!(provider_env_denyreason("CLAUDE_CODE_OAUTH_TOKEN").is_none());
         assert!(provider_env_denyreason("OPENAI_API_KEY").is_none());
+        assert!(provider_env_denyreason("ATLASCLOUD_API_KEY").is_none());
+        assert!(provider_env_denyreason("ATLAS_CLOUD_API_KEY").is_none());
         assert!(provider_env_denyreason("AOE_AGENT_MODEL").is_none());
         // Custom provider keys should pass through.
         assert!(provider_env_denyreason("MY_CUSTOM_VAR").is_none());
@@ -12313,6 +12319,14 @@ mod tests {
         // this one const, so its membership is also the parity guarantee
         // between the runner path and the in-proc stdio path.
         assert!(ALWAYS_FORWARD_ENV.contains(&"SSH_AUTH_SOCK"));
+    }
+
+    #[test]
+    fn always_forward_env_includes_atlascloud_provider_vars() {
+        assert!(ALWAYS_FORWARD_ENV.contains(&"ATLASCLOUD_API_KEY"));
+        assert!(ALWAYS_FORWARD_ENV.contains(&"ATLAS_CLOUD_API_KEY"));
+        assert!(ALWAYS_FORWARD_ENV.contains(&"ATLASCLOUD_BASE_URL"));
+        assert!(ALWAYS_FORWARD_ENV.contains(&"ATLAS_CLOUD_BASE_URL"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Adds Atlas Cloud as an OpenAI-compatible model route for the bundled `aoe-agent` worker. Users can set `AOE_AGENT_MODEL=atlascloud:<model>`, `atlas-cloud:<model>`, or `atlas:<model>`; the bare aliases default to `qwen/qwen3.5-flash`.

The change reuses the worker's existing `@ai-sdk/openai-compatible` dependency, defaults to `https://api.atlascloud.ai/v1`, supports `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY`, and forwards the Atlas Cloud env aliases through structured-view worker spawns. Existing Anthropic, OpenAI, and Google routing is unchanged.

No README, docs, logo, sponsor, credits, or partner copy changes.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

OpenAI Codex

**Any Additional AI Details you'd like to share:**

Used to inspect the existing provider routing, implement the Atlas Cloud integration, and run validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `npm ci --ignore-scripts`
- `npm test` in `acp-worker/aoe-agent` (9 passed)
- `/private/tmp/aoe-tscheck/node_modules/.bin/tsc --noEmit --allowImportingTsExtensions --types node --typeRoots /private/tmp/aoe-tscheck/node_modules/@types`
- `/private/tmp/aoe-tscheck/node_modules/.bin/tsc --outDir /private/tmp/aoe-tsbuild --allowImportingTsExtensions --rewriteRelativeImportExtensions --types node --typeRoots /private/tmp/aoe-tscheck/node_modules/@types`
- `AOE_WEB_DIST=/private/tmp/aoe-web-dist cargo test --features serve always_forward_env_includes_atlascloud_provider_vars`
- `AOE_WEB_DIST=/private/tmp/aoe-web-dist cargo test --features serve provider_env_denyreason_allows_provider_auth_keys`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`
- Atlas Cloud live model catalog: 437 total models / 375 visible; confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.

Note: `npm run build` currently fails after a clean install because the worker package's build script invokes `tsc`, but `typescript` is not declared in `package.json` / `package-lock.json`. I left that existing package metadata gap unchanged and validated TypeScript with a temporary compiler install instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Atlas Cloud model routing with support for multiple aliases and OpenAI-compatible models.
- Added configurable Atlas Cloud API keys, base URLs, and default model settings.
- Moved model-selection logic into a dedicated module while preserving existing Anthropic, OpenAI, and Google routing.
- Forwarded Atlas Cloud environment variables to worker processes.
- Added tests covering model aliases, credentials, and base URL resolution.

## Benefits

Enables Atlas Cloud models through the existing agent workflow without changing current provider behavior. Validation passed across tests, type checks, Rust checks, formatting, and diff checks; clean-install builds remain affected by an existing undeclared worker dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->