### PR TITLE
test(hooks): cover Linux privdrop ownership guards

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,13 +94,63 @@ jobs:
           cargo test --no-default-features --features e2e-tests --test e2e
           cargo check --no-default-features --features default-plugins,e2e-tests --all-targets
 
+  hook-privdrop:
+    name: Hook privdrop tests
+    # The privileged step is safe only on a disposable GitHub-hosted runner.
+    # Do not move this job to a persistent or self-hosted machine.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "true"
+          save-if: true
+      - name: Build the library test binary as the runner user
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_binary="$(
+            cargo test --no-run --lib --message-format=json \
+              | jq -r '
+                  select(
+                    .reason == "compiler-artifact"
+                    and .profile.test == true
+                    and .target.name == "agent_of_empires"
+                    and .executable != null
+                  )
+                  | .executable
+                ' \
+              | tail -n 1
+          )"
+          test -n "$test_binary"
+          printf '%s\n' "$test_binary" > "$RUNNER_TEMP/aoe-lib-test-binary"
+      - name: Exercise alien uid guards
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_binary="$(cat "$RUNNER_TEMP/aoe-lib-test-binary")"
+          test -x "$test_binary"
+          test_count="$(
+            "$test_binary" privdrop_ --list \
+              | awk '/: test$/ { count += 1 } END { print count + 0 }'
+          )"
+          if [ "$test_count" -ne 4 ]; then
+            echo "expected 4 privdrop tests, found $test_count"
+            exit 1
+          fi
+          sudo env AOE_PRIVDROP_TESTS=1 \
+            "$test_binary" privdrop_ --test-threads=1 --nocapture
+
   cargo-linux-ok:
     # Fan-in for the branch ruleset: "Cargo Test (linux)" is a required status
     # check, and matrix jobs report per-leg contexts the ruleset doesn't know
     # about. This job carries the stable context name and fails unless every
     # leg succeeded.
     name: Cargo Test (linux)
-    needs: cargo-linux
+    needs: [cargo-linux, hook-privdrop]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +158,10 @@ jobs:
         run: |
           if [ "${{ needs.cargo-linux.result }}" != "success" ]; then
             echo "linux legs result: ${{ needs.cargo-linux.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.hook-privdrop.result }}" != "success" ]; then
+            echo "hook privdrop result: ${{ needs.hook-privdrop.result }}"
             exit 1
           fi
 

--- a/src/hooks/dir_guard.rs
+++ b/src/hooks/dir_guard.rs
@@ -686,6 +686,8 @@ fn walk_and_unlink_entries(dir_fd: &OwnedFd) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use crate::hooks::test_support::{make_alien_owned, privdrop_test_enabled};
     use crate::hooks::test_support::{make_correct_base, BaseGuard};
     use serial_test::serial;
     use std::io::Read;
