### PR TITLE
fix(web): unstick suspended-session resume, drop 503 toast and draft re-fill

### DIFF
--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -233,17 +233,21 @@ export function AcpRuntime({
       // composer's `sendFromTextarea`), and leaving the draft to the 250ms
       // debounced flush let a remount racing the resume/queue churn re-seed
       // the just-sent text. See #3094 / #3087.
+      // Clear both the text draft and the staged attachments BEFORE awaiting
+      // the send, not only via the pendingAttachments effect: an unmount
+      // during the pending send (send then immediately navigate away) would
+      // otherwise leave the keys behind for the mount-time `getDraftAttachments`
+      // seed to rehydrate, restaging an already-sent image and re-seeding
+      // just-sent text. `attachments` is already captured above, so the send
+      // is unaffected. Nothing is lost on a failed send: `sendPrompt` resolves
+      // rather than throwing (it surfaces errors through the reducer), and the
+      // transient re-queue path carries the attachments on the queued entry.
+      // See #3094 / #3087, and #1000 / #2500 for the persistence contract.
       clearDraft(sessionId);
-      // Clear staged attachments only after the send resolves, so a
-      // failed send keeps them staged for retry instead of dropping them.
-      await acp.sendPrompt(text, attachments);
-      // Drop the persisted draft synchronously here, not only via the
-      // pendingAttachments effect: a send-then-immediately-navigate-away
-      // can unmount before the post-send render commits, which would
-      // otherwise leave an already-sent image behind to rehydrate later.
       pendingAttachmentsRef.current = [];
       setDraftAttachments(sessionId, []);
       setPendingAttachments([]);
+      await acp.sendPrompt(text, attachments);
     },
     onCancel,
   });

--- a/web/src/components/acp/AcpRuntime.tsx
+++ b/web/src/components/acp/AcpRuntime.tsx
@@ -40,7 +40,7 @@ import type {
   ToolCall,
 } from "../../lib/acpTypes";
 import { hasTodoArrayArgsText, parseJsonObject } from "../../lib/acpArgs";
-import { getDraftAttachments, setDraftAttachments } from "../../lib/acpDrafts";
+import { clearDraft, getDraftAttachments, setDraftAttachments } from "../../lib/acpDrafts";
 import { useHistoryWindow } from "../../hooks/useHistoryWindow";
 import { canOfferEarlier, earlierAction } from "../../lib/historyScroll";
 import { useAgentProfile } from "../../lib/agentProfileContext";
