### PR TITLE
chore(deps): bump aoe-agent to AI SDK v7 and ACP SDK 1.0

### DIFF
--- a/acp-worker/aoe-agent/package-lock.json
+++ b/acp-worker/aoe-agent/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.29.0",
-        "@ai-sdk/anthropic": "^3.0.96",
-        "@ai-sdk/google": "^3.0.91",
-        "@ai-sdk/openai": "^3.0.84",
-        "@ai-sdk/openai-compatible": "^2.0.59",
-        "ai": "^6.0.224",
+        "@agentclientprotocol/sdk": "^1.0.0",
+        "@ai-sdk/anthropic": "^4.0.1",
+        "@ai-sdk/google": "^4.0.2",
+        "@ai-sdk/openai": "^4.0.2",
+        "@ai-sdk/openai-compatible": "^3.0.1",
+        "ai": "^7.0.4",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -25,131 +25,123 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.29.0.tgz",
-      "integrity": "sha512-Sb8xJ/cIhqlvxeJiB0+1scBk0LAkVAwJ9WAFG9XCe3LEI5JWAyOxbqaCa8O1HmNnrk4+qHN11eaKH6zL2iHIYA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.96",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.96.tgz",
-      "integrity": "sha512-6VQzaXQdm5FkX6NWOyKzV5GB11C8IqkgsKZE91lg/bdwyvnQJLDwal2qkE0+fC8CCGeW5d+VV8Mw/+H+OcDC1A==",
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.21.tgz",
+      "integrity": "sha512-rvWzefSJiDLBswGFn0oWM7D8p8eo2tKey2anSM2IxaFd/4tLfolWAWP6Zp+82YUURZUoX6f01NI/txF6ekbC4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.38"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.148",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.148.tgz",
-      "integrity": "sha512-C/mTeSdmhu8dAnH3vZaRXffD8Oewo1r4QEGxvCdR8eC9b4PKPs2CLsbg3DVJH/X3Bea5fAu87Ob7P3fSS+oq/g==",
+      "version": "4.0.28",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.28.tgz",
+      "integrity": "sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.38",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.91",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.91.tgz",
-      "integrity": "sha512-d/ho+sDjArFjreE2002t9jE4LXX3wde97dN2HCLCX1l41gaJV3wf/c/19axjUNfIf/4uUq+nJmhBO0lW/dg3yw==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.24.tgz",
+      "integrity": "sha512-W+kTGb/RRe2SEYwbKcKYM3N2EQryS2Iqjgou6wPsyP/2BwBU7Q23CF6/YWE8k7xtseDLcSY59jsR2MDpY4azRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.38"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.84",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.84.tgz",
-      "integrity": "sha512-cmgbeJL0bbY0yTJH4/AdmP5E7MjWRL9G8UdhIi0JlV/So03o82ORJofW8OzwCZPTORVQblFbpZXYGDcUd9NdUQ==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.20.tgz",
+      "integrity": "sha512-/Hu+btLIO2zuYqCp//vBBAGdM/BeN4gds+NWrlv7Y9WrcTXwnEEwh6P3QZIWh2Tt1I1lswuDIpAJ4t/c/rws3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.38"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai-compatible": {
-      "version": "2.0.59",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.59.tgz",
-      "integrity": "sha512-CFsUizO+jL+jSlN13rW2nQE9EbWx+8PSFBdB3TtD0UGYOxtefCVa5hsrNo5NUOJJGX5f4xHiXE1i2m5nQ80QPg==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-3.0.14.tgz",
+      "integrity": "sha512-nUl7dBHUDTqcnuWGnEbKMwDDqL94BxRfibLwYv8uWp+kZn8Zqdxy7tUBt4sv2hpHQi+S2P6bUyqW18xmbykErw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.38"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
-      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.38",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.38.tgz",
-      "integrity": "sha512-/HHGmtKllqjg1OLc023v9w9kK3laW7Z6TzfZukYQWCsGBbzB9p60zTvvpXFVcs44NZBVXL3viOa1HRKUbeee8g==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.12.tgz",
+      "integrity": "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider": "4.0.3",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -167,28 +159,33 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ai": {
-      "version": "6.0.224",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.224.tgz",
-      "integrity": "sha512-plo+hHwMANM+P6FjX8RN6W8c8so5NVZGwvDGCWGWwIbvI5tc0ZV1zhr9v/Kq78zyxKZWE50YCSYbqGiPFEhGww==",
+      "version": "7.0.37",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.37.tgz",
+      "integrity": "sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.148",
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.38",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.28",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/acp-worker/aoe-agent/package.json
+++ b/acp-worker/aoe-agent/package.json
@@ -16,12 +16,12 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.29.0",
-    "@ai-sdk/anthropic": "^3.0.96",
-    "@ai-sdk/openai": "^3.0.84",
-    "@ai-sdk/google": "^3.0.91",
-    "@ai-sdk/openai-compatible": "^2.0.59",
-    "ai": "^6.0.224",
+    "@agentclientprotocol/sdk": "^1.0.0",
+    "@ai-sdk/anthropic": "^4.0.1",
+    "@ai-sdk/google": "^4.0.2",
+    "@ai-sdk/openai": "^4.0.2",
+    "@ai-sdk/openai-compatible": "^3.0.1",
+    "ai": "^7.0.4",
     "zod": "^4.4.3"
   },
   "license": "MIT"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Coherent, atomic bump of every dependency in `acp-worker/aoe-agent` so the Vercel AI SDK core and its providers move in lockstep:

| Package | From | To |
| --- | --- | --- |
| `ai` | 6.0.224 | 7.0.4 |
| `@ai-sdk/openai` | 3.0.84 | 4.0.2 |
| `@ai-sdk/anthropic` | 3.0.96 | 4.0.1 |
| `@ai-sdk/google` | 3.0.91 | 4.0.2 |
| `@ai-sdk/openai-compatible` | 2.0.59 | 3.0.1 |
| `@agentclientprotocol/sdk` | 0.29.0 | 1.0.0 |

This supersedes six individual Dependabot PRs (#3124, #3129, #3125, #3127, #3126, #3128). Landing the AI SDK bumps one at a time would each leave a mismatched `@ai-sdk/provider` spec tree (the core expecting a newer `LanguageModel` spec than the providers supply). That mismatch typechecks but throws `UnsupportedModelVersionError` at runtime, and since CI never builds this package it would ship silently. Bundling the bumps keeps a single deduped `@ai-sdk/provider@4`.

No source changes are needed: `ai@7` still exports `stepCountIs` (now an alias for `isStepCount`), and the narrow surface this package uses (`streamText`, `fullStream` deltas, `tool()`) is unchanged. The ACP SDK 0.29 to 1.0 change is schema-only and still speaks protocol V1.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

CI does not build or typecheck `acp-worker/aoe-agent`, so this was verified locally: `npm install` resolves a single `@ai-sdk/provider@4`, and `tsc` typechecks `src/` clean against the full coherent set.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.8)

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Updated AI SDK dependencies and ACP SDK to their latest major versions.
- Coordinated provider upgrades to ensure compatible, deduplicated dependencies.
- No source code changes or public API changes were required.

## Benefits
- Prevents runtime model-version compatibility errors.
- Maintains ACP protocol V1 compatibility.
- Simplifies dependency maintenance by consolidating related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->