### PR TITLE
feat(web): inline Markdown viewer + Files pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "argon2",
  "axum",
  "base64",
+ "cap-std",
  "cargo-husky",
  "chrono",
  "clap",
@@ -184,6 +185,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -635,6 +642,36 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "cargo-husky"
@@ -1405,6 +1442,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2110,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2442,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -3565,6 +3641,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -5459,6 +5545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,11 @@ xz2 = { version = "0.1", optional = true }
 # the daemon itself uses axum's built-in WS support and never pulls this in.
 tokio-tungstenite = { version = "0.30", default-features = false, features = ["rustls-tls-webpki-roots", "connect"], optional = true }
 
+# Capability-safe file opens for the session file-read endpoint (#3088): open
+# beneath a Dir so a component swapped after the containment check cannot
+# escape the intended root.
+cap-std = { version = "4.0.2", optional = true }
+
 # Unix-only: O_NOFOLLOW for race-free plugin-tree reads/copies (no std constant).
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -234,7 +239,12 @@ serve = [
     "semver",
     "xz2",
     "tokio-tungstenite",
+    # Sandboxed, race-safe file reads for the session file endpoint (#3088):
+    # open beneath a capability Dir so a symlink or component swapped between
+    # the confinement check and the open cannot escape the intended root.
+    "cap-std",
 ]
+cap-std = ["dep:cap-std"]
 
 [dev-dependencies]
 serial_test = "3.4"

--- a/docs/guides/web/diff.md
+++ b/docs/guides/web/diff.md
@@ -46,3 +46,9 @@ lines:
 
 Binary files and files too large to render inline are shown with a
 header and stats but no hunk body.
+
+## Files pane and Markdown
+
+The **Files** pane (the folder icon in the activity bar) browses the session's working directory, not just its git changes, so it lists files even in a non-git scratch session. Selecting a file opens it in a viewer; Markdown (`.md` / `.markdown`) renders as formatted HTML by default, with a **Rendered** / **Raw** toggle. The same toggle appears on Markdown files opened from the diff list.
+
+Files an agent cites in its transcript that live **outside** the session's repo (for example a plan written to `/tmp` or an agent config directory) open only when that agent actually read or wrote them during this session. This provenance check is the boundary: the dashboard cannot open an arbitrary path on the host, only files the session's agent touched.

