### PR TITLE
fix(live): web takeover wins the size-owner lock; keyboard-safe sizing and smooth scrolling on mobile

### DIFF
--- a/src/server/live_ws.rs
+++ b/src/server/live_ws.rs
@@ -24,7 +24,10 @@
 //!   `{"type":"size_owner","is_owner":bool}`: whether this client holds
 //!     the session's size-owner lock. Only the owner resizes the shared
 //!     tmux window and may type; a non-owner renders best-effort at the
-//!     owner's grid and shows a "take over" affordance.
+//!     owner's grid and shows a "take over" affordance. A visible
+//!     non-owner at fast cadence auto-reclaims the lock (claim, never
+//!     steal) once the holder releases it, so ownership returns without
+//!     another "take over" tap.
 //!
 //! Client -> server:
 //!   Binary frames: raw bytes for the pane (keystrokes, escape
@@ -409,6 +412,7 @@ async fn handle_live_ws(
         let mut last_reassert = std::time::Instant::now() - REASSERT_MIN_INTERVAL;
         let mut reassert_guard = ReassertGuard::new(STUCK_REASSERT_RETRY);
         let mut last_heartbeat = std::time::Instant::now() - SIZE_OWNER_HEARTBEAT;
+        let mut last_reclaim = std::time::Instant::now() - SIZE_OWNER_HEARTBEAT;
         loop {
             let sample_started = std::time::Instant::now();
             let lines = capture_settings.window_lines.load(Ordering::Relaxed);
@@ -505,6 +509,51 @@ async fn handle_live_ws(
                             let _ = capture_tx
                                 .send(Message::Text(size_owner_json(false).into()))
                                 .await;
+                        }
+                    }
+                    // Auto-reclaim: a non-owner viewer re-CLAIMS (never
+                    // steals) the lock once it goes vacant or stale, so when
+                    // the current holder lets go (the TUI exits live mode,
+                    // another web viewer disconnects) this client resumes
+                    // ownership and its grid without the user re-tapping
+                    // "take over". Gated to the fast cadence, i.e. a visible
+                    // client at the live edge: a backgrounded PWA or a
+                    // scrolled-up reader must not grab sizing the moment a
+                    // desktop user releases it. While a live holder
+                    // heartbeats, the claim fails cheaply; the throttle keeps
+                    // that probe to one per heartbeat interval.
+                    else if !capture_settings.is_owner.load(Ordering::Relaxed)
+                        && capture_settings.fast.load(Ordering::Relaxed)
+                        && last_reclaim.elapsed() >= SIZE_OWNER_HEARTBEAT
+                    {
+                        let cols = capture_settings.screen_cols.load(Ordering::Relaxed) as u16;
+                        let rows = capture_settings.screen_rows.load(Ordering::Relaxed) as u16;
+                        if cols > 0 && rows > 0 {
+                            last_reclaim = std::time::Instant::now();
+                            let name = capture_tmux.clone();
+                            let who = capture_owner.clone();
+                            let claimed = tokio::task::spawn_blocking(move || {
+                                let session = crate::tmux::Session::from_name(&name);
+                                if session.claim_size_owner(&who, SIZE_OWNER_TTL) {
+                                    session.resize_window(cols, rows);
+                                    true
+                                } else {
+                                    false
+                                }
+                            })
+                            .await
+                            .unwrap_or(false);
+                            if claimed {
+                                capture_settings.is_owner.store(true, Ordering::Relaxed);
+                                last_heartbeat = std::time::Instant::now();
+                                #[cfg(unix)]
+                                if let Some(ch) = &capture_vt {
+                                    ch.set_grid_size(cols, rows);
+                                }
+                                let _ = capture_tx
+                                    .send(Message::Text(size_owner_json(true).into()))
+                                    .await;
+                            }
                         }
                     }
                     // Only the owner drives the window size. Another writer

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -6,7 +6,7 @@ pub mod status_bar;
 pub(crate) mod status_detection;
 mod terminal_session;
 #[cfg(test)]
-mod test_helpers;
+pub(crate) mod test_helpers;
 mod tool_session;
 pub(crate) mod utils;
 #[cfg(unix)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1910,6 +1910,15 @@ impl App {
                 needs_full_refresh = true;
             }
 
