### PR TITLE
fix(serve): persist thought-level picks so they survive a worker respawn

### DIFF
--- a/acp-worker/test-shim/shim.mjs
+++ b/acp-worker/test-shim/shim.mjs
@@ -66,7 +66,10 @@ function emitUnsolicitedNotifIfRequested(client) {
 
 function handleInitialize(params) {
   const agentCapabilities = {
-    loadSession: false,
+    // SHIM_LOAD_SESSION=1 advertises loadSession so the Rust client resumes a
+    // stored id via session/load instead of falling through to session/new.
+    // Default off mirrors the adapters that cannot resume.
+    loadSession: process.env.SHIM_LOAD_SESSION === "1",
   };
   // SHIM_DELETE_CAPABILITY=1 advertises sessionCapabilities.delete
   // so the Rust client's session/delete dispatch path can be
@@ -125,6 +128,52 @@ async function handleDeleteSession(params) {
   return {};
 }
 
+// Config-option catalog the shim advertises when SHIM_THOUGHT_LEVEL=1: one
+// thought-level select, the shape claude-agent-acp and codex use for reasoning
+// effort. `thoughtLevel` tracks the currently selected value so a
+// session/set_config_option response reflects the pick.
+let thoughtLevel = "medium";
+
+function configOptions() {
+  if (process.env.SHIM_THOUGHT_LEVEL !== "1") return undefined;
+  return [
+    {
+      id: "thought_level",
+      name: "Thinking",
+      category: "thought_level",
+      type: "select",
+      currentValue: thoughtLevel,
+      options: [
+        { value: "medium", name: "Medium" },
+        { value: "high", name: "High" },
+      ],
+    },
+  ];
+}
+
+// SHIM_CONFIG_OPTION_RECORD_FILE, when set, appends one `<configId>=<value>`
+// line per session/set_config_option call so tests assert the RPC actually
+// fired (and with which value) rather than inferring it from events.
+async function handleSetConfigOption(params) {
+  const recordFile = process.env.SHIM_CONFIG_OPTION_RECORD_FILE;
+  if (recordFile) {
+    const fs = await import("node:fs/promises");
+    await fs.appendFile(recordFile, `${params.configId}=${params.value}\n`);
+  }
+  if (params.configId === "thought_level") {
+    thoughtLevel = params.value;
+  }
+  return { configOptions: configOptions() ?? [] };
+}
+
+// session/load: resume the stored id the client passed. Registered only when
+// SHIM_LOAD_SESSION=1, matching the advertised capability.
+function handleLoadSession(params) {
+  sessions.set(params.sessionId, {});
+  const options = configOptions();
+  return options ? { configOptions: options } : {};
+}
+
 async function handleNewSession(params) {
   // SHIM_MCP_RECORD_FILE, when set, captures the mcp_servers the client
   // forwarded on session/new so tests assert MCP forwarding end to end.
@@ -135,7 +184,8 @@ async function handleNewSession(params) {
   }
   const sessionId = "shim-" + crypto.randomUUID();
   sessions.set(sessionId, {});
-  return { sessionId };
+  const options = configOptions();
+  return options ? { sessionId, configOptions: options } : { sessionId };
 }
 
 async function handlePrompt(params, client) {
@@ -584,6 +634,9 @@ async function bootstrap() {
     .onRequest("authenticate", () => ({}))
     .onRequest("session/new", ({ params }) => handleNewSession(params))
     .onRequest("session/set_mode", () => ({}))
+    .onRequest("session/set_config_option", ({ params }) =>
+      handleSetConfigOption(params),
+    )
     .onRequest("session/prompt", ({ params, client }) =>
       handlePrompt(params, client),
     )
@@ -591,6 +644,9 @@ async function bootstrap() {
     .onConnect((connection) => emitUnsolicitedNotifIfRequested(connection.client));
   if (process.env.SHIM_DELETE_CAPABILITY === "1") {
     app.onRequest("session/delete", ({ params }) => handleDeleteSession(params));
+  }
+  if (process.env.SHIM_LOAD_SESSION === "1") {
+    app.onRequest("session/load", ({ params }) => handleLoadSession(params));
   }
   app.connect(stream);
 

--- a/src/acp/acp_client.rs
+++ b/src/acp/acp_client.rs
@@ -351,8 +351,10 @@ pub struct SpawnConfig {
     /// Kept separate from `provider_env`, which is request-sourced: it carries
     /// a stricter denylist and loses to these entries on a shared key.
     pub host_environment: Vec<(String, String)>,
-    /// Optional default reasoning effort to apply on fresh ACP sessions
-    /// through the adapter's `thought_level` config option.
+    /// Optional reasoning effort to apply through the adapter's
+    /// `thought_level` config option after the handshake, on a fresh session
+    /// (`session/new`, `session/fork`) and on a resumed one (`session/load`)
+    /// alike, so a session's pinned effort survives a worker respawn.
     pub default_effort: Option<String>,
     /// Optional default mode to apply on fresh ACP sessions through the
     /// adapter's `category:"mode"` config option. Applied strictly: a value
@@ -6245,6 +6247,13 @@ async fn run_connection_task<W, R>(
             // when present; otherwise SessionModeState constrains valid ids.
             let mut available_mode_ids: Option<Vec<String>> = None;
             let mut mode_config_option_id: Option<String> = None;
+            // Thought-level (reasoning effort) option id, captured from whichever
+            // establish call ran so `default_effort` can be applied once after
+            // the match. Captured in all three Fresh branches, not just
+            // session/new: a respawn resumes via session/load, and applying the
+            // effort only on a fresh session is what made a picked effort revert
+            // on every respawn.
+            let mut thought_level_config_option_id: Option<String> = None;
 
             // Drop any http/sse servers the agent did not advertise before they
             // reach session/new or session/load; stdio is always kept. Computed
@@ -6374,6 +6383,11 @@ async fn run_connection_task<W, R>(
                                     .config_options
                                     .as_deref()
                                     .and_then(mode_config_id)
+                                    .map(|id| id.0.to_string());
+                                thought_level_config_option_id = resp
+                                    .config_options
+                                    .as_deref()
+                                    .and_then(thought_level_config_id)
                                     .map(|id| id.0.to_string());
                                 // Surface agent-advertised modes (when carried in
                                 // the ACP `modes` field rather than the `mode`
@@ -6512,6 +6526,11 @@ async fn run_connection_task<W, R>(
                                         .as_deref()
                                         .and_then(mode_config_id)
                                         .map(|id| id.0.to_string());
+                                    thought_level_config_option_id = resp
+                                        .config_options
+                                        .as_deref()
+                                        .and_then(thought_level_config_id)
+                                        .map(|id| id.0.to_string());
                                     // Emit AcpSessionAssigned even on resume so the
                                     // frontend reducer can clear any sticky
                                     // `startupError` / `lastError` from a prior crash
@@ -6615,6 +6634,11 @@ async fn run_connection_task<W, R>(
                             .as_deref()
                             .and_then(mode_config_id)
                             .map(|id| id.0.to_string());
+                        thought_level_config_option_id = new_session
+                            .config_options
+                            .as_deref()
+                            .and_then(thought_level_config_id)
+                            .map(|id| id.0.to_string());
 
                         // Surface the agent-advertised modes (if any) so the UI
                         // can render the actual modes the agent supports rather
@@ -6649,50 +6673,7 @@ async fn run_connection_task<W, R>(
                             let _ = event_tx_for_block.send(event).await;
                         }
 
-                        if let (Some(effort), Some(options)) =
-                            (default_effort.as_deref(), config_options.as_deref())
-                        {
-                            if let Some(config_id) = thought_level_config_id(options) {
-                                info!(
-                                    target: "acp.protocol",
-                                    session = %session_label,
-                                    effort,
-                                    "applying default structured view effort"
-                                );
-                                match connection
-                                    .send_request(SetSessionConfigOptionRequest::new(
-                                        id.clone(),
-                                        config_id,
-                                        SessionConfigValueId::new(effort.to_string()),
-                                    ))
-                                    .block_task()
-                                    .await
-                                {
-                                    Ok(resp) => {
-                                        if let Some(event) =
-                                            config_options_event(Some(resp.config_options))
-                                        {
-                                            let _ = event_tx_for_block.send(event).await;
-                                        }
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            target: "acp.protocol",
-                                            session = %session_label,
-                                            "default structured view effort failed: {e}"
-                                        );
-                                    }
-                                }
-                            } else {
-                                debug!(
-                                    target: "acp.protocol",
-                                    session = %session_label,
-                                    "default structured view effort skipped; no thought_level option"
-                                );
-                            }
-                        }
-
-                        // Mode default mirrors the effort block above. Strict:
+                        // Mode default. Strict:
                         // apply only when the agent advertises a live
                         // `category:"mode"` option; a stale/unknown value is
                         // rejected by the adapter and warned (no-op), never
@@ -6754,6 +6735,56 @@ async fn run_connection_task<W, R>(
                     }
                 }
             };
+
+            // Apply the session's reasoning effort ("thought level") once, after
+            // whichever establish call ran. This sits outside the branches on
+            // purpose: `Instance.acp_effort` is a pin the session carries across
+            // respawns, and a respawn resumes via session/load (or session/fork),
+            // so applying it only on session/new let a picked effort revert to the
+            // agent default on every restart. Resume captures no option id (it
+            // sends neither new nor load and the worker's session is still
+            // configured), so it skips. Strict like the mode default above: a
+            // stale value the agent no longer advertises is rejected and warned,
+            // never failing the spawn.
+            if let (Some(effort), Some(config_id)) = (
+                default_effort.as_deref(),
+                thought_level_config_option_id.as_deref(),
+            ) {
+                info!(
+                    target: "acp.protocol",
+                    session = %session_label,
+                    effort,
+                    "applying structured view effort"
+                );
+                match connection
+                    .send_request(SetSessionConfigOptionRequest::new(
+                        acp_session_id.clone(),
+                        SessionConfigId::new(config_id.to_string()),
+                        SessionConfigValueId::new(effort.to_string()),
+                    ))
+                    .block_task()
+                    .await
+                {
+                    Ok(resp) => {
+                        if let Some(event) = config_options_event(Some(resp.config_options)) {
+                            let _ = event_tx_for_block.send(event).await;
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            target: "acp.protocol",
+                            session = %session_label,
+                            "structured view effort failed: {e}"
+                        );
+                    }
+                }
+            } else if default_effort.is_some() {
+                debug!(
+                    target: "acp.protocol",
+                    session = %session_label,
+                    "structured view effort skipped; no thought_level option"
+                );
+            }
 
             // #2976 Phase B: send session/cancel over the v2 control channel
             // when the runner owns the turn, else as a crate notification

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1714,6 +1714,49 @@ mod tests {
         );
     }
 
+    /// A respawn must carry the session's pinned effort, or the handshake has
+    /// nothing to re-apply and the picked thought level reverts to the agent
+    /// default on every worker restart. An unpinned session stays `None` so it
+    /// inherits whatever the configured default resolves to.
+    #[tokio::test]
+    async fn build_spawn_request_carries_persisted_effort() {
+        use super::{build_spawn_request, ResumeTarget};
+        use crate::server::test_support::build_test_app_state;
+        use crate::session::{Instance, View};
+
+        let mut inst = Instance::new("pinned", "/tmp/aoe-effort-respawn");
+        inst.id = "sess-effort".to_string();
+        inst.view = View::Structured;
+        inst.acp_effort = Some("high".to_string());
+        let mut unpinned = Instance::new("unpinned", "/tmp/aoe-effort-respawn");
+        unpinned.id = "sess-no-effort".to_string();
+        unpinned.view = View::Structured;
+        let state = build_test_app_state(vec![inst, unpinned]);
+
+        let target = |id: &str| ResumeTarget {
+            id: id.to_string(),
+            tool: "claude".to_string(),
+            agent_override: Some("claude".to_string()),
+            model: None,
+            project_path: "/tmp/aoe-effort-respawn".to_string(),
+            stored_acp_session_id: None,
+            source_profile: "default".to_string(),
+            in_flight_turn: false,
+            yolo_mode: false,
+            command: String::new(),
+        };
+
+        let req = build_spawn_request(&state.session_service, &target("sess-effort"))
+            .await
+            .expect("spawn request builds");
+        assert_eq!(req.effort.as_deref(), Some("high"));
+
+        let req = build_spawn_request(&state.session_service, &target("sess-no-effort"))
+            .await
+            .expect("spawn request builds");
+        assert_eq!(req.effort, None);
+    }
+
     // --- reconciler respawn budget (#1945) ---
 
     /// A session that keeps needing a respawn trips the budget after the

--- a/src/server/acp_reconciler.rs
+++ b/src/server/acp_reconciler.rs
@@ -1335,7 +1335,11 @@ async fn build_spawn_request(
     // structured fork's first connect captured the child id, the handshake
     // must still send session/fork. It is cleared once the forked id lands
     // (Task 11), so a later reattach reads None and resumes normally.
-    let (cwd, seed_history_replay, fork_from, acp_mode_id) = {
+    // acp_effort is read here too (not off the snapshotted target) so a pick made
+    // while this respawn was queued still lands: the handshake re-applies it
+    // through the agent's thought-level config option, and a None means the
+    // session inherits whatever the configured default resolves to.
+    let (cwd, seed_history_replay, fork_from, acp_mode_id, acp_effort) = {
         let _guard = inst_lock.lock().await;
         let instances = service.instances.read().await;
         let Some(inst) = instances.iter().find(|i| i.id == target.id) else {
@@ -1346,6 +1350,7 @@ async fn build_spawn_request(
             inst.import_pending == Some(true),
             inst.fork_pending.clone(),
             inst.acp_mode_id.clone(),
+            inst.acp_effort.clone(),
         )
     };
     let agent = supervisor
@@ -1388,7 +1393,7 @@ async fn build_spawn_request(
         additional_dirs: vec![],
         provider_env: vec![],
         model: target.model.clone(),
-        effort: None,
+        effort: acp_effort,
         stored_acp_session_id: target.stored_acp_session_id.clone(),
         fork_from,
         sandbox_info,

--- a/src/server/api/acp.rs
+++ b/src/server/api/acp.rs
@@ -374,6 +374,7 @@ pub async fn spawn_acp(
         .map(|p| (p.key, p.value))
         .collect();
     let model = req.model.or_else(|| instance.agent_model.clone());
+    let effort = instance.acp_effort.clone();
     let stored_acp_session_id = instance.acp_session_id.clone();
     let yolo_mode = instance.yolo_mode;
     let acp_mode_id = instance.acp_mode_id.clone();
@@ -438,7 +439,7 @@ pub async fn spawn_acp(
             additional_dirs: req.additional_dirs,
             provider_env,
             model,
-            effort: None,
+            effort,
             stored_acp_session_id,
             fork_from,
             sandbox_info,
@@ -966,6 +967,10 @@ pub async fn switch_acp_agent(
             additional_dirs: vec![],
             provider_env: vec![],
             model: model.clone(),
+            // Effort vocabularies are adapter-specific ("high" on one adapter,
+            // "xhigh" / "medium" naming on another), so the previous agent's
+            // pick is meaningless here. The new agent starts on its configured
+            // default and the persist below clears the stale value.
             effort: None,
             // Different ACP backend; the cached Claude session id would
             // be rejected by codex / opencode.
@@ -1013,6 +1018,10 @@ pub async fn switch_acp_agent(
             // later spawn/reconciler pass treats this as an import and clears
             // the store before spawning.
             inst.import_pending = None;
+            // Drop the old agent's effort pick: its vocabulary does not carry
+            // to the new agent, so the session falls back to the new agent's
+            // configured default until the user picks again.
+            inst.acp_effort = None;
             if let Some(m) = &model {
                 inst.agent_model = Some(m.clone());
             }
@@ -1025,6 +1034,7 @@ pub async fn switch_acp_agent(
                     inst.agent_name = Some(target_for_save.clone());
                     inst.acp_session_id = None;
                     inst.import_pending = None;
+                    inst.acp_effort = None;
                 }
                 Ok(())
             }) {
@@ -1813,6 +1823,7 @@ pub async fn acp_enable(
     let supervisor = state.acp_supervisor.clone();
     let session_id = id.clone();
     let model = instance.agent_model.clone();
+    let effort = instance.acp_effort.clone();
     let yolo_mode = instance.yolo_mode;
     let acp_mode_id = instance.acp_mode_id.clone();
     // #2252 direction B: a claude terminal session's resumable transcript lives
@@ -1883,7 +1894,7 @@ pub async fn acp_enable(
                 additional_dirs: vec![],
                 provider_env: vec![],
                 model,
-                effort: None,
+                effort,
                 stored_acp_session_id,
                 fork_from,
                 sandbox_info,
@@ -2150,34 +2161,73 @@ pub struct SetConfigOptionRequest {
     pub value: String,
 }
 
-/// Write a picked model back onto the instance, both in the in-memory
+/// Which persisted `Instance` field a successful config-option pick writes to.
+/// Carries the field name for logging and the mutation together so the two
+/// cannot drift apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PersistedSelector {
+    /// `Instance.agent_model`, re-injected on every spawn.
+    Model,
+    /// `Instance.acp_mode_id`, re-asserted via `session/set_mode` on every
+    /// worker (re)spawn (#2897).
+    Mode,
+    /// `Instance.acp_effort`, re-applied through the agent's thought-level
+    /// config option after every handshake.
+    ThoughtLevel,
+}
+
+impl PersistedSelector {
+    fn field(self) -> &'static str {
+        match self {
+            Self::Model => "agent_model",
+            Self::Mode => "acp_mode_id",
+            Self::ThoughtLevel => "acp_effort",
+        }
+    }
+
+    fn apply(self, inst: &mut crate::session::Instance, value: String) {
+        match self {
+            Self::Model => inst.agent_model = Some(value),
+            Self::Mode => inst.acp_mode_id = Some(value),
+            Self::ThoughtLevel => inst.acp_effort = Some(value),
+        }
+    }
+}
+
+/// Write a picked selector value back onto the instance, both in the in-memory
 /// registry (what the reconciler reads to respawn a worker this daemon
 /// lifetime) and on disk (what survives a daemon restart). Called from
 /// `acp_set_config_option` after the live pick succeeds; see the comment there
 /// for why the live call alone is not enough.
-async fn persist_agent_model(state: &Arc<AppState>, id: &str, model: &str) {
+async fn persist_selector(
+    state: &Arc<AppState>,
+    id: &str,
+    selector: PersistedSelector,
+    value: &str,
+) {
     let profile = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
             return;
         };
-        inst.agent_model = Some(model.to_string());
+        selector.apply(inst, value.to_string());
         inst.source_profile.clone()
     };
     match crate::session::Storage::new(&profile, state.file_watch.clone()) {
         Ok(storage) => {
             let id_owned = id.to_string();
-            let model_owned = model.to_string();
+            let value_owned = value.to_string();
             if let Err(e) = storage.update(|instances, _groups| {
                 if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
-                    inst.agent_model = Some(model_owned.clone());
+                    selector.apply(inst, value_owned.clone());
                 }
                 Ok(())
             }) {
                 tracing::error!(
                     target: "http.api.acp",
                     session = %id,
-                    "failed to persist agent_model after config-option pick: {e}"
+                    field = selector.field(),
+                    "failed to persist selector after config-option pick: {e}"
                 );
             }
         }
@@ -2185,20 +2235,26 @@ async fn persist_agent_model(state: &Arc<AppState>, id: &str, model: &str) {
             tracing::error!(
                 target: "http.api.acp",
                 session = %id,
-                "failed to open storage to persist agent_model after config-option pick: {e}"
+                field = selector.field(),
+                "failed to open storage to persist selector after config-option pick: {e}"
             );
         }
     }
 }
 
-/// True when `config_id` is this session's Mode-category config option.
-/// Resolved from the agent's advertised option catalog rather than a hardcoded
-/// id, so a mode pick is told apart from a model / thought-level pick without
-/// assuming any adapter's naming. The daemon keeps no live per-session
-/// `AcpState`, so the option catalog (recorded on `ConfigOptionsUpdated`) is the
-/// only handler-reachable source of a session's advertised options; if it has
-/// no entry yet we return false and skip persistence (no regression).
-async fn is_mode_config_option(state: &Arc<AppState>, id: &str, config_id: &str) -> bool {
+/// Category the agent advertised for `config_id`, or `None` when the option is
+/// unknown. Resolved from the agent's advertised option catalog rather than
+/// hardcoded ids, so a mode pick is told apart from a model / thought-level
+/// pick without assuming any adapter's naming. The daemon keeps no live
+/// per-session `AcpState`, so the option catalog (recorded on
+/// `ConfigOptionsUpdated`) is the only handler-reachable source of a session's
+/// advertised options; if it has no entry yet we return `None` and skip
+/// persistence (no regression).
+async fn config_option_category(
+    state: &Arc<AppState>,
+    id: &str,
+    config_id: &str,
+) -> Option<crate::acp::state::ConfigOptionCategory> {
     let agent = {
         let instances = state.instances.read().await;
         instances.iter().find(|i| i.id == id).map(|i| {
@@ -2208,59 +2264,14 @@ async fn is_mode_config_option(state: &Arc<AppState>, id: &str, config_id: &str)
                 .unwrap_or(i.tool.as_str())
                 .to_string()
         })
-    };
-    let Some(agent) = agent else {
-        return false;
-    };
+    }?;
     crate::acp::option_catalog::load()
         .agents
         .get(&agent)
         .into_iter()
         .flat_map(|entry| entry.options.iter())
-        .any(|opt| {
-            opt.id == config_id && opt.category == crate::acp::state::ConfigOptionCategory::Mode
-        })
-}
-
-/// Write a picked mode back onto the instance, both in the in-memory registry
-/// (what the reconciler reads to respawn a worker this daemon lifetime) and on
-/// disk (what survives a daemon restart). Mirrors `persist_agent_model`; see the
-/// call site in `acp_set_config_option` for why the live pick alone is not
-/// enough. See #3086.
-async fn persist_acp_mode(state: &Arc<AppState>, id: &str, mode_id: &str) {
-    let profile = {
-        let mut instances = state.instances.write().await;
-        let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-            return;
-        };
-        inst.acp_mode_id = Some(mode_id.to_string());
-        inst.source_profile.clone()
-    };
-    match crate::session::Storage::new(&profile, state.file_watch.clone()) {
-        Ok(storage) => {
-            let id_owned = id.to_string();
-            let mode_owned = mode_id.to_string();
-            if let Err(e) = storage.update(|instances, _groups| {
-                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_owned) {
-                    inst.acp_mode_id = Some(mode_owned.clone());
-                }
-                Ok(())
-            }) {
-                tracing::error!(
-                    target: "http.api.acp",
-                    session = %id,
-                    "failed to persist acp_mode_id after config-option pick: {e}"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!(
-                target: "http.api.acp",
-                session = %id,
-                "failed to open storage to persist acp_mode_id after config-option pick: {e}"
-            );
-        }
-    }
+        .find(|opt| opt.id == config_id)
+        .map(|opt| opt.category.clone())
 }
 
 /// Set a per-session selector (model, reasoning effort, etc.) via ACP
@@ -2309,16 +2320,34 @@ pub async fn acp_set_config_option(
             // current adapter and the frontend use; resolve category == Model
             // from the session's config_options if a future adapter uses another
             // id.
-            if req.config_id == "model" {
-                persist_agent_model(&state, &id, &req.value).await;
-            } else if is_mode_config_option(&state, &id, &req.config_id).await {
-                // Persist a Mode-category pick so it survives a worker respawn.
-                // The reconciler re-asserts `acp_mode_id` via `session/set_mode`
-                // on every (re)spawn (#2897); without this write-back the id
-                // stays at its creation value (commonly None) and a respawn
-                // reverts the session to the adapter's prompting default. Mirrors
-                // the model write-back above. See #3086.
-                persist_acp_mode(&state, &id, &req.value).await;
+            // A Mode-category pick is persisted for the same reason: the
+            // reconciler re-asserts `acp_mode_id` via `session/set_mode` on
+            // every (re)spawn (#2897), so without the write-back the id stays
+            // at its creation value (commonly None) and a respawn reverts the
+            // session to the adapter's prompting default. See #3086.
+            //
+            // A ThoughtLevel pick is persisted so the handshake can re-apply it
+            // through the agent's thought-level config option; without it a
+            // respawn spawns with `effort: None` and the pick reverts to the
+            // agent default.
+            let selector = if req.config_id == "model" {
+                Some(PersistedSelector::Model)
+            } else {
+                match config_option_category(&state, &id, &req.config_id).await {
+                    Some(crate::acp::state::ConfigOptionCategory::Model) => {
+                        Some(PersistedSelector::Model)
+                    }
+                    Some(crate::acp::state::ConfigOptionCategory::Mode) => {
+                        Some(PersistedSelector::Mode)
+                    }
+                    Some(crate::acp::state::ConfigOptionCategory::ThoughtLevel) => {
+                        Some(PersistedSelector::ThoughtLevel)
+                    }
+                    Some(crate::acp::state::ConfigOptionCategory::Other(_)) | None => None,
+                }
+            };
+            if let Some(selector) = selector {
+                persist_selector(&state, &id, selector, &req.value).await;
             }
             StatusCode::ACCEPTED.into_response()
         }
@@ -2693,7 +2722,7 @@ mod tests {
             .unwrap();
 
         let state = crate::server::test_support::build_test_app_state(vec![inst]);
-        persist_agent_model(&state, &id, "claude-sonnet-5").await;
+        persist_selector(&state, &id, PersistedSelector::Model, "claude-sonnet-5").await;
 
         // In-memory registry updated (what the reconciler reads to respawn).
         assert_eq!(
@@ -2742,7 +2771,7 @@ mod tests {
             .unwrap();
 
         let state = crate::server::test_support::build_test_app_state(vec![inst]);
-        persist_acp_mode(&state, &id, "agent-full-access").await;
+        persist_selector(&state, &id, PersistedSelector::Mode, "agent-full-access").await;
 
         // In-memory registry updated (what the reconciler re-asserts on respawn).
         assert_eq!(
@@ -2766,9 +2795,61 @@ mod tests {
         );
     }
 
+    /// An explicit thought-level pick must reach both the in-memory registry
+    /// and disk, or the handshake has nothing to re-apply and the pick reverts
+    /// to the agent default on the next respawn.
     #[tokio::test]
     #[serial_test::serial]
-    async fn is_mode_config_option_resolves_mode_from_catalog() {
+    async fn persist_acp_effort_updates_memory_and_storage() {
+        use crate::session::test_support::isolate_app_dir;
+        let _tmp = isolate_app_dir();
+        let profile = "default";
+
+        // A session created without an explicit effort: acp_effort is None, so
+        // it inherits the configured default until the user picks.
+        let mut inst = crate::session::Instance::new("t", "/tmp");
+        inst.source_profile = profile.to_string();
+        assert_eq!(inst.acp_effort, None);
+        let id = inst.id.clone();
+
+        // Seed on disk so the storage write-back can find the row to update.
+        let storage = crate::session::Storage::new_unwatched(profile).unwrap();
+        let seed = inst.clone();
+        storage
+            .update(|instances, _groups| {
+                instances.push(seed);
+                Ok(())
+            })
+            .unwrap();
+
+        let state = crate::server::test_support::build_test_app_state(vec![inst]);
+        persist_selector(&state, &id, PersistedSelector::ThoughtLevel, "high").await;
+
+        // In-memory registry updated (what the reconciler reads to respawn).
+        assert_eq!(
+            state.instances.read().await[0].acp_effort.as_deref(),
+            Some("high")
+        );
+
+        // On disk too (what survives a daemon restart).
+        let reloaded = crate::session::Storage::new_unwatched(profile)
+            .unwrap()
+            .load()
+            .unwrap();
+        assert_eq!(
+            reloaded
+                .iter()
+                .find(|i| i.id == id)
+                .unwrap()
+                .acp_effort
+                .as_deref(),
+            Some("high")
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn config_option_category_resolves_categories_from_catalog() {
         use crate::acp::state::{ConfigOptionCategory, ConfigOptionChoice, ConfigOptionDescriptor};
         use crate::session::test_support::isolate_app_dir;
         let _tmp = isolate_app_dir();
@@ -2798,15 +2879,37 @@ mod tests {
                 current_value: "gpt-5".to_string(),
                 options: vec![],
             },
+            ConfigOptionDescriptor {
+                id: "reasoning-effort".to_string(),
+                name: "Reasoning effort".to_string(),
+                description: None,
+                category: ConfigOptionCategory::ThoughtLevel,
+                current_value: "medium".to_string(),
+                options: vec![ConfigOptionChoice {
+                    value: "high".to_string(),
+                    name: "High".to_string(),
+                    description: None,
+                }],
+            },
         ];
         crate::acp::option_catalog::record("codex", &opts, "2026-07-24T00:00:00Z".to_string())
             .unwrap();
 
         let state = crate::server::test_support::build_test_app_state(vec![inst]);
 
-        assert!(is_mode_config_option(&state, &id, "codex-mode").await);
-        assert!(!is_mode_config_option(&state, &id, "model").await);
-        assert!(!is_mode_config_option(&state, &id, "unknown").await);
+        assert_eq!(
+            config_option_category(&state, &id, "codex-mode").await,
+            Some(ConfigOptionCategory::Mode)
+        );
+        assert_eq!(
+            config_option_category(&state, &id, "model").await,
+            Some(ConfigOptionCategory::Model)
+        );
+        assert_eq!(
+            config_option_category(&state, &id, "reasoning-effort").await,
+            Some(ConfigOptionCategory::ThoughtLevel)
+        );
+        assert_eq!(config_option_category(&state, &id, "unknown").await, None);
     }
 
     #[tokio::test]

--- a/src/server/session_spawn.rs
+++ b/src/server/session_spawn.rs
@@ -278,6 +278,17 @@ pub(crate) async fn spawn_structured_session(
             // on the resolved model. Same single-source resolver the spawn path
             // uses; persist the model here so the composer shows it and the
             // session stays pinned to it. See resolve_spawn_model_effort.
+            // Persist only an EXPLICIT effort, never the resolved default:
+            // `acp_effort` is a pin, and `None` means "inherit whatever the
+            // configured default resolves to at spawn time". Snapshotting the
+            // default here would freeze the session on today's value and make a
+            // later config change invisible to it. The resolved effort still
+            // reaches this session's first spawn below.
+            let explicit_effort = agent_effort
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
             let (resolved_model, mut agent_effort) =
                 crate::session::config::resolve_spawn_model_effort(
                     defaults,
@@ -285,6 +296,7 @@ pub(crate) async fn spawn_structured_session(
                     agent_effort,
                 );
             instance.agent_model = resolved_model;
+            instance.acp_effort = explicit_effort;
             // Don't trust the client's capability decision. Re-resolve
             // whether this agent can actually run in structured view; a custom
             // agent without an `agent_acp_cmd` (or any non-ACP tool)
@@ -326,6 +338,8 @@ pub(crate) async fn spawn_structured_session(
                 // Terminal sessions keep only an explicitly requested model,
                 // never an ACP-derived default (agent_model is ACP-only).
                 instance.agent_model = explicit_model;
+                // acp_effort is ACP-only too: nothing applies it in tmux mode.
+                instance.acp_effort = None;
             }
 
             agent_effort

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -856,6 +856,16 @@ pub struct Instance {
     /// "gpt-5", "llama3.3:ollama").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_model: Option<String>,
+    /// Reasoning effort ("thought level") this session was explicitly pinned
+    /// to, applied through the agent's `category:"thought_level"` config
+    /// option after every worker (re)spawn. `None` means the session inherits
+    /// whatever the per-agent configured default resolves to at spawn time, so
+    /// only an explicit pick (structured view picker, or an explicit effort on
+    /// create) is stored here. Cleared on an agent switch: effort vocabularies
+    /// are adapter-specific, so the old agent's value is meaningless to the
+    /// new one. Additive: absent in older rows, no migration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acp_effort: Option<String>,
     /// Agent-assigned ACP session id captured from `session/new`. When
     /// the agent advertises `agent_capabilities.load_session = true`
     /// (claude-agent-acp does), the next spawn calls `session/load`
@@ -1381,6 +1391,7 @@ impl Instance {
             view: View::Terminal,
             agent_name: None,
             agent_model: None,
+            acp_effort: None,
             acp_session_id: None,
             import_pending: None,
             fork_pending: None,

--- a/tests/integration/acp_effort_respawn.rs
+++ b/tests/integration/acp_effort_respawn.rs
@@ -57,7 +57,7 @@ async fn drive_one_turn(client: &mut AcpClient) {
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     while std::time::Instant::now() < deadline {
         match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await {
-            Ok(Some(evt)) if matches!(evt, Event::Stopped { .. }) => break,
+            Ok(Some(Event::Stopped { .. })) => break,
             Ok(_) | Err(_) => continue,
         }
     }

--- a/tests/integration/acp_effort_respawn.rs
+++ b/tests/integration/acp_effort_respawn.rs
@@ -34,6 +34,7 @@ fn spawn_config(
         cwd: std::env::temp_dir(),
         additional_dirs: vec![],
         provider_env: env,
+        host_environment: vec![],
         default_effort,
         default_mode: None,
         socket_path: None,

--- a/tests/integration/acp_effort_respawn.rs
+++ b/tests/integration/acp_effort_respawn.rs
@@ -1,0 +1,167 @@
+//! A session's pinned reasoning effort ("thought level") must be applied after
+//! every handshake, not just on a fresh `session/new`.
+//!
+//! A worker respawn resumes the stored ACP session via `session/load`, so an
+//! effort applied only in the `session/new` branch silently reverted to the
+//! agent default on every restart (crash, `aoe acp restart`, daemon restart).
+//! These tests drive the real `AcpClient` against the test shim and assert the
+//! `session/set_config_option` RPC actually fired with the pinned value on the
+//! load path as well as the fresh path.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use agent_of_empires::acp::acp_client::{AcpClient, SpawnConfig};
+use agent_of_empires::acp::agent_registry::AgentSpec;
+use agent_of_empires::acp::state::{AcpSessionId, Event};
+
+use crate::common::{shim_path, shim_ready};
+
+fn spawn_config(
+    shim: PathBuf,
+    env: Vec<(String, String)>,
+    stored_acp_session_id: Option<String>,
+    default_effort: Option<String>,
+) -> SpawnConfig {
+    SpawnConfig {
+        agent_key: "claude".into(),
+        spec: AgentSpec {
+            command: "node".into(),
+            args: vec![shim.to_string_lossy().to_string()],
+            description: "thought-level shim".into(),
+            env_allowlist: None,
+        },
+        cwd: std::env::temp_dir(),
+        additional_dirs: vec![],
+        provider_env: env,
+        default_effort,
+        default_mode: None,
+        socket_path: None,
+        stored_acp_session_id,
+        fork_from: None,
+        seed_history_replay: false,
+        artifact_dir: None,
+        sandbox_info: None,
+        source_profile: None,
+        mcp_servers: Vec::new(),
+    }
+}
+
+/// A prompt is only dispatched after the handshake completes, so a `Stopped`
+/// proves any post-handshake config-option work already ran.
+async fn drive_one_turn(client: &mut AcpClient) {
+    client
+        .send_prompt("hello", &[])
+        .await
+        .expect("send_prompt should reach the shim");
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await {
+            Ok(Some(evt)) if matches!(evt, Event::Stopped { .. }) => break,
+            Ok(_) | Err(_) => continue,
+        }
+    }
+}
+
+fn shim_env(record_path: &std::path::Path, load_session: bool) -> Vec<(String, String)> {
+    let mut env = vec![
+        ("SHIM_THOUGHT_LEVEL".into(), "1".into()),
+        (
+            "SHIM_CONFIG_OPTION_RECORD_FILE".into(),
+            record_path.to_string_lossy().to_string(),
+        ),
+    ];
+    if load_session {
+        env.push(("SHIM_LOAD_SESSION".into(), "1".into()));
+    }
+    env
+}
+
+/// The respawn shape: the agent advertises `loadSession` and we hand it a
+/// stored id, so the handshake resumes via `session/load`. The pinned effort
+/// must still be applied, or the pick the user made before the restart is gone.
+#[tokio::test]
+async fn pinned_effort_applied_on_session_load() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let record_path = temp.path().join("config-option-calls.log");
+    let config = spawn_config(
+        shim_path(),
+        shim_env(&record_path, true),
+        Some("stored-effort-session".into()),
+        Some("high".into()),
+    );
+
+    let mut client = AcpClient::spawn(config, AcpSessionId("effort-load".into()))
+        .await
+        .expect("spawn shim");
+    drive_one_turn(&mut client).await;
+    let _ = client.shutdown().await;
+
+    let recorded = std::fs::read_to_string(&record_path).unwrap_or_default();
+    assert!(
+        recorded.lines().any(|line| line == "thought_level=high"),
+        "a session/load respawn must re-apply the pinned effort (recorded: {recorded:?})"
+    );
+}
+
+/// The fresh-session path keeps working, and applies the effort exactly once.
+#[tokio::test]
+async fn pinned_effort_applied_once_on_session_new() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let record_path = temp.path().join("config-option-calls.log");
+    let config = spawn_config(
+        shim_path(),
+        shim_env(&record_path, false),
+        None,
+        Some("high".into()),
+    );
+
+    let mut client = AcpClient::spawn(config, AcpSessionId("effort-new".into()))
+        .await
+        .expect("spawn shim");
+    drive_one_turn(&mut client).await;
+    let _ = client.shutdown().await;
+
+    let recorded = std::fs::read_to_string(&record_path).unwrap_or_default();
+    assert_eq!(
+        recorded
+            .lines()
+            .filter(|line| *line == "thought_level=high")
+            .count(),
+        1,
+        "session/new must apply the effort exactly once (recorded: {recorded:?})"
+    );
+}
+
+/// An unpinned session sends no config-option RPC at all, so it keeps whatever
+/// the agent's own default is.
+#[tokio::test]
+async fn no_config_option_rpc_without_a_pinned_effort() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let record_path = temp.path().join("config-option-calls.log");
+    let config = spawn_config(shim_path(), shim_env(&record_path, true), None, None);
+
+    let mut client = AcpClient::spawn(config, AcpSessionId("effort-none".into()))
+        .await
+        .expect("spawn shim");
+    drive_one_turn(&mut client).await;
+    let _ = client.shutdown().await;
+
+    let recorded = std::fs::read_to_string(&record_path).unwrap_or_default();
+    assert!(
+        recorded.trim().is_empty(),
+        "no effort pinned means no set_config_option call (recorded: {recorded:?})"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -41,6 +41,9 @@ mod acp_smoke;
 #[cfg(feature = "serve")]
 mod acp_session_delete;
 
+#[cfg(feature = "serve")]
+mod acp_effort_respawn;
+
 #[cfg(all(feature = "serve", debug_assertions))]
 mod acp_midturn_resume;
 


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to the review on #3092, which fixed mode persistence and flagged that thought-level (reasoning effort) picks have the same latent gap.

A structured-view effort pick goes through the same `acp_set_config_option` endpoint as model and mode, but nothing persisted it, and every respawn path spawned with `effort: None`. So a picked effort reverted to the agent default on the next worker restart (crash, `aoe acp restart`, daemon restart). Applying it made the gap worse than mode's: `default_effort` was applied only inside the `session/new` branch of the handshake, and a normal respawn resumes via `session/load`, which never applied an effort at all. Mode escaped that because the supervisor re-asserts it post-handshake via `session/set_mode`.

This adds `Instance.acp_effort` (additive, `serde(default)`, no migration) as an explicit pin, persists a ThoughtLevel-category pick to it, threads it through the reconciler respawn and the attach / enable spawn paths, and hoists the effort application out of the `session/new` branch so `session/load` and `session/fork` apply it too. `Resume` captures no option id and skips, which is correct: the worker survived and its session is still configured.

Two deliberate scoping calls:

- **Only an explicit effort is persisted, never a resolved default.** `None` means "inherit whatever the configured default resolves to at spawn time", so snapshotting the default at create would freeze a session on today's value and make a later config change invisible to it. `agent_model` does snapshot its resolved default; that behavior is unchanged here.
- **An agent switch clears the pin.** Effort vocabularies are adapter-specific (`high` on one adapter, different naming on another), so carrying the old agent's value to a new one is meaningless. Switching to structured view on the same agent does carry it.

Along the way `persist_agent_model` and `persist_acp_mode` collapse into one `persist_selector` driven by a typed `PersistedSelector`, rather than adding a third near-identical 35-line copy, and `is_mode_config_option` generalizes into `config_option_category`. Classification still resolves from the agent-name-keyed option catalog, matching the decision made on #3092.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a structured-view session on an agent that advertises a thought-level selector (Codex, or modern claude-agent-acp).
- [ ] Pick a non-default effort (e.g. **High**); confirm the picker shows it and `sessions.json` gains `"acp_effort": "high"` for that session.
- [ ] `aoe acp restart <id>` (or let the worker crash and respawn); confirm the picker comes back on **High** rather than the agent default.
- [ ] `aoe serve --stop` then `aoe serve`, reattach the session, confirm the effort is still **High** (this is the `session/load` path the fix covers).
- [ ] Pick a **model** on a running session; confirm `acp_effort` is untouched (only `agent_model` changes).
- [ ] Switch the session to a different agent; confirm `acp_effort` is cleared and the new agent starts on its own default.
- [ ] On a session where you never picked an effort, change the per-agent default effort in settings, respawn, and confirm the session picks up the NEW default (it is not pinned to the old one).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / structured view (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: no `web/` file changed; this is server-side persistence plus handshake re-application, and a Playwright test cannot exercise a worker respawn. Covered instead by three new integration tests in `tests/integration/acp_effort_respawn.rs` that drive the real `AcpClient` against the test shim (extended with a thought-level config option, an optional `loadSession` capability, and a `set_config_option` record file), plus unit tests in `src/server/api/acp.rs` (ThoughtLevel persistence to memory and disk, category classification from the catalog) and `src/server/acp_reconciler.rs` (the respawn spawn request carries the pin, and stays `None` when unpinned).

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The load-path test was verified red on the pre-fix tree (it recorded no `set_config_option` call at all), while the `session/new` and unpinned control cases passed there, so the shim work is not vacuously green.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The plan went through a `/debate` consult with two other models, which is where the "do not persist a resolved default" and "clear on agent switch" calls came from; I reviewed each commit and made the scoping decisions.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added persistence for a user-selected “thought level” (reasoning effort) so it survives worker respawns, session resumes (`session/load`), and daemon restarts.
- Introduced an explicit per-instance “effort pin” (`acp_effort`) that’s only set when the user pins an effort, and is cleared when switching agents to avoid adapter-specific vocabulary mismatches.
- Ensured the pinned thought level is reapplied at the right points in the ACP lifecycle (including resume/fork paths), and applied exactly once for fresh sessions.
- Refactored how config options are persisted so model, view/mode, and thought-level effort follow a single consistent flow.
- Updated the test shim to support session load/resume and to record config-option RPCs, then added integration tests to verify pinned vs unpinned behavior across `session/new` and `session/load`.

## Benefits

Users no longer lose their selected reasoning effort after restarts or session respawns, while unpinned sessions keep using the configured defaults at spawn time.

## Technical notes (optional)

- Added `Instance.acp_effort: Option<String>` and threaded it through spawn/reconciler/API paths (`build_spawn_request`, structured spawn, and `spawn_acp`/`acp_enable`).
- Refactored persistence into a typed `persist_selector` flow for model, mode, and thought-level effort, and ensured effort application is gated on adapter-advertised `thought_level` config option ids.
- Updated handshake/session establishment to capture and apply `default_effort` for `session/new`, `session/load`, and `session/fork` paths, plus cleared `acp_effort` on agent switching and terminal-mode fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->