### PR TITLE
fix: build serve feature on FreeBSD where rlim_t is i64

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -598,10 +598,12 @@ fn epoch_millis() -> i64 {
 #[cfg(unix)]
 fn raise_fd_limit() {
     use nix::sys::resource::{getrlimit, setrlimit, Resource};
-    const TARGET: u64 = 8192;
     match getrlimit(Resource::RLIMIT_NOFILE) {
         Ok((soft, hard)) => {
-            let target = TARGET.min(hard).max(soft);
+            // `rlim_t` is u64 on Linux/macOS but i64 on the BSDs, so derive the
+            // 8192 ceiling in the limits' own type rather than a hardcoded u64;
+            // this keeps the arithmetic and the setrlimit call below portable.
+            let target = hard.min(8192).max(soft);
             if target > soft {
                 if let Err(e) = setrlimit(Resource::RLIMIT_NOFILE, target, hard) {
                     tracing::warn!(target: "http.middleware", "Failed to raise RLIMIT_NOFILE to {}: {}", target, e);


### PR DESCRIPTION
## What

`raise_fd_limit()` hardcodes `const TARGET: u64 = 8192`, but nix's `rlim_t` is `i64` on FreeBSD (`u64` on Linux/macOS), so `cargo build --features serve` fails with four `E0308` mismatched-types errors at the `setrlimit` call. The TUI (no `serve`) and the Vite/Tailwind frontend already build fine on FreeBSD — this is the only blocker for the web dashboard.

## Fix

Let the `8192` literal infer its type from the limits themselves (`hard.min(8192).max(soft)`), so the arithmetic and the `setrlimit` call use the platform `rlim_t`. Behavior is identical on Linux/macOS; no OS-specific branching.

## Testing

`cargo build --release --features serve` on **FreeBSD 15.1-RELEASE** (amd64, rustc 1.96.1) now succeeds; `aoe serve` starts and serves the dashboard (HTTP 200, PWA manifest, static assets). Verified `cargo fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated file-descriptor limit handling to use the platform’s native resource-limit type.
- Removed the hardcoded `u64` target that caused FreeBSD build failures.
- Preserved existing Linux and macOS behavior while improving portability across BSD systems.

## Benefits

- Fixes `cargo build --features serve` on FreeBSD.
- Keeps the implementation simple without OS-specific branching.
- Verified with a successful FreeBSD release build, dashboard startup, and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->