+            // Another surface (web live view, another TUI) took the
+            // size-owner lock: exit live mode and let its grid stand,
+            // instead of the old silent fight where the next keystroke or
+            // preview-rect jitter stole the lock back.
+            if self.home.poll_live_send_takeover() {
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
             if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
                 crate::session::write_tui_heartbeat();
                 last_heartbeat = std::time::Instant::now();

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -6073,6 +6073,16 @@ impl HomeView {
     fn exit_live_send_and_restore_sizing(&mut self, state: &live_send::LiveSendState) {
         let session = crate::tmux::Session::from_name(&state.tmux_name);
         session.reset_size_to_latest_client();
+        self.teardown_live_send();
+    }
+
+    /// Shared live-send teardown; touches no tmux sizing. Normal exits
+    /// call it via `exit_live_send_and_restore_sizing`; the lost-lock exit
+    /// (`poll_live_send_takeover`) calls it directly, because the surface
+    /// that took over has already sized the window to its own grid and
+    /// re-asserting `window-size latest` would stomp it (the exact flap
+    /// the size-owner lock exists to kill).
+    fn teardown_live_send(&mut self) {
         self.live_send = None;
         self.live_send_worker = None;
         // Leave the capture worker running: the same pane is still
@@ -6144,6 +6154,55 @@ impl HomeView {
             return Some("tmux pane went away while live mode was active.");
         }
         None
+    }
+
+    /// Poll the live-send worker's lock-loss flag (set off-thread when
+    /// another surface takes the size-owner lock) and exit live mode when
+    /// it trips, mirroring the web live view's demote-on-heartbeat. Called
+    /// from the main loop each tick so the exit does not wait for a
+    /// keystroke. Returns true when live mode was exited (a repaint is
+    /// needed).
+    ///
+    /// Deliberately does NOT restore the window's sizing: the new owner
+    /// already resized the window to its grid, and `window-size latest`
+    /// would stomp it.
+    pub(in crate::tui) fn poll_live_send_takeover(&mut self) -> bool {
+        if !self
+            .live_send_worker
+            .as_ref()
+            .is_some_and(live_send::LiveSendWorker::lock_lost)
+        {
+            return false;
+        }
+        let Some(state) = self.live_send.clone() else {
+            // Worker outlived the live-send state (already torn down some
+            // other way); just drop it.
+            self.live_send_worker = None;
+            return false;
+        };
+        // A dead or renamed session also fails the worker's ownership
+        // refresh; prefer the accurate drift message over blaming a
+        // takeover that never happened.
+        if let Some(reason) = self.live_send_drift_reason(&state) {
+            self.exit_live_send_and_restore_sizing(&state);
+            self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
+            return true;
+        }
+        // Name the thief where the owner id makes it unambiguous. The web
+        // dashboard's live viewers register as `live-*`
+        // (src/server/live_ws.rs); other aoe TUIs as `tui-*`.
+        let message = match crate::tmux::Session::from_name(&state.tmux_name).size_owner() {
+            Some((id, _)) if id.starts_with("live-") => {
+                "The web dashboard took over this session's live view."
+            }
+            Some((id, _)) if id.starts_with("tui-") => {
+                "Another aoe TUI took over this session's live view."
+            }
+            _ => "Another surface took over this session's live view.",
+        };
+        self.teardown_live_send();
+        self.info_dialog = Some(InfoDialog::new("Live send ended", message));
+        true
     }
 
     /// Open the permission-response dialog for the currently-selected

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -406,11 +406,11 @@ pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
     out
 }
 
-/// Whether a drained batch must re-assert size ownership BEFORE dispatch.
+/// Whether a drained batch must verify size ownership BEFORE dispatch.
 /// Only geometry changes need that ordering: a `resize-window` racing
 /// another surface's live grid is the flap the size-owner lock exists to
 /// kill. Plain keystrokes never read the lock, so they dispatch without
-/// waiting on the steal's tmux forks.
+/// waiting on the verify's tmux forks.
 pub(super) fn batch_needs_owner_first(batch: &[WorkerMsg]) -> bool {
     batch.iter().any(|m| matches!(m, WorkerMsg::Resize { .. }))
 }
@@ -447,6 +447,11 @@ pub(super) enum WorkerMsg {
 /// keypress, which we accept as the cost of reliability.
 pub(in crate::tui) struct LiveSendWorker {
     tx: Sender<WorkerMsg>,
+    /// Set (sticky) by the worker thread when the size-owner lock is
+    /// observed held by another surface. The UI loop polls this each tick
+    /// and exits live mode; the worker itself never steals the lock back
+    /// after entry, so a web "take over" wins instead of ping-ponging.
+    lock_lost: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl LiveSendWorker {
@@ -457,24 +462,48 @@ impl LiveSendWorker {
     /// input rather than the background capture phase.
     pub(super) fn spawn(tmux_name: String, capture_wake: Option<LiveCaptureWake>) -> Self {
         let (tx, rx) = channel::<WorkerMsg>();
+        let lock_lost = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread_lock_lost = std::sync::Arc::clone(&lock_lost);
         std::thread::spawn(move || {
             use std::sync::atomic::Ordering;
             use std::sync::mpsc::RecvTimeoutError;
 
-            // TUI live-send is an active take-over: own the session's size for
-            // the lifetime of this worker so the web PTY relay and the mobile
-            // live view defer to it. Steal on entry, then maintain ownership
-            // at most once per heartbeat while input flows; refresh on the
-            // idle heartbeat so an idle-but-attached live session is not
-            // stolen from. Released (and `window-size latest` restored) when
-            // live mode exits and the channel closes.
+            // TUI live-send is an active take-over: entering live mode steals
+            // the session's size so the web PTY relay and the mobile live
+            // view defer to it. Entry is the ONLY steal: afterwards
+            // ownership is merely refreshed, and losing it (a web "take
+            // over" tap, another TUI's live entry) flips `lock_lost` so the
+            // UI exits live mode instead of fighting the new owner.
+            // Re-stealing after entry is how a background TUI used to
+            // silently revert a phone takeover: any keystroke, or any
+            // preview-rect jitter (a one-frame toast, a divider drag)
+            // re-asserted this worker's grid and yanked the pane size back.
+            // Released (and `window-size latest` restored) when live mode
+            // exits and the channel closes; on a lost lock the release is a
+            // no-op and the new owner's sizing stands.
             let owner_id = format!(
                 "tui-{}-{}",
                 std::process::id(),
                 LIVE_SEND_WORKER_COUNTER.fetch_add(1, Ordering::Relaxed)
             );
             let session = crate::tmux::Session::from_name(&tmux_name);
-            session.steal_size_owner(&owner_id);
+            // False only when the tmux session is missing/broken at entry
+            // (the steal is unconditional otherwise); retried on the next
+            // resize batch so a slow-to-appear pane still gets owned.
+            let mut owned = session.steal_size_owner(&owner_id);
+            // Refresh-or-flag: bump our heartbeat iff we still hold the
+            // lock; a failed refresh means another surface took over, which
+            // is flagged once and never fought.
+            let maintain = |owned: bool| -> bool {
+                if !owned || thread_lock_lost.load(Ordering::Relaxed) {
+                    return false;
+                }
+                let still_owner = session.refresh_size_owner(&owner_id);
+                if !still_owner {
+                    thread_lock_lost.store(true, Ordering::Relaxed);
+                }
+                still_owner
+            };
 
             // Block (up to a heartbeat) for the first message, then drain
             // anything else that piled up. The drain plus `coalesce` collapses
@@ -498,27 +527,45 @@ impl LiveSendWorker {
                         while let Ok(msg) = rx.try_recv() {
                             batch.push(msg);
                         }
+                        // Geometry must not race another owner's grid, so a
+                        // batch carrying a resize VERIFIES ownership first;
+                        // plain keystrokes never read the lock.
                         if batch_needs_owner_first(&batch) {
-                            session.steal_size_owner(&owner_id);
+                            if !owned {
+                                // Entry steal failed (session missing at
+                                // spawn); live entry is user intent, so keep
+                                // trying to take the size until it works.
+                                owned = session.steal_size_owner(&owner_id);
+                            } else {
+                                maintain(owned);
+                            }
                             last_owner_maintenance = std::time::Instant::now();
                         }
-                        dispatch_batch(&tmux_name, batch);
-                        if let Some(wake) = &capture_wake {
-                            wake.wake();
+                        if thread_lock_lost.load(Ordering::Relaxed) {
+                            // The resize would stomp the new owner's grid.
+                            // Keys still deliver: they were typed before the
+                            // UI could tear live mode down, and pane input
+                            // is not lock-gated.
+                            batch.retain(|m| !matches!(m, WorkerMsg::Resize { .. }));
                         }
-                        if last_owner_maintenance.elapsed() >= crate::tmux::SIZE_OWNER_HEARTBEAT {
-                            session.steal_size_owner(&owner_id);
+                        if !batch.is_empty() {
+                            dispatch_batch(&tmux_name, batch);
+                            if let Some(wake) = &capture_wake {
+                                wake.wake();
+                            }
+                        }
+                        if last_owner_maintenance.elapsed() >= crate::tmux::SIZE_OWNER_HEARTBEAT
+                            && maintain(owned)
+                        {
                             last_owner_maintenance = std::time::Instant::now();
                         }
                     }
                     Err(RecvTimeoutError::Timeout) => {
-                        // Only count a SUCCESSFUL refresh as maintenance: a
-                        // false return means another surface took (or freed)
-                        // the lock while we idled, and the stale timestamp
-                        // makes the next input batch re-steal right away,
-                        // matching the old steal-per-batch reclaim without
-                        // its per-keystroke cost.
-                        if session.refresh_size_owner(&owner_id) {
+                        // Idle heartbeat. A failed refresh here is usually
+                        // the earliest takeover signal (the web steals while
+                        // the desktop sits idle); `maintain` flags it so the
+                        // UI can exit live mode without waiting for input.
+                        if maintain(owned) {
                             last_owner_maintenance = std::time::Instant::now();
                         }
                     }
@@ -527,7 +574,20 @@ impl LiveSendWorker {
             }
             session.release_size_owner(&owner_id);
         });
-        Self { tx }
+        Self { tx, lock_lost }
+    }
+
+    /// True once the worker observed the size-owner lock held by another
+    /// surface. Sticky for the worker's lifetime; the UI loop polls it and
+    /// exits live mode.
+    pub(super) fn lock_lost(&self) -> bool {
+        self.lock_lost.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(super) fn force_lock_lost_for_test(&self) {
+        self.lock_lost
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Enqueue a translated key for dispatch. Returns immediately; the
@@ -2680,9 +2740,9 @@ mod tests {
     #[test]
     fn only_resize_batches_reassert_ownership_before_dispatch() {
         // Keystroke batches must dispatch without waiting on the size-owner
-        // steal (~5 tmux forks); putting the steal back ahead of plain input
+        // check (a few tmux forks); putting it back ahead of plain input
         // re-creates the per-keystroke latency this classifier exists to
-        // avoid. Resizes keep steal-first so geometry never races another
+        // avoid. Resizes keep verify-first so geometry never races another
         // owner's grid.
         assert!(batch_needs_owner_first(&[WorkerMsg::Resize {
             cols: 80,
@@ -2717,5 +2777,150 @@ mod tests {
             Some(String::new()),
             "forward-empty policy must surface empty captures",
         );
+    }
+
+    fn tmux_available() -> bool {
+        crate::tmux::tmux_command()
+            .arg("-V")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn wait_until(what: &str, timeout: std::time::Duration, mut cond: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if cond() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {what}");
+    }
+
+    fn pane_width(name: &str) -> u16 {
+        let out = crate::tmux::tmux_command()
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                &format!("{name}:^.0"),
+                "-F",
+                "#{pane_width}",
+            ])
+            .output()
+            .expect("tmux display-message");
+        String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse()
+            .unwrap_or(0)
+    }
+
+    /// The worker never steals the size-owner lock back after entry: an
+    /// external steal (a web "take over") flips its sticky `lock_lost`
+    /// flag, the thief keeps the lock, and a queued resize is dropped
+    /// instead of stomping the new owner's grid. This is the fix for the
+    /// silent tug-of-war where a background TUI's next keystroke or
+    /// preview-rect jitter reverted a phone takeover.
+    #[test]
+    #[serial_test::serial]
+    fn worker_flags_lock_loss_and_drops_resize_after_external_steal() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = crate::tmux::test_helpers::TmuxTestSession::new("aoe_test_livelock_steal");
+        let out = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                guard.name(),
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(out.status.success());
+        crate::tmux::refresh_session_cache();
+        let session = crate::tmux::Session::from_name(guard.name());
+
+        let worker = LiveSendWorker::spawn(guard.name().to_string(), None);
+        wait_until(
+            "worker entry steal",
+            std::time::Duration::from_secs(5),
+            || matches!(session.size_owner(), Some((id, _)) if id.starts_with("tui-")),
+        );
+        assert!(!worker.lock_lost());
+
+        // A web live viewer takes over (what live_ws's Claim handler does).
+        assert!(session.steal_size_owner("live-test-thief"));
+
+        // The next resize must verify, observe the loss, flag it, and be
+        // dropped. (The idle heartbeat may flag it first; either path is
+        // the behavior under test.)
+        worker.resize(60, 20);
+        wait_until("lock_lost flag", std::time::Duration::from_secs(5), || {
+            worker.lock_lost()
+        });
+        assert_eq!(
+            session.size_owner().map(|(id, _)| id),
+            Some("live-test-thief".to_string()),
+            "worker must not steal the lock back"
+        );
+        // Give any (wrongly) dispatched resize time to land, then confirm
+        // the pane kept the thief's geometry.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert_eq!(
+            pane_width(guard.name()),
+            80,
+            "dropped resize must not dispatch"
+        );
+    }
+
+    /// Control case: while the worker still owns the lock, resizes verify
+    /// successfully and dispatch as before.
+    #[test]
+    #[serial_test::serial]
+    fn worker_resizes_while_it_owns_the_lock() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let guard = crate::tmux::test_helpers::TmuxTestSession::new("aoe_test_livelock_own");
+        let out = crate::tmux::tmux_command()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                guard.name(),
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(out.status.success());
+        crate::tmux::refresh_session_cache();
+        let session = crate::tmux::Session::from_name(guard.name());
+
+        let worker = LiveSendWorker::spawn(guard.name().to_string(), None);
+        wait_until(
+            "worker entry steal",
+            std::time::Duration::from_secs(5),
+            || matches!(session.size_owner(), Some((id, _)) if id.starts_with("tui-")),
+        );
+        worker.resize(60, 20);
+        wait_until(
+            "owned resize dispatch",
+            std::time::Duration::from_secs(5),
+            || pane_width(guard.name()) == 60,
+        );
+        assert!(!worker.lock_lost());
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -14462,6 +14462,44 @@ mod live_send_mode {
         });
     }
 
+    /// A lock-loss flag from the live-send worker (another surface stole
+    /// the size-owner lock) exits live mode from the main-loop poll, with
+    /// no keystroke needed, drops the worker, and explains the takeover in
+    /// an info dialog. The sizing reset is skipped so the thief's grid
+    /// stands; only the shared teardown runs.
+    #[test]
+    #[serial]
+    fn poll_live_send_takeover_exits_live_mode_with_dialog() {
+        use crate::tui::home::live_send::LiveSendWorker;
+        let mut env = create_test_env_with_sessions(1);
+        install_live_for_first_session(&mut env);
+        env.view.live_send_worker = Some(LiveSendWorker::spawn("fake".to_string(), None));
+
+        // Flag not set: the poll is a no-op and live mode stays.
+        assert!(!env.view.poll_live_send_takeover());
+        assert!(env.view.live_send.is_some());
+        assert!(env.view.info_dialog.is_none());
+
+        env.view
+            .live_send_worker
+            .as_ref()
+            .expect("worker mounted")
+            .force_lock_lost_for_test();
+        assert!(env.view.poll_live_send_takeover());
+        assert!(env.view.live_send.is_none(), "live mode must exit");
+        assert!(
+            env.view.live_send_worker.is_none(),
+            "worker must be dropped"
+        );
+        let dialog = env.view.info_dialog.as_ref().expect("info dialog shown");
+        assert_eq!(dialog.title(), "Live send ended");
+        assert!(
+            dialog.message().contains("took over"),
+            "dialog must explain the takeover, got: {}",
+            dialog.message()
+        );
+    }
+
     #[test]
     #[serial]
     fn ctrl_q_exits_live_mode() {

--- a/tests/e2e/live_takeover.rs
+++ b/tests/e2e/live_takeover.rs
@@ -1,0 +1,138 @@
+//! E2E for the live-send takeover exit: when another surface steals the
+//! size-owner lock (what the web dashboard's "take over" does), the TUI
+//! must exit live mode on its own, without a keystroke, and explain who
+//! took over. Guards against the old silent tug-of-war where the TUI
+//! re-stole the lock on the next input batch and reverted the web's grid.
+
+use serial_test::serial;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::harness::{app_dir_in, require_tmux, TuiTestHarness};
+
+/// Replace the pre-seeded config with one that routes activation into
+/// live-send (mirrors `new_session::write_config_attach_mode_live_send`).
+fn write_live_send_config(h: &TuiTestHarness) {
+    let config_dir = app_dir_in(h.home_path());
+    let config_content = format!(
+        r#"[updates]
+update_check_mode = "off"
+
+[app_state]
+has_seen_welcome = true
+has_responded_to_telemetry = true
+last_seen_version = "{version}"
+has_acknowledged_agent_hooks = true
+
+[session]
+default_attach_mode = "live_send"
+"#,
+        version = env!("CARGO_PKG_VERSION"),
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write live-send config");
+}
+
+fn list_sessions_on(socket: &std::path::Path) -> Vec<String> {
+    let output = Command::new("tmux")
+        .arg("-S")
+        .arg(socket)
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output();
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(String::from)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn set_session_option(socket: &std::path::Path, session: &str, opt: &str, value: &str) {
+    let out = Command::new("tmux")
+        .arg("-S")
+        .arg(socket)
+        .args(["set-option", "-t", session, opt, value])
+        .output()
+        .expect("tmux set-option");
+    assert!(
+        out.status.success(),
+        "tmux set-option {opt} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+#[serial]
+fn test_web_takeover_exits_tui_live_mode_with_dialog() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("live_takeover");
+    write_live_send_config(&h);
+
+    // The default `claude` stub exits immediately, which kills the agent
+    // pane before live mode can observe anything (the known short-lived-
+    // shell flake). Shadow it with a long-running stand-in so the pane
+    // survives the whole test.
+    let bin = h.install_path_command("claude");
+    std::fs::write(bin.join("claude"), "#!/bin/sh\nsleep 300\n").expect("write sleeping claude");
+
+    let project = h.project_path();
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "Takeover"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    h.spawn_tui();
+    h.wait_for("Takeover");
+
+    // Activate the session; default_attach_mode routes into live-send.
+    h.send_keys("Enter");
+    h.wait_for_timeout("LIVE", Duration::from_secs(10));
+
+    // Find the agent's tmux session on the harness socket (the harness's
+    // own UI session is `aoe_e2e_*`; agent sessions carry the dev prefix).
+    let socket = h.home_path().join("tmux.sock");
+    let agent_session = list_sessions_on(&socket)
+        .into_iter()
+        .find(|name| name.starts_with("aoe_dev_") && !name.starts_with("aoe_e2e_"))
+        .expect("agent tmux session exists");
+
+    // Steal the size-owner lock the way the web dashboard's Claim handler
+    // does (`steal_size_owner`): overwrite owner + fresh heartbeat with a
+    // `live-*` id.
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_millis()
+        .to_string();
+    set_session_option(&socket, &agent_session, "@aoe_size_owner", "live-e2e-web");
+    set_session_option(&socket, &agent_session, "@aoe_size_owner_hb", &now_ms);
+
+    // With NO further input, the worker's idle heartbeat notices the loss
+    // (<= 1.5s), the main-loop poll exits live mode, and the dialog names
+    // the web dashboard. The LIVE badge must be gone: live mode ended.
+    h.wait_for_timeout("Live send ended", Duration::from_secs(10));
+    h.assert_screen_contains("web dashboard");
+    h.wait_for_absent("LIVE", Duration::from_secs(5));
+
+    // The thief keeps the lock: the TUI must not have stolen it back.
+    let owner = Command::new("tmux")
+        .arg("-S")
+        .arg(&socket)
+        .args([
+            "show-options",
+            "-v",
+            "-t",
+            &agent_session,
+            "@aoe_size_owner",
+        ])
+        .output()
+        .expect("tmux show-options");
+    assert_eq!(
+        String::from_utf8_lossy(&owner.stdout).trim(),
+        "live-e2e-web",
+        "TUI must not re-steal the size-owner lock after takeover"
+    );
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -39,6 +39,7 @@ mod fork_cli;
 mod fork_structured_e2e;
 mod intro;
 mod kiro_launch;
+mod live_takeover;
 mod logs;
 mod new_session;
 mod opencode_sandbox_resume;

--- a/web/src/components/LiveTerminalView.tsx
+++ b/web/src/components/LiveTerminalView.tsx
@@ -61,11 +61,12 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
   const [ensureState, setEnsureState] = useState<"pending" | "ready" | "error">("pending");
   const [ensureError, setEnsureError] = useState<string | null>(null);
   const live = useLiveTerminal(ensureState === "ready" ? session.id : null, wsPath);
-  // Only the iOS-regular-Safari bottom inset comes from the viewport
-  // hook. Keyboard open/closed state does NOT: on a touch device the
-  // keyboard is open exactly when our input has focus, and focus events
-  // are ground truth where viewport-occlusion heuristics misread.
-  const { keyboardHeight } = useMobileKeyboard();
+  // The viewport hook supplies the iOS-regular-Safari bottom inset and
+  // the occlusion-based keyboardOpen used to gate the pane's sizing
+  // latch (occlusion is what shrinks the container, whichever element is
+  // focused). The CHROME's open/closed state still comes from input
+  // focus below, which is exact where occlusion heuristics misread.
+  const { keyboardHeight, keyboardOpen } = useMobileKeyboard();
   const [inputFocused, setInputFocused] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [ctrlActive, setCtrlActive] = useState(false);
@@ -289,6 +290,7 @@ export function LiveTerminalView({ session, active = true, surface = "agent", te
           inputRef={inputRef}
           onInputFocusChange={setInputFocused}
           bottomAlign={surface === "agent"}
+          keyboardOpen={keyboardOpen}
         />
         {coarse && live.state.connected && <KeyboardFab keyboardOpen={inputFocused} onToggle={toggleKeyboard} />}
       </div>

--- a/web/src/components/MobileLiveTerminal.tsx
+++ b/web/src/components/MobileLiveTerminal.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode, RefObject } from "react";
 import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
-import { ansiToLines, findCursorCharIndex, splitUrls, textWidth, wrapLine } from "../lib/liveTermLines";
+import { LineParseCache, findCursorCharIndex, splitUrls, textWidth, wrapLine } from "../lib/liveTermLines";
 import { wheelNotches } from "../lib/liveMouse";
 import { writeClipboard } from "../lib/clipboard";
 import type { LiveFrame } from "../hooks/useLiveTerminal";
@@ -117,6 +117,12 @@ export interface MobileLiveTerminalProps {
    *  prompt sits just above the keyboard. The paired host/container shells are
    *  ordinary terminals, so they top-align like a normal bash window. */
   bottomAlign: boolean;
+  /** True while the soft keyboard occludes the visual viewport (from
+   *  useMobileKeyboard's occlusion measure, not input focus: the occlusion is
+   *  what shrinks the container, regardless of which element is focused).
+   *  Gates the sizing latch so a pane that first measures with the keyboard
+   *  up never ships keyboard-shrunk rows to tmux. Always false on desktop. */
+  keyboardOpen: boolean;
 }
 
 // Backslash-escape whitespace and backslashes in a pasted image path, matching
@@ -392,6 +398,7 @@ export function MobileLiveTerminal({
   inputRef,
   onInputFocusChange,
   bottomAlign,
+  keyboardOpen,
 }: MobileLiveTerminalProps) {
   const { settings, update } = useWebSettings();
   // The live view now renders on desktop too, so it honors the right font-size
@@ -600,23 +607,43 @@ export function MobileLiveTerminal({
     }
     geomRef.current = { target, clientHeight: el.clientHeight, scrollTop: el.scrollTop };
   }, [liveScrollTarget]);
-  const lines = useMemo(() => (frame ? ansiToLines(frame.content) : []), [frame]);
+  // Frame-to-frame parse cache: unchanged lines keep their segment-array
+  // identity across streamed frames, so the wrap cache below and the
+  // memoized Row components skip all untouched rows. Re-deriving the whole
+  // window per frame (and handing every row fresh objects) was the main
+  // scroll-jank driver on multi-thousand-line reading windows. Held in a
+  // state initializer (never set) rather than a ref so the render-time
+  // read is legal; re-running on the same frame converges (see the class).
+  const [parseCache] = useState(() => new LineParseCache());
+  const lines = useMemo(() => (frame ? parseCache.lines(frame.content) : []), [frame, parseCache]);
   // Columns this viewer renders at. Normally the pane is exactly this
   // wide and wrapping is the identity; when another writer resizes the
   // window wider (see the server-side drift re-assert), wrapping keeps
   // the frame readable instead of clipping at the right edge.
   const [renderCols, setRenderCols] = useState(0);
+  // Wrap results keyed on the line's segment-array identity (stable across
+  // frames thanks to LineParseCache), so only changed lines re-wrap and
+  // unchanged visual rows keep THEIR identity too, which is what lets
+  // memo(Row) skip them. State initializer, not a ref, for the same
+  // render-read legality as the parse cache above.
+  const [wrapCache] = useState(() => new WeakMap<AnsiSegment[], { cols: number; rows: AnsiSegment[][] }>());
   const visual = useMemo(() => {
     const cols = renderCols > 0 ? renderCols : Number.POSITIVE_INFINITY;
     const rows: AnsiSegment[][] = [];
     // Visual row index where each pane line starts (for cursor math).
     const lineStartRow: number[] = new Array(lines.length);
     for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      let wrapped = wrapCache.get(line);
+      if (!wrapped || wrapped.cols !== cols) {
+        wrapped = { cols, rows: wrapLine(line, cols) };
+        wrapCache.set(line, wrapped);
+      }
       lineStartRow[i] = rows.length;
-      for (const row of wrapLine(lines[i]!, cols)) rows.push(row);
+      for (const row of wrapped.rows) rows.push(row);
     }
     return { rows, lineStartRow };
-  }, [lines, renderCols]);
+  }, [lines, renderCols, wrapCache]);
   const screenRows = frame?.rows ?? 0;
   const history = frame?.history ?? 0;
   const fetchedHistory = Math.max(0, lines.length - screenRows);
@@ -753,13 +780,33 @@ export function MobileLiveTerminal({
     return el.scrollTop >= liveScrollTarget(el) - lineH * 1.5;
   }, [lineH, liveScrollTarget]);
 
+  // Scroll events arrive per scrolled pixel; a `view` state update (a React
+  // render) for each one competes with the compositor mid-flick. One update
+  // per painted frame is all the virtualization window needs, since it
+  // already carries a full viewport of overscan on both sides. The
+  // layout-effect syncView after a pin stays synchronous (pre-paint).
+  const viewSyncRafRef = useRef(0);
+  const scheduleViewSync = useCallback(() => {
+    if (viewSyncRafRef.current !== 0) return;
+    viewSyncRafRef.current = requestAnimationFrame(() => {
+      viewSyncRafRef.current = 0;
+      syncView();
+    });
+  }, [syncView]);
+  useEffect(
+    () => () => {
+      cancelAnimationFrame(viewSyncRafRef.current);
+    },
+    [],
+  );
+
   // Last scrollTop seen by onScroll, to read the scroll DIRECTION (our pin
   // filters itself out by landing exactly on the target).
   const onScrollLastTopRef = useRef(0);
   const onScroll = useCallback(() => {
     // Forward mode pins the live edge (overflow hidden); the wheel goes to
     // the app, so there is no scrollback reading state to enter.
-    syncView();
+    scheduleViewSync();
     if (forwardModeRef.current) return;
     const el = scrollerRef.current;
     if (!el) return;
@@ -781,7 +828,7 @@ export function MobileLiveTerminal({
     if (el.scrollHeight - el.clientHeight - el.scrollTop < 2 && !movingUp) {
       liveDetachedRef.current = false;
     }
-  }, [atBottom, enterReading, returnToLive, syncView]);
+  }, [atBottom, enterReading, returnToLive, scheduleViewSync]);
 
   const jumpToLatest = useCallback(() => {
     const el = scrollerRef.current;
@@ -1054,14 +1101,27 @@ export function MobileLiveTerminal({
       const width = el.clientWidth;
       const height = el.clientHeight;
       if (width <= 0 || height <= 0) return;
+      const cols = Math.floor(width / charW);
       const latch = latchRef.current;
-      if (Math.abs(width - latch.width) > 1) {
+      const widthChanged = Math.abs(width - latch.width) > 1;
+      // While the keyboard occludes the viewport, the measured height is
+      // the shrunk one. Seeding the latch from it (first mount with the
+      // keyboard up, rotation mid-cycle) would ship keyboard-shrunk rows
+      // to tmux, the exact thing the latch exists to prevent; defer the
+      // seed until the keyboard closes (the height change re-fires the
+      // observer, and the keyboardOpen flip re-runs this effect as a
+      // belt). Columns don't depend on height, so the render width still
+      // updates and drifted frames wrap correctly while deferred.
+      if (keyboardOpen && (widthChanged || latch.maxHeight === 0)) {
+        if (cols >= 20) setRenderCols(cols);
+        return;
+      }
+      if (widthChanged) {
         latch.width = width;
         latch.maxHeight = height;
       } else if (height > latch.maxHeight) {
         latch.maxHeight = height;
       }
-      const cols = Math.floor(width / charW);
       const rows = Math.floor(latch.maxHeight / lineH);
       // Implausibly small means a hidden/mid-transition container; never
       // ship that to tmux.
@@ -1085,7 +1145,7 @@ export function MobileLiveTerminal({
       ro.disconnect();
       if (timer) clearTimeout(timer);
     };
-  }, [active, charW, lineH, sendResize, setWindow, pinIfWasAtBottom]);
+  }, [active, charW, lineH, sendResize, setWindow, pinIfWasAtBottom, keyboardOpen]);
 
   // Cadence: fast only while this pane is the active, visible surface AND
   // at the live edge. Reading scrollback drops to idle: the window is
@@ -1436,9 +1496,15 @@ export function MobileLiveTerminal({
                 {padLines > 0 && <div style={{ height: `${padLines * lineH}px` }} aria-hidden="true" />}
                 {visual.rows.slice(start, end).map((segs, j) => {
                   const i = start + j;
+                  // Keyed by ABSOLUTE buffer position (spacer + window row),
+                  // which is invariant as the agent appends: history grows by
+                  // k, the capture window slides by k, and a given content
+                  // line keeps spacer+index. With a viewport-relative key an
+                  // append shifted every row onto a new key and re-rendered
+                  // the entire mounted slice per streamed frame.
                   return (
                     <Row
-                      key={i}
+                      key={effectiveSpacerLines + i}
                       segs={segs}
                       cursorCol={i === cursorRow ? live.col : null}
                       focused={i === cursorRow && focused}

--- a/web/src/components/__tests__/MobileLiveTerminal.align.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.align.test.tsx
@@ -54,6 +54,7 @@ function renderTerm(bottomAlign: boolean) {
       inputRef={createRef<HTMLTextAreaElement>()}
       onInputFocusChange={vi.fn()}
       bottomAlign={bottomAlign}
+      keyboardOpen={false}
     />,
   );
   return utils.container.querySelector("[data-live-content]") as HTMLElement;

--- a/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.cursorFocusIntegration.test.tsx
@@ -55,6 +55,7 @@ function renderTerm() {
       inputRef={inputRef}
       onInputFocusChange={vi.fn()}
       bottomAlign
+      keyboardOpen={false}
     />,
   );
   const cursorCell = () => utils.container.querySelector("[data-live-cursor]") as HTMLElement | null;

--- a/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.forward.test.tsx
@@ -58,6 +58,7 @@ function renderTerm(f: LiveFrame, forwardWheel = vi.fn(), forwardButton = vi.fn(
       inputRef={createRef<HTMLTextAreaElement>()}
       onInputFocusChange={vi.fn()}
       bottomAlign
+      keyboardOpen={false}
     />,
   );
   const scroller = utils.container.querySelector("[data-live-terminal] > div") as HTMLElement;
@@ -187,6 +188,7 @@ describe("MobileLiveTerminal wheel forwarding", () => {
         inputRef={createRef<HTMLTextAreaElement>()}
         onInputFocusChange={vi.fn()}
         bottomAlign
+        keyboardOpen={false}
       />,
     );
     const scroller = utils.container.querySelector("[data-live-terminal] > div") as HTMLElement;

--- a/web/src/components/__tests__/MobileLiveTerminal.keyboardResize.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.keyboardResize.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+//
+// Regression for the keyboard-open sizing-latch seed bug: rows shipped to
+// tmux come from a latch of the LARGEST container height seen per width, so
+// a keyboard cycle never resizes tmux. But if the pane's FIRST measurement
+// for a width happens while the soft keyboard has the container shrunk
+// (mount with the keyboard up, rotation mid-cycle), the latch used to seed
+// from the shrunk height and tmux got keyboard-shrunk rows, then a second
+// resize on keyboard close. The `keyboardOpen` prop now defers seeding
+// until the keyboard is gone; these tests pin the deferral, the correct
+// late seed, and that a normal keyboard cycle still never changes the grid.
+
+import { createRef } from "react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { MobileLiveTerminal } from "../MobileLiveTerminal";
+
+vi.mock("../../hooks/useWebSettings", () => ({
+  useWebSettings: () => ({ settings: { mobileFontSize: 14, desktopFontSize: 14 }, update: vi.fn() }),
+}));
+
+// Mirror the component's grid math: charW falls back to fontSize * 0.6 in
+// jsdom (the measure span has no layout), lineH is fontSize * LINE_RATIO.
+const CHAR_W = 14 * 0.6;
+const LINE_H = 14 * 1.2;
+const WIDTH = 400;
+const FULL_HEIGHT = 600;
+const SHRUNK_HEIGHT = 250;
+const COLS = Math.floor(WIDTH / CHAR_W);
+const FULL_ROWS = Math.floor(FULL_HEIGHT / LINE_H);
+const RESIZE_DEBOUNCE_MS = 150;
+
+let clientHeight = FULL_HEIGHT;
+let roCallbacks: Array<() => void> = [];
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    private cb: () => void;
+    constructor(cb: () => void) {
+      this.cb = cb;
+    }
+    observe() {
+      roCallbacks.push(this.cb);
+    }
+    unobserve() {}
+    disconnect() {
+      roCallbacks = roCallbacks.filter((c) => c !== this.cb);
+    }
+  } as unknown as typeof ResizeObserver;
+
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", { configurable: true, get: () => WIDTH });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => clientHeight });
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  roCallbacks = [];
+  clientHeight = FULL_HEIGHT;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function props(keyboardOpen: boolean, sendResize = vi.fn()) {
+  return {
+    frame: null,
+    connected: true,
+    active: true,
+    reading: false,
+    sendResize,
+    setWindow: vi.fn(),
+    setCadence: vi.fn(),
+    enterReading: vi.fn(),
+    returnToLive: vi.fn(),
+    sendData: vi.fn(),
+    uploadPastedImage: vi.fn(),
+    forwardWheel: vi.fn(),
+    forwardButton: vi.fn(),
+    ctrlActiveRef: createRef<boolean>() as React.RefObject<boolean>,
+    clearCtrl: vi.fn(),
+    inputRef: createRef<HTMLTextAreaElement>(),
+    onInputFocusChange: vi.fn(),
+    bottomAlign: true,
+    keyboardOpen,
+  };
+}
+
+/** Fire every registered ResizeObserver and let the compute debounce run. */
+function settleLayout() {
+  act(() => {
+    for (const cb of [...roCallbacks]) cb();
+    vi.advanceTimersByTime(RESIZE_DEBOUNCE_MS + 10);
+  });
+}
+
+describe("MobileLiveTerminal keyboard-aware sizing latch", () => {
+  it("defers the first tmux resize while the keyboard has the container shrunk", () => {
+    const sendResize = vi.fn();
+    clientHeight = SHRUNK_HEIGHT;
+    const { rerender } = render(<MobileLiveTerminal {...props(true, sendResize)} />);
+    settleLayout();
+    expect(sendResize).not.toHaveBeenCalled();
+
+    // Keyboard closes: the container grows back and the latch seeds from
+    // the true no-keyboard height, so tmux gets full rows in ONE resize.
+    clientHeight = FULL_HEIGHT;
+    rerender(<MobileLiveTerminal {...props(false, sendResize)} />);
+    settleLayout();
+    expect(sendResize).toHaveBeenCalledTimes(1);
+    expect(sendResize).toHaveBeenCalledWith(COLS, FULL_ROWS);
+  });
+
+  it("keeps the latched grid through a keyboard open/close cycle", () => {
+    const sendResize = vi.fn();
+    const { rerender } = render(<MobileLiveTerminal {...props(false, sendResize)} />);
+    settleLayout();
+    expect(sendResize).toHaveBeenLastCalledWith(COLS, FULL_ROWS);
+
+    clientHeight = SHRUNK_HEIGHT;
+    rerender(<MobileLiveTerminal {...props(true, sendResize)} />);
+    settleLayout();
+    clientHeight = FULL_HEIGHT;
+    rerender(<MobileLiveTerminal {...props(false, sendResize)} />);
+    settleLayout();
+
+    // Every call carried the latched no-keyboard grid; the cycle never
+    // shipped keyboard-shrunk rows.
+    for (const call of sendResize.mock.calls) {
+      expect(call).toEqual([COLS, FULL_ROWS]);
+    }
+  });
+});

--- a/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.paste.test.tsx
@@ -65,6 +65,7 @@ function renderTerm(uploadPastedImage = vi.fn().mockResolvedValue(null)) {
       inputRef={inputRef}
       onInputFocusChange={vi.fn()}
       bottomAlign
+      keyboardOpen={false}
     />,
   );
   return { input: inputRef.current!, sendData, uploadPastedImage };

--- a/web/src/components/__tests__/MobileLiveTerminal.scrollPin.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.scrollPin.test.tsx
@@ -106,6 +106,7 @@ function props() {
     inputRef: createRef<HTMLTextAreaElement>(),
     onInputFocusChange: vi.fn(),
     bottomAlign: true,
+    keyboardOpen: false,
   };
 }
 

--- a/web/src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx
+++ b/web/src/components/__tests__/MobileLiveTerminal.tapFocus.test.tsx
@@ -55,6 +55,7 @@ function renderTerm() {
       inputRef={inputRef}
       onInputFocusChange={vi.fn()}
       bottomAlign
+      keyboardOpen={false}
     />,
   );
   const scroller = utils.container.querySelector("[data-live-terminal]")!.firstElementChild as HTMLElement;

--- a/web/src/lib/ansi.ts
+++ b/web/src/lib/ansi.ts
@@ -223,13 +223,17 @@ function applySgr(style: AnsiStyle, params: number[]): AnsiStyle {
   return next;
 }
 
-/** Parse a string with ANSI SGR codes into styled segments. Non-SGR
- *  CSI sequences and `\r` repaints are stripped/collapsed first. */
-export function parseAnsi(text: string): AnsiSegment[] {
+/** Parse a string with ANSI SGR codes into styled segments, starting from
+ *  `initial` SGR state and reporting the state left in effect at the end.
+ *  This is the resumable core behind [`parseAnsi`]: tmux emits a reset only
+ *  when the style changes, so SGR state legitimately spans lines, and a
+ *  per-line parse cache must thread the carried style through explicitly.
+ *  Non-SGR CSI sequences and `\r` repaints are stripped/collapsed first. */
+export function parseAnsiFrom(text: string, initial: AnsiStyle): { segs: AnsiSegment[]; exit: AnsiStyle } {
   const cleaned = collapseCarriageReturns(text).replace(NON_SGR_CSI, "");
   const segs: AnsiSegment[] = [];
   let last = 0;
-  let cur: AnsiStyle = {};
+  let cur: AnsiStyle = { ...initial };
   for (const m of cleaned.matchAll(SGR)) {
     const idx = m.index ?? 0;
     if (idx > last) {
@@ -243,5 +247,11 @@ export function parseAnsi(text: string): AnsiSegment[] {
   if (last < cleaned.length) {
     segs.push({ text: cleaned.slice(last), style: { ...cur } });
   }
-  return segs.filter((s) => s.text.length > 0);
+  return { segs: segs.filter((s) => s.text.length > 0), exit: cur };
+}
+
+/** Parse a string with ANSI SGR codes into styled segments. Non-SGR
+ *  CSI sequences and `\r` repaints are stripped/collapsed first. */
+export function parseAnsi(text: string): AnsiSegment[] {
+  return parseAnsiFrom(text, {}).segs;
 }

--- a/web/src/lib/liveTermLines.test.ts
+++ b/web/src/lib/liveTermLines.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { ansiToLines, findCursorCharIndex, lineText, splitUrls, wrapLine } from "./liveTermLines";
+import { LineParseCache, ansiToLines, findCursorCharIndex, lineText, splitUrls, wrapLine } from "./liveTermLines";
 
 describe("ansiToLines", () => {
   it("splits plain text into lines and drops the capture trailing terminator", () => {
@@ -156,5 +156,66 @@ describe("splitUrls", () => {
 
   it("does not linkify a bare host:port without a scheme", () => {
     expect(splitUrls("localhost:3000 is up")).toEqual([{ text: "localhost:3000 is up", url: null }]);
+  });
+});
+
+describe("LineParseCache", () => {
+  const CASES = [
+    "one\ntwo\nthree\n",
+    "prompt\n\n\n",
+    "\x1b[31mred\nstill-red\x1b[0m plain\n",
+    "",
+    "no-trailing-newline",
+    "\x1b[1;38;5;208mbold orange\x1b[0m\nnext\n",
+    "a\n\x1b[0m", // escape-only final line (no trailing terminator)
+    "\x1b[7minverse\x1b[27m\n\x1b[4munder\x1b[24m\n",
+  ];
+
+  it("produces output identical to ansiToLines", () => {
+    for (const content of CASES) {
+      const cache = new LineParseCache();
+      expect(cache.lines(content)).toEqual(ansiToLines(content));
+      // Second pass through the same cache (all hits) must match too.
+      expect(cache.lines(content)).toEqual(ansiToLines(content));
+    }
+  });
+
+  it("keeps segment-array identity for unchanged lines across frames", () => {
+    const cache = new LineParseCache();
+    const a = cache.lines("\x1b[32mok\x1b[0m line\nsteady\ntail 1\n");
+    const b = cache.lines("\x1b[32mok\x1b[0m line\nsteady\ntail 2\n");
+    expect(b[0]).toBe(a[0]);
+    expect(b[1]).toBe(a[1]);
+    expect(b[2]).not.toBe(a[2]);
+    expect(lineText(b[2]!)).toBe("tail 2");
+  });
+
+  it("keeps identity when the window slides by one appended line", () => {
+    const cache = new LineParseCache();
+    const a = cache.lines("alpha\nbeta\ngamma\n");
+    const b = cache.lines("beta\ngamma\ndelta\n");
+    // The shifted-but-unchanged lines are the SAME arrays as last frame.
+    expect(b[0]).toBe(a[1]);
+    expect(b[1]).toBe(a[2]);
+  });
+
+  it("does not confuse identical raw lines entered under different SGR state", () => {
+    const cache = new LineParseCache();
+    // "text" is entered plain on line 1 but red-carried on line 3.
+    const lines = cache.lines("text\n\x1b[31mred\ntext\n");
+    expect(lines[0]![0]!.style.fg).toBeUndefined();
+    expect(lines[2]![0]!.style.fg).toBeTruthy();
+    expect(lines[0]).not.toBe(lines[2]);
+  });
+
+  it("evicts entries unused for two frames", () => {
+    const cache = new LineParseCache();
+    const a = cache.lines("gone\n");
+    cache.lines("other\n");
+    cache.lines("another\n");
+    const b = cache.lines("gone\n");
+    // Re-parsed after eviction: equal content, fresh identity.
+    expect(b[0]).toEqual(a[0]);
+    expect(b[0]).not.toBe(a[0]);
   });
 });

--- a/web/src/lib/liveTermLines.ts
+++ b/web/src/lib/liveTermLines.ts
@@ -1,4 +1,4 @@
-import { parseAnsi, type AnsiSegment } from "./ansi";
+import { parseAnsi, parseAnsiFrom, type AnsiSegment, type AnsiStyle } from "./ansi";
 
 // Frame helpers for the mobile live terminal: turn one `capture-pane -e`
 // snapshot into per-line styled segments the component can render as DOM
@@ -25,6 +25,69 @@ export function ansiToLines(content: string): AnsiSegment[][] {
     lines.pop();
   }
   return lines;
+}
+
+interface CachedLine {
+  segs: AnsiSegment[];
+  /** SGR state left in effect after this line, threaded into the next. */
+  exit: AnsiStyle;
+}
+
+/** Key for the SGR state a line is entered with. Two identical raw lines
+ *  parsed under different carried styles are different render results, so
+ *  the entry state is part of the cache key. */
+function styleKey(s: AnsiStyle): string {
+  return `${s.fg ?? ""}|${s.bg ?? ""}|${+!!s.bold}${+!!s.dim}${+!!s.italic}${+!!s.underline}${+!!s.inverse}`;
+}
+
+/**
+ * Frame-to-frame parse cache for [`ansiToLines`]-equivalent output.
+ *
+ * A streamed capture frame is byte-identical to the previous one on almost
+ * every line (only the tail moves), yet re-parsing the whole window per
+ * frame made every line's segment arrays fresh objects, which both burned
+ * main-thread time on multi-thousand-line reading windows and defeated the
+ * row memoization downstream (every mounted row re-rendered per frame, the
+ * scroll-jank driver on phones). `lines()` parses per line, keyed on
+ * (entry SGR state, raw line), and returns the SAME segment arrays for
+ * unchanged lines, so identity-based memo and WeakMap caches hold.
+ *
+ * Two-generation eviction: entries used by the current frame move to the
+ * live generation; the rest are dropped when the next frame arrives.
+ * Memory is bounded to two frames' unique lines, and re-running on the
+ * same content (React StrictMode double-invoke) converges to identical
+ * output and identities.
+ */
+export class LineParseCache {
+  private live = new Map<string, CachedLine>();
+  private prev = new Map<string, CachedLine>();
+
+  lines(content: string): AnsiSegment[][] {
+    this.prev = this.live;
+    this.live = new Map();
+    const raw = content.split("\n");
+    const lines: AnsiSegment[][] = [];
+    let entry: AnsiStyle = {};
+    for (const r of raw) {
+      // NUL separator: it appears in neither a style key (CSS color
+      // strings) nor capture-pane text, so the key cannot be ambiguous.
+      const key = styleKey(entry) + "\u0000" + r;
+      let hit = this.live.get(key) ?? this.prev.get(key);
+      if (!hit) {
+        const parsed = parseAnsiFrom(r, entry);
+        hit = { segs: parsed.segs, exit: parsed.exit };
+      }
+      this.live.set(key, hit);
+      lines.push(hit.segs);
+      entry = hit.exit;
+    }
+    // Mirror ansiToLines: capture-pane terminates every line, including
+    // the last, with `\n`; drop the phantom empty line that creates.
+    if (lines.length > 1 && lines[lines.length - 1]!.length === 0) {
+      lines.pop();
+    }
+    return lines;
+  }
 }
 
 /** Plain text of one rendered line (for tests / cursor math). */

--- a/web/tests/live/live-size-owner-takeover.spec.ts
+++ b/web/tests/live/live-size-owner-takeover.spec.ts
@@ -126,6 +126,46 @@ test("ownership ping-pong keeps the cursor on the prompt row", async ({ browser 
   }
 });
 
+// A demoted-but-visible viewer must get ownership BACK on its own once the
+// holder lets go (the other device disconnects, or the native TUI exits live
+// mode and releases the lock). Before auto-reclaim, the phone stayed a
+// read-only viewer with the "take over" banner until the user tapped it
+// again, every single time the desktop side let go.
+test("released lock auto-reclaims without another take-over tap", async ({ browser }, testInfo) => {
+  test.setTimeout(120_000);
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedPromptbox,
+  });
+  try {
+    const ctxA = await browser.newContext({ ...devices["iPhone 13"] });
+    const ctxB = await browser.newContext({ ...devices["iPhone 13"], viewport: { width: 360, height: 740 } });
+    const a = await ctxA.newPage();
+    const b = await ctxB.newPage();
+
+    await openLiveView(a, serve.baseUrl);
+    await expect(a.locator("[data-live-takeover]")).toHaveCount(0);
+
+    // B steals ownership; A demotes to the banner.
+    await openLiveView(b, serve.baseUrl);
+    await takeOver(b);
+    await a.locator("[data-live-takeover]").waitFor({ state: "visible", timeout: 10_000 });
+
+    // B disconnects, releasing the lock. A is visible at the live edge, so
+    // its capture loop re-claims the vacant lock and the banner clears with
+    // NO tap; the cursor re-aligns once A's grid is re-asserted.
+    await ctxB.close();
+    await a.locator("[data-live-takeover]").waitFor({ state: "detached", timeout: 15_000 });
+    await expect.poll(async () => Math.abs(await cursorToPromptDelta(a)), { timeout: 10_000 }).toBeLessThan(2);
+
+    await ctxA.close();
+  } finally {
+    await serve.stop();
+  }
+});
+
 // (The former "desktop click takes the size lock back" test is gone: with the
 // xterm/PTY renderer removed, every client is a live client, so that scenario
 // is just live-vs-live ownership handoff, covered by the ping-pong test above.


### PR DESCRIPTION
## Description

Investigating the mobile report "agent terminal scrolling is not smooth, and it does not always resize correctly with the keyboard when taking over from a TUI" turned up three root causes; this PR fixes all of them.

**1. Taking over from a TUI silently reverted (the resize bug).** The TUI live-send worker re-stole the size-owner lock after entry: any keystroke, or any preview-rect jitter (a one-frame toast, a divider drag) re-asserted the TUI's grid and yanked the pane back to desktop dims seconds after the phone tapped "take over". And when the TUI released the lock, the phone never re-claimed (client-side resize dedup), so the user had to tap the banner again every time. Now:
- The worker's entry steal is the only steal. Afterwards ownership is only refreshed; a failed refresh sets a sticky `lock_lost` flag and queued resizes are dropped instead of stomping the new owner's grid.
- The TUI main loop polls the flag each tick and exits live mode with no keystroke needed, showing "Live send ended: the web dashboard took over this session's live view" (thief named from the owner-id prefix). The exit deliberately skips the `window-size latest` reset so the new owner's grid stands.
- The web capture loop auto-reclaims: a visible non-owner at fast cadence claims (never steals) the lock once it goes vacant or stale, so ownership returns without another tap. A backgrounded PWA or scrolled-up reader never grabs sizing.

**2. Keyboard-open sizing seed.** tmux rows come from a latch of the largest container height seen per width, so keyboard cycles never resize tmux, but if the pane first measured while the keyboard had the container shrunk (mount with keyboard up, rotation mid-cycle), tmux got keyboard-shrunk rows and then a second corrective resize. The latch now defers seeding while the viewport is occluded and ships one correct full-height resize when the keyboard closes.

**3. Scroll jank.** Every streamed frame re-parsed the entire capture window and handed every mounted row fresh objects, defeating `memo(Row)`; while reading scrollback that was a main-thread burst every 250ms (measured 7.3ms/frame derive at the 4000-line window on a dev box, several times that on phones, plus the full React re-commit). A per-line parse cache keyed on (entry SGR state, raw line) keeps segment-array identity for unchanged lines, a WeakMap wrap cache keeps visual-row identity, rows are keyed by absolute buffer position so appends do not shift keys, and scroll-driven view updates are rAF-coalesced. Derive drops to 1.5ms/frame and unchanged rows skip re-render entirely.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (protocol doc header in `live_ws.rs`; no user-facing docs affected)
- [ ] For UI changes: included screenshot or recording (behavioral fixes; no visual redesign to capture, and the perf change is only visible on a physical phone)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/`: new "released lock auto-reclaims without another take-over tap" scenario in `live-size-owner-takeover.spec.ts` (live suite, real serve + tmux). The existing ownership ping-pong spec still passes, proving reclaim never fights a live holder. The coverage matrix already covers this flow through the existing spec entry; the validator passes with no new entry needed. Vitest additions: `MobileLiveTerminal.keyboardResize.test.tsx` (latch defers while keyboard open, single correct late resize, stable grid through a cycle) and `LineParseCache` tests (output equivalence with `ansiToLines`, identity stability across frames and window slides, entry-style keying, eviction).

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`: `live_takeover.rs` drives the real TUI into live mode, steals the lock as a web-style `live-*` owner via tmux user options, and asserts the takeover dialog appears with zero input, the LIVE badge clears, and the thief keeps the lock. Rust unit coverage: tmux-gated worker tests in `live_send.rs` plus `poll_live_send_takeover_exits_live_mode_with_dialog` in `home/tests.rs`.

How tested: `cargo fmt`, `cargo clippy --features serve,e2e-tests`, `cargo test --features serve,e2e-tests` (5710 passed; the 3 failures, `restart_selected_session_surfaces_resume_failed_after_async_restart`, `acp::supervisor::shutdown_and_wait_degrades_when_load_errs_without_peer`, and `worker_registry::pid_source_for_falls_back_to_peer_pid_on_load_err`, fail identically on the base branch in my sandbox, so they are pre-existing there and unrelated to this diff). Web: full Vitest suite (3529), `tsc -b`, ESLint, oxfmt, coverage-matrix validator, and both live Playwright takeover specs against a real backend.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Claude Fable 5)

**Any Additional AI Details you'd like to share:** Investigation, fixes, and tests were done by Claude Code in a session driven and reviewed by @njbrake; the takeover ping-pong was reproduced from his report of live mode being open in the TUI during a web takeover.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed live-terminal takeover so the previous owner exits cleanly, preserves the new owner’s sizing, and shows a clear notification.
- Added automatic lock reclaim when the active owner disconnects or becomes stale.
- Improved mobile keyboard handling by deferring terminal resizing until the keyboard closes.
- Improved terminal scrolling performance with parsing and rendering caches, stable row identities, and smoother scroll updates.
- Added broad unit, integration, Playwright, and end-to-end test coverage.

## Benefits

- Prevents competing terminal views from overwriting each other.
- Keeps mobile terminal dimensions accurate.
- Makes scrolling smoother during live output.
- Provides clearer takeover behavior and stronger regression protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->