### PR TITLE
fix: exclude trashed sessions from dashboard status summary

### DIFF
--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -19,16 +19,23 @@ export function Dashboard({ sessions, onNewSession, onCloneFromUrl, onToggleSide
   const idleDecayWindowMs = useIdleDecayWindowMs();
   const stats = useMemo(() => {
     const projects = new Set<string>();
+    let total = 0;
     let active = 0;
     let waiting = 0;
     let errors = 0;
     for (const s of sessions) {
+      // Trashed sessions are conceptually deleted (the sidebar buckets them
+      // into a dedicated Trash section, out of the active/archived buckets), so
+      // they must not skew this summary: a session left in an Error state does
+      // not matter once it is in the trash. See #2489.
+      if (s.trashed_at) continue;
+      total++;
       projects.add(s.main_repo_path || s.project_path);
       if (isSessionActive(s, idleDecayWindowMs)) active++;
       if (s.status === "Waiting") waiting++;
       if (s.status === "Error") errors++;
     }
-    return { active, waiting, errors, projects: projects.size };
+    return { total, active, waiting, errors, projects: projects.size };
   }, [idleDecayWindowMs, sessions]);
 
   return (
@@ -90,7 +97,7 @@ export function Dashboard({ sessions, onNewSession, onCloneFromUrl, onToggleSide
       </div>
 
       {/* Session summary for returning users */}
-      {sessions.length > 0 && (
+      {stats.total > 0 && (
         <div className="flex items-center gap-2 text-xs font-mono text-text-muted mb-6">
           {stats.active > 0 && <span className="text-status-running">{stats.active} running</span>}
           {stats.waiting > 0 && <span className="text-status-waiting">{stats.waiting} waiting</span>}
@@ -100,7 +107,7 @@ export function Dashboard({ sessions, onNewSession, onCloneFromUrl, onToggleSide
             </span>
           )}
           <span>
-            {sessions.length} session{sessions.length !== 1 ? "s" : ""} across {stats.projects} project
+            {stats.total} session{stats.total !== 1 ? "s" : ""} across {stats.projects} project
             {stats.projects !== 1 ? "s" : ""}
           </span>
         </div>

--- a/web/src/components/__tests__/DashboardStats.test.tsx
+++ b/web/src/components/__tests__/DashboardStats.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// Regression guard for #2489: the dashboard's returning-user summary must not
+// count trashed sessions. A session left in an Error state does not matter once
+// it is in the trash, so the "N errors" / "N sessions across M projects" line
+// has to exclude anything carrying `trashed_at`.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { Dashboard } from "../Dashboard";
+import type { SessionResponse } from "../../lib/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function session(over: Partial<SessionResponse>): SessionResponse {
+  return {
+    id: "s",
+    title: "t",
+    project_path: "/repo",
+    main_repo_path: "/repo",
+    status: "Idle",
+    archived_at: null,
+    snoozed_until: null,
+    trashed_at: null,
+    ...over,
+  } as SessionResponse;
+}
+
+function renderDashboard(sessions: SessionResponse[]) {
+  return render(
+    <Dashboard
+      sessions={sessions}
+      onSelectSession={vi.fn()}
+      onNewSession={vi.fn()}
+      onCloneFromUrl={vi.fn()}
+      onToggleSidebar={vi.fn()}
+    />,
+  );
+}
+
+describe("Dashboard summary excludes trashed sessions (#2489)", () => {
+  it("does not count a trashed session's Error status", () => {
+    renderDashboard([session({ id: "a", status: "Error", trashed_at: "2026-07-26T00:00:00Z" })]);
+    // The only session is trashed, so the whole summary line is suppressed:
+    // no error count and no "N sessions across M projects" tally.
+    expect(screen.queryByText(/error/i)).toBeNull();
+    expect(screen.queryByText(/across/i)).toBeNull();
+  });
+
+  it("counts only live sessions in the totals", () => {
+    renderDashboard([
+      session({ id: "live", status: "Error", project_path: "/repo-a", main_repo_path: "/repo-a" }),
+      session({
+        id: "gone",
+        status: "Error",
+        project_path: "/repo-b",
+        main_repo_path: "/repo-b",
+        trashed_at: "2026-07-26T00:00:00Z",
+      }),
+    ]);
+    // One live error, one trashed error: the summary reports a single error and
+    // a single session across a single project.
+    expect(screen.getByText("1 error")).toBeTruthy();
+    expect(screen.getByText(/1 session across 1 project/)).toBeTruthy();
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -78,6 +78,13 @@
       "components": ["web/src/components/MobileLiveTerminal.tsx", "web/src/components/LiveTerminalView.tsx"]
     },
     {
+      "id": "dashboard.summary-excludes-trash",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/__tests__/DashboardStats.test.tsx"],
+      "components": ["web/src/components/Dashboard.tsx"]
+    },
+    {
       "id": "app-shell.dashboard-update-banner",
       "kind": "vitest",
       "risk": "medium",


### PR DESCRIPTION
## Description

On the web dashboard homepage, the returning-user status summary counted trashed sessions. A session left in an `Error` state still showed up in the "N errors" tally after being moved to the trash, and it also inflated the "N sessions across M projects" line.

Root cause: `web/src/components/Dashboard.tsx` builds its `stats` by looping over the full `sessions` array. That array is the raw payload from `useSessions()`; the sidebar only buckets trash into its own visual section, it does not remove trashed sessions from the list. The loop had no `trashed_at` guard, so trashed sessions counted toward `active` / `waiting` / `errors` and the total.

Fix: skip sessions carrying `trashed_at` in the stats loop and drive the summary's total off the resulting live count. This matches how trash is treated everywhere else (sidebarSort, useCommandActions already guard on `trashed_at`). See #2489.

Note: this also drops trashed sessions from the total session/project tally, not just the error count, so the whole summary is consistent.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A; no doc drift)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] Added or updated a Vitest spec and updated `web/tests/coverage-matrix.json`

Added `web/src/components/__tests__/DashboardStats.test.tsx` (Vitest + RTL): asserts a trashed error session is excluded (summary suppressed when the only session is trashed) and that a mix of one live + one trashed error session reports "1 error" and "1 session across 1 project". Verified the test fails on both cases without the fix and passes with it. New matrix entry: `dashboard.summary-excludes-trash`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any Additional AI Details you'd like to share:** Root-caused and implemented via Claude Code, reviewed by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

## Test plan
- [x] `cd web && npx vitest run src/components/__tests__/Dashboard*` (8 passed)
- [x] `cd web && npm run format:check` (oxfmt clean)
- [x] `cd web && npm run lint` (ESLint clean)
- [x] `cd web && npx tsc -b` (no type errors)
- [x] `node web/tests/validate-coverage-matrix.mjs` (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the dashboard to exclude trashed sessions from session, project, active, waiting, and error counts.
- Added regression tests for dashboards containing only trashed sessions and mixed live/trashed sessions.
- Registered the new test in the coverage matrix.

## Benefits

Returning users now see accurate statistics based only on active sessions, and trashed-only results no longer display misleading summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->