@@ -227,6 +227,13 @@ export function AcpRuntime({
         .trim();
       const attachments = [...pendingAttachmentsRef.current];
       if (!text && attachments.length === 0) return;
+      // Drop the persisted text draft before awaiting the send. This is the
+      // idle desktop Enter path (`decideEnterAction` returns "default", so
+      // assistant-ui's own keymap submits here rather than through the
+      // composer's `sendFromTextarea`), and leaving the draft to the 250ms
+      // debounced flush let a remount racing the resume/queue churn re-seed
+      // the just-sent text. See #3094 / #3087.
+      clearDraft(sessionId);
       // Clear staged attachments only after the send resolves, so a
       // failed send keeps them staged for retry instead of dropping them.
       await acp.sendPrompt(text, attachments);

--- a/web/src/components/acp/Composer.draft.test.tsx
+++ b/web/src/components/acp/Composer.draft.test.tsx
@@ -156,6 +156,31 @@ describe("Composer per-session draft persistence", () => {
     expect(back.textarea.value).toBe("draft for A");
   });
 
+  // #3094 / #3087: sending cleared the textarea via setText(""), but the
+  // draft removal rode the 250ms debounce, so a remount racing the
+  // resume/queue churn restored the just-sent text. The draft must be
+  // cleared synchronously on send.
+  it("clears the persisted draft synchronously on send (no restore on remount)", async () => {
+    const first = mountComposer("sess-send");
+    fireEvent.change(first.textarea, { target: { value: "sent text" } });
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(window.localStorage.getItem("acp:draft:sess-send")).toBe("sent text");
+
+    // Tap the custom Send button (the path mobile uses) and remount
+    // immediately, before any debounce could run.
+    act(() => {
+      fireEvent.click(first.getByLabelText("Send message"));
+    });
+    expect(window.localStorage.getItem("acp:draft:sess-send")).toBeNull();
+    first.unmount();
+
+    const back = mountComposer("sess-send");
+    await flushComposer();
+    expect(back.textarea.value).toBe("");
+  });
+
   it("flushes the pending debounced write on unmount so a fast switch loses nothing", () => {
     const { textarea, unmount } = mountComposer("sess-a");
     fireEvent.change(textarea, { target: { value: "typed then switched" } });

--- a/web/src/components/acp/Composer.recall.dom.test.tsx
+++ b/web/src/components/acp/Composer.recall.dom.test.tsx
@@ -26,7 +26,14 @@ vi.mock("../../hooks/useFocusTerminalTarget", () => ({ useFocusTerminalTarget: (
 vi.mock("../../lib/agentProfileContext", () => ({
   useAgentProfile: () => ({ clearAliases: [], capabilities: { legacyModeFallback: false } }),
 }));
-vi.mock("../../lib/acpDrafts", () => ({ getDraft: () => "", setDraft: () => {} }));
+vi.mock("../../lib/acpDrafts", () => ({
+  getDraft: () => "",
+  setDraft: () => {},
+  // The send path clears the persisted draft synchronously (#3094 / #3087),
+  // so these must exist on the mock or the Enter-to-send cases throw.
+  clearDraft: () => {},
+  clearDraftAttachments: () => {},
+}));
 vi.mock("./useDictationBurstGuard", () => ({
   useDictationBurstGuard: () => ({
     observeInputType: () => {},

--- a/web/src/components/acp/Composer.tsx
+++ b/web/src/components/acp/Composer.tsx
@@ -34,7 +34,7 @@ import type {
   PromptCapabilities,
   QueuedPrompt,
 } from "../../lib/acpTypes";
-import { getDraft, setDraft } from "../../lib/acpDrafts";
+import { clearDraft, clearDraftAttachments, getDraft, setDraft } from "../../lib/acpDrafts";
 import { TOUR_ANCHORS, tourAnchor } from "../../lib/tourSteps";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
@@ -579,12 +579,13 @@ export function Composer({
         return;
       }
     }
-    void sendFromTextarea(taRef, composerRuntime, enqueuePrompt, supportedPendingAttachments, () =>
+    void sendFromTextarea(taRef, composerRuntime, enqueuePrompt, sessionId, supportedPendingAttachments, () =>
       setPendingAttachments([]),
     );
   }, [
     composerRuntime,
     enqueuePrompt,
+    sessionId,
     setPendingAttachments,
     supportedPendingAttachments,
     queuedPrompts,
@@ -1680,6 +1681,7 @@ function sendFromTextarea(
   taRef: React.RefObject<HTMLTextAreaElement | null>,
   composerRuntime: ReturnType<typeof useComposerRuntime>,
   enqueuePrompt: (text: string, attachments?: PromptAttachmentInput[]) => void | Promise<void>,
+  sessionId: string,
   attachments: PromptAttachmentInput[] = [],
   clearAttachments?: () => void,
 ): void {
@@ -1690,6 +1692,11 @@ function sendFromTextarea(
   if (!text && attachments.length === 0) return;
   void enqueuePrompt(text, attachments.length > 0 ? attachments : undefined);
   composerRuntime.setText("");
+  // Clear the persisted draft synchronously, not via the 250ms debounced
+  // flush: a remount racing a resume/queue re-render otherwise restores the
+  // just-sent text from localStorage. See #3094 / #3087.
+  clearDraft(sessionId);
+  clearDraftAttachments(sessionId);
   clearAttachments?.();
   // Manually reset the textarea height; auto-grow runs on input events
   // and we cleared the value without firing one.

--- a/web/src/components/acp/__tests__/AcpRuntime.draft.test.tsx
+++ b/web/src/components/acp/__tests__/AcpRuntime.draft.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+//
+// #3094 / #3087: the idle desktop Enter path does NOT go through the
+// composer's `sendFromTextarea`. `decideEnterAction` returns "default" when
+// the turn is idle, so assistant-ui's own keymap submits through the runtime's
+// `onNew`. That path used to leave the persisted text draft to the composer's
+// 250ms debounced flush, so a remount racing the resume/queue churn re-seeded
+// the just-sent text. `onNew` must drop the draft itself.
+
+import { act, render } from "@testing-library/react";
+import { useThreadRuntime } from "@assistant-ui/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { emptyAcpState } from "../../../lib/acpTypes";
+
+const sendPrompt = vi.fn(async () => {});
+
+// AcpRuntime drives everything off the useAcpSession store; mock it so the
+// test exercises the runtime's onNew wiring, not the WS machinery.
+vi.mock("../../../hooks/useAcpSession", () => ({
+  useAcpSession: () => ({
+    state: emptyAcpState(),
+    status: "open",
+    hasEverOpened: true,
+    reconnecting: false,
+    retryCount: 0,
+    retryCountdown: 0,
+    maxRetries: 5,
+    manualReconnect: () => {},
+    resolveApproval: async () => {},
+    resolveElicitation: async () => {},
+    sendPrompt,
+    cancelPrompt: async () => {},
+    forceEndTurn: async () => {},
+    lastActivityRef: { current: 0 },
+    dismissError: () => {},
+    dismissPrimer: () => {},
+    removeQueuedPrompt: () => {},
+    editQueuedPrompt: () => {},
+    clearQueue: () => {},
+    dismissRejectedPrompt: () => {},
+    dismissModeSwitchFailed: () => {},
+    setConfigOption: async () => {},
+    dismissConfigOptionSwitchFailed: () => {},
+  }),
+}));
+
+import { AcpRuntime } from "../AcpRuntime";
+
+// Drives the runtime's onNew the same way assistant-ui's built-in
+// Enter-to-send keymap does.
+function Sender({ text }: { text: string }) {
+  const thread = useThreadRuntime();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void thread.append({ role: "user", content: [{ type: "text", text }] });
+      }}
+    >
+      append
+    </button>
+  );
+}
+
+describe("AcpRuntime onNew draft clearing (#3094/#3087)", () => {
+  it("clears the persisted text draft when sending through onNew (idle Enter path)", async () => {
+    window.localStorage.setItem("acp:draft:sess-onnew", "sent via idle enter");
+
+    const view = render(<AcpRuntime sessionId="sess-onnew">{() => <Sender text="sent via idle enter" />}</AcpRuntime>);
+
+    await act(async () => {
+      view.getByText("append").click();
+    });
+
+    expect(sendPrompt).toHaveBeenCalledWith("sent via idle enter", []);
+    expect(window.localStorage.getItem("acp:draft:sess-onnew")).toBeNull();
+    window.localStorage.clear();
+  });
+});

--- a/web/src/components/acp/__tests__/AcpRuntime.draft.test.tsx
+++ b/web/src/components/acp/__tests__/AcpRuntime.draft.test.tsx
@@ -13,7 +13,16 @@ import { describe, expect, it, vi } from "vitest";
 
 import { emptyAcpState } from "../../../lib/acpTypes";
 
-const sendPrompt = vi.fn(async () => {});
+// Resolves only when the test releases it, so the assertions can run while the
+// send is still pending: that is the unmount-during-send window where a draft
+// left behind would rehydrate on remount.
+let releaseSend: (() => void) | null = null;
+const sendPrompt = vi.fn(
+  () =>
+    new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    }),
+);
 
 // AcpRuntime drives everything off the useAcpSession store; mock it so the
 // test exercises the runtime's onNew wiring, not the WS machinery.
@@ -64,8 +73,12 @@ function Sender({ text }: { text: string }) {
 }
 
 describe("AcpRuntime onNew draft clearing (#3094/#3087)", () => {
-  it("clears the persisted text draft when sending through onNew (idle Enter path)", async () => {
+  it("clears the persisted text draft and staged attachments before the send resolves", async () => {
     window.localStorage.setItem("acp:draft:sess-onnew", "sent via idle enter");
+    window.localStorage.setItem(
+      "acp:draft-attachments:sess-onnew",
+      JSON.stringify([{ kind: "image", mimeType: "image/png", dataB64: "aA==", name: "shot.png" }]),
+    );
 
     const view = render(<AcpRuntime sessionId="sess-onnew">{() => <Sender text="sent via idle enter" />}</AcpRuntime>);
 
@@ -73,8 +86,18 @@ describe("AcpRuntime onNew draft clearing (#3094/#3087)", () => {
       view.getByText("append").click();
     });
 
-    expect(sendPrompt).toHaveBeenCalledWith("sent via idle enter", []);
+    // Still mid-send: both keys must already be gone, otherwise an unmount
+    // here would rehydrate the just-sent text and image on remount.
+    expect(sendPrompt).toHaveBeenCalledOnce();
+    expect(releaseSend).not.toBeNull();
     expect(window.localStorage.getItem("acp:draft:sess-onnew")).toBeNull();
+    expect(window.localStorage.getItem("acp:draft-attachments:sess-onnew")).toBeNull();
+    // The staged attachment still rides the send itself.
+    expect(sendPrompt.mock.calls[0]?.[1]).toHaveLength(1);
+
+    await act(async () => {
+      releaseSend?.();
+    });
     window.localStorage.clear();
   });
 });

--- a/web/src/hooks/useAcpSession.queue.test.ts
+++ b/web/src/hooks/useAcpSession.queue.test.ts
@@ -624,6 +624,120 @@ describe("useAcpSession drain race (#1144)", () => {
     expect(result.current.state.lastError ?? "").not.toContain("Could not send prompt");
   });
 
+  it("removes the optimistic row on a worker_not_ready 503 but keeps the turn braked (no re-POST storm) (#3094/#3087)", async () => {
+    // The transient 503 re-queues the prompt. The optimistic transcript row
+    // must be removed (else the drain's resend duplicates it), but the turn
+    // must stay pending so the drain does not hot-loop the wake POST while the
+    // worker is still resuming. Exactly one POST goes out; the retire happens
+    // later on AcpSessionAssigned (see the next test).
+    const { result } = renderHook(() => useAcpSession("sess-idle-rollback", "absent"));
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-rollback",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    promptPostStatus = 503;
+    promptPostBody = "worker_not_ready";
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    // Exactly one wake POST (no storm), message parked, optimistic row gone,
+    // turn still pending (the brake).
+    expect(promptPostCount).toBe(1);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(result.current.state.queuedPrompts[0]?.text).toBe("wake me up");
+    expect(result.current.state.activity.filter((r) => r.kind === "user_prompt")).toHaveLength(0);
+    expect(result.current.state.turnActive).toBe(true);
+  });
+
+  it("drains without duplicating once the respawn handshake lands (#3094/#3087)", async () => {
+    // The stuck-until-Stop bug: after the transient 503 the phantom turn kept
+    // turnActive true, wedging the drain even after the worker resumed, until
+    // the user forced a Stop. AcpSessionAssigned (the respawn handshake) now
+    // retires the phantom turn so the drain fires and delivers exactly one row
+    // (the resend + server UserPromptSent reconcile), no duplicate.
+    const { result, rerender } = renderHook(
+      ({ ws }: { ws: "absent" | "resuming" | "running" }) => useAcpSession("sess-idle-nodup", ws),
+      { initialProps: { ws: "absent" as const } },
+    );
+    await flushAsync();
+    const ws = sockets[0]!;
+    act(() => {
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.({} as Event);
+    });
+    await flushAsync();
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-nodup",
+          seq: 1,
+          event: { Stopped: { reason: "idle_auto_stop" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+    expect(result.current.state.workerIdleStopped).toBe(true);
+
+    // First wake POST returns the transient 503 (rolls back the row, re-queues,
+    // turn stays braked).
+    promptPostStatus = 503;
+    promptPostBody = "worker_not_ready";
+    await act(async () => {
+      await result.current.sendPrompt("resend me");
+    });
+    await flushAsync();
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(result.current.state.turnActive).toBe(true);
+
+    // Respawn handshake lands and the worker comes online (REST poll -> running).
+    // AcpSessionAssigned retires the phantom turn; the drain resends and the
+    // server echoes UserPromptSent, promoting the single optimistic row.
+    promptPostStatus = 200;
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-nodup",
+          seq: 2,
+          event: { AcpSessionAssigned: { acp_session_id: "acp-1" } },
+        }),
+      } as MessageEvent);
+    });
+    rerender({ ws: "running" as const });
+    await flushAsync();
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          session_id: "sess-idle-nodup",
+          seq: 3,
+          event: { UserPromptSent: { text: "resend me" } },
+        }),
+      } as MessageEvent);
+    });
+    await flushAsync();
+
+    expect(result.current.state.queuedPrompts).toEqual([]);
+    expect(
+      result.current.state.activity.filter((r) => r.kind === "user_prompt" && r.text === "resend me"),
+    ).toHaveLength(1);
+  });
+
   it("still surfaces an error banner on a worker_capacity_full 503 (#1748)", async () => {
     // Control: the capacity 503 needs operator action, so unlike
     // worker_not_ready it must keep its banner rather than being silently

--- a/web/src/hooks/useAcpSession.ts
+++ b/web/src/hooks/useAcpSession.ts
@@ -54,8 +54,9 @@ export type Action =
   | { kind: "prepend"; frames: AcpFrame[]; oldestSeq: number }
   | { kind: "handshake"; frames: AcpFrame[] }
   | { kind: "lagged"; skipped: number }
-  | { kind: "user_prompt"; text: string; attachments?: AcpAttachment[] }
+  | { kind: "user_prompt"; text: string; attachments?: AcpAttachment[]; id?: string }
   | { kind: "prompt_send_rejected" }
+  | { kind: "rollback_optimistic_prompt"; id: string }
   | { kind: "error"; message: string }
   | { kind: "clear_error" }
   | { kind: "approval_resolved_locally"; nonce: string }
@@ -608,7 +609,10 @@ export function reducer(state: AcpState, action: Action): AcpState {
     return {
       ...state,
       activity: state.activity.concat({
-        id: `user-${Date.now()}-${state.activity.length}`,
+        // Accept a caller-supplied id so a transient send failure can
+        // roll this exact row back (see `rollback_optimistic_prompt`)
+        // rather than guessing which row to remove.
+        id: action.id ?? `user-${Date.now()}-${state.activity.length}`,
         kind: "user_prompt",
         text: action.text,
         attachments: action.attachments && action.attachments.length > 0 ? action.attachments : undefined,
@@ -641,6 +645,28 @@ export function reducer(state: AcpState, action: Action): AcpState {
         pendingUserPromptSeq: state.pendingUserPromptSeq,
         lastStoppedSeq,
       }),
+    };
+  }
+  if (action.kind === "rollback_optimistic_prompt") {
+    // A transient send failure (worker_not_ready 503 while resuming) re-queues
+    // the prompt, so its optimistic transcript row must be removed: otherwise
+    // the drain's re-send appends a second copy (the duplicate bubbles in the
+    // report) that the server `UserPromptSent` cannot dedupe. Remove exactly
+    // the row we appended; the prompt now lives only in `queuedPrompts` (the
+    // QUEUED strip), matching the busy-agent enqueue path where no optimistic
+    // row exists until the drain actually sends.
+    //
+    // Deliberately DO NOT touch `pendingUserPromptSeq` / `turnActive`: leaving
+    // the turn pending keeps the drain effect braked on `if (state.turnActive)
+    // return` so it does not hot-loop re-POSTing the wake while the worker is
+    // still resuming. The phantom turn is retired instead on the next
+    // `AcpSessionAssigned` (the worker-online signal), which is when the drain
+    // should fire. See #3094 / #3087.
+    const idx = state.activity.findIndex((r) => r.id === action.id);
+    if (idx === -1) return state;
+    return {
+      ...state,
+      activity: state.activity.slice(0, idx).concat(state.activity.slice(idx + 1)),
     };
   }
   if (action.kind === "enqueue_prompt") {
@@ -1528,10 +1554,14 @@ export function useAcpSession(
       }));
       // Optimistically echo the user's message; the agent reply
       // streams back as session/update events on the WS. If the POST
-      // fails we'll surface a banner and the user can retry; the
-      // optimistic row stays so they see what they tried to send.
+      // fails with a 4xx the optimistic row stays so the user sees what
+      // they tried to send; a transient worker_not_ready 503 rolls this
+      // exact row back (by id) because the prompt is re-queued and the
+      // drain would otherwise echo a duplicate. See #3094 / #3087.
+      const optimisticId = `user-opt-${crypto.randomUUID()}`;
       dispatch({
         kind: "user_prompt",
+        id: optimisticId,
         text,
         attachments: previews.length > 0 ? previews : undefined,
       });
@@ -1576,6 +1606,11 @@ export function useAcpSession(
           const workerNotReady = res.status === 503 && detail.startsWith("worker_not_ready");
           if (rejected) {
             dispatch({ kind: "prompt_send_rejected" });
+          } else if (workerNotReady) {
+            // Undo the optimistic row + turn: the caller re-queues this
+            // prompt, so it must live only in the queue until the drain
+            // resends it once the worker is back online. See #3094 / #3087.
+            dispatch({ kind: "rollback_optimistic_prompt", id: optimisticId });
           }
           if (!workerNotReady) {
             dispatch({

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1880,6 +1880,19 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // manual respawn). Clear the banner so it does not outlive the park
     // and leave a dead `RESUME NOW` button. See #3028.
     next.rateLimit = null;
+    // A prompt sent to an idle-dormant worker gets a transient
+    // `worker_not_ready` 503 and is re-queued, but its optimistic dispatch
+    // left `pendingUserPromptSeq` bumped (turn pending) so the drain effect
+    // stays braked instead of hot-looping the wake. The respawn handshake is
+    // the worker-online signal: retire that phantom turn so the drain fires
+    // and delivers the queued prompt, instead of the session sitting stuck
+    // until the user hits Stop. Scoped to a non-empty queue so a normal
+    // (re)spawn without parked work never clears a legitimately active turn.
+    // See #3094 / #3087.
+    if (next.queuedPrompts.length > 0 && next.pendingUserPromptSeq > next.lastStoppedSeq) {
+      next.lastStoppedSeq = next.pendingUserPromptSeq;
+      next.turnActive = isTurnActive(next);
+    }
     return next;
   }
   if ("SessionContextReset" in event) {

--- a/web/src/lib/fetchInterceptor.more.test.ts
+++ b/web/src/lib/fetchInterceptor.more.test.ts
@@ -357,6 +357,33 @@ describe("5xx toast handling", () => {
     await window.fetch("/static");
     expect(reportError).not.toHaveBeenCalled();
   });
+
+  // #3094 / #3087: a prompt POST to a resuming worker returns a transient
+  // worker_not_ready 503 that the structured view hook treats as normal
+  // "queuing, will retry" state, so the generic 5xx toast must stay quiet.
+  it("suppresses the toast for a worker_not_ready 503 on /acp/prompt", async () => {
+    const { original } = await freshInstall();
+    original.mockResolvedValue(new Response("worker_not_ready", { status: 503 }));
+
+    await window.fetch("/api/sessions/abc/acp/prompt", { method: "POST" });
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("still toasts a worker_capacity_full 503 on /acp/prompt (operator action needed)", async () => {
+    const { original } = await freshInstall();
+    original.mockResolvedValue(new Response("worker_capacity_full (4/4)", { status: 503 }));
+
+    await window.fetch("/api/sessions/abc/acp/prompt", { method: "POST" });
+    expect(reportError).toHaveBeenCalledWith("Server error 503 from /api/sessions/abc/acp/prompt");
+  });
+
+  it("still toasts a worker_not_ready 503 on a non-prompt path (route-scoped)", async () => {
+    const { original } = await freshInstall();
+    original.mockResolvedValue(new Response("worker_not_ready", { status: 503 }));
+
+    await window.fetch("/api/sessions/abc/acp/cancel", { method: "POST" });
+    expect(reportError).toHaveBeenCalledWith("Server error 503 from /api/sessions/abc/acp/cancel");
+  });
 });
 
 describe("network error handling", () => {

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -47,6 +47,23 @@ export function isLoginAttemptPath(path: string): boolean {
   return path === "/api/login" || path === "/api/login/elevate";
 }
 
+const ACP_PROMPT_PATH = /^\/api\/sessions\/[^/]+\/acp\/prompt$/;
+
+/** True when a 503 is the retryable `worker_not_ready` a prompt POST returns
+ *  while its idle-dormant worker is still resuming. Reads a clone so the
+ *  original body stays available to the caller (`dispatchPromptNow`). Any
+ *  other 503 body (e.g. `worker_capacity_full`) returns false and keeps its
+ *  toast. See #3094 / #3087. */
+async function isTransientWorkerNotReady(res: Response, path: string): Promise<boolean> {
+  if (res.status !== 503 || !ACP_PROMPT_PATH.test(path)) return false;
+  try {
+    const body = await res.clone().text();
+    return body.startsWith("worker_not_ready");
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Install a global fetch wrapper that:
  * 1. Injects `Authorization: Bearer <token>` when we have a stored token.
@@ -131,6 +148,15 @@ export function installFetchErrorToasts(): void {
         }
       }
       if (isApi && res.status >= 500 && !isServerDown()) {
+        // A prompt POST to a resuming (idle-dormant) worker returns a
+        // transient `worker_not_ready` 503 that the structured view hook
+        // deliberately treats as a normal "queuing, will retry" state, so
+        // the generic 5xx toast here would contradict it. Suppress only that
+        // exact case; a `worker_capacity_full` 503 (operator action needed)
+        // and every other 5xx keep toasting. See #3094 / #3087.
+        if (await isTransientWorkerNotReady(res, path)) {
+          return res;
+        }
         reportError(`Server error ${res.status} from ${path}`);
       }
       return res;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2700,6 +2700,17 @@
       "components": ["web/src/components/acp/Composer.tsx", "web/src/lib/acpDrafts.ts"]
     },
     {
+      "id": "acp.story.composer-draft-cleared-on-send",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/acp/Composer.draft.test.tsx", "src/components/acp/__tests__/AcpRuntime.draft.test.tsx"],
+      "components": [
+        "web/src/components/acp/Composer.tsx",
+        "web/src/components/acp/AcpRuntime.tsx",
+        "web/src/lib/acpDrafts.ts"
+      ]
+    },
+    {
       "id": "acp.story.queue-edit-message",
       "kind": "live-playwright",
       "risk": "medium",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Sending a message to a suspended (idle-dormant) structured view session from the web dashboard got stuck until the user pressed Stop, and left two more artifacts behind. This fixes all three, all frontend.

The prompt POST to a resuming worker returns a transient `worker_not_ready` 503 that the structured view hook already treats as a normal "queuing, will retry" state. But the optimistic `user_prompt` dispatch bumped `pendingUserPromptSeq`, so `turnActive` stayed true after the 503 and wedged the drain effect on `if (state.turnActive) return`, so the queued prompt never sent even once the worker resumed. Pressing Stop published a synthetic `Stopped` that cleared `turnActive` and let the drain fire, which is why Stop "fixed" it. The lingering optimistic row also duplicated in the transcript when the drain later resent the same text.

Fixes:

1. Roll back the optimistic transcript row on the transient 503 (kills the duplicate) while keeping the turn pending, so the drain does not hot-loop the wake POST while the worker is still resuming. Retire the phantom turn on `AcpSessionAssigned` (the respawn-handshake, worker-online signal), scoped to a non-empty queue, so the drain fires and delivers exactly once, no manual Stop.
2. Stop the global fetch wrapper toasting the transient `worker_not_ready` 503 (it fired a red "Server error 503" that contradicted the app's own "queuing" handling). A `worker_capacity_full` 503 and every other 5xx keep toasting.
3. Clear the persisted composer draft synchronously on send, so a remount racing the resume/queue churn no longer re-seeds the just-sent text from localStorage.

Closes #3094
Closes #3087

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard on a structured view session and let it go idle-dormant (or `aoe acp stop` its worker), then send a message: it resumes and delivers without pressing Stop.
- [ ] During that resume, confirm no red "Server error 503" toast appears; only the QUEUED indicator shows.
- [ ] Confirm the sent message appears exactly once in the transcript (no duplicate bubble) after the resume delivers it.
- [ ] Confirm the composer input is empty after sending and stays empty (the text does not reappear).
- [ ] Control: force a `worker_capacity_full` 503 (worker cap reached) and confirm that one still surfaces its error toast.

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Tests are Vitest + RTL, the layer `AGENTS.md` prescribes for reducer / hook / fetch-interceptor logic (not Playwright): `web/src/hooks/useAcpSession.queue.test.ts` (rollback + no-storm + drain-without-duplicate on `AcpSessionAssigned`), `web/src/lib/fetchInterceptor.more.test.ts` (suppress `worker_not_ready`, keep `worker_capacity_full` and route-scoped 5xx toasting), `web/src/components/acp/Composer.draft.test.tsx` (synchronous draft clear on send). All three spec files are already mapped in `web/tests/coverage-matrix.json`; each new case was verified red on the pre-fix tree and green after.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan (cross-checked with a two-model `/debate`), and implementation drafted by Claude under my direction. I made the design calls (roll back the optimistic row but retire the turn on the worker-online signal, not on the 503, to avoid a re-POST storm), reviewed each commit, and confirmed the reproduce-then-fix red/green for every new test.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed suspended-session resume in the web dashboard: if a prompt POST temporarily fails with `worker_not_ready` (503), the UI now rolls back the optimistic transcript row, keeps the prompt queued, and ensures queued prompts are delivered exactly once when the worker resumes.
- Prevented duplicate/phantom transcript and “pending turn” states during resume/reassignment by retiring the correct optimistic/pending entries and cleaning up the resumed turn state.
- Reduced noisy errors: the global error toast is suppressed only for transient `worker_not_ready` prompt responses, while still showing toasts for actionable 5xx cases (e.g., `worker_capacity_full`) and non-prompt routes.
- Kept composer state consistent across remounts and both send paths by clearing persisted draft text and staged attachments synchronously when sending (including the idle desktop “Enter-to-send” flow).
- Added/expanded regression coverage for queue recovery/resume behavior, toast suppression rules, and composer draft/attachment clearing (including Enter-to-send and remount scenarios), plus updated related mocks and coverage mapping.

## Benefits

Users no longer need to stop/restart after a brief worker suspension—queued prompts resume automatically without duplicate transcript entries or previously sent text/attachments reappearing in the composer. The UI is also less disruptive by hiding transient “not ready yet” toasts while still surfacing important capacity and other server issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->