### PR TITLE
fix(web): clear rate-limit banner when a session resumes to life

### DIFF
--- a/web/src/hooks/useRespawnSession.ts
+++ b/web/src/hooks/useRespawnSession.ts
@@ -10,9 +10,11 @@ interface RespawnSnapshot {
 
 /** Shared respawn machine for the structured-view recovery banners.
  *  POSTs to `/acp/spawn` (which re-runs the ACP handshake) and tracks the
- *  idle/retrying/ok/failed lifecycle. The next `AcpSessionAssigned` (or
- *  user prompt) clears the banner on the reducer side, so callers only need
- *  to fire `respawn` and reflect `state`/`error`. Extracted so the
+ *  idle/retrying/ok/failed lifecycle. A fresh `AcpSessionAssigned` or a
+ *  `UserPromptSent` clears the recovery banners on the reducer side
+ *  (`applyNewTurnResets` and the `AcpSessionAssigned` arm null the
+ *  worker-stopped, startup-error, and rate-limit state), so callers only
+ *  need to fire `respawn` and reflect `state`/`error`. Extracted so the
  *  WorkerStopped, StartupError, and compat-failure screens share one
  *  implementation instead of three copies. `resetKey` lets callers scope
  *  status to one recovery incident, e.g. a specific rate-limit reset time,

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -3095,3 +3095,46 @@ describe("applyEvent / UsageUpdated context-window latch (upstream #596 bandaid)
     expect(state.sessionUsage?.size).toBe(200_000);
   });
 });
+
+describe("applyEvent / rate-limit banner clears on resume-to-life", () => {
+  const info = {
+    status: "rate_limited",
+    resets_at: "2026-07-23T15:40:00Z",
+    kind: "rate_limit",
+  };
+  const rateLimitFrame = (seq: number): AcpFrame => ({
+    session_id: "s-1",
+    seq,
+    event: { RateLimit: { info } },
+  });
+
+  it("clears rateLimit on the next UserPromptSent (resumed via a plain prompt)", () => {
+    // Reproduces #3028: a rate-limited turn parks the banner, the session
+    // resumes via a prompt (or a draining queued follow-up), yet the
+    // banner never went away because UserPromptSent didn't clear it.
+    let state = applyEvent(emptyAcpState(), rateLimitFrame(1));
+    expect(state.rateLimit).toEqual(info);
+    state = applyEvent(state, frame(2, "continue"));
+    expect(state.rateLimit).toBeNull();
+  });
+
+  it("clears rateLimit on a fresh AcpSessionAssigned (a new worker healed the park)", () => {
+    let state = applyEvent(emptyAcpState(), rateLimitFrame(1));
+    expect(state.rateLimit).toEqual(info);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AcpSessionAssigned: { acp_session_id: "acp-1" } },
+    });
+    expect(state.rateLimit).toBeNull();
+  });
+
+  it("re-derives rateLimit === null on replay when a turn resumed after the park", () => {
+    // The "stuck 4h later" symptom is replay: reconnect reapplies the
+    // event log, so the post-park UserPromptSent must clear the banner
+    // every time the state is rebuilt, not just on the live dispatch.
+    const log: AcpFrame[] = [rateLimitFrame(1), frame(2, "continue")];
+    const replayed = log.reduce(applyEvent, emptyAcpState());
+    expect(replayed.rateLimit).toBeNull();
+  });
+});

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1111,6 +1111,14 @@ function applyNewTurnResets(next: AcpState): void {
   // Any pending context-primer offer is consumed once the user submits
   // a new prompt; the recovery affordance is one-shot.
   next.contextPrimerAvailable = null;
+  // A fresh turn means the session is live again, so any rate-limit park
+  // is over. Clear the banner here (not only on the auto-resume
+  // `RateLimitAutoResumed` / `AgentSwitched` paths) so a session resumed
+  // by a plain prompt or a draining queued follow-up does not keep a
+  // stale "Rate-limited; resets at ..." banner, and so the dead
+  // `RESUME NOW` button it renders can no longer 409 against an
+  // already-running worker. See #3028.
+  next.rateLimit = null;
 }
 
 /** Pure reducer. Returns a new state; never mutates the input.
@@ -1867,6 +1875,11 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // fired, the runner was SIGTERMed, and the respawn handshake has
     // now landed. See #1240.
     next.agentOrphaned = false;
+    // A fresh worker healed the session, including a rate-limit park that
+    // was resumed without an explicit `RateLimitAutoResumed` (e.g. a
+    // manual respawn). Clear the banner so it does not outlive the park
+    // and leave a dead `RESUME NOW` button. See #3028.
+    next.rateLimit = null;
     return next;
   }
   if ("SessionContextReset" in event) {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The structured-view rate-limit banner (`Rate-limited (rate_limit); resets at ...`) could get stuck on screen over a live, running session, and its `RESUME NOW` button then failed with `Server returned 409. structured view worker already running for session`.

Root cause: the reducer nulled `state.rateLimit` only on `RateLimitAutoResumed` (the opt-in auto-resume reconciler path) and `AgentSwitched`. A session that resumed any other way, a plain follow-up prompt or a draining queued prompt, kept the banner because `UserPromptSent` and `AcpSessionAssigned` never cleared it. Because the banner persists in the event log, every reconnect/replay re-derived the stale banner, which is why the reporter still saw it hours after the reset. The stale banner in turn manufactured the 409: `RESUME NOW` POSTs `/acp/spawn`, and the server only turns an already-running worker into a 200 while `latest_status_event` is still `Stopped{rate_limited}`; once a new turn had started that marker went `None`, so the request fell through to the conflict.

Fix: clear `rateLimit` in `applyNewTurnResets` (so every `UserPromptSent` / `UserDiffCommentsPrompt` clears it) and in the `AcpSessionAssigned` arm (a fresh worker healed the park). This removes the stale banner on both the live path and on replay, and since the `RESUME NOW` button is rendered only from `state.rateLimit`, it disappears the moment a turn resumes, so the live-worker + banner combination that produced the 409 can no longer occur. The `useRespawnSession` docstring, which already claimed a user prompt clears the banner, is corrected to match.

The server-side 409 arm in `acp.rs` is left as-is on purpose: `/acp/spawn` is shared by the Restart button, so widening `AlreadyRunning` to 200 there would change unrelated respawn semantics, and clearing the banner removes the only path that reaches it. The reset-datetime value itself (the original report) is out of scope here; it needs a fresh post-#3061 repro.

Closes #3028

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session in the web dashboard and drive it into a rate limit; confirm the `Rate-limited; resets at ...` banner appears.
- [ ] Send a follow-up prompt (or let a queued follow-up drain) so the session resumes; confirm the banner disappears once the new turn starts.
- [ ] With the session running again, confirm the `RESUME NOW` button is gone and no `409 ... worker already running` error appears.
- [ ] Reload / reconnect the dashboard on that session; confirm the banner does not reappear from replay.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is a reducer-level state bug, not a rendering/interaction one; it is covered by three Vitest reducer cases in `web/src/lib/acpTypes.test.ts` (UserPromptSent clears, AcpSessionAssigned clears, replay re-derives null), verified red on the pre-fix tree and green after. The changed files are `.ts` under `lib/` and `hooks/`, which the coverage-matrix validator (it walks `.tsx` under `components/**`) does not gate.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (fix the reducer clear paths rather than widen the shared spawn endpoint), reviewed each commit, and confirmed the reproduce-then-fix test goes red on the pre-fix tree.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed stale rate-limit recovery banners after sessions resume through follow-up prompts, queued prompts, or fresh worker assignments.
- Added coverage for normal resume, worker reassignment, and event-log replay scenarios.
- Clarified `useRespawnSession` documentation.

## Benefits
Users no longer see an outdated “RESUME NOW” prompt after a session has resumed. The reset-datetime parsing issue remains out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->