### PR TITLE
fix(serve): persist config-option mode picks to acp_mode_id

### DIFF
--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -2191,6 +2191,78 @@ async fn persist_agent_model(state: &Arc<AppState>, id: &str, model: &str) {
     }
 }
 
+/// True when `config_id` is this session's Mode-category config option.
+/// Resolved from the agent's advertised option catalog rather than a hardcoded
+/// id, so a mode pick is told apart from a model / thought-level pick without
+/// assuming any adapter's naming. The daemon keeps no live per-session
+/// `AcpState`, so the option catalog (recorded on `ConfigOptionsUpdated`) is the
+/// only handler-reachable source of a session's advertised options; if it has
+/// no entry yet we return false and skip persistence (no regression).
+async fn is_mode_config_option(state: &Arc<AppState>, id: &str, config_id: &str) -> bool {
+    let agent = {
+        let instances = state.instances.read().await;
+        instances.iter().find(|i| i.id == id).map(|i| {
+            i.agent_name
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(i.tool.as_str())
+                .to_string()
+        })
+    };
+    let Some(agent) = agent else {
+        return false;
+    };
+    crate::acp::option_catalog::load()
+        .agents
+        .get(&agent)
+        .into_iter()
+        .flat_map(|entry| entry.options.iter())
+        .any(|opt| {
+            opt.id == config_id && opt.category == crate::acp::state::ConfigOptionCategory::Mode
+        })
+}
+
+/// Write a picked mode back onto the instance, both in the in-memory registry
+/// (what the reconciler reads to respawn a worker this daemon lifetime) and on
+/// disk (what survives a daemon restart). Mirrors `persist_agent_model`; see the
+/// call site in `acp_set_config_option` for why the live pick alone is not
+/// enough. See #3086.
+async fn persist_acp_mode(state: &Arc<AppState>, id: &str, mode_id: &str) {
+    let profile = {
+        let mut instances = state.instances.write().await;
+        let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+            return;
+        };
+        inst.acp_mode_id = Some(mode_id.to_string());
+        inst.source_profile.clone()
+    };
+    match crate::session::Storage::new(&profile, state.file_watch.clone()) {
+        Ok(storage) => {
+            let id_owned = id.to_string();
+            let mode_owned = mode_id.to_string();
+            if let Err(e) = storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
+                    inst.acp_mode_id = Some(mode_owned.clone());
+                }
+                Ok(())
+            }) {
+                tracing::error!(
+                    target: "http.api.acp",
+                    session = %id,
+                    "failed to persist acp_mode_id after config-option pick: {e}"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "http.api.acp",
+                session = %id,
+                "failed to open storage to persist acp_mode_id after config-option pick: {e}"
+            );
+        }
+    }
+}
+
 /// Set a per-session selector (model, reasoning effort, etc.) via ACP
 /// `session/set_config_option`. The structured view treats every category
 /// through this one endpoint; rejection surfaces as a non-blocking
@@ -2239,6 +2311,14 @@ pub async fn acp_set_config_option(
             // id.
             if req.config_id == "model" {
                 persist_agent_model(&state, &id, &req.value).await;
+            } else if is_mode_config_option(&state, &id, &req.config_id).await {
+                // Persist a Mode-category pick so it survives a worker respawn.
+                // The reconciler re-asserts `acp_mode_id` via `session/set_mode`
+                // on every (re)spawn (#2897); without this write-back the id
+                // stays at its creation value (commonly None) and a respawn
+                // reverts the session to the adapter's prompting default. Mirrors
+                // the model write-back above. See #3086.
+                persist_acp_mode(&state, &id, &req.value).await;
             }
             StatusCode::ACCEPTED.into_response()
         }