@@ -751,6 +753,46 @@ mod tests {
         let err = with_hook_base(|_| Ok(())).unwrap_err();
         let s = format!("{err:#}");
         assert!(s.contains("mode"), "expected mode rejection, got: {s}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial(hook_base)]
+    fn privdrop_init_rejects_alien_uid_base() {
+        if !privdrop_test_enabled() {
+            return;
+        }
+        let (_g, base, _tmp) = BaseGuard::fresh();
+        make_correct_base(&base);
+        let alien_uid = make_alien_owned(&base);
+
+        let err = with_hook_base(|_| Ok(())).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains(&format!("owned by uid={alien_uid}, expected euid=0")),
+            "expected alien base owner rejection, got: {message}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial(hook_base)]
+    fn privdrop_instance_subdir_rejects_alien_uid() {
+        if !privdrop_test_enabled() {
+            return;
+        }
+        let (_g, base, _tmp) = BaseGuard::ready();
+        let instance = base.join("alien_instance");
+        std::fs::create_dir(&instance).unwrap();
+        std::fs::set_permissions(&instance, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let alien_uid = make_alien_owned(&instance);
+
+        let err = open_instance_dir("alien_instance").unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains(&format!("owned by uid={alien_uid}, expected euid=0")),
+            "expected alien instance owner rejection, got: {message}"
+        );
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -4840,6 +4840,38 @@ hooks_auto_accept: false
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn privdrop_host_shell_in_dash_refuses_alien_uid() {
+        use crate::hooks::test_support::{make_alien_owned, privdrop_test_enabled};
+        use std::os::unix::fs::PermissionsExt;
+
+        if !privdrop_test_enabled() {
+            return;
+        }
+        if !dash_available() {
+            panic!("dedicated Linux privdrop job requires dash");
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("aoe-hooks-alien");
+        std::fs::create_dir(&base).unwrap();
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)).unwrap();
+        make_alien_owned(&base);
+
+        let cmd =
+            hook_command_with_base("running", base.to_str().unwrap(), HookInstallTarget::Host);
+        let output = std::process::Command::new("dash")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", "dash_alien_uid")
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "hook must exit 0 on rejection");
+        assert!(
+            !base.join("dash_alien_uid").exists(),
+            "dash must reject an alien-owned parent before creating an instance directory"
+        );
+    }
+
     #[test]
     #[cfg(target_os = "linux")]
     fn host_shell_accepts_acl_suffix_when_mode_tight() {

--- a/src/hooks/test_support.rs
+++ b/src/hooks/test_support.rs
@@ -51,3 +51,38 @@ pub(crate) fn make_correct_base(p: &Path) {
     std::fs::create_dir(p).unwrap();
     std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700)).unwrap();
 }
+
+#[cfg(target_os = "linux")]
+pub(crate) fn privdrop_test_enabled() -> bool {
+    if std::env::var("AOE_PRIVDROP_TESTS").as_deref() != Ok("1") {
+        eprintln!("skipping: set AOE_PRIVDROP_TESTS=1 in the dedicated Linux job");
+        return false;
+    }
+    assert!(
+        nix::unistd::geteuid().is_root(),
+        "AOE_PRIVDROP_TESTS requires the prebuilt test binary to run as root"
+    );
+    true
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn make_alien_owned(path: &Path) -> u32 {
+    use nix::unistd::{chown, Gid, Uid};
+
+    assert!(
+        nix::unistd::geteuid().is_root(),
+        "alien ownership fixtures require root"
+    );
+    let alien_uid = Uid::from_raw(65_534);
+    let alien_gid = Gid::from_raw(65_534);
+    chown(path, Some(alien_uid), Some(alien_gid))
+        .unwrap_or_else(|e| panic!("chown {} to nobody: {e}", path.display()));
+    let metadata = std::fs::symlink_metadata(path).unwrap();
+    use std::os::unix::fs::MetadataExt;
+    assert_eq!(
+        metadata.uid(),
+        alien_uid.as_raw(),
+        "fixture owner did not change"
+    );
+    alien_uid.as_raw()
+}

--- a/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
+++ b/src/migrations/v017_rewrite_hook_strings_for_per_user_base.rs
@@ -697,6 +697,42 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn privdrop_v017_sweep_leaves_alien_uid_entry_intact() {
+        use crate::hooks::test_support::{make_alien_owned, privdrop_test_enabled};
+        use std::os::unix::fs::PermissionsExt;
+
+        if !privdrop_test_enabled() {
+            return;
+        }
+        let tmp = TempDir::new().unwrap();
+        let legacy = tmp.path().join("legacy-aoe-hooks-mixed");
+        fs::create_dir(&legacy).unwrap();
+        fs::set_permissions(&legacy, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let owned = legacy.join("owned-instance");
+        fs::create_dir(&owned).unwrap();
+        fs::write(owned.join("status"), b"idle").unwrap();
+
+        let alien = legacy.join("alien-instance");
+        fs::create_dir(&alien).unwrap();
+        fs::write(alien.join("status"), b"running").unwrap();
+        make_alien_owned(&alien);
+
+        super::sweep_legacy_base_in(&legacy);
+
+        assert!(!owned.exists(), "owned legacy entry must be removed");
+        assert!(
+            alien.join("status").exists(),
+            "alien-owned legacy entry and its contents must survive"
+        );
+        assert!(
+            legacy.exists(),
+            "legacy parent must remain while an alien-owned entry exists"
+        );
+    }
+
     #[test]
     #[serial_test::serial(shell_env)]
     fn legacy_sweep_handles_symlink_at_legacy_path() {


### PR DESCRIPTION
## Description

Closes https://github.com/agent-of-empires/agent-of-empires/issues/2229

Add the Linux ownership regressions deferred from #2221 and wire them into the stable `Cargo Test (linux)` required-check context.

The new coverage verifies that:

- an alien-owned hook base is rejected
- an alien-owned per-instance directory is rejected
- the generated dash host hook refuses an alien-owned base
- the v017 legacy sweep removes owned entries while preserving foreign entries

A dedicated `ubuntu-latest` job builds the library test binary as the normal runner user, asserts that the `privdrop_` filter names exactly four tests, and only then executes that prebuilt binary with `sudo`. The job is explicitly restricted to a disposable GitHub-hosted runner, uses read-only contents permission, and does not persist checkout credentials.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

The new tests pass 4/4. The unchecked test item reflects the disclosed Docker-only full-suite exception below; required upstream CI remains the merge-readiness authority.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -- -D warnings`
- Linux `cargo test --locked --no-run --lib`
- Linux root fixture run: 4 passed, 0 failed, 0 ignored
- workflow YAML parse and `git diff --check`
- independent adversarial review: approved with no blocking findings

`cargo test --locked` in Docker completed 4,266 tests successfully but still failed two existing locked-worktree cleanup tests: `git::worktree::tests::delete_branch_reaps_lingering_locked_worktree` and `session::trash::tests::purge_recovers_when_project_path_diverged_and_locked_entry_survives`. The same pair failed as root and uid 1000; their implementation files are byte-identical to base and outside this diff. Upstream required CI remains the merge-readiness authority.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI GPT-5

**Any Additional AI Details you'd like to share:**

OpenAI GPT-5 was used for implementation, validation orchestration, and PR drafting. A separate independent agent reviewed the final committed diff and validation evidence, with no blocking findings.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added Linux regression coverage for rejecting directories owned by another user.
- Verified host hooks refuse unsafe ownership and legacy cleanup preserves foreign-owned entries.
- Added a dedicated CI job to run these tests with elevated privileges and included it in required Linux checks.

## Benefits
Improves protection against unsafe hook directories and prevents regressions in ownership validation and migration cleanup.

## Technical details
- Added privileged test helpers and four ownership-focused tests.
- Tests run only on Linux under `sudo` with controlled, single-threaded execution.
- CI validates the expected test count before running the suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->