### PR TITLE
fix(acp): drive a real conversation reset for codex /new

### DIFF
--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -339,6 +339,39 @@ const ACP_SESSION_DELETE_TIMEOUT: std::time::Duration = std::time::Duration::fro
 /// adapter from stalling the prompt path that requested the reset.
 const SESSION_RESET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Inner deadline for the connection task's complete reset RPC sequence.
+/// Kept below `SESSION_RESET_TIMEOUT` so the task can report the specific
+/// failure before the caller's outer guard expires, then resume draining
+/// commands instead of remaining parked on a wedged adapter.
+const SESSION_RESET_IN_TASK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(28);
+
+#[derive(Debug)]
+enum ResetRequestError {
+    Acp(agent_client_protocol::Error),
+    TimedOut,
+}
+
+async fn await_reset_request<T, F, Fut>(
+    deadline: tokio::time::Instant,
+    request: F,
+) -> Result<T, ResetRequestError>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T, agent_client_protocol::Error>>,
+{
+    // `send_request` enqueues the stateful RPC synchronously. Keep it
+    // lazy so a command whose caller-created deadline expired in the
+    // queue cannot send a late session/new or config mutation at all.
+    if tokio::time::Instant::now() >= deadline {
+        return Err(ResetRequestError::TimedOut);
+    }
+    match tokio::time::timeout_at(deadline, request()).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(error)) => Err(ResetRequestError::Acp(error)),
+        Err(_) => Err(ResetRequestError::TimedOut),
+    }
+}
+
 /// Configuration for spawning an ACP agent.
 #[derive(Debug, Clone)]
 pub struct SpawnConfig {
@@ -448,14 +481,19 @@ enum ClientCmd {
     },
     /// Drive a real conversation reset: issue a fresh `session/new` on
     /// the live connection, swap the task's ACP session id to the new
-    /// one, and emit `SessionContextReset` + `AcpSessionAssigned` + a
-    /// terminal `Stopped` so bookkeeping and the UI follow. Issued by
-    /// the supervisor when a clear command hits a profile whose adapter
-    /// has no native reset (codex `/new`). `text` carries the user's
-    /// original clear invocation, used only by the mid-turn refusal's
-    /// `PromptRejected` so the retry pill shows what was typed. See #2979.
+    /// one, and emit `SessionCleared` + `SessionContextReset` +
+    /// `AcpSessionAssigned` + a terminal `Stopped` so bookkeeping and
+    /// the UI follow. Issued by the supervisor when a clear command hits
+    /// a profile whose adapter has no native reset (codex `/new`). `text`
+    /// carries the user's original clear invocation, used only by the
+    /// mid-turn refusal's `PromptRejected` so the retry pill shows what
+    /// was typed. See #2979.
     ResetSession {
         text: String,
+        /// Absolute deadline created by the caller. Starting it before the
+        /// command is queued prevents a delayed command from resetting the
+        /// session after the caller has already timed out.
+        deadline: tokio::time::Instant,
         respond_to: oneshot::Sender<ResetSessionOutcome>,
     },
     Shutdown,
@@ -2109,6 +2147,43 @@ impl AcpClient {
         (client, event_tx, cmds)
     }
 
+    /// Like `fake_for_test_cmd_recording`, but answers a driven reset
+    /// with a deterministic failure. Used by supervisor tests to assert
+    /// that a busy or otherwise rejected reset never publishes the
+    /// successful `SessionCleared` boundary.
+    #[cfg(test)]
+    pub fn fake_for_test_reset_failure(
+        session_id: AcpSessionId,
+        message: impl Into<String>,
+    ) -> (Self, mpsc::Sender<Event>) {
+        let (event_tx, event_rx) = mpsc::channel(64);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<ClientCmd>(16);
+        let message = message.into();
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                match cmd {
+                    ClientCmd::ResetSession { respond_to, .. } => {
+                        let _ = respond_to.send(ResetSessionOutcome::Failed {
+                            message: message.clone(),
+                        });
+                    }
+                    ClientCmd::DeleteSession { respond_to, .. } => {
+                        let _ = respond_to.send(DeleteSessionOutcome::UnsupportedMethod);
+                    }
+                    _ => {}
+                }
+            }
+        });
+        let client = Self {
+            session_id,
+            inbound: Some(event_rx),
+            cmd_tx: Some(cmd_tx),
+            pending_responders: Arc::new(Mutex::new(HashMap::new())),
+            _child: None,
+        };
+        (client, event_tx)
+    }
+
     /// Spawn an ACP agent subprocess, run the handshake + create a
     /// session, and start pumping notifications into the inbound channel.
     pub async fn spawn(config: SpawnConfig, session_id: AcpSessionId) -> Result<Self, AcpError> {
@@ -2773,22 +2848,27 @@ impl AcpClient {
 
     /// Drive a real conversation reset on the live worker: the connection
     /// task issues a fresh `session/new`, swaps its ACP session id, and
-    /// emits `SessionContextReset` + `AcpSessionAssigned` + a terminal
-    /// `Stopped`. Used for clear commands whose adapter has no native
-    /// reset (codex `/new`, #2979). `text` is the user's clear invocation,
-    /// surfaced in the mid-turn refusal's `PromptRejected`. Bounded so a
-    /// wedged adapter cannot stall the prompt path; the timeout surfaces
-    /// as a `Failed` outcome.
+    /// emits `SessionCleared` + `SessionContextReset` +
+    /// `AcpSessionAssigned` + a terminal `Stopped`. Used for clear
+    /// commands whose adapter has no native reset (codex `/new`, #2979).
+    /// `text` is the user's clear invocation, surfaced in the mid-turn
+    /// refusal's `PromptRejected`. Bounded so a wedged adapter cannot
+    /// stall the prompt path; a `session/new` timeout surfaces as a
+    /// `Failed` outcome, while post-reset config re-application remains
+    /// best-effort.
     pub async fn reset_session(&self, text: &str) -> Result<ResetSessionOutcome, AcpError> {
         let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
         let (tx, rx) = oneshot::channel();
+        let deadline = tokio::time::Instant::now() + SESSION_RESET_IN_TASK_TIMEOUT;
         // Mirror `delete_session`: the guard wraps BOTH the cmd_tx send
         // and the response wait so a wedged connection task cannot park
-        // the caller indefinitely.
+        // the caller indefinitely. The connection task receives the
+        // caller-created inner deadline so queueing time counts too.
         let request = async {
             if cmd_tx
                 .send(ClientCmd::ResetSession {
                     text: text.to_string(),
+                    deadline,
                     respond_to: tx,
                 })
                 .await
@@ -7639,7 +7719,9 @@ async fn run_connection_task<W, R>(
                                                 break;
                                             }
                                         }
-                                        Some(ClientCmd::ResetSession { text, respond_to }) => {
+                                        Some(ClientCmd::ResetSession {
+                                            text, respond_to, ..
+                                        }) => {
                                             // Resetting under an in-flight
                                             // `session/prompt` would orphan
                                             // the pending turn on the old
@@ -7650,8 +7732,8 @@ async fn run_connection_task<W, R>(
                                             // `PromptRejected` so the caller
                                             // gets a terminal frame (retry
                                             // pill) under the persisted
-                                            // UserPromptSent + divider, not
-                                            // just an HTTP error. See #2979.
+                                            // UserPromptSent, not just an
+                                            // HTTP error. See #2979.
                                             warn!(
                                                 target: "acp.protocol",
                                                 "conversation reset requested during in-flight prompt; refusing"
@@ -7862,7 +7944,11 @@ async fn run_connection_task<W, R>(
                             event_tx_for_block.clone(),
                         );
                     }
-                    Some(ClientCmd::ResetSession { text: _, respond_to }) => {
+                    Some(ClientCmd::ResetSession {
+                        text: _,
+                        deadline: reset_deadline,
+                        respond_to,
+                    }) => {
                         // Driven conversation reset (#2979): a clear command
                         // hit a profile whose adapter has no native reset
                         // (codex `/new`), so open a genuinely fresh session
@@ -7876,6 +7962,10 @@ async fn run_connection_task<W, R>(
                         // runner watches for it and refreshes its own
                         // handshake cache from the response (see
                         // `process/runner.rs`).
+                        // Use the caller-created shared deadline for
+                        // session/new and both config re-application
+                        // requests. Queueing time counts, and per-request
+                        // deadlines cannot accumulate past the outer guard.
                         info!(
                             target: "acp.protocol",
                             session = %session_label,
@@ -7884,25 +7974,48 @@ async fn run_connection_task<W, R>(
                         );
                         let req = NewSessionRequest::new(agent_cwd.clone())
                             .mcp_servers(mcp_servers_for_reset.clone());
-                        match connection.send_request(req).block_task().await {
+                        match await_reset_request(
+                            reset_deadline,
+                            || connection.send_request(req).block_task(),
+                        )
+                        .await
+                        {
                             Ok(new_session)
                                 if new_session.session_id.0 != acp_session_id.0 =>
                             {
                                 let new_id = new_session.session_id.clone();
+                                // session/new is the irreversible reset
+                                // commit. Adopt its id before attempting
+                                // best-effort config restoration so this
+                                // client and the runner cannot disagree
+                                // about which session owns later prompts.
                                 acp_session_id = new_id.clone();
+                                available_mode_ids =
+                                    new_session.modes.as_ref().map(|modes| {
+                                        modes
+                                            .available_modes
+                                            .iter()
+                                            .map(|m| m.id.0.to_string())
+                                            .collect()
+                                    });
+                                mode_config_option_id = new_session
+                                    .config_options
+                                    .as_deref()
+                                    .and_then(mode_config_id)
+                                    .map(|id| id.0.to_string());
                                 info!(
                                     target: "acp.protocol",
                                     session = %session_label,
                                     new_id = %new_id.0,
                                     "conversation reset: session/new succeeded, swapped acp_session_id"
                                 );
-                                // Ordering matters: `SessionContextReset`
-                                // first (listeners null the stored resume id
-                                // and drop fork/import markers), then
-                                // `AcpSessionAssigned` persists the fresh id
-                                // on top, then a terminal `Stopped` ends the
-                                // clear command's synthetic turn so the
-                                // composer unlocks.
+                                // Keep every success boundary on the same
+                                // FIFO. SessionCleared folds the transcript
+                                // only after session/new committed, then
+                                // SessionContextReset clears the old resume
+                                // id before AcpSessionAssigned persists the
+                                // fresh one.
+                                let _ = event_tx_for_block.send(Event::SessionCleared).await;
                                 let _ = event_tx_for_block
                                     .send(Event::SessionContextReset {
                                         reason: "conversation cleared; the agent started a fresh session".into(),
@@ -7918,13 +8031,6 @@ async fn run_connection_task<W, R>(
                                 // the new session starts on adapter defaults,
                                 // so the old session's picker state is stale.
                                 if let Some(modes) = &new_session.modes {
-                                    available_mode_ids = Some(
-                                        modes
-                                            .available_modes
-                                            .iter()
-                                            .map(|m| m.id.0.to_string())
-                                            .collect(),
-                                    );
                                     let infos: Vec<ModeInfo> = modes
                                         .available_modes
                                         .iter()
@@ -7944,11 +8050,6 @@ async fn run_connection_task<W, R>(
                                         })
                                         .await;
                                 }
-                                mode_config_option_id = new_session
-                                    .config_options
-                                    .as_deref()
-                                    .and_then(mode_config_id)
-                                    .map(|id| id.0.to_string());
                                 if let Some(event) =
                                     config_options_event(new_session.config_options.clone())
                                 {
@@ -7982,14 +8083,19 @@ async fn run_connection_task<W, R>(
                                         );
                                         continue;
                                     };
-                                    match connection
-                                        .send_request(SetSessionConfigOptionRequest::new(
-                                            acp_session_id.clone(),
-                                            config_id,
-                                            SessionConfigValueId::new(value.to_string()),
-                                        ))
-                                        .block_task()
-                                        .await
+                                    match await_reset_request(
+                                        reset_deadline,
+                                        || {
+                                            connection
+                                                .send_request(SetSessionConfigOptionRequest::new(
+                                                new_id.clone(),
+                                                config_id,
+                                                SessionConfigValueId::new(value.to_string()),
+                                            ))
+                                                .block_task()
+                                        },
+                                    )
+                                    .await
                                     {
                                         Ok(resp) => {
                                             if let Some(event) = config_options_event(Some(
@@ -7999,13 +8105,23 @@ async fn run_connection_task<W, R>(
                                                     event_tx_for_block.send(event).await;
                                             }
                                         }
-                                        Err(e) => {
+                                        Err(ResetRequestError::Acp(e)) => {
                                             warn!(
                                                 target: "acp.protocol",
                                                 session = %session_label,
                                                 value,
                                                 "re-applying structured view default after reset failed: {e}"
                                             );
+                                        }
+                                        Err(ResetRequestError::TimedOut) => {
+                                            warn!(
+                                                target: "acp.protocol",
+                                                session = %session_label,
+                                                value,
+                                                timeout_secs = SESSION_RESET_IN_TASK_TIMEOUT.as_secs(),
+                                                "post-reset config re-application timed out; skipping remaining defaults"
+                                            );
+                                            break;
                                         }
                                     }
                                 }
@@ -8046,8 +8162,30 @@ async fn run_connection_task<W, R>(
                                 let _ = respond_to
                                     .send(ResetSessionOutcome::Failed { message });
                             }
-                            Err(e) => {
+                            Err(ResetRequestError::Acp(e)) => {
                                 let message = format!("session/new failed: {e}");
+                                warn!(
+                                    target: "acp.protocol",
+                                    session = %session_label,
+                                    "conversation reset failed: {message}"
+                                );
+                                let _ = event_tx_for_block
+                                    .send(Event::PromptRuntimeError {
+                                        message: message.clone(),
+                                    })
+                                    .await;
+                                let _ = event_tx_for_block
+                                    .send(Event::Stopped {
+                                        reason: "session_reset_failed".into(),
+                                    })
+                                    .await;
+                                let _ = respond_to
+                                    .send(ResetSessionOutcome::Failed { message });
+                            }
+                            Err(ResetRequestError::TimedOut) => {
+                                let message =
+                                    "agent did not answer session/new before the reset deadline"
+                                        .to_string();
                                 warn!(
                                     target: "acp.protocol",
                                     session = %session_label,
@@ -8817,6 +8955,14 @@ async fn handle_elicitation_request(
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    #[test]
+    fn reset_request_deadline_precedes_the_outer_guard() {
+        assert!(
+            SESSION_RESET_IN_TASK_TIMEOUT < SESSION_RESET_TIMEOUT,
+            "the in-task deadline must expire before the caller's outer guard"
+        );
+    }
 
     #[tokio::test]
     async fn between_prompt_signals_do_not_block_on_a_full_lifecycle_channel() {
@@ -10681,13 +10827,18 @@ mod tests {
     /// default-effort application path has a target), acks
     /// `session/set_config_option`, and answers every `session/prompt`
     /// with an `agent_message_chunk` notification, a `prompt_delay_secs`
-    /// pause (0 = immediate), then the turn-ending response. Appends every
-    /// inbound request line to the returned capture file so the test can
-    /// assert exactly which protocol requests were issued.
+    /// pause (0 = immediate), then the turn-ending response.
+    /// `reset_new_delay_secs` delays only the second `session/new`, while
+    /// `reset_config_delay_secs` delays only the second config request;
+    /// those hooks exercise the reset deadlines without slowing ordinary
+    /// tests. Appends every inbound request line to the returned capture
+    /// file so tests can assert exactly which requests were issued.
     #[cfg(unix)]
     fn write_reset_fake_agent(
         dir: &std::path::Path,
         prompt_delay_secs: u32,
+        reset_new_delay_secs: u32,
+        reset_config_delay_secs: u32,
     ) -> (std::path::PathBuf, std::path::PathBuf) {
         use std::os::unix::fs::PermissionsExt;
         let capture = dir.join("capture.ndjson");
@@ -10695,7 +10846,10 @@ mod tests {
         let script = r#"#!/bin/sh
 CAPTURE=__CAPTURE__
 DELAY=__DELAY__
+RESET_NEW_DELAY=__RESET_NEW_DELAY__
+RESET_CONFIG_DELAY=__RESET_CONFIG_DELAY__
 count=0
+config_count=0
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$CAPTURE"
   id=$(printf '%s' "$line" | sed -En 's/.*"id":("[^"]*"|[0-9]+).*/\1/p')
@@ -10705,9 +10859,12 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/new"'*)
       count=$((count+1))
+      if [ "$count" -eq 2 ] && [ "$RESET_NEW_DELAY" -gt 0 ]; then sleep "$RESET_NEW_DELAY"; fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"sid-%d","configOptions":[{"id":"effort","name":"Reasoning Effort","category":"thought_level","type":"select","currentValue":"default","options":[{"value":"default","name":"Default"},{"value":"high","name":"High"}]}]}}\n' "$id" "$count"
       ;;
     *'"method":"session/set_config_option"'*)
+      config_count=$((config_count+1))
+      if [ "$config_count" -eq 2 ] && [ "$RESET_CONFIG_DELAY" -gt 0 ]; then sleep "$RESET_CONFIG_DELAY"; fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[]}}\n' "$id"
       ;;
     *'"method":"session/prompt"'*)
@@ -10719,11 +10876,37 @@ while IFS= read -r line; do
 done
 "#
         .replace("__CAPTURE__", capture.to_str().expect("utf8 tmp path"))
-        .replace("__DELAY__", &prompt_delay_secs.to_string());
+        .replace("__DELAY__", &prompt_delay_secs.to_string())
+        .replace("__RESET_NEW_DELAY__", &reset_new_delay_secs.to_string())
+        .replace(
+            "__RESET_CONFIG_DELAY__",
+            &reset_config_delay_secs.to_string(),
+        );
         std::fs::write(&script_path, script).expect("write fake agent script");
         std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
             .expect("chmod fake agent script");
         (script_path, capture)
+    }
+
+    #[cfg(unix)]
+    async fn reset_with_deadline_for_test(
+        client: &AcpClient,
+        deadline: tokio::time::Instant,
+    ) -> ResetSessionOutcome {
+        let cmd_tx = client.cmd_tx.as_ref().expect("connection task running");
+        let (respond_to, response) = oneshot::channel();
+        cmd_tx
+            .send(ClientCmd::ResetSession {
+                text: "/new".into(),
+                deadline,
+                respond_to,
+            })
+            .await
+            .expect("send reset command");
+        tokio::time::timeout(std::time::Duration::from_secs(4), response)
+            .await
+            .expect("connection task must answer the reset")
+            .expect("reset response channel open")
     }
 
     #[cfg(unix)]
@@ -10753,20 +10936,159 @@ done
         }
     }
 
+    /// The deadline starts before enqueueing. If it has already expired
+    /// when the connection loop dequeues the command, the stateful
+    /// session/new must not be sent at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn expired_reset_deadline_does_not_send_session_new() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let (script, capture) = write_reset_fake_agent(tmp.path(), 0, 0, 0);
+        let config = reset_fake_spawn_config(&script, tmp.path());
+        let client = AcpClient::spawn(config, AcpSessionId("reset-expired".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        let outcome = reset_with_deadline_for_test(&client, tokio::time::Instant::now()).await;
+        assert!(
+            matches!(outcome, ResetSessionOutcome::Failed { .. }),
+            "an expired reset must fail, got {outcome:?}"
+        );
+        let wire = std::fs::read_to_string(&capture).expect("read capture");
+        assert_eq!(
+            wire.matches("\"method\":\"session/new\"").count(),
+            1,
+            "the expired command must not send a second session/new;\n{wire}"
+        );
+
+        let valid = reset_with_deadline_for_test(
+            &client,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(2),
+        )
+        .await;
+        assert!(
+            matches!(valid, ResetSessionOutcome::Reset { .. }),
+            "the loop must continue after rejecting the expired command"
+        );
+        let _ = client.shutdown().await;
+    }
+
+    /// A `session/new` that never answers must release the real connection
+    /// loop at the caller-created deadline. A second reset then proves the
+    /// loop resumed draining commands instead of remaining parked on the
+    /// abandoned request.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reset_session_new_timeout_releases_the_connection_loop() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let (script, _capture) = write_reset_fake_agent(tmp.path(), 0, 1, 0);
+        let config = reset_fake_spawn_config(&script, tmp.path());
+        let client = AcpClient::spawn(config, AcpSessionId("reset-timeout-new".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        let first = reset_with_deadline_for_test(
+            &client,
+            tokio::time::Instant::now() + std::time::Duration::from_millis(200),
+        )
+        .await;
+        assert!(
+            matches!(
+                first,
+                ResetSessionOutcome::Failed { ref message }
+                    if message.contains("before the reset deadline")
+            ),
+            "the stalled session/new must fail at the inner deadline, got {first:?}"
+        );
+
+        let second = reset_with_deadline_for_test(
+            &client,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(3),
+        )
+        .await;
+        assert!(
+            matches!(
+                second,
+                ResetSessionOutcome::Reset {
+                    ref new_acp_session_id
+                } if new_acp_session_id == "sid-3"
+            ),
+            "the connection loop must process a later reset, got {second:?}"
+        );
+        let _ = client.shutdown().await;
+    }
+
+    /// Once `session/new` returns, the reset is irreversible. A wedged
+    /// best-effort config re-application must still release the command
+    /// loop, adopt the fresh id, and report reset success; otherwise the
+    /// client and runner would disagree about the live session.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reset_config_timeout_commits_and_releases_the_connection_loop() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let (script, capture) = write_reset_fake_agent(tmp.path(), 0, 0, 1);
+        let mut config = reset_fake_spawn_config(&script, tmp.path());
+        config.default_effort = Some("high".into());
+        let client = AcpClient::spawn(config, AcpSessionId("reset-timeout-config".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        let first = reset_with_deadline_for_test(
+            &client,
+            tokio::time::Instant::now() + std::time::Duration::from_millis(200),
+        )
+        .await;
+        assert!(
+            matches!(
+                first,
+                ResetSessionOutcome::Reset {
+                    ref new_acp_session_id
+                } if new_acp_session_id == "sid-2"
+            ),
+            "a post-commit config timeout must preserve reset success, got {first:?}"
+        );
+
+        client
+            .send_prompt("after config timeout", &[])
+            .await
+            .expect("queue follow-up prompt");
+        let capture_deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let prompt_line = loop {
+            let wire = std::fs::read_to_string(&capture).expect("read capture");
+            if let Some(line) = wire
+                .lines()
+                .find(|line| line.contains("\"method\":\"session/prompt\""))
+            {
+                break line.to_string();
+            }
+            assert!(
+                std::time::Instant::now() < capture_deadline,
+                "connection loop did not process the follow-up prompt;\n{wire}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        };
+        assert!(
+            prompt_line.contains("\"sessionId\":\"sid-2\""),
+            "the follow-up prompt must use the committed fresh id: {prompt_line}"
+        );
+        let _ = client.shutdown().await;
+    }
+
     /// #2979: a clear command on a profile with no native agent-side reset
     /// (codex-acp swallows `/new` as an unknown command) must drive a REAL
     /// conversation reset on the live worker: a second `session/new` that
-    /// swaps the ACP session id, with `SessionContextReset` +
-    /// `AcpSessionAssigned` + a terminal `Stopped` emitted so the UI's
-    /// boundary bookkeeping and context tracker follow. The raw alias text
-    /// must NOT be forwarded as a `session/prompt`. (Baseline failure
+    /// swaps the ACP session id, with `SessionCleared` +
+    /// `SessionContextReset` + `AcpSessionAssigned` + a terminal `Stopped`
+    /// emitted so the UI's boundary bookkeeping and context tracker follow.
+    /// The raw alias text must NOT be forwarded as a `session/prompt`.
+    /// (Baseline failure
     /// before the fix: the text-forward path issued exactly one
     /// `session/new` and a `session/prompt` carrying "/new".)
     #[cfg(unix)]
     #[tokio::test]
     async fn codex_clear_drives_fresh_session_new_on_live_worker() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
-        let (script, capture) = write_reset_fake_agent(tmp.path(), 0);
+        let (script, capture) = write_reset_fake_agent(tmp.path(), 0, 0, 0);
         let mut config = reset_fake_spawn_config(&script, tmp.path());
         // A configured default effort must survive the reset: spawn applies
         // it after its session/new, and the driven reset must re-apply it
@@ -10777,9 +11099,9 @@ done
             .await
             .expect("spawn scripted fake agent");
 
-        // What the service now does for a codex `/new` after publishing the
-        // UserPromptSent + SessionCleared pair: drive the reset instead of
-        // forwarding the raw text.
+        // What the service now does for a codex `/new` after publishing
+        // UserPromptSent: drive the reset instead of forwarding the raw
+        // text. The successful reset itself emits SessionCleared.
         let outcome = client.reset_session("/new").await.expect("reset_session");
         match &outcome {
             ResetSessionOutcome::Reset { new_acp_session_id } => {
@@ -10793,8 +11115,8 @@ done
             }
         }
 
-        // The reset's event triple, in order: reset bookkeeping, then the
-        // fresh id, then the terminal Stopped that ends the clear turn.
+        // The reset's ordered boundary events: clear the transcript, reset
+        // bookkeeping, assign the fresh id, then end the synthetic turn.
         let mut events = Vec::new();
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
@@ -10808,6 +11130,10 @@ done
                 break;
             }
         }
+        let cleared_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::SessionCleared))
+            .expect("a successful driven reset must emit SessionCleared");
         let reset_pos = events
             .iter()
             .position(|e| matches!(e, Event::SessionContextReset { .. }))
@@ -10822,9 +11148,9 @@ done
             })
             .expect("reset must emit AcpSessionAssigned with the fresh id");
         assert!(
-            reset_pos < assigned_pos,
-            "SessionContextReset must precede AcpSessionAssigned so the \
-             stored id ends up as the fresh one, got {events:?}"
+            cleared_pos < reset_pos && reset_pos < assigned_pos,
+            "SessionCleared must precede SessionContextReset, which must \
+             precede AcpSessionAssigned, got {events:?}"
         );
         assert!(
             matches!(events.last(), Some(Event::Stopped { reason }) if reason == "session_reset"),
@@ -10881,15 +11207,15 @@ done
     /// be refused — resetting under the turn would orphan it on the old
     /// session id — and the refusal must mirror the busy-Prompt path's
     /// `PromptRejected` so a raw API caller gets a terminal frame (retry
-    /// pill) under the persisted UserPromptSent + divider, not just an
-    /// HTTP error.
+    /// pill) under the persisted UserPromptSent, not just an HTTP error.
+    /// The success-only `SessionCleared` boundary must remain absent.
     #[cfg(unix)]
     #[tokio::test]
     async fn reset_during_in_flight_prompt_is_refused_with_prompt_rejected() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         // 3s prompt delay: long enough to land the reset mid-turn, short
         // enough to keep the test snappy.
-        let (script, capture) = write_reset_fake_agent(tmp.path(), 3);
+        let (script, capture) = write_reset_fake_agent(tmp.path(), 3, 0, 0);
         let config = reset_fake_spawn_config(&script, tmp.path());
         let mut client = AcpClient::spawn(config, AcpSessionId("reset-busy-2979".into()))
             .await
@@ -10920,6 +11246,7 @@ done
         // The refusal emits PromptRejected(agent_busy) carrying the user's
         // clear invocation, then the in-flight turn still ends normally.
         let mut saw_rejected = false;
+        let mut saw_cleared = false;
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
             let ev = tokio::time::timeout_at(deadline, client.next_event())
@@ -10932,6 +11259,7 @@ done
                     assert_eq!(text, "/new", "the retry pill needs the typed alias");
                     saw_rejected = true;
                 }
+                Event::SessionCleared => saw_cleared = true,
                 Event::Stopped { .. } => break,
                 _ => {}
             }
@@ -10939,6 +11267,10 @@ done
         assert!(
             saw_rejected,
             "the mid-turn refusal must emit PromptRejected before the turn's Stopped"
+        );
+        assert!(
+            !saw_cleared,
+            "a busy reset must not emit the success-only SessionCleared boundary"
         );
 
         let wire = std::fs::read_to_string(&capture).expect("read capture");

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -451,8 +451,11 @@ enum ClientCmd {
     /// one, and emit `SessionContextReset` + `AcpSessionAssigned` + a
     /// terminal `Stopped` so bookkeeping and the UI follow. Issued by
     /// the supervisor when a clear command hits a profile whose adapter
-    /// has no native reset (codex `/new`). See #2979.
+    /// has no native reset (codex `/new`). `text` carries the user's
+    /// original clear invocation, used only by the mid-turn refusal's
+    /// `PromptRejected` so the retry pill shows what was typed. See #2979.
     ResetSession {
+        text: String,
         respond_to: oneshot::Sender<ResetSessionOutcome>,
     },
     Shutdown,
@@ -2085,7 +2088,7 @@ impl AcpClient {
                         let _ = respond_to.send(DeleteSessionOutcome::UnsupportedMethod);
                         "delete_session"
                     }
-                    ClientCmd::ResetSession { respond_to } => {
+                    ClientCmd::ResetSession { respond_to, .. } => {
                         let _ = respond_to.send(ResetSessionOutcome::Reset {
                             new_acp_session_id: "fresh-id".into(),
                         });
@@ -2772,9 +2775,11 @@ impl AcpClient {
     /// task issues a fresh `session/new`, swaps its ACP session id, and
     /// emits `SessionContextReset` + `AcpSessionAssigned` + a terminal
     /// `Stopped`. Used for clear commands whose adapter has no native
-    /// reset (codex `/new`, #2979). Bounded so a wedged adapter cannot
-    /// stall the prompt path; the timeout surfaces as a `Failed` outcome.
-    pub async fn reset_session(&self) -> Result<ResetSessionOutcome, AcpError> {
+    /// reset (codex `/new`, #2979). `text` is the user's clear invocation,
+    /// surfaced in the mid-turn refusal's `PromptRejected`. Bounded so a
+    /// wedged adapter cannot stall the prompt path; the timeout surfaces
+    /// as a `Failed` outcome.
+    pub async fn reset_session(&self, text: &str) -> Result<ResetSessionOutcome, AcpError> {
         let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
         let (tx, rx) = oneshot::channel();
         // Mirror `delete_session`: the guard wraps BOTH the cmd_tx send
@@ -2782,7 +2787,10 @@ impl AcpClient {
         // the caller indefinitely.
         let request = async {
             if cmd_tx
-                .send(ClientCmd::ResetSession { respond_to: tx })
+                .send(ClientCmd::ResetSession {
+                    text: text.to_string(),
+                    respond_to: tx,
+                })
                 .await
                 .is_err()
             {
@@ -7631,17 +7639,29 @@ async fn run_connection_task<W, R>(
                                                 break;
                                             }
                                         }
-                                        Some(ClientCmd::ResetSession { respond_to }) => {
+                                        Some(ClientCmd::ResetSession { text, respond_to }) => {
                                             // Resetting under an in-flight
                                             // `session/prompt` would orphan
                                             // the pending turn on the old
                                             // session id. Refuse; the user
                                             // can stop the turn and retry
-                                            // the clear. See #2979.
+                                            // the clear. Mirror the busy-
+                                            // Prompt arm above: emit a
+                                            // `PromptRejected` so the caller
+                                            // gets a terminal frame (retry
+                                            // pill) under the persisted
+                                            // UserPromptSent + divider, not
+                                            // just an HTTP error. See #2979.
                                             warn!(
                                                 target: "acp.protocol",
                                                 "conversation reset requested during in-flight prompt; refusing"
                                             );
+                                            let _ = event_tx_for_block
+                                                .send(Event::PromptRejected {
+                                                    reason: "agent_busy".into(),
+                                                    text,
+                                                })
+                                                .await;
                                             let _ = respond_to.send(ResetSessionOutcome::Failed {
                                                 message: "a turn is in flight; stop it before clearing the conversation"
                                                     .into(),
@@ -7842,7 +7862,7 @@ async fn run_connection_task<W, R>(
                             event_tx_for_block.clone(),
                         );
                     }
-                    Some(ClientCmd::ResetSession { respond_to }) => {
+                    Some(ClientCmd::ResetSession { text: _, respond_to }) => {
                         // Driven conversation reset (#2979): a clear command
                         // hit a profile whose adapter has no native reset
                         // (codex `/new`), so open a genuinely fresh session
@@ -7933,6 +7953,58 @@ async fn run_connection_task<W, R>(
                                     config_options_event(new_session.config_options.clone())
                                 {
                                     let _ = event_tx_for_block.send(event).await;
+                                }
+                                // Re-apply the configured structured-view
+                                // defaults exactly like the spawn path does
+                                // after its session/new: the fresh session
+                                // starts on adapter defaults, so a
+                                // configured effort/mode pick must be
+                                // re-sent or `/new` silently downgrades it
+                                // until the next worker restart. Best-effort
+                                // with a warn, mirroring spawn.
+                                let reset_config_options =
+                                    new_session.config_options.as_deref();
+                                for (value, config_id) in [
+                                    (
+                                        default_effort.as_deref(),
+                                        reset_config_options
+                                            .and_then(thought_level_config_id),
+                                    ),
+                                    (
+                                        default_mode.as_deref(),
+                                        reset_config_options.and_then(mode_config_id),
+                                    ),
+                                ] {
+                                    let (Some(value), Some(config_id)) = (value, config_id)
+                                    else {
+                                        continue;
+                                    };
+                                    match connection
+                                        .send_request(SetSessionConfigOptionRequest::new(
+                                            acp_session_id.clone(),
+                                            config_id,
+                                            SessionConfigValueId::new(value.to_string()),
+                                        ))
+                                        .block_task()
+                                        .await
+                                    {
+                                        Ok(resp) => {
+                                            if let Some(event) = config_options_event(Some(
+                                                resp.config_options,
+                                            )) {
+                                                let _ =
+                                                    event_tx_for_block.send(event).await;
+                                            }
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                target: "acp.protocol",
+                                                session = %session_label,
+                                                value,
+                                                "re-applying structured view default after reset failed: {e}"
+                                            );
+                                        }
+                                    }
                                 }
                                 let _ = event_tx_for_block
                                     .send(Event::Stopped {
@@ -10602,16 +10674,24 @@ mod tests {
 
     /// Write a scripted stdio ACP agent for the conversation-reset tests
     /// (#2979): answers `initialize`, mints `sid-1`, `sid-2`, ... on each
-    /// `session/new`, ends every `session/prompt` turn immediately, and
-    /// appends every inbound request line to the returned capture file so
-    /// the test can assert exactly which protocol requests were issued.
+    /// `session/new` (each carrying a `thought_level` config option so the
+    /// default-effort application path has a target), acks
+    /// `session/set_config_option`, and answers every `session/prompt`
+    /// with an `agent_message_chunk` notification, a `prompt_delay_secs`
+    /// pause (0 = immediate), then the turn-ending response. Appends every
+    /// inbound request line to the returned capture file so the test can
+    /// assert exactly which protocol requests were issued.
     #[cfg(unix)]
-    fn write_reset_fake_agent(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    fn write_reset_fake_agent(
+        dir: &std::path::Path,
+        prompt_delay_secs: u32,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
         use std::os::unix::fs::PermissionsExt;
         let capture = dir.join("capture.ndjson");
         let script_path = dir.join("fake-reset-agent.sh");
         let script = r#"#!/bin/sh
 CAPTURE=__CAPTURE__
+DELAY=__DELAY__
 count=0
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$CAPTURE"
@@ -10622,15 +10702,21 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/new"'*)
       count=$((count+1))
-      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"sid-%d"}}\n' "$id" "$count"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"sid-%d","configOptions":[{"id":"effort","name":"Reasoning Effort","category":"thought_level","type":"select","currentValue":"default","options":[{"value":"default","name":"Default"},{"value":"high","name":"High"}]}]}}\n' "$id" "$count"
+      ;;
+    *'"method":"session/set_config_option"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[]}}\n' "$id"
       ;;
     *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sid-%d","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working"}}}}\n' "$count"
+      if [ "$DELAY" -gt 0 ]; then sleep "$DELAY"; fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
       ;;
   esac
 done
 "#
-        .replace("__CAPTURE__", capture.to_str().expect("utf8 tmp path"));
+        .replace("__CAPTURE__", capture.to_str().expect("utf8 tmp path"))
+        .replace("__DELAY__", &prompt_delay_secs.to_string());
         std::fs::write(&script_path, script).expect("write fake agent script");
         std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
             .expect("chmod fake agent script");
@@ -10677,8 +10763,13 @@ done
     #[tokio::test]
     async fn codex_clear_drives_fresh_session_new_on_live_worker() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
-        let (script, capture) = write_reset_fake_agent(tmp.path());
-        let config = reset_fake_spawn_config(&script, tmp.path());
+        let (script, capture) = write_reset_fake_agent(tmp.path(), 0);
+        let mut config = reset_fake_spawn_config(&script, tmp.path());
+        // A configured default effort must survive the reset: spawn applies
+        // it after its session/new, and the driven reset must re-apply it
+        // after its own session/new (the fresh session starts on adapter
+        // defaults). See the maintainer's open question 2 in #2979.
+        config.default_effort = Some("high".into());
         let mut client = AcpClient::spawn(config, AcpSessionId("reset-2979".into()))
             .await
             .expect("spawn scripted fake agent");
@@ -10686,7 +10777,7 @@ done
         // What the service now does for a codex `/new` after publishing the
         // UserPromptSent + SessionCleared pair: drive the reset instead of
         // forwarding the raw text.
-        let outcome = client.reset_session().await.expect("reset_session");
+        let outcome = client.reset_session("/new").await.expect("reset_session");
         match &outcome {
             ResetSessionOutcome::Reset { new_acp_session_id } => {
                 assert_eq!(
@@ -10765,6 +10856,93 @@ done
         assert!(
             wire.contains("\"sessionId\":\"sid-2\""),
             "the follow-up prompt must address the swapped session id;\nwire capture:\n{wire}"
+        );
+        let effort_count = wire
+            .matches("\"method\":\"session/set_config_option\"")
+            .count();
+        assert_eq!(
+            effort_count, 2,
+            "the configured default effort must be re-applied after the \
+             reset's session/new, mirroring spawn (got {effort_count} \
+             session/set_config_option request(s));\nwire capture:\n{wire}"
+        );
+        assert_eq!(
+            wire.matches("\"value\":\"high\"").count(),
+            2,
+            "both applications must carry the configured effort value;\nwire capture:\n{wire}"
+        );
+        let _ = client.shutdown().await;
+    }
+
+    /// #2979: a reset requested while a `session/prompt` is in flight must
+    /// be refused — resetting under the turn would orphan it on the old
+    /// session id — and the refusal must mirror the busy-Prompt path's
+    /// `PromptRejected` so a raw API caller gets a terminal frame (retry
+    /// pill) under the persisted UserPromptSent + divider, not just an
+    /// HTTP error.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reset_during_in_flight_prompt_is_refused_with_prompt_rejected() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        // 3s prompt delay: long enough to land the reset mid-turn, short
+        // enough to keep the test snappy.
+        let (script, capture) = write_reset_fake_agent(tmp.path(), 3);
+        let config = reset_fake_spawn_config(&script, tmp.path());
+        let mut client = AcpClient::spawn(config, AcpSessionId("reset-busy-2979".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        client.send_prompt("hello", &[]).await.expect("send prompt");
+        // The fake emits an agent_message_chunk as soon as it receives the
+        // prompt; seeing it proves the connection task is inside the
+        // in-flight select, so the reset below cannot race into the idle
+        // loop and spuriously succeed.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let ev = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for the turn to start")
+                .expect("event channel closed");
+            if matches!(&ev, Event::AgentMessageChunk { .. }) {
+                break;
+            }
+        }
+
+        let outcome = client.reset_session("/new").await.expect("reset_session");
+        assert!(
+            matches!(&outcome, ResetSessionOutcome::Failed { message } if message.contains("turn is in flight")),
+            "a mid-turn reset must be refused, got {outcome:?}"
+        );
+
+        // The refusal emits PromptRejected(agent_busy) carrying the user's
+        // clear invocation, then the in-flight turn still ends normally.
+        let mut saw_rejected = false;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let ev = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for PromptRejected + Stopped")
+                .expect("event channel closed");
+            match &ev {
+                Event::PromptRejected { reason, text } => {
+                    assert_eq!(reason, "agent_busy");
+                    assert_eq!(text, "/new", "the retry pill needs the typed alias");
+                    saw_rejected = true;
+                }
+                Event::Stopped { .. } => break,
+                _ => {}
+            }
+        }
+        assert!(
+            saw_rejected,
+            "the mid-turn refusal must emit PromptRejected before the turn's Stopped"
+        );
+
+        let wire = std::fs::read_to_string(&capture).expect("read capture");
+        assert_eq!(
+            wire.matches("\"method\":\"session/new\"").count(),
+            1,
+            "a refused reset must not have issued a second session/new;\nwire capture:\n{wire}"
         );
         let _ = client.shutdown().await;
     }

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -107,6 +107,11 @@ pub enum AcpError {
     /// answer and resubmit (rather than the question aborting). See #2100.
     #[error("submitted answer is invalid: {0}")]
     InvalidAnswer(String),
+    /// A driven conversation reset (`session/new` on the live worker for
+    /// a clear command with no native adapter reset, #2979) failed; the
+    /// conversation keeps its prior context.
+    #[error("conversation reset failed: {0}")]
+    ResetFailed(String),
 }
 
 /// Boxed payload for `AcpError::IncompatibleAgent`. Carries the
@@ -328,6 +333,12 @@ const ACP_DELETE_ERROR_MSG_MAX: usize = 256;
 /// cleanup with no operator-visible failure mode.
 const ACP_SESSION_DELETE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Hard cap on a driven conversation reset's `session/new` round-trip
+/// (#2979). A fresh session on a live, already-initialized adapter
+/// normally answers in well under a second; the timeout keeps a wedged
+/// adapter from stalling the prompt path that requested the reset.
+const SESSION_RESET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Configuration for spawning an ACP agent.
 #[derive(Debug, Clone)]
 pub struct SpawnConfig {
@@ -435,7 +446,28 @@ enum ClientCmd {
         acp_session_id: String,
         respond_to: oneshot::Sender<DeleteSessionOutcome>,
     },
+    /// Drive a real conversation reset: issue a fresh `session/new` on
+    /// the live connection, swap the task's ACP session id to the new
+    /// one, and emit `SessionContextReset` + `AcpSessionAssigned` + a
+    /// terminal `Stopped` so bookkeeping and the UI follow. Issued by
+    /// the supervisor when a clear command hits a profile whose adapter
+    /// has no native reset (codex `/new`). See #2979.
+    ResetSession {
+        respond_to: oneshot::Sender<ResetSessionOutcome>,
+    },
     Shutdown,
+}
+
+/// Outcome of a driven conversation reset (`ClientCmd::ResetSession`).
+#[derive(Debug)]
+pub enum ResetSessionOutcome {
+    /// `session/new` succeeded and the connection task swapped its ACP
+    /// session id; carries the fresh id for logging.
+    Reset { new_acp_session_id: String },
+    /// The reset did not happen: `session/new` failed, timed out, a turn
+    /// was in flight, or a stale runner replayed the old session from its
+    /// handshake cache. The conversation keeps its context.
+    Failed { message: String },
 }
 
 /// How the connection task should handle the ACP handshake against the
@@ -2023,6 +2055,57 @@ impl AcpClient {
         (client, event_tx, saw_delete)
     }
 
+    /// Like `fake_for_test`, but wires a live `cmd_tx` whose consumer
+    /// records the name of every command received (in order) and answers
+    /// the request/response-shaped ones so callers don't park on their
+    /// oneshot: `ResetSession` gets a successful `Reset` outcome carrying
+    /// `"fresh-id"`, `DeleteSession` an `UnsupportedMethod`. Used to
+    /// assert supervisor-level command routing (#2979).
+    #[cfg(test)]
+    pub fn fake_for_test_cmd_recording(
+        session_id: AcpSessionId,
+    ) -> (
+        Self,
+        mpsc::Sender<Event>,
+        std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    ) {
+        let (event_tx, event_rx) = mpsc::channel(64);
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<ClientCmd>(16);
+        let cmds = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let cmds_task = cmds.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                let name = match cmd {
+                    ClientCmd::Prompt(_) => "prompt",
+                    ClientCmd::Cancel => "cancel",
+                    ClientCmd::ForceStop => "force_stop",
+                    ClientCmd::SetMode(_) => "set_mode",
+                    ClientCmd::SetConfigOption { .. } => "set_config_option",
+                    ClientCmd::DeleteSession { respond_to, .. } => {
+                        let _ = respond_to.send(DeleteSessionOutcome::UnsupportedMethod);
+                        "delete_session"
+                    }
+                    ClientCmd::ResetSession { respond_to } => {
+                        let _ = respond_to.send(ResetSessionOutcome::Reset {
+                            new_acp_session_id: "fresh-id".into(),
+                        });
+                        "reset_session"
+                    }
+                    ClientCmd::Shutdown => "shutdown",
+                };
+                cmds_task.lock().expect("cmd record mutex").push(name);
+            }
+        });
+        let client = Self {
+            session_id,
+            inbound: Some(event_rx),
+            cmd_tx: Some(cmd_tx),
+            pending_responders: Arc::new(Mutex::new(HashMap::new())),
+            _child: None,
+        };
+        (client, event_tx, cmds)
+    }
+
     /// Spawn an ACP agent subprocess, run the handshake + create a
     /// session, and start pumping notifications into the inbound channel.
     pub async fn spawn(config: SpawnConfig, session_id: AcpSessionId) -> Result<Self, AcpError> {
@@ -2682,6 +2765,46 @@ impl AcpClient {
         {
             Ok(outcome) => outcome,
             Err(_) => DeleteSessionOutcome::TimedOut,
+        }
+    }
+
+    /// Drive a real conversation reset on the live worker: the connection
+    /// task issues a fresh `session/new`, swaps its ACP session id, and
+    /// emits `SessionContextReset` + `AcpSessionAssigned` + a terminal
+    /// `Stopped`. Used for clear commands whose adapter has no native
+    /// reset (codex `/new`, #2979). Bounded so a wedged adapter cannot
+    /// stall the prompt path; the timeout surfaces as a `Failed` outcome.
+    pub async fn reset_session(&self) -> Result<ResetSessionOutcome, AcpError> {
+        let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
+        let (tx, rx) = oneshot::channel();
+        // Mirror `delete_session`: the guard wraps BOTH the cmd_tx send
+        // and the response wait so a wedged connection task cannot park
+        // the caller indefinitely.
+        let request = async {
+            if cmd_tx
+                .send(ClientCmd::ResetSession { respond_to: tx })
+                .await
+                .is_err()
+            {
+                return ResetSessionOutcome::Failed {
+                    message: "connect task gone".into(),
+                };
+            }
+            match rx.await {
+                Ok(outcome) => outcome,
+                Err(_) => ResetSessionOutcome::Failed {
+                    message: "respond channel closed".into(),
+                },
+            }
+        };
+        match tokio::time::timeout(SESSION_RESET_TIMEOUT, request).await {
+            Ok(outcome) => Ok(outcome),
+            Err(_) => Ok(ResetSessionOutcome::Failed {
+                message: format!(
+                    "agent did not answer session/new within {}s",
+                    SESSION_RESET_TIMEOUT.as_secs()
+                ),
+            }),
         }
     }
 
@@ -6255,8 +6378,16 @@ async fn run_connection_task<W, R>(
                 &init.agent_capabilities.mcp_capabilities,
                 &session_label,
             );
+            // Kept for the driven conversation reset (#2979): the handshake
+            // below consumes `mcp_servers`, but a later `session/new` issued
+            // for a clear command must forward the same gated list.
+            let mcp_servers_for_reset = mcp_servers.clone();
 
-            let acp_session_id: SessionId = match mode {
+            // Mutable: a driven conversation reset (#2979) swaps in the
+            // fresh id from its `session/new` so every later
+            // `session/prompt` / cancel / mode switch addresses the new
+            // conversation.
+            let mut acp_session_id: SessionId = match mode {
                 ConnectMode::Resume {
                     acp_session_id: stored,
                     in_flight_turn: _,
@@ -7500,6 +7631,22 @@ async fn run_connection_task<W, R>(
                                                 break;
                                             }
                                         }
+                                        Some(ClientCmd::ResetSession { respond_to }) => {
+                                            // Resetting under an in-flight
+                                            // `session/prompt` would orphan
+                                            // the pending turn on the old
+                                            // session id. Refuse; the user
+                                            // can stop the turn and retry
+                                            // the clear. See #2979.
+                                            warn!(
+                                                target: "acp.protocol",
+                                                "conversation reset requested during in-flight prompt; refusing"
+                                            );
+                                            let _ = respond_to.send(ResetSessionOutcome::Failed {
+                                                message: "a turn is in flight; stop it before clearing the conversation"
+                                                    .into(),
+                                            });
+                                        }
                                         Some(ClientCmd::Shutdown) | None => {
                                             info!(
                                                 target: "acp.protocol",
@@ -7694,6 +7841,157 @@ async fn run_connection_task<W, R>(
                             ConfigOptionDispatchPurpose::Generic,
                             event_tx_for_block.clone(),
                         );
+                    }
+                    Some(ClientCmd::ResetSession { respond_to }) => {
+                        // Driven conversation reset (#2979): a clear command
+                        // hit a profile whose adapter has no native reset
+                        // (codex `/new`), so open a genuinely fresh session
+                        // on the live worker and swap onto its id.
+                        //
+                        // Deliberately over the byte relay, NOT the v2
+                        // control channel: the runner's `EstablishSession`
+                        // replays its cached handshake once a session
+                        // exists, which would hand back the old id. The
+                        // relay request reaches the agent directly; the
+                        // runner watches for it and refreshes its own
+                        // handshake cache from the response (see
+                        // `process/runner.rs`).
+                        info!(
+                            target: "acp.protocol",
+                            session = %session_label,
+                            old_id = %acp_session_id.0,
+                            "conversation reset: issuing fresh session/new on the live worker"
+                        );
+                        let req = NewSessionRequest::new(agent_cwd.clone())
+                            .mcp_servers(mcp_servers_for_reset.clone());
+                        match connection.send_request(req).block_task().await {
+                            Ok(new_session)
+                                if new_session.session_id.0 != acp_session_id.0 =>
+                            {
+                                let new_id = new_session.session_id.clone();
+                                acp_session_id = new_id.clone();
+                                info!(
+                                    target: "acp.protocol",
+                                    session = %session_label,
+                                    new_id = %new_id.0,
+                                    "conversation reset: session/new succeeded, swapped acp_session_id"
+                                );
+                                // Ordering matters: `SessionContextReset`
+                                // first (listeners null the stored resume id
+                                // and drop fork/import markers), then
+                                // `AcpSessionAssigned` persists the fresh id
+                                // on top, then a terminal `Stopped` ends the
+                                // clear command's synthetic turn so the
+                                // composer unlocks.
+                                let _ = event_tx_for_block
+                                    .send(Event::SessionContextReset {
+                                        reason: "conversation cleared; the agent started a fresh session".into(),
+                                    })
+                                    .await;
+                                let _ = event_tx_for_block
+                                    .send(Event::AcpSessionAssigned {
+                                        acp_session_id: new_id.0.to_string(),
+                                    })
+                                    .await;
+                                // Re-announce the fresh session's modes and
+                                // config options (mirroring the handshake):
+                                // the new session starts on adapter defaults,
+                                // so the old session's picker state is stale.
+                                if let Some(modes) = &new_session.modes {
+                                    available_mode_ids = Some(
+                                        modes
+                                            .available_modes
+                                            .iter()
+                                            .map(|m| m.id.0.to_string())
+                                            .collect(),
+                                    );
+                                    let infos: Vec<ModeInfo> = modes
+                                        .available_modes
+                                        .iter()
+                                        .map(|m| ModeInfo {
+                                            id: m.id.0.to_string(),
+                                            name: m.name.clone(),
+                                            description: m.description.clone(),
+                                        })
+                                        .collect();
+                                    let _ = event_tx_for_block
+                                        .send(Event::ModesAvailable {
+                                            current_mode_id: modes
+                                                .current_mode_id
+                                                .0
+                                                .to_string(),
+                                            modes: infos,
+                                        })
+                                        .await;
+                                }
+                                mode_config_option_id = new_session
+                                    .config_options
+                                    .as_deref()
+                                    .and_then(mode_config_id)
+                                    .map(|id| id.0.to_string());
+                                if let Some(event) =
+                                    config_options_event(new_session.config_options.clone())
+                                {
+                                    let _ = event_tx_for_block.send(event).await;
+                                }
+                                let _ = event_tx_for_block
+                                    .send(Event::Stopped {
+                                        reason: "session_reset".into(),
+                                    })
+                                    .await;
+                                let _ = respond_to.send(ResetSessionOutcome::Reset {
+                                    new_acp_session_id: new_id.0.to_string(),
+                                });
+                            }
+                            Ok(_) => {
+                                // Same id back: a stale runner (predating
+                                // this reset path) answered the relay
+                                // session/new from its handshake cache.
+                                // Report honestly rather than pretending the
+                                // model forgot; a worker restart clears it.
+                                let message = "the worker replayed the existing session \
+                                     instead of creating a fresh one; restart the \
+                                     structured view worker to clear context"
+                                    .to_string();
+                                warn!(
+                                    target: "acp.protocol",
+                                    session = %session_label,
+                                    "conversation reset failed: {message}"
+                                );
+                                let _ = event_tx_for_block
+                                    .send(Event::PromptRuntimeError {
+                                        message: message.clone(),
+                                    })
+                                    .await;
+                                let _ = event_tx_for_block
+                                    .send(Event::Stopped {
+                                        reason: "session_reset_failed".into(),
+                                    })
+                                    .await;
+                                let _ = respond_to
+                                    .send(ResetSessionOutcome::Failed { message });
+                            }
+                            Err(e) => {
+                                let message = format!("session/new failed: {e}");
+                                warn!(
+                                    target: "acp.protocol",
+                                    session = %session_label,
+                                    "conversation reset failed: {message}"
+                                );
+                                let _ = event_tx_for_block
+                                    .send(Event::PromptRuntimeError {
+                                        message: message.clone(),
+                                    })
+                                    .await;
+                                let _ = event_tx_for_block
+                                    .send(Event::Stopped {
+                                        reason: "session_reset_failed".into(),
+                                    })
+                                    .await;
+                                let _ = respond_to
+                                    .send(ResetSessionOutcome::Failed { message });
+                            }
+                        }
                     }
                     Some(ClientCmd::Shutdown) | None => {
                         info!(target: "acp.protocol", "shutdown received, exiting connection loop");
@@ -10300,6 +10598,175 @@ mod tests {
                 .any(|(k, _)| k == "CLAUDE_CONFIG_DIR"),
             "CLAUDE_CONFIG_DIR must not land in inherit_env"
         );
+    }
+
+    /// Write a scripted stdio ACP agent for the conversation-reset tests
+    /// (#2979): answers `initialize`, mints `sid-1`, `sid-2`, ... on each
+    /// `session/new`, ends every `session/prompt` turn immediately, and
+    /// appends every inbound request line to the returned capture file so
+    /// the test can assert exactly which protocol requests were issued.
+    #[cfg(unix)]
+    fn write_reset_fake_agent(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+        let capture = dir.join("capture.ndjson");
+        let script_path = dir.join("fake-reset-agent.sh");
+        let script = r#"#!/bin/sh
+CAPTURE=__CAPTURE__
+count=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$CAPTURE"
+  id=$(printf '%s' "$line" | sed -En 's/.*"id":("[^"]*"|[0-9]+).*/\1/p')
+  case $line in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":false}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      count=$((count+1))
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"sid-%d"}}\n' "$id" "$count"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      ;;
+  esac
+done
+"#
+        .replace("__CAPTURE__", capture.to_str().expect("utf8 tmp path"));
+        std::fs::write(&script_path, script).expect("write fake agent script");
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake agent script");
+        (script_path, capture)
+    }
+
+    #[cfg(unix)]
+    fn reset_fake_spawn_config(script: &std::path::Path, cwd: &std::path::Path) -> SpawnConfig {
+        SpawnConfig {
+            agent_key: "codex".into(),
+            spec: AgentSpec {
+                command: script.to_string_lossy().into_owned(),
+                args: vec![],
+                description: "scripted reset fake".into(),
+                env_allowlist: None,
+            },
+            cwd: cwd.to_path_buf(),
+            additional_dirs: vec![],
+            provider_env: vec![],
+            host_environment: vec![],
+            default_effort: None,
+            default_mode: None,
+            socket_path: None,
+            stored_acp_session_id: None,
+            fork_from: None,
+            seed_history_replay: false,
+            artifact_dir: None,
+            sandbox_info: None,
+            source_profile: None,
+            mcp_servers: Vec::new(),
+        }
+    }
+
+    /// #2979: a clear command on a profile with no native agent-side reset
+    /// (codex-acp swallows `/new` as an unknown command) must drive a REAL
+    /// conversation reset on the live worker: a second `session/new` that
+    /// swaps the ACP session id, with `SessionContextReset` +
+    /// `AcpSessionAssigned` + a terminal `Stopped` emitted so the UI's
+    /// boundary bookkeeping and context tracker follow. The raw alias text
+    /// must NOT be forwarded as a `session/prompt`. (Baseline failure
+    /// before the fix: the text-forward path issued exactly one
+    /// `session/new` and a `session/prompt` carrying "/new".)
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codex_clear_drives_fresh_session_new_on_live_worker() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let (script, capture) = write_reset_fake_agent(tmp.path());
+        let config = reset_fake_spawn_config(&script, tmp.path());
+        let mut client = AcpClient::spawn(config, AcpSessionId("reset-2979".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        // What the service now does for a codex `/new` after publishing the
+        // UserPromptSent + SessionCleared pair: drive the reset instead of
+        // forwarding the raw text.
+        let outcome = client.reset_session().await.expect("reset_session");
+        match &outcome {
+            ResetSessionOutcome::Reset { new_acp_session_id } => {
+                assert_eq!(
+                    new_acp_session_id, "sid-2",
+                    "the reset must swap onto the fresh session id"
+                );
+            }
+            ResetSessionOutcome::Failed { message } => {
+                panic!("reset must succeed against a live agent: {message}")
+            }
+        }
+
+        // The reset's event triple, in order: reset bookkeeping, then the
+        // fresh id, then the terminal Stopped that ends the clear turn.
+        let mut events = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let ev = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for reset events")
+                .expect("event channel closed");
+            let stop = matches!(&ev, Event::Stopped { .. });
+            events.push(ev);
+            if stop {
+                break;
+            }
+        }
+        let reset_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::SessionContextReset { .. }))
+            .expect("reset must emit SessionContextReset");
+        let assigned_pos = events
+            .iter()
+            .position(|e| {
+                matches!(
+                    e,
+                    Event::AcpSessionAssigned { acp_session_id } if acp_session_id == "sid-2"
+                )
+            })
+            .expect("reset must emit AcpSessionAssigned with the fresh id");
+        assert!(
+            reset_pos < assigned_pos,
+            "SessionContextReset must precede AcpSessionAssigned so the \
+             stored id ends up as the fresh one, got {events:?}"
+        );
+        assert!(
+            matches!(events.last(), Some(Event::Stopped { reason }) if reason == "session_reset"),
+            "the reset must end the clear turn with Stopped(session_reset), got {events:?}"
+        );
+
+        // A follow-up prompt must address the NEW session id.
+        client.send_prompt("hello", &[]).await.expect("send prompt");
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let ev = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for follow-up turn to end")
+                .expect("event channel closed");
+            if matches!(&ev, Event::Stopped { .. }) {
+                break;
+            }
+        }
+
+        let wire = std::fs::read_to_string(&capture).expect("read capture");
+        let new_count = wire.matches("\"method\":\"session/new\"").count();
+        assert_eq!(
+            new_count, 2,
+            "a codex clear must issue a fresh session/new on the live worker \
+             (got {new_count} session/new request(s));\nwire capture:\n{wire}"
+        );
+        assert!(
+            !wire.contains("\"text\":\"/new\""),
+            "the raw clear alias must not be forwarded as a session/prompt \
+             (codex-acp would swallow it as an unknown command);\nwire capture:\n{wire}"
+        );
+        assert!(
+            wire.contains("\"sessionId\":\"sid-2\""),
+            "the follow-up prompt must address the swapped session id;\nwire capture:\n{wire}"
+        );
+        let _ = client.shutdown().await;
     }
 
     #[tokio::test]

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -7977,6 +7977,9 @@ async fn run_connection_task<W, R>(
                                 ] {
                                     let (Some(value), Some(config_id)) = (value, config_id)
                                     else {
+                                        debug!(
+                                            "post-reset config option skipped: no configured value or matching option id"
+                                        );
                                         continue;
                                     };
                                     match connection

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -1385,6 +1385,36 @@ fn between_prompt_signal_update(
     update
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BetweenPromptWorkState {
+    tool_calls: bool,
+    background_agents: bool,
+}
+
+impl BetweenPromptWorkState {
+    fn is_busy(self) -> bool {
+        self.tool_calls || self.background_agents
+    }
+}
+
+fn between_prompt_work_state(
+    tools: &std::sync::Mutex<std::collections::HashMap<String, bool>>,
+    background_agents: &std::sync::Mutex<std::collections::HashSet<String>>,
+) -> BetweenPromptWorkState {
+    let tool_calls = !tools
+        .lock()
+        .expect("between-prompt tools mutex poisoned")
+        .is_empty();
+    let background_agents = !background_agents
+        .lock()
+        .expect("between-prompt bg-agents mutex poisoned")
+        .is_empty();
+    BetweenPromptWorkState {
+        tool_calls,
+        background_agents,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn between_prompt_should_fire(
     active: bool,
@@ -7125,18 +7155,14 @@ async fn run_connection_task<W, R>(
                             0 => None,
                             at => Some(at),
                         };
-                        let tools_in_flight = !between_prompt_tools
-                            .lock()
-                            .expect("between-prompt tools mutex poisoned")
-                            .is_empty();
                         // A tracked async background agent still running is
                         // work in flight just like an open tool: suppress the
                         // idle watchdog until its tailer reports terminal and
                         // removes it from the set. See #2573.
-                        let bg_agents_in_flight = !between_prompt_bg_agents
-                            .lock()
-                            .expect("between-prompt bg-agents mutex poisoned")
-                            .is_empty();
+                        let work_in_flight = between_prompt_work_state(
+                            &between_prompt_tools,
+                            &between_prompt_bg_agents,
+                        );
                         let cost_seen = between_prompt_cost_seen.load(Ordering::Relaxed);
                         if between_prompt_should_fire(
                             between_prompt_active.load(Ordering::Relaxed),
@@ -7144,7 +7170,7 @@ async fn run_connection_task<W, R>(
                             last_lifecycle_at.load(Ordering::Relaxed),
                             wake_at,
                             cost_seen,
-                            tools_in_flight || bg_agents_in_flight,
+                            work_in_flight.is_busy(),
                             between_prompt_off_protocol.load(Ordering::Relaxed),
                             BETWEEN_PROMPT_IDLE_GRACE,
                             OFF_PROTOCOL_WORK_GRACE_FLOOR,
@@ -7976,10 +8002,39 @@ async fn run_connection_task<W, R>(
                         );
                     }
                     Some(ClientCmd::ResetSession {
-                        text: _,
+                        text,
                         deadline: reset_deadline,
                         respond_to,
                     }) => {
+                        let work_in_flight = between_prompt_work_state(
+                            &between_prompt_tools,
+                            &between_prompt_bg_agents,
+                        );
+                        if work_in_flight.is_busy() {
+                            // The parent prompt may already be complete while an
+                            // open tool or async sub-agent from that session is
+                            // still producing events. Resetting here would move
+                            // the connection onto a fresh session and attribute
+                            // those old-session events to the new conversation.
+                            warn!(
+                                target: "acp.protocol",
+                                tool_calls_in_flight = work_in_flight.tool_calls,
+                                background_agents_in_flight = work_in_flight.background_agents,
+                                "conversation reset requested while between-prompt work is in flight; refusing"
+                            );
+                            let _ = event_tx_for_block
+                                .send(Event::PromptRejected {
+                                    reason: "agent_busy".into(),
+                                    text,
+                                })
+                                .await;
+                            let _ = respond_to.send(ResetSessionOutcome::Failed {
+                                message:
+                                    "agent work is still in flight; wait for it to finish before clearing the conversation"
+                                        .into(),
+                            });
+                            continue;
+                        }
                         // Driven conversation reset (#2979): a clear command
                         // hit a profile whose adapter has no native reset
                         // (codex `/new`), so open a genuinely fresh session
@@ -10871,9 +10926,44 @@ mod tests {
         reset_new_delay_secs: u32,
         reset_config_delay_secs: u32,
     ) -> (std::path::PathBuf, std::path::PathBuf) {
+        write_reset_fake_agent_with_initial_update(
+            dir,
+            prompt_delay_secs,
+            reset_new_delay_secs,
+            reset_config_delay_secs,
+            None,
+        )
+    }
+
+    /// Variant that emits one unsolicited update immediately after the
+    /// initial `session/new`. This reproduces between-prompt work without
+    /// reaching into the connection task's private tracking state.
+    #[cfg(unix)]
+    fn write_reset_fake_agent_with_initial_update(
+        dir: &std::path::Path,
+        prompt_delay_secs: u32,
+        reset_new_delay_secs: u32,
+        reset_config_delay_secs: u32,
+        initial_update: Option<serde_json::Value>,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
         use std::os::unix::fs::PermissionsExt;
         let capture = dir.join("capture.ndjson");
         let script_path = dir.join("fake-reset-agent.sh");
+        let initial_notification = initial_update
+            .map(|update| {
+                let payload = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": "sid-1",
+                        "update": update,
+                    },
+                })
+                .to_string();
+                let shell_quoted = format!("'{}'", payload.replace('\'', "'\"'\"'"));
+                format!("if [ \"$count\" -eq 1 ]; then printf '%s\\n' {shell_quoted}; fi")
+            })
+            .unwrap_or_else(|| ":".into());
         let script = r#"#!/bin/sh
 CAPTURE=__CAPTURE__
 DELAY=__DELAY__
@@ -10892,6 +10982,7 @@ while IFS= read -r line; do
       count=$((count+1))
       if [ "$count" -eq 2 ] && [ "$RESET_NEW_DELAY" -gt 0 ]; then sleep "$RESET_NEW_DELAY"; fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"sid-%d","configOptions":[{"id":"effort","name":"Reasoning Effort","category":"thought_level","type":"select","currentValue":"default","options":[{"value":"default","name":"Default"},{"value":"high","name":"High"}]}]}}\n' "$id" "$count"
+      __INITIAL_NOTIFICATION__
       ;;
     *'"method":"session/set_config_option"'*)
       config_count=$((config_count+1))
@@ -10909,6 +11000,7 @@ done
         .replace("__CAPTURE__", capture.to_str().expect("utf8 tmp path"))
         .replace("__DELAY__", &prompt_delay_secs.to_string())
         .replace("__RESET_NEW_DELAY__", &reset_new_delay_secs.to_string())
+        .replace("__INITIAL_NOTIFICATION__", &initial_notification)
         .replace(
             "__RESET_CONFIG_DELAY__",
             &reset_config_delay_secs.to_string(),
@@ -10938,6 +11030,48 @@ done
             .await
             .expect("connection task must answer the reset")
             .expect("reset response channel open")
+    }
+
+    #[cfg(unix)]
+    async fn assert_between_prompt_reset_refused(
+        client: &mut AcpClient,
+        capture: &std::path::Path,
+    ) {
+        let outcome = client.reset_session("/new").await.expect("reset_session");
+        assert!(
+            matches!(
+                &outcome,
+                ResetSessionOutcome::Failed { message }
+                    if message.contains("agent work is still in flight")
+            ),
+            "between-prompt work must block a reset, got {outcome:?}"
+        );
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let event = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for reset refusal")
+                .expect("event channel closed");
+            match event {
+                Event::PromptRejected { reason, text } => {
+                    assert_eq!(reason, "agent_busy");
+                    assert_eq!(text, "/new");
+                    break;
+                }
+                Event::SessionCleared => {
+                    panic!("a refused between-prompt reset must not emit SessionCleared")
+                }
+                _ => {}
+            }
+        }
+
+        let wire = std::fs::read_to_string(capture).expect("read capture");
+        assert_eq!(
+            wire.matches("\"method\":\"session/new\"").count(),
+            1,
+            "a refused reset must not issue a second session/new;\nwire capture:\n{wire}"
+        );
     }
 
     #[cfg(unix)]
@@ -11001,6 +11135,99 @@ done
             matches!(valid, ResetSessionOutcome::Reset { .. }),
             "the loop must continue after rejecting the expired command"
         );
+        let _ = client.shutdown().await;
+    }
+
+    /// An ACP tool can remain open after its parent prompt has returned.
+    /// Resetting while that tool is still producing events would attach its
+    /// old-session updates to the fresh conversation.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reset_between_prompts_with_open_tool_is_refused() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let initial_update = serde_json::json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "between-prompt-tool",
+            "title": "long-running tool",
+            "kind": "other",
+            "status": "in_progress",
+            "rawInput": {},
+        });
+        let (script, capture) =
+            write_reset_fake_agent_with_initial_update(tmp.path(), 0, 0, 0, Some(initial_update));
+        let config = reset_fake_spawn_config(&script, tmp.path());
+        let mut client = AcpClient::spawn(config, AcpSessionId("reset-open-tool".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let event = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for open tool")
+                .expect("event channel closed");
+            if matches!(
+                event,
+                Event::ToolCallStarted { ref tool_call }
+                    if tool_call.id == "between-prompt-tool"
+            ) {
+                break;
+            }
+        }
+
+        assert_between_prompt_reset_refused(&mut client, &capture).await;
+        let _ = client.shutdown().await;
+    }
+
+    /// A tracked async sub-agent outlives its parent prompt. Its tailer keeps
+    /// publishing progress and completion, so a reset must wait until that
+    /// tailer removes the agent from the between-prompt in-flight set.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reset_between_prompts_with_background_agent_is_refused() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let transcript = tmp.path().join("background-agent.jsonl");
+        std::fs::write(&transcript, "").expect("create background-agent transcript");
+        let initial_update = serde_json::json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "between-prompt-agent-tool",
+            "_meta": {
+                "claudeCode": {
+                    "toolName": "Agent",
+                    "toolResponse": {
+                        "agentId": "between-prompt-agent",
+                        "description": "keep working after the parent turn",
+                        "prompt": "continue the delegated task",
+                        "resolvedModel": "test-model",
+                        "outputFile": transcript.to_str().expect("utf8 transcript path"),
+                        "status": "async_launched",
+                    },
+                },
+            },
+        });
+        let (script, capture) =
+            write_reset_fake_agent_with_initial_update(tmp.path(), 0, 0, 0, Some(initial_update));
+        let config = reset_fake_spawn_config(&script, tmp.path());
+        let mut client = AcpClient::spawn(config, AcpSessionId("reset-background-agent".into()))
+            .await
+            .expect("spawn scripted fake agent");
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let event = tokio::time::timeout_at(deadline, client.next_event())
+                .await
+                .expect("timed out waiting for background-agent launch")
+                .expect("event channel closed");
+            if matches!(
+                event,
+                Event::BackgroundAgentLaunched { ref agent_id, .. }
+                    if agent_id == "between-prompt-agent"
+            ) {
+                break;
+            }
+        }
+
+        assert_between_prompt_reset_refused(&mut client, &capture).await;
         let _ = client.shutdown().await;
     }
 
@@ -11235,8 +11462,8 @@ done
     }
 
     /// #2979: a reset requested while a `session/prompt` is in flight must
-    /// be refused — resetting under the turn would orphan it on the old
-    /// session id — and the refusal must mirror the busy-Prompt path's
+    /// be refused because resetting under the turn would orphan it on the old
+    /// session id. The refusal must mirror the busy-Prompt path's
     /// `PromptRejected` so a raw API caller gets a terminal frame (retry
     /// pill) under the persisted UserPromptSent, not just an HTTP error.
     /// The success-only `SessionCleared` boundary must remain absent.

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -32,12 +32,12 @@ pub struct AgentProfile {
     /// When true, the adapter has no native handler for this profile's
     /// clear aliases: forwarding the raw text would be swallowed as an
     /// unknown command and the conversation would keep its full context
-    /// (codex-acp has no `/new`; upstream declined to add one in
-    /// codex-acp#317). The server must drive the reset itself by opening a
-    /// fresh `session/new` on the live worker and swapping the ACP session id,
-    /// instead of forwarding the prompt. False for claude-agent-acp,
-    /// which implements `/clear` locally, so Claude keeps the
-    /// text-forward path. See #2979.
+    /// (codex-acp has no `/new`; adding one was declined in the upstream
+    /// codex-acp issue `#317`). The server must drive the reset itself by
+    /// opening a fresh `session/new` on the live worker and swapping the
+    /// ACP session id, instead of forwarding the prompt. False for
+    /// claude-agent-acp, which implements `/clear` locally, so Claude
+    /// keeps the text-forward path. See #2979.
     pub clear_requires_driven_reset: bool,
     /// When true, the server synthesises a `PlanUpdated` event from a
     /// `kind: switch_mode` tool call (Claude's ExitPlanMode shape).
@@ -148,7 +148,8 @@ pub const CODEX: AgentProfile = AgentProfile {
     clear_aliases: &["/new"],
     // codex-acp advertises no `new`/`clear`/reset command; a forwarded
     // `/new` is answered with "unknown command" and the conversation
-    // keeps its context (upstream codex-acp#317 declined to add one).
+    // keeps its context (adding one was declined in the upstream
+    // codex-acp issue `#317`).
     // The supervisor must drive the reset via `session/new`. See #2979.
     clear_requires_driven_reset: true,
     supports_exit_plan_mode: false,
@@ -405,12 +406,12 @@ mod tests {
         assert!(!OMP.is_clear_command("/clear"));
     }
 
-    /// #2979: only codex needs the server-driven reset because codex-acp has no
-    /// native `/new` (upstream codex-acp#317), so the text-forward path
-    /// silently keeps the conversation's context. Claude's `/clear` is
-    /// handled by its adapter and must stay on the forward path; the
-    /// other `/new` mappings (opencode, omp, kimi) are unverified and
-    /// deliberately keep the old behavior until observed.
+    /// #2979: only codex needs the server-driven reset because codex-acp
+    /// has no native `/new` (the upstream codex-acp issue `#317`), so the
+    /// text-forward path silently keeps the conversation's context.
+    /// Claude's `/clear` is handled by its adapter and must stay on the
+    /// forward path; the other `/new` mappings (opencode, omp, kimi) are
+    /// unverified and deliberately keep the old behavior until observed.
     #[test]
     fn clear_requires_driven_reset_only_for_codex() {
         assert!(resolve("codex").clear_requires_driven_reset);

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -33,8 +33,8 @@ pub struct AgentProfile {
     /// clear aliases: forwarding the raw text would be swallowed as an
     /// unknown command and the conversation would keep its full context
     /// (codex-acp has no `/new`; upstream declined to add one in
-    /// codex-acp#317). The server must drive the reset itself — a fresh
-    /// `session/new` on the live worker that swaps the ACP session id —
+    /// codex-acp#317). The server must drive the reset itself by opening a
+    /// fresh `session/new` on the live worker and swapping the ACP session id,
     /// instead of forwarding the prompt. False for claude-agent-acp,
     /// which implements `/clear` locally, so Claude keeps the
     /// text-forward path. See #2979.
@@ -405,7 +405,7 @@ mod tests {
         assert!(!OMP.is_clear_command("/clear"));
     }
 
-    /// #2979: only codex needs the server-driven reset — codex-acp has no
+    /// #2979: only codex needs the server-driven reset because codex-acp has no
     /// native `/new` (upstream codex-acp#317), so the text-forward path
     /// silently keeps the conversation's context. Claude's `/clear` is
     /// handled by its adapter and must stay on the forward path; the
@@ -413,7 +413,7 @@ mod tests {
     /// deliberately keep the old behavior until observed.
     #[test]
     fn clear_requires_driven_reset_only_for_codex() {
-        assert!(CODEX.clear_requires_driven_reset);
+        assert!(resolve("codex").clear_requires_driven_reset);
         for profile in [
             &CLAUDE,
             &CLAUDE_CODE,

--- a/src/acp/agent_profiles.rs
+++ b/src/acp/agent_profiles.rs
@@ -29,6 +29,16 @@ pub struct AgentProfile {
     /// for agents whose reset semantic isn't a slash command (or isn't
     /// known yet).
     pub clear_aliases: &'static [&'static str],
+    /// When true, the adapter has no native handler for this profile's
+    /// clear aliases: forwarding the raw text would be swallowed as an
+    /// unknown command and the conversation would keep its full context
+    /// (codex-acp has no `/new`; upstream declined to add one in
+    /// codex-acp#317). The server must drive the reset itself — a fresh
+    /// `session/new` on the live worker that swaps the ACP session id —
+    /// instead of forwarding the prompt. False for claude-agent-acp,
+    /// which implements `/clear` locally, so Claude keeps the
+    /// text-forward path. See #2979.
+    pub clear_requires_driven_reset: bool,
     /// When true, the server synthesises a `PlanUpdated` event from a
     /// `kind: switch_mode` tool call (Claude's ExitPlanMode shape).
     /// Other agents that change modes shouldn't fire empty Plans.
@@ -113,6 +123,9 @@ pub const CLAUDE: AgentProfile = AgentProfile {
     key: "claude",
     parent_meta_namespaces: &["claudeCode"],
     clear_aliases: &["/clear"],
+    // claude-agent-acp handles `/clear` locally ("Local-only commands"),
+    // so the forwarded text performs a real reset; no driven reset needed.
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: true,
     supports_wakeup_tools: true,
     emits_heartbeat_keepalives: true,
@@ -133,6 +146,11 @@ pub const CODEX: AgentProfile = AgentProfile {
     key: "codex",
     parent_meta_namespaces: &[],
     clear_aliases: &["/new"],
+    // codex-acp advertises no `new`/`clear`/reset command; a forwarded
+    // `/new` is answered with "unknown command" and the conversation
+    // keeps its context (upstream codex-acp#317 declined to add one).
+    // The supervisor must drive the reset via `session/new`. See #2979.
+    clear_requires_driven_reset: true,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -150,6 +168,11 @@ pub const OPENCODE: AgentProfile = AgentProfile {
     key: "opencode",
     parent_meta_namespaces: &[],
     clear_aliases: &["/new"],
+    // OpenCode also maps `/new`, but whether its adapter handles the
+    // text natively is unverified; keep the text-forward path until
+    // observed rather than driving a reset it may already perform
+    // itself (see the open question in #2979).
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -165,6 +188,7 @@ pub const GEMINI: AgentProfile = AgentProfile {
     key: "gemini",
     parent_meta_namespaces: &[],
     clear_aliases: &[],
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -178,6 +202,7 @@ pub const VIBE: AgentProfile = AgentProfile {
     key: "vibe",
     parent_meta_namespaces: &[],
     clear_aliases: &[],
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -189,6 +214,7 @@ pub const PI: AgentProfile = AgentProfile {
     key: "pi",
     parent_meta_namespaces: &[],
     clear_aliases: &[],
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -202,6 +228,7 @@ pub const OMP: AgentProfile = AgentProfile {
     key: "omp",
     parent_meta_namespaces: &[],
     clear_aliases: &["/new"],
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -218,6 +245,7 @@ pub const KIMI: AgentProfile = AgentProfile {
     key: "kimi",
     parent_meta_namespaces: &[],
     clear_aliases: &["/new"],
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -241,6 +269,7 @@ pub const DEFAULT: AgentProfile = AgentProfile {
     key: "default",
     parent_meta_namespaces: &[],
     clear_aliases: &[],
+    clear_requires_driven_reset: false,
     supports_exit_plan_mode: false,
     supports_wakeup_tools: false,
     emits_heartbeat_keepalives: false,
@@ -374,6 +403,31 @@ mod tests {
         assert!(!GEMINI.is_clear_command("/restore"));
         assert!(OMP.is_clear_command("/new"));
         assert!(!OMP.is_clear_command("/clear"));
+    }
+
+    /// #2979: only codex needs the server-driven reset — codex-acp has no
+    /// native `/new` (upstream codex-acp#317), so the text-forward path
+    /// silently keeps the conversation's context. Claude's `/clear` is
+    /// handled by its adapter and must stay on the forward path; the
+    /// other `/new` mappings (opencode, omp, kimi) are unverified and
+    /// deliberately keep the old behavior until observed.
+    #[test]
+    fn clear_requires_driven_reset_only_for_codex() {
+        assert!(CODEX.clear_requires_driven_reset);
+        for profile in [
+            &CLAUDE,
+            &CLAUDE_CODE,
+            &AOE_AGENT,
+            &OPENCODE,
+            &GEMINI,
+            &VIBE,
+            &PI,
+            &OMP,
+            &KIMI,
+            &DEFAULT,
+        ] {
+            assert!(!profile.clear_requires_driven_reset, "{}", profile.key);
+        }
     }
 
     #[test]

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -181,7 +181,7 @@ pub enum PromptDisposition {
     Forward,
     /// The text is a clear command for a profile whose adapter has no
     /// native reset handler (`clear_requires_driven_reset`, e.g. codex's
-    /// `/new`): do NOT forward it — codex-acp would swallow it as an
+    /// `/new`): do NOT forward it because codex-acp would swallow it as an
     /// unknown command and keep the conversation's context. Drive
     /// [`Supervisor::reset_session_context`] instead.
     ResetContext,
@@ -4476,7 +4476,7 @@ mod tests {
     }
 
     /// #2979: `reset_session_context` must route a `ResetSession` command
-    /// to the worker's client — never a `Prompt` — and re-assert an
+    /// to the worker's client, never a `Prompt`, and re-assert an
     /// explicitly persisted session mode afterwards so the fresh ACP
     /// session doesn't silently fall back to the adapter default.
     #[tokio::test]

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -1093,9 +1093,12 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// and every turn concatenates into one giant message.
     ///
     /// Also detects the conversation-reset slash command (claude's
-    /// `/clear`, codex's / opencode's `/new`) and emits a follow-up
-    /// `Event::SessionCleared` so the UI can fold the pre-clear
-    /// transcript and drop now-stale session-scoped capability caches.
+    /// `/clear`, codex's / opencode's `/new`). For a natively handled
+    /// clear it emits a follow-up `Event::SessionCleared` so the UI can
+    /// fold the pre-clear transcript and drop now-stale session-scoped
+    /// capability caches. A driven reset defers that boundary until
+    /// [`Supervisor::reset_session_context`] succeeds, so a busy or
+    /// failed reset cannot make the UI hide an uncleared conversation.
     /// Adapters don't emit a structured signal for these, so detection
     /// is text-based but routed through the session's `AgentProfile`
     /// so each agent's aliases match the right surface. See #1101.
@@ -1156,7 +1159,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             self.sink.delete_attachments_for_seq(session_id, seq);
             return disposition;
         }
-        if is_clear {
+        if is_clear && disposition == PromptDisposition::Forward {
             self.publish_next(session_id, &Event::SessionCleared);
         }
         disposition
@@ -2204,22 +2207,26 @@ impl<S: BroadcastSink> Supervisor<S> {
 
     /// Drive a real conversation reset on a running structured view worker:
     /// a fresh `session/new` on the live connection that swaps the ACP
-    /// session id (the connection task emits `SessionContextReset` +
-    /// `AcpSessionAssigned` + a terminal `Stopped` so bookkeeping and the
-    /// UI follow). Used instead of `send_prompt` when a clear command hits
-    /// a profile whose adapter has no native reset (codex `/new`), where
-    /// forwarding the text would be swallowed as an unknown command and
-    /// the context would silently survive. See #2979.
+    /// session id (the connection task emits `SessionCleared` +
+    /// `SessionContextReset` + `AcpSessionAssigned` + a terminal `Stopped`
+    /// so bookkeeping and the UI follow). Used instead of `send_prompt`
+    /// when a clear command hits a profile whose adapter has no native
+    /// reset (codex `/new`), where forwarding the text would be swallowed
+    /// as an unknown command and the context would silently survive. See
+    /// #2979.
     ///
     /// After a successful reset, re-asserts the session's persisted mode
     /// (or the profile's YOLO bypass mode) the same way `spawn_inner`
     /// does after a fresh spawn: the new ACP session starts on the
     /// adapter's default mode, and losing an explicit "auto-approve"
     /// pick across `/new` would resurface permission prompts mid-flow.
-    /// Best-effort, mirroring the spawn path. `text` is the user's clear
-    /// invocation (surfaced by the mid-turn refusal's `PromptRejected`);
-    /// `acp_mode_id` / `yolo_mode` are the caller's persisted `Instance`
-    /// values, exactly as a `SpawnRequest` would carry them.
+    /// Best-effort, mirroring the spawn path. The connection task emits
+    /// `SessionCleared` only when the reset succeeds; a busy, failed, or
+    /// timed-out `session/new` leaves the existing conversation visible.
+    /// `text` is the user's clear invocation (surfaced by the mid-turn
+    /// refusal's `PromptRejected`); `acp_mode_id` / `yolo_mode` are the
+    /// caller's persisted `Instance` values, exactly as a `SpawnRequest`
+    /// would carry them.
     pub async fn reset_session_context(
         &self,
         session_id: &str,
@@ -4380,15 +4387,13 @@ mod tests {
         // that codex-acp would swallow as an unknown command (#2979).
         assert_eq!(disposition, PromptDisposition::ResetContext);
         let frames = sink.frames.lock().unwrap().clone();
-        assert_eq!(
-            frames.len(),
-            2,
-            "expected UserPromptSent + SessionCleared, got {frames:?}"
-        );
+        assert_eq!(frames.len(), 1, "expected UserPromptSent, got {frames:?}");
         assert!(matches!(&frames[0].2, Event::UserPromptSent { .. }));
         assert!(
-            matches!(&frames[1].2, Event::SessionCleared),
-            "codex /new must clear when agent_key resolves to the codex profile"
+            !frames
+                .iter()
+                .any(|(_, _, event)| matches!(event, Event::SessionCleared)),
+            "codex /new must defer SessionCleared until the driven reset succeeds"
         );
         // Sanity: claude's `/clear` must NOT fire for a codex-keyed
         // session, since codex's profile doesn't list it as an alias.
@@ -4517,6 +4522,51 @@ mod tests {
             cmds.lock().unwrap().clone(),
             vec!["reset_session", "set_mode"],
             "an explicit persisted mode must be re-asserted after the reset"
+        );
+    }
+
+    /// A rejected driven reset keeps the existing ACP conversation, so
+    /// it must not publish the success-only clear boundary. In production
+    /// the in-flight command loop returns this failure after publishing
+    /// `PromptRejected(agent_busy)`.
+    #[tokio::test]
+    async fn reset_session_context_does_not_clear_when_reset_is_busy() {
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        let (client, _tx) = AcpClient::fake_for_test_reset_failure(
+            AcpSessionId("s-reset-busy".into()),
+            "a turn is in flight; stop it before clearing the conversation",
+        );
+        sup.workers.lock().await.insert(
+            "s-reset-busy".into(),
+            WorkerHandle {
+                client: Arc::new(client),
+                drain_task: tokio::spawn(async {}),
+                restart_history: vec![],
+                kind: WorkerKind::Stdio,
+            },
+        );
+
+        let error = sup
+            .reset_session_context("s-reset-busy", "/new", None, false)
+            .await
+            .expect_err("busy reset must be rejected");
+        assert!(
+            matches!(
+                &error,
+                SupervisorError::Acp(AcpError::ResetFailed(message))
+                    if message.contains("turn is in flight")
+            ),
+            "the busy classification must remain visible, got {error:?}"
+        );
+        assert!(
+            !sink
+                .frames
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, _, event)| matches!(event, Event::SessionCleared)),
+            "a busy reset must not publish SessionCleared"
         );
     }
 

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -29,7 +29,9 @@ use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use super::acp_client::{AcpClient, AcpError, DeleteSessionOutcome, SpawnConfig};
+use super::acp_client::{
+    AcpClient, AcpError, DeleteSessionOutcome, ResetSessionOutcome, SpawnConfig,
+};
 use super::agent_registry::{AgentRegistry, AgentSpec};
 use super::approvals::{ApprovalDecision, Nonce};
 use super::elicitations::{ElicitationOutcome, ElicitationResolution};
@@ -167,6 +169,22 @@ pub enum SupervisorError {
     /// the requested end state (no worker for this session) holds.
     #[error("resume of session {0:?} was cancelled by a concurrent shutdown")]
     SpawnCancelled(String),
+}
+
+/// What the caller should do with the prompt text after
+/// `publish_user_prompt_with_attachments` recorded it. The publish step
+/// owns clear-command detection (it already resolves the session's
+/// `AgentProfile`), so it also owns the routing decision. See #2979.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptDisposition {
+    /// Forward the text to the agent as an ordinary `session/prompt`.
+    Forward,
+    /// The text is a clear command for a profile whose adapter has no
+    /// native reset handler (`clear_requires_driven_reset`, e.g. codex's
+    /// `/new`): do NOT forward it — codex-acp would swallow it as an
+    /// unknown command and keep the conversation's context. Drive
+    /// [`Supervisor::reset_session_context`] instead.
+    ResetContext,
 }
 
 /// Frame published to the broadcast channel; mirrors
@@ -1081,9 +1099,9 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// Adapters don't emit a structured signal for these, so detection
     /// is text-based but routed through the session's `AgentProfile`
     /// so each agent's aliases match the right surface. See #1101.
-    pub async fn publish_user_prompt(&self, session_id: &str, text: String) {
+    pub async fn publish_user_prompt(&self, session_id: &str, text: String) -> PromptDisposition {
         self.publish_user_prompt_with_attachments(session_id, text, &[])
-            .await;
+            .await
     }
 
     /// Like `publish_user_prompt` but also persists the prompt's
@@ -1096,10 +1114,18 @@ impl<S: BroadcastSink> Supervisor<S> {
         session_id: &str,
         text: String,
         attachments: &[crate::acp::event_store::AttachmentBlob],
-    ) {
+    ) -> PromptDisposition {
         let agent_key = self.agent_key_for_session(session_id).await;
         let profile = super::agent_profiles::resolve(&agent_key);
         let is_clear = profile.is_clear_command(&text);
+        // Decided from the profile regardless of whether the publish below
+        // persists: the raw alias must never reach an adapter that would
+        // swallow it as an unknown command. See #2979.
+        let disposition = if is_clear && profile.clear_requires_driven_reset {
+            PromptDisposition::ResetContext
+        } else {
+            PromptDisposition::Forward
+        };
         let seq = next_seq(&self.next_seqs, session_id);
         let mut refs = Vec::with_capacity(attachments.len());
         for blob in attachments {
@@ -1108,7 +1134,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                 // written for this seq and abort before publishing, so the
                 // UserPromptSent never carries refs load_attachment() can't serve.
                 self.sink.delete_attachments_for_seq(session_id, seq);
-                return;
+                return disposition;
             }
             refs.push(crate::acp::state::PromptAttachmentRef {
                 id: blob.id.clone(),
@@ -1128,11 +1154,12 @@ impl<S: BroadcastSink> Supervisor<S> {
         );
         if !persisted {
             self.sink.delete_attachments_for_seq(session_id, seq);
-            return;
+            return disposition;
         }
         if is_clear {
             self.publish_next(session_id, &Event::SessionCleared);
         }
+        disposition
     }
 
     /// Publish a "Send diff comments" submission as a typed
@@ -2172,6 +2199,67 @@ impl<S: BroadcastSink> Supervisor<S> {
     ) -> Result<(), SupervisorError> {
         let client = self.ready_client(session_id).await?;
         client.send_prompt(text, attachments).await?;
+        Ok(())
+    }
+
+    /// Drive a real conversation reset on a running structured view worker:
+    /// a fresh `session/new` on the live connection that swaps the ACP
+    /// session id (the connection task emits `SessionContextReset` +
+    /// `AcpSessionAssigned` + a terminal `Stopped` so bookkeeping and the
+    /// UI follow). Used instead of `send_prompt` when a clear command hits
+    /// a profile whose adapter has no native reset (codex `/new`), where
+    /// forwarding the text would be swallowed as an unknown command and
+    /// the context would silently survive. See #2979.
+    ///
+    /// After a successful reset, re-asserts the session's persisted mode
+    /// (or the profile's YOLO bypass mode) the same way `spawn_inner`
+    /// does after a fresh spawn: the new ACP session starts on the
+    /// adapter's default mode, and losing an explicit "auto-approve"
+    /// pick across `/new` would resurface permission prompts mid-flow.
+    /// Best-effort, mirroring the spawn path. `acp_mode_id` / `yolo_mode`
+    /// are the caller's persisted `Instance` values, exactly as a
+    /// `SpawnRequest` would carry them.
+    pub async fn reset_session_context(
+        &self,
+        session_id: &str,
+        acp_mode_id: Option<&str>,
+        yolo_mode: bool,
+    ) -> Result<(), SupervisorError> {
+        let client = self.ready_client(session_id).await?;
+        match client.reset_session().await? {
+            ResetSessionOutcome::Reset { new_acp_session_id } => {
+                info!(
+                    target: "acp.supervisor",
+                    session = %session_id,
+                    new_acp_session_id = %new_acp_session_id,
+                    "conversation reset: fresh session/new swapped the ACP session id"
+                );
+            }
+            ResetSessionOutcome::Failed { message } => {
+                return Err(SupervisorError::Acp(AcpError::ResetFailed(message)));
+            }
+        }
+        // An explicit persisted mode (#2897) wins over the yolo bool,
+        // matching spawn_inner's precedence.
+        let mode_id = match (acp_mode_id, yolo_mode) {
+            (Some(id), _) => Some(id.to_string()),
+            (None, true) => {
+                let agent_key = self.agent_key_for_session(session_id).await;
+                super::agent_profiles::resolve(&agent_key)
+                    .yolo_mode_id
+                    .map(str::to_string)
+            }
+            (None, false) => None,
+        };
+        if let Some(mode_id) = mode_id {
+            if let Err(e) = client.set_mode(&mode_id).await {
+                warn!(
+                    target: "acp.supervisor",
+                    session = %session_id,
+                    "set_mode({mode_id}) after conversation reset failed: {e}"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -4233,7 +4321,11 @@ mod tests {
     async fn publish_user_prompt_emits_session_cleared_for_clear_command() {
         let sink = VecSink::new();
         let sup = Supervisor::new(sink.clone());
-        sup.publish_user_prompt("s-1", "/clear".into()).await;
+        let disposition = sup.publish_user_prompt("s-1", "/clear".into()).await;
+        // Claude's adapter handles `/clear` natively, so the text keeps
+        // the forward path; the codex-only driven reset (#2979) must not
+        // change this. See `clear_requires_driven_reset`.
+        assert_eq!(disposition, PromptDisposition::Forward);
         let frames = sink.frames.lock().unwrap().clone();
         assert_eq!(frames.len(), 2);
         assert!(matches!(
@@ -4280,7 +4372,11 @@ mod tests {
 
         let sink = VecSink::new();
         let sup = Supervisor::new(sink.clone());
-        sup.publish_user_prompt(session_id, "/new".into()).await;
+        let disposition = sup.publish_user_prompt(session_id, "/new".into()).await;
+        // codex-acp has no native `/new`; the publish step must route the
+        // caller onto the driven-reset path instead of the text forward
+        // that codex-acp would swallow as an unknown command (#2979).
+        assert_eq!(disposition, PromptDisposition::ResetContext);
         let frames = sink.frames.lock().unwrap().clone();
         assert_eq!(
             frames.len(),
@@ -4296,7 +4392,12 @@ mod tests {
         // session, since codex's profile doesn't list it as an alias.
         let sink2 = VecSink::new();
         let sup2 = Supervisor::new(sink2.clone());
-        sup2.publish_user_prompt(session_id, "/clear".into()).await;
+        let disposition2 = sup2.publish_user_prompt(session_id, "/clear".into()).await;
+        assert_eq!(
+            disposition2,
+            PromptDisposition::Forward,
+            "a non-alias prompt on codex must keep the forward path"
+        );
         let frames2 = sink2.frames.lock().unwrap().clone();
         assert_eq!(
             frames2.len(),
@@ -4358,11 +4459,63 @@ mod tests {
     async fn publish_user_prompt_does_not_emit_session_cleared_for_normal_prompts() {
         let sink = VecSink::new();
         let sup = Supervisor::new(sink.clone());
-        sup.publish_user_prompt("s-1", "tell me about /clear".into())
+        let disposition = sup
+            .publish_user_prompt("s-1", "tell me about /clear".into())
             .await;
+        assert_eq!(disposition, PromptDisposition::Forward);
         let frames = sink.frames.lock().unwrap().clone();
         assert_eq!(frames.len(), 1);
         assert!(matches!(&frames[0].2, Event::UserPromptSent { .. }));
+    }
+
+    /// #2979: `reset_session_context` must route a `ResetSession` command
+    /// to the worker's client — never a `Prompt` — and re-assert an
+    /// explicitly persisted session mode afterwards so the fresh ACP
+    /// session doesn't silently fall back to the adapter default.
+    #[tokio::test]
+    async fn reset_session_context_issues_reset_cmd_and_reasserts_mode() {
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink);
+        let (client, _tx, cmds) =
+            AcpClient::fake_for_test_cmd_recording(AcpSessionId("s-reset".into()));
+        sup.workers.lock().await.insert(
+            "s-reset".into(),
+            WorkerHandle {
+                client: Arc::new(client),
+                drain_task: tokio::spawn(async {}),
+                restart_history: vec![],
+                kind: WorkerKind::Stdio,
+            },
+        );
+
+        // No persisted mode: exactly one ResetSession, no Prompt forward.
+        sup.reset_session_context("s-reset", None, false)
+            .await
+            .expect("reset ok");
+        assert_eq!(
+            cmds.lock().unwrap().clone(),
+            vec!["reset_session"],
+            "the clear alias must drive a reset, not a prompt forward"
+        );
+
+        // With a persisted explicit mode (#2897), the reset re-asserts it
+        // on the fresh session, mirroring the spawn path.
+        cmds.lock().unwrap().clear();
+        sup.reset_session_context("s-reset", Some("plan"), false)
+            .await
+            .expect("reset ok");
+        // set_mode is fire-and-forget through cmd_tx; give the recording
+        // consumer a beat to drain it.
+        tokio::task::yield_now().await;
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while cmds.lock().unwrap().len() < 2 && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            cmds.lock().unwrap().clone(),
+            vec!["reset_session", "set_mode"],
+            "an explicit persisted mode must be re-asserted after the reset"
+        );
     }
 
     /// Incompatible-session tracking (#2109): a session marked for one

--- a/src/acp/supervisor.rs
+++ b/src/acp/supervisor.rs
@@ -2216,17 +2216,19 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// does after a fresh spawn: the new ACP session starts on the
     /// adapter's default mode, and losing an explicit "auto-approve"
     /// pick across `/new` would resurface permission prompts mid-flow.
-    /// Best-effort, mirroring the spawn path. `acp_mode_id` / `yolo_mode`
-    /// are the caller's persisted `Instance` values, exactly as a
-    /// `SpawnRequest` would carry them.
+    /// Best-effort, mirroring the spawn path. `text` is the user's clear
+    /// invocation (surfaced by the mid-turn refusal's `PromptRejected`);
+    /// `acp_mode_id` / `yolo_mode` are the caller's persisted `Instance`
+    /// values, exactly as a `SpawnRequest` would carry them.
     pub async fn reset_session_context(
         &self,
         session_id: &str,
+        text: &str,
         acp_mode_id: Option<&str>,
         yolo_mode: bool,
     ) -> Result<(), SupervisorError> {
         let client = self.ready_client(session_id).await?;
-        match client.reset_session().await? {
+        match client.reset_session(text).await? {
             ResetSessionOutcome::Reset { new_acp_session_id } => {
                 info!(
                     target: "acp.supervisor",
@@ -4489,7 +4491,7 @@ mod tests {
         );
 
         // No persisted mode: exactly one ResetSession, no Prompt forward.
-        sup.reset_session_context("s-reset", None, false)
+        sup.reset_session_context("s-reset", "/new", None, false)
             .await
             .expect("reset ok");
         assert_eq!(
@@ -4501,7 +4503,7 @@ mod tests {
         // With a persisted explicit mode (#2897), the reset re-asserts it
         // on the fresh session, mirroring the spawn path.
         cmds.lock().unwrap().clear();
-        sup.reset_session_context("s-reset", Some("plan"), false)
+        sup.reset_session_context("s-reset", "/new", Some("plan"), false)
             .await
             .expect("reset ok");
         // set_mode is fire-and-forget through cmd_tx; give the recording

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -1355,8 +1355,8 @@ impl RunnerShared {
         Some(bytes)
     }
 
-    /// Track a daemon-issued relay `session/new` — a driven conversation
-    /// reset (#2979) — so its response can refresh the handshake cache.
+    /// Track a daemon-issued relay `session/new` for a driven conversation
+    /// reset (#2979), so its response can refresh the handshake cache.
     /// The daemon's crate connection uses string UUID request ids, which
     /// `intercept_handshake` / `parse_request` (i64-only) never match, so
     /// the request passes through to the agent untouched; this only

--- a/src/process/runner.rs
+++ b/src/process/runner.rs
@@ -722,6 +722,16 @@ struct RunnerShared {
     /// forwarding it to the daemon. Prompt responses are NOT here; they use
     /// the async `prompt_requests` path that fires `PromptCompleted`.
     pending_client_responses: Mutex<HashMap<i64, tokio::sync::oneshot::Sender<serde_json::Value>>>,
+    /// Ids of daemon-issued relay `session/new` requests, keyed by the raw
+    /// JSON rendering of the id (the daemon's crate connection uses string
+    /// UUID ids, which the i64-based trackers above never match). A v2
+    /// daemon only sends `session/new` over the relay for a driven
+    /// conversation reset (#2979: a clear command on an adapter with no
+    /// native reset); the stdout fanout uses the tracked id to refresh the
+    /// cached handshake session from the response, so `ControlBody::Cancel`
+    /// and later cache replays address the fresh conversation instead of
+    /// the pre-reset one. The response itself still flows to the daemon.
+    relay_session_news: Mutex<HashSet<String>>,
 }
 
 /// Runner-owned ACP handshake state (#2976 Phase B).
@@ -822,6 +832,12 @@ async fn write_control_frame(
 /// and log once at warn so the leak is visible.
 const MAX_OUTSTANDING_REQUESTS: usize = 1024;
 
+/// Cap on tracked daemon-issued relay `session/new` ids (driven
+/// conversation resets, #2979). Resets are user-paced and one-shot, so
+/// anything beyond a handful means responses stopped arriving; refuse
+/// new entries rather than growing without bound.
+const MAX_RELAY_SESSION_NEWS: usize = 8;
+
 impl RunnerShared {
     fn new() -> Self {
         Self {
@@ -834,6 +850,7 @@ impl RunnerShared {
             handshake: Mutex::new(RunnerHandshake::default()),
             next_req_id: AtomicI64::new(RUNNER_REQUEST_ID_BASE),
             pending_client_responses: Mutex::new(HashMap::new()),
+            relay_session_news: Mutex::new(HashSet::new()),
         }
     }
 
@@ -894,6 +911,12 @@ impl RunnerShared {
                 }
             }
         }
+
+        // #2979: refresh the cached handshake session when this line answers
+        // a daemon-driven relay `session/new` (conversation reset). Gated on
+        // a non-empty tracking set so idle traffic isn't re-parsed; the
+        // response is forwarded to the daemon below either way.
+        self.refresh_session_cache_from_relay(line).await;
 
         let mut guard = self.active_outbound.lock().await;
         if let Some(out) = guard.as_mut() {
@@ -1331,6 +1354,57 @@ impl RunnerShared {
         bytes.push(b'\n');
         Some(bytes)
     }
+
+    /// Track a daemon-issued relay `session/new` — a driven conversation
+    /// reset (#2979) — so its response can refresh the handshake cache.
+    /// The daemon's crate connection uses string UUID request ids, which
+    /// `intercept_handshake` / `parse_request` (i64-only) never match, so
+    /// the request passes through to the agent untouched; this only
+    /// records the id for the fanout to correlate. Bounded: at most a
+    /// handful of resets can ever be in flight, so a small cap guards
+    /// against ids whose responses never arrive.
+    async fn note_relay_session_new(&self, line: &[u8]) {
+        let Some((id_key, method)) = parse_request_any_id(line) else {
+            return;
+        };
+        if method != "session/new" {
+            return;
+        }
+        let mut set = self.relay_session_news.lock().await;
+        if set.len() < MAX_RELAY_SESSION_NEWS {
+            set.insert(id_key);
+        }
+    }
+
+    /// If `line` answers a tracked relay `session/new`, refresh the cached
+    /// handshake session with the fresh `(sessionId, result)` so
+    /// `ControlBody::Cancel` and later cache replays address the post-reset
+    /// conversation. The response is NOT swallowed; the daemon still owns
+    /// it. An error response just clears the tracking (the reset failed and
+    /// the old session stays live).
+    async fn refresh_session_cache_from_relay(&self, line: &[u8]) {
+        if self.relay_session_news.lock().await.is_empty() {
+            return;
+        }
+        let Some((id_key, result)) = parse_response_any_id(line) else {
+            return;
+        };
+        if !self.relay_session_news.lock().await.remove(&id_key) {
+            return;
+        }
+        let Some(result) = result else {
+            return;
+        };
+        let Some(sid) = result.get("sessionId").and_then(|v| v.as_str()) else {
+            return;
+        };
+        info!(
+            target: "acp.runner",
+            new_acp_session_id = %sid,
+            "daemon-driven session/new observed on the relay; refreshing handshake cache"
+        );
+        self.handshake.lock().await.session = Some((sid.to_string(), result));
+    }
 }
 
 /// Extract the `result` object from a runner-issued request's JSON-RPC
@@ -1364,6 +1438,34 @@ fn parse_request(line: &[u8]) -> Option<(i64, String)> {
     let id = peek.id?.as_i64()?;
     let method = peek.method?;
     Some((id, method))
+}
+
+/// Like [`parse_request`], but keys the id by its raw JSON rendering so
+/// string ids are covered too: the daemon's crate connection allocates
+/// UUID-string request ids, which the i64 trackers deliberately never
+/// match. Used to correlate a daemon-driven relay `session/new` (#2979)
+/// with its response.
+fn parse_request_any_id(line: &[u8]) -> Option<(String, String)> {
+    let peek: JsonRpcPeek = serde_json::from_slice(line).ok()?;
+    let id = peek.id?;
+    let method = peek.method?;
+    Some((id.to_string(), method))
+}
+
+/// Response counterpart of [`parse_request_any_id`]: `(id key, result)`,
+/// where `result` is `None` for an error envelope. Returns None for
+/// requests (a `method` is present), notifications (no id), and
+/// malformed lines.
+fn parse_response_any_id(line: &[u8]) -> Option<(String, Option<serde_json::Value>)> {
+    let peek: JsonRpcResponsePeek = serde_json::from_slice(line).ok()?;
+    if peek.method.is_some() {
+        return None;
+    }
+    let id = peek.id?;
+    if peek.error.is_some() {
+        return Some((id.to_string(), None));
+    }
+    Some((id.to_string(), peek.result))
 }
 
 /// Extract the response id from a JSON-RPC response line, i.e. a line
@@ -1538,6 +1640,11 @@ async fn handle_connection(
                 }
                 shared.note_daemon_response(&line).await;
                 shared.note_prompt_request(&line).await;
+                // #2979: a daemon-driven conversation reset issues
+                // `session/new` over the relay (string id, so the i64
+                // trackers above ignore it); record it so the fanout can
+                // refresh the cached handshake session from the response.
+                shared.note_relay_session_new(&line).await;
                 let mut stdin = agent_stdin.lock().await;
                 if stdin.write_all(&line).await.is_err() || stdin.flush().await.is_err() {
                     warn!(
@@ -1893,6 +2000,99 @@ mod tests {
         // misclassifying them.
         let line = br#"{"jsonrpc":"2.0","id":"abc","method":"foo","params":{}}"#;
         assert_eq!(parse_request(line), None);
+    }
+
+    #[test]
+    fn parse_request_any_id_covers_string_and_numeric_ids() {
+        // The daemon's crate connection uses UUID-string ids, which the
+        // i64 peek above skips; the any-id variant keys them by their raw
+        // JSON rendering so a relay session/new (#2979) can be tracked.
+        let line = br#"{"jsonrpc":"2.0","id":"abc","method":"session/new","params":{}}"#;
+        assert_eq!(
+            parse_request_any_id(line),
+            Some(("\"abc\"".into(), "session/new".into()))
+        );
+        let line = br#"{"jsonrpc":"2.0","id":9,"method":"session/new","params":{}}"#;
+        assert_eq!(
+            parse_request_any_id(line),
+            Some(("9".into(), "session/new".into()))
+        );
+        assert_eq!(
+            parse_request_any_id(br#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_response_any_id_returns_result_and_flags_errors() {
+        let ok = br#"{"jsonrpc":"2.0","id":"abc","result":{"sessionId":"sid-2"}}"#;
+        let (id, result) = parse_response_any_id(ok).expect("response parses");
+        assert_eq!(id, "\"abc\"");
+        assert_eq!(
+            result.and_then(|r| r.get("sessionId").cloned()),
+            Some(serde_json::json!("sid-2"))
+        );
+        let err = br#"{"jsonrpc":"2.0","id":"abc","error":{"code":-32603,"message":"x"}}"#;
+        assert_eq!(parse_response_any_id(err), Some(("\"abc\"".into(), None)));
+        // Requests and notifications are not responses.
+        assert_eq!(
+            parse_response_any_id(br#"{"jsonrpc":"2.0","id":1,"method":"m","params":{}}"#),
+            None
+        );
+    }
+
+    /// #2979: a daemon-driven relay `session/new` (conversation reset)
+    /// must refresh the runner's cached handshake session so
+    /// `ControlBody::Cancel` and later cache replays address the fresh
+    /// conversation, not the pre-reset one. An error response leaves the
+    /// cache untouched (the reset failed; the old session stays live).
+    #[tokio::test]
+    async fn relay_session_new_response_refreshes_handshake_cache() {
+        let shared = RunnerShared::new();
+        shared.handshake.lock().await.session =
+            Some(("sid-1".into(), serde_json::json!({ "sessionId": "sid-1" })));
+
+        shared
+            .note_relay_session_new(
+                br#"{"jsonrpc":"2.0","id":"uuid-1","method":"session/new","params":{"cwd":"/p"}}"#,
+            )
+            .await;
+        shared
+            .refresh_session_cache_from_relay(
+                br#"{"jsonrpc":"2.0","id":"uuid-1","result":{"sessionId":"sid-2"}}"#,
+            )
+            .await;
+        assert_eq!(
+            shared.acp_session_id().await.as_deref(),
+            Some("sid-2"),
+            "the cache must follow the daemon-driven reset"
+        );
+
+        // Error response: tracked id is consumed but the cache keeps the
+        // last-established session.
+        shared
+            .note_relay_session_new(
+                br#"{"jsonrpc":"2.0","id":"uuid-2","method":"session/new","params":{"cwd":"/p"}}"#,
+            )
+            .await;
+        shared
+            .refresh_session_cache_from_relay(
+                br#"{"jsonrpc":"2.0","id":"uuid-2","error":{"code":-32603,"message":"boom"}}"#,
+            )
+            .await;
+        assert_eq!(shared.acp_session_id().await.as_deref(), Some("sid-2"));
+        assert!(
+            shared.relay_session_news.lock().await.is_empty(),
+            "tracked ids are one-shot"
+        );
+
+        // An untracked response never rewrites the cache.
+        shared
+            .refresh_session_cache_from_relay(
+                br#"{"jsonrpc":"2.0","id":"uuid-3","result":{"sessionId":"sid-9"}}"#,
+            )
+            .await;
+        assert_eq!(shared.acp_session_id().await.as_deref(), Some("sid-2"));
     }
 
     #[test]

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -442,9 +442,9 @@ impl SessionService {
         // as authoritative and dedupes against its own optimistic row.
         //
         // The publish step owns clear-command detection and tells us what to
-        // do with the text: forward it as an ordinary prompt, or — for a
-        // clear alias whose adapter has no native reset (codex `/new`) —
-        // drive a real reset on the live worker instead. Forwarding the raw
+        // do with the text: either forward it as an ordinary prompt or drive
+        // a real reset on the live worker for a clear alias whose adapter has
+        // no native reset (codex `/new`). Forwarding the raw
         // alias there would be swallowed as an unknown command and the
         // conversation would silently keep its context. See #2979.
         let disposition = self

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -457,7 +457,7 @@ impl SessionService {
             }
             crate::acp::supervisor::PromptDisposition::ResetContext => {
                 self.acp_supervisor
-                    .reset_session_context(id, acp_mode_id.as_deref(), yolo_mode)
+                    .reset_session_context(id, text, acp_mode_id.as_deref(), yolo_mode)
                     .await
             }
         };

--- a/src/server/session_service.rs
+++ b/src/server/session_service.rs
@@ -388,7 +388,7 @@ impl SessionService {
         // to sessions it created. Ownership is immutable after creation, so
         // a read snapshot suffices; deliberately no instance_lock here (the
         // pending-turn drain calls this while holding it).
-        let acp_mode_id = {
+        let (acp_mode_id, yolo_mode) = {
             let instances = self.instances.read().await;
             let Some(inst) = instances.iter().find(|i| i.id == id) else {
                 return Err(SendTurnError::SessionNotFound);
@@ -398,7 +398,7 @@ impl SessionService {
                     return Err(SendTurnError::NotOwner);
                 }
             }
-            inst.acp_mode_id.clone()
+            (inst.acp_mode_id.clone(), inst.yolo_mode)
         };
         // Resume a worker that is not currently live. Two cases:
         //   - Idle-dormant wake: the worker was auto-stopped for inactivity
@@ -440,10 +440,28 @@ impl SessionService {
         // to the agent so the replay buffer / on-disk store captures it
         // even if the agent forward fails. The frontend treats UserPromptSent
         // as authoritative and dedupes against its own optimistic row.
-        self.acp_supervisor
+        //
+        // The publish step owns clear-command detection and tells us what to
+        // do with the text: forward it as an ordinary prompt, or — for a
+        // clear alias whose adapter has no native reset (codex `/new`) —
+        // drive a real reset on the live worker instead. Forwarding the raw
+        // alias there would be swallowed as an unknown command and the
+        // conversation would silently keep its context. See #2979.
+        let disposition = self
+            .acp_supervisor
             .publish_user_prompt_with_attachments(id, text.to_string(), attachments)
             .await;
-        match self.acp_supervisor.send_prompt(id, text, attachments).await {
+        let outcome = match disposition {
+            crate::acp::supervisor::PromptDisposition::Forward => {
+                self.acp_supervisor.send_prompt(id, text, attachments).await
+            }
+            crate::acp::supervisor::PromptDisposition::ResetContext => {
+                self.acp_supervisor
+                    .reset_session_context(id, acp_mode_id.as_deref(), yolo_mode)
+                    .await
+            }
+        };
+        match outcome {
             Ok(()) => Ok(()),
             // Intentional override of the canonical UnknownSession 404: the
             // respawn we kicked above did not finish within `send_prompt`'s

--- a/web/src/lib/acpTypes.test.ts
+++ b/web/src/lib/acpTypes.test.ts
@@ -818,6 +818,66 @@ describe("applyEvent / ACP session id lifecycle", () => {
     expect(state.contextPrimerAvailable).toBeNull();
   });
 
+  it("codex /new driven reset drops the context tracker to the post-reset baseline (#2979)", () => {
+    // The server-side reset for a codex `/new` publishes UserPromptSent +
+    // SessionCleared, then the live worker's fresh session/new emits
+    // SessionContextReset + AcpSessionAssigned + Stopped(session_reset).
+    // The tracker must not hold the pre-/new usage across that boundary,
+    // and the fresh session's first UsageUpdated is the new baseline.
+    let state = applyEvent(emptyAcpState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UsageUpdated: { usage: { used: 75000, size: 200000 } } },
+    });
+    expect(state.sessionUsage?.used).toBe(75000);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { UserPromptSent: { text: "/new" } },
+    });
+    expect(state.turnActive).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: "SessionCleared",
+    });
+    expect(state.sessionUsage).toBeNull();
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: {
+        SessionContextReset: { reason: "conversation cleared; the agent started a fresh session" },
+      },
+    });
+    // The fresh ACP session restarts agent-side accounting at zero, so
+    // the per-clear cost baseline no longer maps onto incoming values.
+    expect(state.sessionUsage).toBeNull();
+    expect(state.usageBaseline).toBeNull();
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 5,
+      event: { AcpSessionAssigned: { acp_session_id: "fresh-uuid" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 6,
+      event: { Stopped: { reason: "session_reset" } },
+    });
+    // The clear command's synthetic turn is closed; composer unlocks.
+    expect(state.turnActive).toBe(false);
+    // The reset boundary counts as the turn's output: no spurious
+    // "Command produced no output." row under the divider.
+    expect(state.activity.some((r) => r.kind === "empty_output")).toBe(false);
+    // The fresh session's first usage report is the post-reset baseline,
+    // not the pre-/new 75k the tracker used to hold (#2979).
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 7,
+      event: { UsageUpdated: { usage: { used: 1200, size: 200000 } } },
+    });
+    expect(state.sessionUsage?.used).toBe(1200);
+  });
+
   it("UserPromptSent clears contextPrimerAvailable (one-shot affordance)", () => {
     let state = applyEvent(emptyAcpState(), {
       session_id: "s-1",

--- a/web/src/lib/acpTypes.ts
+++ b/web/src/lib/acpTypes.ts
@@ -1916,6 +1916,12 @@ export function applyEvent(state: AcpState, frame: AcpFrame): AcpState {
       text: event.SessionContextReset.reason || "Conversation context reset; agent transcript was unavailable.",
       at: new Date().toISOString(),
     });
+    // The reset row is this turn's visible product. A server-driven
+    // conversation reset (codex `/new`, #2979) ends its turn with
+    // `Stopped(session_reset)` and no agent output; without this the
+    // empty-output fallback would stack "Command produced no output."
+    // under the reset boundary.
+    next.turnHasOutput = true;
     // Offer the opt-in primer affordance. The banner only appears
     // when there is a prior user prompt (we're already inside that
     // branch), and stays one-shot: any UserPromptSent below clears

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1973,6 +1973,20 @@
       ]
     },
     {
+      "id": "acp.codex-new-reset",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/acp-codex-new-reset.spec.ts"],
+      "components": [
+        "src/acp/acp_client.rs",
+        "src/acp/agent_profiles.rs",
+        "src/acp/supervisor.rs",
+        "src/process/runner.rs",
+        "src/server/session_service.rs",
+        "web/src/lib/acpTypes.ts"
+      ]
+    },
+    {
       "id": "acp.idle-dormant-wake",
       "kind": "vitest",
       "risk": "high",

--- a/web/tests/live/acp-codex-new-reset.spec.ts
+++ b/web/tests/live/acp-codex-new-reset.spec.ts
@@ -60,21 +60,15 @@ test("codex /new opens a fresh session/new and swaps the acp session id", async 
     const firstId = (await assignedIds())[0]!;
 
     // `/new` goes through the ordinary prompt endpoint; the server-side
-    // clear detection reroutes it onto the driven-reset path. Retry while
-    // the prompt path is still warming up (503 worker_not_ready).
-    await expect
-      .poll(
-        async () => {
-          const res = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ text: "/new" }),
-          });
-          return res.status;
-        },
-        { timeout: 30_000, intervals: [500] },
-      )
-      .toBe(202);
+    // clear detection reroutes it onto the driven-reset path. The assigned
+    // session id above proves the worker is ready, so submit this stateful
+    // request exactly once.
+    const resetResponse = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "/new" }),
+    });
+    expect(resetResponse.status).toBe(202);
 
     // The reset's full event contract, in one poll: clear boundary, reset
     // boundary, a second assigned id, and the terminal Stopped.

--- a/web/tests/live/acp-codex-new-reset.spec.ts
+++ b/web/tests/live/acp-codex-new-reset.spec.ts
@@ -1,0 +1,110 @@
+// Live: a codex `/new` drives a REAL conversation reset (#2979).
+//
+// codex-acp has no native `/new` (upstream codex-acp#317), so forwarding
+// the raw text used to be swallowed as an unknown command while the UI
+// rendered a "Conversation cleared" boundary the model never honored.
+// The server now opens a fresh `session/new` on the live worker and swaps
+// the stored acp_session_id. This spec drives the production path against
+// a real `aoe serve` + the fake codex ACP agent and asserts the observable
+// contract on the event stream:
+//
+//   - the clear boundary (`SessionCleared`) still renders,
+//   - the reset boundary (`SessionContextReset`) fires,
+//   - a SECOND `AcpSessionAssigned` lands with a NEW acp session id
+//     (proof the worker ran a fresh session/new rather than replaying
+//     the old conversation),
+//   - the clear turn terminates with `Stopped(session_reset)`.
+//
+// API-only (no page): the reducer-side tracker behavior is unit-tested in
+// `src/lib/acpTypes.test.ts`; the Rust reset mechanics in `src/acp/`.
+
+import { test, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../helpers/aoeServe";
+
+test("codex /new opens a fresh session/new and swaps the acp session id", async ({}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    acp: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "codex-new-reset", tool: "codex" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionId = sessions[0]!.id;
+
+    const replayFrames = async (): Promise<unknown[]> => {
+      const replay = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/replay?since=0`).then((r) => r.json());
+      return replay.frames ?? [];
+    };
+    const assignedIds = async (): Promise<string[]> => {
+      const ids: string[] = [];
+      for (const f of await replayFrames()) {
+        const ev = (f as { event?: Record<string, { acp_session_id?: string }> }).event;
+        if (ev && typeof ev === "object" && "AcpSessionAssigned" in ev) {
+          const id = ev.AcpSessionAssigned?.acp_session_id;
+          if (id) ids.push(id);
+        }
+      }
+      return ids;
+    };
+
+    await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/enable`, { method: "POST" });
+
+    // Handshake oracle: the first AcpSessionAssigned frame proves the fake
+    // codex worker is live and its initial session/new completed.
+    await expect
+      .poll(async () => (await assignedIds()).length, { timeout: 45_000, intervals: [500] })
+      .toBeGreaterThan(0);
+    const firstId = (await assignedIds())[0]!;
+
+    // `/new` goes through the ordinary prompt endpoint; the server-side
+    // clear detection reroutes it onto the driven-reset path. Retry while
+    // the prompt path is still warming up (503 worker_not_ready).
+    await expect
+      .poll(
+        async () => {
+          const res = await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/acp/prompt`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text: "/new" }),
+          });
+          return res.status;
+        },
+        { timeout: 30_000, intervals: [500] },
+      )
+      .toBe(202);
+
+    // The reset's full event contract, in one poll: clear boundary, reset
+    // boundary, a second assigned id, and the terminal Stopped.
+    await expect
+      .poll(
+        async () => {
+          const json = JSON.stringify(await replayFrames());
+          return (
+            json.includes('"SessionCleared"') &&
+            json.includes("SessionContextReset") &&
+            json.includes("session_reset") &&
+            (await assignedIds()).length >= 2
+          );
+        },
+        { timeout: 45_000, intervals: [500] },
+      )
+      .toBe(true);
+
+    const ids = await assignedIds();
+    const freshId = ids[ids.length - 1]!;
+    expect(freshId, "the reset must mint a NEW acp session id via session/new").not.toBe(firstId);
+
+    // The raw alias must not have been forwarded as a prompt: the fake
+    // codex agent echoes scripted turns for real prompts, so a forwarded
+    // "/new" would have produced an assistant turn instead of the reset
+    // triple asserted above. Belt-and-suspenders: no agent message chunk
+    // may reference the swallowed-unknown-command path.
+    const json = JSON.stringify(await replayFrames());
+    expect(json).not.toContain("unknown command");
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
## Description

Closes https://github.com/agent-of-empires/agent-of-empires/issues/2979

In web structured Codex sessions, sending `/new` renders the "Conversation cleared" boundary but the underlying Codex conversation never resets: the supervisor emits only the UI-level `SessionCleared` event and forwards the raw `/new` text to codex-acp, which treats it as an unknown command, so context persists. Claude is unaffected because it handles `/clear` natively.

This implements the issue's Proposal A, Codex-scoped. Upstream declined `/new` handling in codex-acp (agentclientprotocol/codex-acp#317: "just have the client create new sessions via session/new"), so the reset is driven client-side:

- `agent_profiles.rs`: new `clear_requires_driven_reset` flag, `true` only for CODEX. Claude stays `false` (native `/clear` text-forward unchanged); OpenCode/OMP/Kimi stay `false` pending the issue's open generalization question.
- `supervisor.rs`: `publish_user_prompt_with_attachments` returns a `PromptDisposition` (`Forward` | `ResetContext`); `reset_session_context` drives the reset then re-asserts the persisted `acp_mode_id`/yolo mode and re-applies the spawn-time `default_effort`/`default_mode` config options on the fresh session — answering the open question about mode/config-option survival.
- `acp_client.rs`: new `ClientCmd::ResetSession` — the connection task opens a fresh `session/new` on the live worker (no restart), swaps the stored ACP session id, and emits `SessionContextReset` → `AcpSessionAssigned` (ordering keeps the fresh id persisted for the #3083 listener) → `Stopped(session_reset)`. Mid-turn resets are refused with a `PromptRejected` frame (parity with the busy-prompt path); failures surface as `PromptRuntimeError` + `Stopped(session_reset_failed)`.
- `session_service.rs`: `send_turn` branches on the disposition, so a clear alias on Codex never reaches `send_prompt`.
- `process/runner.rs`: the reset goes over the byte relay (the v2 control channel replays the cached handshake and would resurrect the old id); the runner tracks relay `session/new` requests and refreshes its handshake cache so `Cancel`/reattach replays follow the fresh session.
- `web/src/lib/acpTypes.ts`: `SessionContextReset` marks the turn as having output so the reset divider doesn't add a spurious "Command produced no output." row.

Failing baseline captured first on the unfixed code: the fake codex agent received one `session/new` plus a `session/prompt` carrying `/new` addressed to the old session id.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt --check`, clippy (`-D warnings` on the CI feature set), `acp::` + `server::` suites (1002 tests), web fmt/lint and the web suite all pass. The full `--lib --bins` run has 7 failures in `git::worktree`/`session::trash` that reproduce identically at the base commit on this machine (localized git output), i.e. pre-existing and unrelated. The visible change is an event-stream boundary already covered by the reducer test rather than a styling change, so no screenshot is attached.

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

`web/tests/live/acp-codex-new-reset.spec.ts`: real `aoe serve` with a fake codex ACP agent through the real runner — `/new` yields `SessionCleared`, `SessionContextReset`, a second `AcpSessionAssigned` with a new id, and `Stopped(session_reset)`. The vitest reducer test asserts the context tracker drops to the post-reset baseline.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The reset path is exercised end-to-end by the scripted-agent Rust integration tests (two `session/new` calls on the wire, id swap, alias never forwarded, `default_effort` re-applied after reset, mid-turn refusal with `PromptRejected`) and the live web spec above.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Fable 5 (Claude Code)

**Any Additional AI Details you'd like to share:**

Implementation and tests were AI-authored under human direction with an independent adversarial review pass before submission; validation commands and their results are listed above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed Codex `/new` in structured web sessions to trigger a real ACP “conversation reset” (`session/new`) instead of sending `/new` as plain prompt text.
- Implemented a Codex-only “driven reset” path for clear aliases where the adapter can’t reset natively, so the app drives the reset by resetting the underlying ACP session/context.
- Added safeguards to reject reset attempts when the session is busy (e.g., an in-flight prompt or active tool/background work), returning clear failure outcomes.
- Ensured the reset truly replaces the underlying ACP session id, then reapplies the persisted session mode and default configuration so subsequent turns continue with the expected settings.
- Updated relay/session tracking so the system doesn’t reuse stale session state after a reset (including runner handshake cache refresh).
- Refined the event/UI reset boundary so the timeline and “reset boundary visibility” match an actual reset sequence.
- Added coverage: Rust unit/integration tests, web reducer tests, and a live Playwright test validating `/new` produces the expected reset event order and a new ACP session id (plus a coverage-matrix entry).

## Benefits

Codex “Conversation cleared” in the web UI now corresponds to an actual reset of model conversation state, preserves the user’s configured session settings through the reset, and keeps the web event timeline consistent with what the ACP worker really did.

## Further considerations

The driven-reset behavior is currently focused on Codex; extending the same mechanism to other adapters that can’t reset natively could improve consistency across agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->