@@ -2635,6 +2715,98 @@ mod tests {
                 .as_deref(),
             Some("claude-sonnet-5")
         );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn persist_acp_mode_updates_memory_and_storage() {
+        use crate::session::test_support::isolate_app_dir;
+        let _tmp = isolate_app_dir();
+        let profile = "default";
+
+        // A Codex session created without an explicit mode: acp_mode_id is None,
+        // which is the exact state that made a picked mode vanish on respawn.
+        let mut inst = crate::session::Instance::new("t", "/tmp");
+        inst.source_profile = profile.to_string();
+        assert_eq!(inst.acp_mode_id, None);
+        let id = inst.id.clone();
+
+        // Seed on disk so the storage write-back can find the row to update.
+        let storage = crate::session::Storage::new_unwatched(profile).unwrap();
+        let seed = inst.clone();
+        storage
+            .update(|instances, _groups| {
+                instances.push(seed);
+                Ok(())
+            })
+            .unwrap();
+
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+        persist_acp_mode(&state, &id, "agent-full-access").await;
+
+        // In-memory registry updated (what the reconciler re-asserts on respawn).
+        assert_eq!(
+            state.instances.read().await[0].acp_mode_id.as_deref(),
+            Some("agent-full-access")
+        );
+
+        // On disk too (what survives a daemon restart).
+        let reloaded = crate::session::Storage::new_unwatched(profile)
+            .unwrap()
+            .load()
+            .unwrap();
+        assert_eq!(
+            reloaded
+                .iter()
+                .find(|i| i.id == id)
+                .unwrap()
+                .acp_mode_id
+                .as_deref(),
+            Some("agent-full-access")
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn is_mode_config_option_resolves_mode_from_catalog() {
+        use crate::acp::state::{ConfigOptionCategory, ConfigOptionChoice, ConfigOptionDescriptor};
+        use crate::session::test_support::isolate_app_dir;
+        let _tmp = isolate_app_dir();
+
+        let mut inst = crate::session::Instance::new("codex", "/tmp");
+        inst.agent_name = Some("codex".to_string());
+        let id = inst.id.clone();
+
+        let opts = vec![
+            ConfigOptionDescriptor {
+                id: "codex-mode".to_string(),
+                name: "Mode".to_string(),
+                description: None,
+                category: ConfigOptionCategory::Mode,
+                current_value: "agent".to_string(),
+                options: vec![ConfigOptionChoice {
+                    value: "agent-full-access".to_string(),
+                    name: "Agent (full access)".to_string(),
+                    description: None,
+                }],
+            },
+            ConfigOptionDescriptor {
+                id: "model".to_string(),
+                name: "Model".to_string(),
+                description: None,
+                category: ConfigOptionCategory::Model,
+                current_value: "gpt-5".to_string(),
+                options: vec![],
+            },
+        ];
+        crate::acp::option_catalog::record("codex", &opts, "2026-07-24T00:00:00Z".to_string())
+            .unwrap();
+
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+
+        assert!(is_mode_config_option(&state, &id, "codex-mode").await);
+        assert!(!is_mode_config_option(&state, &id, "model").await);
+        assert!(!is_mode_config_option(&state, &id, "unknown").await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Structured-view sessions set every per-session selector (model, mode, thought level) through one endpoint, `acp_set_config_option`. That handler only persisted a **model** pick (via `persist_agent_model`); a **Mode**-category pick was applied to the live worker but never written to `Instance.acp_mode_id`, so the id stayed at its creation value (commonly `None`).

#2897 already re-asserts `acp_mode_id` on every worker (re)spawn and routes it to Codex's config-option channel, but with nothing persisted it had nothing to apply. So a picked mode (Codex "Agent (full access)", modern claude plan mode) vanished on the next respawn (crash, `aoe acp restart`, or a `session/load` that falls back to `session/new`), and Codex silently re-armed approval prompts, stalling hands-off and cron-driven workflows.

This adds `is_mode_config_option`, which resolves the session's Mode-category config id from the agent's advertised option catalog (not a hardcoded id, so it works for any config-option-mode adapter), and `persist_acp_mode`, which mirrors `persist_agent_model` by writing the picked value to `Instance.acp_mode_id` both in the in-memory registry and on disk. The handler now persists a mode pick alongside the existing model pick, so #2897's re-assert keeps the chosen mode across respawns.

The daemon keeps no live per-session `AcpState`, so the option catalog (recorded on `ConfigOptionsUpdated`) is the only handler-reachable source of a session's advertised options; when it has no entry the code skips persistence, matching prior behavior with no regression.

Closes #3086

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a Codex structured-view session created without an explicit mode (so `acp_mode_id` is `None` in `sessions.json`).
- [ ] Pick **Agent (full access)**; confirm approval prompts stop.
- [ ] `aoe acp restart <id>` (or let the worker respawn).
- [ ] Confirm the picker stays on **Agent (full access)** and Codex does not prompt again; `sessions.json` shows `acp_mode_id` = `agent-full-access`.
- [ ] Pick a **model** on a running session, confirm `acp_mode_id` is left untouched (only `agent_model` changes).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is a server-side persistence + respawn-survival fix with no `web/` file changed. It is covered by two Rust unit tests in `src/server/api/acp.rs` (`persist_acp_mode_updates_memory_and_storage` asserts the memory + disk write-back; `is_mode_config_option_resolves_mode_from_catalog` asserts mode is told apart from model/unknown via the option catalog). A Playwright test cannot exercise a worker respawn.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and ran the manual test steps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Persisted mode selections made through the configuration picker so they survive worker respawns and restarts.
- Added detection based on the session’s advertised options, avoiding hardcoded mode identifiers.
- Kept model selection persistence unchanged.
- Added tests covering mode detection and in-memory/on-disk persistence.

This preserves user-selected workflows and prevents approval prompts from unexpectedly returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->