### PR TITLE
fix: prevent structured view crash on reused tool ids

### DIFF
--- a/web/src/components/acp/AcpRuntime.test.ts
+++ b/web/src/components/acp/AcpRuntime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SUBAGENT_TASK_NAME, TODO_GROUP_NAME, TOOL_GROUP_NAME, activityToThreadMessages } from "./AcpRuntime";
-import type { ActivityRow, ToolCall } from "../../lib/acpTypes";
+import { applyEvent, emptyAcpState, type AcpFrame, type ActivityRow, type ToolCall } from "../../lib/acpTypes";
 
 function userRow(text: string, id = "u1"): ActivityRow {
   return {
@@ -55,6 +55,113 @@ function messageRow(text: string, id = "m1"): ActivityRow {
     at: "2026-05-12T00:00:00Z",
   };
 }
+
+describe("activityToThreadMessages; reused tool ids", () => {
+  it("keeps message ids unique when a rate-limited adapter reuses a tool_call_id", () => {
+    const session_id = "digests";
+    const tool_call_id = "toolu_reused_after_resume";
+    const frames: AcpFrame[] = [
+      { session_id, seq: 1, event: { UserPromptSent: { text: "first digest" } } },
+      {
+        session_id,
+        seq: 2,
+        event: {
+          ToolCallStarted: {
+            tool_call: {
+              id: tool_call_id,
+              name: "Terminal",
+              kind: "execute",
+              args_preview: "{}",
+              started_at: "2026-07-20T14:48:22Z",
+            },
+          },
+        },
+      },
+      {
+        session_id,
+        seq: 3,
+        event: { ToolCallCompleted: { tool_call_id, is_error: false, content: "first result" } },
+      },
+      { session_id, seq: 4, event: { UserPromptSent: { text: "second digest" } } },
+      {
+        session_id,
+        seq: 5,
+        event: {
+          ToolCallStarted: {
+            tool_call: {
+              id: tool_call_id,
+              name: "Terminal",
+              kind: "execute",
+              args_preview: "{}",
+              started_at: "2026-07-25T00:00:05Z",
+            },
+          },
+        },
+      },
+      {
+        session_id,
+        seq: 6,
+        event: { ToolCallCompleted: { tool_call_id, is_error: false, content: "second result" } },
+      },
+      {
+        session_id,
+        seq: 7,
+        event: { AgentMessageChunk: { text: "You've hit your weekly limit" } },
+      },
+      {
+        session_id,
+        seq: 8,
+        event: {
+          RateLimit: {
+            info: {
+              status: "You've hit your weekly limit",
+              resets_at: "2026-07-28T06:00:00Z",
+              kind: "rate_limit",
+            },
+          },
+        },
+      },
+      { session_id, seq: 9, event: { Stopped: { reason: "rate_limited" } } },
+      { session_id, seq: 10, event: { UserPromptSent: { text: "third digest" } } },
+      {
+        session_id,
+        seq: 11,
+        event: {
+          ToolCallStarted: {
+            tool_call: {
+              id: tool_call_id,
+              name: "Terminal",
+              kind: "execute",
+              args_preview: "{}",
+              started_at: "2026-07-25T00:17:03Z",
+            },
+          },
+        },
+      },
+      {
+        session_id,
+        seq: 12,
+        event: { ToolCallCompleted: { tool_call_id, is_error: false, content: "third result" } },
+      },
+      {
+        session_id,
+        seq: 13,
+        event: { AgentMessageChunk: { text: "You've hit your weekly limit" } },
+      },
+    ];
+
+    const state = frames.reduce(applyEvent, emptyAcpState());
+    const messages = activityToThreadMessages(state.activity, false);
+    const ids = messages.map((message) => message.id);
+
+    expect(state.activity.filter((row) => row.kind === "tool_complete").map((row) => row.id)).toEqual([
+      `done-${tool_call_id}`,
+      `done-${tool_call_id}-6`,
+      `done-${tool_call_id}-12`,
+    ]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
 
 describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
   it("folds a run of ≥3 consecutive tool calls into one group", () => {

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1315,8 +1315,15 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
     // duration label survives page reload. Events persisted before
     // `completed_at` landed fall back to "now" (same bug as before for
     // those specific rows only).
+    const baseId = `done-${tool_call_id}`;
+    // Some adapters reuse a tool_call_id after reconnecting. Keep the
+    // historical id for the first completion, but disambiguate later rows
+    // with the event seq. Otherwise separate assistant groups can inherit
+    // the same `assistant-done-<tool_call_id>` message id and assistant-ui's
+    // MessageRepository crashes the entire structured view.
+    const rowId = next.activity.some((row) => row.id === baseId) ? `${baseId}-${frame.seq}` : baseId;
     next.activity = pushActivity(next.activity, {
-      id: `done-${tool_call_id}`,
+      id: rowId,
       kind: is_error ? "tool_error" : "tool_complete",
       text,
       toolCallId: tool_call_id,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -2038,6 +2038,13 @@
       "components": ["web/src/components/acp/ToolCards.tsx"]
     },
     {
+      "id": "acp.reused-tool-message-ids",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/acp/AcpRuntime.test.ts"],
+      "components": ["web/src/components/acp/AcpRuntime.tsx", "web/src/lib/acpTypes.ts"]
+    },
+    {
       "id": "acp.tool-density",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
## Description

Claude can reuse a `tool_call_id` after reconnecting or resuming a structured session. The reducer assigned every completion the same `done-<tool_call_id>` activity id. When reused completions landed in separate assistant groups, those groups inherited the same message id and assistant-ui's `MessageRepository` crashed the entire structured view.

Keep the historical completion id for the first occurrence and append the durable event sequence to later collisions. This preserves normal-session ids while making reused completions unique. The regression test mirrors the observed multi-turn digest session, including a weekly rate-limit stop, and asserts both the terminal row ids and final assistant message ids are unique.

The structured-view coverage matrix now records the regression.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (not applicable; no documentation change)
- [x] For UI changes: included screenshot or recording (not applicable; no visual change)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the failure is a deterministic reducer-to-runtime ID conversion; the Vitest regression exercises the real event sequence directly, and the coverage matrix is updated.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Verification

- `cd web && npx vitest run src/components/acp/AcpRuntime.test.ts`
- `cd web && npm run format:check`
- `cd web && npm run lint`
- `cd web && npx tsc -b`
- `cd web && node tests/validate-coverage-matrix.mjs`
- `cd web && npm run build`
- `git diff --check`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** OpenAI Codex, GPT-5.6-sol

**Any Additional AI Details you'd like to share:** Investigated the persisted event sequence and browser error log, implemented the fix, and added the regression test.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented structured-view crashes when Claude reuses tool IDs after reconnecting or resuming.
- Added regression coverage for reused tool IDs, including rate-limit recovery scenarios.
- Updated the coverage matrix to track this high-risk behavior.

## Benefits

- Keeps activity rows and assistant messages uniquely identifiable.
- Preserves existing IDs for normal sessions while safely disambiguating collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->