### PR TITLE
feat(session): make per-session color labels optional via session.show_session_colors

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1218,6 +1218,26 @@ pub struct SessionConfig {
     )]
     pub unread_indicator: bool,
 
+    /// Show per-session color labels: the colored dot on sidebar rows and the
+    /// `Color` section in the session context menu. Web dashboard only; the TUI
+    /// does not render session colors. Turning this off hides them without
+    /// forbidding anything, `aoe session color` and the REST endpoint keep
+    /// working and stored values are preserved, so flipping back reveals them
+    /// again.
+    ///
+    /// `global_only`: the dashboard resolves one settings object for the whole
+    /// client, not one per workspace, and the sidebar mixes sessions from
+    /// several profiles in the all-profiles view. A per-profile override would
+    /// advertise semantics the web cannot honor.
+    #[serde(default = "default_true")]
+    #[setting(
+        label = "Session Color Labels",
+        widget = "toggle",
+        category = "Interaction",
+        global_only
+    )]
+    pub show_session_colors: bool,
+
     /// Pin favorited sessions to the top of their sibling scope in every sort
     /// order of the TUI session list, not just Attention. A group holding a
     /// favorited session is pinned the same way. When on (default), favoriting
@@ -1451,6 +1471,7 @@ impl Default for SessionConfig {
             click_action: ClickAction::default(),
             confirm_before_quit: true,
             unread_indicator: true,
+            show_session_colors: true,
             favorites_first: true,
             show_tips: true,
             tie_workdir_to_name: true,

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1546,6 +1546,7 @@ mod tests {
             "session.click_action",
             "session.live_send_exit_chord",
             "session.mouse_capture",
+            "session.show_session_colors",
         ] {
             assert!(
                 interaction.contains(&ident.to_string()),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -78,6 +78,7 @@ import { normalizeProjectPathKey } from "./lib/registeredProjects";
 import { IdleDecayWindowContext, parseIdleDecayWindowMs, useIdleDecayWindowMs } from "./lib/idleDecay";
 import { parseUnreadIndicatorEnabled, UnreadIndicatorContext, useUnreadIndicatorEnabled } from "./lib/unreadIndicator";
 import { parseSessionRowTagMode, SessionRowTagContext, type SessionRowTagMode } from "./lib/sessionRowTag";
+import { parseSessionColorsEnabled, SessionColorsContext } from "./lib/sessionColors";
 import { toastBus, reportError } from "./lib/toastBus";
 import { resolveToRepoRelative, type FileRef } from "./lib/fileRef";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
@@ -155,11 +156,13 @@ export default function App() {
   const [idleDecayWindowMs, setIdleDecayWindowMs] = useState(IDLE_DECAY_WINDOW_MS);
   const [unreadIndicatorEnabled, setUnreadIndicatorEnabled] = useState(true);
   const [sessionRowTagMode, setSessionRowTagMode] = useState<SessionRowTagMode>("branch");
+  const [sessionColorsEnabled, setSessionColorsEnabled] = useState(true);
 
   const applyAppSettings = useCallback((settings: Record<string, unknown> | null | undefined) => {
     setIdleDecayWindowMs(parseIdleDecayWindowMs(settings));
     setUnreadIndicatorEnabled(parseUnreadIndicatorEnabled(settings));
     setSessionRowTagMode(parseSessionRowTagMode(settings));
+    setSessionColorsEnabled(parseSessionColorsEnabled(settings));
   }, []);
 
   const refreshAppSettings = useCallback(async () => {
@@ -235,13 +238,19 @@ export default function App() {
     <IdleDecayWindowContext.Provider value={idleDecayWindowMs}>
       <UnreadIndicatorContext.Provider value={unreadIndicatorEnabled}>
         <SessionRowTagContext.Provider value={sessionRowTagMode}>
-          {/* PluginUiProvider must sit above AppContent: AppContent itself reads
-              the plugin UI snapshot (usePluginPanes), so the provider can't live
-              inside its own return. */}
-          <PluginUiProvider>
-            <AppContent loginRequired={loginRequired} onLogout={handleLogout} onSettingsRefresh={refreshAppSettings} />
-          </PluginUiProvider>
-          <ElevationPrompt />
+          <SessionColorsContext.Provider value={sessionColorsEnabled}>
+            {/* PluginUiProvider must sit above AppContent: AppContent itself reads
+                the plugin UI snapshot (usePluginPanes), so the provider can't live
+                inside its own return. */}
+            <PluginUiProvider>
+              <AppContent
+                loginRequired={loginRequired}
+                onLogout={handleLogout}
+                onSettingsRefresh={refreshAppSettings}
+              />
+            </PluginUiProvider>
+            <ElevationPrompt />
+          </SessionColorsContext.Provider>
         </SessionRowTagContext.Provider>
       </UnreadIndicatorContext.Provider>
     </IdleDecayWindowContext.Provider>

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -589,7 +589,9 @@ export function SettingsView({
                 values={session}
                 onSaveField={saveSubField}
                 onAfterSave={(descriptor) => {
-                  if (descriptor.field === "row_tag") return onSettingsRefresh();
+                  if (descriptor.field === "row_tag" || descriptor.field === "show_session_colors") {
+                    return onSettingsRefresh();
+                  }
                 }}
                 advancedSubtitle="Idle auto-stop, attach modes, live-send, and other session tuning."
               />

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -76,6 +76,7 @@ import { useWebSettings } from "../hooks/useWebSettings";
 import { exceedsTouchSlop } from "../lib/longPress";
 import { useUnreadIndicatorEnabled } from "../lib/unreadIndicator";
 import { computeSessionRowTag, useSessionRowTagMode } from "../lib/sessionRowTag";
+import { useSessionColorsEnabled } from "../lib/sessionColors";
 import { TOUR_ANCHORS, tourAnchor } from "../lib/tourSteps";
 import {
   createSession,
@@ -956,6 +957,7 @@ export const SessionRow = memo(function SessionRow({
 }) {
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const unreadIndicatorEnabled = useUnreadIndicatorEnabled();
+  const sessionColorsEnabled = useSessionColorsEnabled();
   const {
     status: sessionStatus,
     createdAt,
@@ -1467,7 +1469,7 @@ export const SessionRow = memo(function SessionRow({
             <span
               className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${showUnreadGlyph ? "text-status-unread font-semibold" : isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited || effectivePinned ? "font-semibold" : ""} ${effectiveArchived || effectiveSnoozed ? "italic opacity-70" : ""}`}
             >
-              {sessionColorDot && (
+              {sessionColorsEnabled && sessionColorDot && (
                 <span
                   title={`Color: ${sessionColor}`}
                   aria-label={`Color: ${sessionColor}`}
@@ -1762,7 +1764,7 @@ export const SessionRow = memo(function SessionRow({
                     </button>
                   );
                 })}
-                {!readOnly && (
+                {!readOnly && sessionColorsEnabled && (
                   <>
                     <div className="border-t border-surface-700/20 my-1" />
                     <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -23,6 +23,7 @@ const SINGLE_BULK_API: RowBulkApi = {
 };
 import { UnreadIndicatorContext } from "../../lib/unreadIndicator";
 import { SessionRowTagContext, type SessionRowTagMode } from "../../lib/sessionRowTag";
+import { SessionColorsContext } from "../../lib/sessionColors";
 import { useSidebarTriage } from "../../hooks/useSidebarTriage";
 import type { SessionResponse, Workspace } from "../../lib/types";
 import { OPEN_SESSION_EVENT } from "../../lib/sessionRoute";
@@ -76,11 +77,21 @@ function workspace(id: string, sessions: SessionResponse[]): Workspace {
   };
 }
 
-function Wrap({ children, rowTagMode = "branch" }: { children: ReactNode; rowTagMode?: SessionRowTagMode }) {
+function Wrap({
+  children,
+  rowTagMode = "branch",
+  colorsEnabled = true,
+}: {
+  children: ReactNode;
+  rowTagMode?: SessionRowTagMode;
+  colorsEnabled?: boolean;
+}) {
   const ref = useRef(0);
   return (
     <DragSuppressContext.Provider value={ref}>
-      <SessionRowTagContext.Provider value={rowTagMode}>{children}</SessionRowTagContext.Provider>
+      <SessionRowTagContext.Provider value={rowTagMode}>
+        <SessionColorsContext.Provider value={colorsEnabled}>{children}</SessionColorsContext.Provider>
+      </SessionRowTagContext.Provider>
     </DragSuppressContext.Provider>
   );
 }
@@ -865,5 +876,30 @@ describe("SessionRow color label (#2383)", () => {
     fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
     expect(screen.queryByTestId("sidebar-context-menu-color-red")).toBeNull();
     expect(screen.queryByTestId("sidebar-context-menu-color-clear")).toBeNull();
+  });
+
+  // `session.show_session_colors = false` (#3104). The gate hides, it does not
+  // forbid: the stored value is untouched, so re-enabling brings the dot back.
+  it("renders no color dot when session colors are disabled, even with a color stored", () => {
+    const ws = workspace("w-off-dot", [session({ id: "sess-off-dot", color: "red" })]);
+    render(
+      <Wrap colorsEnabled={false}>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    expect(screen.queryByTestId("sidebar-session-color-dot")).toBeNull();
+  });
+
+  it("hides the whole color section when session colors are disabled", () => {
+    const ws = workspace("w-off-menu", [session({ id: "sess-off-menu", color: "green" })]);
+    render(
+      <Wrap colorsEnabled={false}>
+        <Row ws={ws} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    for (const key of ["red", "amber", "green", "clear"]) {
+      expect(screen.queryByTestId(`sidebar-context-menu-color-${key}`)).toBeNull();
+    }
   });
 });

--- a/web/src/lib/__tests__/sessionColors.test.ts
+++ b/web/src/lib/__tests__/sessionColors.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSessionColorsEnabled } from "../sessionColors";
+
+// The parser encodes a compatibility contract: only a literal `false` turns
+// session colors off, so a daemon predating `session.show_session_colors`
+// keeps rendering them. A careless rewrite into a truthiness check would
+// silently disable colors for every older server, hence the explicit cases.
+describe("parseSessionColorsEnabled", () => {
+  it("defaults to enabled when there are no settings at all", () => {
+    expect(parseSessionColorsEnabled(undefined)).toBe(true);
+    expect(parseSessionColorsEnabled(null)).toBe(true);
+  });
+
+  it("defaults to enabled when `session` is missing or not an object", () => {
+    expect(parseSessionColorsEnabled({})).toBe(true);
+    expect(parseSessionColorsEnabled({ session: "nope" })).toBe(true);
+    expect(parseSessionColorsEnabled({ session: null })).toBe(true);
+  });
+
+  it("defaults to enabled when the field is absent or malformed", () => {
+    expect(parseSessionColorsEnabled({ session: { row_tag: "branch" } })).toBe(true);
+    expect(parseSessionColorsEnabled({ session: { show_session_colors: "false" } })).toBe(true);
+    expect(parseSessionColorsEnabled({ session: { show_session_colors: 0 } })).toBe(true);
+  });
+
+  it("disables only on an explicit boolean false", () => {
+    expect(parseSessionColorsEnabled({ session: { show_session_colors: false } })).toBe(false);
+    expect(parseSessionColorsEnabled({ session: { show_session_colors: true } })).toBe(true);
+  });
+});

--- a/web/src/lib/sessionColors.ts
+++ b/web/src/lib/sessionColors.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+
+/** Default to on, matching the server's `session.show_session_colors` default
+ *  and the value the gate falls back to before `/api/settings` has resolved. */
+const DEFAULT_SESSION_COLORS_ENABLED = true;
+
+export const SessionColorsContext = createContext<boolean>(DEFAULT_SESSION_COLORS_ENABLED);
+
+/** Read `session.show_session_colors` from an `/api/settings` payload. Only an
+ *  explicit `false` disables it; a missing or malformed value keeps the default
+ *  (on), so an older daemon that doesn't send the field still shows colors. */
+export function parseSessionColorsEnabled(settings: Record<string, unknown> | null | undefined): boolean {
+  const session = settings?.session;
+  if (!session || typeof session !== "object") {
+    return DEFAULT_SESSION_COLORS_ENABLED;
+  }
+  return (session as Record<string, unknown>).show_session_colors !== false;
+}
+
+export function useSessionColorsEnabled(): boolean {
+  return useContext(SessionColorsContext);
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -988,6 +988,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.session-color-toggle",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/lib/__tests__/sessionColors.test.ts", "src/components/__tests__/SessionRowTriage.test.tsx"],
+      "components": ["web/src/lib/sessionColors.ts", "web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "sidebar.dormant-dot",
       "kind": "vitest",
       "risk": "low",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Per-session color labels (#2383, shipped in #2851) were always on in the web dashboard. Every session context menu carried a `Color` section (three swatches plus `Clear color`) and every sidebar row rendered a colored status dot, with no way to turn either off. That is four permanent extra rows in a menu that already holds notification presets, triage actions, and destructive actions, on a surface that has to stay usable on a phone.

Session coloring was the only ungated display affordance in the sidebar. `session.unread_indicator` gates the unread dot and its menu item, `session.show_tips` gates the tips badge, `session.row_tag` gates the `[branch]` tag. This adds `session.show_session_colors`, default on, and gates both the dot and the menu section behind it.

The gate hides, it does not forbid. `aoe session color` and `PATCH /api/sessions/{id}/color` keep working when the toggle is off, and stored values are never cleared or migrated, so flipping back is lossless. That matters because the original motivation for colors was agents self-signalling status so a human can scan the fleet; turning those writes into errors would break agent scripts because someone tidied their sidebar. A color set while the toggle is off is a suppressed presentation signal, not a lost write.

Settings are single-source in this repo (#1692), so the one `#[setting(...)]` annotation is the only Rust edit: the schema derive surfaces the field on the TUI Interaction tab, in the web Session section, and in `PATCH /api/settings` validation, with no registry, `FieldKey`, or override-struct wiring. It is `global_only` because the dashboard resolves one settings object for the whole client rather than one per workspace, and the sidebar mixes profiles in the all-profiles view, so a per-profile override would advertise semantics the web cannot honor. Additive `#[serde(default)]`, so an existing `config.toml` reads as `true` and no migration is needed.

Worth knowing for review: the TUI renders no session colors at all and this PR does not add that, so the setting is web-only in effect. The field doc comment says so explicitly, since the knob still appears on the TUI settings screen via the shared schema.

Closes #3104

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Default is unchanged: with no config edit, right-click a session in the web sidebar and confirm the `Color` section still shows three swatches, and that picking one paints a dot on the row.
- [ ] Open Settings, go to Session, and confirm a `Session Color Labels` toggle is present and on.
- [ ] Turn it off. Without reloading the page, confirm the color dot disappears from the row and the `Color` section disappears from the context menu.
- [ ] With the toggle still off, run `aoe session color <id> red` and confirm the command succeeds rather than erroring.
- [ ] Turn the toggle back on and confirm the `red` set in the previous step is now visible, proving nothing was cleared.
- [ ] Launch the TUI, open the settings screen, and confirm `Session Color Labels` appears under the Interaction tab and round-trips.
- [ ] Optional, older-config check: remove `show_session_colors` from `[session]` in `config.toml` entirely and confirm colors stay visible (absent means on).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: per `AGENTS.md` test routing, render-logic and request-payload permutations belong in Vitest, not Playwright. Added three Vitest cases instead: two component cases in `web/src/components/__tests__/SessionRowTriage.test.tsx` (one per gated surface, so each conditional is pinned separately) and a parser contract test in `web/src/lib/__tests__/sessionColors.test.ts`. `web/tests/coverage-matrix.json` gained a `sidebar.session-color-toggle` entry, scoped to the files those specs actually exercise.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `agent-of-empires` `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls and reviewed each commit. The plan went through a multi-model debate before implementation, which changed three things: the field name (`session_colors` became `show_session_colors`, since `show_tips` is the closer analogue and the original name read as "enable the feature," contradicting the decision to keep writes working), the doc comment (now states the web-only scope and the writes-still-land semantics), and the addition of the parser contract test. A proposed refactor consolidating the four sibling display-setting contexts into one `AppSettingsContext` was rejected for this PR and noted as a follow-up, since most of that diff would have been proving unrelated unread and row-tag behavior still worked.

Two pre-existing issues surfaced during validation and were deliberately left alone: `cargo clippy` without `--features serve` fails on a dead-code warning for `SessionPoller::inject_test_update` (`src/session/poller.rs:276`, its callers are feature-gated), and `--features serve` flags findings in `src/session/groups.rs` and `src/tui/home/mod.rs`. Verified all of them reproduce on the base commit with none of my changes applied.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a default-enabled setting to show or hide session colors in the web dashboard.
- When disabled, session color dots and color menu controls are hidden, while stored colors and CLI/REST updates remain unchanged.
- Added live web updates when the setting changes, with compatibility defaults for older or incomplete settings data.
- Exposed the setting in web, TUI, and settings API configuration views.
- Added regression tests for setting parsing, sidebar behavior, TUI visibility, and coverage tracking.

## Benefits

Users can reduce visual clutter without losing saved session colors or color-management functionality. Existing configurations remain compatible, and colors return automatically when the setting is re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->