### PR TITLE
feat: add featured aoaoe orchestrator plugin entry (8.0.0)

### DIFF
--- a/plugins/featured.toml
+++ b/plugins/featured.toml
@@ -37,3 +37,7 @@ versions = {"0.1.0" = "sha256:6b506512d4efbc8a70c4d989188e701e547f5c35bd690c2827
 [plugins."agent-of-empires.cron"]
 source = "gh:agent-of-empires/plugin-cron"
 versions = {"1.0.0" = "sha256:b98ab9304a9906bd33acdcc5b4c1f5e9d6eb44db442d7409f82dcd8b0eeac2ac"}
+
+[plugins."dev.talador12.aoaoe"]
+source = "gh:Talador12/agent-of-agent-of-empires"
+versions = {"8.0.0" = "sha256:38c1c6708edea12da6128c5f7e466a6f78909314ec6e4194b9cfadacf3341dd7"}


### PR DESCRIPTION
## Description

Adds the **aoaoe orchestrator** plugin ([`gh:Talador12/agent-of-agent-of-empires`](https://github.com/Talador12/agent-of-agent-of-empires), id `dev.talador12.aoaoe`) to the featured index, pinning release [v8.0.0](https://github.com/Talador12/agent-of-agent-of-empires/releases/tag/v8.0.0) by its source tree hash.

This is the plugin form of the orchestrator from #553, delivered per the decision on #2699 to ship orchestration as an installable plugin living in my repo rather than inside aoe core.

## What the plugin does

- **Attention queue** — ranks every session by who needs eyes next (status + time-in-status escalation): dashboard card, sortable "Attention" column via `row-column`/`sort-key`, row badges, per-session pane with tick/pause actions, status-bar segment, deduplicated notifications for urgent sessions.
- **Spawn from GitHub issues** — one session per open issue in a configured repo via `sessions.create`, seeded with the issue as `initial_turn`, `idempotency_key = "issue:<repo>#<n>"` so reruns never double-spawn. Dry-run by default.
- **Reasoners** — deterministic `rules` engine by default (no LLM, no tokens); `claude-code` / `opencode` opt-in.
- **Guardrails** — `dry_run=true` and `allow_nudge=false` by default; nudges only ever go to plugin-created sessions (host-enforced ownership); 5s tick floor; per-session in-batch action cooldowns; quiet hours. Does **not** request `session.unattended`.

Design writeup (mechanism-in-aoe vs policy-in-plugin boundary, and the host primitives it does *not* work around): [DESIGN.md](https://github.com/Talador12/agent-of-agent-of-empires/blob/v8.0.0/DESIGN.md).

## Hash provenance

```
$ git clone --depth 1 --branch v8.0.0 https://github.com/Talador12/agent-of-agent-of-empires
$ aoe plugin hash agent-of-agent-of-empires
sha256:38c1c6708edea12da6128c5f7e466a6f78909314ec6e4194b9cfadacf3341dd7
```

Generated with `aoe plugin hash` built from current main (1.13.1) on Linux, LF endings, clean checkout. Build outputs go to `.aoe-build/` only (worker: `node .aoe-build/dist/plugin/worker.js`), so the install cannot trip the load-time tree hash the way plugin-github 1.1.0 did.

## Verification done

- Manifest parses against `aoe-plugin-api` (`PluginManifest::from_toml_str`), api_version 11, capabilities: `runtime.worker, session.read, notifications, acp.capabilities.read, session.create, session.prompt, process.spawn, net`.
- `aoe plugin install gh:Talador12/agent-of-agent-of-empires --yes` on aoe 1.13.1: fetches v8.0.0, runs the build, records grants, plugin lists as enabled, commands graft onto the CLI/palette.
- Worker protocol exercised end-to-end against a scripted host (JSON-RPC over stdio): `sessions.list` → ranked queue → `ui.state.set` pushes for all six declared slots + `events.publish("queue.updated")`.
- 5098 tests green in the plugin repo, including a fake-host contract test for the worker.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A — data-only change to `plugins/featured.toml`, no UI code touched)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

<!-- This PR adds one entry to plugins/featured.toml (no executable code). Behavioral test coverage for the plugin itself lives in its own repo: 5098 tests including a fake-host JSON-RPC contract test for the worker. -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Fable 5) under my direction.

**Any Additional AI Details you'd like to share:**
The plugin implementation, the hash provenance steps, and this PR were prepared with Claude Code; I direct the work and review what it produces. Reviewer discussion will be answered by me (Talador12) directly.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `dev.talador12.aoaoe` to the featured plugin index.
- Pinned the plugin to the vetted `v8.0.0` release using its source tree hash.
- Enables installation of the orchestrator as a standalone plugin, including attention ranking, issue-based sessions, notifications, configurable reasoning, and safety guardrails.

## Benefits

- Makes the orchestrator discoverable and installable through the featured registry.
- Ensures reproducible installations from a verified release.
- Keeps orchestrator functionality separate from aoe core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