--- a/src/server/api/file_provenance.rs
+++ b/src/server/api/file_provenance.rs
@@ -1,0 +1,419 @@
+//! Provenance-based confinement for the session file-read endpoint (#3088).
+//!
+//! The web dashboard can render a Markdown (or any) file that belongs to a
+//! session. A read is allowed only when the canonicalized target is either
+//!   - under one of the session's project roots (project_path + worktree
+//!     paths), or
+//!   - a path the session's agent actually touched this session (Write / Edit /
+//!     Read / apply_patch / memory-recall), recovered from the ACP event log.
+//!
+//! Provenance, not a directory allowlist, is the boundary: the dashboard can
+//! open exactly what the agent already worked with (whose content was already
+//! in the transcript), and nothing it never touched. See the debate synthesis
+//! on #3088 for why an ambient `/tmp` + agent-home allowlist was rejected.
+
+use std::collections::HashSet;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use axum::http::StatusCode;
+
+use crate::acp::state::Event;
+
+/// Keys under which the various agents stash a file path in a tool call's
+/// `args_preview` JSON. Mirrors the client's `pickStr` order in
+/// `web/src/components/acp/ToolCards.tsx`.
+const PATH_KEYS: [&str; 4] = ["file_path", "path", "filePath", "filename"];
+
+/// Pull a file path out of a tool call's `args_preview` JSON blob. Returns
+/// `None` when the blob does not parse (it is capped at 16 KB at ingest, so a
+/// huge leading argument can truncate the JSON) or carries no path key; callers
+/// treat that as "path unknown", never "denied", and fall back to the
+/// structured `diffs[].path`.
+fn extract_path_from_args_preview(args_preview: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(args_preview).ok()?;
+    let obj = value.as_object()?;
+    for key in PATH_KEYS {
+        if let Some(s) = obj.get(key).and_then(|v| v.as_str()) {
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Build the set of paths a session's agent touched, from its ACP event log.
+///
+/// Folds both `ToolCallStarted` and `ToolCallUpdated`: claude-agent-acp ships
+/// the initial tool call with an empty `raw_input` and fills the path in on a
+/// later update, so the update frames must be scanned too. Paths are collected
+/// exactly as the agent emitted them (absolute for Claude's Read/Write/Edit),
+/// so entries are directly usable as absolute allow-set keys.
+pub fn collect_touched_paths(events: &[(u64, Event)]) -> HashSet<PathBuf> {
+    let mut out = HashSet::new();
+    let mut add = |s: &str| {
+        if !s.is_empty() {
+            out.insert(PathBuf::from(s));
+        }
+    };
+    for (_seq, event) in events {
+        match event {
+            Event::ToolCallStarted { tool_call } => {
+                if let Some(p) = extract_path_from_args_preview(&tool_call.args_preview) {
+                    add(&p);
+                }
+                for d in &tool_call.diffs {
+                    add(&d.path);
+                }
+                if let Some(mr) = &tool_call.memory_recall {
+                    for p in &mr.paths {
+                        add(p);
+                    }
+                }
+            }
+            Event::ToolCallUpdated {
+                args_preview,
+                diffs,
+                ..
+            } => {
+                if let Some(ap) = args_preview {
+                    if let Some(p) = extract_path_from_args_preview(ap) {
+                        add(&p);
+                    }
+                }
+                if let Some(diffs) = diffs {
+                    for d in diffs {
+                        add(&d.path);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Reject a relative request that tries to climb out of its root. Absolute
+/// requests skip this (they are matched against roots / provenance instead).
+fn has_traversal(requested: &Path) -> bool {
+    requested.components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    })
+}
+
+/// Resolve and confine a requested path.
+///
+/// `project_roots` must already be canonicalized. `touched` is the raw
+/// provenance set (canonicalized here, lazily; entries that no longer resolve
+/// are skipped). Returns the canonical path to read, or an HTTP error.
+///
+/// Security invariants (see #3088 debate): the path is canonicalized (symlinks
+/// resolved, `..` collapsed) before any containment check; containment uses
+/// `Path::starts_with` (component-aware, so `/repo-evil` is not under `/repo`);
+/// the returned canonical path is what the caller must open (never the raw
+/// request), closing the symlink-swap gap between check and read.
+pub fn confine_path(
+    project_roots: &[PathBuf],
+    touched: &HashSet<PathBuf>,
+    requested: &Path,
+) -> Result<PathBuf, (StatusCode, &'static str)> {
+    if requested.as_os_str().is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "empty path"));
+    }
+
+    let canonical = if requested.is_absolute() {
+        requested
+            .canonicalize()
+            .map_err(|_| (StatusCode::NOT_FOUND, "file not found"))?
+    } else {
+        if has_traversal(requested) {
+            return Err((StatusCode::BAD_REQUEST, "path escapes project"));
+        }
+        // A relative request is always resolved against the primary project
+        // root (the first entry). Multi-repo members are reached by their
+        // absolute worktree path via provenance / project-root containment.
+        let root = project_roots
+            .first()
+            .ok_or((StatusCode::INTERNAL_SERVER_ERROR, "no project root"))?;
+        root.join(requested)
+            .canonicalize()
+            .map_err(|_| (StatusCode::NOT_FOUND, "file not found"))?
+    };
+
+    // Under a project root: any file (the agent's own workspace).
+    if project_roots.iter().any(|r| canonical.starts_with(r)) {
+        return Ok(canonical);
+    }
+
+    // Otherwise it must be a path the agent touched this session. Compare
+    // canonical forms so a symlinked-but-touched path still matches.
+    let touched_hit = touched
+        .iter()
+        .any(|t| t.canonicalize().map(|ct| ct == canonical).unwrap_or(false));
+    if touched_hit {
+        return Ok(canonical);
+    }
+
+    Err((StatusCode::FORBIDDEN, "path not readable for this session"))
+}
+
+/// Read a confined, canonical path with a byte cap.
+///
+/// Rejects non-regular files (directories, FIFOs, devices, `/proc` nodes)
+/// before reading, so a blocking or endless special file can't stall or OOM the
+/// server. Reads at most `cap + 1` bytes to detect truncation without
+/// allocating an unbounded buffer. Returns `(content, is_binary, truncated)`;
+/// binary content yields an empty string (the client shows a "binary file"
+/// notice), matching the diff endpoint.
+pub fn read_bounded(
+    path: &Path,
+    cap: usize,
+) -> Result<(String, bool, bool), (StatusCode, &'static str)> {
+    let mut file =
+        std::fs::File::open(path).map_err(|_| (StatusCode::NOT_FOUND, "file not found"))?;
+    let meta = file
+        .metadata()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "stat failed"))?;
+    if !meta.file_type().is_file() {
+        return Err((StatusCode::BAD_REQUEST, "not a regular file"));
+    }
+
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(cap as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "read failed"))?;
+
+    let truncated = bytes.len() > cap;
+    if truncated {
+        bytes.truncate(cap);
+    }
+    let is_binary = bytes.contains(&0);
+    let content = if is_binary {
+        String::new()
+    } else {
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+    Ok((content, is_binary, truncated))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::state::{DiffPreview, MemoryRecall, ToolCall};
+    use std::fs;
+
+    fn tool_call(args_preview: &str, diffs: Vec<&str>, recall: Vec<&str>) -> ToolCall {
+        ToolCall {
+            id: "t1".into(),
+            name: "Write".into(),
+            kind: "edit".into(),
+            args_preview: args_preview.into(),
+            started_at: chrono::Utc::now(),
+            parent_tool_call_id: None,
+            memory_recall: if recall.is_empty() {
+                None
+            } else {
+                Some(MemoryRecall {
+                    mode: "recall".into(),
+                    paths: recall.into_iter().map(String::from).collect(),
+                    synthesized_text: None,
+                })
+            },
+            diffs: diffs
+                .into_iter()
+                .map(|p| DiffPreview {
+                    path: p.into(),
+                    old_text: None,
+                    new_text: None,
+                    created_at: chrono::Utc::now(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn collects_paths_from_all_channels() {
+        let events = vec![
+            (
+                1u64,
+                Event::ToolCallStarted {
+                    tool_call: tool_call(r#"{"file_path":"/tmp/plan.md"}"#, vec![], vec![]),
+                },
+            ),
+            (
+                2,
+                Event::ToolCallStarted {
+                    tool_call: tool_call(
+                        "{}",
+                        vec!["/tmp/patched.rs"],
+                        vec!["/home/u/.claude/mem.md"],
+                    ),
+                },
+            ),
+            (
+                3,
+                Event::ToolCallUpdated {
+                    tool_call_id: "t3".into(),
+                    title: None,
+                    args_preview: Some(r#"{"path":"/tmp/late.txt"}"#.into()),
+                    started_at: None,
+                    diffs: Some(vec![DiffPreview {
+                        path: "/tmp/diff-late.rs".into(),
+                        old_text: None,
+                        new_text: None,
+                        created_at: chrono::Utc::now(),
+                    }]),
+                },
+            ),
+        ];
+        let set = collect_touched_paths(&events);
+        for p in [
+            "/tmp/plan.md",
+            "/tmp/patched.rs",
+            "/home/u/.claude/mem.md",
+            "/tmp/late.txt",
+            "/tmp/diff-late.rs",
+        ] {
+            assert!(set.contains(&PathBuf::from(p)), "missing {p}");
+        }
+    }
+
+    #[test]
+    fn unparseable_args_preview_is_ignored_not_denied() {
+        // A 16 KB-truncated args_preview may be invalid JSON; that must not
+        // panic or fabricate a path, and the diffs fallback still lands.
+        let events = vec![(
+            1u64,
+            Event::ToolCallStarted {
+                tool_call: tool_call(r#"{"content":"unterminated"#, vec!["/tmp/x.rs"], vec![]),
+            },
+        )];
+        let set = collect_touched_paths(&events);
+        assert_eq!(set.len(), 1);
+        assert!(set.contains(&PathBuf::from("/tmp/x.rs")));
+    }
+
+    #[test]
+    fn extract_prefers_key_order() {
+        assert_eq!(
+            extract_path_from_args_preview(r#"{"filename":"b","file_path":"a"}"#),
+            Some("a".into())
+        );
+        assert_eq!(extract_path_from_args_preview(r#"{"nope":"x"}"#), None);
+        assert_eq!(extract_path_from_args_preview("not json"), None);
+    }
+
+    #[test]
+    fn confine_allows_relative_in_project_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        fs::write(root.join("a.md"), "# hi").unwrap();
+        let roots = vec![root.clone()];
+        let touched = HashSet::new();
+
+        assert!(confine_path(&roots, &touched, Path::new("a.md")).is_ok());
+        assert_eq!(
+            confine_path(&roots, &touched, Path::new("../etc/passwd"))
+                .unwrap_err()
+                .0,
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            confine_path(&roots, &touched, Path::new("")).unwrap_err().0,
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn confine_absolute_requires_project_or_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_root = outside.path().canonicalize().unwrap();
+
+        let in_project = root.join("in.md");
+        fs::write(&in_project, "x").unwrap();
+        let touched_file = outside_root.join("plan.md");
+        fs::write(&touched_file, "x").unwrap();
+        let untouched_file = outside_root.join("secret.md");
+        fs::write(&untouched_file, "x").unwrap();
+
+        let roots = vec![root.clone()];
+        let mut touched = HashSet::new();
+        touched.insert(touched_file.clone());
+
+        // Absolute path inside the project root: allowed.
+        assert!(confine_path(&roots, &touched, &in_project).is_ok());
+        // Absolute path the agent touched: allowed.
+        assert!(confine_path(&roots, &touched, &touched_file).is_ok());
+        // Absolute path outside project and never touched: forbidden.
+        assert_eq!(
+            confine_path(&roots, &touched, &untouched_file)
+                .unwrap_err()
+                .0,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn confine_rejects_symlink_escape_and_sibling_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let secret_dir = tempfile::tempdir().unwrap();
+        let secret = secret_dir.path().canonicalize().unwrap().join("id_rsa");
+        fs::write(&secret, "KEY").unwrap();
+
+        // Symlink inside the project pointing outside: canonicalization
+        // resolves it to the secret, which is under no root -> rejected.
+        #[cfg(unix)]
+        {
+            let link = root.join("link.md");
+            std::os::unix::fs::symlink(&secret, &link).unwrap();
+            let err = confine_path(&[root.clone()], &HashSet::new(), &link).unwrap_err();
+            assert_eq!(err.0, StatusCode::FORBIDDEN);
+        }
+
+        // A sibling dir sharing a string prefix ("<root>-evil") is NOT under
+        // the root: component-aware starts_with, not string prefix.
+        let evil = PathBuf::from(format!("{}-evil", root.display()));
+        fs::create_dir_all(&evil).ok();
+        let evil_file = evil.join("x.md");
+        fs::write(&evil_file, "x").unwrap();
+        let err = confine_path(&[root.clone()], &HashSet::new(), &evil_file).unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+        fs::remove_dir_all(&evil).ok();
+    }
+
+    #[test]
+    fn read_bounded_text_binary_dir_and_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let text = root.join("t.md");
+        fs::write(&text, "# hello\nworld").unwrap();
+        let (content, is_binary, truncated) = read_bounded(&text, 1000).unwrap();
+        assert_eq!(content, "# hello\nworld");
+        assert!(!is_binary && !truncated);
+
+        let bin = root.join("b.bin");
+        fs::write(&bin, [0u8, 1, 2, 3]).unwrap();
+        let (content, is_binary, _) = read_bounded(&bin, 1000).unwrap();
+        assert!(is_binary && content.is_empty());
+
+        let big = root.join("big.md");
+        fs::write(&big, "abcdef").unwrap();
+        let (content, _, truncated) = read_bounded(&big, 3).unwrap();
+        assert!(truncated && content.len() == 3);
+
+        // A directory is not a regular file.
+        assert_eq!(
+            read_bounded(root, 1000).unwrap_err().0,
+            StatusCode::BAD_REQUEST
+        );
+    }
+}

--- a/src/server/api/file_provenance.rs
+++ b/src/server/api/file_provenance.rs
@@ -418,7 +418,9 @@ mod tests {
             std::os::unix::fs::symlink(&secret, &link).unwrap();
             // canonicalize resolves the link to the secret, outside every root.
             assert_eq!(
-                read(&[root.clone()], &HashSet::new(), &link).unwrap_err().0,
+                read(std::slice::from_ref(&root), &HashSet::new(), &link)
+                    .unwrap_err()
+                    .0,
                 StatusCode::FORBIDDEN
             );
         }
@@ -430,7 +432,7 @@ mod tests {
         let evil_file = evil.join("x.md");
         fs::write(&evil_file, "x").unwrap();
         assert_eq!(
-            read(&[root.clone()], &HashSet::new(), &evil_file)
+            read(std::slice::from_ref(&root), &HashSet::new(), &evil_file)
                 .unwrap_err()
                 .0,
             StatusCode::FORBIDDEN
@@ -494,10 +496,14 @@ mod tests {
             canonical: root.join("swapped.md"),
             root: root.clone(),
         };
-        let err = read_confined(&swapped, 5_000_000).unwrap_err();
-        assert_eq!(err.0, StatusCode::NOT_FOUND);
-        // And the secret never reached the caller.
-        assert_ne!(fs::read_to_string(&secret).unwrap(), "");
+        // The outside file's bytes never reach the caller: the open is refused
+        // outright rather than followed.
+        let result = read_confined(&swapped, 5_000_000);
+        assert!(
+            !matches!(&result, Ok((content, _, _)) if content == "KEY"),
+            "capability open leaked the outside file"
+        );
+        assert_eq!(result.unwrap_err().0, StatusCode::NOT_FOUND);
     }
 
     /// The provenance set means replaying the whole event log, so it must not be
@@ -510,7 +516,7 @@ mod tests {
         let mut called = false;
 
         let confined = confine_path(
-            &[root.clone()],
+            std::slice::from_ref(&root),
             || {
                 called = true;
                 HashSet::new()

--- a/src/server/api/file_provenance.rs
+++ b/src/server/api/file_provenance.rs
@@ -123,10 +123,12 @@ pub struct Confined {
 
 /// Resolve and confine a requested path.
 ///
-/// `project_roots` must already be canonicalized. `touched` is the raw
-/// provenance set (canonicalized here, lazily; entries that no longer resolve
-/// are skipped). Returns the canonical path plus the root to open beneath, or
-/// an HTTP error.
+/// `project_roots` must already be canonicalized. `touched` builds the raw
+/// provenance set and is invoked **only** when the target is not under a
+/// project root: recovering the set means replaying the whole session event
+/// log, which the common case (a file in the session's own workspace) never
+/// needs. Returns the canonical path plus the root to open beneath, or an HTTP
+/// error.
 ///
 /// Security invariants (see #3088 debate): the path is canonicalized (symlinks
 /// resolved, `..` collapsed) before any containment check; containment uses
@@ -136,7 +138,7 @@ pub struct Confined {
 /// filesystem changes between here and the read.
 pub fn confine_path(
     project_roots: &[PathBuf],
-    touched: &HashSet<PathBuf>,
+    touched: impl FnOnce() -> HashSet<PathBuf>,
     requested: &Path,
 ) -> Result<Confined, (StatusCode, &'static str)> {
     if requested.as_os_str().is_empty() {
@@ -170,10 +172,10 @@ pub fn confine_path(
         });
     }
 
-    // Otherwise it must be a path the agent touched this session. Compare
-    // canonical forms so a symlinked-but-touched path still matches; open it
-    // beneath its own parent directory.
-    let touched_hit = touched
+    // Outside every project root, so fall back to provenance: only now is it
+    // worth replaying the event log. Compare canonical forms so a
+    // symlinked-but-touched path still matches; open it beneath its own parent.
+    let touched_hit = touched()
         .iter()
         .any(|t| t.canonicalize().map(|ct| ct == canonical).unwrap_or(false));
     if touched_hit {
@@ -351,7 +353,7 @@ mod tests {
         touched: &HashSet<PathBuf>,
         requested: &Path,
     ) -> Result<(String, bool, bool), (StatusCode, &'static str)> {
-        let confined = confine_path(roots, touched, requested)?;
+        let confined = confine_path(roots, || touched.clone(), requested)?;
         read_confined(&confined, 5_000_000)
     }
 
@@ -448,7 +450,7 @@ mod tests {
         assert!(is_binary && content.is_empty());
 
         fs::write(root.join("big.md"), "abcdef").unwrap();
-        let confined = confine_path(&roots, &touched, Path::new("big.md")).unwrap();
+        let confined = confine_path(&roots, || touched.clone(), Path::new("big.md")).unwrap();
         let (content, _, truncated) = read_confined(&confined, 3).unwrap();
         assert!(truncated && content.len() == 3);
 
@@ -458,5 +460,66 @@ mod tests {
             read(&roots, &touched, Path::new("sub")).unwrap_err().0,
             StatusCode::BAD_REQUEST
         );
+    }
+
+    /// The capability open is the TOCTOU defense, so provoke it directly rather
+    /// than only reaching it with a stable tree: hand `read_confined` a target
+    /// that escapes `root` via a symlink, the shape a component swapped after
+    /// `confine_path` validated containment would produce. `cap_std` re-checks
+    /// every component at open time and refuses it; a plain
+    /// `File::open(canonical)` would happily follow the link and leak the
+    /// outside file, so this test fails if that hardening is ever reverted.
+    #[cfg(unix)]
+    #[test]
+    fn read_confined_refuses_symlink_escaping_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let secret = outside.path().canonicalize().unwrap().join("id_rsa");
+        fs::write(&secret, "KEY").unwrap();
+
+        // A file, and a sibling symlink pointing out of the root.
+        fs::write(root.join("ok.md"), "fine").unwrap();
+        std::os::unix::fs::symlink(&secret, root.join("swapped.md")).unwrap();
+
+        // Sanity: a real in-root file opens through the same path.
+        let good = Confined {
+            canonical: root.join("ok.md"),
+            root: root.clone(),
+        };
+        assert_eq!(read_confined(&good, 5_000_000).unwrap().0, "fine");
+
+        // The escaping symlink is refused at open time, not followed.
+        let swapped = Confined {
+            canonical: root.join("swapped.md"),
+            root: root.clone(),
+        };
+        let err = read_confined(&swapped, 5_000_000).unwrap_err();
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+        // And the secret never reached the caller.
+        assert_ne!(fs::read_to_string(&secret).unwrap(), "");
+    }
+
+    /// The provenance set means replaying the whole event log, so it must not be
+    /// built when the target resolves under a project root (the common case).
+    #[test]
+    fn provenance_is_not_built_for_a_project_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        fs::write(root.join("a.md"), "x").unwrap();
+        let mut called = false;
+
+        let confined = confine_path(
+            &[root.clone()],
+            || {
+                called = true;
+                HashSet::new()
+            },
+            Path::new("a.md"),
+        )
+        .unwrap();
+
+        assert_eq!(confined.root, root);
+        assert!(!called, "event log replayed for an in-project file");
     }
 }

--- a/src/server/api/file_provenance.rs
+++ b/src/server/api/file_provenance.rs
@@ -11,12 +11,19 @@
 //! open exactly what the agent already worked with (whose content was already
 //! in the transcript), and nothing it never touched. See the debate synthesis
 //! on #3088 for why an ambient `/tmp` + agent-home allowlist was rejected.
+//!
+//! The final read opens the file beneath a `cap_std` capability directory, so a
+//! path component swapped between the containment check and the open (TOCTOU)
+//! cannot escape the intended root: `cap_std::fs::Dir::open` refuses `..` and
+//! symlinks that leave the directory.
 
 use std::collections::HashSet;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 use axum::http::StatusCode;
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
 
 use crate::acp::state::Event;
 
@@ -105,22 +112,33 @@ fn has_traversal(requested: &Path) -> bool {
     })
 }
 
+/// A read that passed confinement: the canonical target plus the directory it
+/// must be opened beneath (a project root, or the file's own parent for a
+/// provenance hit). [`read_confined`] opens `canonical` relative to `root`
+/// through a `cap_std` capability directory.
+pub struct Confined {
+    pub canonical: PathBuf,
+    pub root: PathBuf,
+}
+
 /// Resolve and confine a requested path.
 ///
 /// `project_roots` must already be canonicalized. `touched` is the raw
 /// provenance set (canonicalized here, lazily; entries that no longer resolve
-/// are skipped). Returns the canonical path to read, or an HTTP error.
+/// are skipped). Returns the canonical path plus the root to open beneath, or
+/// an HTTP error.
 ///
 /// Security invariants (see #3088 debate): the path is canonicalized (symlinks
 /// resolved, `..` collapsed) before any containment check; containment uses
-/// `Path::starts_with` (component-aware, so `/repo-evil` is not under `/repo`);
-/// the returned canonical path is what the caller must open (never the raw
-/// request), closing the symlink-swap gap between check and read.
+/// `Path::starts_with` (component-aware, so `/repo-evil` is not under `/repo`).
+/// The actual open is delegated to [`read_confined`], which uses the returned
+/// `root` as a capability boundary so the open cannot escape it even if the
+/// filesystem changes between here and the read.
 pub fn confine_path(
     project_roots: &[PathBuf],
     touched: &HashSet<PathBuf>,
     requested: &Path,
-) -> Result<PathBuf, (StatusCode, &'static str)> {
+) -> Result<Confined, (StatusCode, &'static str)> {
     if requested.as_os_str().is_empty() {
         return Err((StatusCode::BAD_REQUEST, "empty path"));
     }
@@ -144,24 +162,34 @@ pub fn confine_path(
             .map_err(|_| (StatusCode::NOT_FOUND, "file not found"))?
     };
 
-    // Under a project root: any file (the agent's own workspace).
-    if project_roots.iter().any(|r| canonical.starts_with(r)) {
-        return Ok(canonical);
+    // Under a project root: open beneath that root (any file; the workspace).
+    if let Some(root) = project_roots.iter().find(|r| canonical.starts_with(r)) {
+        return Ok(Confined {
+            canonical,
+            root: root.clone(),
+        });
     }
 
     // Otherwise it must be a path the agent touched this session. Compare
-    // canonical forms so a symlinked-but-touched path still matches.
+    // canonical forms so a symlinked-but-touched path still matches; open it
+    // beneath its own parent directory.
     let touched_hit = touched
         .iter()
         .any(|t| t.canonicalize().map(|ct| ct == canonical).unwrap_or(false));
     if touched_hit {
-        return Ok(canonical);
+        let root = canonical
+            .parent()
+            .ok_or((StatusCode::FORBIDDEN, "path has no parent"))?
+            .to_path_buf();
+        return Ok(Confined { canonical, root });
     }
 
     Err((StatusCode::FORBIDDEN, "path not readable for this session"))
 }
 
-/// Read a confined, canonical path with a byte cap.
+/// Read a confined target with a byte cap, opening it beneath a `cap_std`
+/// capability directory so the open is race-safe against a component swapped
+/// after [`confine_path`] validated containment.
 ///
 /// Rejects non-regular files (directories, FIFOs, devices, `/proc` nodes)
 /// before reading, so a blocking or endless special file can't stall or OOM the
@@ -169,16 +197,25 @@ pub fn confine_path(
 /// allocating an unbounded buffer. Returns `(content, is_binary, truncated)`;
 /// binary content yields an empty string (the client shows a "binary file"
 /// notice), matching the diff endpoint.
-pub fn read_bounded(
-    path: &Path,
+pub fn read_confined(
+    confined: &Confined,
     cap: usize,
 ) -> Result<(String, bool, bool), (StatusCode, &'static str)> {
-    let mut file =
-        std::fs::File::open(path).map_err(|_| (StatusCode::NOT_FOUND, "file not found"))?;
+    let dir = Dir::open_ambient_dir(&confined.root, ambient_authority())
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "open root failed"))?;
+    let rel = confined
+        .canonical
+        .strip_prefix(&confined.root)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "path not beneath root"))?;
+    // cap_std refuses `..` and symlinks that escape `dir`, so this open stays
+    // beneath `root` regardless of what changed since the canonicalize check.
+    let mut file = dir
+        .open(rel)
+        .map_err(|_| (StatusCode::NOT_FOUND, "file not found"))?;
     let meta = file
         .metadata()
         .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "stat failed"))?;
-    if !meta.file_type().is_file() {
+    if !meta.is_file() {
         return Err((StatusCode::BAD_REQUEST, "not a regular file"));
     }
 
@@ -308,74 +345,80 @@ mod tests {
         assert_eq!(extract_path_from_args_preview("not json"), None);
     }
 
+    // Read a confined request end to end (confine then cap_std-backed read).
+    fn read(
+        roots: &[PathBuf],
+        touched: &HashSet<PathBuf>,
+        requested: &Path,
+    ) -> Result<(String, bool, bool), (StatusCode, &'static str)> {
+        let confined = confine_path(roots, touched, requested)?;
+        read_confined(&confined, 5_000_000)
+    }
+
     #[test]
-    fn confine_allows_relative_in_project_rejects_traversal() {
+    fn allows_relative_in_project_rejects_traversal() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().canonicalize().unwrap();
         fs::write(root.join("a.md"), "# hi").unwrap();
         let roots = vec![root.clone()];
         let touched = HashSet::new();
 
-        assert!(confine_path(&roots, &touched, Path::new("a.md")).is_ok());
+        assert_eq!(read(&roots, &touched, Path::new("a.md")).unwrap().0, "# hi");
         assert_eq!(
-            confine_path(&roots, &touched, Path::new("../etc/passwd"))
+            read(&roots, &touched, Path::new("../etc/passwd"))
                 .unwrap_err()
                 .0,
             StatusCode::BAD_REQUEST
         );
         assert_eq!(
-            confine_path(&roots, &touched, Path::new("")).unwrap_err().0,
+            read(&roots, &touched, Path::new("")).unwrap_err().0,
             StatusCode::BAD_REQUEST
         );
     }
 
     #[test]
-    fn confine_absolute_requires_project_or_provenance() {
+    fn absolute_requires_project_or_provenance() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().canonicalize().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let outside_root = outside.path().canonicalize().unwrap();
 
         let in_project = root.join("in.md");
-        fs::write(&in_project, "x").unwrap();
+        fs::write(&in_project, "in").unwrap();
         let touched_file = outside_root.join("plan.md");
-        fs::write(&touched_file, "x").unwrap();
+        fs::write(&touched_file, "plan").unwrap();
         let untouched_file = outside_root.join("secret.md");
-        fs::write(&untouched_file, "x").unwrap();
+        fs::write(&untouched_file, "secret").unwrap();
 
         let roots = vec![root.clone()];
         let mut touched = HashSet::new();
         touched.insert(touched_file.clone());
 
-        // Absolute path inside the project root: allowed.
-        assert!(confine_path(&roots, &touched, &in_project).is_ok());
-        // Absolute path the agent touched: allowed.
-        assert!(confine_path(&roots, &touched, &touched_file).is_ok());
-        // Absolute path outside project and never touched: forbidden.
+        assert_eq!(read(&roots, &touched, &in_project).unwrap().0, "in");
+        assert_eq!(read(&roots, &touched, &touched_file).unwrap().0, "plan");
         assert_eq!(
-            confine_path(&roots, &touched, &untouched_file)
-                .unwrap_err()
-                .0,
+            read(&roots, &touched, &untouched_file).unwrap_err().0,
             StatusCode::FORBIDDEN
         );
     }
 
     #[test]
-    fn confine_rejects_symlink_escape_and_sibling_prefix() {
+    fn rejects_symlink_escape_and_sibling_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().canonicalize().unwrap();
         let secret_dir = tempfile::tempdir().unwrap();
         let secret = secret_dir.path().canonicalize().unwrap().join("id_rsa");
         fs::write(&secret, "KEY").unwrap();
 
-        // Symlink inside the project pointing outside: canonicalization
-        // resolves it to the secret, which is under no root -> rejected.
         #[cfg(unix)]
         {
             let link = root.join("link.md");
             std::os::unix::fs::symlink(&secret, &link).unwrap();
-            let err = confine_path(&[root.clone()], &HashSet::new(), &link).unwrap_err();
-            assert_eq!(err.0, StatusCode::FORBIDDEN);
+            // canonicalize resolves the link to the secret, outside every root.
+            assert_eq!(
+                read(&[root.clone()], &HashSet::new(), &link).unwrap_err().0,
+                StatusCode::FORBIDDEN
+            );
         }
 
         // A sibling dir sharing a string prefix ("<root>-evil") is NOT under
@@ -384,35 +427,35 @@ mod tests {
         fs::create_dir_all(&evil).ok();
         let evil_file = evil.join("x.md");
         fs::write(&evil_file, "x").unwrap();
-        let err = confine_path(&[root.clone()], &HashSet::new(), &evil_file).unwrap_err();
-        assert_eq!(err.0, StatusCode::FORBIDDEN);
+        assert_eq!(
+            read(&[root.clone()], &HashSet::new(), &evil_file)
+                .unwrap_err()
+                .0,
+            StatusCode::FORBIDDEN
+        );
         fs::remove_dir_all(&evil).ok();
     }
 
     #[test]
-    fn read_bounded_text_binary_dir_and_cap() {
+    fn binary_dir_and_cap() {
         let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
+        let root = dir.path().canonicalize().unwrap();
+        let roots = vec![root.clone()];
+        let touched = HashSet::new();
 
-        let text = root.join("t.md");
-        fs::write(&text, "# hello\nworld").unwrap();
-        let (content, is_binary, truncated) = read_bounded(&text, 1000).unwrap();
-        assert_eq!(content, "# hello\nworld");
-        assert!(!is_binary && !truncated);
-
-        let bin = root.join("b.bin");
-        fs::write(&bin, [0u8, 1, 2, 3]).unwrap();
-        let (content, is_binary, _) = read_bounded(&bin, 1000).unwrap();
+        fs::write(root.join("b.bin"), [0u8, 1, 2, 3]).unwrap();
+        let (content, is_binary, _) = read(&roots, &touched, Path::new("b.bin")).unwrap();
         assert!(is_binary && content.is_empty());
 
-        let big = root.join("big.md");
-        fs::write(&big, "abcdef").unwrap();
-        let (content, _, truncated) = read_bounded(&big, 3).unwrap();
+        fs::write(root.join("big.md"), "abcdef").unwrap();
+        let confined = confine_path(&roots, &touched, Path::new("big.md")).unwrap();
+        let (content, _, truncated) = read_confined(&confined, 3).unwrap();
         assert!(truncated && content.len() == 3);
 
         // A directory is not a regular file.
+        fs::create_dir(root.join("sub")).unwrap();
         assert_eq!(
-            read_bounded(root, 1000).unwrap_err().0,
+            read(&roots, &touched, Path::new("sub")).unwrap_err().0,
             StatusCode::BAD_REQUEST
         );
     }

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -14,6 +14,8 @@ pub(super) use super::AppState;
 mod acp;
 #[cfg(feature = "serve")]
 mod client_log;
+#[cfg(feature = "serve")]
+mod file_provenance;
 mod git;
 mod log_level;
 mod mcp;
@@ -53,7 +55,7 @@ pub use sessions::{
     ensure_terminal, force_smart_rename, get_recent_projects, kill_terminal, list_sessions,
     paste_image, preview_volume_ignores_globs, read_output, rename_session, restore_session,
     search_sessions, send_message, serve_session_artifact, session_diff_file, session_diff_files,
-    set_worktree_name, start_session, stop_session, summarize_session, trash_session,
+    session_file, set_worktree_name, start_session, stop_session, summarize_session, trash_session,
     update_session_archive, update_session_color, update_session_diff_base, update_session_group,
     update_session_notifications, update_session_pin, update_session_snooze, update_session_unread,
     update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -6177,6 +6177,16 @@ pub struct SessionFileQuery {
     pub path: String,
 }
 
+/// Response for the session file-read endpoint. Mirrors the typed shape of its
+/// sibling [`RichFileContentsResponse`]; `content` is empty for a binary or
+/// truncated file (the client renders a notice instead).
+#[derive(Serialize)]
+pub struct SessionFileResponse {
+    pub content: String,
+    pub is_binary: bool,
+    pub truncated: bool,
+}
+
 /// Read a session file for the dashboard file viewer (#3088).
 ///
 /// Git-agnostic (works on non-git scratch sessions). A read is allowed when the
@@ -6210,34 +6220,39 @@ pub async fn session_file(
             .filter_map(|p| p.canonicalize().ok())
             .collect();
 
-        // Build the touched-path allow-set by paging the whole session log.
-        // ponytail: per-request scan; cache per session if it shows up hot on
-        // long/active sessions.
-        let mut events = Vec::new();
-        let mut since = 0u64;
-        loop {
-            let page = store.replay_page(&session_id, since, Some(1000));
-            let advance = page.last_scanned_seq;
-            events.extend(page.events);
-            match (page.has_more, advance) {
-                (true, Some(seq)) => since = seq,
-                _ => break,
+        // Provenance fallback: page the whole session log and collect the paths
+        // the agent touched. Deferred behind a closure so it runs only when the
+        // target is outside every project root; a workspace file (the common
+        // case) never pays for the replay.
+        // ponytail: per-request scan on the miss path; cache per session keyed
+        // on highest_seq if it shows up hot on long/active sessions.
+        let touched = || {
+            let mut events = Vec::new();
+            let mut since = 0u64;
+            loop {
+                let page = store.replay_page(&session_id, since, Some(1000));
+                let advance = page.last_scanned_seq;
+                events.extend(page.events);
+                match (page.has_more, advance) {
+                    (true, Some(seq)) => since = seq,
+                    _ => break,
+                }
             }
-        }
-        let touched = super::file_provenance::collect_touched_paths(&events);
+            super::file_provenance::collect_touched_paths(&events)
+        };
 
         let confined = super::file_provenance::confine_path(
             &roots,
-            &touched,
+            touched,
             std::path::Path::new(&requested),
         )?;
         let (content, is_binary, truncated) =
             super::file_provenance::read_confined(&confined, MAX_CONTENTS_BYTES)?;
-        Ok::<_, (StatusCode, &'static str)>(serde_json::json!({
-            "content": content,
-            "is_binary": is_binary,
-            "truncated": truncated,
-        }))
+        Ok::<_, (StatusCode, &'static str)>(SessionFileResponse {
+            content,
+            is_binary,
+            truncated,
+        })
     })
     .await;
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -6182,8 +6182,8 @@ pub struct SessionFileQuery {
 /// Git-agnostic (works on non-git scratch sessions). A read is allowed when the
 /// canonical target is under a session project root (project_path + worktree
 /// paths) or is a path the agent touched this session, recovered from the ACP
-/// event log. Confinement and bounded reading live in
-/// [`super::file_provenance`].
+/// event log. Confinement and bounded reading live in the private
+/// `file_provenance` module.
 pub async fn session_file(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -6226,13 +6226,13 @@ pub async fn session_file(
         }
         let touched = super::file_provenance::collect_touched_paths(&events);
 
-        let canonical = super::file_provenance::confine_path(
+        let confined = super::file_provenance::confine_path(
             &roots,
             &touched,
             std::path::Path::new(&requested),
         )?;
         let (content, is_binary, truncated) =
-            super::file_provenance::read_bounded(&canonical, MAX_CONTENTS_BYTES)?;
+            super::file_provenance::read_confined(&confined, MAX_CONTENTS_BYTES)?;
         Ok::<_, (StatusCode, &'static str)>(serde_json::json!({
             "content": content,
             "is_binary": is_binary,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -6173,6 +6173,93 @@ pub async fn session_diff_file(
 }
 
 #[derive(Deserialize)]
+pub struct SessionFileQuery {
+    pub path: String,
+}
+
+/// Read a session file for the dashboard file viewer (#3088).
+///
+/// Git-agnostic (works on non-git scratch sessions). A read is allowed when the
+/// canonical target is under a session project root (project_path + worktree
+/// paths) or is a path the agent touched this session, recovered from the ACP
+/// event log. Confinement and bounded reading live in
+/// [`super::file_provenance`].
+pub async fn session_file(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    axum::extract::Query(query): axum::extract::Query<SessionFileQuery>,
+) -> impl IntoResponse {
+    let ctx = match resolve_diff_repos(&state, &id).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let project_paths: Vec<std::path::PathBuf> = ctx
+        .repos
+        .iter()
+        .map(|r| std::path::PathBuf::from(&r.path))
+        .collect();
+    let store = state.acp_event_store.clone();
+    let session_id = id.clone();
+    let requested = query.path.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        // Canonicalize project roots up front; a root that no longer resolves
+        // is dropped so a stale worktree can't break or widen confinement.
+        let roots: Vec<std::path::PathBuf> = project_paths
+            .iter()
+            .filter_map(|p| p.canonicalize().ok())
+            .collect();
+
+        // Build the touched-path allow-set by paging the whole session log.
+        // ponytail: per-request scan; cache per session if it shows up hot on
+        // long/active sessions.
+        let mut events = Vec::new();
+        let mut since = 0u64;
+        loop {
+            let page = store.replay_page(&session_id, since, Some(1000));
+            let advance = page.last_scanned_seq;
+            events.extend(page.events);
+            match (page.has_more, advance) {
+                (true, Some(seq)) => since = seq,
+                _ => break,
+            }
+        }
+        let touched = super::file_provenance::collect_touched_paths(&events);
+
+        let canonical = super::file_provenance::confine_path(
+            &roots,
+            &touched,
+            std::path::Path::new(&requested),
+        )?;
+        let (content, is_binary, truncated) =
+            super::file_provenance::read_bounded(&canonical, MAX_CONTENTS_BYTES)?;
+        Ok::<_, (StatusCode, &'static str)>(serde_json::json!({
+            "content": content,
+            "is_binary": is_binary,
+            "truncated": truncated,
+        }))
+    })
+    .await;
+
+    match result {
+        Ok(Ok(value)) => (StatusCode::OK, Json(value)).into_response(),
+        Ok(Err((status, msg))) => (
+            status,
+            Json(serde_json::json!({"error": "file_read", "message": msg})),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(target: "http.api.sessions", "session_file panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
 pub struct VolumeIgnoresPreviewQuery {
     pub path: String,
     #[serde(default)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1626,6 +1626,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::session_diff_files),
         )
         .route("/api/sessions/{id}/diff/file", get(api::session_diff_file))
+        .route("/api/sessions/{id}/file", get(api::session_file))
         .route(
             "/api/sessions/{id}/artifacts/{*path}",
             get(api::serve_session_artifact),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -80,7 +80,7 @@ import { parseUnreadIndicatorEnabled, UnreadIndicatorContext, useUnreadIndicator
 import { parseSessionRowTagMode, SessionRowTagContext, type SessionRowTagMode } from "./lib/sessionRowTag";
 import { parseSessionColorsEnabled, SessionColorsContext } from "./lib/sessionColors";
 import { toastBus, reportError } from "./lib/toastBus";
-import { resolveToRepoRelative, type FileRef } from "./lib/fileRef";
+import { isAbsolutePath, resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
 import { dispatchFocusTerminal, requestSessionInputFocus, setPendingTerminalFocus } from "./lib/terminalFocus";
 import { hydrateWebUiStateFromServer, initWebUiSync } from "./lib/webUiSync";
@@ -694,6 +694,7 @@ function AppContent({
   const activeSession = activeWorkspace?.sessions.find((s) => s.id === activeSessionId);
   const allPaneIds: string[] = [
     "diff",
+    "files",
     "terminal",
     // The background-agents panel only applies to structured-view (ACP)
     // sessions; a plain terminal session never launches sub-agents.
@@ -1224,7 +1225,7 @@ function AppContent({
         // provenance-confined /file endpoint is the gate, so open it in the
         // FileContentViewer and let the server allow or refuse. A relative
         // path we couldn't resolve has no absolute target to try. See #3088.
-        if (ref.path.startsWith("/")) {
+        if (isAbsolutePath(ref.path)) {
           setSelectedFile({ path: ref.path, line: ref.line, cited: true, external: true });
           return;
         }
@@ -1650,7 +1651,10 @@ function AppContent({
         return <BackgroundAgentsPanel sessionId={activeSessionId} />;
       }
       if (id === "files") {
-        return <FilesPane sessionId={activeSessionId} />;
+        // Remount on session switch so the selected file (and any in-flight
+        // read) resets instead of requesting the old path from the new
+        // session. See #3088 review.
+        return <FilesPane key={activeSessionId ?? "none"} sessionId={activeSessionId} />;
       }
       if (id === "diff") {
         return (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1219,25 +1219,29 @@ function AppContent({
     (ref: FileRef) => {
       if (!activeSession) return;
       const resolved = resolveToRepoRelative(ref.path, activeSession);
-      if (!resolved) {
-        // Outside the session's repo roots. The agent may still have touched
-        // it this session (e.g. a plan written to /tmp or ~/.claude); the
-        // provenance-confined /file endpoint is the gate, so open it in the
-        // FileContentViewer and let the server allow or refuse. A relative
-        // path we couldn't resolve has no absolute target to try. See #3088.
-        if (isAbsolutePath(ref.path)) {
-          setSelectedFile({ path: ref.path, line: ref.line, cited: true, external: true });
-          return;
-        }
-        toastBus.handler?.error(`Could not open ${ref.path}: not inside this session's repo`);
+      // A git session with an in-repo path uses the diff viewer (#1718). A
+      // scratch (non-git) session has no diff endpoint, so it always uses the
+      // provenance-confined /file viewer, as does any out-of-repo absolute path
+      // the agent touched this session (a plan in /tmp, ~/.claude, etc.). #3088.
+      if (resolved && !activeSession.scratch) {
+        setSelectedFile({
+          path: resolved.relativePath,
+          repoName: resolved.repoName,
+          line: ref.line,
+          cited: true,
+        });
         return;
       }
-      setSelectedFile({
-        path: resolved.relativePath,
-        repoName: resolved.repoName,
-        line: ref.line,
-        cited: true,
-      });
+      if (resolved || isAbsolutePath(ref.path)) {
+        setSelectedFile({
+          path: resolved?.relativePath ?? ref.path,
+          line: ref.line,
+          cited: true,
+          external: true,
+        });
+        return;
+      }
+      toastBus.handler?.error(`Could not open ${ref.path}: not inside this session's repo`);
     },
     [activeSession],
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -109,6 +109,8 @@ import { PaneDndController } from "./components/PaneDndController";
 import { visibleToFullIndex, type DropTarget } from "./components/paneDnd";
 import { BackgroundAgentsPanel } from "./components/acp/BackgroundAgentsPanel";
 import { DiffPane } from "./components/DiffPane";
+import { FilesPane } from "./components/FilesPane";
+import { FileContentViewer } from "./components/diff/FileContentViewer";
 import { PairedShellPane } from "./components/PairedTerminal";
 import { BUILTIN_PANES, isTerminalTabId, terminalIndexOf, terminalTabId, type DockLocation } from "./lib/panes";
 import { MobileRightPanelPicker } from "./components/MobileRightPanelPicker";
@@ -452,8 +454,14 @@ function AppContent({
      *  file may have no diff against the base (full-file fallback, #1810), so
      *  it must not be auto-cleared for being absent from the diff list. */
     cited?: boolean;
+    /** An absolute path OUTSIDE the session's repo roots that the agent
+     *  touched this session (a cited `/tmp/plan.md`, `~/.claude/x.md`). Read
+     *  via the provenance-confined `/file` endpoint and rendered by
+     *  FileContentViewer instead of the git-diff viewer. See #3088. */
+    external?: boolean;
   } | null>(null);
   const selectedFilePath = selectedFile?.path ?? null;
+  const selectedFileExternal = selectedFile?.external ?? false;
   const selectedRepoName = selectedFile?.repoName;
   const selectedFileLine = selectedFile?.line;
   // Dock panes render as tabbed groups (#2437): each dock holds an ordered set
@@ -586,7 +594,7 @@ function AppContent({
       const defaultDock: DockLocation =
         pluginPaneById.get(kind)?.defaultDock ?? BUILTIN_PANES.find((p) => p.id === kind)?.defaultDock ?? "right";
       if (isPluginPaneId(kind)) togglePlugin(kind, defaultDock);
-      else toggleKind(kind as "diff" | "terminal" | "agents", defaultDock);
+      else toggleKind(kind as "diff" | "terminal" | "agents" | "files", defaultDock);
     },
     [toggleKind, togglePlugin, pluginPaneById],
   );
@@ -1211,6 +1219,15 @@ function AppContent({
       if (!activeSession) return;
       const resolved = resolveToRepoRelative(ref.path, activeSession);
       if (!resolved) {
+        // Outside the session's repo roots. The agent may still have touched
+        // it this session (e.g. a plan written to /tmp or ~/.claude); the
+        // provenance-confined /file endpoint is the gate, so open it in the
+        // FileContentViewer and let the server allow or refuse. A relative
+        // path we couldn't resolve has no absolute target to try. See #3088.
+        if (ref.path.startsWith("/")) {
+          setSelectedFile({ path: ref.path, line: ref.line, cited: true, external: true });
+          return;
+        }
         toastBus.handler?.error(`Could not open ${ref.path}: not inside this session's repo`);
         return;
       }
@@ -1632,6 +1649,9 @@ function AppContent({
       if (id === "agents") {
         return <BackgroundAgentsPanel sessionId={activeSessionId} />;
       }
+      if (id === "files") {
+        return <FilesPane sessionId={activeSessionId} />;
+      }
       if (id === "diff") {
         return (
           <DiffPane
@@ -1703,18 +1723,26 @@ function AppContent({
                   )}
                 </div>
 
-                {selectedFilePath && activeSessionId && (
-                  <DiffFileViewer
-                    sessionId={activeSessionId}
-                    filePath={selectedFilePath}
-                    repoName={selectedRepoName}
-                    targetLine={selectedFileLine}
-                    revision={revision}
-                    onClose={handleCloseFile}
-                    commentsEnabled={commentsEnabled}
-                    commentsStore={diffComments}
-                  />
-                )}
+                {selectedFilePath &&
+                  activeSessionId &&
+                  (selectedFileExternal ? (
+                    <FileContentViewer
+                      sessionId={activeSessionId}
+                      filePath={selectedFilePath}
+                      onBack={handleCloseFile}
+                    />
+                  ) : (
+                    <DiffFileViewer
+                      sessionId={activeSessionId}
+                      filePath={selectedFilePath}
+                      repoName={selectedRepoName}
+                      targetLine={selectedFileLine}
+                      revision={revision}
+                      onClose={handleCloseFile}
+                      commentsEnabled={commentsEnabled}
+                      commentsStore={diffComments}
+                    />
+                  ))}
               </div>
             }
             right={

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -1,0 +1,74 @@
+import { useMemo, useState } from "react";
+import { useFilesIndex } from "./acp/useFilesIndex";
+import { FileContentViewer } from "./diff/FileContentViewer";
+
+interface Props {
+  sessionId: string | null;
+}
+
+/**
+ * Browse the files under a session's project_path and view them (#3088).
+ * Backed by `GET /api/sessions/:id/acp/files` (git-agnostic, so non-git scratch
+ * sessions list their files too); selecting a file opens it in
+ * {@link FileContentViewer}, which renders Markdown and confines reads server
+ * side. A flat, filterable list (ponytail: add a tree if it gets unwieldy).
+ */
+export function FilesPane({ sessionId }: Props) {
+  const { files, loading } = useFilesIndex(sessionId ?? "");
+  const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const shown = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    const list = q ? files.filter((f) => f.toLowerCase().includes(q)) : files;
+    return list.slice(0, 500);
+  }, [files, filter]);
+
+  if (!sessionId) {
+    return (
+      <div className="flex-1 flex items-center justify-center bg-surface-900 text-text-dim">
+        <span className="text-sm">No active session</span>
+      </div>
+    );
+  }
+
+  if (selected) {
+    return <FileContentViewer sessionId={sessionId} filePath={selected} onBack={() => setSelected(null)} />;
+  }
+
+  return (
+    <div className="flex-1 flex flex-col bg-surface-900 overflow-hidden">
+      <div className="px-3 py-2 border-b border-surface-700/20 shrink-0">
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter files..."
+          aria-label="Filter files"
+          className="w-full bg-surface-950 border border-surface-700/40 rounded px-2 py-1 text-[12px] font-mono text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600"
+        />
+      </div>
+      <div className="flex-1 min-h-0 overflow-auto">
+        {loading ? (
+          <div className="p-3 text-sm text-text-dim">Loading files...</div>
+        ) : shown.length === 0 ? (
+          <div className="p-3 text-sm text-text-dim">
+            {files.length === 0 ? "No files in this session" : "No matching files"}
+          </div>
+        ) : (
+          shown.map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setSelected(f)}
+              className="w-full text-left px-3 py-1 font-mono text-[12px] text-text-secondary hover:bg-surface-800 hover:text-text-primary truncate cursor-pointer"
+              title={f}
+            >
+              {f}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useFilesIndex } from "./acp/useFilesIndex";
 import { FileContentViewer } from "./diff/FileContentViewer";
 
@@ -14,15 +15,25 @@ interface Props {
  * side. A flat, filterable list (ponytail: add a tree if it gets unwieldy).
  */
 export function FilesPane({ sessionId }: Props) {
-  const { files, loading } = useFilesIndex(sessionId ?? "");
+  const { files, loading, error, reload } = useFilesIndex(sessionId ?? "");
   const [filter, setFilter] = useState("");
   const [selected, setSelected] = useState<string | null>(null);
+  // Row nodes by path, so closing the viewer can return focus to the row the
+  // user opened instead of dumping them at the top of the pane.
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
 
   const shown = useMemo(() => {
     const q = filter.trim().toLowerCase();
     const list = q ? files.filter((f) => f.toLowerCase().includes(q)) : files;
     return list.slice(0, 500);
   }, [files, filter]);
+
+  // The list is unmounted while the viewer is open, so flush the state change
+  // first: the row has to exist again before it can take focus.
+  const handleBack = (path: string) => {
+    flushSync(() => setSelected(null));
+    rowRefs.current.get(path)?.focus();
+  };
 
   if (!sessionId) {
     return (
@@ -33,7 +44,7 @@ export function FilesPane({ sessionId }: Props) {
   }
 
   if (selected) {
-    return <FileContentViewer sessionId={sessionId} filePath={selected} onBack={() => setSelected(null)} />;
+    return <FileContentViewer sessionId={sessionId} filePath={selected} onBack={() => handleBack(selected)} />;
   }
 
   return (
@@ -51,6 +62,18 @@ export function FilesPane({ sessionId }: Props) {
       <div className="flex-1 min-h-0 overflow-auto">
         {loading ? (
           <div className="p-3 text-sm text-text-dim">Loading files...</div>
+        ) : error ? (
+          // A failed fetch must not read as "this session has no files".
+          <div className="p-3 flex flex-col items-start gap-2">
+            <span className="text-sm text-status-error">Could not load the file list</span>
+            <button
+              type="button"
+              onClick={reload}
+              className="px-2 py-0.5 text-[11px] font-mono rounded border border-surface-700/40 text-text-dim hover:text-text-secondary cursor-pointer transition-colors"
+            >
+              Retry
+            </button>
+          </div>
         ) : shown.length === 0 ? (
           <div className="p-3 text-sm text-text-dim">
             {files.length === 0 ? "No files in this session" : "No matching files"}
@@ -60,6 +83,10 @@ export function FilesPane({ sessionId }: Props) {
             <button
               key={f}
               type="button"
+              ref={(el) => {
+                if (el) rowRefs.current.set(f, el);
+                else rowRefs.current.delete(f);
+              }}
               onClick={() => setSelected(f)}
               className="w-full text-left px-3 py-1 font-mono text-[12px] text-text-secondary hover:bg-surface-800 hover:text-text-primary truncate cursor-pointer"
               title={f}

--- a/web/src/components/__tests__/FilesPane.test.tsx
+++ b/web/src/components/__tests__/FilesPane.test.tsx
@@ -8,7 +8,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { FilesPane } from "../FilesPane";
 import * as api from "../../lib/api";
 
-const filesMock = vi.hoisted(() => ({ files: [] as string[], loading: false }));
+const filesMock = vi.hoisted(() => ({
+  files: [] as string[],
+  loading: false,
+  error: false,
+  reload: vi.fn(),
+}));
 
 vi.mock("../acp/useFilesIndex", () => ({
   useFilesIndex: () => filesMock,
@@ -29,6 +34,8 @@ beforeEach(() => {
   window.localStorage.clear();
   filesMock.files = ["docs/plan.md", "src/main.rs", "notes.md"];
   filesMock.loading = false;
+  filesMock.error = false;
+  filesMock.reload = vi.fn();
 });
 afterEach(() => {
   cleanup();
@@ -63,5 +70,44 @@ describe("FilesPane", () => {
   it("shows an empty state without a session", () => {
     render(<FilesPane sessionId={null} />);
     expect(screen.getByText("No active session")).toBeTruthy();
+  });
+
+  it("distinguishes a failed fetch from an empty session, and retries", () => {
+    filesMock.files = [];
+    filesMock.error = true;
+    render(<FilesPane sessionId="s1" />);
+
+    // Must not read as "this session has no files".
+    expect(screen.getByText("Could not load the file list")).toBeTruthy();
+    expect(screen.queryByText("No files in this session")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(filesMock.reload).toHaveBeenCalled();
+  });
+
+  it("says the session is empty when the fetch succeeded with no files", () => {
+    filesMock.files = [];
+    filesMock.error = false;
+    render(<FilesPane sessionId="s1" />);
+    expect(screen.getByText("No files in this session")).toBeTruthy();
+    expect(screen.queryByText("Could not load the file list")).toBeNull();
+  });
+
+  it("returns focus to the opened row when the viewer closes", async () => {
+    vi.spyOn(api, "getSessionFile").mockResolvedValue({
+      content: "# Plan",
+      is_binary: false,
+      truncated: false,
+    });
+    render(<FilesPane sessionId="s1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "docs/plan.md" }));
+    const back = await screen.findByRole("button", { name: "Back to files" });
+    fireEvent.click(back);
+
+    // The row the user opened regains focus, not the top of the pane.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole("button", { name: "docs/plan.md" }));
+    });
   });
 });

--- a/web/src/components/__tests__/FilesPane.test.tsx
+++ b/web/src/components/__tests__/FilesPane.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// FilesPane contract (#3088): lists a session's project files, filters them,
+// and opens one in the FileContentViewer on click.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { FilesPane } from "../FilesPane";
+import * as api from "../../lib/api";
+
+const filesMock = vi.hoisted(() => ({ files: [] as string[], loading: false }));
+
+vi.mock("../acp/useFilesIndex", () => ({
+  useFilesIndex: () => filesMock,
+  fuzzyFilter: <T,>(items: T[]) => items,
+}));
+
+vi.mock("../../hooks/useShikiTheme", () => ({
+  useShikiTheme: () => ({ theme: "github-dark", appearance: "dark" }),
+}));
+vi.mock("../../lib/highlighter", () => ({
+  ensureThemeLoaded: vi.fn().mockResolvedValue("github-dark"),
+  getHighlighter: vi.fn().mockResolvedValue({ codeToHtml: (c: string) => `<pre>${c}</pre>` }),
+  langKeyForExt: (s: string) => s,
+  loadLanguage: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  filesMock.files = ["docs/plan.md", "src/main.rs", "notes.md"];
+  filesMock.loading = false;
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("FilesPane", () => {
+  it("lists project files and filters them", () => {
+    render(<FilesPane sessionId="s1" />);
+    expect(screen.getByRole("button", { name: "docs/plan.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "src/main.rs" })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Filter files"), { target: { value: ".md" } });
+    expect(screen.getByRole("button", { name: "docs/plan.md" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "src/main.rs" })).toBeNull();
+  });
+
+  it("opens a file in the viewer on click", async () => {
+    vi.spyOn(api, "getSessionFile").mockResolvedValue({
+      content: "# Plan",
+      is_binary: false,
+      truncated: false,
+    });
+    const { container } = render(<FilesPane sessionId="s1" />);
+    fireEvent.click(screen.getByRole("button", { name: "docs/plan.md" }));
+    await waitFor(() => {
+      expect(container.querySelector("h1")?.textContent).toBe("Plan");
+    });
+    expect(api.getSessionFile).toHaveBeenCalledWith("s1", "docs/plan.md");
+  });
+
+  it("shows an empty state without a session", () => {
+    render(<FilesPane sessionId={null} />);
+    expect(screen.getByText("No active session")).toBeTruthy();
+  });
+});

--- a/web/src/components/acp/Markdown.test.tsx
+++ b/web/src/components/acp/Markdown.test.tsx
@@ -250,12 +250,12 @@ describe("anchor file-ref interception", () => {
   });
 });
 
-// #3088 (superseding the inert-anchor treatment of #2587): an out-of-repo
-// ABSOLUTE path is now clickable, because the agent may have touched it this
-// session; clicking routes to the provenance-confined file viewer via
-// onOpenFileRef, and the server is the gate. In-repo and relative paths keep
-// their #1718 intercept.
-describe("anchor routing for local paths (#3088)", () => {
+// #2587: a local file path that resolves to no known repo root cannot be
+// opened from the transcript link, so it renders as inert text instead of a
+// link that dead-ends. An out-of-repo file the agent actually wrote or read is
+// reachable from its tool card instead, which opens the provenance-confined
+// viewer (#3088); see ToolCards.render.test.tsx.
+describe("anchor inert-path for unresolvable local paths (#2587)", () => {
   function getAnchor(): React.ComponentType<React.ComponentPropsWithoutRef<"a">> {
     render(<Markdown text="x" />);
     return primitiveCalls.at(-1)!.components.a as React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
@@ -268,21 +268,19 @@ describe("anchor routing for local paths (#3088)", () => {
     workspace_repos: [],
   };
 
-  it("routes an outside-repo ABSOLUTE path to the file viewer", () => {
+  it("renders an outside-repo absolute path as inert text, not a link", () => {
     const Anchor = getAnchor();
     const onOpenFileRef = vi.fn();
     const { container } = render(
       <AcpFileRefContext.Provider value={{ onOpenFileRef, fileRefSession: session }}>
-        <Anchor href="/tmp/plan.md">plan.md</Anchor>
+        <Anchor href="/tmp/codex-agent-views/shot.png">shot.png</Anchor>
       </AcpFileRefContext.Provider>,
     );
-    const a = container.querySelector("a");
-    expect(a).not.toBeNull();
-    expect(container.querySelector("span.acp-inert-path")).toBeNull();
-    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
-    fireEvent(a!, event);
-    expect(onOpenFileRef).toHaveBeenCalledWith({ path: "/tmp/plan.md" });
-    expect(event.defaultPrevented).toBe(true);
+    expect(container.querySelector("a")).toBeNull();
+    const span = container.querySelector("span.acp-inert-path");
+    expect(span).not.toBeNull();
+    expect(span?.textContent).toBe("shot.png");
+    expect(onOpenFileRef).not.toHaveBeenCalled();
   });
 
   it("still intercepts an in-repo path as a clickable file link", () => {

--- a/web/src/components/acp/Markdown.test.tsx
+++ b/web/src/components/acp/Markdown.test.tsx
@@ -250,10 +250,12 @@ describe("anchor file-ref interception", () => {
   });
 });
 
-// #2587: a local file path that resolves to no known repo root cannot be
-// opened in the dashboard, so it must render as inert text instead of a
-// link that dead-ends in a toast or routes to the SPA.
-describe("anchor inert-path for unresolvable local paths (#2587)", () => {
+// #3088 (superseding the inert-anchor treatment of #2587): an out-of-repo
+// ABSOLUTE path is now clickable, because the agent may have touched it this
+// session; clicking routes to the provenance-confined file viewer via
+// onOpenFileRef, and the server is the gate. In-repo and relative paths keep
+// their #1718 intercept.
+describe("anchor routing for local paths (#3088)", () => {
   function getAnchor(): React.ComponentType<React.ComponentPropsWithoutRef<"a">> {
     render(<Markdown text="x" />);
     return primitiveCalls.at(-1)!.components.a as React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
@@ -266,19 +268,21 @@ describe("anchor inert-path for unresolvable local paths (#2587)", () => {
     workspace_repos: [],
   };
 
-  it("renders an outside-repo absolute path as inert text, not a link", () => {
+  it("routes an outside-repo ABSOLUTE path to the file viewer", () => {
     const Anchor = getAnchor();
     const onOpenFileRef = vi.fn();
     const { container } = render(
       <AcpFileRefContext.Provider value={{ onOpenFileRef, fileRefSession: session }}>
-        <Anchor href="/tmp/codex-agent-views/shot.png">shot.png</Anchor>
+        <Anchor href="/tmp/plan.md">plan.md</Anchor>
       </AcpFileRefContext.Provider>,
     );
-    expect(container.querySelector("a")).toBeNull();
-    const span = container.querySelector("span.acp-inert-path");
-    expect(span).not.toBeNull();
-    expect(span?.textContent).toBe("shot.png");
-    expect(onOpenFileRef).not.toHaveBeenCalled();
+    const a = container.querySelector("a");
+    expect(a).not.toBeNull();
+    expect(container.querySelector("span.acp-inert-path")).toBeNull();
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    fireEvent(a!, event);
+    expect(onOpenFileRef).toHaveBeenCalledWith({ path: "/tmp/plan.md" });
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("still intercepts an in-repo path as a clickable file link", () => {

--- a/web/src/components/acp/Markdown.tsx
+++ b/web/src/components/acp/Markdown.tsx
@@ -129,13 +129,16 @@ function TranscriptLink({ href, onClick, children, ...rest }: React.ComponentPro
     );
   }
 
-  // A local file reference (relative resolves to repo-relative; an absolute
-  // path may be openable via provenance if the agent touched it this session)
-  // is intercepted below and routed to the in-app file viewer via
-  // onOpenFileRef. The server's provenance check is the gate for out-of-repo
-  // absolute paths, so we open optimistically rather than pre-rendering inert
-  // (#3088, superseding the inert-anchor treatment of #2587). Non-file links
-  // fall through to the new-tab anchor.
+  // A local file reference that resolves to no known repo root stays inert
+  // (#2587): the client cannot tell from the path alone whether the agent
+  // touched it, so a link here would lie about being openable for the common
+  // never-touched case. An out-of-repo file the agent DID write or read is
+  // reachable from its tool card, whose path opens the provenance-confined
+  // viewer directly (#3088).
+  if (ref && fileRefSession && !resolveToRepoRelative(ref.path, fileRefSession)) {
+    return <span className="acp-inert-path">{children}</span>;
+  }
+
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
     if (ref && onOpenFileRef) {
       e.preventDefault();

--- a/web/src/components/acp/Markdown.tsx
+++ b/web/src/components/acp/Markdown.tsx
@@ -129,14 +129,13 @@ function TranscriptLink({ href, onClick, children, ...rest }: React.ComponentPro
     );
   }
 
-  // Outside the session's repo roots. An absolute path may still be openable
-  // via provenance (the agent touched it this session); keep it clickable so
-  // onOpenFileRef can route it to the provenance-confined file viewer (#3088).
-  // A relative path we can't resolve has no target, so it stays inert (#2587).
-  if (ref && fileRefSession && !resolveToRepoRelative(ref.path, fileRefSession) && !ref.path.startsWith("/")) {
-    return <span className="acp-inert-path">{children}</span>;
-  }
-
+  // A local file reference (relative resolves to repo-relative; an absolute
+  // path may be openable via provenance if the agent touched it this session)
+  // is intercepted below and routed to the in-app file viewer via
+  // onOpenFileRef. The server's provenance check is the gate for out-of-repo
+  // absolute paths, so we open optimistically rather than pre-rendering inert
+  // (#3088, superseding the inert-anchor treatment of #2587). Non-file links
+  // fall through to the new-tab anchor.
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
     if (ref && onOpenFileRef) {
       e.preventDefault();

--- a/web/src/components/acp/Markdown.tsx
+++ b/web/src/components/acp/Markdown.tsx
@@ -129,7 +129,11 @@ function TranscriptLink({ href, onClick, children, ...rest }: React.ComponentPro
     );
   }
 
-  if (ref && fileRefSession && !resolveToRepoRelative(ref.path, fileRefSession)) {
+  // Outside the session's repo roots. An absolute path may still be openable
+  // via provenance (the agent touched it this session); keep it clickable so
+  // onOpenFileRef can route it to the provenance-confined file viewer (#3088).
+  // A relative path we can't resolve has no target, so it stays inert (#2587).
+  if (ref && fileRefSession && !resolveToRepoRelative(ref.path, fileRefSession) && !ref.path.startsWith("/")) {
     return <span className="acp-inert-path">{children}</span>;
   }
 

--- a/web/src/components/acp/ToolCards.render.test.tsx
+++ b/web/src/components/acp/ToolCards.render.test.tsx
@@ -1012,3 +1012,50 @@ describe("ToolCards repo-relative paths (#2143)", () => {
     expect(titled!.textContent).toContain("main.rs");
   });
 });
+
+describe("clickable file path (#3088)", () => {
+  const session: FileRefSession = {
+    id: "s1",
+    project_path: "/repo",
+    main_repo_path: null,
+    workspace_repos: [],
+  };
+
+  function renderWithOpen(tool: Parameters<typeof ToolCard>[0]["tool"], onOpenFileRef: (r: unknown) => void) {
+    return render(
+      <AcpFileRefContext.Provider value={{ fileRefSession: session, onOpenFileRef }}>
+        <AgentProfileProvider toolKey={null}>
+          <ToolCard tool={tool} result={undefined} />
+        </AgentProfileProvider>
+      </AcpFileRefContext.Provider>,
+    );
+  }
+
+  it("opens the read file via onOpenFileRef when clicked", () => {
+    const onOpenFileRef = vi.fn();
+    const { container } = renderWithOpen(fixtures.read, onOpenFileRef);
+    const button = container.querySelector('button[title="/tmp/main.rs"]');
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+    expect(onOpenFileRef).toHaveBeenCalledWith({ path: "/tmp/main.rs" });
+  });
+
+  it("opens the written file via onOpenFileRef when clicked", () => {
+    const onOpenFileRef = vi.fn();
+    const { container } = renderWithOpen(fixtures.write, onOpenFileRef);
+    const button = container.querySelector('button[title="/tmp/new.rs"]');
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+    expect(onOpenFileRef).toHaveBeenCalledWith({ path: "/tmp/new.rs" });
+  });
+
+  it("renders a plain path (no button) without an open handler", () => {
+    const { container } = render(
+      <WrapWithSession session={session}>
+        <ToolCard tool={fixtures.read} result={undefined} />
+      </WrapWithSession>,
+    );
+    expect(container.querySelector('button[title="/tmp/main.rs"]')).toBeNull();
+    expect(container.querySelector('[title="/tmp/main.rs"]')).not.toBeNull();
+  });
+});

--- a/web/src/components/acp/ToolCards.tsx
+++ b/web/src/components/acp/ToolCards.tsx
@@ -799,6 +799,34 @@ function ExecuteToolCard({ tool, result }: Props) {
   );
 }
 
+/**
+ * The file path shown in a read/write/edit card header. When a file-ref open
+ * handler is available (structured view), render it as a button that opens the
+ * file in the in-app viewer; the server confines the read to the session's
+ * project or the paths its agent touched (#3088). Falls back to plain text when
+ * there is no handler or no real path. `stopPropagation` so clicking the path
+ * opens the file instead of toggling the card body.
+ */
+function ClickableFilePath({ rawPath, display }: { rawPath: string; display: React.ReactNode }) {
+  const { onOpenFileRef } = useAcpFileRef();
+  if (!onOpenFileRef || rawPath === "(unknown file)") {
+    return <span title={rawPath}>{display}</span>;
+  }
+  return (
+    <button
+      type="button"
+      title={rawPath}
+      onClick={(e) => {
+        e.stopPropagation();
+        onOpenFileRef({ path: rawPath });
+      }}
+      className="cursor-pointer text-left hover:text-text-primary hover:underline"
+    >
+      {display}
+    </button>
+  );
+}
+
 /* ── read ───────────────────────────────────────────────────────── */
 
 function ReadToolCard({ tool, result }: Props) {
@@ -825,7 +853,7 @@ function ReadToolCard({ tool, result }: Props) {
       endedAt={result?.at}
       icon={<FileText className="h-3.5 w-3.5" />}
       label="read"
-      primary={<span title={rawPath}>{path}</span>}
+      primary={<ClickableFilePath rawPath={rawPath} display={path} />}
       meta={
         <>
           {range && <span className="text-[11px] text-text-dim">{range}</span>}
@@ -908,7 +936,12 @@ function EditToolCard({ tool, result }: Props) {
       endedAt={result?.at}
       icon={<Pencil className="h-3.5 w-3.5" />}
       label={verb}
-      primary={<span title={rawPath}>{multiFile ? `${path} +${structuredDiffs.length - 1} more` : path}</span>}
+      primary={
+        <ClickableFilePath
+          rawPath={rawPath}
+          display={multiFile ? `${path} +${structuredDiffs.length - 1} more` : path}
+        />
+      }
       meta={errorChip ? undefined : meta}
       expanded={open}
       onToggle={status === "err" || hasDiff ? () => setOpen((v) => !v) : undefined}

--- a/web/src/components/acp/useFilesIndex.ts
+++ b/web/src/components/acp/useFilesIndex.ts
@@ -3,7 +3,7 @@
 // fuzzyFilter helper is used by both the file adapter and any other
 // place that wants prefix-then-substring ordering.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /** Lightweight fuzzy filter: prefer prefix matches, then substring. */
 export function fuzzyFilter<T extends { label: string; description?: string }>(
@@ -36,9 +36,17 @@ export function fuzzyFilter<T extends { label: string; description?: string }>(
 export function useFilesIndex(sessionId: string): {
   files: string[];
   loading: boolean;
+  /** True when the last fetch failed. Lets a caller distinguish "this session
+   *  has no files" from "we could not read the list". See #3088 review. */
+  error: boolean;
+  /** Re-run the fetch, so a failed list is not a dead end. */
+  reload: () => void;
 } {
   const [files, setFiles] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const reload = useCallback(() => setAttempt((n) => n + 1), []);
   // Render-time: reset loading when sessionId changes
   const [trackedSessionId, setTrackedSessionId] = useState(sessionId);
   if (sessionId !== trackedSessionId) {
@@ -49,13 +57,19 @@ export function useFilesIndex(sessionId: string): {
     let cancelled = false;
     // loading is set to true in render-time above when sessionId changes
     fetch(`/api/sessions/${encodeURIComponent(sessionId)}/acp/files`)
-      .then((r) => (r.ok ? r.json() : { files: [] }))
+      .then((r) => {
+        if (!r.ok) throw new Error(`files list failed: ${r.status}`);
+        return r.json();
+      })
       .then((data: { files?: string[] }) => {
         if (cancelled) return;
         setFiles(data.files ?? []);
+        setError(false);
       })
       .catch(() => {
-        if (!cancelled) setFiles([]);
+        if (cancelled) return;
+        setFiles([]);
+        setError(true);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -63,6 +77,6 @@ export function useFilesIndex(sessionId: string): {
     return () => {
       cancelled = true;
     };
-  }, [sessionId]);
-  return useMemo(() => ({ files, loading }), [files, loading]);
+  }, [sessionId, attempt]);
+  return useMemo(() => ({ files, loading, error, reload }), [files, loading, error, reload]);
 }

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -387,10 +387,6 @@ export function DiffFileViewer({
   // Full-file fallback: an agent-cited file with no diff against the base. The
   // server sends its whole body in new_content with an empty patch. See #1810.
   const isFullFile = contents.file.status === "unchanged";
-  // Inline Markdown rendering (#3088). Any `.md`/`.markdown` file can be shown
-  // rendered instead of as syntax-highlighted source / diff; render the current
-  // (new) body, falling back to the old body for a deleted file. Excludes binary
-  // and truncated files, which have no usable text to render.
 
   return (
     <div className="flex-1 flex flex-col bg-surface-900 overflow-hidden" onKeyDown={onKeyDown}>

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -138,6 +138,13 @@ export function DiffFileViewer({
   const resolvedPath = contents?.file.path ?? filePath;
   const oldPath = contents?.file.old_path ?? resolvedPath;
 
+  // Markdown rendering (#3088). Defined before the keydown handler that reads
+  // `showRendered`. `contents` may be null before load, so guard with optional
+  // chaining; binary/truncated are only known once contents arrive.
+  const isMarkdown = extensionToLanguage(resolvedPath) === "markdown";
+  const markdownAvailable = isMarkdown && !contents?.is_binary && !contents?.truncated;
+  const showRendered = markdownAvailable && settings.markdownPreview === "rendered";
+
   const commentsActive = commentsEnabled && !!commentsStore;
   const comments = useMemo(() => commentsStore?.comments ?? [], [commentsStore]);
 
@@ -298,12 +305,18 @@ export function DiffFileViewer({
     [oldContent, newContent],
   );
 
-  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
-      e.preventDefault();
-      setFindOpen(true);
-    }
-  }, []);
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // In rendered Markdown mode there is no FindBar, so leave Cmd/Ctrl+F to
+      // the browser's native find instead of swallowing it. See #3088.
+      if (showRendered) return;
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        setFindOpen(true);
+      }
+    },
+    [showRendered],
+  );
 
   // Position the diff scroll when a file first opens: held at the top by
   // default, or at the cited line's approximate fraction when opened from a
@@ -378,9 +391,6 @@ export function DiffFileViewer({
   // rendered instead of as syntax-highlighted source / diff; render the current
   // (new) body, falling back to the old body for a deleted file. Excludes binary
   // and truncated files, which have no usable text to render.
-  const isMarkdown = extensionToLanguage(resolvedPath) === "markdown";
-  const markdownAvailable = isMarkdown && !contents.is_binary && !contents.truncated;
-  const showRendered = markdownAvailable && settings.markdownPreview === "rendered";
 
   return (
     <div className="flex-1 flex flex-col bg-surface-900 overflow-hidden" onKeyDown={onKeyDown}>
@@ -515,7 +525,7 @@ export function DiffFileViewer({
           </div>
         )}
         {showRendered ? (
-          <MarkdownFileView content={newContent || oldContent} />
+          <MarkdownFileView content={contents.file.status === "deleted" ? oldContent : newContent} />
         ) : contents.is_binary ? (
           <div className="flex-1 flex items-center justify-center text-text-dim">
             <span className="text-sm">{isFullFile ? "Binary file" : "Binary file changed"}</span>

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -14,6 +14,7 @@ import { CommentForm } from "./comments/CommentForm";
 import type { AnchoredComment, DiffSide } from "./comments/types";
 import { DiffWorkerPoolProvider } from "./pierre/DiffWorkerPoolProvider";
 import { FullFileViewer } from "./FullFileViewer";
+import { MarkdownFileView } from "./MarkdownFileView";
 import { FindBar } from "./find/FindBar";
 import { changedLines } from "./find/changedLines";
 import type { FindMatch } from "./find/findMatches";
@@ -373,6 +374,13 @@ export function DiffFileViewer({
   // Full-file fallback: an agent-cited file with no diff against the base. The
   // server sends its whole body in new_content with an empty patch. See #1810.
   const isFullFile = contents.file.status === "unchanged";
+  // Inline Markdown rendering (#3088). Any `.md`/`.markdown` file can be shown
+  // rendered instead of as syntax-highlighted source / diff; render the current
+  // (new) body, falling back to the old body for a deleted file. Excludes binary
+  // and truncated files, which have no usable text to render.
+  const isMarkdown = extensionToLanguage(resolvedPath) === "markdown";
+  const markdownAvailable = isMarkdown && !contents.is_binary && !contents.truncated;
+  const showRendered = markdownAvailable && settings.markdownPreview === "rendered";
 
   return (
     <div className="flex-1 flex flex-col bg-surface-900 overflow-hidden" onKeyDown={onKeyDown}>
@@ -409,56 +417,90 @@ export function DiffFileViewer({
           {contents.file.deletions > 0 && <span className="text-status-error">-{contents.file.deletions}</span>}
         </span>
         <div className="ml-auto flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setFindOpen((v) => !v)}
-            aria-pressed={findOpen}
-            title="Find in diff (Cmd/Ctrl+F)"
-            aria-label="Find in diff"
-            className={`px-2 py-0.5 text-[11px] font-mono rounded cursor-pointer transition-colors ${
-              findOpen ? "bg-brand-600 text-white" : "text-text-dim hover:text-text-secondary"
-            }`}
-          >
-            Find
-          </button>
-          <div className="flex items-center rounded border border-surface-700/40 overflow-hidden">
-            <button
-              type="button"
-              onClick={() => update({ diffViewLayout: "unified" })}
-              aria-pressed={settings.diffViewLayout === "unified"}
-              title="Unified diff"
-              className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
-                settings.diffViewLayout === "unified"
-                  ? "bg-brand-600 text-white"
-                  : "text-text-dim hover:text-text-secondary"
-              }`}
-            >
-              Unified
-            </button>
-            <button
-              type="button"
-              onClick={() => update({ diffViewLayout: "split" })}
-              aria-pressed={settings.diffViewLayout === "split"}
-              title={
-                settings.diffViewLayout === "split" && !isWide
-                  ? "Split selected, but this pane is too narrow; showing unified"
-                  : "Side-by-side diff"
-              }
-              className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
-                settings.diffViewLayout === "split"
-                  ? splitActive
+          {markdownAvailable && (
+            <div className="flex items-center rounded border border-surface-700/40 overflow-hidden">
+              <button
+                type="button"
+                onClick={() => update({ markdownPreview: "rendered" })}
+                aria-pressed={settings.markdownPreview === "rendered"}
+                title="Rendered Markdown"
+                className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                  settings.markdownPreview === "rendered"
                     ? "bg-brand-600 text-white"
-                    : "bg-brand-600/40 text-white/80"
-                  : "text-text-dim hover:text-text-secondary"
+                    : "text-text-dim hover:text-text-secondary"
+                }`}
+              >
+                Rendered
+              </button>
+              <button
+                type="button"
+                onClick={() => update({ markdownPreview: "raw" })}
+                aria-pressed={settings.markdownPreview === "raw"}
+                title="Raw Markdown source"
+                className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                  settings.markdownPreview === "raw"
+                    ? "bg-brand-600 text-white"
+                    : "text-text-dim hover:text-text-secondary"
+                }`}
+              >
+                Raw
+              </button>
+            </div>
+          )}
+          {!showRendered && (
+            <button
+              type="button"
+              onClick={() => setFindOpen((v) => !v)}
+              aria-pressed={findOpen}
+              title="Find in diff (Cmd/Ctrl+F)"
+              aria-label="Find in diff"
+              className={`px-2 py-0.5 text-[11px] font-mono rounded cursor-pointer transition-colors ${
+                findOpen ? "bg-brand-600 text-white" : "text-text-dim hover:text-text-secondary"
               }`}
             >
-              Split
+              Find
             </button>
-          </div>
+          )}
+          {!showRendered && (
+            <div className="flex items-center rounded border border-surface-700/40 overflow-hidden">
+              <button
+                type="button"
+                onClick={() => update({ diffViewLayout: "unified" })}
+                aria-pressed={settings.diffViewLayout === "unified"}
+                title="Unified diff"
+                className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                  settings.diffViewLayout === "unified"
+                    ? "bg-brand-600 text-white"
+                    : "text-text-dim hover:text-text-secondary"
+                }`}
+              >
+                Unified
+              </button>
+              <button
+                type="button"
+                onClick={() => update({ diffViewLayout: "split" })}
+                aria-pressed={settings.diffViewLayout === "split"}
+                title={
+                  settings.diffViewLayout === "split" && !isWide
+                    ? "Split selected, but this pane is too narrow; showing unified"
+                    : "Side-by-side diff"
+                }
+                className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                  settings.diffViewLayout === "split"
+                    ? splitActive
+                      ? "bg-brand-600 text-white"
+                      : "bg-brand-600/40 text-white/80"
+                    : "text-text-dim hover:text-text-secondary"
+                }`}
+              >
+                Split
+              </button>
+            </div>
+          )}
         </div>
       </div>
 
-      {findOpen && !contents.is_binary && !contents.truncated && (
+      {findOpen && !showRendered && !contents.is_binary && !contents.truncated && (
         <FindBar lines={findLines} onJump={handleFindJump} onClose={() => setFindOpen(false)} />
       )}
 
@@ -472,7 +514,9 @@ export function DiffFileViewer({
             <span className="text-xs text-text-dim bg-surface-900/80 rounded px-2 py-1">Loading diff...</span>
           </div>
         )}
-        {contents.is_binary ? (
+        {showRendered ? (
+          <MarkdownFileView content={newContent || oldContent} />
+        ) : contents.is_binary ? (
           <div className="flex-1 flex items-center justify-center text-text-dim">
             <span className="text-sm">{isFullFile ? "Binary file" : "Binary file changed"}</span>
           </div>

--- a/web/src/components/diff/FileContentViewer.tsx
+++ b/web/src/components/diff/FileContentViewer.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { getSessionFile } from "../../lib/api";
+import { useWebSettings } from "../../hooks/useWebSettings";
+import { extensionToLanguage } from "./comments/language";
+import { FullFileViewer } from "./FullFileViewer";
+import { MarkdownFileView } from "./MarkdownFileView";
+
+interface Props {
+  sessionId: string;
+  /** Project-relative or absolute path; the server enforces provenance. */
+  filePath: string;
+  /** Called when the user wants to go back to the file list. */
+  onBack?: () => void;
+}
+
+interface Loaded {
+  content: string;
+  is_binary: boolean;
+  truncated: boolean;
+}
+
+/**
+ * View a session file fetched from the provenance-confined `/file` endpoint
+ * (#3088). Markdown renders via {@link MarkdownFileView} with a Rendered/Raw
+ * toggle (sharing the `markdownPreview` setting with the diff viewer); other
+ * files fall back to the shared shiki {@link FullFileViewer}.
+ */
+export function FileContentViewer({ sessionId, filePath, onBack }: Props) {
+  const { settings, update } = useWebSettings();
+  // Result keyed by target: a stale response (from a rapid file switch) is
+  // dropped at render time by comparing keys, so no state is reset in render or
+  // synchronously in the effect. Mirrors FullFileViewer's async-only writes.
+  const key = `${sessionId} ${filePath}`;
+  const [loaded, setLoaded] = useState<{ key: string; data: Loaded | null; error: string | null }>({
+    key,
+    data: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    getSessionFile(sessionId, filePath)
+      .then((resp) => {
+        if (cancelled) return;
+        setLoaded({ key, data: resp ?? null, error: resp ? null : "Failed to load file" });
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded({ key, data: null, error: "Failed to load file" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, filePath, key]);
+
+  const current = loaded.key === key ? loaded : { key, data: null, error: null };
+  const data = current.data;
+  const error = current.error;
+  const loading = data === null && error === null;
+
+  const isMarkdown = extensionToLanguage(filePath) === "markdown";
+  const showRendered = isMarkdown && !data?.is_binary && settings.markdownPreview === "rendered";
+
+  return (
+    <div className="flex-1 flex flex-col bg-surface-900 overflow-hidden">
+      <div className="px-3 py-2 border-b border-surface-700/20 flex items-center gap-2 shrink-0">
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="text-text-dim hover:text-text-secondary cursor-pointer transition-colors flex items-center gap-1 text-[11px]"
+            title="Back to files"
+            aria-label="Back to files"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+            <span className="hidden sm:inline">Files</span>
+          </button>
+        )}
+        <span className="font-mono text-[12px] text-text-primary truncate">{filePath}</span>
+        {isMarkdown && !data?.is_binary && (
+          <div className="ml-auto flex items-center rounded border border-surface-700/40 overflow-hidden">
+            <button
+              type="button"
+              onClick={() => update({ markdownPreview: "rendered" })}
+              aria-pressed={settings.markdownPreview === "rendered"}
+              title="Rendered Markdown"
+              className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                settings.markdownPreview === "rendered"
+                  ? "bg-brand-600 text-white"
+                  : "text-text-dim hover:text-text-secondary"
+              }`}
+            >
+              Rendered
+            </button>
+            <button
+              type="button"
+              onClick={() => update({ markdownPreview: "raw" })}
+              aria-pressed={settings.markdownPreview === "raw"}
+              title="Raw Markdown source"
+              className={`px-2 py-0.5 text-[11px] font-mono cursor-pointer transition-colors ${
+                settings.markdownPreview === "raw"
+                  ? "bg-brand-600 text-white"
+                  : "text-text-dim hover:text-text-secondary"
+              }`}
+            >
+              Raw
+            </button>
+          </div>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex-1 flex items-center justify-center text-text-dim">
+          <span className="text-sm">Loading file...</span>
+        </div>
+      ) : error ? (
+        <div className="flex-1 flex items-center justify-center text-status-error">
+          <span className="text-sm">{error}</span>
+        </div>
+      ) : data?.is_binary ? (
+        <div className="flex-1 flex items-center justify-center text-text-dim">
+          <span className="text-sm">Binary file</span>
+        </div>
+      ) : data?.truncated ? (
+        <div className="flex-1 flex items-center justify-center text-text-dim">
+          <div className="text-center px-4">
+            <p className="text-sm mb-1">File too large to display inline</p>
+            <p className="text-xs">Open it in your editor instead.</p>
+          </div>
+        </div>
+      ) : data && showRendered ? (
+        <MarkdownFileView content={data.content} />
+      ) : data ? (
+        <FullFileViewer content={data.content} filePath={filePath} />
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/diff/FileContentViewer.tsx
+++ b/web/src/components/diff/FileContentViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getSessionFile } from "../../lib/api";
 import { useWebSettings } from "../../hooks/useWebSettings";
 import { extensionToLanguage } from "./comments/language";
@@ -27,6 +27,7 @@ interface Loaded {
  */
 export function FileContentViewer({ sessionId, filePath, onBack }: Props) {
   const { settings, update } = useWebSettings();
+  const containerRef = useRef<HTMLDivElement>(null);
   // Result keyed by target: a stale response (from a rapid file switch) is
   // dropped at render time by comparing keys, so no state is reset in render or
   // synchronously in the effect. Mirrors FullFileViewer's async-only writes.
@@ -60,8 +61,19 @@ export function FileContentViewer({ sessionId, filePath, onBack }: Props) {
   const isMarkdown = extensionToLanguage(filePath) === "markdown";
   const showRendered = isMarkdown && !data?.is_binary && settings.markdownPreview === "rendered";
 
+  // Move focus into the viewer when a file opens, so keyboard and screen-reader
+  // users land on the content instead of staying on the (now unmounted) file
+  // row. FilesPane restores focus to that row on close. See #3088 review.
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, [filePath]);
+
   return (
-    <div className="flex-1 flex flex-col bg-surface-900 overflow-hidden">
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      className="flex-1 flex flex-col bg-surface-900 overflow-hidden focus:outline-none"
+    >
       <div className="px-3 py-2 border-b border-surface-700/20 flex items-center gap-2 shrink-0">
         {onBack && (
           <button

--- a/web/src/components/diff/MarkdownFileView.tsx
+++ b/web/src/components/diff/MarkdownFileView.tsx
@@ -1,0 +1,26 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface Props {
+  /** Markdown source to render. */
+  content: string;
+}
+
+/// Rendered view of a Markdown file (#3088). Mirrors the diff-comment renderer
+/// (`CommentMarkdown`): plain `react-markdown` with `remark-gfm`, rendered to
+/// React elements so file/agent-authored content is escaped without
+/// `dangerouslySetInnerHTML`. We deliberately do NOT reuse the structured view
+/// `<Markdown>`, which needs `@assistant-ui/react-markdown`'s runtime provider
+/// (only mounted under the ACP panel), nor `remark-breaks`: Markdown files are
+/// CommonMark, where a single newline is a soft break, so hardening every wrap
+/// into a `<br>` would break paragraph reflow. Reuses the shared `acp-markdown`
+/// prose styles (index.css), which are plain CSS with no runtime dependency.
+export function MarkdownFileView({ content }: Props) {
+  return (
+    <div className="flex-1 min-h-0 overflow-auto px-4 py-3">
+      <div className="acp-markdown text-sm leading-relaxed max-w-[80ch]">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/diff/__tests__/DiffFileViewer.markdown.test.tsx
+++ b/web/src/components/diff/__tests__/DiffFileViewer.markdown.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+//
+// Covers the Rendered/Raw Markdown toggle in DiffFileViewer (#3088): a `.md`
+// file renders formatted by default, the toggle flips back to the diff and
+// persists via useWebSettings, and non-Markdown files expose no toggle.
+//
+// The Pierre renderer is mocked (as in DiffFileViewer.split.test.tsx) since it
+// needs real DOM + workers; MarkdownFileView (react-markdown) runs for real.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiffFileViewer } from "../DiffFileViewer";
+import type { RichFileContentsResponse } from "../../../lib/types";
+
+const mdContents: RichFileContentsResponse = {
+  file: { path: "notes.md", old_path: null, status: "modified", additions: 1, deletions: 0 },
+  old_content: "old line\n",
+  new_content: "# Heading\n\nbody text\n",
+  patch: "--- a/notes.md\n+++ b/notes.md\n@@ -1 +1,3 @@\n-old line\n+# Heading\n+\n+body text\n",
+  is_binary: false,
+  truncated: false,
+};
+
+const tsContents: RichFileContentsResponse = {
+  file: { path: "a.ts", old_path: null, status: "modified", additions: 1, deletions: 1 },
+  old_content: "old\n",
+  new_content: "new\n",
+  patch: "--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-old\n+new\n",
+  is_binary: false,
+  truncated: false,
+};
+
+const mock = vi.hoisted(() => ({ contents: undefined as RichFileContentsResponse | undefined }));
+
+vi.mock("../../../hooks/useFileContents", () => ({
+  useFileContents: () => ({
+    contents: mock.contents,
+    loading: mock.contents === undefined,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@pierre/diffs/react", () => ({
+  FileDiff: ({ fileDiff }: { fileDiff: { name: string } }) => <div data-testid="pierre-diff">{fileDiff.name}</div>,
+  Virtualizer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  WorkerPoolContextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  class WideRO {
+    cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentRect: { width: 1000 } } as ResizeObserverEntry], this as unknown as ResizeObserver);
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", WideRO);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+});
+
+describe("DiffFileViewer markdown toggle", () => {
+  it("renders a .md file as formatted markdown by default and hides diff controls", async () => {
+    mock.contents = mdContents;
+    const { container } = render(<DiffFileViewer sessionId="s1" filePath="notes.md" />);
+
+    await waitFor(() => {
+      expect(container.querySelector("h1")?.textContent).toBe("Heading");
+    });
+    // Rendered mode replaces the diff and suppresses diff-only controls.
+    expect(screen.queryByTestId("pierre-diff")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Split" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Find in diff" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Rendered" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("flips to Raw, shows the diff, and persists the preference", async () => {
+    mock.contents = mdContents;
+    render(<DiffFileViewer sessionId="s1" filePath="notes.md" />);
+    await screen.findByRole("button", { name: "Raw" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pierre-diff")).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: "Split" })).toBeTruthy();
+    expect(JSON.parse(window.localStorage.getItem("aoe-web-settings") ?? "{}").markdownPreview).toBe("raw");
+  });
+
+  it("shows no Rendered/Raw toggle for a non-markdown file", async () => {
+    mock.contents = tsContents;
+    render(<DiffFileViewer sessionId="s1" filePath="a.ts" />);
+    await screen.findByText(/Modified/i);
+    expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Raw" })).toBeNull();
+  });
+});

--- a/web/src/components/diff/__tests__/FileContentViewer.test.tsx
+++ b/web/src/components/diff/__tests__/FileContentViewer.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+//
+// FileContentViewer contract (#3088): fetches the provenance-confined /file
+// endpoint and renders Markdown (rendered by default, Raw toggle) or a shiki
+// full-file view for other extensions, plus the binary notice.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { FileContentViewer } from "../FileContentViewer";
+import * as api from "../../../lib/api";
+
+vi.mock("../../../hooks/useShikiTheme", () => ({
+  useShikiTheme: () => ({ theme: "github-dark", appearance: "dark" }),
+}));
+
+vi.mock("../../../lib/highlighter", () => ({
+  ensureThemeLoaded: vi.fn().mockResolvedValue("github-dark"),
+  getHighlighter: vi.fn().mockResolvedValue({
+    codeToHtml: (code: string) => `<pre class="shiki"><code>${code}</code></pre>`,
+  }),
+  langKeyForExt: (s: string) => s,
+  loadLanguage: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("FileContentViewer", () => {
+  it("renders a .md file as formatted markdown by default and toggles to raw", async () => {
+    vi.spyOn(api, "getSessionFile").mockResolvedValue({
+      content: "# Plan\n\nstep one",
+      is_binary: false,
+      truncated: false,
+    });
+
+    const { container } = render(<FileContentViewer sessionId="s1" filePath="/tmp/plan.md" />);
+    await waitFor(() => {
+      expect(container.querySelector("h1")?.textContent).toBe("Plan");
+    });
+    expect(screen.getByRole("button", { name: "Rendered" }).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+    await waitFor(() => {
+      // Raw mode renders the shiki full-file view (or its <pre> fallback), which
+      // shows the literal source including the "#".
+      expect(container.textContent).toContain("# Plan");
+    });
+    expect(container.querySelector("h1")).toBeNull();
+  });
+
+  it("renders a non-markdown file via the shiki viewer (no toggle)", async () => {
+    vi.spyOn(api, "getSessionFile").mockResolvedValue({
+      content: "export const a = 1;",
+      is_binary: false,
+      truncated: false,
+    });
+    const { container } = render(<FileContentViewer sessionId="s1" filePath="/repo/a.ts" />);
+    await waitFor(() => {
+      expect(container.textContent).toContain("export const a = 1;");
+    });
+    expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
+  });
+
+  it("shows a binary notice", async () => {
+    vi.spyOn(api, "getSessionFile").mockResolvedValue({
+      content: "",
+      is_binary: true,
+      truncated: false,
+    });
+    render(<FileContentViewer sessionId="s1" filePath="/tmp/blob.md" />);
+    await screen.findByText("Binary file");
+  });
+
+  it("shows an error when the fetch fails", async () => {
+    vi.spyOn(api, "getSessionFile").mockResolvedValue(null);
+    render(<FileContentViewer sessionId="s1" filePath="/tmp/x.md" />);
+    await screen.findByText("Failed to load file");
+  });
+});

--- a/web/src/components/diff/__tests__/MarkdownFileView.test.tsx
+++ b/web/src/components/diff/__tests__/MarkdownFileView.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+//
+// MarkdownFileView contract (#3088): renders a Markdown file to formatted
+// HTML. Verifies it
+//   - renders standard Markdown (headings, lists, links, GFM tables),
+//   - escapes raw HTML rather than injecting it (no rehype-raw / no
+//     dangerouslySetInnerHTML), so a hostile file cannot run script.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { MarkdownFileView } from "../MarkdownFileView";
+
+afterEach(cleanup);
+
+describe("MarkdownFileView", () => {
+  it("renders headings, lists, and links", () => {
+    const md = ["# Title", "", "- one", "- two", "", "[link](https://example.com)"].join("\n");
+    const { container } = render(<MarkdownFileView content={md} />);
+    expect(container.querySelector("h1")?.textContent).toBe("Title");
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe("https://example.com");
+    expect(a?.textContent).toBe("link");
+  });
+
+  it("renders GFM tables via remark-gfm", () => {
+    const md = ["| a | b |", "| - | - |", "| 1 | 2 |"].join("\n");
+    const { container } = render(<MarkdownFileView content={md} />);
+    expect(container.querySelector("table")).toBeTruthy();
+    expect(container.querySelectorAll("td")).toHaveLength(2);
+  });
+
+  it("does not inject raw HTML from the file", () => {
+    const md = 'text\n\n<img src=x onerror="alert(1)">\n\n<script>alert(2)</script>';
+    const { container } = render(<MarkdownFileView content={md} />);
+    // Without rehype-raw, react-markdown does not turn raw HTML into live DOM.
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img[onerror]")).toBeNull();
+    expect(container.textContent).toContain("text");
+  });
+});

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -68,6 +68,12 @@ function normalizeSnapshot(settings: WebSettings): WebSettings {
     autoOpenDiffPane: normalizeBool(settings.autoOpenDiffPane, defaults.autoOpenDiffPane),
     autoOpenTerminalPane: normalizeBool(settings.autoOpenTerminalPane, defaults.autoOpenTerminalPane),
     autoOpenPluginPanes: normalizeBool(settings.autoOpenPluginPanes, defaults.autoOpenPluginPanes),
+    // Same reason: a corrupted value must not reach the viewer as a third state
+    // that renders neither the rendered nor the raw branch.
+    markdownPreview:
+      settings.markdownPreview === "rendered" || settings.markdownPreview === "raw"
+        ? settings.markdownPreview
+        : defaults.markdownPreview,
   };
 }
 

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -14,6 +14,10 @@ export interface WebSettings {
   maxPersistentTerminals: number;
   diffViewMode: "flat" | "tree";
   diffViewLayout: "unified" | "split";
+  /** How Markdown files render in the file viewer: `rendered` shows formatted
+   *  HTML (default), `raw` shows the syntax-highlighted source / diff. Only
+   *  affects `.md`/`.markdown` files. Client-local. See #3088. */
+  markdownPreview: "rendered" | "raw";
   collapsedDiffDirs: string[];
   /** Which edge the session sidebar slides in from on mobile. Client-local;
    *  desktop layout (md:static) is unaffected. See #2244. */
@@ -39,6 +43,7 @@ function getDefaults(): WebSettings {
     maxPersistentTerminals: DEFAULT_PERSISTENT_TERMINALS,
     diffViewMode: window.innerWidth < 768 ? "flat" : "tree",
     diffViewLayout: "unified",
+    markdownPreview: "rendered",
     collapsedDiffDirs: [],
     sidebarSide: "left",
     autoOpenDiffPane: true,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -211,6 +211,22 @@ export function getSessionFileContents(
   return fetchJson<RichFileContentsResponse>(`/api/sessions/${id}/diff/file?${params.toString()}`);
 }
 
+export interface SessionFileResponse {
+  content: string;
+  is_binary: boolean;
+  truncated: boolean;
+}
+
+/**
+ * Read a session file for the file viewer (#3088). Path may be project-relative
+ * or an absolute path the agent touched this session; the server enforces
+ * provenance confinement. See `GET /api/sessions/{id}/file`.
+ */
+export function getSessionFile(id: string, filePath: string): Promise<SessionFileResponse | null> {
+  const params = new URLSearchParams({ path: filePath });
+  return fetchJson<SessionFileResponse>(`/api/sessions/${id}/file?${params.toString()}`);
+}
+
 // --- Settings ---
 
 export interface SettingsResponse {

--- a/web/src/lib/fileRef.ts
+++ b/web/src/lib/fileRef.ts
@@ -165,9 +165,10 @@ function normalizeRoot(root: string): string {
  * `/a/app` from spuriously matching `/a/app_old`.
  */
 /** True for an absolute path in POSIX (`/x`) or Windows drive-letter (`C:/x`,
- *  `C:\x`) form. Shared by the transcript-link gates so their "is this an
- *  openable absolute path" check agrees with {@link resolveToRepoRelative}'s
- *  own absolute detection. See #3088. */
+ *  `C:\x`) form. The single absolute-path predicate for this module:
+ *  {@link resolveToRepoRelative} calls it too, so a caller deciding whether a
+ *  path is an openable absolute path cannot disagree with how the resolver
+ *  classifies it. See #3088. */
 export function isAbsolutePath(path: string): boolean {
   return path.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(path);
 }
@@ -178,8 +179,7 @@ export function resolveToRepoRelative(
 ): { relativePath: string; repoName?: string } | null {
   const target = normalizePathForMatch(path);
 
-  const isAbsolute = target.startsWith("/") || /^[a-z]:\//.test(target);
-  if (!isAbsolute) {
+  if (!isAbsolutePath(target)) {
     // Already repo-relative; strip a leading `./` for cleanliness.
     const rel = target.replace(/^\.\//, "");
     return rel ? { relativePath: rel } : null;

--- a/web/src/lib/fileRef.ts
+++ b/web/src/lib/fileRef.ts
@@ -164,6 +164,14 @@ function normalizeRoot(root: string): string {
  * repo (`main_repo_path`). The trailing-slash guard prevents
  * `/a/app` from spuriously matching `/a/app_old`.
  */
+/** True for an absolute path in POSIX (`/x`) or Windows drive-letter (`C:/x`,
+ *  `C:\x`) form. Shared by the transcript-link gates so their "is this an
+ *  openable absolute path" check agrees with {@link resolveToRepoRelative}'s
+ *  own absolute detection. See #3088. */
+export function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(path);
+}
+
 export function resolveToRepoRelative(
   path: string,
   session: FileRefSession,

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -270,7 +270,10 @@ export function syncPluginTabs(layout: DockLayout, available: { id: TabId; defau
 // ActivityBar toggle or by clicking an inline sub-agent card, so it never
 // auto-opens as an empty tab. A v1 layout predates it, so it can never
 // have been "open" there either.
-const AUTO_OPEN_PANES = BUILTIN_PANES.filter((p) => p.id !== "agents");
+// The Files pane, like Sub agents, is opened on demand from the ActivityBar
+// (not auto-seeded into a fresh layout), so a new session opens with just the
+// diff + terminal tabs it always had. See #3088.
+const AUTO_OPEN_PANES = BUILTIN_PANES.filter((p) => p.id !== "agents" && p.id !== "files");
 
 function defaultTemplate(): DockLayout {
   // Desktop opens diff + terminal in the right dock (matches the historical

--- a/web/src/lib/paneLayout.ts
+++ b/web/src/lib/paneLayout.ts
@@ -409,7 +409,7 @@ export interface PaneLayoutApi {
   /** Reorder, move across docks/groups, or split into a new group. */
   placeTab: (tabId: TabId, target: PlaceTarget) => void;
   /** Activity-bar toggle for a built-in kind ("diff" or "terminal"). */
-  toggleKind: (kind: "diff" | "terminal" | "agents", defaultDock: DockLocation) => void;
+  toggleKind: (kind: "diff" | "terminal" | "agents" | "files", defaultDock: DockLocation) => void;
   /** Add/remove a plugin pane tab (activity-bar toggle). */
   togglePlugin: (id: TabId, defaultDock: DockLocation) => void;
   syncPlugins: (available: { id: TabId; defaultDock: DockLocation }[]) => void;
@@ -532,11 +532,11 @@ export function usePaneLayout(sessionId: string | null): PaneLayoutApi {
     [mutate],
   );
   const toggleKind = useCallback(
-    (kind: "diff" | "terminal" | "agents", defaultDock: DockLocation) =>
+    (kind: "diff" | "terminal" | "agents" | "files", defaultDock: DockLocation) =>
       mutate((l) => {
-        // Single-instance panes (diff, agents) toggle their one tab; the
+        // Single-instance panes (diff, files, agents) toggle their one tab; the
         // terminal kind is multi-instance and toggles the whole group.
-        if (kind === "diff" || kind === "agents") {
+        if (kind === "diff" || kind === "agents" || kind === "files") {
           const at = findTab(l, kind);
           if (at) return isDockCollapsed(l, at.dock) ? openOrRevealTab(l, kind, defaultDock) : removeTab(l, kind);
           return openOrRevealTab(l, kind, defaultDock);

--- a/web/src/lib/panes.ts
+++ b/web/src/lib/panes.ts
@@ -3,9 +3,9 @@
 // `pane` UI slot; see the plugin slot renderers. The activity bar maps over
 // this list to draw one toggle icon per pane.
 
-import { Bot, FileDiff, SquareTerminal, type LucideIcon } from "lucide-react";
+import { Bot, FileDiff, FolderTree, SquareTerminal, type LucideIcon } from "lucide-react";
 
-export type BuiltinPaneId = "diff" | "terminal" | "agents";
+export type BuiltinPaneId = "diff" | "terminal" | "agents" | "files";
 
 /** Where a pane is docked. Right is a vertical column beside the main view;
  *  bottom is a horizontal strip below it (left is intentionally deferred). */
@@ -20,6 +20,7 @@ export interface PaneDescriptor {
 
 export const BUILTIN_PANES: PaneDescriptor[] = [
   { id: "diff", title: "Diff", icon: FileDiff, defaultDock: "right" },
+  { id: "files", title: "Files", icon: FolderTree, defaultDock: "right" },
   { id: "terminal", title: "Terminal", icon: SquareTerminal, defaultDock: "right" },
   { id: "agents", title: "Sub agents", icon: Bot, defaultDock: "right" },
 ];

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1434,6 +1434,19 @@
       ]
     },
     {
+      "id": "right-panel.markdown-viewer",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/diff/__tests__/MarkdownFileView.test.tsx",
+        "src/components/diff/__tests__/DiffFileViewer.markdown.test.tsx"
+      ],
+      "components": [
+        "web/src/components/diff/MarkdownFileView.tsx",
+        "web/src/components/diff/DiffFileViewer.tsx"
+      ]
+    },
+    {
       "id": "diff-comments.send-flow",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1444,6 +1444,28 @@
       "components": ["web/src/components/diff/MarkdownFileView.tsx", "web/src/components/diff/DiffFileViewer.tsx"]
     },
     {
+      "id": "right-panel.files-viewer",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/diff/__tests__/FileContentViewer.test.tsx",
+        "src/components/__tests__/FilesPane.test.tsx"
+      ],
+      "components": ["web/src/components/FilesPane.tsx", "web/src/components/diff/FileContentViewer.tsx"]
+    },
+    {
+      "id": "right-panel.files-pane-live",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/right-panel-files.spec.ts"],
+      "components": [
+        "web/src/components/FilesPane.tsx",
+        "web/src/components/diff/FileContentViewer.tsx",
+        "web/src/components/diff/MarkdownFileView.tsx",
+        "web/src/App.tsx"
+      ]
+    },
+    {
       "id": "diff-comments.send-flow",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1441,10 +1441,7 @@
         "src/components/diff/__tests__/MarkdownFileView.test.tsx",
         "src/components/diff/__tests__/DiffFileViewer.markdown.test.tsx"
       ],
-      "components": [
-        "web/src/components/diff/MarkdownFileView.tsx",
-        "web/src/components/diff/DiffFileViewer.tsx"
-      ]
+      "components": ["web/src/components/diff/MarkdownFileView.tsx", "web/src/components/diff/DiffFileViewer.tsx"]
     },
     {
       "id": "diff-comments.send-flow",

--- a/web/tests/live/right-panel-diff-files.spec.ts
+++ b/web/tests/live/right-panel-diff-files.spec.ts
@@ -98,6 +98,10 @@ base("right panel diff list: counts, tree/flat toggle, keyboard select", async (
     const firstRow = page.locator('button[data-index="0"]').first();
     await firstRow.hover();
     await firstRow.click();
+    // README.md defaults to the rendered Markdown view (#3088), which shows
+    // "Old" as a heading rather than the raw "# Old" diff text; switch to Raw
+    // to assert the diff source.
+    await page.getByRole("button", { name: "Raw", exact: true }).first().click();
     await expect(page.getByText("# Old").first()).toBeVisible({
       timeout: 10_000,
     });

--- a/web/tests/live/right-panel-diff-files.spec.ts
+++ b/web/tests/live/right-panel-diff-files.spec.ts
@@ -98,11 +98,12 @@ base("right panel diff list: counts, tree/flat toggle, keyboard select", async (
     const firstRow = page.locator('button[data-index="0"]').first();
     await firstRow.hover();
     await firstRow.click();
-    // README.md defaults to the rendered Markdown view (#3088), which shows
-    // "Old" as a heading rather than the raw "# Old" diff text; switch to Raw
-    // to assert the diff source.
-    await page.getByRole("button", { name: "Raw", exact: true }).first().click();
-    await expect(page.getByText("# Old").first()).toBeVisible({
+    // README.md defaults to the rendered Markdown view (#3088). The current
+    // (new) content is "# New", which renders as an <h1>New</h1>, so assert the
+    // rendered heading. Avoid clicking the Raw toggle here, which would steal
+    // keyboard focus from the file list and break the ArrowDown/Enter
+    // navigation asserted next.
+    await expect(page.getByRole("heading", { name: "New" }).first()).toBeVisible({
       timeout: 10_000,
     });
 

--- a/web/tests/live/right-panel-files.spec.ts
+++ b/web/tests/live/right-panel-files.spec.ts
@@ -1,0 +1,58 @@
+// Live-backend spec: the Files pane + provenance file viewer (#3088).
+//
+// Registers a NON-git scratch directory as a session (the case from the
+// original report: a scratch session has no git diff, so its files never
+// appeared in the diff list). Opens the Files pane from the activity bar,
+// clicks a Markdown file, and asserts it renders as formatted HTML rather than
+// raw source. Exercises the git-agnostic /acp/files listing and the
+// provenance-confined /file read end to end.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, resolveAoeBinary } from "../helpers/aoeServe";
+import { writeFiles } from "../helpers/gitFixture";
+
+base("files pane renders a Markdown file in a scratch session", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      // A plain (non-git) directory: no `git init`, so there is no diff.
+      const projectDir = join(home, "scratch-project");
+      writeFiles(projectDir, {
+        "plan.md": "# The Plan\n\n- step one\n- step two\n",
+        "readme.txt": "not markdown\n",
+      });
+      const addRes = spawnSync(resolveAoeBinary(), ["add", projectDir, "-t", "rp-files-md", "-c", "claude"], { env });
+      if (addRes.status !== 0) {
+        throw new Error(`aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`);
+      }
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/`);
+    const sessionRow = page.getByRole("link").filter({ hasText: "rp-files-md" }).first();
+    await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+    await sessionRow.click();
+
+    // Open the Files pane from the activity bar (not auto-opened).
+    await page.getByRole("button", { name: "Toggle Files pane" }).first().click();
+
+    // The scratch dir's files list even though there is no git diff.
+    const planRow = page.getByRole("button", { name: "plan.md" }).first();
+    await expect(planRow).toBeVisible({ timeout: 10_000 });
+    await planRow.click();
+
+    // Rendered by default: "# The Plan" becomes an <h1>The Plan</h1>, and the
+    // list items render as a real <ul>, not raw "- step one" text.
+    await expect(page.getByRole("heading", { name: "The Plan" }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole("listitem").filter({ hasText: "step one" }).first()).toBeVisible();
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/right-panel-notifications.spec.ts
+++ b/web/tests/live/right-panel-notifications.spec.ts
@@ -116,6 +116,10 @@ base(
         .first()
         .click();
 
+      // notes.md defaults to the rendered Markdown view (#3088); the comment
+      // gutter only exists in the diff view, so switch to Raw first.
+      await page.getByRole("button", { name: "Raw", exact: true }).first().click();
+
       // Select a line to comment by clicking its @pierre/diffs gutter line
       // number. The renderer exposes `[data-line-number-content]` cells that
       // contain only the number; a single click selects the line and opens


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds inline Markdown viewing to the web dashboard, in two places, plus a general session file browser.

**1. Markdown in the diff viewer.** `.md` / `.markdown` files in the diff/file list now render as formatted Markdown by default, with a **Rendered** / **Raw** toggle (Raw keeps the syntax-highlighted source / diff). Rendering uses the already-bundled `react-markdown` + `remark-gfm` and escapes content (no `dangerouslySetInnerHTML`, no `rehype-raw`). The choice persists as a client-local `markdownPreview` setting.

**2. Files pane.** A new **Files** activity-bar pane browses the session's working directory, not just its git changes, so it lists files even in a non-git scratch session (the reported gap: scratch sessions have no diff, so their files never appeared). Selecting a file opens it in a viewer that renders Markdown or falls back to the shared shiki full-file view.

**3. Provenance-confined file endpoint.** `GET /api/sessions/{id}/file` reads a file for the viewer, git-agnostic. A read is allowed only when the canonical target is under a session project root, or is a path the agent actually touched this session (Write/Edit/Read/apply_patch/memory-recall), recovered from the ACP event log. Transcript links to files the agent wrote outside the repo (a plan in `/tmp`, a note in an agent config dir) are now openable via this endpoint; the server's provenance check is the gate.

**Dependency note:** the sandboxed read adds `cap-std` (optional, gated behind the `serve` feature). An in-tree `rustix`/`libc` `openat2` + `O_NOFOLLOW` path would avoid the ~9 transitive crates, but it reintroduces the OS-specific branching AGENTS.md wants isolated under `src/process/`, so the capability crate was the deliberate trade-off.

The confinement design was reviewed via `/debate` (two models): it canonicalizes before any check, uses component-aware `Path::starts_with`, opens the canonical path (no TOCTOU symlink swap), rejects non-regular files (FIFO/device/`/proc`), and bounds the read. An earlier ambient `/tmp` + agent-home allowlist was rejected in favor of provenance, because env-controlled roots and a `.md`-only rule were not a real boundary.

Closes #3088

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a session with a changed `.md` file; click it in the diff list and confirm it renders as formatted Markdown, then click **Raw** to see the diff/source.
- [ ] Reload and open another `.md`; confirm the Rendered/Raw choice persisted.
- [ ] Create a scratch (non-git) session with a `.md` in its directory; open the **Files** pane (folder icon), confirm the file is listed, click it, and confirm it renders.
- [ ] In a session where the agent wrote a Markdown file outside the repo (e.g. `/tmp/plan.md`), click that path in the transcript and confirm it opens rendered.
- [ ] Confirm a non-Markdown file opens in the syntax-highlighted viewer with no Rendered/Raw toggle.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Added a live Playwright spec (`right-panel-files.spec.ts`) exercising the scratch-session repro end to end, Vitest for the Markdown/Files components, and Rust unit tests for the path-confinement + provenance extraction. Coverage matrix updated with `right-panel.markdown-viewer`, `right-panel.files-viewer`, and `right-panel.files-pane-live`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (default to rendered; provenance instead of an ambient allowlist for out-of-project reads) and reviewed each commit; the confinement design was run through a multi-model `/debate`.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added inline Markdown viewing in the web diff/file viewer for `.md`/`.markdown` files, with a Rendered/Raw toggle and persisted preference.
- Introduced a new “Files” pane to browse and open session working-directory files (including non-git/scratch sessions), with Markdown rendering and the same rendered/raw toggle.
- Added a provenance-confined, git-agnostic backend endpoint to serve session files, allowing reads only for project roots or files the agent actually touched; safely handles binary and oversized content.
- Updated transcript link behavior so absolute/out-of-repo file references route to the in-app viewer instead of being blocked as inert text.
- Added/updated tests and coverage (Vitest, React Testing Library, Playwright, and Rust), plus documentation for the Files pane and Markdown behavior.

## Benefits

Users can read agent-generated plans and design notes directly in the dashboard (rendered Markdown by default) without switching to an IDE, while the server continues to restrict file viewing to authorized/provenanced content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
